### PR TITLE
Implement Type-1 decryption

### DIFF
--- a/doc/api/next_api_changes/behavior/20634-JKS.rst
+++ b/doc/api/next_api_changes/behavior/20634-JKS.rst
@@ -1,0 +1,8 @@
+``Type1Font`` objects now decrypt the encrypted part
+----------------------------------------------------
+
+Type 1 fonts have a large part of their code encrypted as an obsolete
+copy-protection measure. This part is now available decrypted as the
+``decrypted`` attribute of :class:`~matplotlib.type1font.Type1Font`.
+This decrypted data is not yet parsed, but this is a prerequisite for
+implementing subsetting.

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -15,6 +15,8 @@ def test_Type1Font():
     assert font.parts[2] == rawdata[0x8985:0x8ba6]
     assert font.parts[1:] == slanted.parts[1:]
     assert font.parts[1:] == condensed.parts[1:]
+    assert font.decrypted.startswith(b'dup\n/Private 18 dict dup begin')
+    assert font.decrypted.endswith(b'mark currentfile closefile\n')
 
     differ = difflib.Differ()
     diff = list(differ.compare(
@@ -67,3 +69,11 @@ def test_overprecision():
     assert matrix == '0.001 0 0.000167 0.001 0 0'
     # and here we had -9.48090361795083
     assert angle == '-9.4809'
+
+
+def test_encrypt_decrypt_roundtrip():
+    data = b'this is my plaintext \0\1\2\3'
+    encrypted = t1f.Type1Font._encrypt(data, 'eexec')
+    decrypted = t1f.Type1Font._decrypt(encrypted, 'eexec')
+    assert encrypted != decrypted
+    assert data == decrypted


### PR DESCRIPTION
## PR Summary

Implement decryption of the encrypted part of Type-1 fonts. This is a prerequisite of subsetting (#127) although that will need a lot more code.

I looked at using fonttools for Type-1 subsetting, but it seems to lack much of the functionality needed for that, although it does implement this decryption algorithm. (The code in this PR is completely my own implementation.)

cc @aitikgupta - subsetting TTF fonts is more important than Type-1 since it affects a lot more users, but if you want to take a look at Type-1 subsetting, this is the first step

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
