### PR TITLE
MNT: Rename callbacksSM to callbacks

### DIFF
--- a/doc/api/next_api_changes/deprecations/20799-GL.rst
+++ b/doc/api/next_api_changes/deprecations/20799-GL.rst
@@ -1,0 +1,3 @@
+``ScalarMappable.callbacksSM``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+is deprecated. Use ``ScalarMappable.callbacks`` instead.

--- a/doc/api/next_api_changes/removals/19552-GL.rst
+++ b/doc/api/next_api_changes/removals/19552-GL.rst
@@ -2,4 +2,4 @@ ScalarMappable update checkers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ``ScalarMappable.update_dict``, ``ScalarMappable.add_checker()``, and
 ``ScalarMappable.check_update()`` have been removed. A callback can
-be registered in ``ScalarMappable.callbacksSM`` to be notified of updates.
+be registered in ``ScalarMappable.callbacks`` to be notified of updates.

--- a/examples/images_contours_and_fields/multi_image.py
+++ b/examples/images_contours_and_fields/multi_image.py
@@ -47,7 +47,7 @@ def update(changed_image):
 
 
 for im in images:
-    im.callbacksSM.connect('changed', update)
+    im.callbacks.connect('changed', update)
 
 plt.show()
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4923,7 +4923,7 @@ default: :rc:`scatter.edgecolors`
             vbar.set_cmap(collection.get_cmap())
             vbar.set_clim(collection.get_clim())
 
-        collection.callbacksSM.connect('changed', on_changed)
+        collection.callbacks.connect('changed', on_changed)
 
         return collection
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -263,7 +263,10 @@ class ScalarMappable:
         self.set_cmap(cmap)  # The Colormap instance of this ScalarMappable.
         #: The last colorbar associated with this ScalarMappable. May be None.
         self.colorbar = None
-        self.callbacksSM = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry()
+
+    callbacksSM = _api.deprecated("3.5", alternative="callbacks")(
+        property(lambda self: self.callbacks))
 
     def _scale_norm(self, norm, vmin, vmax):
         """
@@ -495,5 +498,5 @@ class ScalarMappable:
         Call this whenever the mappable is changed to notify all the
         callbackSM listeners to the 'changed' signal.
         """
-        self.callbacksSM.process('changed', self)
+        self.callbacks.process('changed', self)
         self.stale = True

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -404,7 +404,7 @@ class Colorbar:
             alpha = mappable.get_alpha()
 
         mappable.colorbar = self
-        mappable.colorbar_cid = mappable.callbacksSM.connect(
+        mappable.colorbar_cid = mappable.callbacks.connect(
             'changed', self.update_normal)
 
         _api.check_in_list(
@@ -981,7 +981,7 @@ class Colorbar:
         """
         self.ax.remove()
 
-        self.mappable.callbacksSM.disconnect(self.mappable.colorbar_cid)
+        self.mappable.callbacks.disconnect(self.mappable.colorbar_cid)
         self.mappable.colorbar = None
         self.mappable.colorbar_cid = None
 


### PR DESCRIPTION
## PR Summary

This makes the code more consistent throughout with objects having a `callbacks` attribute, rather than associating a name with them on the end and using camelCase.

First noticed by @timhoffm in https://github.com/matplotlib/matplotlib/pull/19553#issuecomment-893788816

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
