### PR TITLE
Describe possible need for loading the 'lmodern' package when using PGF files

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -777,6 +777,10 @@ class FigureCanvasPgf(FigureCanvasBase):
 %% Make sure the required packages are loaded in your preamble
 %%   \\usepackage{pgf}
 %%
+%% Also ensure that all the required font packages are loaded; for instance, 
+%% the lmodern package is often necessary when using math font.
+%%   \\usepackage{lmodern}
+%%
 %% Figures using additional raster images can only be included by \\input if
 %% they are in the same directory as the main LaTeX file. For loading figures
 %% from other directories you can use the `import` package

--- a/tutorials/text/pgf.py
+++ b/tutorials/text/pgf.py
@@ -187,6 +187,11 @@ Troubleshooting
   using either the ``rasterized=True`` keyword, or ``.set_rasterized(True)`` as
   per :doc:`this example </gallery/misc/rasterization_demo>`.
 
+* Various math font are compiled and rendered only if corresponding font
+  packages are loaded. The ``lmodern`` package is often required when using
+  math symbols. See `discussion <https://matrix.to/#/!BXmyZMTnRjWJldDRLV:gitter.im/$M7KxLQuyUosx2byFxIsKJE8QS_14NRiWqmmlb6nSIfE?via=gitter.im&via=matrix.org>`
+  for more details.
+
 * If you still need help, please see :ref:`reporting-problems`
 
 .. _LaTeX: http://www.tug.org


### PR DESCRIPTION
## PR Summary

The PR adds a suggestion to use the `lmodern` package when using `.pgf` files generated by Matplotlib. Changes are made both to a documentation page as well as the commented preamble printed in every generated `.pgf` file.

This was found to be necessary specifically in the case of a math-bold-faced, uppercase Greek letter 'delta' was not rendered when the `lmodern` package was not loaded.

See discussion for more details:
https://matrix.to/#/!BXmyZMTnRjWJldDRLV:gitter.im/$M7KxLQuyUosx2byFxIsKJE8QS_14NRiWqmmlb6nSIfE?via=gitter.im&via=matrix.org

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).