### PR TITLE
introduce variables for spine position

### DIFF
--- a/examples/ticks_and_spines/centered_spines_with_arrows.py
+++ b/examples/ticks_and_spines/centered_spines_with_arrows.py
@@ -4,8 +4,8 @@ Centered spines with arrows
 ===========================
 
 This example shows a way to draw a "math textbook" style plot, where the
-spines ("axes lines") are drawn at ``x0 = 0`` and ``y0 = 0.2``, and have arrows at
-their ends.
+spines ("axes lines") are drawn at ``x0 = 0`` and ``y0 = 0.2``, and have
+arrows at their ends.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/ticks_and_spines/centered_spines_with_arrows.py
+++ b/examples/ticks_and_spines/centered_spines_with_arrows.py
@@ -4,7 +4,7 @@ Centered spines with arrows
 ===========================
 
 This example shows a way to draw a "math textbook" style plot, where the
-spines ("axes lines") are drawn at ``x = 0`` and ``y = 0``, and have arrows at
+spines ("axes lines") are drawn at ``x0 = 0`` and ``y0 = 0.2``, and have arrows at
 their ends.
 """
 
@@ -13,18 +13,20 @@ import numpy as np
 
 
 fig, ax = plt.subplots()
-# Move the left and bottom spines to x = 0 and y = 0, respectively.
-ax.spines[["left", "bottom"]].set_position(("data", 0))
+x0, y0 = 0, 0.2
+# Move the left and bottom spines to x0 and y0, respectively.
+ax.spines.left.set_position(("data", x0))
+ax.spines.bottom.set_position(("data", y0))
 # Hide the top and right spines.
 ax.spines[["top", "right"]].set_visible(False)
 
 # Draw arrows (as black triangles: ">k"/"^k") at the end of the axes.  In each
-# case, one of the coordinates (0) is a data coordinate (i.e., y = 0 or x = 0,
+# case, one of the coordinates is a data coordinate (i.e., y0 or x0,
 # respectively) and the other one (1) is an axes coordinate (i.e., at the very
 # right/top of the axes).  Also, disable clipping (clip_on=False) as the marker
 # actually spills out of the axes.
-ax.plot(1, 0, ">k", transform=ax.get_yaxis_transform(), clip_on=False)
-ax.plot(0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
+ax.plot(1, y0, ">k", transform=ax.get_yaxis_transform(), clip_on=False)
+ax.plot(x0, 1, "^k", transform=ax.get_xaxis_transform(), clip_on=False)
 
 # Some sample data.
 x = np.linspace(-0.5, 1., 100)


### PR DESCRIPTION
## PR Summary

When reading https://matplotlib.org/stable/gallery/ticks_and_spines/centered_spines_with_arrows.html it was not directly clear which coordinate (x or y) is used at which place. To address this issue, I introduce variables for spine positions, and use them throughout the example.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
