### PR TITLE
Fixed typo in _constrained_layout.py (#20782)

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -301,7 +301,7 @@ def _make_margin_suptitles(fig, renderer, *, w_pad=0, h_pad=0):
             bbox = inv_trans_fig(fig._supxlabel.get_tightbbox(renderer))
             fig._layoutgrid.edit_margin_min('bottom', bbox.height + 2 * h_pad)
 
-    if fig._supylabel is not None and fig._supxlabel.get_in_layout():
+    if fig._supylabel is not None and fig._supylabel.get_in_layout():
         p = fig._supylabel.get_position()
         if getattr(fig._supylabel, '_autopos', False):
             fig._supylabel.set_position((w_pad_local, p[1]))


### PR DESCRIPTION
## PR Summary
Fixed #20782. In https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/_constrained_layout.py#L304

fixed typo

   `if fig._supylabel is not None and fig._supxlabel.get_in_layout():`

  to

   ` if fig._supylabel is not None and fig._supylabel.get_in_layout():`
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
