### PR TITLE
Document $MPLSETUPCFG.

### DIFF
--- a/doc/faq/environment_variables_faq.rst
+++ b/doc/faq/environment_variables_faq.rst
@@ -35,6 +35,13 @@ Environment variables
   used to find a base directory in which the :file:`matplotlib` subdirectory is
   created.
 
+.. envvar:: MPLSETUPCFG
+
+   This optional variable can be set to the full path of a :file:`setup.cfg`
+   configuration file used to customize the Matplotlib build.  By default, a
+   :file:`setup.cfg` file in the root of the Matplotlib source tree will be
+   read.  Supported build options are listed in :file:`setup.cfg.template`.
+
 .. envvar:: PATH
 
   The list of directories searched to find executable programs.


### PR DESCRIPTION
## PR Summary

xref https://github.com/matplotlib/matplotlib/issues/20661#issuecomment-882082358.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
