### PR TITLE
CI: Build merged version on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ commands:
       - run:
           name: Check-skip
           command: |
-            export COMMIT_MESSAGE=$(git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " ")
+            git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " " > commit_message.txt
+            export COMMIT_MESSAGE=$(cat commit_message.txt);
             echo "Got commit message:"
             echo "${COMMIT_MESSAGE}"
             if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]); then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,19 @@ commands:
               git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
             fi
 
+  check-skip:
+    steps:
+      - run:
+          name: Check-skip
+          command: |
+            export COMMIT_MESSAGE=$(git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " ")
+            echo "Got commit message:"
+            echo "${COMMIT_MESSAGE}"
+            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]); then
+              echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
+              circleci-agent step halt;
+            fi
+
   apt-install:
     steps:
       - run:
@@ -139,6 +152,7 @@ jobs:
       - image: circleci/python:3.8
     steps:
       - checkout
+      - check-skip
       - merge
 
       - apt-install

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,20 @@ version: 2.1
 #
 
 commands:
+  check-skip:
+    steps:
+      - run:
+          name: Check-skip
+          command: |
+            git log --max-count=1 --pretty=format:"%B" | tr "\n" " " > commit_message.txt
+            export COMMIT_MESSAGE=$(cat commit_message.txt);
+            echo "Got commit message:"
+            echo "${COMMIT_MESSAGE}"
+            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]); then
+              echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
+              circleci-agent step halt;
+            fi
+
   merge:
     steps:
       - run:
@@ -22,20 +36,6 @@ commands:
             if [[ $(cat merge.txt) != "" ]]; then
               echo "Merging $(cat merge.txt)";
               git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
-            fi
-
-  check-skip:
-    steps:
-      - run:
-          name: Check-skip
-          command: |
-            git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " " > commit_message.txt
-            export COMMIT_MESSAGE=$(cat commit_message.txt);
-            echo "Got commit message:"
-            echo "${COMMIT_MESSAGE}"
-            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]); then
-              echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
-              circleci-agent step halt;
             fi
 
   apt-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,11 +14,10 @@ commands:
       - run:
           name: Check-skip
           command: |
-            git log --max-count=1 --pretty=format:"%B" | tr "\n" " " > commit_message.txt
-            export COMMIT_MESSAGE=$(cat commit_message.txt);
+            export git_log=$(git log --max-count=1 --pretty=format:"%B" | tr "\n" " ")
             echo "Got commit message:"
-            echo "${COMMIT_MESSAGE}"
-            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$COMMIT_MESSAGE" == *"[skip circle]"* ]] || [[ "$COMMIT_MESSAGE" == *"[circle skip]"* ]]); then
+            echo "${git_log}"
+            if [[ -v CIRCLE_PULL_REQUEST ]] && ([[ "$git_log" == *"[skip circle]"* ]] || [[ "$git_log" == *"[circle skip]"* ]]); then
               echo "Skip detected, exiting job ${CIRCLE_JOB} for PR ${CIRCLE_PULL_REQUEST}."
               circleci-agent step halt;
             fi
@@ -32,10 +31,10 @@ commands:
               git remote add upstream git://github.com/matplotlib/matplotlib.git
             fi
             git fetch upstream
