### PR TITLE
Rename parameter selectors

### DIFF
--- a/doc/api/next_api_changes/deprecations/20585-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20585-EP.rst
@@ -1,10 +1,9 @@
 RectangleSelector and EllipseSelector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``maxdist`` is deprecated, use ``grab_range`` argument instead
-``marker_props`` is deprecated, use ``handle_props`` argument instead
+The *maxdist* argument is deprecated, use *grab_range* instead.
+The *marker_props* argument is deprecated, use *handle_props* instead.
 
 PolygonSelector
 ~~~~~~~~~~~~~~~
-``vertex_select_radius`` is deprecated, use ``grab_range`` argument instead
-``markerprops`` is deprecated, use ``handle_props`` argument instead
-
+The *vertex_select_radius* argument is deprecated, use *grab_range* instead.
+The *markerprops* argument is deprecated, use *handle_props* instead.

--- a/doc/api/next_api_changes/deprecations/20585-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20585-EP.rst
@@ -1,9 +1,32 @@
+Unification of Selector API
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The API for Selector widgets has been unified to use
+
+- *props* for the properties of the Artist representing the selection.
+- *handle_props* for the Artists representing handles for modifying the selection.
+- *grab_range* for the maximal tolerance to grab a handle with the mouse.
+
+This affects the following parameters and attributes:
+
+
 RectangleSelector and EllipseSelector
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The *maxdist* argument is deprecated, use *grab_range* instead.
+The *rectprops* argument is deprecated, use *props* instead.
 The *marker_props* argument is deprecated, use *handle_props* instead.
 
 PolygonSelector
-~~~~~~~~~~~~~~~
-The *vertex_select_radius* argument is deprecated, use *grab_range* instead.
+^^^^^^^^^^^^^^^
+The *vertex_select_radius* argument and attribute is deprecated, use *grab_range* instead.
+The *lineprops* argument is deprecated, use *props* instead.
 The *markerprops* argument is deprecated, use *handle_props* instead.
+The *maxdist* argument and attribute is deprecated, use *grab_range* instead.
+
+SpanSelector
+^^^^^^^^^^^^
+The *rectprops* argument is deprecated, use *props* instead.
+The *maxdist* argument and attribute is deprecated, use *grab_range* instead.
+
+LassoSelector
+^^^^^^^^^^^^^
+The *lineprops* argument is deprecated, use *props* instead.

--- a/doc/api/next_api_changes/deprecations/20585-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20585-EP.rst
@@ -1,0 +1,10 @@
+RectangleSelector and EllipseSelector
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``maxdist`` is deprecated, use ``handle_grab_distance`` argument instead
+``marker_props`` is deprecated, use ``handle_props`` argument instead
+
+PolygonSelector
+~~~~~~~~~~~~~~~
+``vertex_select_radius`` is deprecated, use ``handle_grab_distance`` argument instead
+``markerprops`` is deprecated, use ``handle_props`` argument instead
+

--- a/doc/api/next_api_changes/deprecations/20585-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20585-EP.rst
@@ -1,10 +1,10 @@
 RectangleSelector and EllipseSelector
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-``maxdist`` is deprecated, use ``handle_grab_distance`` argument instead
+``maxdist`` is deprecated, use ``grab_range`` argument instead
 ``marker_props`` is deprecated, use ``handle_props`` argument instead
 
 PolygonSelector
 ~~~~~~~~~~~~~~~
-``vertex_select_radius`` is deprecated, use ``handle_grab_distance`` argument instead
+``vertex_select_radius`` is deprecated, use ``grab_range`` argument instead
 ``markerprops`` is deprecated, use ``handle_props`` argument instead
 

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -53,7 +53,7 @@ span = SpanSelector(
     onselect,
     "horizontal",
     useblit=True,
-    rectprops=dict(alpha=0.5, facecolor="tab:blue"),
+    props=dict(alpha=0.5, facecolor="tab:blue"),
     interactive=True,
     drag_from_anywhere=True
 )

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -98,7 +98,7 @@ def test_ellipse():
         pass
 
     tool = widgets.EllipseSelector(ax, onselect=onselect,
-                                   maxdist=10, interactive=True)
+                                   handle_grab_distance=10, interactive=True)
     tool.extents = (100, 150, 100, 150)
 
     # drag the rectangle
@@ -152,8 +152,9 @@ def test_rectangle_handles():
         pass
 
     tool = widgets.RectangleSelector(ax, onselect=onselect,
-                                     maxdist=10, interactive=True,
-                                     marker_props={'markerfacecolor': 'r',
+                                     handle_grab_distance=10,
+                                     interactive=True,
+                                     handle_props={'markerfacecolor': 'r',
                                                    'markeredgecolor': 'b'})
     tool.extents = (100, 150, 100, 150)
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -52,7 +52,7 @@ def test_rectangle_selector():
         check_rectangle(drawtype='none', minspanx=10, minspany=10)
 
     check_rectangle(minspanx=10, minspany=10, spancoords='pixels')
-    check_rectangle(rectprops=dict(fill=True))
+    check_rectangle(props=dict(fill=True))
 
 
 @pytest.mark.parametrize('drag_from_anywhere, new_center',
@@ -221,7 +221,7 @@ def check_span(*args, **kwargs):
 def test_span_selector():
     check_span('horizontal', minspan=10, useblit=True)
     check_span('vertical', onmove_callback=True, button=1)
-    check_span('horizontal', rectprops=dict(fill=True))
+    check_span('horizontal', props=dict(fill=True))
 
 
 @pytest.mark.parametrize('drag_from_anywhere', [True, False])
@@ -320,7 +320,7 @@ def check_lasso_selector(**kwargs):
 
 def test_lasso_selector():
     check_lasso_selector()
-    check_lasso_selector(useblit=False, lineprops=dict(color='red'))
+    check_lasso_selector(useblit=False, props=dict(color='red'))
     check_lasso_selector(useblit=True, button=1)
 
 
@@ -674,7 +674,7 @@ def test_rect_visibility(fig_test, fig_ref):
         pass
 
     tool = widgets.RectangleSelector(ax_test, onselect,
-                                     rectprops={'visible': False})
+                                     props={'visible': False})
     tool.extents = (0.2, 0.8, 0.3, 0.7)
 
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -98,7 +98,7 @@ def test_ellipse():
         pass
 
     tool = widgets.EllipseSelector(ax, onselect=onselect,
-                                   handle_grab_distance=10, interactive=True)
+                                   grab_range=10, interactive=True)
     tool.extents = (100, 150, 100, 150)
 
     # drag the rectangle
