### PR TITLE
Deprecate unused LassoSelector event handlers.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20603-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20603-AL.rst
@@ -1,0 +1,3 @@
+``LassoSelector.onpress`` and ``LassoSelector.onrelease``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated (they are straight aliases for ``press`` and ``release``).

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3061,6 +3061,7 @@ class LassoSelector(_SelectorWidget):
         self.ax.add_line(self.line)
         self.artists = [self.line]
 
+    @_api.deprecated("3.5", alternative="press")
     def onpress(self, event):
         self.press(event)
 
@@ -3068,6 +3069,7 @@ class LassoSelector(_SelectorWidget):
         self.verts = [self._get_data(event)]
         self.line.set_visible(True)
 
+    @_api.deprecated("3.5", alternative="release")
     def onrelease(self, event):
         self.release(event)
 
@@ -3083,9 +3085,7 @@ class LassoSelector(_SelectorWidget):
         if self.verts is None:
             return
         self.verts.append(self._get_data(event))
-
         self.line.set_data(list(zip(*self.verts)))
-
         self.update()
 
 


### PR DESCRIPTION
These are unused since 61ab6df (and have trivial replacements if
someone *really* wants to call them manually, which seems unlikely).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
