### PR TITLE
Fix selector onselect call when the selector is removed by an "empty" click and add `ignore_event_outside` argument

### DIFF
--- a/doc/users/next_whats_new/widget_ignore_events.rst
+++ b/doc/users/next_whats_new/widget_ignore_events.rst
@@ -1,0 +1,7 @@
+Ignore events outside selection
+-------------------------------
+The `~matplotlib.widgets.SpanSelector`, `~matplotlib.widgets.RectangleSelector`
+and `~matplotlib.widgets.EllipseSelector` have a new keyword argument,
+*ignore_event_outside*, which when set to `True` will ignore events outside of
+the current selection. The handles or the new dragging functionality can instead
+be used to change the selection.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -190,6 +190,63 @@ def test_rectangle_handles():
         tool._corner_handles.artist.get_markeredgecolor(), 'b')
 
 
+@pytest.mark.parametrize('interactive', [True, False])
+def test_rectangle_selector_onselect(interactive):
+    # check when press and release events take place at the same position
+    ax = get_ax()
+
+    def onselect(vmin, vmax):
+        ax._got_onselect = True
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=interactive)
+    do_event(tool, 'press', xdata=100, ydata=110, button=1)
+    # move outside of axis
+    do_event(tool, 'onmove', xdata=150, ydata=120, button=1)
+    do_event(tool, 'release', xdata=150, ydata=120, button=1)
+
+    assert tool.ax._got_onselect
+    assert tool.extents == (100.0, 150.0, 110.0, 120.0)
+
+    # Reset tool.ax._got_onselect
+    tool.ax._got_onselect = False
+
+    do_event(tool, 'press', xdata=10, ydata=100, button=1)
+    do_event(tool, 'release', xdata=10, ydata=100, button=1)
+
+    assert tool.ax._got_onselect
+
+
+@pytest.mark.parametrize('ignore_event_outside', [True, False])
+def test_rectangle_selector_ignore_outside(ignore_event_outside):
+    ax = get_ax()
+    def onselect(vmin, vmax):
+        ax._got_onselect = True
+
+    tool = widgets.RectangleSelector(ax, onselect,
+                                     ignore_event_outside=ignore_event_outside)
+    do_event(tool, 'press', xdata=100, ydata=110, button=1)
+    do_event(tool, 'onmove', xdata=150, ydata=120, button=1)
+    do_event(tool, 'release', xdata=150, ydata=120, button=1)
+
+    assert tool.ax._got_onselect
+    assert tool.extents == (100.0, 150.0, 110.0, 120.0)
+
+    # Reset
+    ax._got_onselect = False
+    # Trigger event outside of span
+    do_event(tool, 'press', xdata=150, ydata=150, button=1)
+    do_event(tool, 'onmove', xdata=160, ydata=160, button=1)
+    do_event(tool, 'release', xdata=160, ydata=160, button=1)
+    if ignore_event_outside:
+        # event have been ignored and span haven't changed.
+        assert not ax._got_onselect
+        assert tool.extents == (100.0, 150.0, 110.0, 120.0)
+    else:
+        # A new shape is created
+        assert ax._got_onselect
+        assert tool.extents == (150.0, 160.0, 150.0, 160.0)
+
+
 def check_span(*args, **kwargs):
     ax = get_ax()
 
@@ -222,13 +279,79 @@ def test_span_selector():
     check_span('horizontal', minspan=10, useblit=True)
     check_span('vertical', onmove_callback=True, button=1)
     check_span('horizontal', props=dict(fill=True))
+    check_span('horizontal', interactive=True)
+
+
+@pytest.mark.parametrize('interactive', [True, False])
+def test_span_selector_onselect(interactive):
+    # check when press and release events take place at the same position
+    ax = get_ax()
+
+    def onselect(vmin, vmax):
+        ax._got_onselect = True
+
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal',
+                                interactive=interactive)
+    do_event(tool, 'press', xdata=100, ydata=100, button=1)
+    # move outside of axis
+    do_event(tool, 'onmove', xdata=150, ydata=100, button=1)
+    do_event(tool, 'release', xdata=150, ydata=100, button=1)
+
+    assert tool.ax._got_onselect
+    assert tool.extents == (100, 150)
+
+    # Reset tool.ax._got_onselect
+    tool.ax._got_onselect = False
+
+    do_event(tool, 'press', xdata=10, ydata=100, button=1)
+    do_event(tool, 'release', xdata=10, ydata=100, button=1)
+
+    assert tool.ax._got_onselect
+
+
+@pytest.mark.parametrize('ignore_event_outside', [True, False])
+def test_span_selector_ignore_outside(ignore_event_outside):
+    ax = get_ax()
+    def onselect(vmin, vmax):
+        ax._got_onselect = True
+
+    def onmove(vmin, vmax):
+        ax._got_on_move = True
+
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal',
+                                onmove_callback=onmove,
+                                ignore_event_outside=ignore_event_outside)
+    do_event(tool, 'press', xdata=100, ydata=100, button=1)
+    do_event(tool, 'onmove', xdata=125, ydata=125, button=1)
+    do_event(tool, 'release', xdata=125, ydata=125, button=1)
+    assert ax._got_onselect
+    assert ax._got_on_move
+    assert tool.extents == (100, 125)
+
+    # Reset
+    ax._got_onselect = False
+    ax._got_on_move = False
+    # Trigger event outside of span
+    do_event(tool, 'press', xdata=150, ydata=150, button=1)
+    do_event(tool, 'onmove', xdata=160, ydata=160, button=1)
+    do_event(tool, 'release', xdata=160, ydata=160, button=1)
+    if ignore_event_outside:
+        # event have been ignored and span haven't changed.
+        assert not ax._got_onselect
+        assert not ax._got_on_move
+        assert tool.extents == (100, 125)
+    else:
+        # A new shape is created
+        assert ax._got_onselect
+        assert ax._got_on_move
+        assert tool.extents == (150, 160)
 
 
 @pytest.mark.parametrize('drag_from_anywhere', [True, False])
 def test_span_selector_drag(drag_from_anywhere):
     ax = get_ax()
 
-    def onselect(epress, erelease):
+    def onselect(*args):
         pass
 
     # Create span
@@ -263,7 +386,7 @@ def test_span_selector_drag(drag_from_anywhere):
 def test_span_selector_direction():
     ax = get_ax()
 
-    def onselect(epress, erelease):
+    def onselect(*args):
         pass
 
     tool = widgets.SpanSelector(ax, onselect, 'horizontal', interactive=True)
@@ -702,7 +825,7 @@ def test_MultiCursor(horizOn, vertOn):
 def test_rect_visibility(fig_test, fig_ref):
     # Check that requesting an invisible selector makes it invisible
     ax_test = fig_test.subplots()
-    ax_ref = fig_ref.subplots()
+    _ = fig_ref.subplots()
 
     def onselect(verts):
         pass


### PR DESCRIPTION
## PR Summary

- Fix #20666, but I think this is a misleading behaviour because event are expected to be ignore when the width of the selector is smaller than `minspan`, therefore it would surprising that `onselect` is called when the width is 0 (`vmin == vmax`).
Maybe a better alternative is to add a callback which is called when clearing the selector?
- Add `ignore_outside_event` argument to selectors

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
