### PR TITLE
Fix line dash offset format in PS output

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -329,7 +329,8 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
             if np.array_equal(seq, oldseq) and oldo == offset:
                 return
 
-        self._pswriter.write(f"[{_nums_to_str(*seq)}] {offset:d} setdash\n"
+        self._pswriter.write(f"[{_nums_to_str(*seq)}]"
+                             f" {_nums_to_str(offset)} setdash\n"
                              if seq is not None and len(seq) else
                              "[] 0 setdash\n")
         if store:

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -222,3 +222,15 @@ def test_fonttype(fonttype):
     test = b'/FontType ' + bytes(f"{fonttype}", encoding='utf-8') + b' def'
 
     assert re.search(test, buf.getvalue(), re.MULTILINE)
+
+
+def test_linedash():
+    """Test that dashed lines do not break PS output"""
+    fig, ax = plt.subplots()
+
+    ax.plot([0, 1], linestyle="--")
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="ps")
+
+    assert buf.tell() > 0


### PR DESCRIPTION
## PR Summary

A recent change introduced a regression in the PS backend. The line dash offset parameter is written as an integer (string format `d` operator). However according to the PS language spec, the offset can be any number and with the default `"--"` dash setting, the offset is a float.

With the current master, `linestyle="--"` raises a `ValueError` upon saving.

```python
plt.plot([0, 1], linestyle="--")
plt.savefig("x.ps")
```

This PR uses `_nums_to_str()` to format the offset value.

Should I add a test case for this?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
