### PR TITLE
Fix setting artists properties of selectors

### DIFF
--- a/doc/api/next_api_changes/deprecations/20693-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20693-EP.rst
@@ -1,0 +1,4 @@
+PolygonSelector
+^^^^^^^^^^^^^^^
+The *line* attribute is deprecated. If you want to change the selector
+artist properties, use the ``set_props`` or ``set_handle_props`` methods.

--- a/doc/users/next_whats_new/setting_artists_properties_selector.rst
+++ b/doc/users/next_whats_new/setting_artists_properties_selector.rst
@@ -1,0 +1,5 @@
+Setting artist properties of selectors
+--------------------------------------
+
+The artist properties of selectors can be changed using the ``set_props`` and
+``set_handle_props`` methods.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -106,15 +106,13 @@ def test_rectangle_selector_set_props_handle_props():
 
     artist = tool._selection_artist
     assert artist.get_facecolor() == mcolors.to_rgba('b', alpha=0.2)
-    props = dict(facecolor='r', alpha=0.3)
-    tool.set_props(**props)
-    assert artist.get_facecolor() == mcolors.to_rgba(*props.values())
+    tool.set_props(facecolor='r', alpha=0.3)
+    assert artist.get_facecolor() == mcolors.to_rgba('r', alpha=0.3)
 
     for artist in tool._handles_artists:
         assert artist.get_markeredgecolor() == 'black'
         assert artist.get_alpha() == 0.5
-    handle_props = dict(markeredgecolor='r', alpha=0.3)
-    tool.set_handle_props(**handle_props)
+    tool.set_handle_props(markeredgecolor='r', alpha=0.3)
     for artist in tool._handles_artists:
         assert artist.get_markeredgecolor() == 'r'
         assert artist.get_alpha() == 0.3
@@ -450,15 +448,13 @@ def test_span_selector_set_props_handle_props():
 
     artist = tool._selection_artist
     assert artist.get_facecolor() == mcolors.to_rgba('b', alpha=0.2)
-    props = dict(facecolor='r', alpha=0.3)
-    tool.set_props(**props)
-    assert artist.get_facecolor() == mcolors.to_rgba(*props.values())
+    tool.set_props(facecolor='r', alpha=0.3)
+    assert artist.get_facecolor() == mcolors.to_rgba('r', alpha=0.3)
 
     for artist in tool._handles_artists:
         assert artist.get_color() == 'b'
         assert artist.get_alpha() == 0.5
-    handle_props = dict(color='r', alpha=0.3)
-    tool.set_handle_props(**handle_props)
+    tool.set_handle_props(color='r', alpha=0.3)
     for artist in tool._handles_artists:
         assert artist.get_color() == 'r'
         assert artist.get_alpha() == 0.3
@@ -865,16 +861,14 @@ def test_polygon_selector_set_props_handle_props():
     artist = tool._selection_artist
     assert artist.get_color() == 'b'
     assert artist.get_alpha() == 0.2
-    props = dict(color='r', alpha=0.3)
-    tool.set_props(**props)
-    assert artist.get_color() == props['color']
-    assert artist.get_alpha() == props['alpha']
+    tool.set_props(color='r', alpha=0.3)
+    assert artist.get_color() == 'r'
+    assert artist.get_alpha() == 0.3
 
     for artist in tool._handles_artists:
         assert artist.get_color() == 'b'
         assert artist.get_alpha() == 0.5
-    handle_props = dict(color='r', alpha=0.3)
-    tool.set_handle_props(**handle_props)
+    tool.set_handle_props(color='r', alpha=0.3)
     for artist in tool._handles_artists:
         assert artist.get_color() == 'r'
         assert artist.get_alpha() == 0.3

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -90,6 +90,36 @@ def test_rectangle_drag(drag_from_anywhere, new_center):
     assert tool.center == (180, 190)
 
 
