### PR TITLE
Fix color normalization in plot types scatter

### DIFF
--- a/plot_types/basic/scatter_plot.py
+++ b/plot_types/basic/scatter_plot.py
@@ -21,7 +21,7 @@ colors = np.random.uniform(15, 80, len(x))
 # plot
 fig, ax = plt.subplots()
 
-ax.scatter(x, y, s=sizes, c=colors, vmin=-100, vmax=0)
+ax.scatter(x, y, s=sizes, c=colors, vmin=0, vmax=100)
 
 ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
        ylim=(0, 8), yticks=np.arange(1, 8))


### PR DESCRIPTION
Adjust the norm limits to include the colors values (between 15 and 80).
