### PR TITLE
Support vmin/vmax with bins='log' in hexbin

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4799,7 +4799,8 @@ default: :rc:`scatter.edgecolors`
                 _api.warn_external("Only one of 'bins' and 'norm' arguments "
                                    f"can be supplied, ignoring bins={bins}")
             else:
-                norm = mcolors.LogNorm()
+                norm = mcolors.LogNorm(vmin=vmin, vmax=vmax)
+                vmin, vmax = None, None
             bins = None
 
         if isinstance(norm, mcolors.LogNorm):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4800,7 +4800,7 @@ default: :rc:`scatter.edgecolors`
                                    f"can be supplied, ignoring bins={bins}")
             else:
                 norm = mcolors.LogNorm(vmin=vmin, vmax=vmax)
-                vmin, vmax = None, None
+                vmin = vmax = None
             bins = None
 
         if isinstance(norm, mcolors.LogNorm):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -786,7 +786,7 @@ def test_hexbin_log():
 
 
 def test_hexbin_log_clim():
-    x, y = (np.arange(200) / 200).reshape((2, 100))
+    x, y = np.arange(200).reshape((2, 100))
     fig, ax = plt.subplots()
     h = ax.hexbin(x, y, bins='log', vmin=2, vmax=100)
     assert h.get_clim() == (2, 100)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -785,6 +785,13 @@ def test_hexbin_log():
     plt.colorbar(h)
 
 
+def test_hexbin_log_clim():
+    x, y = (np.arange(200) / 200).reshape((2, 100))
+    fig, ax = plt.subplots()
+    h = ax.hexbin(x, y, bins='log', vmin=2, vmax=100)
+    assert h.get_clim() == (2, 100)
+
+
 def test_inverted_limits():
     # Test gh:1553
     # Calling invert_xaxis prior to plotting should not disable autoscaling


### PR DESCRIPTION
## PR Summary

Matplotlib 3.3 [deprecated](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.3.0.html#parameters-norm-and-vmin-vmax-should-not-be-used-simultaneously) passing `norm` and `vmin` or `vmax` parameters simultaneously to certain functions. The [hexbin](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.hexbin.html) plotting method supports a `bins='log'` parameter that applies logarithmic scaling to the colormap of the resulting histogram. Under the hood, this behavior is implemented by generating a `LogNorm` and setting it to the `norm` parameter. This means that `plt.hexbin([], [], bins='log', vmin=1)` raises a deprecation warning (or error in the dev branch), `Passing parameters norm and vmin/vmax simultaneously is deprecated... Please pass vmin/vmax directly to the norm when creating it`.

This error is confusing since the user didn't create a norm, and the `bins='log'` parameter seems to be a convenience to let the user avoid importing and creating a `LogNorm`, so I think any vmin/vmax parameters should be accounted for when creating the `LogNorm` under the hood. This PR does that and adds a test for this situation.

The incompatibility between `bins='log'` and vmin/vmax is not mentioned in the docs, so I don't think this PR needs any doc changes.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
