### PR TITLE
Fix broken link in 'Contributing' docs

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -119,7 +119,7 @@ A brief overview is:
       git clone https://github.com/<YOUR GITHUB USERNAME>/matplotlib.git
 
 4. Enter the directory and install the local version of Matplotlib.
-   See ref`<installing_for_devs>` for instructions
+   See :ref:`installing_for_devs` for instructions
 
 5. Create a branch to hold your changes::
 


### PR DESCRIPTION
## PR Summary

In the ["Contributing" section of the docs](https://matplotlib.org/devdocs/devel/contributing.html#contributing-code), there's incorrect syntax resulting in a missing link to the "Setting up Matplotlib for development" page. It appears as "See ref\`<installing_for_devs>\` for instructions" instead.

## PR Checklist

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
  - Building the docs ends with an nondescript error for me (`make: *** [Makefile:34: html] Error 1`), but it did the same before this change
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
