### PR TITLE
Backport PR #20597 on branch v3.4.x

### DIFF
--- a/extern/ttconv/pprdrv_tt.cpp
+++ b/extern/ttconv/pprdrv_tt.cpp
@@ -841,17 +841,24 @@ void ttfont_sfnts(TTStreamWriter& stream, struct TTFONT *font)
 
     /* Now, generate those silly numTables numbers. */
     sfnts_pputUSHORT(stream, count);            /* number of tables */
-    if ( count == 9 )
-    {
-        sfnts_pputUSHORT(stream, 7);          /* searchRange */
-        sfnts_pputUSHORT(stream, 3);          /* entrySelector */
-        sfnts_pputUSHORT(stream, 81);         /* rangeShift */
+
+    int search_range = 1;
+    int entry_sel = 0;
+
+    while (search_range <= count) {
+        search_range <<= 1;
+        entry_sel++;
     }
+    entry_sel = entry_sel > 0 ? entry_sel - 1 : 0;
+    search_range = (search_range >> 1) * 16;
+    int range_shift = count * 16 - search_range;
+
+    sfnts_pputUSHORT(stream, search_range);      /* searchRange */
+    sfnts_pputUSHORT(stream, entry_sel);         /* entrySelector */
+    sfnts_pputUSHORT(stream, range_shift);       /* rangeShift */
+
 #ifdef DEBUG_TRUETYPE
-    else
-    {
-        debug("only %d tables selected",count);
-    }
+    debug("only %d tables selected",count);
 #endif
 
     /* Now, emmit the table directory. */


### PR DESCRIPTION
## PR Summary

Manual backport of #20597 because of merge conflicts

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