+def test_rectangle_selector_set_props_handle_props():
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True,
+                                     props=dict(facecolor='b', alpha=0.2),
+                                     handle_props=dict(alpha=0.5))
+    # Create rectangle
+    do_event(tool, 'press', xdata=0, ydata=10, button=1)
+    do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
+    do_event(tool, 'release', xdata=100, ydata=120, button=1)
+
+    artist = tool.artists[0]
+    assert artist.get_facecolor() == mcolors.to_rgba('b', alpha=0.2)
+    props = dict(facecolor='r', alpha=0.3)
+    tool.set_props(**props)
+    assert artist.get_facecolor() == mcolors.to_rgba(*props.values())
+
+    for artist in tool._handles_artists:
+        assert artist.get_markeredgecolor() == 'black'
+        assert artist.get_alpha() == 0.5
+    handle_props = dict(markeredgecolor='r', alpha=0.3)
+    tool.set_handle_props(**handle_props)
+    for artist in tool._handles_artists:
+        assert artist.get_markeredgecolor() == 'r'
+        assert artist.get_alpha() == 0.3
+
+
 def test_ellipse():
     """For ellipse, test out the key modifiers"""
     ax = get_ax()
@@ -185,9 +215,9 @@ def test_rectangle_handles():
 
     # Check that marker_props worked.
     assert mcolors.same_color(
-        tool._corner_handles.artist.get_markerfacecolor(), 'r')
+        tool._corner_handles.artists[0].get_markerfacecolor(), 'r')
     assert mcolors.same_color(
-        tool._corner_handles.artist.get_markeredgecolor(), 'b')
+        tool._corner_handles.artists[0].get_markeredgecolor(), 'b')
 
 
 @pytest.mark.parametrize('interactive', [True, False])
@@ -402,6 +432,36 @@ def test_span_selector_direction():
 
     with pytest.raises(ValueError):
         tool.direction = 'invalid_string'
+
+
+def test_span_selector_set_props_handle_props():
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal', interactive=True,
+                                props=dict(facecolor='b', alpha=0.2),
+                                handle_props=dict(alpha=0.5))
+    # Create rectangle
+    do_event(tool, 'press', xdata=0, ydata=10, button=1)
+    do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
+    do_event(tool, 'release', xdata=100, ydata=120, button=1)
+
+    artist = tool.artists[0]
+    assert artist.get_facecolor() == mcolors.to_rgba('b', alpha=0.2)
+    props = dict(facecolor='r', alpha=0.3)
+    tool.set_props(**props)
+    assert artist.get_facecolor() == mcolors.to_rgba(*props.values())
+
+    for artist in tool._handles_artists:
+        assert artist.get_color() == 'b'
+        assert artist.get_alpha() == 0.5
+    handle_props = dict(color='r', alpha=0.3)
+    tool.set_handle_props(**handle_props)
+    for artist in tool._handles_artists:
+        assert artist.get_color() == 'r'
+        assert artist.get_alpha() == 0.3
 
 
 def test_tool_line_handle():
@@ -779,6 +839,45 @@ def test_polygon_selector():
                       + polygon_place_vertex(50, 150)
                       + polygon_place_vertex(50, 50))
     check_polygon_selector(event_sequence, expected_result, 1)
