### PR TITLE
Modernize mathtext examples

### DIFF
--- a/examples/text_labels_and_annotations/mathtext_asarray.py
+++ b/examples/text_labels_and_annotations/mathtext_asarray.py
@@ -21,10 +21,11 @@ def text_to_rgba(s, *, dpi, **kwargs):
     # (If desired, one can also directly save the image to the filesystem.)
     fig = Figure(facecolor="none")
     fig.text(0, 0, s, **kwargs)
-    buf = BytesIO()
-    fig.savefig(buf, dpi=dpi, format="png", bbox_inches="tight", pad_inches=0)
-    buf.seek(0)
-    rgba = plt.imread(buf)
+    with BytesIO() as buf:
+        fig.savefig(buf, dpi=dpi, format="png", bbox_inches="tight",
+                    pad_inches=0)
+        buf.seek(0)
+        rgba = plt.imread(buf)
     return rgba
 
 

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -107,20 +107,19 @@ def doall():
 if '--latex' in sys.argv:
     # Run: python mathtext_examples.py --latex
     # Need amsmath and amssymb packages.
-    fd = open("mathtext_examples.ltx", "w")
-    fd.write("\\documentclass{article}\n")
-    fd.write("\\usepackage{amsmath, amssymb}\n")
-    fd.write("\\begin{document}\n")
-    fd.write("\\begin{enumerate}\n")
+    with open("mathtext_examples.ltx", "w") as fd:
+        fd.write("\\documentclass{article}\n")
+        fd.write("\\usepackage{amsmath, amssymb}\n")
+        fd.write("\\begin{document}\n")
+        fd.write("\\begin{enumerate}\n")
 
-    for i in range(n_lines):
-        s = mathext_demos[i]
-        s = re.sub(r"(?<!\\)\$", "$$", s)
-        fd.write("\\item %s\n" % s)
+        for i in range(n_lines):
+            s = mathext_demos[i]
+            s = re.sub(r"(?<!\\)\$", "$$", s)
+            fd.write("\\item %s\n" % s)
 
-    fd.write("\\end{enumerate}\n")
-    fd.write("\\end{document}\n")
-    fd.close()
+        fd.write("\\end{enumerate}\n")
+        fd.write("\\end{document}\n")
 
     subprocess.call(["pdflatex", "mathtext_examples.ltx"])
 else:

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -62,23 +62,24 @@ def doall():
     mpl_grey_rvb = (51. / 255., 51. / 255., 51. / 255.)
 
     # Creating figure and axis.
-    plt.figure(figsize=(6, 7))
-    plt.axes([0.01, 0.01, 0.98, 0.90], facecolor="white", frameon=True)
-    plt.gca().set_xlim(0., 1.)
-    plt.gca().set_ylim(0., 1.)
-    plt.gca().set_title("Matplotlib's math rendering engine",
-                        color=mpl_grey_rvb, fontsize=14, weight='bold')
-    plt.gca().set_xticklabels([])
-    plt.gca().set_yticklabels([])
+    fig = plt.figure(figsize=(6, 7))
+    ax = fig.add_axes([0.01, 0.01, 0.98, 0.90],
+                      facecolor="white", frameon=True)
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    ax.set_title("Matplotlib's math rendering engine",
+                 color=mpl_grey_rvb, fontsize=14, weight='bold')
+    ax.set_xticklabels([])
+    ax.set_yticklabels([])
 
     # Gap between lines in axes coords
     line_axesfrac = 1 / n_lines
 
     # Plotting header demonstration formula
     full_demo = mathext_demos[0]
-    plt.annotate(full_demo,
-                 xy=(0.5, 1. - 0.59 * line_axesfrac),
-                 color=mpl_orange_rvb, ha='center', fontsize=20)
+    ax.annotate(full_demo,
+                xy=(0.5, 1. - 0.59 * line_axesfrac),
+                color=mpl_orange_rvb, ha='center', fontsize=20)
 
     # Plotting features demonstration formulae
     for i_line in range(1, n_lines):
@@ -86,16 +87,16 @@ def doall():
         baseline_next = baseline - line_axesfrac
         title = mathtext_titles[i_line] + ":"
         fill_color = ['white', mpl_blue_rvb][i_line % 2]
-        plt.fill_between([0., 1.], [baseline, baseline],
-                         [baseline_next, baseline_next],
-                         color=fill_color, alpha=0.5)
-        plt.annotate(title,
-                     xy=(0.07, baseline - 0.3 * line_axesfrac),
-                     color=mpl_grey_rvb, weight='bold')
+        ax.fill_between([0, 1], [baseline, baseline],
+                        [baseline_next, baseline_next],
+                        color=fill_color, alpha=0.5)
+        ax.annotate(title,
+                    xy=(0.07, baseline - 0.3 * line_axesfrac),
+                    color=mpl_grey_rvb, weight='bold')
         demo = mathext_demos[i_line]
