### PR TITLE
Handle NaN values in `plot_surface` zsort

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -8,7 +8,6 @@ artists into 3D versions which can be added to an Axes3D.
 """
 
 import math
-import sys
 
 import numpy as np
 
@@ -737,7 +736,7 @@ class Poly3DCollection(PolyCollection):
         def nansafe(func):
             def f(x):
                 value = func(x)
-                return sys.maxsize if np.isnan(value) else value
+                return np.inf if np.isnan(value) else value
             return f
 
         self._zsortfunc = nansafe(self._zsort_functions[zsort])

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -738,6 +738,14 @@ class Poly3DCollection(PolyCollection):
         self.stale = True
 
     def _zsortval(self, zs):
+        """
+        Compute the value to use for z-sorting given the viewer z
+        coordinates of an object `zs`, with larger values drawn underneath
+        smaller values.
+
+        This function should never return `nan`, and returns `np.inf` if no
+        non-nan value is computable.
+        """
         nans = np.isnan(zs)
         return np.inf if nans.all() else self._zsortfunc(zs[~nans])
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -8,6 +8,7 @@ artists into 3D versions which can be added to an Axes3D.
 """
 
 import math
+import sys
 
 import numpy as np
 
@@ -733,7 +734,13 @@ class Poly3DCollection(PolyCollection):
             The function applied on the z-coordinates of the vertices in the
             viewer's coordinate system, to determine the z-order.
         """
-        self._zsortfunc = self._zsort_functions[zsort]
+        def nansafe(func):
+            def f(x):
+                value = func(x)
+                return sys.maxsize if np.isnan(value) else value
+            return f
+
+        self._zsortfunc = nansafe(self._zsort_functions[zsort])
         self._sort_zpos = None
         self.stale = True
 


### PR DESCRIPTION
## PR Summary

Closes #8222 #12395

While investigating different ways of solving #18114 I came across the issue where NaNs in data causing strange plotting issues. I tracked this down to the sorting of polygons where the python builtin `sorted` method is used. This doesn’t deal with NaNs so we need to be sure to make the zsort functions NaN safe. This does that by checking if the function returns NaN and if so returning `sys.maxsize`.

I want to separate this from #18114 as I found two open issues I think it solves, #8222 and #12395.

`plot_surface` does warn that it can't deal with NaNs but it looks like that was added in response to #12395. This seems to solve that, so perhaps the warning can be removed?

I still need to add some tests but I wanted to check there was interest in adding this before writing those. It seems like a fairly simple problem to solve so maybe there is some deeper reason this hasn't been done?

The before and after plots of the two issues are

### #8222 Before
![before_8222](https://user-images.githubusercontent.com/17545360/125631180-c5fa2267-dc99-4928-8cd6-a64f99e57d02.png)


### #8222 After
![after_8222](https://user-images.githubusercontent.com/17545360/125631183-915946bc-a7fc-4d7e-bed5-54e3cf35e767.png)



### #12395 Before
![before_12395](https://user-images.githubusercontent.com/17545360/125631211-e17d156a-42d0-4ed8-ad94-3155b82a4a5f.png)


### #12395 After 
![after_12395](https://user-images.githubusercontent.com/17545360/125631222-3f38b329-52f8-4b32-ad34-349962ca3304.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
