### PR TITLE
Cleanup related to usage of axs

### DIFF
--- a/examples/color/custom_cmap.py
+++ b/examples/color/custom_cmap.py
@@ -88,7 +88,7 @@ n_bins = [3, 6, 10, 100]  # Discretizes the interpolation into bins
 cmap_name = 'my_list'
 fig, axs = plt.subplots(2, 2, figsize=(6, 9))
 fig.subplots_adjust(left=0.02, bottom=0.06, right=0.95, top=0.94, wspace=0.05)
-for n_bin, ax in zip(n_bins, axs.ravel()):
+for n_bin, ax in zip(n_bins, axs.flat):
     # Create the colormap
     cmap = LinearSegmentedColormap.from_list(cmap_name, colors, N=n_bin)
     # Fewer bins will result in "coarser" colomap interpolation

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -96,7 +96,7 @@ cmap = cmap.with_extremes(under="magenta", over="yellow")
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)
 
-for ax, extend in zip(axs.ravel(), extends):
+for ax, extend in zip(axs.flat, extends):
     cs = ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend, origin=origin)
     fig.colorbar(cs, ax=ax, shrink=0.9)
     ax.set_title("extend = %s" % extend)

--- a/examples/style_sheets/ggplot.py
+++ b/examples/style_sheets/ggplot.py
@@ -23,7 +23,7 @@ plt.style.use('ggplot')
 np.random.seed(19680801)
 
 fig, axs = plt.subplots(ncols=2, nrows=2)
-ax1, ax2, ax3, ax4 = axs.ravel()
+ax1, ax2, ax3, ax4 = axs.flat
 
 # scatter plot (Note: `plt.scatter` doesn't use default colors)
 x, y = np.random.normal(size=(2, 200))

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6439,7 +6439,7 @@ def test_secondary_formatter():
         secax.xaxis.get_major_formatter(), mticker.ScalarFormatter)
 
 
-def color_boxes(fig, axs):
+def color_boxes(fig, ax):
     """
     Helper for the tests below that test the extents of various axes elements
     """
@@ -6447,7 +6447,7 @@ def color_boxes(fig, axs):
 
     renderer = fig.canvas.get_renderer()
     bbaxis = []
-    for nn, axx in enumerate([axs.xaxis, axs.yaxis]):
+    for nn, axx in enumerate([ax.xaxis, ax.yaxis]):
         bb = axx.get_tightbbox(renderer)
         if bb:
             axisr = plt.Rectangle(
@@ -6459,7 +6459,7 @@ def color_boxes(fig, axs):
 
     bbspines = []
     for nn, a in enumerate(['bottom', 'top', 'left', 'right']):
-        bb = axs.spines[a].get_window_extent(renderer)
+        bb = ax.spines[a].get_window_extent(renderer)
         spiner = plt.Rectangle(
             (bb.x0, bb.y0), width=bb.width, height=bb.height,
             linewidth=0.7, edgecolor="green", facecolor="none", transform=None,
@@ -6467,7 +6467,7 @@ def color_boxes(fig, axs):
         fig.add_artist(spiner)
         bbspines += [bb]
 
-    bb = axs.get_window_extent()
+    bb = ax.get_window_extent()
     rect2 = plt.Rectangle(
         (bb.x0, bb.y0), width=bb.width, height=bb.height,
         linewidth=1.5, edgecolor="magenta", facecolor="none", transform=None,
@@ -6475,7 +6475,7 @@ def color_boxes(fig, axs):
     fig.add_artist(rect2)
     bbax = bb
 
-    bb2 = axs.get_tightbbox(renderer)
+    bb2 = ax.get_tightbbox(renderer)
     rect2 = plt.Rectangle(
         (bb2.x0, bb2.y0), width=bb2.width, height=bb2.height,
         linewidth=3, edgecolor="red", facecolor="none", transform=None,

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -115,12 +115,12 @@ def test_imshow_antialiased(fig_test, fig_ref,
     A = np.random.rand(int(dpi * img_size), int(dpi * img_size))
     for fig in [fig_test, fig_ref]:
         fig.set_size_inches(fig_size, fig_size)
-    axs = fig_test.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation='antialiased')
-    axs = fig_ref.subplots()
-    axs.set_position([0, 0, 1, 1])
-    axs.imshow(A, interpolation=interpolation)
+    ax = fig_test.subplots()
+    ax.set_position([0, 0, 1, 1])
+    ax.imshow(A, interpolation='antialiased')
+    ax = fig_ref.subplots()
+    ax.set_position([0, 0, 1, 1])
+    ax.imshow(A, interpolation=interpolation)
 
 
 @check_figures_equal(extensions=['png'])
@@ -131,14 +131,14 @@ def test_imshow_zoom(fig_test, fig_ref):
     A = np.random.rand(int(dpi * 3), int(dpi * 3))
     for fig in [fig_test, fig_ref]:
         fig.set_size_inches(2.9, 2.9)
-    axs = fig_test.subplots()
-    axs.imshow(A, interpolation='antialiased')
-    axs.set_xlim([10, 20])
-    axs.set_ylim([10, 20])
-    axs = fig_ref.subplots()
-    axs.imshow(A, interpolation='nearest')
-    axs.set_xlim([10, 20])
-    axs.set_ylim([10, 20])
+    ax = fig_test.subplots()
+    ax.imshow(A, interpolation='antialiased')
+    ax.set_xlim([10, 20])
+    ax.set_ylim([10, 20])
+    ax = fig_ref.subplots()
+    ax.imshow(A, interpolation='nearest')
+    ax.set_xlim([10, 20])
+    ax.set_ylim([10, 20])
 
 
 @check_figures_equal()


### PR DESCRIPTION
## PR Summary

- Use ax instead of axs when the object is clearly a single Axes
- Use axs.flat instead of ax.ravel()

This only changes examples and tests; i.e. no API changes involved.