### PR TITLE
Fix bounds when initialising `SpanSelector`

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -302,6 +302,35 @@ def test_tool_line_handle():
     assert tool_line_handle.positions == positions
 
 
+@pytest.mark.parametrize('direction', ("horizontal", "vertical"))
+def test_span_selector_bound(direction):
+    fig, ax = plt.subplots(1, 1)
+    ax.plot([10, 20], [10, 30])
+    ax.figure.canvas.draw()
+    x_bound = ax.get_xbound()
+    y_bound = ax.get_ybound()
+
+    tool = widgets.SpanSelector(ax, print, direction, interactive=True)
+    assert ax.get_xbound() == x_bound
+    assert ax.get_ybound() == y_bound
+
+    bound = x_bound if direction == 'horizontal' else y_bound
+    assert tool._edge_handles.positions == list(bound)
+
+    press_data = [10.5, 11.5]
+    move_data = [11, 13]  # Updating selector is done in onmove
+    release_data = move_data
+    do_event(tool, 'press', xdata=press_data[0], ydata=press_data[1], button=1)
+    do_event(tool, 'onmove', xdata=move_data[0], ydata=move_data[1], button=1)
+
+    assert ax.get_xbound() == x_bound
+    assert ax.get_ybound() == y_bound
+
+    index = 0 if direction == 'horizontal' else 1
+    handle_positions = [press_data[index], release_data[index]]
+    assert tool._edge_handles.positions == handle_positions
+
+
 def check_lasso_selector(**kwargs):
     ax = get_ax()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2156,7 +2156,12 @@ class SpanSelector(_SelectorWidget):
             self.artists.append(self._rect)
 
     def _setup_edge_handle(self, props):
-        self._edge_handles = ToolLineHandles(self.ax, self.extents,
+        # Define initial position using the axis bounds to keep the same bounds
+        if self.direction == 'horizontal':
+            positions = self.ax.get_xbound()
+        else:
+            positions = self.ax.get_ybound()
+        self._edge_handles = ToolLineHandles(self.ax, positions,
                                              direction=self.direction,
                                              line_props=props,
                                              useblit=self.useblit)


### PR DESCRIPTION
## PR Summary

Fix #20665

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