-            echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
-            if [[ $(cat merge.txt) != "" ]]; then
-              echo "Merging $(cat merge.txt)";
-              git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
+            export merge=${CI_PULL_REQUEST//*pull\//}
+            if [[ "$merge" != "" ]]; then
+              echo "Merging ${merge})";
+              git pull --ff-only upstream "refs/pull/${merge}/merge";
             fi
 
   apt-install:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,6 @@ commands:
               git remote add upstream git://github.com/matplotlib/matplotlib.git
             fi
             git fetch upstream
-            echo $(git log -1 --pretty=%B) | tee gitlog.txt
             echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
             if [[ $(cat merge.txt) != "" ]]; then
               echo "Merging $(cat merge.txt)";

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ commands:
             git fetch upstream
             export merge=${CI_PULL_REQUEST//*pull\//}
             if [[ "$merge" != "" ]]; then
-              echo "Merging ${merge})";
+              echo "Merging ${merge}";
               git pull --ff-only upstream "refs/pull/${merge}/merge";
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,22 @@ version: 2.1
 #
 
 commands:
+  merge:
+    steps:
+      - run:
+          name: Merge with upstream
+          command: |
+            if ! git remote -v | grep upstream; then
+              git remote add upstream git://github.com/matplotlib/matplotlib.git
+            fi
+            git fetch upstream
+            echo $(git log -1 --pretty=%B) | tee gitlog.txt
+            echo ${CI_PULL_REQUEST//*pull\//} | tee merge.txt
+            if [[ $(cat merge.txt) != "" ]]; then
+              echo "Merging $(cat merge.txt)";
+              git pull --ff-only upstream "refs/pull/$(cat merge.txt)/merge";
+            fi
+
   apt-install:
     steps:
       - run:
@@ -124,6 +140,7 @@ jobs:
       - image: circleci/python:3.8
     steps:
       - checkout
+      - merge
 
       - apt-install
       - fonts-install

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -10,3 +10,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: docs-python38
+          job-title: Check the rendered docs here!

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,122 +3,143 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/python?view=azure-devops
 
-strategy:
-  matrix:
-    Linux_py37:
+stages:
+
+- stage: Check
+  jobs:
+  - job: Skip
+    pool:
       vmImage: 'ubuntu-18.04'
-      python.version: '3.7'
-    Linux_py38:
-      vmImage: 'ubuntu-18.04'
-      python.version: '3.8'
-    Linux_py39:
-      vmImage: 'ubuntu-18.04'
-      python.version: '3.9'
-    macOS_py37:
-      vmImage: 'macOS-10.15'
-      python.version: '3.7'
-    macOS_py38:
-      vmImage: 'macOS-latest'
-      python.version: '3.8'
-    macOS_py39:
-      vmImage: 'macOS-latest'
-      python.version: '3.9'
-    Windows_py37:
-      vmImage: 'vs2017-win2016'
-      python.version: '3.7'
-    Windows_py38:
-      vmImage: 'windows-latest'
-      python.version: '3.8'
-    Windows_py39:
-      vmImage: 'windows-latest'
-      python.version: '3.9'
-  maxParallel: 4
+    variables:
+      DECODE_PERCENTS: 'false'
+      RET: 'true'
+    steps:
+    - bash: |
+        git_log=`git log --max-count=1 --skip=1 --pretty=format:"%B" | tr "\n" " "`
+        echo "##vso[task.setvariable variable=log]$git_log"
+    - bash: echo "##vso[task.setvariable variable=RET]false"
+      condition: or(contains(variables.log, '[skip azp]'), contains(variables.log, '[azp skip]'), contains(variables.log, '[skip ci]'), contains(variables.log, '[ci skip]'))
+    - bash: echo "##vso[task.setvariable variable=start_main;isOutput=true]$RET"
+      name: result
 
-pool:
-  vmImage: '$(vmImage)'
+- stage: Main
+  condition: and(succeeded(), eq(dependencies.Check.outputs['Skip.result.start_main'], 'true'))
+  dependsOn: Check
+  jobs:
+    - job: Pytest
+      strategy:
+        matrix:
+          Linux_py37:
+            vmImage: 'ubuntu-18.04'
+            python.version: '3.7'
+          Linux_py38:
+            vmImage: 'ubuntu-18.04'
+            python.version: '3.8'
+          Linux_py39:
+            vmImage: 'ubuntu-18.04'
+            python.version: '3.9'
+          macOS_py37:
+            vmImage: 'macOS-10.15'
+            python.version: '3.7'
+          macOS_py38:
+            vmImage: 'macOS-latest'
+            python.version: '3.8'
+          macOS_py39:
+            vmImage: 'macOS-latest'
+            python.version: '3.9'
+          Windows_py37:
+            vmImage: 'vs2017-win2016'
+            python.version: '3.7'
+          Windows_py38:
+            vmImage: 'windows-latest'
+            python.version: '3.8'
+          Windows_py39:
+            vmImage: 'windows-latest'
+            python.version: '3.9'
+        maxParallel: 4
+      pool:
+        vmImage: '$(vmImage)'
+      steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: '$(python.version)'
+          architecture: 'x64'
+        displayName: 'Use Python $(python.version)'
+        condition: and(succeeded(), ne(variables['python.version'], 'Pre'))
 
-steps:
+      - task: stevedower.python.InstallPython.InstallPython@1
+        displayName: 'Use prerelease Python'
+        inputs:
+          prerelease: true
+        condition: and(succeeded(), eq(variables['python.version'], 'Pre'))
 
-- task: UsePythonVersion@0
-  inputs:
-    versionSpec: '$(python.version)'
-    architecture: 'x64'
-  displayName: 'Use Python $(python.version)'
-  condition: and(succeeded(), ne(variables['python.version'], 'Pre'))
+      - bash: |
+          set -e
+          case "$(python -c 'import sys; print(sys.platform)')" in
+          linux)
+            sudo apt update
+            sudo apt install \
+              cm-super \
+              dvipng \
+              ffmpeg \
+              gdb \
+              gir1.2-gtk-3.0 \
+              graphviz \
+              inkscape \
+              libcairo2 \
+              libgirepository-1.0.1 \
+              lmodern \
+              fonts-freefont-otf \
+              poppler-utils \
+              texlive-pictures \
+              texlive-fonts-recommended \
+              texlive-latex-base \
+              texlive-latex-extra \
+              texlive-latex-recommended \
+              texlive-xetex texlive-luatex \
+              ttf-wqy-zenhei
+            ;;
+          darwin)
+            brew install --cask xquartz
+            brew install pkg-config ffmpeg imagemagick mplayer ccache
+            ;;
+          win32)
+            ;;
+          *)
+            exit 1
+            ;;
+          esac
+        displayName: 'Install dependencies'
 
