### PR TITLE
Set the canvas cursor when using a SpanSelector

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2264,6 +2264,8 @@ class SpanSelector(_SelectorWidget):
         # self._pressv is deprecated but we still need to maintain it
         self._pressv = None
 
+        self._active_handle = None
+
         return False
 
     def _onmove(self, event):
@@ -2805,6 +2807,7 @@ class RectangleSelector(_SelectorWidget):
         # call desired function
         self.onselect(self._eventpress, self._eventrelease)
         self.update()
+        self._active_handle = None
 
         return False
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib import docstring
-from . import _api, cbook, colors, ticker
+from . import _api, backend_tools, cbook, colors, ticker
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
 
@@ -2192,8 +2192,26 @@ class SpanSelector(_SelectorWidget):
                                              useblit=self.useblit)
         self.artists.extend([line for line in self._edge_handles.artists])
 
+    def _set_cursor(self, enabled):
+        """Update the canvas cursor based on direction of the selector."""
+        if enabled:
+            cursor = (backend_tools.Cursors.RESIZE_HORIZONTAL
+                      if self.direction == 'horizontal' else
+                      backend_tools.Cursors.RESIZE_VERTICAL)
+        else:
+            cursor = backend_tools.Cursors.POINTER
+
+        self.ax.figure.canvas.set_cursor(cursor)
+
+    def connect_default_events(self):
+        # docstring inherited
+        super().connect_default_events()
+        if getattr(self, '_interactive', False):
+            self.connect_event('motion_notify_event', self._hover)
+
     def _press(self, event):
         """Button press event handler."""
+        self._set_cursor(True)
         if self._interactive and self._rect.get_visible():
             self._set_active_handle(event)
         else:
@@ -2248,6 +2266,7 @@ class SpanSelector(_SelectorWidget):
 
     def _release(self, event):
         """Button release event handler."""
+        self._set_cursor(False)
         if not self._interactive:
             self._rect.set_visible(False)
 
@@ -2267,6 +2286,19 @@ class SpanSelector(_SelectorWidget):
         self._active_handle = None
 
         return False
+
+    def _hover(self, event):
+        """Update the canvas cursor if it's over a handle."""
+        if self.ignore(event):
+            return
+
+        if self._active_handle is not None:
+            # Do nothing if button is pressed and a handle is active, which may
+            # occur with drag_from_anywhere=True.
+            return
+
+        _, e_dist = self._edge_handles.closest(event.x, event.y)
+        self._set_cursor(e_dist <= self.grab_range)
 
     def _onmove(self, event):
         """Motion notify event handler."""


### PR DESCRIPTION
## PR Summary

This sets either a horizontal or vertcal resize cursor when initiating a selection, moving the span, or when hovering over an end handle.

This is half of #20724.

I said I was going to move things to `ToolLineHandles`, but there are two reasons why I didn't:
* It doesn't have `grab_range`, which is needed for determining when we're hovering.
* It doesn't have access to the parent widget, so can't know when it's inactive, or a handle is already active.

I could propagate the information over, but seemed like more work than just handling the cursor entirely in the `SpanSelector` widget. I could finish moving it if we think that makes a better design.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).