### PR TITLE
added function linanimate.

### DIFF
--- a/examples/animation/animate_linanimate.py
+++ b/examples/animation/animate_linanimate.py
@@ -6,10 +6,12 @@ fig, ax = plt.subplots()
 xdata, ydata = [], []
 ln, = plt.plot([], [], 'r-')
 
+
 def init():
     ax.set_xlim(0, 2*np.pi)
     ax.set_ylim(-1, 1)
     return ln,
+
 
 def update(frame):
     xdata.append(frame)
@@ -17,5 +19,6 @@ def update(frame):
     ln.set_data(xdata, ydata)
     return ln,
 
-ani, fps = linanimate(fig, update,  init_func=init, lf=0, uf=2*np.pi, fps=60, duration=5)
+ani, fps = linanimate(fig, update,  init_func=init, lf=0,
+                      uf=2*np.pi, fps=60, duration=5)
 ani.save('linanimate_example.mp4', fps=fps)

--- a/examples/animation/animate_linanimate.py
+++ b/examples/animation/animate_linanimate.py
@@ -1,0 +1,21 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.animation import linanimate
+
+fig, ax = plt.subplots()
+xdata, ydata = [], []
+ln, = plt.plot([], [], 'r-')
+
+def init():
+    ax.set_xlim(0, 2*np.pi)
+    ax.set_ylim(-1, 1)
+    return ln,
+
+def update(frame):
+    xdata.append(frame)
+    ydata.append(np.cos(frame))
+    ln.set_data(xdata, ydata)
+    return ln,
+
+ani, fps = linanimate(fig, update,  init_func=init, lf=0, uf=2*np.pi, fps=60, duration=5)
+ani.save('linanimate_example.mp4', fps=fps)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1711,3 +1711,59 @@ class FuncAnimation(TimedAnimation):
 
             for a in self._drawn_artists:
                 a.set_animated(self._blit)
+
+
+def linanimate(fig, func, lf, uf,\
+        duration, fps=30, **kwargs):
+    """
+    Makes an animation by repeatedly calling a function *func*, over a
+    linear time, from lf to uf, with delta_t calculated from
+    fps and duration.
+    .. note::
+
+        You must store the created Animation in a variable that lives as long
+        as the animation should run. Otherwise, the Animation object will be
+        garbage-collected and the animation stops.
+
+    Parameters
+    ----------
+    fig : `~matplotlib.figure.Figure`
+        The figure object used to get needed events, such as draw or resize.
+
+    func : callable
+        The function to call at each frame.  The first argument will
+        be the next value in *frames*.   Any additional positional
+        arguments can be supplied via the *fargs* parameter.
+
+        The required signature is::
+
+            def func(frame, *fargs) -> iterable_of_artists
+
+        If ``blit == True``, *func* must return an iterable of all artists
+        that were modified or created. This information is used by the blitting
+        algorithm to determine which parts of the figure have to be updated.
+        The return value is unused if ``blit == False`` and may be omitted in
+        that case.
+
+    lf: float
+        The lowest value which will be passed into func.
+
+    uf: float
+        The highest value which will be passed into func.
+
+    fps: float
+        Frames per second (for animation)
+
+    duration: float (optional)
+        Running time of the animation if ran at specified fps.
+
+    """
+    # get the number of frames req. for the animation
+    frame_count = round(abs(uf - lf) * fps)
+    # the sepation of values of x (frame param) required to have specified fps.
+    if duration:
+        time_multiplier = duration / abs(uf - lf)
+    else:
+        time_multiplier = 1
+    return FuncAnimation(fig, func, frames=np.linspace(lf, uf, \
+            round(frame_count * time_multiplier)), **kwargs), fps

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1713,8 +1713,8 @@ class FuncAnimation(TimedAnimation):
                 a.set_animated(self._blit)
 
 
-def linanimate(fig, func, lf, uf,\
-        duration, fps=30, **kwargs):
+def linanimate(fig, func, lf, uf,
+               duration, fps=30, **kwargs):
     """
     Makes an animation by repeatedly calling a function *func*, over a
     linear time, from lf to uf, with delta_t calculated from
@@ -1765,5 +1765,5 @@ def linanimate(fig, func, lf, uf,\
         time_multiplier = duration / abs(uf - lf)
     else:
         time_multiplier = 1
-    return FuncAnimation(fig, func, frames=np.linspace(lf, uf, \
-            round(frame_count * time_multiplier)), **kwargs), fps
+    return FuncAnimation(fig, func, frames=np.linspace(lf, uf,
+                         round(frame_count * time_multiplier)), **kwargs)


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
