### PR TITLE
Fix collection offsets

### DIFF
--- a/doc/users/next_whats_new/collection_offsets.rst
+++ b/doc/users/next_whats_new/collection_offsets.rst
@@ -2,4 +2,4 @@ Setting collection offset transform after initialization
 --------------------------------------------------------
 `~matplotlib.collections.Collection.set_offset_transform` was added.
 
-Previously the offset transform could not be set after initialization.
+Previously the offset transform could not be set after initialization. This can be helpful when creating a `Collection` outside an axes object and later adding it with `ax.add_collection` and settings the offset transform to `ax.transData`.

--- a/doc/users/next_whats_new/collection_offsets.rst
+++ b/doc/users/next_whats_new/collection_offsets.rst
@@ -1,5 +1,5 @@
 Setting collection offset transform after initialization
 --------------------------------------------------------
-`~matplotlib.collections.Collection.set_offset_transform` was added.
+`.collections.Collection.set_offset_transform()` was added.
 
-Previously the offset transform could not be set after initialization. This can be helpful when creating a `Collection` outside an axes object and later adding it with `ax.add_collection` and settings the offset transform to `ax.transData`.
+Previously the offset transform could not be set after initialization. This can be helpful when creating a `.collections.Collection` outside an axes object and later adding it with `.Axes.add_collection()` and settings the offset transform to `.Axes.transData`.

