### PR TITLE
Fix Circle merge on master branch.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,10 +31,10 @@ commands:
               git remote add upstream git://github.com/matplotlib/matplotlib.git
             fi
             git fetch upstream
-            export merge=${CI_PULL_REQUEST//*pull\//}
-            if [[ "$merge" != "" ]]; then
-              echo "Merging ${merge}";
-              git pull --ff-only upstream "refs/pull/${merge}/merge";
+            if [[ "$CIRCLE_BRANCH" != "master" ]] && \
+               [[ "$CIRCLE_PR_NUMBER" != "" ]]; then
+              echo "Merging ${CIRCLE_PR_NUMBER}"
+              git pull --ff-only upstream "refs/pull/${CIRCLE_PR_NUMBER}/merge"
             fi
 
   apt-install:


### PR DESCRIPTION
## PR Summary

There exists a PR on a random fork, which fills in `CI_PULL_REQUEST`, which we don't want to use as merge target when building `master`. Instead, check `CIRCLE_PR_NUMBER`, which is set only on forked PRs. Also, check branch name (which is current, not the _target_) to be certain.

Followup to #20680, @larsoner 

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).