### PR TITLE
Deprecate support for case-insensitive scales.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20753-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20753-AL.rst
@@ -1,0 +1,4 @@
+Case-insensitive scales
+~~~~~~~~~~~~~~~~~~~~~~~
+Previously, scales could be set case-insensitively (e.g. ``set_xscale("LoG")``).
+This is deprecated; all builtin scales use lowercase names.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -588,9 +588,13 @@ def scale_factory(scale, axis, **kwargs):
     scale : {%(names)s}
     axis : `matplotlib.axis.Axis`
     """
-    scale = scale.lower()
-    _api.check_in_list(_scale_mapping, scale=scale)
-    return _scale_mapping[scale](axis, **kwargs)
+    if scale != scale.lower():
+        _api.warn_deprecated(
+            "3.5", message="Support for case-insensitive scales is deprecated "
+            "since %(since)s and support will be removed %(removal)s.")
+        scale = scale.lower()
+    scale_cls = _api.check_getitem(_scale_mapping, scale=scale)
+    return scale_cls(axis, **kwargs)
 
 
 if scale_factory.__doc__:


### PR DESCRIPTION
``set_xscale("LOG")`` is likely rare, and removing it avoids having to
duplicate the logic if we want to support setting norms via strs (#20752).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
