### PR TITLE
FIX/ENH: Introduce a monolithic legend handler for Line2D

### DIFF
--- a/doc/api/next_api_changes/2018-06-01-AFV.rst
+++ b/doc/api/next_api_changes/2018-06-01-AFV.rst
@@ -1,0 +1,32 @@
+Change of the (default) legend handler for Line2D instances
+-----------------------------------------------------------
+
+The default legend handler for Line2D instances (`.HandlerLine2D`) now
+consistently exposes all the attributes and methods related to the line
+marker (:ghissue:`11358`). This makes easy to change the marker features
+after instantiating a legend.
+
+.. code::
+
+  import matplotlib.pyplot as plt
+
+  fig, ax = plt.subplots()
+
+  ax.plot([1, 3, 2], marker="s", label="Line", color="pink", mec="red", ms=8)
+  leg = ax.legend()
+
+  leg.legendHandles[0].set_color("lightgray")
+  leg.legendHandles[0].set_mec("black")  # marker edge color
+
+The former legend handler for Line2D objects has been renamed
+`.HandlerLine2DCompound`. To revert to the behavior that was used before
+Matplotlib 3, one can use
+
+.. code::
+
+  import matplotlib.legend as mlegend
+  from matplotlib.legend_handler import HandlerLine2DCompound
+  from matplotlib.lines import Line2D
+
+  mlegend.Legend.update_default_handler_map({Line2D: HandlerLine2DCompound()})
+

--- a/doc/api/next_api_changes/behavior/20699-AFV.rst
+++ b/doc/api/next_api_changes/behavior/20699-AFV.rst
@@ -19,8 +19,7 @@ after instantiating a legend.
   leg.legendHandles[0].set_mec("black")  # marker edge color
 
 The former legend handler for Line2D objects has been renamed
-`.HandlerLine2DCompound`. To revert to the behavior that was used before
-Matplotlib 3, one can use
+`.HandlerLine2DCompound`. To revert to the previous behavior, one can use
 
 .. code::
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -207,8 +207,9 @@ class HandlerNpointsYoffsets(HandlerNpoints):
 class HandlerLine2DCompound(HandlerNpoints):
     """
     Original handler for `.Line2D` instances, that relies on combining
-    a line-only with a marker-only artist.
+    a line-only with a marker-only artist.  May be deprecated in the future.
     """
+
     def __init__(self, marker_pad=0.3, numpoints=None, **kwargs):
         """
         Parameters
@@ -257,25 +258,22 @@ class HandlerLine2D(HandlerNpoints):
     """
     Handler for `.Line2D` instances.
 
-    A class similar to the original handler for `.Line2D` instances but
-    that uses a monolithic artist rather than using one artist for the
-    line and another one for the marker(s).  NB: the former handler, in
-    use before Matplotlib 3, is still available as `.HandlerLine2DCompound`.
-
+    See Also
+    --------
+    HandlerLine2DCompound : An earlier handler implementation, which used one
+                            artist for the line and another for the marker(s).
     """
+
     def __init__(self, marker_pad=0.3, numpoints=None, **kw):
         """
         Parameters
         ----------
         marker_pad : float
             Padding between points in legend entry.
-
         numpoints : int
             Number of points to show in legend entry.
-
-        Notes
-        -----
-        Any other keyword arguments are given to `HandlerNpoints`.
+        **kwargs
+            Keyword arguments forwarded to `.HandlerNpoints`.
         """
         HandlerNpoints.__init__(self, marker_pad=marker_pad,
                                 numpoints=numpoints, **kw)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -295,7 +295,7 @@ class HandlerLine2D(HandlerNpoints):
             xdata = np.linspace(xdata[0], xdata[-1], 3)
             markevery = [1]
 
-        ydata = ((height - ydescent) / 2.) * np.ones(xdata.shape, float)
+        ydata = np.full_like(xdata, (height - ydescent) / 2)
         legline = Line2D(xdata, ydata, markevery=markevery)
 
         self.update_prop(legline, orig_handle, legend)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1358,8 +1358,12 @@ def test_markevery():
     ax.legend()
 
 
-@image_comparison(['markevery_line'], remove_text=True)
+@image_comparison(['markevery_line'], remove_text=True, tol=0.005)
 def test_markevery_line():
+    # TODO: a slight change in rendering between Inkscape versions may explain
+    # why one had to introduce a small non-zero tolerance for the SVG test
+    # to pass. One may try to remove this hack once Travis' Inkscape version
+    # is modern enough. FWIW, no failure with 0.92.3 on my computer (#11358).
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * np.sqrt(x/10 + 0.5)
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -865,9 +865,7 @@ def test_legend_text_axes():
 
 
 def test_handlerline2d():
-    '''Test consistency of the marker for the (monolithic) Line2D legend
-    handler (see #11357).
-    '''
+    # Test marker consistency for monolithic Line2D legend handler (#11357).
     fig, ax = plt.subplots()
     ax.scatter([0, 1], [0, 1], marker="v")
     handles = [mlines.Line2D([0], [0], marker="v")]

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 import matplotlib.transforms as mtransforms
 import matplotlib.collections as mcollections
+import matplotlib.lines as mlines
 from matplotlib.legend_handler import HandlerTuple
 import matplotlib.legend as mlegend
 from matplotlib import rc_context
@@ -861,3 +862,14 @@ def test_legend_text_axes():
 
     assert leg.axes is ax
     assert leg.get_texts()[0].axes is ax
+
+
+def test_handlerline2d():
+    '''Test consistency of the marker for the (monolithic) Line2D legend
+    handler (see #11357).
+    '''
+    fig, ax = plt.subplots()
+    ax.scatter([0, 1], [0, 1], marker="v")
+    handles = [mlines.Line2D([0], [0], marker="v")]
+    leg = ax.legend(handles, ["Aardvark"], numpoints=1)
+    assert handles[0].get_marker() == leg.legendHandles[0].get_marker()


### PR DESCRIPTION
## PR Summary

This is a rebase of #11358 (fixing #2035, #11357, #18391, #20552) on top of #20670 (to address https://github.com/matplotlib/matplotlib/pull/11358#discussion_r194247428) and with an additional commit on top to address other comments.

I decided to keep both legend handlers public for now (based on comments in the original thread); we can always decide to deprecate the old handler later.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
... except for `markevery=<float>` or `(<float>, <float>)` which is a
spec relative to the axes size (keeping handling of that specific case
into _mark_every_path).