### PR TITLE
Be more lenient with placement of @deprecated wrt @class/staticmethod.

### DIFF
--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -21,17 +21,52 @@ def test_check_shape(target, test_shape):
         _api.check_shape(target, aardvark=data)
 
 
-def test_classproperty_deprecation():
+def test_deprecated():
     class A:
         @_api.deprecated("0.0.0")
-        @_api.classproperty
-        def f(cls):
+        def meth(self):
             pass
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
-        A.f
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
-        a = A()
-        a.f
+
+        @_api.deprecated("0.0.0")
+        @classmethod
+        def cmeth1(cls):
+            pass
+
+        @classmethod
+        @_api.deprecated("0.0.0")
+        def cmeth2(cls):
+            pass
+
+        @_api.deprecated("0.0.0")
+        @staticmethod
+        def smeth1():
+            pass
+
+        @staticmethod
+        @_api.deprecated("0.0.0")
+        def smeth2():
+            pass
+
+        @_api.deprecated("0.0.0")
+        @property
+        def prop(self):
+            pass
+
+        @_api.deprecated("0.0.0")
+        @_api.classproperty
+        def cprop(cls):
+            pass
+
+    a = A()
+    for call in [
+            a.meth,
+            a.cmeth1, a.cmeth2, A.cmeth1, A.cmeth2,
+            a.smeth1, a.smeth2, A.smeth1, A.smeth2,
+            lambda: getattr(a, "prop"),
+            lambda: getattr(A, "cprop"), lambda: getattr(a, "cprop"),
+    ]:
+        with pytest.warns(_api.MatplotlibDeprecationWarning):
+            call()
 
 
 def test_deprecate_privatize_attribute():


### PR DESCRIPTION
We can support putting `@deprecated` over `@classmethod`/`@staticmethod`
by extracting the underlying function and redecorating it after
constructing the deprecation wrapper.

Also add a bunch more tests for `@deprecated`.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
