### PR TITLE
ENH: Add the ability to block callback signals

### DIFF
--- a/doc/users/next_whats_new/callback_blocking.rst
+++ b/doc/users/next_whats_new/callback_blocking.rst
@@ -1,0 +1,25 @@
+``CallbackRegistry`` objects gain a method to temporarily block signals
+-----------------------------------------------------------------------
+
+The context manager `~matplotlib.cbook.CallbackRegistry.blocked` can be used
+to block callback signals from being processed by the ``CallbackRegistry``.
+The optional keyword, *signal*, can be used to block a specific signal
+from being processed and let all other signals pass.
+
+.. code-block::
+
+    import matplotlib.pyplot as plt
+    
+    fig, ax = plt.subplots()
+    ax.imshow([[0, 1], [2, 3]])
+
+    # Block all interactivity through the canvas callbacks
+    with fig.canvas.callbacks.blocked():
+        plt.show()
+
+    fig, ax = plt.subplots()
+    ax.imshow([[0, 1], [2, 3]])
+
+    # Only block key press events
+    with fig.canvas.callbacks.blocked(signal="key_press_event"):
+        plt.show()

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -122,7 +122,8 @@ def _weak_or_strong_ref(func, callback):
 
 class CallbackRegistry:
     """
-    Handle registering and disconnecting for a set of signals and callbacks:
+    Handle registering, processing, blocking, and disconnecting
+    for a set of signals and callbacks:
 
         >>> def oneat(x):
         ...    print('eat', x)
@@ -140,8 +141,14 @@ class CallbackRegistry:
         >>> callbacks.process('eat', 456)
         eat 456
         >>> callbacks.process('be merry', 456) # nothing will be called
+
         >>> callbacks.disconnect(id_eat)
         >>> callbacks.process('eat', 456)      # nothing will be called
+
+        >>> with callbacks.blocked(signal='drink'):
+        ...     callbacks.process('drink', 123) # nothing will be called
+        >>> callbacks.process('drink', 123)
+        drink 123
 
     In practice, one should always disconnect all callbacks when they are
     no longer needed to avoid dangling references (and thus memory leaks).
@@ -279,6 +286,31 @@ class CallbackRegistry:
                         self.exception_handler(exc)
                     else:
                         raise
+
+    @contextlib.contextmanager
+    def blocked(self, *, signal=None):
+        """
+        Block callback signals from being processed.
+
+        A context manager to temporarily block/disable callback signals
+        from being processed by the registered listeners.
+
+        Parameters
+        ----------
+        signal : str, optional
+            The callback signal to block. The default is to block all signals.
+        """
+        orig = self.callbacks
+        try:
+            if signal is None:
+                # Empty out the callbacks
+                self.callbacks = {}
+            else:
+                # Only remove the specific signal
+                self.callbacks = {k: orig[k] for k in orig if k != signal}
+            yield
+        finally:
+            self.callbacks = orig
 
 
 class silent_list(list):


### PR DESCRIPTION
## PR Summary

CallbackRegistry objects gain a context manager `.block()` method that can be used to temporarily block callback signals from being processed.


```python
with callbacks.block():
    callbacks.process("test")  # Does nothing
with callbacks.block(signal="test"):
    callbacks.process("test")  # Does nothing
```

Closes #20802 
Would help with disabling norm update signals in #19553

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
