### PR TITLE
Re-remove deprecated Qt globals.

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -89,12 +89,6 @@ cursord = {
         (cursors.RESIZE_VERTICAL, "SizeVerCursor"),
     ]
 }
-SUPER = 0  # Deprecated.
-ALT = 1  # Deprecated.
-CTRL = 2  # Deprecated.
-SHIFT = 3  # Deprecated.
-MODIFIER_KEYS = [  # Deprecated.
-    (SPECIAL_KEYS[key], mod, key) for mod, key in _MODIFIER_KEYS]
 
 
 # make place holder


### PR DESCRIPTION
## PR Summary

These were removed in 15c39a3d0b87f024acc791cd3257ee95806403f5, but resurrected in the Qt6 PR.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).