-- task: stevedower.python.InstallPython.InstallPython@1
-  displayName: 'Use prerelease Python'
-  inputs:
-    prerelease: true
-  condition: and(succeeded(), eq(variables['python.version'], 'Pre'))
+      - bash: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements/testing/all.txt -r requirements/testing/extra.txt ||
+            [[ "$PYTHON_VERSION" = 'Pre' ]]
+        displayName: 'Install dependencies with pip'
 
-- bash: |
-    set -e
-    case "$(python -c 'import sys; print(sys.platform)')" in
-    linux)
-      sudo apt update
-      sudo apt install \
-        cm-super \
-        dvipng \
-        ffmpeg \
-        gdb \
-        gir1.2-gtk-3.0 \
-        graphviz \
-        inkscape \
-        libcairo2 \
-        libgirepository-1.0.1 \
-        lmodern \
-        fonts-freefont-otf \
-        poppler-utils \
-        texlive-pictures \
-        texlive-fonts-recommended \
-        texlive-latex-base \
-        texlive-latex-extra \
-        texlive-latex-recommended \
-        texlive-xetex texlive-luatex \
-        ttf-wqy-zenhei
-      ;;
-    darwin)
-      brew install --cask xquartz
-      brew install pkg-config ffmpeg imagemagick mplayer ccache
-      ;;
-    win32)
-      ;;
-    *)
-      exit 1
-      ;;
-    esac
-  displayName: 'Install dependencies'
+      - bash: |
+          python -m pip install -ve . ||
+            [[ "$PYTHON_VERSION" = 'Pre' ]]
+        displayName: "Install self"
 
-- bash: |
-    python -m pip install --upgrade pip
-    python -m pip install -r requirements/testing/all.txt -r requirements/testing/extra.txt ||
-      [[ "$PYTHON_VERSION" = 'Pre' ]]
-  displayName: 'Install dependencies with pip'
+      - script: env
+        displayName: 'print env'
 
-- bash: |
-    python -m pip install -ve . ||
-      [[ "$PYTHON_VERSION" = 'Pre' ]]
-  displayName: "Install self"
+      - bash: |
+          PYTHONFAULTHANDLER=1 python -m pytest --junitxml=junit/test-results.xml -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n 2 ||
+            [[ "$PYTHON_VERSION" = 'Pre' ]]
+        displayName: 'pytest'
 
