### PR TITLE
Ensure all params are restored after `reset_ticks`.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -167,10 +167,12 @@ class Tick(martist.Artist):
             GRIDLINE_INTERPOLATION_STEPS
         self.label1 = mtext.Text(
             np.nan, np.nan,
-            fontsize=labelsize, color=labelcolor, visible=label1On)
+            fontsize=labelsize, color=labelcolor, visible=label1On,
+            rotation=self._labelrotation[1])
         self.label2 = mtext.Text(
             np.nan, np.nan,
-            fontsize=labelsize, color=labelcolor, visible=label2On)
+            fontsize=labelsize, color=labelcolor, visible=label2On,
+            rotation=self._labelrotation[1])
 
         self._apply_tickdir(tickdir)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4779,6 +4779,26 @@ def test_reset_grid():
         assert ax.xaxis.majorTicks[0].gridline.get_visible()
 
 
+@check_figures_equal(extensions=['png'])
+def test_reset_ticks(fig_test, fig_ref):
+    for fig in [fig_ref, fig_test]:
+        ax = fig.add_subplot()
+        ax.grid(True)
+        ax.tick_params(
+            direction='in', length=10, width=5, color='C0', pad=12,
+            labelsize=14, labelcolor='C1', labelrotation=45,
+            grid_color='C2', grid_alpha=0.8, grid_linewidth=3,
+            grid_linestyle='--')
+        fig.draw_no_output()
+
+    # After we've changed any setting on ticks, reset_ticks will mean
+    # re-creating them from scratch. This *should* appear the same as not
+    # resetting them.
+    for ax in fig_test.axes:
+        ax.xaxis.reset_ticks()
+        ax.yaxis.reset_ticks()
+
+
 def test_vline_limit():
     fig = plt.figure()
     ax = fig.gca()


### PR DESCRIPTION
## PR Summary

Currently, only label rotation was broken, but I set up the test to check everything.

Fixes #20791.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).