### PR TITLE
Cleanup examples

### DIFF
--- a/examples/animation/animate_decay.py
+++ b/examples/animation/animate_decay.py
@@ -22,8 +22,7 @@ def data_gen():
 
 
 def init():
-    ax.set_ylim(-1.1, 1.1)
-    ax.set_xlim(0, 10)
+    ax.set(xlim=(0, 10), ylim=(-1.1, 1.1))
     del xdata[:]
     del ydata[:]
     line.set_data(xdata, ydata)

--- a/examples/animation/bayes_update.py
+++ b/examples/animation/bayes_update.py
@@ -30,8 +30,7 @@ class UpdateDist:
         self.ax = ax
 
         # Set up plot parameters
-        self.ax.set_xlim(0, 1)
-        self.ax.set_ylim(0, 10)
+        self.ax.set(xlim=(0, 1), ylim=(0, 10))
         self.ax.grid(True)
 
         # This vertical line represents the theoretical value, to

--- a/examples/animation/rain.py
+++ b/examples/animation/rain.py
@@ -20,8 +20,8 @@ np.random.seed(19680801)
 # Create new Figure and an Axes which fills it.
 fig = plt.figure(figsize=(7, 7))
 ax = fig.add_axes([0, 0, 1, 1], frameon=False)
-ax.set_xlim(0, 1), ax.set_xticks([])
-ax.set_ylim(0, 1), ax.set_yticks([])
+ax.set(xticks=[], xlim=(0, 1),
+       yticks=[], ylim=(0, 1))
 
 # Create rain data
 n_drops = 50

--- a/examples/animation/strip_chart.py
+++ b/examples/animation/strip_chart.py
@@ -21,8 +21,7 @@ class Scope:
         self.ydata = [0]
         self.line = Line2D(self.tdata, self.ydata)
         self.ax.add_line(self.line)
-        self.ax.set_ylim(-.1, 1.1)
-        self.ax.set_xlim(0, self.maxt)
+        self.ax.set(xlim=(0, self.maxt), ylim=(-.1, 1.1))
 
     def update(self, y):
         lastt = self.tdata[-1]

--- a/examples/axisartist/axis_direction.py
+++ b/examples/axisartist/axis_direction.py
@@ -11,8 +11,7 @@ import mpl_toolkits.axisartist as axisartist
 def setup_axes(fig, pos):
     ax = fig.add_subplot(pos, axes_class=axisartist.Axes)
 
-    ax.set_ylim(-0.1, 1.5)
-    ax.set_yticks([0, 1])
+    ax.set(ylim=(-0.1, 1.5), yticks=[0, 1])
 
     ax.axis[:].set_visible(False)
 

--- a/examples/axisartist/demo_ticklabel_alignment.py
+++ b/examples/axisartist/demo_ticklabel_alignment.py
@@ -23,19 +23,16 @@ fig = plt.figure(figsize=(3, 5))
 fig.subplots_adjust(left=0.5, hspace=0.7)
 
 ax = setup_axes(fig, 311)
-ax.set_ylabel("ha=right")
-ax.set_xlabel("va=baseline")
+ax.set(xlabel="va=baseline", ylabel="ha=right")
 
 ax = setup_axes(fig, 312)
 ax.axis["left"].major_ticklabels.set_ha("center")
 ax.axis["bottom"].major_ticklabels.set_va("top")
-ax.set_ylabel("ha=center")
-ax.set_xlabel("va=top")
+ax.set(xlabel="va=top", ylabel="ha=center")
 
 ax = setup_axes(fig, 313)
 ax.axis["left"].major_ticklabels.set_ha("left")
 ax.axis["bottom"].major_ticklabels.set_va("bottom")
-ax.set_ylabel("ha=left")
-ax.set_xlabel("va=bottom")
+ax.set(xlabel="va=bottom", ylabel="ha=left")
 
 plt.show()

--- a/examples/axisartist/demo_ticklabel_direction.py
+++ b/examples/axisartist/demo_ticklabel_direction.py
@@ -11,8 +11,7 @@ import mpl_toolkits.axisartist.axislines as axislines
 
 def setup_axes(fig, pos):
     ax = fig.add_subplot(pos, axes_class=axislines.Axes)
-    ax.set_yticks([0.2, 0.8])
-    ax.set_xticks([0.2, 0.8])
+    ax.set(xticks=[0.2, 0.8], yticks=[0.2, 0.8])
     return ax
 
 