@@ -152,7 +152,7 @@ def test_rectangle_handles():
         pass
 
     tool = widgets.RectangleSelector(ax, onselect=onselect,
-                                     handle_grab_distance=10,
+                                     grab_range=10,
                                      interactive=True,
                                      handle_props={'markerfacecolor': 'r',
                                                    'markeredgecolor': 'b'})

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2714,9 +2714,9 @@ class RectangleSelector(_SelectorWidget):
 
     interactive = _api.deprecate_privatize_attribute("3.5")
 
-    maxdist = _api.deprecated("3.5")(
-        property(lambda self: self.grab_range)
-        )
+    maxdist = _api.deprecated("3.5", name="maxdist", alternative="grab_range")(
+        property(lambda self: self.grab_range,
+                 lambda self, value: setattr(self, "grab_range", value)))
 
     def _press(self, event):
         """Button press event handler."""
@@ -3238,8 +3238,10 @@ class PolygonSelector(_SelectorWidget):
         self.artists = [self.line, self._polygon_handles.artist]
         self.set_visible(True)
 
-    vertex_select_radius = _api.deprecated("3.5")(
-        property(lambda self: self.grab_range)
+    vertex_select_radius = _api.deprecated("3.5", name="vertex_select_radius",
+                                           alternative="grab_range")(
+        property(lambda self: self.grab_range,
+                 lambda self, value: setattr(self, "grab_range", value))
         )
 
     @property

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1577,7 +1577,7 @@ class Cursor(AxesWidget):
 
     Other Parameters
     ----------------
-    **props
+    **lineprops
         `.Line2D` properties that control the appearance of the lines.
         See also `~.Axes.axhline`.
 
@@ -1586,9 +1586,8 @@ class Cursor(AxesWidget):
     See :doc:`/gallery/widgets/cursor`.
     """
 
-    @_api.rename_parameter("3.5", "lineprops", "props")
     def __init__(self, ax, horizOn=True, vertOn=True, useblit=False,
-                 **props):
+                 **lineprops):
         super().__init__(ax)
 
         self.connect_event('motion_notify_event', self.onmove)
@@ -1600,9 +1599,9 @@ class Cursor(AxesWidget):
         self.useblit = useblit and self.canvas.supports_blit
 
         if self.useblit:
-            props['animated'] = True
-        self.lineh = ax.axhline(ax.get_ybound()[0], visible=False, **props)
-        self.linev = ax.axvline(ax.get_xbound()[0], visible=False, **props)
+            lineprops['animated'] = True
+        self.lineh = ax.axhline(ax.get_ybound()[0], visible=False, **lineprops)
+        self.linev = ax.axvline(ax.get_xbound()[0], visible=False, **lineprops)
 
         self.background = None
         self.needclear = False
@@ -1676,9 +1675,8 @@ class MultiCursor(Widget):
         plt.show()
 
     """
-    @_api.rename_parameter("3.5", "lineprops", "props")
     def __init__(self, canvas, axes, useblit=True, horizOn=False, vertOn=True,
-                 **props):
+                 **lineprops):
 
         self.canvas = canvas
         self.axes = axes
@@ -1696,16 +1694,16 @@ class MultiCursor(Widget):
         self.needclear = False
 
         if self.useblit:
-            props['animated'] = True
+            lineprops['animated'] = True
 
         if vertOn:
