### PR TITLE
DOC: fix various typos

### DIFF
--- a/doc/api/next_api_changes/deprecations/19483-JMK.rst
+++ b/doc/api/next_api_changes/deprecations/19483-JMK.rst
@@ -1,7 +1,7 @@
 ``epoch2num`` and ``num2epoch`` are deprecated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These methods convert from unix timestamps to matplotlib floats, but are not
-useed internally to matplotlib, and should not be needed by endusers.
+used internally to matplotlib, and should not be needed by endusers.
 To convert a unix timestamp to datetime, simply use
 `datetime.datetime.utcfromtimestamp`, or to use numpy datetime64
 ``dt = np.datetim64(e*1e6, 'us')``.  

--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -41,7 +41,7 @@ with compiled extensions
   minor versions initially released in the 24 months prior to our planned
   release date or the oldest that support our minimum Python + NumPy
 
-without complied extensions
+without compiled extensions
   minor versions initially released in the 12 months prior to our planned
   release date or the oldest that supports our minimum Python.
 

--- a/doc/devel/style_guide.rst
+++ b/doc/devel/style_guide.rst
@@ -153,8 +153,8 @@ reliability and consistency in documentation. They are not interchangeable.
   |                  |                          |   motion."   |              |
   +------------------+--------------------------+--------------+--------------+
   | Explicit,        | Explicit approach of     | - Explicit   | - object     |
-  | Object Oriented  | programing in Matplotlib.| - explicit   |   oriented   |
-  | Programming (OOP)|                          | - OOP        | - OO-style   |
+  | Object Oriented  | programming in           | - explicit   |   oriented   |
+  | Programming (OOP)| Matplotlib.              | - OOP        | - OO-style   |
   +------------------+--------------------------+--------------+--------------+
   | Implicit,        | Implicit approach of     | - Implicit   | - MATLAB like|
   | ``pyplot``       | programming in Matplotlib| - implicit   | - Pyplot     |

--- a/examples/subplots_axes_and_figures/colorbar_placement.py
+++ b/examples/subplots_axes_and_figures/colorbar_placement.py
@@ -79,7 +79,7 @@ plt.show()
 
 ######################################################################
 # One way around this issue is to use an `.Axes.inset_axes` to locate the
-# axes in axes co-ordinates.  Note that if you zoom in on the axes, and
+# axes in axes coordinates.  Note that if you zoom in on the axes, and
 # change the shape of the axes, the colorbar will also change position.
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)

--- a/examples/widgets/annotated_cursor.py
+++ b/examples/widgets/annotated_cursor.py
@@ -65,7 +65,7 @@ class AnnotatedCursor(Cursor):
 
     Other Parameters
     ----------------
-    textprops : `matplotlib.text` properties as dictionay
+    textprops : `matplotlib.text` properties as dictionary
         Specifies the appearance of the rendered text object.
 
     **cursorargs : `matplotlib.widgets.Cursor` properties
@@ -161,7 +161,7 @@ class AnnotatedCursor(Cursor):
         # Draw the widget, if event coordinates are valid.
         if plotpoint is not None:
             # Update position and displayed text.
-            # Position: Where the event occured.
+            # Position: Where the event occurred.
             # Text: Determined by set_position() method earlier
             # Position is transformed to pixel coordinates,
             # an offset is added there and this is transformed back.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -401,7 +401,7 @@ def to_filehandle(fname, flag='r', return_opened=False, encoding=None):
         if fname.endswith('.gz'):
             fh = gzip.open(fname, flag)
         elif fname.endswith('.bz2'):
-            # python may not be complied with bz2 support,
+            # python may not be compiled with bz2 support,
             # bury import until we need it
             import bz2
             fh = bz2.BZ2File(fname, flag)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1927,7 +1927,7 @@ class QuadMesh(Collection):
 
     A quadrilateral mesh is a grid of M by N adjacent qudrilaterals that are
     defined via a (M+1, N+1) grid of vertices. The quadrilateral (m, n) is