-        plt.annotate(demo,
-                     xy=(0.05, baseline - 0.75 * line_axesfrac),
-                     color=mpl_grey_rvb, fontsize=16)
+        ax.annotate(demo,
+                    xy=(0.05, baseline - 0.75 * line_axesfrac),
+                    color=mpl_grey_rvb, fontsize=16)
 
     for i in range(n_lines):
         s = mathext_demos[i]

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -59,15 +59,15 @@ def doall():
     mpl_grey_rgb = (51 / 255, 51 / 255, 51 / 255)
 
     # Creating figure and axis.
-    fig = plt.figure(figsize=(6, 7))
+    fig = plt.figure(figsize=(7, 7))
     ax = fig.add_axes([0.01, 0.01, 0.98, 0.90],
                       facecolor="white", frameon=True)
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
     ax.set_title("Matplotlib's math rendering engine",
                  color=mpl_grey_rgb, fontsize=14, weight='bold')
-    ax.set_xticklabels([])
-    ax.set_yticklabels([])
+    ax.set_xticks([])
+    ax.set_yticks([])
 
     # Gap between lines in axes coords
     line_axesfrac = 1 / n_lines
@@ -91,10 +91,10 @@ def doall():
                         [baseline_next, baseline_next],
                         color=fill_color, alpha=0.2)
         ax.annotate(f'{title}:',
-                    xy=(0.07, baseline - 0.3 * line_axesfrac),
+                    xy=(0.06, baseline - 0.3 * line_axesfrac),
                     color=mpl_grey_rgb, weight='bold')
         ax.annotate(demo,
-                    xy=(0.05, baseline - 0.75 * line_axesfrac),
+                    xy=(0.04, baseline - 0.75 * line_axesfrac),
                     color=mpl_grey_rgb, fontsize=16)
 
     plt.show()

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -5,10 +5,12 @@ Mathtext Examples
 
 Selected features of Matplotlib's math rendering engine.
 """
-import matplotlib.pyplot as plt
+import re
 import subprocess
 import sys
-import re
+
+import matplotlib.pyplot as plt
+
 
 # Selection of features following "Writing mathematical expressions" tutorial,
 # with randomly picked examples.

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -57,9 +57,7 @@ mathext_demos = {
 
 def doall():
     # Colors used in Matplotlib online documentation.
-    mpl_blue_rvb = (191. / 255., 209. / 256., 212. / 255.)
-    mpl_orange_rvb = (202. / 255., 121. / 256., 0. / 255.)
-    mpl_grey_rvb = (51. / 255., 51. / 255., 51. / 255.)
+    mpl_grey_rgb = (51 / 255, 51 / 255, 51 / 255)
 
     # Creating figure and axis.
     fig = plt.figure(figsize=(6, 7))
@@ -68,7 +66,7 @@ def doall():
     ax.set_xlim(0, 1)
     ax.set_ylim(0, 1)
     ax.set_title("Matplotlib's math rendering engine",
-                 color=mpl_grey_rvb, fontsize=14, weight='bold')
+                 color=mpl_grey_rgb, fontsize=14, weight='bold')
     ax.set_xticklabels([])
     ax.set_yticklabels([])
 
@@ -79,24 +77,24 @@ def doall():
     full_demo = mathext_demos[0]
     ax.annotate(full_demo,
                 xy=(0.5, 1. - 0.59 * line_axesfrac),
-                color=mpl_orange_rvb, ha='center', fontsize=20)
+                color='tab:orange', ha='center', fontsize=20)
 
     # Plotting features demonstration formulae
     for i_line in range(1, n_lines):
         baseline = 1 - i_line * line_axesfrac
         baseline_next = baseline - line_axesfrac
         title = mathtext_titles[i_line] + ":"
-        fill_color = ['white', mpl_blue_rvb][i_line % 2]
+        fill_color = ['white', 'tab:blue'][i_line % 2]
         ax.fill_between([0, 1], [baseline, baseline],
                         [baseline_next, baseline_next],
-                        color=fill_color, alpha=0.5)
+                        color=fill_color, alpha=0.2)
         ax.annotate(title,
                     xy=(0.07, baseline - 0.3 * line_axesfrac),
-                    color=mpl_grey_rvb, weight='bold')
+                    color=mpl_grey_rgb, weight='bold')
         demo = mathext_demos[i_line]
         ax.annotate(demo,
                     xy=(0.05, baseline - 0.75 * line_axesfrac),
-                    color=mpl_grey_rvb, fontsize=16)
+                    color=mpl_grey_rgb, fontsize=16)
 
     for i in range(n_lines):
         s = mathext_demos[i]

--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -10,49 +10,48 @@ import subprocess
 import sys
 import re
 
-# Selection of features following "Writing mathematical expressions" tutorial
-mathtext_titles = {
-    0: "Header demo",
-    1: "Subscripts and superscripts",
-    2: "Fractions, binomials and stacked numbers",
-    3: "Radicals",
-    4: "Fonts",
-    5: "Accents",
-    6: "Greek, Hebrew",
-    7: "Delimiters, functions and Symbols"}
-n_lines = len(mathtext_titles)
+# Selection of features following "Writing mathematical expressions" tutorial,
+# with randomly picked examples.
+mathtext_demos = {
+    "Header demo":
+        r"$W^{3\beta}_{\delta_1 \rho_1 \sigma_2} = "
+        r"U^{3\beta}_{\delta_1 \rho_1} + \frac{1}{8 \pi 2} "
+        r"\int^{\alpha_2}_{\alpha_2} d \alpha^\prime_2 \left[\frac{ "
+        r"U^{2\beta}_{\delta_1 \rho_1} - \alpha^\prime_2U^{1\beta}_"
+        r"{\rho_1 \sigma_2} }{U^{0\beta}_{\rho_1 \sigma_2}}\right]$",
 
-# Randomly picked examples
-mathext_demos = {
-    0: r"$W^{3\beta}_{\delta_1 \rho_1 \sigma_2} = "
-    r"U^{3\beta}_{\delta_1 \rho_1} + \frac{1}{8 \pi 2} "
-    r"\int^{\alpha_2}_{\alpha_2} d \alpha^\prime_2 \left[\frac{ "
-    r"U^{2\beta}_{\delta_1 \rho_1} - \alpha^\prime_2U^{1\beta}_"
-    r"{\rho_1 \sigma_2} }{U^{0\beta}_{\rho_1 \sigma_2}}\right]$",
+    "Subscripts and superscripts":
+        r"$\alpha_i > \beta_i,\ "
+        r"\alpha_{i+1}^j = {\rm sin}(2\pi f_j t_i) e^{-5 t_i/\tau},\ "
+        r"\ldots$",
 
-    1: r"$\alpha_i > \beta_i,\ "
-    r"\alpha_{i+1}^j = {\rm sin}(2\pi f_j t_i) e^{-5 t_i/\tau},\ "
-    r"\ldots$",
+    "Fractions, binomials and stacked numbers":
+        r"$\frac{3}{4},\ \binom{3}{4},\ \genfrac{}{}{0}{}{3}{4},\ "
+        r"\left(\frac{5 - \frac{1}{x}}{4}\right),\ \ldots$",
 
-    2: r"$\frac{3}{4},\ \binom{3}{4},\ \genfrac{}{}{0}{}{3}{4},\ "
-    r"\left(\frac{5 - \frac{1}{x}}{4}\right),\ \ldots$",
+    "Radicals":
+        r"$\sqrt{2},\ \sqrt[3]{x},\ \ldots$",
 
-    3: r"$\sqrt{2},\ \sqrt[3]{x},\ \ldots$",
+    "Fonts":
+        r"$\mathrm{Roman}\ , \ \mathit{Italic}\ , \ \mathtt{Typewriter} \ "
+        r"\mathrm{or}\ \mathcal{CALLIGRAPHY}$",
 
-    4: r"$\mathrm{Roman}\ , \ \mathit{Italic}\ , \ \mathtt{Typewriter} \ "
-    r"\mathrm{or}\ \mathcal{CALLIGRAPHY}$",
+    "Accents":
+        r"$\acute a,\ \bar a,\ \breve a,\ \dot a,\ \ddot a, \ \grave a, \ "
+        r"\hat a,\ \tilde a,\ \vec a,\ \widehat{xyz},\ \widetilde{xyz},\ "
+        r"\ldots$",
 
-    5: r"$\acute a,\ \bar a,\ \breve a,\ \dot a,\ \ddot a, \ \grave a, \ "
-    r"\hat a,\ \tilde a,\ \vec a,\ \widehat{xyz},\ \widetilde{xyz},\ "
-    r"\ldots$",
+    "Greek, Hebrew":
+        r"$\alpha,\ \beta,\ \chi,\ \delta,\ \lambda,\ \mu,\ "
+        r"\Delta,\ \Gamma,\ \Omega,\ \Phi,\ \Pi,\ \Upsilon,\ \nabla,\ "
+        r"\aleph,\ \beth,\ \daleth,\ \gimel,\ \ldots$",
 
-    6: r"$\alpha,\ \beta,\ \chi,\ \delta,\ \lambda,\ \mu,\ "
-    r"\Delta,\ \Gamma,\ \Omega,\ \Phi,\ \Pi,\ \Upsilon,\ \nabla,\ "
-    r"\aleph,\ \beth,\ \daleth,\ \gimel,\ \ldots$",
-
-    7: r"$\coprod,\ \int,\ \oint,\ \prod,\ \sum,\ "
-    r"\log,\ \sin,\ \approx,\ \oplus,\ \star,\ \varpropto,\ "
-    r"\infty,\ \partial,\ \Re,\ \leftrightsquigarrow, \ \ldots$"}
+    "Delimiters, functions and Symbols":
+        r"$\coprod,\ \int,\ \oint,\ \prod,\ \sum,\ "
+        r"\log,\ \sin,\ \approx,\ \oplus,\ \star,\ \varpropto,\ "
+        r"\infty,\ \partial,\ \Re,\ \leftrightsquigarrow, \ \ldots$",
+}
+n_lines = len(mathtext_demos)
 
 
 def doall():
@@ -73,32 +72,31 @@ def doall():
     # Gap between lines in axes coords
     line_axesfrac = 1 / n_lines
 
-    # Plotting header demonstration formula
-    full_demo = mathext_demos[0]
+    # Plot header demonstration formula.
+    full_demo = mathtext_demos['Header demo']
     ax.annotate(full_demo,
                 xy=(0.5, 1. - 0.59 * line_axesfrac),
                 color='tab:orange', ha='center', fontsize=20)
 
-    # Plotting features demonstration formulae
-    for i_line in range(1, n_lines):
+    # Plot feature demonstration formulae.
+    for i_line, (title, demo) in enumerate(mathtext_demos.items()):
+        print(i_line, demo)
+        if i_line == 0:
+            continue
+
         baseline = 1 - i_line * line_axesfrac
         baseline_next = baseline - line_axesfrac
-        title = mathtext_titles[i_line] + ":"
         fill_color = ['white', 'tab:blue'][i_line % 2]
         ax.fill_between([0, 1], [baseline, baseline],
                         [baseline_next, baseline_next],
                         color=fill_color, alpha=0.2)
-        ax.annotate(title,
+        ax.annotate(f'{title}:',
                     xy=(0.07, baseline - 0.3 * line_axesfrac),
                     color=mpl_grey_rgb, weight='bold')
-        demo = mathext_demos[i_line]
         ax.annotate(demo,
                     xy=(0.05, baseline - 0.75 * line_axesfrac),
                     color=mpl_grey_rgb, fontsize=16)
 
-    for i in range(n_lines):
-        s = mathext_demos[i]
-        print(i, s)
     plt.show()
 
 
@@ -111,8 +109,7 @@ if '--latex' in sys.argv:
         fd.write("\\begin{document}\n")
         fd.write("\\begin{enumerate}\n")
 
-        for i in range(n_lines):
-            s = mathext_demos[i]
+        for s in mathtext_demos.values():
             s = re.sub(r"(?<!\\)\$", "$$", s)
             fd.write("\\item %s\n" % s)
 

--- a/examples/text_labels_and_annotations/mathtext_fontfamily_example.py
+++ b/examples/text_labels_and_annotations/mathtext_fontfamily_example.py
@@ -13,25 +13,26 @@ If no parameter is set, the global value
 
 import matplotlib.pyplot as plt
 
-plt.figure(figsize=(6, 5))
+
+fig, ax = plt.subplots(figsize=(6, 5))
 
 # A simple plot for the background.
-plt.plot(range(11), color="0.9")
+ax.plot(range(11), color="0.9")
 
 # A text mixing normal text and math text.
 msg = (r"Normal Text. $Text\ in\ math\ mode:\ "
        r"\int_{0}^{\infty } x^2 dx$")
 
 # Set the text in the plot.
-plt.text(1, 7, msg, size=12, math_fontfamily='cm')
+ax.text(1, 7, msg, size=12, math_fontfamily='cm')
 
 # Set another font for the next text.
-plt.text(1, 3, msg, size=12, math_fontfamily='dejavuserif')
+ax.text(1, 3, msg, size=12, math_fontfamily='dejavuserif')
 
 # *math_fontfamily* can be used in most places where there is text,
 # like in the title:
-plt.title(r"$Title\ in\ math\ mode:\ \int_{0}^{\infty } x^2 dx$",
-          math_fontfamily='stixsans', size=14)
+ax.set_title(r"$Title\ in\ math\ mode:\ \int_{0}^{\infty } x^2 dx$",
+             math_fontfamily='stixsans', size=14)
 
 # Note that the normal text is not changed by *math_fontfamily*.
 plt.show()


### PR DESCRIPTION
## PR Summary

The mathtext example uses two dictionaries, but that was only to preserve order, which we can do with a single dictionary directly now. Also, move to the object-oriented API, use current cycle colours instead of the old theme colours, and tweak the size so that the text doesn't overflow.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).