-            self.vlines = [ax.axvline(xmid, visible=False, **props)
+            self.vlines = [ax.axvline(xmid, visible=False, **lineprops)
                            for ax in axes]
         else:
             self.vlines = []
 
         if horizOn:
-            self.hlines = [ax.axhline(ymid, visible=False, **props)
+            self.hlines = [ax.axhline(ymid, visible=False, **lineprops)
                            for ax in axes]
         else:
             self.hlines = []
@@ -2108,13 +2106,13 @@ class SpanSelector(_SelectorWidget):
         self.new_axes(ax)
 
         # Setup handles
-        _handle_props = dict(color=props.get('facecolor', 'r'))
-        _handle_props.update(cbook.normalize_kwargs(handle_props,
-                                                    Line2D._alias_map))
+        handle_props = {
+            'color': (props or{}).get('facecolor', 'r'),
+            **cbook.normalize_kwargs(handle_props, Line2D._alias_map)}
 
         if self._interactive:
             self._edge_order = ['min', 'max']
-            self._setup_edge_handle(_handle_props)
+            self._setup_edge_handle(handle_props)
 
         self._active_handle = None
 
@@ -2676,29 +2674,25 @@ class RectangleSelector(_SelectorWidget):
 
         self.grab_range = grab_range
 
-        if props is None:
-            _handle_props = dict(markeredgecolor='black')
-        else:
-            _handle_props = dict(
-                markeredgecolor=props.get('edgecolor', 'black')
-                )
-        _handle_props.update(cbook.normalize_kwargs(handle_props,
-                                                    Line2D._alias_map))
+        handle_props = {
+            'markeredgecolor': (props or {}).get('edgecolor', 'black'),
+            **cbook.normalize_kwargs(handle_props, Line2D._alias_map)}
+
         self._corner_order = ['NW', 'NE', 'SE', 'SW']
         xc, yc = self.corners
         self._corner_handles = ToolHandles(self.ax, xc, yc,
-                                           marker_props=_handle_props,
+                                           marker_props=handle_props,
                                            useblit=self.useblit)
 
         self._edge_order = ['W', 'N', 'E', 'S']
         xe, ye = self.edge_centers
         self._edge_handles = ToolHandles(self.ax, xe, ye, marker='s',
-                                         marker_props=_handle_props,
+                                         marker_props=handle_props,
                                          useblit=self.useblit)
 
         xc, yc = self.center
         self._center_handle = ToolHandles(self.ax, [xc], [yc], marker='s',
-                                          marker_props=_handle_props,
+                                          marker_props=handle_props,
                                           useblit=self.useblit)
 
         self._active_handle = None

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2523,7 +2523,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         Selections with an x-span less than *minspanx* are ignored.
 
     minspany : float, default: 0
-        Selections with an y-span less than *minspany* are ignored.
+        Selections with a y-span less than *minspany* are ignored.
 
     useblit : bool, default: False
         Whether to use blitting for faster drawing (if supported by the
@@ -2704,6 +2704,10 @@ class RectangleSelector(_SelectorWidget):
     active_handle = _api.deprecate_privatize_attribute("3.5")
 
     interactive = _api.deprecate_privatize_attribute("3.5")
+
+    maxdist = _api.deprecated("3.5")(
+        property(lambda self: self.handle_grab_distance)
+        )
 
     def _press(self, event):
         """Button press event handler."""
@@ -3212,6 +3216,10 @@ class PolygonSelector(_SelectorWidget):
 
         self.artists = [self.line, self._polygon_handles.artist]
         self.set_visible(True)
+
+    vertex_select_radius = _api.deprecated("3.5")(
+        property(lambda self: self.handle_grab_distance)
+        )
 
     @property
     def _nverts(self):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2107,7 +2107,7 @@ class SpanSelector(_SelectorWidget):
 
         # Setup handles
         handle_props = {
-            'color': (props or {}).get('facecolor', 'r'),
+            'color': props.get('facecolor', 'r'),
             **cbook.normalize_kwargs(handle_props, Line2D._alias_map)}
 
         if self._interactive:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2020,8 +2020,10 @@ class SpanSelector(_SelectorWidget):
         If True, use the backend-dependent blitting features for faster
         canvas updates.
 
-    rectprops : dict, default: None
+    rectprops : dict, optional
         Dictionary of `matplotlib.patches.Patch` properties.
+        Default:
+            ``dict(facecolor='red', alpha=0.5)``
 
     onmove_callback : func(min, max), min/max are floats, default: None
         Called on mouse move while the span is being selected.
@@ -2352,8 +2354,11 @@ class ToolLineHandles:
         Positions of handles in data coordinates.
     direction : {"horizontal", "vertical"}
         Direction of handles, either 'vertical' or 'horizontal'
-    line_props : dict
+    line_props : dict, optional
         Additional line properties. See `matplotlib.lines.Line2D`.
+    useblit : bool, default: True
+        Whether to use blitting for faster drawing (if supported by the
+        backend).
     """
 
     def __init__(self, ax, positions, direction, line_props=None,
@@ -2451,10 +2456,13 @@ class ToolHandles:
         Matplotlib axes where tool handles are displayed.
     x, y : 1D arrays
         Coordinates of control handles.
-    marker : str
+    marker : str, default: 'o'
         Shape of marker used to display handle. See `matplotlib.pyplot.plot`.
-    marker_props : dict
+    marker_props : dict, optional
         Additional marker properties. See `matplotlib.lines.Line2D`.
+    useblit : bool, default: True
+        Whether to use blitting for faster drawing (if supported by the
+        backend).
     """
 
     def __init__(self, ax, x, y, marker='o', marker_props=None, useblit=True):
@@ -2515,10 +2523,6 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         where *eclick* and *erelease* are the mouse click and release
         `.MouseEvent`\s that start and complete the selection.
 
-    drawtype : {"box", "line", "none"}, default: "box"
-        Whether to draw the full rectangle box, the diagonal line of the
-        rectangle, or nothing at all.
-
     minspanx : float, default: 0
         Selections with an x-span less than *minspanx* are ignored.
 
@@ -2529,17 +2533,10 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         Whether to use blitting for faster drawing (if supported by the
         backend).
 
-    lineprops : dict, optional
-        Properties with which the line is drawn, if ``drawtype == "line"``.
-        Default::
-
-            dict(color="black", linestyle="-", linewidth=2, alpha=0.5)
-
     rectprops : dict, optional
-        Properties with which the rectangle is drawn, if ``drawtype ==
-        "box"``.  Default::
-
-            dict(facecolor="red", edgecolor="black", alpha=0.2, fill=True)
+        Properties with which the __ARTIST_NAME__ is drawn.
+        Default:
+            ``dict(facecolor='red', edgecolor='black', alpha=0.2, fill=True))``
 
     spancoords : {"data", "pixels"}, default: "data"
         Whether to interpret *minspanx* and *minspany* in data or in pixel
@@ -2552,7 +2549,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         Distance in pixels within which the interactive tool handles can be
         activated.
 
-    handle_props : dict
+    handle_props : dict, optional
         Properties with which the interactive handles are drawn.
 
     interactive : bool, default: False
@@ -2577,7 +2574,8 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
     """
 
 
-@docstring.Substitution(_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
+@docstring.Substitution(_RECTANGLESELECTOR_PARAMETERS_DOCSTRING.replace(
+    '__ARTIST_NAME__', 'rectangle'))
 class RectangleSelector(_SelectorWidget):
     """
     Select a rectangular region of an axes.
@@ -2973,7 +2971,8 @@ class RectangleSelector(_SelectorWidget):
             return np.array(self._to_draw.get_data())
 
 
-@docstring.Substitution(_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
+@docstring.Substitution(_RECTANGLESELECTOR_PARAMETERS_DOCSTRING.replace(
+    '__ARTIST_NAME__', 'ellipse'))
 class EllipseSelector(RectangleSelector):
     """
     Select an elliptical region of an axes.
@@ -3075,6 +3074,9 @@ class LassoSelector(_SelectorWidget):
     onselect : function
         Whenever the lasso is released, the *onselect* function is called and
         passed the vertices of the selected path.
+    useblit : bool, default: True
+        Whether to use blitting for faster drawing (if supported by the
+        backend).
     button : `.MouseButton` or list of `.MouseButton`, optional
         The mouse buttons used for rectangle selection.  Default is ``None``,
         which corresponds to all buttons.
@@ -3150,17 +3152,17 @@ class PolygonSelector(_SelectorWidget):
         ``(xdata, ydata)`` tuples.
 
     useblit : bool, default: False
+        Whether to use blitting for faster drawing (if supported by the
+        backend).
 
-    lineprops : dict
+    lineprops : dict, optional
         Artist properties for the line representing the edges of the polygon.
-        Default::
-
+        Default:
             dict(color='k', linestyle='-', linewidth=2, alpha=0.5)
 
-    handle_props : dict
+    handle_props : dict, optional
         Artist properties for the markers drawn at the vertices of the polygon.
-        Default::
-
+        Default:
             dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)
 
     handle_grab_distance : float, default: 15px
@@ -3400,6 +3402,9 @@ class Lasso(AxesWidget):
         The parent axes for the widget.
     xy : (float, float)
         Coordinates of the start of the lasso.
+    useblit : bool, default: True
+        Whether to use blitting for faster drawing (if supported by the
+        backend).
     callback : callable
         Whenever the lasso is released, the *callback* function is called and
         passed the vertices of the selected path.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -16,6 +16,7 @@ from numbers import Integral, Number
 import numpy as np
 
 import matplotlib as mpl
+from matplotlib import docstring
 from . import _api, cbook, colors, ticker
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
@@ -2576,6 +2577,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
     """
 
 
+@docstring.Substitution(_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
 class RectangleSelector(_SelectorWidget):
     """
     Select a rectangular region of an axes.
@@ -2600,7 +2602,6 @@ class RectangleSelector(_SelectorWidget):
 
     See also: :doc:`/gallery/widgets/rectangle_selector`
     """
-    __doc__ %= (_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
 
     _shape_klass = Rectangle
 
@@ -2968,6 +2969,7 @@ class RectangleSelector(_SelectorWidget):
             return np.array(self._to_draw.get_data())
 
 
+@docstring.Substitution(_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
 class EllipseSelector(RectangleSelector):
     """
     Select an elliptical region of an axes.
@@ -3004,7 +3006,6 @@ class EllipseSelector(RectangleSelector):
     >>> fig.canvas.mpl_connect('key_press_event', toggle_selector)
     >>> plt.show()
     """
-    __doc__ %= (_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
 
     _shape_klass = Ellipse
     draw_shape = _api.deprecate_privatize_attribute('3.5')

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3139,9 +3139,17 @@ class PolygonSelector(_SelectorWidget):
     markerprops : dict, default: \
 ``dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)``.
         Artist properties for the markers drawn at the vertices of the polygon.
+        Deprecated, use *handle_props* instead.
+    handle_props : dict, default: \
+``dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)``.
+        Artist properties for the markers drawn at the vertices of the polygon.
     vertex_select_radius : float, default: 15px
         A vertex is selected (to complete the polygon or to move a vertex) if
         the mouse click is within *vertex_select_radius* pixels of the vertex.
+        Deprecated, use *handle_grab_distance* instead.
+    handle_grab_distance : float, default: 15px
+        A vertex is selected (to complete the polygon or to move a vertex) if
+        the mouse click is within *handle_grab_distance* pixels of the vertex.
 
     Examples
     --------
@@ -3154,8 +3162,11 @@ class PolygonSelector(_SelectorWidget):
     point.
     """
 
+    @_api.rename_parameter("3.5", "markerprops", "handle_props")
+    @_api.rename_parameter("3.5", "vertex_select_radius",
+                           "handle_grab_distance")
     def __init__(self, ax, onselect, useblit=False,
-                 lineprops=None, markerprops=None, vertex_select_radius=15):
+                 lineprops=None, handle_props=None, handle_grab_distance=15):
         # The state modifiers 'move', 'square', and 'center' are expected by
         # _SelectorWidget but are not supported by PolygonSelector
         # Note: could not use the existing 'move' state modifier in-place of
@@ -3177,15 +3188,15 @@ class PolygonSelector(_SelectorWidget):
         self.line = Line2D(self._xs, self._ys, **lineprops)
         self.ax.add_line(self.line)
 
-        if markerprops is None:
-            markerprops = dict(markeredgecolor='k',
-                               markerfacecolor=lineprops.get('color', 'k'))
+        if handle_props is None:
+            handle_props = dict(markeredgecolor='k',
+                                markerfacecolor=lineprops.get('color', 'k'))
         self._polygon_handles = ToolHandles(self.ax, self._xs, self._ys,
                                             useblit=self.useblit,
-                                            marker_props=markerprops)
+                                            marker_props=handle_props)
 
         self._active_handle_idx = -1
-        self.vertex_select_radius = vertex_select_radius
+        self.handle_grab_distance = handle_grab_distance
 
         self.artists = [self.line, self._polygon_handles.artist]
         self.set_visible(True)
@@ -3223,7 +3234,7 @@ class PolygonSelector(_SelectorWidget):
         if ((self._polygon_completed or 'move_vertex' in self._state)
                 and len(self._xs) > 0):
             h_idx, h_dist = self._polygon_handles.closest(event.x, event.y)
-            if h_dist < self.vertex_select_radius:
+            if h_dist < self.handle_grab_distance:
                 self._active_handle_idx = h_idx
         # Save the vertex positions at the time of the press event (needed to
         # support the 'move_all' state modifier).
@@ -3297,7 +3308,7 @@ class PolygonSelector(_SelectorWidget):
                                                           self._ys[0]))
             v0_dist = np.hypot(x0 - event.x, y0 - event.y)
             # Lock on to the start vertex if near it and ready to complete.
-            if len(self._xs) > 3 and v0_dist < self.vertex_select_radius:
+            if len(self._xs) > 3 and v0_dist < self.handle_grab_distance:
                 self._xs[-1], self._ys[-1] = self._xs[0], self._ys[0]
             else:
                 self._xs[-1], self._ys[-1] = event.xdata, event.ydata

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2047,7 +2047,7 @@ class SpanSelector(_SelectorWidget):
         when *interactive* is True. See `matplotlib.lines.Line2D` for valid
         properties.
 
-    handle_grab_distance : float, default: 10
+    grab_range : float, default: 10
         Distance in pixels within which the interactive tool handles can be
         activated.
 
@@ -2074,7 +2074,7 @@ class SpanSelector(_SelectorWidget):
     @_api.rename_parameter("3.5", "span_stays", "interactive")
     def __init__(self, ax, onselect, direction, minspan=0, useblit=False,
                  props=None, onmove_callback=None, interactive=False,
-                 button=None, handle_props=None, handle_grab_distance=10,
+                 button=None, handle_props=None, grab_range=10,
                  drag_from_anywhere=False):
 
         super().__init__(ax, onselect, useblit=useblit, button=button)
@@ -2098,7 +2098,7 @@ class SpanSelector(_SelectorWidget):
         self.onmove_callback = onmove_callback
         self.minspan = minspan
 
-        self.handle_grab_distance = handle_grab_distance
+        self.grab_range = grab_range
         self._interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
 
@@ -2305,7 +2305,7 @@ class SpanSelector(_SelectorWidget):
         # Use 'C' to match the notation used in the RectangleSelector
         if 'move' in self._state:
             self._active_handle = 'C'
-        elif e_dist > self.handle_grab_distance:
+        elif e_dist > self.grab_range:
             # Not close to any handles
             self._active_handle = None
             if self.drag_from_anywhere and self._contains(event):
@@ -2553,7 +2553,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
     button : `.MouseButton`, list of `.MouseButton`, default: all buttons
         Button(s) that trigger rectangle selection.
 
-    handle_grab_distance : float, default: 10
+    grab_range : float, default: 10
         Distance in pixels within which the interactive tool handles can be
         activated.
 
@@ -2615,7 +2615,7 @@ class RectangleSelector(_SelectorWidget):
 
     _shape_klass = Rectangle
 
-    @_api.rename_parameter("3.5", "maxdist", "handle_grab_distance")
+    @_api.rename_parameter("3.5", "maxdist", "grab_range")
     @_api.rename_parameter("3.5", "marker_props", "handle_props")
     @_api.rename_parameter("3.5", "rectprops", "props")
     @_api.delete_parameter("3.5", "drawtype")
@@ -2623,7 +2623,7 @@ class RectangleSelector(_SelectorWidget):
     def __init__(self, ax, onselect, drawtype='box',
                  minspanx=0, minspany=0, useblit=False,
                  lineprops=None, props=None, spancoords='data',
-                 button=None, handle_grab_distance=10, handle_props=None,
+                 button=None, grab_range=10, handle_props=None,
                  interactive=False, state_modifier_keys=None,
                  drag_from_anywhere=False):
         super().__init__(ax, onselect, useblit=useblit, button=button,
@@ -2674,7 +2674,7 @@ class RectangleSelector(_SelectorWidget):
         self.spancoords = spancoords
         self._drawtype = drawtype
 
-        self.handle_grab_distance = handle_grab_distance
+        self.grab_range = grab_range
 
         if props is None:
             _handle_props = dict(markeredgecolor='black')
@@ -2721,7 +2721,7 @@ class RectangleSelector(_SelectorWidget):
     interactive = _api.deprecate_privatize_attribute("3.5")
 
     maxdist = _api.deprecated("3.5")(
-        property(lambda self: self.handle_grab_distance)
+        property(lambda self: self.grab_range)
         )
 
     def _press(self, event):
@@ -2938,11 +2938,11 @@ class RectangleSelector(_SelectorWidget):
             self._active_handle = 'C'
             self._extents_on_press = self.extents
         # Set active handle as closest handle, if mouse click is close enough.
-        elif m_dist < self.handle_grab_distance * 2:
+        elif m_dist < self.grab_range * 2:
             # Prioritise center handle over other handles
             self._active_handle = 'C'
-        elif (c_dist > self.handle_grab_distance and
-                  e_dist > self.handle_grab_distance):
+        elif (c_dist > self.grab_range and
+                  e_dist > self.grab_range):
             # Not close to any handles
             if self.drag_from_anywhere and self._contains(event):
                 # Check if we've clicked inside the region
@@ -3190,9 +3190,9 @@ class PolygonSelector(_SelectorWidget):
         the default value of ``markeredgecolor`` which will be the same as the
         ``color`` property in *props*.
 
-    handle_grab_distance : float, default: 15px
+    grab_range : float, default: 10
         A vertex is selected (to complete the polygon or to move a vertex) if
-        the mouse click is within *handle_grab_distance* pixels of the vertex.
+        the mouse click is within *grab_range* pixels of the vertex.
 
     Examples
     --------
@@ -3207,10 +3207,9 @@ class PolygonSelector(_SelectorWidget):
 
     @_api.rename_parameter("3.5", "lineprops", "props")
     @_api.rename_parameter("3.5", "markerprops", "handle_props")
-    @_api.rename_parameter("3.5", "vertex_select_radius",
-                           "handle_grab_distance")
+    @_api.rename_parameter("3.5", "vertex_select_radius", "grab_range")
     def __init__(self, ax, onselect, useblit=False,
-                 props=None, handle_props=None, handle_grab_distance=15):
+                 props=None, handle_props=None, grab_range=10):
         # The state modifiers 'move', 'square', and 'center' are expected by
         # _SelectorWidget but are not supported by PolygonSelector
         # Note: could not use the existing 'move' state modifier in-place of
@@ -3240,13 +3239,13 @@ class PolygonSelector(_SelectorWidget):
                                             marker_props=handle_props)
 
         self._active_handle_idx = -1
-        self.handle_grab_distance = handle_grab_distance
+        self.grab_range = grab_range
 
         self.artists = [self.line, self._polygon_handles.artist]
         self.set_visible(True)
 
     vertex_select_radius = _api.deprecated("3.5")(
-        property(lambda self: self.handle_grab_distance)
+        property(lambda self: self.grab_range)
         )
 
     @property
@@ -3282,7 +3281,7 @@ class PolygonSelector(_SelectorWidget):
         if ((self._polygon_completed or 'move_vertex' in self._state)
                 and len(self._xs) > 0):
             h_idx, h_dist = self._polygon_handles.closest(event.x, event.y)
-            if h_dist < self.handle_grab_distance:
+            if h_dist < self.grab_range:
                 self._active_handle_idx = h_idx
         # Save the vertex positions at the time of the press event (needed to
         # support the 'move_all' state modifier).
@@ -3356,7 +3355,7 @@ class PolygonSelector(_SelectorWidget):
                                                           self._ys[0]))
             v0_dist = np.hypot(x0 - event.x, y0 - event.y)
             # Lock on to the start vertex if near it and ready to complete.
-            if len(self._xs) > 3 and v0_dist < self.handle_grab_distance:
+            if len(self._xs) > 3 and v0_dist < self.grab_range:
                 self._xs[-1], self._ys[-1] = self._xs[0], self._ys[0]
             else:
                 self._xs[-1], self._ys[-1] = event.xdata, event.ydata

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2569,22 +2569,12 @@ class RectangleSelector(_SelectorWidget):
         button : `.MouseButton`, list of `.MouseButton`, default: all buttons
             Button(s) that trigger rectangle selection.
 
-        maxdist : float, default: 10
-            Distance in pixels within which the interactive tool handles can be
-            activated. Deprecated, use *handle_grab_distance* instead.
-
         handle_grab_distance : float, default: 10
             Distance in pixels within which the interactive tool handles can be
             activated.
 
-        marker_props : dict
-            Properties with which the interactive handles are drawn.  Currently
-            not implemented and ignored. Deprecated, use *handle_props*
-            instead.
-
         handle_props : dict
-            Properties with which the interactive handles are drawn.  Currently
-            not implemented and ignored.
+            Properties with which the interactive handles are drawn.
 
         interactive : bool, default: False
             Whether to draw a set of handles that allow interaction with the
@@ -3128,25 +3118,26 @@ class PolygonSelector(_SelectorWidget):
     ----------
     ax : `~matplotlib.axes.Axes`
         The parent axes for the widget.
+
     onselect : function
         When a polygon is completed or modified after completion,
         the *onselect* function is called and passed a list of the vertices as
         ``(xdata, ydata)`` tuples.
+
     useblit : bool, default: False
-    lineprops : dict, default: \
-``dict(color='k', linestyle='-', linewidth=2, alpha=0.5)``.
+
+    lineprops : dict
         Artist properties for the line representing the edges of the polygon.
-    markerprops : dict, default: \
-``dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)``.
+        Default::
+
+            dict(color='k', linestyle='-', linewidth=2, alpha=0.5)
+
+    handle_props : dict
         Artist properties for the markers drawn at the vertices of the polygon.
-        Deprecated, use *handle_props* instead.
-    handle_props : dict, default: \
-``dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)``.
-        Artist properties for the markers drawn at the vertices of the polygon.
-    vertex_select_radius : float, default: 15px
-        A vertex is selected (to complete the polygon or to move a vertex) if
-        the mouse click is within *vertex_select_radius* pixels of the vertex.
-        Deprecated, use *handle_grab_distance* instead.
+        Default::
+
+            dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)
+
     handle_grab_distance : float, default: 15px
         A vertex is selected (to complete the polygon or to move a vertex) if
         the mouse click is within *handle_grab_distance* pixels of the vertex.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2498,12 +2498,8 @@ class ToolHandles:
         return min_index, dist[min_index]
 
 
-class RectangleSelector(_SelectorWidget):
+_RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
     r"""
-    Select a rectangular region of an axes.
-
-    For the cursor to remain responsive you must keep a reference to it.
-
     Parameters
     ----------
     ax : `~matplotlib.axes.Axes`
@@ -2577,11 +2573,34 @@ class RectangleSelector(_SelectorWidget):
     drag_from_anywhere : bool, optional
         If `True`, the widget can be moved by clicking anywhere within
         its bounds.
+    """
+
+
+class RectangleSelector(_SelectorWidget):
+    """
+    Select a rectangular region of an axes.
+
+    For the cursor to remain responsive you must keep a reference to it.
+
+    %s
 
     Examples
     --------
-    :doc:`/gallery/widgets/rectangle_selector`
+    >>> import matplotlib.pyplot as plt
+    >>> import matplotlib.widgets as mwidgets
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot([1, 2, 3], [10, 50, 100])
+    >>> def onselect(eclick, erelease):
+    ...     print(eclick.xdata, eclick.ydata)
+    ...     print(erelease.xdata, erelease.ydata)
+    >>> rectprops = dict(facecolor='blue', alpha=0.5)
+    >>> rect = mwidgets.RectangleSelector(ax, onselect, rectprops=rectprops,
+                                          interactive=True)
+    >>> fig.show()
+
+    See also: :doc:`/gallery/widgets/rectangle_selector`
     """
+    __doc__ %= (_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
 
     _shape_klass = Rectangle
 
@@ -2955,36 +2974,38 @@ class EllipseSelector(RectangleSelector):
 
     For the cursor to remain responsive you must keep a reference to it.
 
-    Example usage::
+    %s
 
-        import numpy as np
-        import matplotlib.pyplot as plt
-        from matplotlib.widgets import EllipseSelector
-
-        def onselect(eclick, erelease):
-            "eclick and erelease are matplotlib events at press and release."
-            print('startposition: (%f, %f)' % (eclick.xdata, eclick.ydata))
-            print('endposition  : (%f, %f)' % (erelease.xdata, erelease.ydata))
-            print('used button  : ', eclick.button)
-
-        def toggle_selector(event):
-            print(' Key pressed.')
-            if event.key in ['Q', 'q'] and toggle_selector.ES.active:
-                print('EllipseSelector deactivated.')
-                toggle_selector.RS.set_active(False)
-            if event.key in ['A', 'a'] and not toggle_selector.ES.active:
-                print('EllipseSelector activated.')
-                toggle_selector.ES.set_active(True)
-
-        x = np.arange(100.) / 99
-        y = np.sin(x)
-        fig, ax = plt.subplots()
-        ax.plot(x, y)
-
-        toggle_selector.ES = EllipseSelector(ax, onselect)
-        fig.canvas.mpl_connect('key_press_event', toggle_selector)
-        plt.show()
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from matplotlib.widgets import EllipseSelector
+    >>> def onselect(eclick, erelease):
+    ...     "eclick and erelease are matplotlib events at press and release."
+    ...     print(f'startposition: {eclick.xdata}, {eclick.ydata})
+    ...     print(f'endposition  : {erelease.xdata}, {erelease.ydata})
+    ...     print('used button  : ', eclick.button)
+    ...
+    >>> def toggle_selector(event):
+    ...     print(' Key pressed.')
+    ...     if event.key in ['Q', 'q'] and toggle_selector.ES.active:
+    ...         print('EllipseSelector deactivated.')
+    ...         toggle_selector.RS.set_active(False)
+    ...     if event.key in ['A', 'a'] and not toggle_selector.ES.active:
+    ...         print('EllipseSelector activated.')
+    ...         toggle_selector.ES.set_active(True)
+    ...
+    >>> x = np.arange(100.) / 99
+    >>> y = np.sin(x)
+    >>> fig, ax = plt.subplots()
+    >>> ax.plot(x, y)
+    >>> toggle_selector.ES = EllipseSelector(ax, onselect)
+    >>> fig.canvas.mpl_connect('key_press_event', toggle_selector)
+    >>> plt.show()
     """
+    __doc__ %= (_RECTANGLESELECTOR_PARAMETERS_DOCSTRING)
+
     _shape_klass = Ellipse
     draw_shape = _api.deprecate_privatize_attribute('3.5')
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2499,10 +2499,84 @@ class ToolHandles:
 
 
 class RectangleSelector(_SelectorWidget):
-    """
+    r"""
     Select a rectangular region of an axes.
 
     For the cursor to remain responsive you must keep a reference to it.
+
+    Parameters
+    ----------
+    ax : `~matplotlib.axes.Axes`
+        The parent axes for the widget.
+
+    onselect : function
+        A callback function that is called after a selection is completed.
+        It must have the signature::
+
+            def onselect(eclick: MouseEvent, erelease: MouseEvent)
+
+        where *eclick* and *erelease* are the mouse click and release
+        `.MouseEvent`\s that start and complete the selection.
+
+    drawtype : {"box", "line", "none"}, default: "box"
+        Whether to draw the full rectangle box, the diagonal line of the
+        rectangle, or nothing at all.
+
+    minspanx : float, default: 0
+        Selections with an x-span less than *minspanx* are ignored.
+
+    minspany : float, default: 0
+        Selections with an y-span less than *minspany* are ignored.
+
+    useblit : bool, default: False
+        Whether to use blitting for faster drawing (if supported by the
+        backend).
+
+    lineprops : dict, optional
+        Properties with which the line is drawn, if ``drawtype == "line"``.
+        Default::
+
+            dict(color="black", linestyle="-", linewidth=2, alpha=0.5)
+
+    rectprops : dict, optional
+        Properties with which the rectangle is drawn, if ``drawtype ==
+        "box"``.  Default::
+
+            dict(facecolor="red", edgecolor="black", alpha=0.2, fill=True)
+
+    spancoords : {"data", "pixels"}, default: "data"
+        Whether to interpret *minspanx* and *minspany* in data or in pixel
+        coordinates.
+
+    button : `.MouseButton`, list of `.MouseButton`, default: all buttons
+        Button(s) that trigger rectangle selection.
+
+    handle_grab_distance : float, default: 10
+        Distance in pixels within which the interactive tool handles can be
+        activated.
+
+    handle_props : dict
+        Properties with which the interactive handles are drawn.
+
+    interactive : bool, default: False
+        Whether to draw a set of handles that allow interaction with the
+        widget after it is drawn.
+
+    state_modifier_keys : dict, optional
+        Keyboard modifiers which affect the widget's behavior.  Values
+        amend the defaults.
+
+        - "move": Move the existing shape, default: no modifier.
+        - "clear": Clear the current shape, default: "escape".
+        - "square": Makes the shape square, default: "shift".
+        - "center": Make the initial point the center of the shape,
+          default: "ctrl".
+
+        "square" and "center" can be combined.
+
+    drag_from_anywhere : bool, optional
+        If `True`, the widget can be moved by clicking anywhere within
+        its bounds.
 
     Examples
     --------
@@ -2521,81 +2595,6 @@ class RectangleSelector(_SelectorWidget):
                  button=None, handle_grab_distance=10, handle_props=None,
                  interactive=False, state_modifier_keys=None,
                  drag_from_anywhere=False):
-        r"""
-        Parameters
-        ----------
-        ax : `~matplotlib.axes.Axes`
-            The parent axes for the widget.
-
-        onselect : function
-            A callback function that is called after a selection is completed.
-            It must have the signature::
-
-                def onselect(eclick: MouseEvent, erelease: MouseEvent)
-
-            where *eclick* and *erelease* are the mouse click and release
-            `.MouseEvent`\s that start and complete the selection.
-
-        drawtype : {"box", "line", "none"}, default: "box"
-            Whether to draw the full rectangle box, the diagonal line of the
-            rectangle, or nothing at all.
-
-        minspanx : float, default: 0
-            Selections with an x-span less than *minspanx* are ignored.
-
-        minspany : float, default: 0
-            Selections with an y-span less than *minspany* are ignored.
-
-        useblit : bool, default: False
-            Whether to use blitting for faster drawing (if supported by the
-            backend).
-
-        lineprops : dict, optional
-            Properties with which the line is drawn, if ``drawtype == "line"``.
-            Default::
-
-                dict(color="black", linestyle="-", linewidth=2, alpha=0.5)
-
-        rectprops : dict, optional
-            Properties with which the rectangle is drawn, if ``drawtype ==
-            "box"``.  Default::
-
-                dict(facecolor="red", edgecolor="black", alpha=0.2, fill=True)
-
-        spancoords : {"data", "pixels"}, default: "data"
-            Whether to interpret *minspanx* and *minspany* in data or in pixel
-            coordinates.
-
-        button : `.MouseButton`, list of `.MouseButton`, default: all buttons
-            Button(s) that trigger rectangle selection.
-
-        handle_grab_distance : float, default: 10
-            Distance in pixels within which the interactive tool handles can be
-            activated.
-
-        handle_props : dict
-            Properties with which the interactive handles are drawn.
-
-        interactive : bool, default: False
-            Whether to draw a set of handles that allow interaction with the
-            widget after it is drawn.
-
-        state_modifier_keys : dict, optional
-            Keyboard modifiers which affect the widget's behavior.  Values
-            amend the defaults.
-
-            - "move": Move the existing shape, default: no modifier.
-            - "clear": Clear the current shape, default: "escape".
-            - "square": Makes the shape square, default: "shift".
-            - "center": Make the initial point the center of the shape,
-              default: "ctrl".
-
-            "square" and "center" can be combined.
-
-        drag_from_anywhere : bool, optional
-            If `True`, the widget can be moved by clicking anywhere within
-            its bounds.
-        """
         super().__init__(ax, onselect, useblit=useblit, button=button,
                          state_modifier_keys=state_modifier_keys)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2025,6 +2025,7 @@ class SpanSelector(_SelectorWidget):
     props : dict, optional
         Dictionary of `matplotlib.patches.Patch` properties.
         Default:
+
             ``dict(facecolor='red', alpha=0.5)``
 
     onmove_callback : func(min, max), min/max are floats, default: None
@@ -2043,7 +2044,7 @@ class SpanSelector(_SelectorWidget):
 
     handle_props : dict, default: None
         Properties of the handle lines at the edges of the span. Only used
-        when *interactive* is True. See `~matplotlib.lines.Line2D` for valid
+        when *interactive* is True. See `matplotlib.lines.Line2D` for valid
         properties.
 
     handle_grab_distance : float, default: 10
@@ -2539,9 +2540,11 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         backend).
 
     props : dict, optional
-        Properties with which the __ARTIST_NAME__ is drawn.
+        Properties with which the __ARTIST_NAME__ is drawn. See
+        `matplotlib.patches.Patch` for valid properties.
         Default:
-            ``dict(facecolor='red', edgecolor='black', alpha=0.2, fill=True))``
+
+            ``dict(facecolor='red', edgecolor='black', alpha=0.2, fill=True)``
 
     spancoords : {"data", "pixels"}, default: "data"
         Whether to interpret *minspanx* and *minspany* in data or in pixel
@@ -2555,7 +2558,11 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         activated.
 
     handle_props : dict, optional
-        Properties with which the interactive handles are drawn.
+        Properties with which the interactive handles (marker artists) are
+        drawn. See the marker arguments in `matplotlib.lines.Line2D` for valid
+        properties.  Default values are defined in ``mpl.rcParams`` except for
+        the default value of ``markeredgecolor`` which will be the same as the
+        ``edgecolor`` property in *props*.
 
     interactive : bool, default: False
         Whether to draw a set of handles that allow interaction with the
@@ -2670,9 +2677,11 @@ class RectangleSelector(_SelectorWidget):
         self.handle_grab_distance = handle_grab_distance
 
         if props is None:
-            _handle_props = dict(markeredgecolor='r')
+            _handle_props = dict(markeredgecolor='black')
         else:
-            _handle_props = dict(markeredgecolor=props.get('edgecolor', 'r'))
+            _handle_props = dict(
+                markeredgecolor=props.get('edgecolor', 'black')
+                )
         _handle_props.update(cbook.normalize_kwargs(handle_props,
                                                     Line2D._alias_map))
         self._corner_order = ['NW', 'NE', 'SE', 'SW']
@@ -3086,9 +3095,8 @@ class LassoSelector(_SelectorWidget):
         Whether to use blitting for faster drawing (if supported by the
         backend).
     props : dict, optional
-        Properties with which the line is drawn.
-        Default:
-            ``dict()``
+        Properties with which the line is drawn, see `matplotlib.lines.Line2D`
+        for valid properties. Default values are defined in ``mpl.rcParams``.
     button : `.MouseButton` or list of `.MouseButton`, optional
         The mouse buttons used for rectangle selection.  Default is ``None``,
         which corresponds to all buttons.
@@ -3169,14 +3177,18 @@ class PolygonSelector(_SelectorWidget):
         backend).
 
     props : dict, optional
-        Artist properties for the line representing the edges of the polygon.
+        Properties with which the line is drawn, see `matplotlib.lines.Line2D`
+        for valid properties.
         Default:
-            dict(color='k', linestyle='-', linewidth=2, alpha=0.5)
+
+            ``dict(color='k', linestyle='-', linewidth=2, alpha=0.5)``
 
     handle_props : dict, optional
         Artist properties for the markers drawn at the vertices of the polygon.
-        Default:
-            dict(marker='o', markersize=7, mec='k', mfc='k', alpha=0.5)
+        See the marker arguments in `matplotlib.lines.Line2D` for valid
+        properties.  Default values are defined in ``mpl.rcParams`` except for
+        the default value of ``markeredgecolor`` which will be the same as the
+        ``color`` property in *props*.
 
     handle_grab_distance : float, default: 15px
         A vertex is selected (to complete the polygon or to move a vertex) if

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2027,7 +2027,7 @@ class SpanSelector(_SelectorWidget):
 
     span_stays : bool, default: False
         If True, the span stays visible after the mouse is released.
-        Deprecated, use interactive instead.
+        Deprecated, use *interactive* instead.
 
     interactive : bool, default: False
         Whether to draw a set of handles that allow interaction with the
@@ -2511,12 +2511,14 @@ class RectangleSelector(_SelectorWidget):
 
     _shape_klass = Rectangle
 
+    @_api.rename_parameter("3.5", "maxdist", "handle_grab_distance")
+    @_api.rename_parameter("3.5", "marker_props", "handle_props")
     @_api.delete_parameter("3.5", "drawtype")
     @_api.delete_parameter("3.5", "lineprops")
     def __init__(self, ax, onselect, drawtype='box',
                  minspanx=0, minspany=0, useblit=False,
                  lineprops=None, rectprops=None, spancoords='data',
-                 button=None, maxdist=10, marker_props=None,
+                 button=None, handle_grab_distance=10, handle_props=None,
                  interactive=False, state_modifier_keys=None,
                  drag_from_anywhere=False):
         r"""
@@ -2569,9 +2571,18 @@ class RectangleSelector(_SelectorWidget):
 
         maxdist : float, default: 10
             Distance in pixels within which the interactive tool handles can be
+            activated. Deprecated, use *handle_grab_distance* instead.
+
+        handle_grab_distance : float, default: 10
+            Distance in pixels within which the interactive tool handles can be
             activated.
 
         marker_props : dict
+            Properties with which the interactive handles are drawn.  Currently
+            not implemented and ignored. Deprecated, use *handle_props*
+            instead.
+
+        handle_props : dict
             Properties with which the interactive handles are drawn.  Currently
             not implemented and ignored.
 
@@ -2643,13 +2654,13 @@ class RectangleSelector(_SelectorWidget):
         self.spancoords = spancoords
         self._drawtype = drawtype
 
-        self.maxdist = maxdist
+        self.handle_grab_distance = handle_grab_distance
 
         if rectprops is None:
             props = dict(markeredgecolor='r')
         else:
             props = dict(markeredgecolor=rectprops.get('edgecolor', 'r'))
-        props.update(cbook.normalize_kwargs(marker_props, Line2D._alias_map))
+        props.update(cbook.normalize_kwargs(handle_props, Line2D._alias_map))
         self._corner_order = ['NW', 'NE', 'SE', 'SW']
         xc, yc = self.corners
         self._corner_handles = ToolHandles(self.ax, xc, yc, marker_props=props,
@@ -2899,10 +2910,11 @@ class RectangleSelector(_SelectorWidget):
             self._active_handle = 'C'
             self._extents_on_press = self.extents
         # Set active handle as closest handle, if mouse click is close enough.
-        elif m_dist < self.maxdist * 2:
+        elif m_dist < self.handle_grab_distance * 2:
             # Prioritise center handle over other handles
             self._active_handle = 'C'
-        elif c_dist > self.maxdist and e_dist > self.maxdist:
+        elif (c_dist > self.handle_grab_distance and
+                  e_dist > self.handle_grab_distance):
             # Not close to any handles
             if self.drag_from_anywhere and self._contains(event):
                 # Check if we've clicked inside the region

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2107,7 +2107,7 @@ class SpanSelector(_SelectorWidget):
 
         # Setup handles
         handle_props = {
-            'color': (props or{}).get('facecolor', 'r'),
+            'color': (props or {}).get('facecolor', 'r'),
             **cbook.normalize_kwargs(handle_props, Line2D._alias_map)}
 
         if self._interactive:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2542,7 +2542,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
         `matplotlib.patches.Patch` for valid properties.
         Default:
 
-            ``dict(facecolor='red', edgecolor='black', alpha=0.2, fill=True)``
+        ``dict(facecolor='red', edgecolor='black', alpha=0.2, fill=True)``
 
     spancoords : {"data", "pixels"}, default: "data"
         Whether to interpret *minspanx* and *minspany* in data or in pixel


### PR DESCRIPTION
## PR Summary

Follow up of #20558. Rename parameters (`maxdist`, `markers_props`, etc.) to make them consistent between the different selectors.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
