### PR TITLE
Cleanup font subsetting code

### DIFF
--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -61,18 +61,7 @@ class CharacterTracker:
 
     def track(self, font, s):
         """Record that string *s* is being typeset using font *font*."""
-        if isinstance(font, str):
-            # Unused, can be removed after removal of track_characters.
-            fname = font
-        else:
-            fname = font.fname
-        self.used.setdefault(fname, set()).update(map(ord, s))
-
-    # Not public, can be removed when pdf/ps merge_used_characters is removed.
-    def merge(self, other):
-        """Update self with a font path to character codepoints."""
-        for fname, charset in other.items():
-            self.used.setdefault(fname, set()).update(charset)
+        self.used.setdefault(font.fname, set()).update(map(ord, s))
 
 
 class RendererPDFPSBase(RendererBase):

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -63,6 +63,10 @@ class CharacterTracker:
         """Record that string *s* is being typeset using font *font*."""
         self.used.setdefault(font.fname, set()).update(map(ord, s))
 
+    def track_glyph(self, font, glyph):
+        """Record that codepoint *glyph* is being typeset using font *font*."""
+        self.used.setdefault(font.fname, set()).add(glyph)
+
 
 class RendererPDFPSBase(RendererBase):
     # The following attributes must be defined by the subclasses:

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -135,16 +135,16 @@ def _move_path_to_path_or_stream(src, dst):
         shutil.move(src, dst, copy_function=shutil.copyfile)
 
 
-def _font_to_ps_type3(font_path, glyph_ids):
+def _font_to_ps_type3(font_path, chars):
     """
-    Subset *glyph_ids* from the font at *font_path* into a Type 3 font.
+    Subset *chars* from the font at *font_path* into a Type 3 font.
 
     Parameters
     ----------
     font_path : path-like
         Path to the font to be subsetted.
-    glyph_ids : list of int
-        The glyph indices to include in the subsetted font.
+    chars : str
+        The characters to include in the subsetted font.
 
     Returns
     -------
@@ -153,6 +153,7 @@ def _font_to_ps_type3(font_path, glyph_ids):
         verbatim into a PostScript file.
     """
     font = get_font(font_path, hinting_factor=1)
+    glyph_ids = [font.get_char_index(c) for c in chars]
 
     preamble = """\
 %!PS-Adobe-3.0 Resource-Font
@@ -983,15 +984,13 @@ class FigureCanvasPS(FigureCanvasBase):
                         in ps_renderer._character_tracker.used.items():
                     if not chars:
                         continue
-                    font = get_font(font_path)
-                    glyph_ids = [font.get_char_index(c) for c in chars]
                     fonttype = mpl.rcParams['ps.fonttype']
                     # Can't use more than 255 chars from a single Type 3 font.
-                    if len(glyph_ids) > 255:
+                    if len(chars) > 255:
                         fonttype = 42
                     fh.flush()
                     if fonttype == 3:
-                        fh.write(_font_to_ps_type3(font_path, glyph_ids))
+                        fh.write(_font_to_ps_type3(font_path, chars))
                     else:  # Type 42 only.
                         _font_to_ps_type42(font_path, chars, fh)
             print("end", file=fh)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -670,7 +670,7 @@ grestore
             f"{angle:f} rotate\n")
         lastfont = None
         for font, fontsize, num, ox, oy in glyphs:
-            self._character_tracker.track(font, chr(num))
+            self._character_tracker.track_glyph(font, num)
             if (font.postscript_name, fontsize) != lastfont:
                 lastfont = font.postscript_name, fontsize
                 self._pswriter.write(
@@ -955,13 +955,13 @@ class FigureCanvasPS(FigureCanvasBase):
                         fh.write(_font_to_ps_type3(font_path, glyph_ids))
                     else:
                         try:
+                            subset_str = ''.join(chr(c) for c in chars)
                             _log.debug(
                                 "SUBSET %s characters: %s", font_path,
-                                ''.join(chr(c) for c in chars)
+                                subset_str
                             )
                             fontdata = _backend_pdf_ps.get_glyphs_subset(
-                                font_path, "".join(chr(c) for c in chars)
-                            )
+                                font_path, subset_str)
                             _log.debug(
                                 "SUBSET %s %d -> %d", font_path,
                                 os.stat(font_path).st_size,


### PR DESCRIPTION
## PR Summary

I noticed a few things while reviewing font-related PRs, but as they were not directly related to those PRs, did not comment on them (except for the Type 42 PS subsetting bit, as that one was merged before I could comment.)

See commit messages for details, but this removes redundant character<->ordinal conversion, splits Type 42 PS subsetting into a separate function, and removes some deprecated code.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).