### PR TITLE
Hide some `_SelectorWidget` state internals.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20601-ES.rst
+++ b/doc/api/next_api_changes/deprecations/20601-ES.rst
@@ -1,0 +1,9 @@
+Selector widget state internals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Several `~matplotlib.widgets.EllipseSelector`,
+`~matplotlib.widgets.RectangleSelector` and `~matplotlib.widgets.SpanSelector`
+class internals have been privatized and deprecated:
+
+- ``eventpress``
+- ``eventrelease``
+- ``state``


### PR DESCRIPTION
## PR Summary

For example, `eventrelease` is only set in the `release` handler, before calling the subclass's `_release`, and then immediately set to `None`. Within that time, it could be accessed from the `onselect` handler, but that's just the second argument passed to it anyway. So there's not really any use for `eventrelease` as a class attribute.

The other two are similarly internal state tracking, and should not be modified externally.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).