--- a/doc/users/next_whats_new/collection_offsets.rst
+++ b/doc/users/next_whats_new/collection_offsets.rst
@@ -1,0 +1,5 @@
+Setting collection offset transform after initialization
+--------------------------------------------------------
+`~matplotlib.collections.Collection.set_offset_transform` was added.
+
+Previously the offset transform could not be set after initialization.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -230,6 +230,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
     def set_offset_transform(self, transOffset):
         """
         Set the artist offset transform.
+
         Parameters
         ----------
         transOffset : `.Transform`

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -229,6 +229,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
     def set_offset_transform(self, transOffset):
         self._transOffset = transOffset
+        self.pchanged()
+        self.stale = True
 
     def get_datalim(self, transData):
         # Calculate the data limits and return them as a `.Bbox`.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -194,20 +194,18 @@ class Collection(artist.Artist, cm.ScalarMappable):
         else:
             self._joinstyle = None
 
+        # default to zeros
         self._offsets = np.zeros((1, 2))
-        # save if offsets passed in were none...
-        self._offsetsNone = offsets is None
-        self._uniform_offsets = None
+
         if offsets is not None:
             offsets = np.asanyarray(offsets, float)
             # Broadcast (2,) -> (1, 2) but nothing else.
             if offsets.shape == (2,):
                 offsets = offsets[None, :]
-            if transOffset is not None:
-                self._offsets = offsets
-                self._transOffset = transOffset
-            else:
-                self._uniform_offsets = offsets
+            self._offsets = offsets
+
+        if transOffset is not None:
+            self._transOffset = transOffset
 
         self._path_effects = None
         self.update(kwargs)
@@ -229,6 +227,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
             t = t._as_mpl_transform(self.axes)
         return t
 
+    def set_offset_transform(self, transOffset):
+        self._transOffset = transOffset
+
     def get_datalim(self, transData):
         # Calculate the data limits and return them as a `.Bbox`.
         #
@@ -248,8 +249,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         transform = self.get_transform()
         transOffset = self.get_offset_transform()
-        if (not self._offsetsNone and
-                not transOffset.contains_branch(transData)):
+        hasOffsets = np.any(self._offsets)  # True if any non-zero offsets
+        if (hasOffsets and not transOffset.contains_branch(transData)):
             # if there are offsets but in some coords other than data,
             # then don't use them for autoscaling.
             return transforms.Bbox.null()
@@ -279,7 +280,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                     self.get_transforms(),
                     transOffset.transform_non_affine(offsets),
                     transOffset.get_affine().frozen())
-            if not self._offsetsNone:
+            if hasOffsets:
                 # this is for collections that have their paths (shapes)
                 # in physical, axes-relative, or figure-relative units
                 # (i.e. like scatter). We can't uniquely set limits based on
@@ -542,20 +543,12 @@ class Collection(artist.Artist, cm.ScalarMappable):
         offsets = np.asanyarray(offsets, float)
         if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
             offsets = offsets[None, :]
-        # This decision is based on how they are initialized above in __init__.
-        if self._uniform_offsets is None:
-            self._offsets = offsets
-        else:
-            self._uniform_offsets = offsets
+        self._offsets = offsets
         self.stale = True
 
     def get_offsets(self):
         """Return the offsets for the collection."""
-        # This decision is based on how they are initialized above in __init__.
-        if self._uniform_offsets is None:
-            return self._offsets
-        else:
-            return self._uniform_offsets
+        return self._offsets
 
     def _get_default_linewidth(self):
         # This may be overridden in a subclass.
@@ -1441,9 +1434,6 @@ class LineCollection(Collection):
                 seg = np.asarray(seg, float)
             _segments.append(seg)
 
-        if self._uniform_offsets is not None:
-            _segments = self._add_offsets(_segments)
-
         self._paths = [mpath.Path(_seg) for _seg in _segments]
         self.stale = True
 
@@ -1473,19 +1463,6 @@ class LineCollection(Collection):
             segments.append(vertices)
 
         return segments
-
-    def _add_offsets(self, segs):
-        offsets = self._uniform_offsets
-        Nsegs = len(segs)
-        Noffs = offsets.shape[0]
-        if Noffs == 1:
-            for i in range(Nsegs):
-                segs[i] = segs[i] + i * offsets
-        else:
-            for i in range(Nsegs):
-                io = i % Noffs
-                segs[i] = segs[i] + offsets[io:io + 1]
-        return segs
 
     def _get_default_linewidth(self):
         return mpl.rcParams['lines.linewidth']

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1048,3 +1048,34 @@ def test_get_segments():
     readback, = lc.get_segments()
     # these should comeback un-changed!
     assert np.all(segments == readback)
+
+
+def test_set_offsets_late():
+    identity = mtransforms.IdentityTransform()
+    sizes = [2]
+
+    null = mcollections.CircleCollection(sizes=sizes)
+
+    init = mcollections.CircleCollection(sizes=sizes, offsets=(10, 10))
+
+    late = mcollections.CircleCollection(sizes=sizes)
+    late.set_offsets((10, 10))
+
+    # Bbox.__eq__ doesn't compare bounds
+    null_bounds = null.get_datalim(identity).bounds
+    init_bounds = init.get_datalim(identity).bounds
+    late_bounds = late.get_datalim(identity).bounds
+
+    # offsets and transform are applied when set after initialization
+    assert null_bounds != init_bounds
+    assert init_bounds == late_bounds
+
+
+def test_set_offset_transform():
+    skew = mtransforms.Affine2D().skew(2, 2)
+    init = mcollections.Collection([], transOffset=skew)
+
+    late = mcollections.Collection([])
+    late.set_offset_transform(skew)
+
+    assert skew == init.get_offset_transform() == late.get_offset_transform()


### PR DESCRIPTION
## PR Summary

Made some suggested changes related to issue #20698.

* Merged `Collection._uniform_offsets` and `Collection._offsets`, removed the former, kept the latter. Any function dependent on this variable was removed.
* Removed `Collection._offsetsNone`, replaced with a check if offsets were non-zero where used.
* Added `Collection.set_offset_transform()`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

I did add `Collection.set_offset_transform()`, but this isn't really a new feature, since it can already be set during initialization, so I'm not sure if/how it should be documented. I can add a mention if necessary.

---

Update 2021-07-23 09:47:
* Copied the body of `Artist.set_transform()` to `Collection.set_offset_transform()` to be consistent.
* Added a release note.