### PR TITLE
Dynamically generate CbarAxes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20606-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20606-AL.rst
@@ -1,0 +1,4 @@
+``axes_grid1.axes_grid.CbarAxes`` and ``axes_grid1.axisartist.CbarAxes``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These classes are deprecated (they are now dynamically generated based on the
+owning axes class).

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -3,7 +3,7 @@ import functools
 
 import numpy as np
 
-from matplotlib import _api
+from matplotlib import _api, cbook
 from matplotlib.gridspec import SubplotSpec
 
 from .axes_divider import Size, SubplotDivider, Divider
@@ -43,8 +43,12 @@ class CbarAxesBase:
         self.orientation = orientation
 
 
+@_api.deprecated("3.5")
 class CbarAxes(CbarAxesBase, Axes):
     pass
+
+
+_cbaraxes_class_factory = cbook._make_class_factory(CbarAxesBase, "Cbar{}")
 
 
 class Grid:
@@ -310,8 +314,6 @@ class Grid:
 class ImageGrid(Grid):
     # docstring inherited
 
-    _defaultCbarAxesClass = CbarAxes
-
     def __init__(self, fig,
                  rect,
                  nrows_ncols,
@@ -416,7 +418,7 @@ class ImageGrid(Grid):
             else:
                 self._colorbar_pad = self._vert_pad_size.fixed_size
         self.cbar_axes = [
-            self._defaultCbarAxesClass(
+            _cbaraxes_class_factory(self._defaultAxesClass)(
                 self.axes_all[0].figure, self._divider.get_position(),
                 orientation=self._colorbar_location)
             for _ in range(self.ngrids)]

--- a/lib/mpl_toolkits/axisartist/axes_grid.py
+++ b/lib/mpl_toolkits/axisartist/axes_grid.py
@@ -1,7 +1,9 @@
+from matplotlib import _api
 import mpl_toolkits.axes_grid1.axes_grid as axes_grid_orig
 from .axislines import Axes
 
 
+@_api.deprecated("3.5")
 class CbarAxes(axes_grid_orig.CbarAxesBase, Axes):
     pass
 
@@ -12,7 +14,6 @@ class Grid(axes_grid_orig.Grid):
 
 class ImageGrid(axes_grid_orig.ImageGrid):
     _defaultAxesClass = Axes
-    _defaultCbarAxesClass = CbarAxes
 
 
 AxesGrid = ImageGrid


### PR DESCRIPTION
This is a followup to the introduction of _make_class_factory, and
avoids having to define a separate CbarAxes class in axisartist.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
