### PR TITLE
Use ticklabels([]) instead of ticklabels('')

### DIFF
--- a/examples/subplots_axes_and_figures/zoom_inset_axes.py
+++ b/examples/subplots_axes_and_figures/zoom_inset_axes.py
@@ -33,8 +33,8 @@ axins.imshow(Z2, extent=extent, origin="lower")
 x1, x2, y1, y2 = -1.5, -0.9, -2.5, -1.9
 axins.set_xlim(x1, x2)
 axins.set_ylim(y1, y2)
-axins.set_xticklabels('')
-axins.set_yticklabels('')
+axins.set_xticklabels([])
+axins.set_yticklabels([])
 
 ax.indicate_inset_zoom(axins, edgecolor="black")
 

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -68,8 +68,8 @@ def doall():
     plt.gca().set_ylim(0., 1.)
     plt.gca().set_title("Matplotlib's math rendering engine",
                         color=mpl_grey_rvb, fontsize=14, weight='bold')
-    plt.gca().set_xticklabels("", visible=False)
-    plt.gca().set_yticklabels("", visible=False)
+    plt.gca().set_xticklabels([])
+    plt.gca().set_yticklabels([])
 
     # Gap between lines in axes coords
     line_axesfrac = 1 / n_lines

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -147,6 +147,7 @@ class GeoAxes(Axes):
     set_xscale = set_yscale
 
     def set_xlim(self, *args, **kwargs):
+        """Not supported. Please consider using Cartopy."""
         raise TypeError("Changing axes limits of a geographic projection is "
                         "not supported.  Please consider using Cartopy.")
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -16,8 +16,8 @@ def example_plot(ax, fontsize=12, nodec=False):
         ax.set_ylabel('y-label', fontsize=fontsize)
         ax.set_title('Title', fontsize=fontsize)
     else:
-        ax.set_xticklabels('')
-        ax.set_yticklabels('')
+        ax.set_xticklabels([])
+        ax.set_yticklabels([])
 
 
 def example_pcolor(ax, fontsize=12):
@@ -428,8 +428,8 @@ def test_colorbar_align():
             if nn != 1:
                 cb.ax.xaxis.set_ticks([])
                 cb.ax.yaxis.set_ticks([])
-                ax.set_xticklabels('')
-                ax.set_yticklabels('')
+                ax.set_xticklabels([])
+                ax.set_yticklabels([])
         fig.set_constrained_layout_pads(w_pad=4 / 72, h_pad=4 / 72, hspace=0.1,
                                         wspace=0.1)
 

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -636,12 +636,12 @@ def test_large_subscript_title():
     ax = axs[0]
     ax.set_title(r'$\sum_{i} x_i$')
     ax.set_title('New way', loc='left')
-    ax.set_xticklabels('')
+    ax.set_xticklabels([])
 
     ax = axs[1]
     ax.set_title(r'$\sum_{i} x_i$', y=1.01)
     ax.set_title('Old Way', loc='left')
-    ax.set_xticklabels('')
+    ax.set_xticklabels([])
 
 
 def test_wrap():

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -296,8 +296,8 @@ pads = [0, 0.05, 0.1, 0.2]
 for pad, ax in zip(pads, axs.flat):
     pc = ax.pcolormesh(arr, **pc_kwargs)
     fig.colorbar(pc, ax=ax, shrink=0.6, pad=pad)
-    ax.set_xticklabels('')
-    ax.set_yticklabels('')
+    ax.set_xticklabels([])
+    ax.set_yticklabels([])
     ax.set_title(f'pad: {pad}')
 fig.set_constrained_layout_pads(w_pad=2 / 72, h_pad=2 / 72, hspace=0.2,
                                 wspace=0.2)


### PR DESCRIPTION
The string variant is not supported according to the docstring. It's
only working by accident due to the list comprehension in 
https://github.com/matplotlib/matplotlib/blob/30cbdf7d2e2963f585f9ab21d7c1d31bd09197d0/lib/matplotlib/axis.py#L1705
