### PR TITLE
Add directional sizing cursors

### DIFF
--- a/doc/api/next_api_changes/deprecations/19441-AL.rst
+++ b/doc/api/next_api_changes/deprecations/19441-AL.rst
@@ -1,4 +1,5 @@
-``backend_gtk3.cursord``
-~~~~~~~~~~~~~~~~~~~~~~~~
-This dict is deprecated, in order to make the module importable on headless
-environments.
+``cursord`` in GTK, Qt, and wx backends
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``backend_gtk3.cursord``, ``backend_qt.cursord``, and
+``backend_wx.cursord`` dictionaries are deprecated. This makes the GTK module
+importable on headless environments.

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -11,7 +11,7 @@ These tools are used by `matplotlib.backend_managers.ToolManager`
     `matplotlib.backend_managers.ToolManager`
 """
 
-from enum import IntEnum
+import enum
 import re
 import time
 from types import SimpleNamespace
@@ -25,9 +25,13 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib import cbook
 
 
-class Cursors(IntEnum):  # Must subclass int for the macOS backend.
+class Cursors(enum.IntEnum):  # Must subclass int for the macOS backend.
     """Backend-independent cursor types."""
-    HAND, POINTER, SELECT_REGION, MOVE, WAIT = range(5)
+    POINTER = enum.auto()
+    HAND = enum.auto()
+    SELECT_REGION = enum.auto()
+    MOVE = enum.auto()
+    WAIT = enum.auto()
 cursors = Cursors  # Backcompat.
 
 # Views positions tool

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -32,6 +32,8 @@ class Cursors(enum.IntEnum):  # Must subclass int for the macOS backend.
     SELECT_REGION = enum.auto()
     MOVE = enum.auto()
     WAIT = enum.auto()
+    RESIZE_HORIZONTAL = enum.auto()
+    RESIZE_VERTICAL = enum.auto()
 cursors = Cursors  # Backcompat.
 
 # Views positions tool

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -34,7 +34,9 @@ cursord = {
     cursors.POINTER: "arrow",
     cursors.SELECT_REGION: "tcross",
     cursors.WAIT: "watch",
-    }
+    cursors.RESIZE_HORIZONTAL: "sb_h_double_arrow",
+    cursors.RESIZE_VERTICAL: "sb_v_double_arrow",
+}
 
 
 @contextmanager

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -95,6 +95,8 @@ def _mpl_to_gtk_cursor(mpl_cursor):
         cursors.POINTER: "default",
         cursors.SELECT_REGION: "crosshair",
         cursors.WAIT: "wait",
+        cursors.RESIZE_HORIZONTAL: "ew-resize",
+        cursors.RESIZE_VERTICAL: "ns-resize",
     }[mpl_cursor]
     return Gdk.Cursor.new_from_name(Gdk.Display.get_default(), name)
 

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -79,7 +79,9 @@ cursord = {  # deprecated in Matplotlib 3.5.
     cursors.POINTER: QtCore.Qt.ArrowCursor,
     cursors.SELECT_REGION: QtCore.Qt.CrossCursor,
     cursors.WAIT: QtCore.Qt.WaitCursor,
-    }
+    cursors.RESIZE_HORIZONTAL: QtCore.Qt.SizeHorCursor,
+    cursors.RESIZE_VERTICAL: QtCore.Qt.SizeVerCursor,
+}
 
 
 # make place holder

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -73,7 +73,7 @@ _MODIFIER_KEYS = [
     (QtCore.Qt.ShiftModifier, QtCore.Qt.Key_Shift),
     (QtCore.Qt.MetaModifier, QtCore.Qt.Key_Meta),
 ]
-cursord = {
+cursord = {  # deprecated in Matplotlib 3.5.
     cursors.MOVE: QtCore.Qt.SizeAllCursor,
     cursors.HAND: QtCore.Qt.PointingHandCursor,
     cursors.POINTER: QtCore.Qt.ArrowCursor,

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -380,6 +380,8 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
                 backend_tools.Cursors.SELECT_REGION: 'crosshair',
                 backend_tools.Cursors.MOVE: 'move',
                 backend_tools.Cursors.WAIT: 'wait',
+                backend_tools.Cursors.RESIZE_HORIZONTAL: 'ew-resize',
+                backend_tools.Cursors.RESIZE_VERTICAL: 'ns-resize',
             }[cursor]
             self.canvas.send_event("cursor", cursor=cursor)
         self.cursor = cursor

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -21,7 +21,7 @@ import numpy as np
 from PIL import Image
 import tornado
 
-from matplotlib import _api, backend_bases
+from matplotlib import _api, backend_bases, backend_tools
 from matplotlib.backends import backend_agg
 from matplotlib.backend_bases import _Backend
 
@@ -364,7 +364,7 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
 
     def __init__(self, canvas):
         self.message = ''
-        self.cursor = 0
+        self.cursor = None
         super().__init__(canvas)
 
     def set_message(self, message):
@@ -374,6 +374,13 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
 
     def set_cursor(self, cursor):
         if cursor != self.cursor:
+            cursor = {
+                backend_tools.Cursors.HAND: 'pointer',
+                backend_tools.Cursors.POINTER: 'default',
+                backend_tools.Cursors.SELECT_REGION: 'crosshair',
+                backend_tools.Cursors.MOVE: 'move',
+                backend_tools.Cursors.WAIT: 'wait',
+            }[cursor]
             self.canvas.send_event("cursor", cursor=cursor)
         self.cursor = cursor
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1043,7 +1043,7 @@ def _set_frame_icon(frame):
     frame.SetIcons(bundle)
 
 
-cursord = {
+cursord = {  # deprecated in Matplotlib 3.5.
     cursors.MOVE: wx.CURSOR_HAND,
     cursors.HAND: wx.CURSOR_HAND,
     cursors.POINTER: wx.CURSOR_ARROW,

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1049,6 +1049,8 @@ cursord = {  # deprecated in Matplotlib 3.5.
     cursors.POINTER: wx.CURSOR_ARROW,
     cursors.SELECT_REGION: wx.CURSOR_CROSS,
     cursors.WAIT: wx.CURSOR_WAIT,
+    cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
+    cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
 }
 
 

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -444,22 +444,7 @@ mpl.figure.prototype.handle_figure_label = function (fig, msg) {
 };
 
 mpl.figure.prototype.handle_cursor = function (fig, msg) {
-    var cursor = msg['cursor'];
-    switch (cursor) {
-        case 0:
-            cursor = 'pointer';
-            break;
-        case 1:
-            cursor = 'default';
-            break;
-        case 2:
-            cursor = 'crosshair';
-            break;
-        case 3:
-            cursor = 'move';
-            break;
-    }
-    fig.rubberband_canvas.style.cursor = cursor;
+    fig.rubberband_canvas.style.cursor = msg['cursor'];
 };
 
 mpl.figure.prototype.handle_message = function (fig, msg) {

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1380,6 +1380,8 @@ set_cursor(PyObject* unused, PyObject* args)
       case 4: [[NSCursor openHandCursor] set]; break;
       /* OSX handles busy state itself so no need to set a cursor here */
       case 5: break;
+      case 6: [[NSCursor resizeLeftRightCursor] set]; break;
+      case 7: [[NSCursor resizeUpDownCursor] set]; break;
       default: return NULL;
     }
     Py_RETURN_NONE;

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1373,13 +1373,13 @@ set_cursor(PyObject* unused, PyObject* args)
 {
     int i;
     if(!PyArg_ParseTuple(args, "i", &i)) return NULL;
-    switch (i)
-    { case 0: [[NSCursor pointingHandCursor] set]; break;
+    switch (i) {
       case 1: [[NSCursor arrowCursor] set]; break;
-      case 2: [[NSCursor crosshairCursor] set]; break;
-      case 3: [[NSCursor openHandCursor] set]; break;
+      case 2: [[NSCursor pointingHandCursor] set]; break;
+      case 3: [[NSCursor crosshairCursor] set]; break;
+      case 4: [[NSCursor openHandCursor] set]; break;
       /* OSX handles busy state itself so no need to set a cursor here */
-      case 4: break;
+      case 5: break;
       default: return NULL;
     }
     Py_RETURN_NONE;


### PR DESCRIPTION
## PR Summary

Tested on GTK, macOS, Qt, and Tk, though for macOS, I was using VNC and couldn't see any change, so that was just a check that it didn't crash.

Also, deprecate `cursord` from the other backends.

I'm not sure about the names; as you can see all toolkits use different names:
* RESIZE_EAST_WEST: 
  * GTK: ew-resize
  * macOS: resizeLeftRightCursor
  * Qt: SizeHorCursor
  * Tk: sb_h_double_arrow
  *  wx: CURSOR_SIZEWE
* RESIZE_NORTH_SOUTH:
  * GTK: ns-resize
  * Tk: sb_v_double_arrow
  *  wx: CURSOR_SIZENS
  * macOS: resizeUpDownCursor
  * Qt: SizeVerCursor
 
## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [?] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).