### PR TITLE
Implement Font-Fallback in Matplotlib

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ commands:
               texlive-latex-recommended \
               texlive-pictures \
               texlive-xetex \
+              ttf-wqy-zenhei \
               graphviz \
               fonts-crosextra-carlito \
               fonts-freefont-otf \

--- a/doc/api/ft2font.rst
+++ b/doc/api/ft2font.rst
@@ -1,0 +1,8 @@
+**********************
+``matplotlib.ft2font``
+**********************
+
+.. automodule:: matplotlib.ft2font
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -120,6 +120,7 @@ Alphabetical list of modules:
    figure_api.rst
    font_manager_api.rst
    fontconfig_pattern_api.rst
+   ft2font.rst
    gridspec_api.rst
    hatch_api.rst
    image_api.rst

--- a/doc/users/next_whats_new/font_fallback.rst
+++ b/doc/users/next_whats_new/font_fallback.rst
@@ -1,0 +1,27 @@
+Font Fallback in Agg
+--------------------
+
+It is now possible to specify a list of fonts families and the Agg renderer
+will try them in order to locate a required glyph.
+
+.. plot::
+   :caption: Demonstration of mixed English and Chinese text with font fallback.
+   :alt: The phrase "There are 几个汉字 in between!" rendered in various fonts.
+   :include-source: True
+
+   import matplotlib.pyplot as plt
+
+   text = "There are 几个汉字 in between!"
+
+   plt.rcParams["font.size"] = 20
+   fig = plt.figure(figsize=(4.75, 1.85))
+   fig.text(0.05, 0.85, text, family=["WenQuanYi Zen Hei"])
+   fig.text(0.05, 0.65, text, family=["Noto Sans CJK JP"])
+   fig.text(0.05, 0.45, text, family=["DejaVu Sans", "Noto Sans CJK JP"])
+   fig.text(0.05, 0.25, text, family=["DejaVu Sans", "WenQuanYi Zen Hei"])
+
+   plt.show()
+
+
+This currently only works with the Agg backend, but support for the vector
+backends is planned for Matplotlib 3.7.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -31,7 +31,7 @@ import matplotlib as mpl
 from matplotlib import _api, cbook
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
-from matplotlib.font_manager import findfont, get_font
+from matplotlib.font_manager import fontManager as _fontManager, get_font
 from matplotlib.ft2font import (LOAD_FORCE_AUTOHINT, LOAD_NO_HINTING,
                                 LOAD_DEFAULT, LOAD_NO_AUTOHINT)
 from matplotlib.mathtext import MathTextParser
@@ -272,7 +272,7 @@ class RendererAgg(RendererBase):
         """
         Get the `.FT2Font` for *font_prop*, clear its buffer, and set its size.
         """
-        font = get_font(findfont(font_prop))
+        font = get_font(_fontManager._find_fonts_by_props(font_prop))
         font.clear()
         size = font_prop.get_size_in_points()
         font.set_size(size, self.dpi)

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -167,11 +167,6 @@ OSXFontDirectories = [
 ]
 
 