--- a/examples/axisartist/simple_axis_direction03.py
+++ b/examples/axisartist/simple_axis_direction03.py
@@ -11,8 +11,7 @@ import mpl_toolkits.axisartist as axisartist
 
 def setup_axes(fig, pos):
     ax = fig.add_subplot(pos, axes_class=axisartist.Axes)
-    ax.set_yticks([0.2, 0.8])
-    ax.set_xticks([0.2, 0.8])
+    ax.set(xticks=[0.2, 0.8], yticks=[0.2, 0.8])
     return ax
 
 

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -205,7 +205,7 @@ if __name__ == '__main__':
     ax.add_patch(poly)
     p = PolygonInteractor(ax, poly)
 
-    ax.set_title('Click and drag a point to move it')
-    ax.set_xlim((-2, 2))
-    ax.set_ylim((-2, 2))
+    ax.set(xlim=(-2, 2), ylim=(-2, 2),
+           title='Click and drag a point to move it')
+
     plt.show()

--- a/examples/images_contours_and_fields/affine_image.py
+++ b/examples/images_contours_and_fields/affine_image.py
@@ -40,8 +40,7 @@ def do_plot(ax, Z, transform):
     x1, x2, y1, y2 = im.get_extent()
     ax.plot([x1, x2, x2, x1, x1], [y1, y1, y2, y2, y1], "y--",
             transform=trans_data)
-    ax.set_xlim(-5, 5)
-    ax.set_ylim(-4, 4)
+    ax.set(xlim=(-5, 5), ylim=(-4, 4))
 
 
 # prepare image and figure

--- a/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -42,9 +42,7 @@ def _annotate(ax, x, y, title):
     # this all gets repeated below:
     X, Y = np.meshgrid(x, y)
     ax.plot(X.flat, Y.flat, 'o', color='m')
-    ax.set_xlim(-0.7, 5.2)
-    ax.set_ylim(-0.7, 3.2)
-    ax.set_title(title)
+    ax.set(xlim=(-0.7, 5.2), ylim=(-0.7, 3.2), title=title)
 
 _annotate(ax, x, y, "shading='flat'")
 

--- a/examples/lines_bars_and_markers/eventcollection_demo.py
+++ b/examples/lines_bars_and_markers/eventcollection_demo.py
@@ -52,10 +52,7 @@ ax.add_collection(yevents1)
 ax.add_collection(yevents2)
 
 # set the limits
-ax.set_xlim([0, 1])
-ax.set_ylim([0, 1])
-
-ax.set_title('line plot with data points')
+ax.set(xlim=[0, 1], ylim=[0, 1], title='line plot with data points')
 
 # display the plot
 plt.show()

--- a/examples/lines_bars_and_markers/markevery_demo.py
+++ b/examples/lines_bars_and_markers/markevery_demo.py
@@ -65,9 +65,7 @@ for ax, case in zip(axs, cases):
 axs = plt.figure(figsize=figsize, constrained_layout=True).subplots(rows, cols)
 axs = trim_axs(axs, len(cases))
 for ax, case in zip(axs, cases):
-    ax.set_title('markevery=%s' % str(case))
-    ax.set_xscale('log')
-    ax.set_yscale('log')
+    ax.set(xscale='log', yscale='log', title=f'markevery={case!r}')
     ax.plot(x, y, 'o', ls='-', ms=4, markevery=case)
 
 ###############################################################################
@@ -79,10 +77,8 @@ for ax, case in zip(axs, cases):
 axs = plt.figure(figsize=figsize, constrained_layout=True).subplots(rows, cols)
 axs = trim_axs(axs, len(cases))
 for ax, case in zip(axs, cases):
-    ax.set_title('markevery=%s' % str(case))
     ax.plot(x, y, 'o', ls='-', ms=4, markevery=case)
-    ax.set_xlim((6, 6.7))
-    ax.set_ylim((1.1, 1.7))
+    ax.set(xlim=(6, 6.7), ylim=(1.1, 1.7), title=f'markevery={case!r}')
 
 # define data for polar plots
 r = np.linspace(0, 3.0, 200)
@@ -95,7 +91,7 @@ axs = plt.figure(figsize=figsize, constrained_layout=True).subplots(
     rows, cols, subplot_kw={'projection': 'polar'})
 axs = trim_axs(axs, len(cases))
 for ax, case in zip(axs, cases):
