### PR TITLE
DOC: Add a release mode tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,15 +124,13 @@ commands:
           command: |
             # Set epoch to date of latest tag.
             export SOURCE_DATE_EPOCH="$(git log -1 --format=%at $(git describe --abbrev=0))"
-            # Include analytics only when deploying to devdocs.
-            if [ "$CIRCLE_PROJECT_USERNAME" != "matplotlib" ] || \
-               [ "$CIRCLE_BRANCH" != "master" ] || \
-               [[ "$CIRCLE_PULL_REQUEST" == https://github.com/matplotlib/matplotlib/pull/* ]]; then
-              export ANALYTICS=False
-            else
-              export ANALYTICS=True
+            # Set release mode only when deploying to devdocs.
+            if [ "$CIRCLE_PROJECT_USERNAME" = "matplotlib" ] && \
+               [ "$CIRCLE_BRANCH" = "master" ] && \
+               [ "$CIRCLE_PR_NUMBER" = "" ]; then
+              export RELEASE_TAG='-t release'
             fi
-            make html O="-T -Ainclude_analytics=$ANALYTICS"
+            make html O="-T $RELEASE_TAG"
             rm -r build/html/_sources
           working_directory: doc
       - save_cache:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -542,12 +542,27 @@ graphviz_dot = shutil.which('dot')
 # graphviz_output_format = 'svg'
 
 
+def reduce_plot_formats(app):
+    if app.builder.name == 'html':
+        keep = 'png'
+    elif app.builder.name == 'latex':
+        keep = 'pdf'
+    else:
+        return
+    app.config.plot_formats = [entry
+                               for entry in app.config.plot_formats
+                               if entry[0] == keep]
+
+
 def setup(app):
     if any(st in version for st in ('post', 'alpha', 'beta')):
         bld_type = 'dev'
     else:
         bld_type = 'rel'
     app.add_config_value('releaselevel', bld_type, 'env')
+
+    if not _doc_release_mode:
+        app.connect('builder-inited', reduce_plot_formats)
 
 # -----------------------------------------------------------------------------
 # Source code links

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -91,6 +91,7 @@ def _check_dependencies():
         "matplotlib": 'matplotlib',
         "numpydoc": 'numpydoc',
         "PIL.Image": 'pillow',
+        "pydata_sphinx_theme": 'pydata_sphinx_theme',
         "sphinx_copybutton": 'sphinx_copybutton',
         "sphinx_gallery": 'sphinx_gallery',
         "sphinxcontrib.inkscapeconverter": 'sphinxcontrib-svg2pdfconverter',

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -22,6 +22,9 @@ import sphinx
 from datetime import datetime
 import time
 
+# Release mode enables optimizations and other related options.
+_doc_release_mode = tags.has('release')  # noqa
+
 # are we running circle CI?
 CIRCLECI = 'CIRCLECI' in os.environ
 
@@ -175,10 +178,10 @@ sphinx_gallery_conf = {
     'remove_config_comments': True,
     'min_reported_time': 1,
     'thumbnail_size': (320, 224),
-    'compress_images': () if CIRCLECI else ('thumbnails', 'images'),
+    'compress_images': ('thumbnails', 'images') if _doc_release_mode else (),
     'matplotlib_animations': True,
-    # 3.7 CI doc build should not use hidpi images during the testing phase
-    'image_srcset': [] if sys.version_info[:2] == (3, 7) else ["2x"],
+    # Doc build should not use hidpi images during the testing phase.
+    'image_srcset': ["2x"] if _doc_release_mode else [],
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
 }
 
@@ -293,7 +296,7 @@ html_theme = "pydata_sphinx_theme"
 html_logo = "_static/logo2.svg"
 html_theme_options = {
     "logo_link": "index",
-    "collapse_navigation": True if CIRCLECI else False,
+    "collapse_navigation": not _doc_release_mode,
     "icon_links": [
         {
             "name": "gitter",
@@ -319,7 +322,7 @@ html_theme_options = {
     "show_prev_next": False,
     "navbar_center": ["mpl_nav_bar.html"],
 }
-include_analytics = False
+include_analytics = _doc_release_mode
 if include_analytics:
     html_theme_options["google_analytics_id"] = "UA-55954603-1"
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -181,8 +181,7 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'compress_images': ('thumbnails', 'images') if _doc_release_mode else (),
     'matplotlib_animations': True,
-    # Doc build should not use hidpi images during the testing phase.
-    'image_srcset': ["2x"] if _doc_release_mode else [],
+    'image_srcset': ["2x"],
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
 }
 

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -345,7 +345,7 @@ build the docs from the ``ver-doc`` branch.  An easy way to arrange this is::
   pip install -r requirements/doc/doc-requirements.txt
   git checkout v2.0.0-doc
   git clean -xfd
-  make -Cdoc O="-Ainclude_analytics=True -j$(nproc)" html latexpdf LATEXMKOPTS="-silent -f"
+  make -Cdoc O="-t release -j$(nproc)" html latexpdf LATEXMKOPTS="-silent -f"
 
 which will build both the html and pdf version of the documentation.
 


### PR DESCRIPTION
## PR Summary

This adds a release mode tag, which encapsulates all the things we disabled for CircleCI, as well as other things we'd put in tagged release docs. It disables these by default, so local development will be quicker as well. And then it _re-enables_ release mode when building devdocs.

This covers image compression, HiDPI images, the theme navigation, analytics, and plot directive formats.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).