-@lru_cache(64)
-def _cached_realpath(path):
-    return os.path.realpath(path)
-
-
 def get_fontext_synonyms(fontext):
     """
     Return a list of file extensions that are synonyms for
@@ -1354,7 +1349,110 @@ class FontManager:
         """Return the list of available fonts."""
         return list(set([font.name for font in self.ttflist]))
 
-    @lru_cache()
+    def _find_fonts_by_props(self, prop, fontext='ttf', directory=None,
+                             fallback_to_default=True, rebuild_if_missing=True):
+        """
+        Find font families that most closely match the given properties.
+
+        Parameters
+        ----------
+        prop : str or `~matplotlib.font_manager.FontProperties`
+            The font properties to search for. This can be either a
+            `.FontProperties` object or a string defining a
+            `fontconfig patterns`_.
+
+        fontext : {'ttf', 'afm'}, default: 'ttf'
+            The extension of the font file:
+
+            - 'ttf': TrueType and OpenType fonts (.ttf, .ttc, .otf)
+            - 'afm': Adobe Font Metrics (.afm)
+
+        directory : str, optional
+            If given, only search this directory and its subdirectories.
+
+        fallback_to_default : bool
+            If True, will fallback to the default font family (usually
+            "DejaVu Sans" or "Helvetica") if none of the families were found.
+
+        rebuild_if_missing : bool
+            Whether to rebuild the font cache and search again if the first
+            match appears to point to a nonexisting font (i.e., the font cache
+            contains outdated entries).
+
+        Returns
+        -------
+        list[str]
+            The paths of the fonts found
+
+        Notes
+        -----
+        This is an extension/wrapper of the original findfont API, which only
+        returns a single font for given font properties. Instead, this API
+        returns an dict containing multiple fonts and their filepaths
+        which closely match the given font properties.  Since this internally
+        uses the original API, there's no change to the logic of performing the
+        nearest neighbor search.  See `findfont` for more details.
+
+        """
+
+        rc_params = tuple(tuple(rcParams[key]) for key in [
+            "font.serif", "font.sans-serif", "font.cursive", "font.fantasy",
+            "font.monospace"])
+
+        prop = FontProperties._from_any(prop)
+
+        fpaths = []
+        for family in prop.get_family():
+            cprop = prop.copy()
+
+            # set current prop's family
+            cprop.set_family(family)
+
+            # do not fall back to default font
+            try:
+                fpaths.append(
+                    self._findfont_cached(
+                        cprop, fontext, directory,
+                        fallback_to_default=False,
+                        rebuild_if_missing=rebuild_if_missing,
+                        rc_params=rc_params,
+                    )
+                )
+            except ValueError:
+                if family in font_family_aliases:
+                    _log.warning(
+                        "findfont: Generic family %r not found because "
+                        "none of the following families were found: %s",
+                        family,
+                        ", ".join(self._expand_aliases(family))
+                    )
+                else:
+                    _log.warning(
+                        'findfont: Font family \'%s\' not found.', family
+                    )
+
+        # only add default family if no other font was found and
+        # fallback_to_default is enabled
+        if not fpaths:
+            if fallback_to_default:
+                dfamily = self.defaultFamily[fontext]
+                cprop = prop.copy()
+                cprop.set_family(dfamily)
+                fpaths.append(
+                    self._findfont_cached(
+                        cprop, fontext, directory,
+                        fallback_to_default=True,
+                        rebuild_if_missing=rebuild_if_missing,
+                        rc_params=rc_params,
+                    )
+                )
+            else:
+                raise ValueError("Failed to find any font, and fallback "
+                                 "to the default font was disabled.")
+
+        return fpaths
+
+    @lru_cache(1024)
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,
                          rebuild_if_missing, rc_params):
 
@@ -1447,9 +1545,19 @@ def is_opentype_cff_font(filename):
 
 
 @lru_cache(64)
-def _get_font(filename, hinting_factor, *, _kerning_factor, thread_id):
+def _get_font(font_filepaths, hinting_factor, *, _kerning_factor, thread_id):
+    first_fontpath, *rest = font_filepaths
     return ft2font.FT2Font(
-        filename, hinting_factor, _kerning_factor=_kerning_factor)
+        first_fontpath, hinting_factor,
+        _fallback_list=[
+            ft2font.FT2Font(
+                fpath, hinting_factor,
+                _kerning_factor=_kerning_factor
+            )
+            for fpath in rest
+        ],
+        _kerning_factor=_kerning_factor
+    )
 
 
 # FT2Font objects cannot be used across fork()s because they reference the same
@@ -1461,16 +1569,51 @@ if hasattr(os, "register_at_fork"):
     os.register_at_fork(after_in_child=_get_font.cache_clear)
 
 
-def get_font(filename, hinting_factor=None):
+@lru_cache(64)
+def _cached_realpath(path):
     # Resolving the path avoids embedding the font twice in pdf/ps output if a
     # single font is selected using two different relative paths.
-    filename = _cached_realpath(filename)
+    return os.path.realpath(path)
+
+
+@_api.rename_parameter('3.6', "filepath", "font_filepaths")
+def get_font(font_filepaths, hinting_factor=None):
+    """
+    Get an `.ft2font.FT2Font` object given a list of file paths.
+
+    Parameters
+    ----------
+    font_filepaths : Iterable[str, Path, bytes], str, Path, bytes
+        Relative or absolute paths to the font files to be used.
+
+        If a single string, bytes, or `pathlib.Path`, then it will be treated
+        as a list with that entry only.
+
+        If more than one filepath is passed, then the returned FT2Font object
+        will fall back through the fonts, in the order given, to find a needed
+        glyph.
+
+    Returns
+    -------
+    `.ft2font.FT2Font`
+
+    """
+    if isinstance(font_filepaths, (str, Path, bytes)):
+        paths = (_cached_realpath(font_filepaths),)
+    else:
+        paths = tuple(_cached_realpath(fname) for fname in font_filepaths)
+
     if hinting_factor is None:
         hinting_factor = rcParams['text.hinting_factor']
-    # also key on the thread ID to prevent segfaults with multi-threading
-    return _get_font(filename, hinting_factor,
-                     _kerning_factor=rcParams['text.kerning_factor'],
-                     thread_id=threading.get_ident())
+
+    return _get_font(
+        # must be a tuple to be cached
+        paths,
+        hinting_factor,
+        _kerning_factor=rcParams['text.kerning_factor'],
+        # also key on the thread ID to prevent segfaults with multi-threading
+        thread_id=threading.get_ident()
+    )
 
 
 def _load_fontmanager(*, try_read_cache=True):

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+import io
+
+import pytest
+
+from matplotlib import ft2font
+from matplotlib.testing.decorators import check_figures_equal
+import matplotlib.font_manager as fm
+import matplotlib.pyplot as plt
+
+
+def test_fallback_errors():
+    file_name = fm.findfont('DejaVu Sans')
+
+    with pytest.raises(TypeError, match="Fallback list must be a list"):
+        # failing to be a list will fail before the 0
+        ft2font.FT2Font(file_name, _fallback_list=(0,))
+
+    with pytest.raises(
+            TypeError, match="Fallback fonts must be FT2Font objects."
+    ):
+        ft2font.FT2Font(file_name, _fallback_list=[0])
+
+
+def test_ft2font_positive_hinting_factor():
+    file_name = fm.findfont('DejaVu Sans')
+    with pytest.raises(
+            ValueError, match="hinting_factor must be greater than 0"
+    ):
+        ft2font.FT2Font(file_name, 0)
+
+
+def test_fallback_smoke():
+    fp = fm.FontProperties(family=["WenQuanYi Zen Hei"])
+    if Path(fm.findfont(fp)).name != "wqy-zenhei.ttc":
+        pytest.skip("Font wqy-zenhei.ttc may be missing")
+
+    fp = fm.FontProperties(family=["Noto Sans CJK JP"])
+    if Path(fm.findfont(fp)).name != "NotoSansCJK-Regular.ttc":
+        pytest.skip("Noto Sans CJK JP font may be missing.")
+
+    plt.rcParams['font.size'] = 20
+    fig = plt.figure(figsize=(4.75, 1.85))
+    fig.text(0.05, 0.45, "There are 几个汉字 in between!",
+             family=['DejaVu Sans', "Noto Sans CJK JP"])
+    fig.text(0.05, 0.25, "There are 几个汉字 in between!",
+             family=['DejaVu Sans', "WenQuanYi Zen Hei"])
+    fig.text(0.05, 0.65, "There are 几个汉字 in between!",
+             family=["Noto Sans CJK JP"])
+    fig.text(0.05, 0.85, "There are 几个汉字 in between!",
+             family=["WenQuanYi Zen Hei"])
+
+    # TODO enable fallback for other backends!
+    for fmt in ['png', 'raw']:  # ["svg", "pdf", "ps"]:
+        fig.savefig(io.BytesIO(), format=fmt)
+
+
+@pytest.mark.parametrize('family_name, file_name',
+                         [("WenQuanYi Zen Hei",  "wqy-zenhei.ttc"),
+                          ("Noto Sans CJK JP", "NotoSansCJK-Regular.ttc")]
+                         )
+@check_figures_equal(extensions=["png"])
+def test_font_fallback_chinese(fig_test, fig_ref, family_name, file_name):
+    fp = fm.FontProperties(family=[family_name])
+    if Path(fm.findfont(fp)).name != file_name:
+        pytest.skip(f"Font {family_name} ({file_name}) is missing")
+
+    text = ["There are", "几个汉字", "in between!"]
+
+    plt.rcParams["font.size"] = 20
+    test_fonts = [["DejaVu Sans", family_name]] * 3
+    ref_fonts = [["DejaVu Sans"], [family_name], ["DejaVu Sans"]]
+
+    for j, (txt, test_font, ref_font) in enumerate(
+            zip(text, test_fonts, ref_fonts)
+    ):
+        fig_ref.text(0.05, .85 - 0.15*j, txt, family=ref_font)
+        fig_test.text(0.05, .85 - 0.15*j, txt, family=test_font)

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -3,6 +3,7 @@
 #define NO_IMPORT_ARRAY
 
 #include <algorithm>
+#include <iterator>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -183,12 +184,8 @@ FT2Image::draw_rect_filled(unsigned long x0, unsigned long y0, unsigned long x1,
     m_dirty = true;
 }
 
-static FT_UInt ft_get_char_index_or_warn(FT_Face face, FT_ULong charcode)
+static void ft_glyph_warn(FT_ULong charcode)
 {
-    FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
-    if (glyph_index) {
-        return glyph_index;
-    }
     PyObject *text_helpers = NULL, *tmp = NULL;
     if (!(text_helpers = PyImport_ImportModule("matplotlib._text_helpers")) ||
         !(tmp = PyObject_CallMethod(text_helpers, "warn_on_missing_glyph", "k", charcode))) {
@@ -200,9 +197,20 @@ exit:
     if (PyErr_Occurred()) {
         throw py::exception();
     }
-    return 0;
 }
 
+static FT_UInt
+ft_get_char_index_or_warn(FT_Face face, FT_ULong charcode, bool warn = true)
+{
+    FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
+    if (glyph_index) {
+        return glyph_index;
+    }
+    if (warn) {
+        ft_glyph_warn(charcode);
+    }
+    return 0;
+}
 
 // ft_outline_decomposer should be passed to FT_Outline_Decompose.  On the
 // first pass, vertices and codes are set to NULL, and index is simply
@@ -333,7 +341,10 @@ FT2Font::get_path()
     return Py_BuildValue("NN", vertices.pyobj(), codes.pyobj());
 }
 
-FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(NULL)
+FT2Font::FT2Font(FT_Open_Args &open_args,
+                 long hinting_factor_,
+                 std::vector<FT2Font *> &fallback_list)
+    : image(), face(NULL)
 {
     clear();
 
@@ -360,6 +371,9 @@ FT2Font::FT2Font(FT_Open_Args &open_args, long hinting_factor_) : image(), face(
 
     FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
     FT_Set_Transform(face, &transform, 0);
+
+    // Set fallbacks
+    std::copy(fallback_list.begin(), fallback_list.end(), std::back_inserter(fallbacks));
 }
 
 FT2Font::~FT2Font()
@@ -383,6 +397,12 @@ void FT2Font::clear()
     }
 
     glyphs.clear();
+    glyph_to_font.clear();
+    char_to_font.clear();
+
+    for (size_t i = 0; i < fallbacks.size(); i++) {
+        fallbacks[i]->clear();
+    }
 }
 
 void FT2Font::set_size(double ptsize, double dpi)
@@ -394,6 +414,10 @@ void FT2Font::set_size(double ptsize, double dpi)
     }
     FT_Matrix transform = { 65536 / hinting_factor, 0, 0, 65536 };
     FT_Set_Transform(face, &transform, 0);
+
+    for (size_t i = 0; i < fallbacks.size(); i++) {
+        fallbacks[i]->set_size(ptsize, dpi);
+    }
 }
 
 void FT2Font::set_charmap(int i)
@@ -414,12 +438,32 @@ void FT2Font::select_charmap(unsigned long i)
     }
 }
 
-int FT2Font::get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode)
+int FT2Font::get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode, bool fallback = false)
+{
+    if (fallback && glyph_to_font.find(left) != glyph_to_font.end() &&
+        glyph_to_font.find(right) != glyph_to_font.end()) {
+        FT2Font *left_ft_object = glyph_to_font[left];
+        FT2Font *right_ft_object = glyph_to_font[right];
+        if (left_ft_object != right_ft_object) {
+            // we do not know how to do kerning between different fonts
+            return 0;
+        }
+        // if left_ft_object is the same as right_ft_object,
+        // do the exact same thing which set_text does.
+        return right_ft_object->get_kerning(left, right, mode, false);
+    }
+    else
+    {
+        FT_Vector delta;
+        return get_kerning(left, right, mode, delta);
+    }
+}
+
+int FT2Font::get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode, FT_Vector &delta)
 {
     if (!FT_HAS_KERNING(face)) {
         return 0;
     }
-    FT_Vector delta;
 
     if (!FT_Get_Kerning(face, left, right, mode, &delta)) {
         return (int)(delta.x) / (hinting_factor << kerning_factor);
@@ -431,6 +475,9 @@ int FT2Font::get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode)
 void FT2Font::set_kerning_factor(int factor)
 {
     kerning_factor = factor;
+    for (size_t i = 0; i < fallbacks.size(); i++) {
+        fallbacks[i]->set_kerning_factor(factor);
+    }
 }
 
 void FT2Font::set_text(
@@ -440,47 +487,54 @@ void FT2Font::set_text(
 
     angle = angle / 360.0 * 2 * M_PI;
 
-    // this computes width and height in subpixels so we have to divide by 64
+    // this computes width and height in subpixels so we have to multiply by 64
     matrix.xx = (FT_Fixed)(cos(angle) * 0x10000L);
     matrix.xy = (FT_Fixed)(-sin(angle) * 0x10000L);
     matrix.yx = (FT_Fixed)(sin(angle) * 0x10000L);
     matrix.yy = (FT_Fixed)(cos(angle) * 0x10000L);
-
-    FT_Bool use_kerning = FT_HAS_KERNING(face);
-    FT_UInt previous = 0;
 
     clear();
 
     bbox.xMin = bbox.yMin = 32000;
     bbox.xMax = bbox.yMax = -32000;
 
-    for (unsigned int n = 0; n < N; n++) {
-        FT_UInt glyph_index;
+    FT_UInt previous = 0;
+    FT2Font *previous_ft_object = NULL;
+
+    for (size_t n = 0; n < N; n++) {
+        FT_UInt glyph_index = 0;
         FT_BBox glyph_bbox;
         FT_Pos last_advance;
 
-        glyph_index = ft_get_char_index_or_warn(face, codepoints[n]);
+        FT_Error charcode_error, glyph_error;
+        FT2Font *ft_object_with_glyph = this;
+        bool was_found = load_char_with_fallback(ft_object_with_glyph, glyph_index, glyphs,
+                                                 char_to_font, glyph_to_font, codepoints[n], flags,
+                                                 charcode_error, glyph_error, false);
+        if (!was_found) {
+            ft_glyph_warn((FT_ULong)codepoints[n]);
+
+            // render missing glyph tofu
+            // come back to top-most font
+            ft_object_with_glyph = this;
+            char_to_font[codepoints[n]] = ft_object_with_glyph;
+            glyph_to_font[glyph_index] = ft_object_with_glyph;
+            ft_object_with_glyph->load_glyph(glyph_index, flags, ft_object_with_glyph, false);
+        }
 
         // retrieve kerning distance and move pen position
-        if (use_kerning && previous && glyph_index) {
+        if ((ft_object_with_glyph == previous_ft_object) &&  // if both fonts are the same
+            ft_object_with_glyph->has_kerning() &&           // if the font knows how to kern
+            previous && glyph_index                          // and we really have 2 glyphs
+            ) {
             FT_Vector delta;
-            FT_Get_Kerning(face, previous, glyph_index, FT_KERNING_DEFAULT, &delta);
-            pen.x += delta.x / (hinting_factor << kerning_factor);
+            pen.x += ft_object_with_glyph->get_kerning(previous, glyph_index, FT_KERNING_DEFAULT, delta);
         }
-        if (FT_Error error = FT_Load_Glyph(face, glyph_index, flags)) {
-            throw_ft_error("Could not load glyph", error);
-        }
-        // ignore errors, jump to next glyph
 
         // extract glyph image and store it in our table
+        FT_Glyph &thisGlyph = glyphs[glyphs.size() - 1];
 
-        FT_Glyph thisGlyph;
-        if (FT_Error error = FT_Get_Glyph(face->glyph, &thisGlyph)) {
-            throw_ft_error("Could not get glyph", error);
-        }
-        // ignore errors, jump to next glyph
-
-        last_advance = face->glyph->advance.x;
+        last_advance = ft_object_with_glyph->get_face()->glyph->advance.x;
         FT_Glyph_Transform(thisGlyph, 0, &pen);
         FT_Glyph_Transform(thisGlyph, &matrix, 0);
         xys.push_back(pen.x);
@@ -496,7 +550,8 @@ void FT2Font::set_text(
         pen.x += last_advance;
 
         previous = glyph_index;
-        glyphs.push_back(thisGlyph);
+        previous_ft_object = ft_object_with_glyph;
+
     }
 
     FT_Vector_Transform(&pen, &matrix);
@@ -507,17 +562,110 @@ void FT2Font::set_text(
     }
 }
 
-void FT2Font::load_char(long charcode, FT_Int32 flags)
+void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool fallback = false)
 {
-    FT_UInt glyph_index = ft_get_char_index_or_warn(face, (FT_ULong)charcode);
-    if (FT_Error error = FT_Load_Glyph(face, glyph_index, flags)) {
-        throw_ft_error("Could not load charcode", error);
+    // if this is parent FT2Font, cache will be filled in 2 ways:
+    // 1. set_text was previously called
+    // 2. set_text was not called and fallback was enabled
+    if (fallback && char_to_font.find(charcode) != char_to_font.end()) {
+        ft_object = char_to_font[charcode];
+        // since it will be assigned to ft_object anyway
+        FT2Font *throwaway = NULL;
+        ft_object->load_char(charcode, flags, throwaway, false);
+    } else if (fallback) {
+        FT_UInt final_glyph_index;
+        FT_Error charcode_error, glyph_error;
+        FT2Font *ft_object_with_glyph = this;
+        bool was_found = load_char_with_fallback(ft_object_with_glyph, final_glyph_index, glyphs, char_to_font,
+                                glyph_to_font, charcode, flags, charcode_error, glyph_error, true);
+        if (!was_found) {
+            ft_glyph_warn(charcode);
+            if (charcode_error) {
+                throw_ft_error("Could not load charcode", charcode_error);
+            }
+            else if (glyph_error) {
+                throw_ft_error("Could not load charcode", glyph_error);
+            }
+        }
+        ft_object = ft_object_with_glyph;
+    } else {
+        ft_object = this;
+        FT_UInt glyph_index = ft_get_char_index_or_warn(face, (FT_ULong)charcode);
+
+        if (FT_Error error = FT_Load_Glyph(face, glyph_index, flags)) {
+            throw_ft_error("Could not load charcode", error);
+        }
+        FT_Glyph thisGlyph;
+        if (FT_Error error = FT_Get_Glyph(face->glyph, &thisGlyph)) {
+            throw_ft_error("Could not get glyph", error);
+        }
+        glyphs.push_back(thisGlyph);
     }
-    FT_Glyph thisGlyph;
-    if (FT_Error error = FT_Get_Glyph(face->glyph, &thisGlyph)) {
-        throw_ft_error("Could not get glyph", error);
+}
+
+bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
+                                      FT_UInt &final_glyph_index,
+                                      std::vector<FT_Glyph> &parent_glyphs,
+                                      std::unordered_map<long, FT2Font *> &parent_char_to_font,
+                                      std::unordered_map<FT_UInt, FT2Font *> &parent_glyph_to_font,
+                                      long charcode,
+                                      FT_Int32 flags,
+                                      FT_Error &charcode_error,
+                                      FT_Error &glyph_error,
+                                      bool override = false)
+{
+    FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
+
+    if (glyph_index || override) {
+        charcode_error = FT_Load_Glyph(face, glyph_index, flags);
+        if (charcode_error) {
+            return false;
+        }
+
+        FT_Glyph thisGlyph;
+        glyph_error = FT_Get_Glyph(face->glyph, &thisGlyph);
+        if (glyph_error) {
+            return false;
+        }
+
+        final_glyph_index = glyph_index;
+
+        // cache the result for future
+        // need to store this for anytime a character is loaded from a parent
+        // FT2Font object or to generate a mapping of individual characters to fonts
+        ft_object_with_glyph = this;
+        parent_glyph_to_font[final_glyph_index] = this;
+        parent_char_to_font[charcode] = this;
+        parent_glyphs.push_back(thisGlyph);
+        return true;
     }
-    glyphs.push_back(thisGlyph);
+
+    else {
+        for (size_t i = 0; i < fallbacks.size(); ++i) {
+            bool was_found = fallbacks[i]->load_char_with_fallback(
+                ft_object_with_glyph, final_glyph_index, parent_glyphs, parent_char_to_font,
+                parent_glyph_to_font, charcode, flags, charcode_error, glyph_error, override);
+            if (was_found) {
+                return true;
+            }
+        }
+        return false;
+    }
+}
+
+void FT2Font::load_glyph(FT_UInt glyph_index,
+                         FT_Int32 flags,
+                         FT2Font *&ft_object,
+                         bool fallback = false)
+{
+    // cache is only for parent FT2Font
+    if (fallback && glyph_to_font.find(glyph_index) != glyph_to_font.end()) {
+        ft_object = glyph_to_font[glyph_index];
+    } else {
+        ft_object = this;
+    }
+
+    ft_object->load_glyph(glyph_index, flags);
 }
 
 void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
@@ -530,6 +678,28 @@ void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
         throw_ft_error("Could not get glyph", error);
     }
     glyphs.push_back(thisGlyph);
+}
+
+FT_UInt FT2Font::get_char_index(FT_ULong charcode, bool fallback = false)
+{
+    FT2Font *ft_object = NULL;
+    if (fallback && char_to_font.find(charcode) != char_to_font.end()) {
+        // fallback denotes whether we want to search fallback list.
+        // should call set_text/load_char_with_fallback to parent FT2Font before
+        // wanting to use fallback list here. (since that populates the cache)
+        ft_object = char_to_font[charcode];
+    } else {
+        // set as self
+        ft_object = this;
+    }
+
+    // historically, get_char_index never raises a warning
+    return ft_get_char_index_or_warn(ft_object->get_face(), charcode, false);
+}
+
+void FT2Font::get_cbox(FT_BBox &bbox)
+{
+    FT_Glyph_Get_CBox(glyphs.back(), ft_glyph_bbox_subpixels, &bbox);
 }
 
 void FT2Font::get_width_height(long *width, long *height)
@@ -622,8 +792,14 @@ void FT2Font::draw_glyph_to_bitmap(FT2Image &im, int x, int y, size_t glyphInd, 
     im.draw_bitmap(&bitmap->bitmap, x + bitmap->left, y);
 }
 
-void FT2Font::get_glyph_name(unsigned int glyph_number, char *buffer)
+void FT2Font::get_glyph_name(unsigned int glyph_number, char *buffer, bool fallback = false)
 {
+    if (fallback && glyph_to_font.find(glyph_number) != glyph_to_font.end()) {
+        // cache is only for parent FT2Font
+        FT2Font *ft_object = glyph_to_font[glyph_number];
+        ft_object->get_glyph_name(glyph_number, buffer, false);
+        return;
+    }
     if (!FT_HAS_GLYPH_NAMES(face)) {
         /* Note that this generated name must match the name that
            is generated by ttconv in ttfont_CharStrings_getname. */

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -1,10 +1,12 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
 /* A python interface to FreeType */
+#pragma once
 #ifndef MPL_FT2FONT_H
 #define MPL_FT2FONT_H
 #include <vector>
 #include <stdint.h>
+#include <unordered_map>
 
 extern "C" {
 #include <ft2build.h>
@@ -69,7 +71,7 @@ class FT2Font
 {
 
   public:
-    FT2Font(FT_Open_Args &open_args, long hinting_factor);
+    FT2Font(FT_Open_Args &open_args, long hinting_factor, std::vector<FT2Font *> &fallback_list);
     virtual ~FT2Font();
     void clear();
     void set_size(double ptsize, double dpi);
@@ -77,9 +79,21 @@ class FT2Font
     void select_charmap(unsigned long i);
     void set_text(
         size_t N, uint32_t *codepoints, double angle, FT_Int32 flags, std::vector<double> &xys);
-    int get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode);
+    int get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode, bool fallback);
+    int get_kerning(FT_UInt left, FT_UInt right, FT_UInt mode, FT_Vector &delta);
     void set_kerning_factor(int factor);
-    void load_char(long charcode, FT_Int32 flags);
+    void load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool fallback);
+    bool load_char_with_fallback(FT2Font *&ft_object_with_glyph,
+                                 FT_UInt &final_glyph_index,
+                                 std::vector<FT_Glyph> &parent_glyphs,
+                                 std::unordered_map<long, FT2Font *> &parent_char_to_font,
+                                 std::unordered_map<FT_UInt, FT2Font *> &parent_glyph_to_font,
+                                 long charcode,
+                                 FT_Int32 flags,
+                                 FT_Error &charcode_error,
+                                 FT_Error &glyph_error,
+                                 bool override);
+    void load_glyph(FT_UInt glyph_index, FT_Int32 flags, FT2Font *&ft_object, bool fallback);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags);
     void get_width_height(long *width, long *height);
     void get_bitmap_offset(long *x, long *y);
@@ -89,14 +103,17 @@ class FT2Font
     void get_xys(bool antialiased, std::vector<double> &xys);
     void draw_glyphs_to_bitmap(bool antialiased);
     void draw_glyph_to_bitmap(FT2Image &im, int x, int y, size_t glyphInd, bool antialiased);
-    void get_glyph_name(unsigned int glyph_number, char *buffer);
+    void get_glyph_name(unsigned int glyph_number, char *buffer, bool fallback);
     long get_name_index(char *name);
+    FT_UInt get_char_index(FT_ULong charcode, bool fallback);
+    void get_cbox(FT_BBox &bbox);
     PyObject* get_path();
 
     FT_Face const &get_face() const
     {
         return face;
     }
+
     FT2Image &get_image()
     {
         return image;
@@ -117,12 +134,19 @@ class FT2Font
     {
         return hinting_factor;
     }
+    FT_Bool has_kerning() const
+    {
+        return FT_HAS_KERNING(face);
+    }
 
   private:
     FT2Image image;
     FT_Face face;
     FT_Vector pen;    /* untransformed origin  */
     std::vector<FT_Glyph> glyphs;
+    std::vector<FT2Font *> fallbacks;
+    std::unordered_map<FT_UInt, FT2Font *> glyph_to_font;
+    std::unordered_map<long, FT2Font *> char_to_font;
     FT_BBox bbox;
     FT_Pos advance;
     long hinting_factor;


### PR DESCRIPTION
## PR Summary
This PR modifies the internal structure of `FT2Font` (the interface between fonts and Matplotlib) in favor of implementing [Font Fallback](https://www.w3schools.com/css/css_font_fallbacks.asp) for Matplotlib, and allow Agg backend to use the new codepath.
It builds on the previous PR: https://github.com/matplotlib/matplotlib/pull/20549, which was the 'first-step', i.e., "parsing multiple families".. this PR implements _using_ those families for font fallback.

This would help us in multi-language support, for example (Previous / After):
<p float="left" align="middle">
  <img src="https://user-images.githubusercontent.com/43996118/128605750-9d76fa4a-ce57-45c6-af23-761334d48ef7.png" width="45%" />
  <img src="https://user-images.githubusercontent.com/43996118/128605746-9f79ebeb-c03d-407e-9e27-c3203a210908.png" width="45%" />
</p>

^the fonts are chosen such that the difference is visually noticeable.

A flowchart explaining the text rendering algorithm with font fallback:
![FontFallback](https://user-images.githubusercontent.com/43996118/129720023-14f5d67f-f279-433f-ad78-e5eccb6c784a.png)

Here's the script:
```python
import matplotlib.pyplot as plt
# "Authentic" is a fancy font, whereas "SimHei" is a CJK font
plt.rcParams['font.family'] = ['Authentic', 'SimHei']
plt.rcParams['font.size'] = 30

plt.figtext(0.18, 0.45, "There are 多个汉字 in between!")
plt.show()
```

Fixes https://github.com/matplotlib/matplotlib/issues/18883, https://github.com/matplotlib/matplotlib/issues/15260

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
