### PR TITLE
Deprecate globals using module-level `__getattr__`.

### DIFF
--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -37,13 +37,11 @@ def _generate_deprecation_warning(
         removal = f"in {removal}" if removal else "two minor releases later"
     if not message:
         message = (
-            "\nThe %(name)s %(obj_type)s"
+            ("\nThe %(name)s %(obj_type)s" if obj_type else "%(name)s")
             + (" will be deprecated in a future version"
                if pending else
                (" was deprecated in Matplotlib %(since)s"
-                + (" and will be removed %(removal)s"
-                   if removal else
-                   "")))
+                + (" and will be removed %(removal)s" if removal else "")))
             + "."
             + (" Use %(alternative)s instead." if alternative else "")
             + (" %(addendum)s" if addendum else ""))

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -40,8 +40,26 @@ _log = logging.getLogger(__name__)
 # for some info about screen dpi
 PIXELS_PER_INCH = 75
 
-# Delay time for idle checks
-IDLE_DELAY = 5  # Documented as deprecated as of Matplotlib 3.1.
+
+# module-level deprecations.
+@functools.lru_cache(None)
+def __getattr__(name):
+    if name == "IDLE_DELAY":
+        _api.warn_deprecated("3.1", name=name)
+        return 5
+    elif name == "cursord":
+        _api.warn_deprecated("3.5", name=name)
+        return {  # deprecated in Matplotlib 3.5.
+            cursors.MOVE: wx.CURSOR_HAND,
+            cursors.HAND: wx.CURSOR_HAND,
+            cursors.POINTER: wx.CURSOR_ARROW,
+            cursors.SELECT_REGION: wx.CURSOR_CROSS,
+            cursors.WAIT: wx.CURSOR_WAIT,
+            cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
+            cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
+        }
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def error_msg_wx(msg, parent=None):
@@ -721,7 +739,15 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
 
     def set_cursor(self, cursor):
         # docstring inherited
-        cursor = wx.Cursor(_api.check_getitem(cursord, cursor=cursor))
+        cursor = wx.Cursor(_api.check_getitem({
+            cursors.MOVE: wx.CURSOR_HAND,
+            cursors.HAND: wx.CURSOR_HAND,
+            cursors.POINTER: wx.CURSOR_ARROW,
+            cursors.SELECT_REGION: wx.CURSOR_CROSS,
+            cursors.WAIT: wx.CURSOR_WAIT,
+            cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
+            cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
+        }, cursor=cursor))
         self.SetCursor(cursor)
         self.Update()
 
@@ -1047,17 +1073,6 @@ def _set_frame_icon(frame):
             return
         bundle.AddIcon(icon)
     frame.SetIcons(bundle)
-
-
-cursord = {  # deprecated in Matplotlib 3.5.
-    cursors.MOVE: wx.CURSOR_HAND,
-    cursors.HAND: wx.CURSOR_HAND,
-    cursors.POINTER: wx.CURSOR_ARROW,
-    cursors.SELECT_REGION: wx.CURSOR_CROSS,
-    cursors.WAIT: wx.CURSOR_WAIT,
-    cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
-    cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
-}
 
 
 class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -12,6 +12,7 @@ In Matplotlib they are drawn into a dedicated `~.axes.Axes`.
 """
 
 import copy
+import functools
 import logging
 import textwrap
 
@@ -193,10 +194,21 @@ workaround is not used by default (see issue #1188).
        textwrap.indent(_make_axes_other_param_doc, "    "),
        _colormap_kw_doc))
 
-# Deprecated since 3.4.
-colorbar_doc = docstring.interpd.params["colorbar_doc"]
-colormap_kw_doc = _colormap_kw_doc
-make_axes_kw_doc = _make_axes_param_doc + _make_axes_other_param_doc
+
+# module-level deprecations.
+@functools.lru_cache(None)
+def __getattr__(name):
+    if name == "colorbar_doc":
+        _api.warn_deprecated("3.4", name=name)
+        return docstring.interpd.params["colorbar_doc"]
+    elif name == "colormap_kw_doc":
+        _api.warn_deprecated("3.4", name=name)
+        return _colormap_kw_doc
+    elif name == "make_axes_kw_doc":
+        _api.warn_deprecated("3.4", name=name)
+        return _make_axes_param_doc + _make_axes_other_param_doc
+    else:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 def _set_ticks_on_axis_warn(*args, **kw):

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -12,6 +12,7 @@ Core functions and attributes for the matplotlib style library:
 """
 
 import contextlib
+import functools
 import logging
 import os
 from pathlib import Path
@@ -26,15 +27,18 @@ _log = logging.getLogger(__name__)
 __all__ = ['use', 'context', 'available', 'library', 'reload_library']
 
 
+# module-level deprecations.
+@functools.lru_cache(None)
+def __getattr__(name):
+    if name == "STYLE_FILE_PATTERN":
+        _api.warn_deprecated("3.5", name=name)
+        return re.compile(r'([\S]+).%s$' % STYLE_EXTENSION)
+
+
 BASE_LIBRARY_PATH = os.path.join(mpl.get_data_path(), 'stylelib')
 # Users may want multiple library paths, so store a list of paths.
 USER_LIBRARY_PATHS = [os.path.join(mpl.get_configdir(), 'stylelib')]
 STYLE_EXTENSION = 'mplstyle'
-
-# Deprecated in Matplotlib 3.5.
-STYLE_FILE_PATTERN = re.compile(r'([\S]+).%s$' % STYLE_EXTENSION)
-
-
 # A list of rcParams that should not be applied from styles
 STYLE_BLACKLIST = {
     'interactive', 'backend', 'backend.qt4', 'webagg.port', 'webagg.address',


### PR DESCRIPTION
This PR is mostly just to propose a pattern for defining module-level
`__getattr__`s for deprecating globals.

Relying on lru_cache rather than defining variables as `global` (see
change in `__init__.py`) avoids having to repeat *twice* the variable
name, and allows immediately returning its value without assigning it.
It means later accesses will be very slightly slower (because they'll
still go through the lru_cache layer), but that should hopefully be
negligible, and will mostly concern deprecated variables anyways.

One *could* consider adding a helper API in `_api.deprecation` that just
provides the decoration with `@lru_cache` and generates the
AttributeError message when needed, but that seems rather overkill.
(See https://github.com/matplotlib/matplotlib/pull/20620#issuecomment-878609537, in response to which this was written:
I don't have any "magic" idea this time :-), I now think the #10735
isn't really worth it.)

The change in deprecation.py allows one to skip `obj_name` and get a
message like "foo is deprecated..." rather than "The foo  is
deprecated...".

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