+
+
+def test_polygon_selector_set_props_handle_props():
+    ax = get_ax()
+
+    ax._selections_count = 0
+
+    def onselect(vertices):
+        ax._selections_count += 1
+        ax._current_result = vertices
+
+    tool = widgets.PolygonSelector(ax, onselect,
+                                   props=dict(color='b', alpha=0.2),
+                                   handle_props=dict(alpha=0.5))
+
+    event_sequence = (polygon_place_vertex(50, 50)
+                      + polygon_place_vertex(150, 50)
+                      + polygon_place_vertex(50, 150)
+                      + polygon_place_vertex(50, 50))
+
+    for (etype, event_args) in event_sequence:
+        do_event(tool, etype, **event_args)
+
+    artist = tool.artists[0]
+    assert artist.get_color() == 'b'
+    assert artist.get_alpha() == 0.2
+    props = dict(color='r', alpha=0.3)
+    tool.set_props(**props)
+    assert artist.get_color() == props['color']
+    assert artist.get_alpha() == props['alpha']
+
+    for artist in tool._handles_artists:
+        assert artist.get_color() == 'b'
+        assert artist.get_alpha() == 0.5
+    handle_props = dict(color='r', alpha=0.3)
+    tool.set_handle_props(**handle_props)
+    for artist in tool._handles_artists:
+        assert artist.get_color() == 'r'
+        assert artist.get_alpha() == 0.3
 
 
 @pytest.mark.parametrize(

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -104,7 +104,7 @@ def test_rectangle_selector_set_props_handle_props():
     do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
     do_event(tool, 'release', xdata=100, ydata=120, button=1)
 
-    artist = tool.artists[0]
+    artist = tool._selection_artist
     assert artist.get_facecolor() == mcolors.to_rgba('b', alpha=0.2)
     props = dict(facecolor='r', alpha=0.3)
     tool.set_props(**props)
@@ -448,7 +448,7 @@ def test_span_selector_set_props_handle_props():
     do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
     do_event(tool, 'release', xdata=100, ydata=120, button=1)
 
-    artist = tool.artists[0]
+    artist = tool._selection_artist
     assert artist.get_facecolor() == mcolors.to_rgba('b', alpha=0.2)
     props = dict(facecolor='r', alpha=0.3)
     tool.set_props(**props)
@@ -862,7 +862,7 @@ def test_polygon_selector_set_props_handle_props():
     for (etype, event_args) in event_sequence:
         do_event(tool, etype, **event_args)
 
-    artist = tool.artists[0]
+    artist = tool._selection_artist
     assert artist.get_color() == 'b'
     assert artist.get_alpha() == 0.2
     props = dict(color='r', alpha=0.3)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2021,7 +2021,11 @@ class _SelectorWidget(AxesWidget):
         Set the properties of the selector artist. See the `props` argument
         in the selector docstring to know which properties are supported.
         """
-        self._selection_artist.set(**props)
+        artist = self._selection_artist
+        alias_map = getattr(artist, '_alias_map', None)
+        if alias_map:
+            props = cbook.normalize_kwargs(props, alias_map)
+        artist.set(**props)
         if self.useblit:
             self.update()
         self._props.update(props)
@@ -2034,6 +2038,11 @@ class _SelectorWidget(AxesWidget):
         """
         if not hasattr(self, '_handles_artists'):
             raise NotImplementedError("This selector doesn't have handles.")
+
+        artist = self._handles_artists[0]
+        alias_map = getattr(artist, '_alias_map', None)
+        if alias_map:
+            handle_props = cbook.normalize_kwargs(handle_props, alias_map)
         for handle in self._handles_artists:
             handle.set(**handle_props)
         if self.useblit:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2180,7 +2180,9 @@ class SpanSelector(_SelectorWidget):
         # prev attribute is deprecated but we still need to maintain it
         self._prev = (0, 0)
 
-    rect = _api.deprecate_privatize_attribute("3.5")
+    rect = _api.deprecated("3.5")(
+        property(lambda self: self.artists[0])
+        )
 
     rectprops = _api.deprecated("3.5")(
         property(lambda self: self._props)
@@ -2842,7 +2844,9 @@ class RectangleSelector(_SelectorWidget):
 
         self._extents_on_press = None
 
-    to_draw = _api.deprecate_privatize_attribute("3.5")
+    to_draw = _api.deprecated("3.5")(
+        property(lambda self: self.artists[0])
+        )
 
     drawtype = _api.deprecate_privatize_attribute("3.5")
 
@@ -3370,6 +3374,10 @@ class PolygonSelector(_SelectorWidget):
 
         self._artists = [line] + list(self._handles_artists)
         self.set_visible(True)
+
+    line = _api.deprecated("3.5")(
+        property(lambda self: self.artists[0])
+        )
 
     vertex_select_radius = _api.deprecated("3.5", name="vertex_select_radius",
                                            alternative="grab_range")(

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2012,7 +2012,7 @@ class _SelectorWidget(AxesWidget):
     def artists(self):
         """Tuple of the artists of the selector."""
         if getattr(self, '_handles_artists', None) is not None:
-            return (self._selection_artist, ) + self._handles_artists
+            return (self._selection_artist, *self._handles_artists)
         else:
             return (self._selection_artist, )
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2022,9 +2022,7 @@ class _SelectorWidget(AxesWidget):
         in the selector docstring to know which properties are supported.
         """
         artist = self._selection_artist
-        alias_map = getattr(artist, '_alias_map', None)
-        if alias_map:
-            props = cbook.normalize_kwargs(props, alias_map)
+        props = cbook.normalize_kwargs(props, artist)
         artist.set(**props)
         if self.useblit:
             self.update()
@@ -2040,9 +2038,7 @@ class _SelectorWidget(AxesWidget):
             raise NotImplementedError("This selector doesn't have handles.")
 
         artist = self._handles_artists[0]
-        alias_map = getattr(artist, '_alias_map', None)
-        if alias_map:
-            handle_props = cbook.normalize_kwargs(handle_props, alias_map)
+        handle_props = cbook.normalize_kwargs(handle_props, artist)
         for handle in self._handles_artists:
             handle.set(**handle_props)
         if self.useblit:
@@ -2178,7 +2174,7 @@ class SpanSelector(_SelectorWidget):
         # Setup handles
         self._handle_props = {
             'color': props.get('facecolor', 'r'),
-            **cbook.normalize_kwargs(handle_props, Line2D._alias_map)}
+            **cbook.normalize_kwargs(handle_props, Line2D)}
 
         if self._interactive:
             self._edge_order = ['min', 'max']
@@ -2824,7 +2820,7 @@ class RectangleSelector(_SelectorWidget):
             self._handle_props = {
                 'markeredgecolor': (self._props or {}).get(
                     'edgecolor', 'black'),
-                **cbook.normalize_kwargs(handle_props, Line2D._alias_map)}
+                **cbook.normalize_kwargs(handle_props, Line2D)}
 
             self._corner_order = ['NW', 'NE', 'SE', 'SW']
             xc, yc = self.corners
@@ -2863,8 +2859,8 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def _handles_artists(self):
-        return (self._center_handle.artists + self._corner_handles.artists +
-                self._edge_handles.artists)
+        return (*self._center_handle.artists, *self._corner_handles.artists,
+                *self._edge_handles.artists)
 
     def _press(self, event):
         """Button press event handler."""
@@ -3498,8 +3494,7 @@ class PolygonSelector(_SelectorWidget):
         else:
             # Calculate distance to the start vertex.
             x0, y0 = self._selection_artist.get_transform().transform(
-                    (self._xs[0],
-                     self._ys[0])
+                    (self._xs[0], self._ys[0])
                 )
             v0_dist = np.hypot(x0 - event.x, y0 - event.y)
             # Lock on to the start vertex if near it and ready to complete.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2011,10 +2011,8 @@ class _SelectorWidget(AxesWidget):
     @property
     def artists(self):
         """Tuple of the artists of the selector."""
-        if getattr(self, '_handles_artists', None) is not None:
-            return (self._selection_artist, *self._handles_artists)
-        else:
-            return (self._selection_artist, )
+        handles_artists = getattr(self, '_handles_artists', ())
+        return (self._selection_artist,) + handles_artists
 
     def set_props(self, **props):
         """
@@ -2245,6 +2243,8 @@ class SpanSelector(_SelectorWidget):
     def _handles_artists(self):
         if self._edge_handles is not None:
             return self._edge_handles.artists
+        else:
+            return ()
 
     def _set_cursor(self, enabled):
         """Update the canvas cursor based on direction of the selector."""


### PR DESCRIPTION
## PR Summary

Fix #20618 by adding `set_props` and `set_handle_props` method. ~~This PR needs a bit of tidying up but I would like to know if we are happy with this approach!~~

A few others changes:
- `selector.artists` is now a property returning a tuple of all artists to disallow changing the artists through a public API
- Add `_selection_artist` and `_handles_artists` to access the corresponding artists internally. ~~Remove the use of `SpanSelector._rect` and other, because it is already accessible through `artists[0]`, maybe this is still better to keep a separate attribute?~~

```python
import matplotlib.pyplot as plt
from matplotlib.widgets import SpanSelector
import numpy as np

values = np.arange(-10, 100)

fig = plt.figure()
ax = fig.add_subplot()
ax.plot(values, values)

span = SpanSelector(ax, print, "horizontal", interactive=True)

span.set_props(color='green')
span.set_handle_props(color='green')
```

Alternative could be:
- use `props` and `handle_props` setter
- add methods to get artists, something along the line of: `get_main_artist` `get_handle_artists`, which could use as `span.get_main_artist().set(facecolor='green')`, for `get_handle_artists`, it would be necessary to loop over the tuple

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
