### PR TITLE
Add HiDPI-related config for mathmpl

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -82,6 +82,7 @@ Alphabetical list of modules:
    rcsetup_api.rst
    sankey_api.rst
    scale_api.rst
+   sphinxext_mathmpl_api.rst
    sphinxext_plot_directive_api.rst
    spines_api.rst
    style_api.rst

--- a/doc/api/sphinxext_mathmpl_api.rst
+++ b/doc/api/sphinxext_mathmpl_api.rst
@@ -1,0 +1,7 @@
+================================
+``matplotlib.sphinxext.mathmpl``
+================================
+
+.. automodule:: matplotlib.sphinxext.mathmpl
+   :exclude-members: latex_math
+   :no-undoc-members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -178,6 +178,7 @@ sphinx_gallery_conf = {
 }
 
 plot_gallery = 'True'
+mathmpl_fontsize = 11.0
 
 # Monkey-patching gallery signature to include search keywords
 gen_rst.SPHX_GLR_SIG = """\n

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -179,6 +179,7 @@ sphinx_gallery_conf = {
 
 plot_gallery = 'True'
 mathmpl_fontsize = 11.0
+mathmpl_srcset = ['2x']
 
 # Monkey-patching gallery signature to include search keywords
 gen_rst.SPHX_GLR_SIG = """\n

--- a/doc/users/next_whats_new/mathmpl_hidpi.rst
+++ b/doc/users/next_whats_new/mathmpl_hidpi.rst
@@ -1,0 +1,13 @@
+More configuration of ``mathmpl:`` sphinx extension
+---------------------------------------------------
+
+The `matplotlib.sphinxext.mathmpl` sphinx extension supports two new
+configuration options that may be specified in your ``conf.py``:
+
+- ``mathmpl_fontsize`` (float), which sets the font size of the math text in
+  points;
+- ``mathmpl_srcset`` (list of str), which provides a list of sizes to support
+  `responsive resolution images
+  <https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images>`__
+  The list should contain additional x-descriptors (``'1.5x'``, ``'2x'``, etc.)
+  to generate (1x is the default and always included.)

--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -1,3 +1,68 @@
+r"""
+A role and directive to display mathtext in Sphinx
+==================================================
+
+.. warning::
+    In most cases, you will likely want to use one of `Sphinx's builtin Math
+    extensions
+    <https://www.sphinx-doc.org/en/master/usage/extensions/math.html>`__
+    instead of this one.
+
+Mathtext may be included in two ways:
+
+1. Inline, using the role::
+
+     This text uses inline math: :mathmpl:`\alpha > \beta`.
+
+   which produces:
+
+     This text uses inline math: :mathmpl:`\alpha > \beta`.
+
+2. Standalone, using the directive::
+
+     Here is some standalone math:
+
+     .. mathmpl::
+
+         \alpha > \beta
+
+   which produces:
+
+     Here is some standalone math:
+
+     .. mathmpl::
+
+         \alpha > \beta
+
+Options
+-------
+
+The ``mathmpl`` role and directive both support the following options:
+
+    fontset : str, default: 'cm'
+        The font set to use when displaying math. See :rc:`mathtext.fontset`.
+
+    fontsize : float
+        The font size, in points. Defaults to the value from the extension
+        configuration option defined below.
+
+Configuration options
+---------------------
+
+The mathtext extension has the following configuration options:
+
+    mathmpl_fontsize : float, default: 10.0
+        Default font size, in points.
+
+    mathmpl_srcset : list of str, default: []
+        Additional image sizes to generate when embedding in HTML, to support
+        `responsive resolution images
+        <https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images>`__.
+        The list should contain additional x-descriptors (``'1.5x'``, ``'2x'``,
+        etc.) to generate (1x is the default and always included.)
+
+"""
+
 import hashlib
 from pathlib import Path
 
@@ -35,6 +100,9 @@ math_role.options = {'fontset': fontset_choice,
 
 
 class MathDirective(Directive):
+    """
+    The ``.. mathmpl::`` directive, as documented in the module's docstring.
+    """
     has_content = True
     required_arguments = 0
     optional_arguments = 0


### PR DESCRIPTION
## PR Summary

Namely, `fontsize`, and `srcset`. We need these for our new theme, which uses 11pt fonts instead of 10pt, and to match the gallery that provides 2x images.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).