### PR TITLE
Fix for #9608: RectangleSelector now reports mouse button press and release events correctly

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2698,12 +2698,7 @@ class RectangleSelector(_SelectorWidget):
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
-        if self._active_handle is None:
-            x = event.xdata
-            y = event.ydata
-            self.visible = True
-        else:
-            self.set_visible(True)
+        self.set_visible(True)
 
         return False
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2701,8 +2701,6 @@ class RectangleSelector(_SelectorWidget):
         if self._active_handle is None:
             x = event.xdata
             y = event.ydata
-            self.visible = False
-            self.extents = x, x, y, y
             self.visible = True
         else:
             self.set_visible(True)
@@ -2713,18 +2711,6 @@ class RectangleSelector(_SelectorWidget):
         """Button release event handler."""
         if not self._interactive:
             self._to_draw.set_visible(False)
-
-        # update the eventpress and eventrelease with the resulting extents
-        x0, x1, y0, y1 = self.extents
-        self._eventpress.xdata = x0
-        self._eventpress.ydata = y0
-        xy0 = self.ax.transData.transform([x0, y0])
-        self._eventpress.x, self._eventpress.y = xy0
-
-        self._eventrelease.xdata = x1
-        self._eventrelease.ydata = y1
-        xy1 = self.ax.transData.transform([x1, y1])
-        self._eventrelease.x, self._eventrelease.y = xy1
 
         # calculate dimensions of box or line
         if self.spancoords == 'data':


### PR DESCRIPTION
## PR Summary

"Normalisation" of the click and release mouse button events for the RectangleSelector is removed. The click and release mouse button events reported by the onselect function now reflect the actual press and release coordinates, and not the extent of the rectangle.

If the extent of the rectangle is required, then extent should be explicitly called.


## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

widgets.py definitely needs work on style conventions - about 200 lines of output on python -m flake8 --docstring-convention=all C:\Users\_____\Documents\GitHub\matplotlib\lib\matplotlib\widgets.py