-    ax.set_title('markevery=%s' % str(case))
+    ax.set_title(f'markevery={case!r}')
     ax.plot(theta, r, 'o', ls='-', ms=4, markevery=case)
 
 plt.show()

--- a/examples/misc/demo_agg_filter.py
+++ b/examples/misc/demo_agg_filter.py
@@ -224,8 +224,7 @@ def drop_shadow_line(ax):
         shadow.set_agg_filter(gauss)
         shadow.set_rasterized(True)  # to support mixed-mode renderers
 
-    ax.set_xlim(0., 1.)
-    ax.set_ylim(0., 1.)
+    ax.set(xlim=(0, 1), ylim=(0, 1))
 
     ax.xaxis.set_visible(False)
     ax.yaxis.set_visible(False)

--- a/examples/misc/demo_ribbon_box.py
+++ b/examples/misc/demo_ribbon_box.py
@@ -78,8 +78,7 @@ def main():
         ax.add_artist(RibbonBoxImage(ax, bbox, bc, interpolation="bicubic"))
         ax.annotate(str(h), (year, h), va="bottom", ha="center")
 
-    ax.set_xlim(years[0] - 0.5, years[-1] + 0.5)
-    ax.set_ylim(0, 10000)
+    ax.set(xlim=(years[0] - 0.5, years[-1] + 0.5), ylim=(0, 10000))
 
     background_gradient = np.zeros((2, 2, 4))
     background_gradient[:, :, :3] = [1, 1, 0]

