### PR TITLE
Improved implementation of Path.copy and deepcopy

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -264,8 +264,13 @@ class Path:
         Return a shallow copy of the `Path`, which will share the
         vertices and codes with the source `Path`.
         """
-        import copy
-        return copy.copy(self)
+        try:
+            codes = self.codes
+        except AttributeError:
+            codes = None
+        return self.__class__(
+            self.vertices, codes,
+            _interpolation_steps=self._interpolation_steps)
 
     copy = __copy__
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -9,6 +9,7 @@ such as `.PathPatch` and `.PathCollection`, can be used for convenient `Path`
 visualisation.
 """
 
+import copy
 from functools import lru_cache
 from weakref import WeakValueDictionary
 
@@ -259,20 +260,12 @@ class Path:
         """
         return self._readonly
 
-    def __copy__(self):
+    def copy(self):
         """
         Return a shallow copy of the `Path`, which will share the
         vertices and codes with the source `Path`.
         """
-        try:
-            codes = self.codes
-        except AttributeError:
-            codes = None
-        return self.__class__(
-            self.vertices, codes,
-            _interpolation_steps=self._interpolation_steps)
-
-    copy = __copy__
+        return copy.copy(self)
 
     def __deepcopy__(self, memo=None):
         """

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -1,4 +1,3 @@
-import copy
 import re
 
 import numpy as np
@@ -333,8 +332,28 @@ def test_path_deepcopy():
     codes = [Path.MOVETO, Path.LINETO]
     path1 = Path(verts)
     path2 = Path(verts, codes)
-    copy.deepcopy(path1)
-    copy.deepcopy(path2)
+    path1_copy = path1.deepcopy()
+    path2_copy = path2.deepcopy()
+    assert(path1 is not path1_copy)
+    assert(path1.vertices is not path1_copy.vertices)
+    assert(path2 is not path2_copy)
+    assert(path2.vertices is not path2_copy.vertices)
+    assert(path2.codes is not path2_copy.codes)
+
+
+def test_path_shallowcopy():
+    # Should not raise any error
+    verts = [[0, 0], [1, 1]]
+    codes = [Path.MOVETO, Path.LINETO]
+    path1 = Path(verts)
+    path2 = Path(verts, codes)
+    path1_copy = path1.copy()
+    path2_copy = path2.copy()
+    assert(path1 is not path1_copy)
+    assert(path1.vertices is path1_copy.vertices)
+    assert(path2 is not path2_copy)
+    assert(path2.vertices is path2_copy.vertices)
+    assert(path2.codes is path2_copy.codes)
 
 
 @pytest.mark.parametrize('phi', np.concatenate([

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -334,11 +334,11 @@ def test_path_deepcopy():
     path2 = Path(verts, codes)
     path1_copy = path1.deepcopy()
     path2_copy = path2.deepcopy()
-    assert(path1 is not path1_copy)
-    assert(path1.vertices is not path1_copy.vertices)
-    assert(path2 is not path2_copy)
-    assert(path2.vertices is not path2_copy.vertices)
-    assert(path2.codes is not path2_copy.codes)
+    assert path1 is not path1_copy
+    assert path1.vertices is not path1_copy.vertices
+    assert path2 is not path2_copy
+    assert path2.vertices is not path2_copy.vertices
+    assert path2.codes is not path2_copy.codes
 
 
 def test_path_shallowcopy():
@@ -349,11 +349,11 @@ def test_path_shallowcopy():
     path2 = Path(verts, codes)
     path1_copy = path1.copy()
     path2_copy = path2.copy()
-    assert(path1 is not path1_copy)
-    assert(path1.vertices is path1_copy.vertices)
-    assert(path2 is not path2_copy)
-    assert(path2.vertices is path2_copy.vertices)
-    assert(path2.codes is path2_copy.codes)
+    assert path1 is not path1_copy
+    assert path1.vertices is path1_copy.vertices
+    assert path2 is not path2_copy
+    assert path2.vertices is path2_copy.vertices
+    assert path2.codes is path2_copy.codes
 
 
 @pytest.mark.parametrize('phi', np.concatenate([


### PR DESCRIPTION
## PR Summary

The original Path.copy raised RecursionError, the new implementation mimicks deepcopy, but Path members are shared.

Path tests were updated to utilize member functions copy and deepcopy instead of builtin copy functional protocol.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
