### PR TITLE
Fix leak if affine_transform is passed invalid vertices.

### DIFF
--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -453,17 +453,19 @@ static PyObject *Py_affine_transform(PyObject *self, PyObject *args, PyObject *k
 
     if (PyArray_NDIM(vertices_arr) == 2) {
         numpy::array_view<double, 2> vertices(vertices_arr);
+        Py_DECREF(vertices_arr);
+
         npy_intp dims[] = { (npy_intp)vertices.size(), 2 };
         numpy::array_view<double, 2> result(dims);
         CALL_CPP("affine_transform", (affine_transform_2d(vertices, trans, result)));
-        Py_DECREF(vertices_arr);
         return result.pyobj();
     } else { // PyArray_NDIM(vertices_arr) == 1
         numpy::array_view<double, 1> vertices(vertices_arr);
+        Py_DECREF(vertices_arr);
+
         npy_intp dims[] = { (npy_intp)vertices.size() };
         numpy::array_view<double, 1> result(dims);
         CALL_CPP("affine_transform", (affine_transform_1d(vertices, trans, result)));
-        Py_DECREF(vertices_arr);
         return result.pyobj();
     }
 }


### PR DESCRIPTION
## PR Summary

`CALL_CPP` may raise an exception, so we should drop the `vertices` ref before calling it. We've already added an automatically-dropping ref with the `array_view`, so we don't need this one.

Fixes #20641.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).