### PR TITLE
Fix TTF headers for type 42 stix font

### DIFF
--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -800,16 +800,23 @@ void ttfont_sfnts(TTStreamWriter& stream, struct TTFONT *font)
 
     /* Now, generate those silly numTables numbers. */
     sfnts_pputUSHORT(stream, count);            /* number of tables */
-    if ( count == 9 )
-    {
-        sfnts_pputUSHORT(stream, 7);          /* searchRange */
-        sfnts_pputUSHORT(stream, 3);          /* entrySelector */
-        sfnts_pputUSHORT(stream, 81);         /* rangeShift */
+
+    int search_range = 1;
+    int entry_sel = 0;
+
+    while (search_range <= count) {
+        search_range <<= 1;
+        entry_sel++;
     }
-    else
-    {
-        debug("only %d tables selected",count);
-    }
+    entry_sel = entry_sel > 0 ? entry_sel - 1 : 0;
+    search_range = (search_range >> 1) * 16;
+    int range_shift = count * 16 - search_range;
+
+    sfnts_pputUSHORT(stream, search_range);      /* searchRange */
+    sfnts_pputUSHORT(stream, entry_sel);         /* entrySelector */
+    sfnts_pputUSHORT(stream, range_shift);       /* rangeShift */
+
+    debug("only %d tables selected",count);
 
     /* Now, emmit the table directory. */
     for (x=0; x < 9; x++)


### PR DESCRIPTION
## PR Summary
The combination of Type 42 font, STIX math font and EPS output format leads to broken output files. Here is an example
[broken.zip](https://github.com/matplotlib/matplotlib/files/6780293/broken.zip)

    import matplotlib.pyplot as plt
    from matplotlib import rcParams

    rcParams["ps.fonttype"] = 42
    rcParams["mathtext.fontset"] = "stix"

    plt.text(0.5, 0.5, "Mass $m$")
    plt.savefig("broken.eps")

The embedded TTF font is damaged due to missing bytes in the file header. The embedded font contains 6 tables which causes (this if)[https://github.com/matplotlib/matplotlib/blob/8c764dc86b6b24fced137105e6f97a5d62d4a717/extern/ttconv/pprdrv_tt.cpp#L803] to omit the values for searchRange, entrySelection and rangeShift.

I agree with the comment that the values are "silly" but for a valid TTF font, these values need to be present. In fact, the number written in the case of exactly 9 tables are not correct either. For 9 tables, the correct values would be 128, 3 and 16, see [Table 4 in the reference manual.](https://developer.apple.com/fonts/TrueType-Reference-Manual/RM06/Chap6.html)

This PR implements the correct computation for searchRange, entrySelection and rangeShift regardless of the number of tables and ensured correctly formatted TTF fonts. With this change, STIX Type 42 fonts are correctly embedded in EPS files.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).