### PR TITLE
Shorten the `@deprecated` docs.

### DIFF
--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -73,31 +73,24 @@ def warn_deprecated(
     ----------
     since : str
         The release at which this API became deprecated.
-
     message : str, optional
         Override the default deprecation message.  The ``%(since)s``,
         ``%(name)s``, ``%(alternative)s``, ``%(obj_type)s``, ``%(addendum)s``,
         and ``%(removal)s`` format specifiers will be replaced by the values
         of the respective arguments passed to this function.
-
     name : str, optional
         The name of the deprecated object.
-
     alternative : str, optional
         An alternative API that the user may use in place of the deprecated
         API.  The deprecation warning will tell the user about this alternative
         if provided.
-
     pending : bool, optional
         If True, uses a PendingDeprecationWarning instead of a
         DeprecationWarning.  Cannot be used together with *removal*.
-
     obj_type : str, optional
         The object type being deprecated.
-
     addendum : str, optional
         Additional text appended directly to the final message.
-
     removal : str, optional
         The expected removal version.  With the default (an empty string), a
         removal version is automatically computed from *since*.  Set to other
@@ -106,7 +99,7 @@ def warn_deprecated(
 
     Examples
     --------
-    Basic example::
+    ::
 
         # To warn of the deprecation of "matplotlib.name_of_module"
         warn_deprecated('1.4.0', name='matplotlib.name_of_module',
@@ -135,46 +128,13 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
     ``@deprecated`` would mess up ``__init__`` inheritance when installing its
     own (deprecation-emitting) ``C.__init__``).
 
-    Parameters
-    ----------
-    since : str
-        The release at which this API became deprecated.
-
-    message : str, optional
-        Override the default deprecation message.  The ``%(since)s``,
-        ``%(name)s``, ``%(alternative)s``, ``%(obj_type)s``, ``%(addendum)s``,
-        and ``%(removal)s`` format specifiers will be replaced by the values
-        of the respective arguments passed to this function.
-
-    name : str, optional
-        The name used in the deprecation message; if not provided, the name
-        is automatically determined from the deprecated object.
-
-    alternative : str, optional
-        An alternative API that the user may use in place of the deprecated
-        API.  The deprecation warning will tell the user about this alternative
-        if provided.
-
-    pending : bool, optional
-        If True, uses a PendingDeprecationWarning instead of a
-        DeprecationWarning.  Cannot be used together with *removal*.
-
-    obj_type : str, optional
-        The object type being deprecated; by default, 'class' if decorating
-        a class, 'attribute' if decorating a property, 'function' otherwise.
-
-    addendum : str, optional
-        Additional text appended directly to the final message.
-
-    removal : str, optional
-        The expected removal version.  With the default (an empty string), a
-        removal version is automatically computed from *since*.  Set to other
-        Falsy values to not schedule a removal date.  Cannot be used together
-        with *pending*.
+    Parameters are the same as for `warn_deprecated`, except that *obj_type*
+    defaults to 'class' if decorating a class, 'attribute' if decorating a
+    property, and 'function' otherwise.
 
     Examples
     --------
-    Basic example::
+    ::
 
         @deprecated('1.4.0')
         def the_function_to_deprecate():


### PR DESCRIPTION
For internal APIs, it seems reasonable to avoid the duplication of
the description of parameters (if anything, the shortened version makes
the difference in `obj_type`'s behavior clearer).

Also compress a bit the docstring of `warn_deprecated`.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