--- a/examples/mplot3d/contour3d_3.py
+++ b/examples/mplot3d/contour3d_3.py
@@ -26,12 +26,8 @@ cset = ax.contour(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
 cset = ax.contour(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
 cset = ax.contour(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
 
-ax.set_xlim(-40, 40)
-ax.set_ylim(-40, 40)
-ax.set_zlim(-100, 100)
-
-ax.set_xlabel('X')
-ax.set_ylabel('Y')
-ax.set_zlabel('Z')
+ax.set(xlabel='X', xlim=(-40, 40),
+       ylabel='Y', ylim=(-40, 40),
+       zlabel='Z', zlim=(-100, 100))
 
 plt.show()

--- a/examples/mplot3d/contourf3d_2.py
+++ b/examples/mplot3d/contourf3d_2.py
@@ -26,12 +26,8 @@ cset = ax.contourf(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
 cset = ax.contourf(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
 cset = ax.contourf(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
 
-ax.set_xlim(-40, 40)
-ax.set_ylim(-40, 40)
-ax.set_zlim(-100, 100)
-
-ax.set_xlabel('X')
-ax.set_ylabel('Y')
-ax.set_zlabel('Z')
+ax.set(xlabel='X', xlim=(-40, 40),
+       ylabel='Y', ylim=(-40, 40),
+       zlabel='Z', zlim=(-100, 100))
 
 plt.show()

--- a/examples/pyplots/text_commands.py
+++ b/examples/pyplots/text_commands.py
@@ -13,10 +13,7 @@ fig.suptitle('bold figure suptitle', fontsize=14, fontweight='bold')
 
 ax = fig.add_subplot()
 fig.subplots_adjust(top=0.85)
-ax.set_title('axes title')
-
-ax.set_xlabel('xlabel')
-ax.set_ylabel('ylabel')
+ax.set(xlabel='xlabel', ylabel='ylabel', title='axes title')
 
 ax.text(3, 8, 'boxed italics text in data coords', style='italic',
         bbox={'facecolor': 'red', 'alpha': 0.5, 'pad': 10})

--- a/examples/scales/log_bar.py
+++ b/examples/scales/log_bar.py
@@ -24,7 +24,6 @@ ax.set_xticks(x + dimw / 2)
 ax.set_xticklabels(map(str, x))
 ax.set_yscale('log')
 
-ax.set_xlabel('x')
-ax.set_ylabel('y')
+ax.set(xlabel='x', ylabel='y')
 
 plt.show()

--- a/examples/shapes_and_collections/line_collection.py
+++ b/examples/shapes_and_collections/line_collection.py
@@ -32,8 +32,7 @@ segs = np.ma.masked_where((segs > 50) & (segs < 60), segs)
 
 # We need to set the plot limits.
 fig, ax = plt.subplots()
-ax.set_xlim(x.min(), x.max())
-ax.set_ylim(ys.min(), ys.max())
+ax.set(xlim=(x.min(), x.max()), ylim=(ys.min(), ys.max()))
 
 # *colors* is sequence of rgba tuples.
 # *linestyle* is a string or dash tuple. Legal string values are
@@ -62,8 +61,7 @@ ys = [x + i for i in x]
 
 # We need to set the plot limits, they will not autoscale
 fig, ax = plt.subplots()
-ax.set_xlim(np.min(x), np.max(x))
-ax.set_ylim(np.min(ys), np.max(ys))
+ax.set(xlim=(np.min(x), np.max(x)), ylim=(np.min(ys), np.max(ys)))
 
 # colors is sequence of rgba tuples
 # linestyle is a string or dash tuple. Legal string values are

--- a/examples/showcase/mandelbrot.py
+++ b/examples/showcase/mandelbrot.py
@@ -60,8 +60,7 @@ if __name__ == '__main__':
     M = light.shade(M, cmap=plt.cm.hot, vert_exag=1.5,
                     norm=colors.PowerNorm(0.3), blend_mode='hsv')
     ax.imshow(M, extent=[xmin, xmax, ymin, ymax], interpolation="bicubic")
-    ax.set_xticks([])
-    ax.set_yticks([])
+    ax.set(xticks=[], yticks=[])
 
     # Some advertisement for matplotlib
     year = time.strftime("%Y")

--- a/examples/showcase/xkcd.py
+++ b/examples/showcase/xkcd.py
@@ -18,9 +18,7 @@ with plt.xkcd():
     ax = fig.add_axes((0.1, 0.2, 0.8, 0.7))
     ax.spines.right.set_color('none')
     ax.spines.top.set_color('none')
-    ax.set_xticks([])
-    ax.set_yticks([])
-    ax.set_ylim([-30, 10])
+    ax.set(xticks=[], yticks=[], ylim=[-30, 10])
 
     data = np.ones(100)
     data[70:] -= np.arange(30)
@@ -31,8 +29,7 @@ with plt.xkcd():
 
     ax.plot(data)
 
-    ax.set_xlabel('time')
-    ax.set_ylabel('my overall health')
+    ax.set(xlabel='time', ylabel='my overall health')
     fig.text(
         0.5, 0.05,
         '"Stove Ownership" from xkcd by Randall Munroe',
@@ -50,8 +47,8 @@ with plt.xkcd():
     ax.spines.right.set_color('none')
     ax.spines.top.set_color('none')
     ax.xaxis.set_ticks_position('bottom')
-    ax.set_xticks([0, 1])
-    ax.set_xticklabels(['CONFIRMED BY\nEXPERIMENT', 'REFUTED BY\nEXPERIMENT'])
+    ax.set_xticks([0, 1],
+                  ['CONFIRMED BY\nEXPERIMENT', 'REFUTED BY\nEXPERIMENT'])
     ax.set_xlim([-0.5, 1.5])
     ax.set_yticks([])
     ax.set_ylim([0, 110])

--- a/examples/specialty_plots/leftventricle_bulleye.py
+++ b/examples/specialty_plots/leftventricle_bulleye.py
@@ -122,9 +122,7 @@ def bullseye_plot(ax, data, seg_bold=None, cmap=None, norm=None):
         if 17 in seg_bold:
             ax.plot(theta0, r0, '-k', lw=linewidth + 2)
 
-    ax.set_ylim([0, 1])
-    ax.set_yticklabels([])
-    ax.set_xticklabels([])
+    ax.set(ylim=[0, 1], xticklabels=[], yticklabels=[])
 
 
 # Create the fake data

--- a/examples/specialty_plots/skewt.py
+++ b/examples/specialty_plots/skewt.py
@@ -250,8 +250,7 @@ if __name__ == '__main__':
     # Disables the log-formatting that comes with semilogy
     ax.yaxis.set_major_formatter(ScalarFormatter())
     ax.yaxis.set_minor_formatter(NullFormatter())
-    ax.set_yticks(np.linspace(100, 1000, 10))
-    ax.set_ylim(1050, 100)
+    ax.set(yticks=np.linspace(100, 1000, 10), ylim=(1050, 100))
 
     ax.xaxis.set_major_locator(MultipleLocator(10))
     ax.set_xlim(-50, 50)

--- a/examples/statistics/boxplot.py
+++ b/examples/statistics/boxplot.py
@@ -48,8 +48,7 @@ axs[1, 2].boxplot(data, labels=labels, showfliers=False)
 axs[1, 2].set_title('showfliers=False', fontsize=fs)
 
 for ax in axs.flat:
-    ax.set_yscale('log')
-    ax.set_yticklabels([])
+    ax.set(yscale='log', yticklabels=[])
 
 fig.subplots_adjust(hspace=0.4)
 plt.show()
@@ -88,8 +87,7 @@ axs[1, 2].boxplot(data, whis=[15, 85])
 axs[1, 2].set_title('whis=[15, 85]\n#percentiles', fontsize=fs)
 
 for ax in axs.flat:
-    ax.set_yscale('log')
-    ax.set_yticklabels([])
+    ax.set(yscale='log', yticklabels=[])
 
 fig.suptitle("I never said they'd be pretty")
 fig.subplots_adjust(hspace=0.4)

--- a/examples/statistics/boxplot_color.py
+++ b/examples/statistics/boxplot_color.py
@@ -47,8 +47,7 @@ for bplot in (bplot1, bplot2):
 # adding horizontal grid lines
 for ax in [ax1, ax2]:
     ax.yaxis.grid(True)
-    ax.set_xlabel('Three separate samples')
-    ax.set_ylabel('Observed values')
+    ax.set(xlabel='Three separate samples', ylabel='Observed values')
 
 plt.show()
 

--- a/examples/statistics/bxp.py
+++ b/examples/statistics/bxp.py
@@ -63,8 +63,7 @@ axs[1, 2].bxp(stats, showfliers=False)
 axs[1, 2].set_title('showfliers=False', fontsize=fs)
 
 for ax in axs.flat:
-    ax.set_yscale('log')
-    ax.set_yticklabels([])
+    ax.set(yscale='log', yticklabels=[])
 
 fig.subplots_adjust(hspace=0.4)
 plt.show()
@@ -96,8 +95,7 @@ axs[1, 1].bxp(stats, meanprops=meanlineprops, meanline=True,
 axs[1, 1].set_title('Custom mean\nas line', fontsize=fs)
 
 for ax in axs.flat:
-    ax.set_yscale('log')
-    ax.set_yticklabels([])
+    ax.set(yscale='log', yticklabels=[])
 
 fig.suptitle("I never said they'd be pretty")
 fig.subplots_adjust(hspace=0.4)

--- a/examples/statistics/multiple_histograms_side_by_side.py
+++ b/examples/statistics/multiple_histograms_side_by_side.py
@@ -57,8 +57,7 @@ for x_loc, binned_data in zip(x_locations, binned_data_sets):
 ax.set_xticks(x_locations)
 ax.set_xticklabels(labels)
 
-ax.set_ylabel("Data values")
-ax.set_xlabel("Data sets")
+ax.set(xlabel="Data sets", ylabel="Data values")
 
 plt.show()
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -21,8 +21,7 @@ def plot_scatter(ax, prng, nb_samples=100):
     for mu, sigma, marker in [(-.5, 0.75, 'o'), (0.75, 1., 's')]:
         x, y = prng.normal(loc=mu, scale=sigma, size=(2, nb_samples))
         ax.plot(x, y, ls='none', marker=marker)
-    ax.set_xlabel('X-label')
-    ax.set_title('Axes title')
+    ax.set(xlabel='X-label', title='Axes title')
     return ax
 
 
@@ -63,8 +62,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
                                 radius=1.0, color=sty_dict['color']))
     # Force the limits to be the same across the styles (because different
     # styles may have different numbers of available colors).
-    ax.set_xlim([-4, 8])
-    ax.set_ylim([-5, 6])
+    ax.set(xlim=[-4, 8], ylim=[-5, 6])
     ax.set_aspect('equal', adjustable='box')  # to plot circles as circles
     return ax
 
@@ -75,9 +73,7 @@ def plot_image_and_patch(ax, prng, size=(20, 20)):
     ax.imshow(values, interpolation='none')
     c = plt.Circle((5, 5), radius=5, label='patch')
     ax.add_patch(c)
-    # Remove ticks
-    ax.set_xticks([])
-    ax.set_yticks([])
+    ax.set(xticks=[], yticks=[])  # Remove ticks
 
 
 def plot_histograms(ax, prng, nb_samples=10000):

--- a/examples/subplots_axes_and_figures/align_labels_demo.py
+++ b/examples/subplots_axes_and_figures/align_labels_demo.py
@@ -27,11 +27,9 @@ ax.set_xlabel('XLabel0')
 for i in range(2):
     ax = fig.add_subplot(gs[1, i])
     ax.plot(np.arange(1., 0., -0.1) * 2000., np.arange(1., 0., -0.1))
-    ax.set_ylabel('YLabel1 %d' % i)
-    ax.set_xlabel('XLabel1 %d' % i)
+    ax.set(xlabel=f'XLabel1 {i}', ylabel=f'YLabel1 {i}')
     if i == 0:
-        for tick in ax.get_xticklabels():
-            tick.set_rotation(55)
+        ax.tick_params(rotation=55)
 fig.align_labels()  # same as fig.align_xlabels(); fig.align_ylabels()
 
 plt.show()

--- a/examples/text_labels_and_annotations/demo_text_path.py
+++ b/examples/text_labels_and_annotations/demo_text_path.py
@@ -127,7 +127,6 @@ if __name__ == "__main__":
 
     ax2.add_artist(ab)
 
-    ax2.set_xlim(0, 1)
-    ax2.set_ylim(0, 1)
+    ax2.set(xlim=(0, 1), ylim=(0, 1))
 
     plt.show()

--- a/examples/text_labels_and_annotations/text_rotation.py
+++ b/examples/text_labels_and_annotations/text_rotation.py
@@ -29,9 +29,7 @@ def addtext(ax, props):
     ax.text(4.5, 0.5, 'text -45', props, rotation=-45)
     for x in range(0, 5):
         ax.scatter(x + 0.5, 0.5, color='r', alpha=0.5)
-    ax.set_yticks([0, .5, 1])
-    ax.set_xticks(np.arange(0, 5.1, 0.5))
-    ax.set_xlim(0, 5)
+    ax.set(yticks=[0, .5, 1], xticks=np.arange(0, 5.1, 0.5), xlim=(0, 5))
     ax.grid(True)
 
 

--- a/examples/ticks_and_spines/tick-formatters.py
+++ b/examples/ticks_and_spines/tick-formatters.py
@@ -28,8 +28,7 @@ def setup(ax, title):
     ax.xaxis.set_ticks_position('bottom')
     ax.tick_params(which='major', width=1.00, length=5)
     ax.tick_params(which='minor', width=0.75, length=2.5, labelsize=10)
-    ax.set_xlim(0, 5)
-    ax.set_ylim(0, 1)
+    ax.set(xlim=(0, 5), ylim=(0, 1))
     ax.text(0.0, 0.2, title, transform=ax.transAxes,
             fontsize=14, fontname='Monospace', color='tab:blue')
 

--- a/examples/ticks_and_spines/tick-locators.py
+++ b/examples/ticks_and_spines/tick-locators.py
@@ -24,8 +24,7 @@ def setup(ax, title):
     ax.xaxis.set_ticks_position('bottom')
     ax.tick_params(which='major', width=1.00, length=5)
     ax.tick_params(which='minor', width=0.75, length=2.5)
-    ax.set_xlim(0, 5)
-    ax.set_ylim(0, 1)
+    ax.set(xlim=(0, 5), ylim=(0, 1))
     ax.text(0.0, 0.2, title, transform=ax.transAxes,
             fontsize=14, fontname='Monospace', color='tab:blue')
 

--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -35,8 +35,8 @@ def onselect(xmin, xmax):
 
     if len(region_x) >= 2:
         line2.set_data(region_x, region_y)
-        ax2.set_xlim(region_x[0], region_x[-1])
-        ax2.set_ylim(region_y.min(), region_y.max())
+        ax2.set(xlim=(region_x[0], region_x[-1]),
+                ylim=(region_y.min(), region_y.max()))
         fig.canvas.draw_idle()
 
 


### PR DESCRIPTION
- <s>Use `set_xticks(positions, labels)` instead of `set_xticks(positions); set_xticklabels(labels)`.</s> *Moved to #20636 for easier review*.
- Use batch `ax.set()` instead of multiple `set_*` calls when appropritate.
