### PR TITLE
Fix suplabel autopos

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -370,7 +370,10 @@ default: %(va)s
 
         x = kwargs.pop('x', None)
         y = kwargs.pop('y', None)
-        autopos = x is None and y is None
+        if info['name'] in ['_supxlabel', '_suptitle']:
+            autopos = y is None
+        elif info['name'] == '_supylabel':
+            autopos = x is None
         if x is None:
             x = info['x0']
         if y is None:

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -537,3 +537,26 @@ def test_align_labels():
                                after_align[1].x0, rtol=0, atol=1e-05)
     # ensure labels do not go off the edge
     assert after_align[0].x0 >= 1
+
+
+def test_suplabels():
+    fig, ax = plt.subplots(constrained_layout=True)
+    fig.draw_no_output()
+    pos0 = ax.get_tightbbox(fig.canvas.get_renderer())
+    fig.supxlabel('Boo')
+    fig.supylabel('Booy')
+    fig.draw_no_output()
+    pos = ax.get_tightbbox(fig.canvas.get_renderer())
+    assert pos.y0 > pos0.y0 + 10.0
+    assert pos.x0 > pos0.x0 + 10.0
+
+    fig, ax = plt.subplots(constrained_layout=True)
+    fig.draw_no_output()
+    pos0 = ax.get_tightbbox(fig.canvas.get_renderer())
+    # check that specifying x (y) doesn't ruin the layout
+    fig.supxlabel('Boo', x=0.5)
+    fig.supylabel('Boo', y=0.5)
+    fig.draw_no_output()
+    pos = ax.get_tightbbox(fig.canvas.get_renderer())
+    assert pos.y0 > pos0.y0 + 10.0
+    assert pos.x0 > pos0.x0 + 10.0


### PR DESCRIPTION
## PR Summary
Closes #20760

If you specify the x-position of an supxlabel (or y position of supylabel) it should not disqualify the label from constrained_layout...

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots(constrained_layout=True)
lab = fig.supxlabel('Boo', x=0.7)
plt.show()
```

### Before:

![Before](https://user-images.githubusercontent.com/1562854/127404991-6bdbc7da-5b44-44ac-8e14-ecedf8498d36.png)


### After

![After](https://user-images.githubusercontent.com/1562854/127404999-c8706b78-1900-439d-9d8e-e0badf1ff84c.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