-- script: env
-  displayName: 'print env'
+      - bash: |
+          bash <(curl -s https://codecov.io/bash)  -f "!*.gcov" -X gcov
+        displayName: 'Upload to codecov.io'
 
-- bash: |
-    PYTHONFAULTHANDLER=1 python -m pytest --junitxml=junit/test-results.xml -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n 2 ||
-      [[ "$PYTHON_VERSION" = 'Pre' ]]
-  displayName: 'pytest'
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: '**/test-results.xml'
+          testRunTitle: 'Python $(python.version)'
+        condition: succeededOrFailed()
 
-- bash: |
-    bash <(curl -s https://codecov.io/bash)  -f "!*.gcov" -X gcov
-  displayName: 'Upload to codecov.io'
-
-- task: PublishTestResults@2
-  inputs:
-    testResultsFiles: '**/test-results.xml'
-    testRunTitle: 'Python $(python.version)'
-  condition: succeededOrFailed()
-
-- publish: $(System.DefaultWorkingDirectory)/result_images
-  artifact: $(Agent.JobName)-result_images
-  condition: and(failed(), ne(variables['python.version'], 'Pre'))
+      - publish: $(System.DefaultWorkingDirectory)/result_images
+        artifact: $(Agent.JobName)-result_images
+        condition: and(failed(), ne(variables['python.version'], 'Pre'))

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -220,14 +220,15 @@ will run on all supported platforms and versions of Python.
   .. _tox: https://tox.readthedocs.io/
 
 * If you know your changes do not need to be tested (this is very rare!), all
-  CIs can be skipped by including ``[ci skip]`` or ``[skip ci]`` in your
-  commit message. If you know only a subset of CIs need to be run (e.g.,
-  if you are changing some block of plain reStructuredText and only want
-  only CircleCI to run to render the result), individual CIs can be skipped
-  to save bandwidth using:
+  CIs can be skipped for a given commit by including ``[ci skip]`` or
+  ``[skip ci]`` in the commit message. If you know only a subset of CIs need
+  to be run (e.g., if you are changing some block of plain reStructuredText and
+  want only CircleCI to run to render the result), individual CIs can be
+  skipped on individual commits as well by using the following substrings
+  in commit messages:
 
   - GitHub Actions: ``[skip actions]``
-  - AppVeyor: ``[skip appveyor]``
+  - AppVeyor: ``[skip appveyor]`` (must be in the first line of the commit)
   - Azure Pipelines: ``[skip azp]``
   - CircleCI: ``[skip circle]``
 

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -219,6 +219,17 @@ will run on all supported platforms and versions of Python.
 
   .. _tox: https://tox.readthedocs.io/
 
+* If you know your changes do not need to be tested (this is very rare!), all
+  CIs can be skipped by including ``[ci skip]`` or ``[skip ci]`` in your
+  commit message. If you know only a subset of CIs need to be run (e.g.,
+  if you are changing some block of plain reStructuredText and only want
+  only CircleCI to run to render the result), individual CIs can be skipped
+  to save bandwidth using:
+
+  - GitHub Actions: ``[skip actions]``
+  - AppVeyor: ``[skip appveyor]``
+  - Azure Pipelines: ``[skip azp]``
+  - CircleCI: ``[skip circle]``
 
 .. _pr-squashing:
 


### PR DESCRIPTION
## PR Summary

1. Build a merged version of each PR instead of the branch itself on CircleCI.
2. Update `circleci-artifacts-redirector-action` to say "Check the rendered docs here!" as its GitHub status title, but this will only take effect once this PR is merged (because the action is triggered by `status` and thus always runs on whatever is in the action in `master`).
3. Add `[skip circle]` and `[circle skip]` support to skip CircleCI
4. Add `[skip azp]` and `[azp skip]` support to skip Azure
5. Document in devdocs that these `skip` options exist, alongside `[skip actions]` and `[skip appveyor]` (which are natively supported by those platforms)

Closes #20658

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
