### PR TITLE
Fix some very unlikely leaks in extensions.

### DIFF
--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -656,19 +656,21 @@ PyMODINIT_FUNC PyInit__backend_agg(void)
 {
     PyObject *m;
 
+    import_array();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
         return NULL;
     }
 
-    import_array();
-
     if (!PyRendererAgg_init_type(m, &PyRendererAggType)) {
+        Py_DECREF(m);
         return NULL;
     }
 
     if (!PyBufferRegion_init_type(m, &PyBufferRegionType)) {
+        Py_DECREF(m);
         return NULL;
     }
 

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -170,6 +170,8 @@ PyMODINIT_FUNC PyInit__contour(void)
 {
     PyObject *m;
 
+    import_array();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
@@ -177,10 +179,9 @@ PyMODINIT_FUNC PyInit__contour(void)
     }
 
     if (!PyQuadContourGenerator_init_type(m, &PyQuadContourGeneratorType)) {
+        Py_DECREF(m);
         return NULL;
     }
-
-    import_array();
 
     return m;
 }

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -312,6 +312,8 @@ PyMODINIT_FUNC PyInit__image(void)
 {
     PyObject *m;
 
+    import_array();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
@@ -336,10 +338,9 @@ PyMODINIT_FUNC PyInit__image(void)
         PyModule_AddIntConstant(m, "LANCZOS", LANCZOS) ||
         PyModule_AddIntConstant(m, "BLACKMAN", BLACKMAN) ||
         PyModule_AddIntConstant(m, "_n_interpolation", _n_interpolation)) {
+        Py_DECREF(m);
         return NULL;
     }
-
-    import_array();
 
     return m;
 }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -908,13 +908,14 @@ static struct PyModuleDef moduledef = {
 PyMODINIT_FUNC PyInit__path(void)
 {
     PyObject *m;
+
+    import_array();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
         return NULL;
     }
-
-    import_array();
 
     return m;
 }

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1551,6 +1551,8 @@ PyMODINIT_FUNC PyInit_ft2font(void)
 {
     PyObject *m;
 
+    import_array();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
@@ -1558,14 +1560,17 @@ PyMODINIT_FUNC PyInit_ft2font(void)
     }
 
     if (!PyFT2Image_init_type(m, &PyFT2ImageType)) {
+        Py_DECREF(m);
         return NULL;
     }
 
     if (!PyGlyph_init_type(m, &PyGlyphType)) {
+        Py_DECREF(m);
         return NULL;
     }
 
     if (!PyFT2Font_init_type(m, &PyFT2FontType)) {
+        Py_DECREF(m);
         return NULL;
     }
 
@@ -1607,6 +1612,7 @@ PyMODINIT_FUNC PyInit_ft2font(void)
         add_dict_int(d, "LOAD_TARGET_MONO", (unsigned long)FT_LOAD_TARGET_MONO) ||
         add_dict_int(d, "LOAD_TARGET_LCD", (unsigned long)FT_LOAD_TARGET_LCD) ||
         add_dict_int(d, "LOAD_TARGET_LCD_V", (unsigned long)FT_LOAD_TARGET_LCD_V)) {
+        Py_DECREF(m);
         return NULL;
     }
 
@@ -1615,6 +1621,7 @@ PyMODINIT_FUNC PyInit_ft2font(void)
 
     if (error) {
         PyErr_SetString(PyExc_RuntimeError, "Could not initialize the freetype2 library");
+        Py_DECREF(m);
         return NULL;
     }
 
@@ -1625,15 +1632,15 @@ PyMODINIT_FUNC PyInit_ft2font(void)
         FT_Library_Version(_ft2Library, &major, &minor, &patch);
         sprintf(version_string, "%d.%d.%d", major, minor, patch);
         if (PyModule_AddStringConstant(m, "__freetype_version__", version_string)) {
+            Py_DECREF(m);
             return NULL;
         }
     }
 
     if (PyModule_AddStringConstant(m, "__freetype_build_type__", STRINGIFY(FREETYPE_BUILD_TYPE))) {
+        Py_DECREF(m);
         return NULL;
     }
-
-    import_array();
 
     return m;
 }

--- a/src/qhull_wrap.cpp
+++ b/src/qhull_wrap.cpp
@@ -322,13 +322,13 @@ PyInit__qhull(void)
 {
     PyObject* m;
 
+    import_array();
+
     m = PyModule_Create(&qhull_module);
 
     if (m == NULL) {
         return NULL;
     }
-
-    import_array();
 
     return m;
 }

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -510,6 +510,8 @@ PyMODINIT_FUNC PyInit__tri(void)
 {
     PyObject *m;
 
+    import_array();
+
     m = PyModule_Create(&moduledef);
 
     if (m == NULL) {
@@ -517,16 +519,17 @@ PyMODINIT_FUNC PyInit__tri(void)
     }
 
     if (!PyTriangulation_init_type(m, &PyTriangulationType)) {
+        Py_DECREF(m);
         return NULL;
     }
     if (!PyTriContourGenerator_init_type(m, &PyTriContourGeneratorType)) {
+        Py_DECREF(m);
         return NULL;
     }
     if (!PyTrapezoidMapTriFinder_init_type(m, &PyTrapezoidMapTriFinderType)) {
+        Py_DECREF(m);
         return NULL;
     }
-
-    import_array();
 
     return m;
 }


### PR DESCRIPTION
## PR Summary

The newly created module may leak if any following initialization fails. Since `import_array` is a macro that hides a `return`-on-failure, that needs to move earlier before the module creation.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).