### PR TITLE
Don't forget to disable autoscaling after interactive zoom.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4292,25 +4292,17 @@ class _AxesBase(martist.Artist):
             Whether this axis is twinned in the *y*-direction.
         """
         if len(bbox) == 3:
-            Xmin, Xmax = self.get_xlim()
-            Ymin, Ymax = self.get_ylim()
-
             xp, yp, scl = bbox  # Zooming code
-
             if scl == 0:  # Should not happen
                 scl = 1.
-
             if scl > 1:
                 direction = 'in'
             else:
                 direction = 'out'
                 scl = 1/scl
-
             # get the limits of the axes
-            tranD2C = self.transData.transform
-            xmin, ymin = tranD2C((Xmin, Ymin))
-            xmax, ymax = tranD2C((Xmax, Ymax))
-
+            (xmin, ymin), (xmax, ymax) = self.transData.transform(
+                np.transpose([self.get_xlim(), self.get_ylim()]))
             # set the range
             xwidth = xmax - xmin
             ywidth = ymax - ymin
@@ -4318,7 +4310,6 @@ class _AxesBase(martist.Artist):
             ycen = (ymax + ymin)*.5
             xzc = (xp*(scl - 1) + xcen)/scl
             yzc = (yp*(scl - 1) + ycen)/scl
-
             bbox = [xzc - xwidth/2./scl, yzc - ywidth/2./scl,
                     xzc + xwidth/2./scl, yzc + ywidth/2./scl]
         elif len(bbox) != 4:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4362,8 +4362,10 @@ class _AxesBase(martist.Artist):
 
         if not twinx and mode != "y":
             self.set_xbound(new_xbound)
+            self.set_autoscalex_on(False)
         if not twiny and mode != "x":
             self.set_ybound(new_ybound)
+            self.set_autoscaley_on(False)
 
     def start_pan(self, x, y, button):
         """

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -178,6 +178,8 @@ def test_interactive_zoom():
     tb.zoom()
     assert ax.get_navigate_mode() is None
 
+    assert not ax.get_autoscalex_on() and not ax.get_autoscaley_on()
+
 
 def test_toolbar_zoompan():
     expected_warning_regex = (


### PR DESCRIPTION
## PR Summary

(set_x/ybound doesn't disable autoscaling, unlike set_x/ylim.)

... and also, as a separate commit:
PEP8ify _set_view_from_bbox.

Closes https://github.com/matplotlib/matplotlib/issues/20519.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
