### PR TITLE
TST/MNT: deprecate unused fixture

### DIFF
--- a/doc/api/next_api_changes/deprecations/20795-TAC.rst
+++ b/doc/api/next_api_changes/deprecations/20795-TAC.rst
@@ -1,0 +1,5 @@
+Remove unused pytest fixture
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The fixture ``matplotlib.testing.conftest.mpl_image_comparison_parameters``
+is not used internally by Matplotlib.  If you use this please copy it
+into your code base.

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -97,6 +97,7 @@ def mpl_test_settings(request):
 
 
 @pytest.fixture
+@_api.deprecated("3.5", alternative="none")
 def mpl_image_comparison_parameters(request, extension):
     # This fixture is applied automatically by the image_comparison decorator.
     #

--- a/lib/matplotlib/tests/conftest.py
+++ b/lib/matplotlib/tests/conftest.py
@@ -1,4 +1,3 @@
 from matplotlib.testing.conftest import (mpl_test_settings,
-                                         mpl_image_comparison_parameters,
                                          pytest_configure, pytest_unconfigure,
                                          pd)

--- a/lib/mpl_toolkits/tests/conftest.py
+++ b/lib/mpl_toolkits/tests/conftest.py
@@ -1,3 +1,2 @@
 from matplotlib.testing.conftest import (mpl_test_settings,
-                                         mpl_image_comparison_parameters,
                                          pytest_configure, pytest_unconfigure)


### PR DESCRIPTION
This is left over from an early pass at nose -> pytest conversion

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
