### PR TITLE
Webagg backend: get rid of tornado

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -8,9 +8,8 @@ Displays Agg images in the browser, with interactivity
 #   way over a web socket.
 #
 # - `backend_webagg.py` contains a concrete implementation of a basic
-#   application, implemented with tornado.
+#   application, implemented with asyncio.
 
-import datetime
 from io import BytesIO, StringIO
 import json
 import logging
@@ -19,7 +18,7 @@ from pathlib import Path
 
 import numpy as np
 from PIL import Image
-import tornado
+import asyncio
 
 from matplotlib import _api, backend_bases
 from matplotlib.backends import backend_agg
@@ -79,43 +78,43 @@ def _handle_key(key):
     return key
 
 
-class TimerTornado(backend_bases.TimerBase):
+class TimerAsyncio(backend_bases.TimerBase):
     def __init__(self, *args, **kwargs):
-        self._timer = None
+        self._task = None
         super().__init__(*args, **kwargs)
+
+    async def _timer_task(self, interval):
+        while True:
+            try:
+                await asyncio.sleep(interval)
+                self._on_timer()
+
+                if self._single:
+                    break
+            except asyncio.CancelledError:
+                break
 
     def _timer_start(self):
         self._timer_stop()
-        if self._single:
-            ioloop = tornado.ioloop.IOLoop.instance()
-            self._timer = ioloop.add_timeout(
-                datetime.timedelta(milliseconds=self.interval),
-                self._on_timer)
-        else:
-            self._timer = tornado.ioloop.PeriodicCallback(
-                self._on_timer,
-                max(self.interval, 1e-6))
-            self._timer.start()
+
+        self._task = asyncio.ensure_future(
+            self._timer_task(max(self.interval / 1_000., 1e-6))
+        )
 
     def _timer_stop(self):
-        if self._timer is None:
-            return
-        elif self._single:
-            ioloop = tornado.ioloop.IOLoop.instance()
-            ioloop.remove_timeout(self._timer)
-        else:
-            self._timer.stop()
-        self._timer = None
+        if self._task is not None:
+            self._task.cancel()
+        self._task = None
 
     def _timer_set_interval(self):
         # Only stop and restart it if the timer has already been started
-        if self._timer is not None:
+        if self._task is not None:
             self._timer_stop()
             self._timer_start()
 
 
 class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
-    _timer_cls = TimerTornado
+    _timer_cls = TimerAsyncio
     # Webagg and friends having the right methods, but still
     # having bugs in practice.  Do not advertise that it works until
     # we can debug this.


### PR DESCRIPTION
## PR Summary

This allows using the webagg backend in JupyterLite, by replacing tornado with asyncio. See https://github.com/matplotlib/ipympl/issues/334 and https://github.com/jtpio/jupyterlite/pull/219

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
