### PR TITLE
Simplify curvilinear grid examples.

### DIFF
--- a/examples/axisartist/demo_curvelinear_grid.py
+++ b/examples/axisartist/demo_curvelinear_grid.py
@@ -27,24 +27,17 @@ def curvelinear_test1(fig):
     Grid for custom transform.
     """
 
-    def tr(x, y):
-        x, y = np.asarray(x), np.asarray(y)
-        return x, y - x
-
-    def inv_tr(x, y):
-        x, y = np.asarray(x), np.asarray(y)
-        return x, y + x
+    def tr(x, y): return x, y - x
+    def inv_tr(x, y): return x, y + x
 
     grid_helper = GridHelperCurveLinear((tr, inv_tr))
 
     ax1 = fig.add_subplot(1, 2, 1, axes_class=Axes, grid_helper=grid_helper)
-    # ax1 will have a ticks and gridlines defined by the given
-    # transform (+ transData of the Axes). Note that the transform of
-    # the Axes itself (i.e., transData) is not affected by the given
-    # transform.
-
-    xx, yy = tr([3, 6], [5, 10])
-    ax1.plot(xx, yy, linewidth=2.0)
+    # ax1 will have ticks and gridlines defined by the given transform (+
+    # transData of the Axes).  Note that the transform of the Axes itself
+    # (i.e., transData) is not affected by the given transform.
+    xx, yy = tr(np.array([3, 6]), np.array([5, 10]))
+    ax1.plot(xx, yy)
 
     ax1.set_aspect(1)
     ax1.set_xlim(0, 10)

--- a/examples/axisartist/demo_curvelinear_grid2.py
+++ b/examples/axisartist/demo_curvelinear_grid2.py
@@ -24,14 +24,10 @@ def curvelinear_test1(fig):
     """Grid for custom transform."""
 
     def tr(x, y):
-        sgn = np.sign(x)
-        x, y = np.abs(np.asarray(x)), np.asarray(y)
-        return sgn*x**.5, y
+        return np.sign(x)*abs(x)**.5, y
 
     def inv_tr(x, y):
-        sgn = np.sign(x)
-        x, y = np.asarray(x), np.asarray(y)
-        return sgn*x**2, y
+        return np.sign(x)*x**2, y
 
     grid_helper = GridHelperCurveLinear(
         (tr, inv_tr),


### PR DESCRIPTION
Since 8840d6e we ensure that `x` and `y` passed to `tr` and `inv_tr`
are already arrays (see the definition of
`_UserTransform2D.transform_non_affine`), so we don't need additional
casting-to-arrays.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