-    defind by the vertices ::
+    defined by the vertices ::
 
                (m+1, n) ----------- (m+1, n+1)
                   /                   /

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -561,7 +561,7 @@ class Colorbar:
         self.vmin, self.vmax = self._boundaries[self._inside][[0, -1]]
         # Compute the X/Y mesh.
         X, Y, extendlen = self._mesh()
-        # draw the extend triangles, and shrink the inner axes to accomodate.
+        # draw the extend triangles, and shrink the inner axes to accommodate.
         # also adds the outline path to self.outline spine:
         self._do_extends(extendlen)
 
@@ -622,7 +622,7 @@ class Colorbar:
     def _do_extends(self, extendlen):
         """
         Make adjustments of the inner axes for the extend triangles (or
-        rectanges) and add them as patches.
+        rectangles) and add them as patches.
         """
         # extend lengths are fraction of the *inner* part of colorbar,
         # not the total colorbar:
@@ -659,7 +659,7 @@ class Colorbar:
             return
 
         # Make extend triangles or rectangles filled patches.  These are
-        # defined in the outer parent axes' co-ordinates:
+        # defined in the outer parent axes' coordinates:
         mappable = getattr(self, 'mappable', None)
         if (isinstance(mappable, contour.ContourSet)
                 and any(hatch is not None for hatch in mappable.hatches)):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1731,7 +1731,7 @@ class BoundaryNorm(Normalize):
         else:
             max_col = self.Ncmap
         # this gives us the bins in the lookup table in the range
-        # [0, _n_regions - 1]  (the offset is baked-in in the init)
+        # [0, _n_regions - 1]  (the offset is set in the init)
         iret = np.digitize(xx, self.boundaries) - 1 + self._offset
         # if we have more colors than regions, stretch the region
         # index computed above to full range of the color bins.  This

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1731,7 +1731,7 @@ class BoundaryNorm(Normalize):
         else:
             max_col = self.Ncmap
         # this gives us the bins in the lookup table in the range
-        # [0, _n_regions - 1]  (the offset is baked in the init)
+        # [0, _n_regions - 1]  (the offset is baked-in in the init)
         iret = np.digitize(xx, self.boundaries) - 1 + self._offset
         # if we have more colors than regions, stretch the region
         # index computed above to full range of the color bins.  This

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -354,7 +354,7 @@ class TestSpectral:
                                              num=pad_to_spectrum_real // 2 + 1)
         else:
             # frequencies for specgram, psd, and csd
-            # need to handle even and odd differentl
+            # need to handle even and odd differently
             if pad_to_density_real % 2:
                 freqs_density = np.linspace(-Fs / 2, Fs / 2,
                                             num=2 * pad_to_density_real,

--- a/plot_types/unstructured/README.rst
+++ b/plot_types/unstructured/README.rst
@@ -1,6 +1,6 @@
 .. _unstructured_plots:
 
-Unstructured co-ordinates
+Unstructured coordinates
 -------------------------
 
 Sometimes we collect data ``z`` at coordinates ``(x,y)`` and want to visualize

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -63,7 +63,7 @@ Currently, the supported fonts are:
 family            fonts
 ================= ============================================================
 ``'serif'``         ``'New Century Schoolbook'``, ``'Bookman'``, ``'Times'``,
-                    ``'Palatino'``, ``'Charter'``, ``'Computer Moderm Roman'``
+                    ``'Palatino'``, ``'Charter'``, ``'Computer Modern Roman'``
 
 ``'sans-serif'``  ``'Helvetica'``, ``'Avant Garde'``, ``'Computer Modern
                   Serif'``


### PR DESCRIPTION
Found via `codespell -q 3 -S ./extern,./doc/users/credits.rst,./doc/api/prev_api_changes,./doc/users/prev_whats_new -L afe,ans,axises,ba,coo,flate,fo,hist,inout,ment,nd,offsetp,oly,ot,te,thisy,vas,whis,wit`