### PR TITLE
Shorten issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,16 +1,12 @@
 name: Bug Report
-description: Report a bug or issue with Matplotlib
+description: Report a bug or issue with Matplotlib.
 title: "[Bug]: "
 body:
-  - type: markdown
-    attributes:
-      value: |
-        To help us understand and resolve your issue, please fill out the form to the best of your ability. 
   - type: textarea
     id: summary
     attributes:
       label: Bug summary
-      description: Please provide 1-2 short sentences that succinctly describes the bug
+      description:  Describe the bug in 1-2 short sentences 
       placeholder: 
       value:
     validations:
@@ -28,63 +24,62 @@ body:
     id: actual
     attributes:
       label: Actual outcome
-      description: Please provide the output produced by the above code, which may be a screenshot, console output, etc. 
-      placeholder: if applicable, paste the console output and images here
+      description: |
+        Paste the output produced by the code provided above, e.g.
+        console output, images/videos produced by the code, any relevant screenshots/screencasts, etc.
     validations:
       required: true
   - type: textarea
     id: expected
     attributes:
       label: Expected outcome
-      description: Please provide a description (or visual example) of the expected outcome from the code snippet. If this used to work in an earlier version of Matplotlib, please note the version it used to work on
+      description: Describe (or provide a visual example of) the expected outcome from the code snippet.
     validations:
       required: true
+  - type: textarea
+    id: details
+    attributes:
+      label: Additional information
+      description: |
+        - What are the conditions under which this bug happens? input parameters, edge cases, etc?
+        - Has this worked in earlier versions?
+        - Do you know why this bug is happening?
+        - Do you maybe even know a fix?
   - type: input
     id: operating-system
     attributes:
       label: Operating system
-      description: What operating system are you using?
-      placeholder: Windows, OS/X, Arch, Debian, Ubuntu, etc.  
+      description: Windows, OS/X, Arch, Debian, Ubuntu, etc.
   - type: input
     id: matplotlib-version
     attributes:
       label: Matplotlib Version
-      placeholder: import matplotlib; print(matplotlib.__version__)
+      description: "From Python prompt: `import matplotlib; print(matplotlib.__version__)`"
     validations:
       required: true
   - type: input
     id: matplotlib-backend
     attributes: 
       label: Matplotlib Backend
-      placeholder: print(matplotlib.get_backend())
+      description: "From Python prompt: `import matplotlib; print(matplotlib.get_backend())`"
   - type: input
     id: python-version
     attributes:
       label: Python version
-      placeholder: python --version
+      description: "In console: `python --version`"
   - type: input
     id: jupyter-version
     attributes:
       label: Jupyter version
-      placeholder: jupyter notebook --version, jupyter lab --version
-  - type: textarea
-    id: other-libraries
-    attributes:
-      label: Other libraries
-      description: please provide the versions of any other libraries that are relevant to this bug report.
+      description: "In console: `jupyter notebook --version` or `jupyter lab --version`"
   - type: dropdown
     id: install
     attributes:
       label: Installation
-      description: how did you install matplotlib?
+      description: How did you install matplotlib?
       options:
         - pip
         - conda
-        - Linux package manager (Debian/Fedora/etc.)
-        - source
-  - type: input
-    id: conda-channel
-    attributes:
-      label: Conda channel
-      description: If you installed from conda, please specify which channel you used if not the default?
-      placeholder: conda-forge
+        - Linux package manager
+        - from source (.tar.gz)
+        - git checkout

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -3,16 +3,14 @@ description: Create a report to help us improve the documentation
 title: "[Doc]: "
 labels: [Documentation]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        To help us understand and resolve your issue, please fill out the form to the best of your ability.
   - type: input
     id: link
     attributes:
       label: Documentation Link
-      description: Please provide a link to any documentation or examples that you are referencing.  
-      placeholder: https://matplotlib.org/devdocs/
+      description: |
+        Link to any documentation or examples that you are referencing.
+        Suggested improvements should be based on the development version of the docs: https://matplotlib.org/devdocs/
+      placeholder: https://matplotlib.org/devdocs/...
   - type: textarea
     id: problem
     attributes:
@@ -28,7 +26,6 @@ body:
     id: improvement
     attributes:
       label: Suggested improvement
-      description: How can we improve the documentation?
       placeholder: |
         * This line should be be changed to say [...]
         * Include a paragraph explaining [...]
@@ -37,15 +34,6 @@ body:
     id: matplotlib-version
     attributes:
       label: Matplotlib Version
-      placeholder: import matplotlib; print(matplotlib.__version__)
+      description: "From Python prompt: `import matplotlib; print(matplotlib.__version__)`"
     validations:
       required: true
-  - type: input
-    id: matplotlib-doc-version
-    attributes:
-      label: Matplotlib documentation version
-      placeholder: check under the logo
-    validations:
-      required: true
-
-  

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -6,12 +6,12 @@ body:
   - type: markdown
     attributes:
       value: |
-         Thanks for thinking of a way to improve Matplotlib. Please search the issues for relevant feature requests before creating a new feature request.  
+         Please search the [issues](https://github.com/matplotlib/matplotlib/issues) for relevant feature requests before creating a new feature request.
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: Please provide a clear and concise description of the problem this feature will solve. 
+      description: Briefly describe the problem this feature will solve. (2-4 sentences)
       placeholder: |
         * I'm always frustrated when [...] because [...]
         * I would like it if [...] happened when I [...] because [...]
@@ -22,15 +22,4 @@ body:
     id: solution
     attributes:
       label: Proposed solution
-      description: Please provide a clear and concise description of a way to accomplish what you want.
-      placeholder: Add an option so that when [...]  [...] will happen
-  - type: textarea
-    id: prior-art
-    attributes:
-      label: Additional context and prior art
-      description: Add any other context or screenshots about the feature request here. You can also include links to examples of other programs that have something similar to your request.
-      placeholder: Another project [...] solved this by [...]
-
-
-
-
+      description: Describe a way to accomplish the goals of this feature request.


### PR DESCRIPTION
## PR Summary

Followup to #20688.

The goal is to make this as concise as possible.

Previews can be seen here: https://github.com/timhoffm/matplotlib/tree/doc-issue-template/.github/ISSUE_TEMPLATE