### PR TITLE
Make test_change_epoch more robust.

### DIFF
--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1095,12 +1095,15 @@ def test_datetime64_in_list():
 def test_change_epoch():
     date = np.datetime64('2000-01-01')
 
+    # use private method to clear the epoch and allow it to be set...
+    mdates._reset_epoch_test_example()
+    mdates.get_epoch()  # Set default.
+
     with pytest.raises(RuntimeError):
         # this should fail here because there is a sentinel on the epoch
         # if the epoch has been used then it cannot be set.
         mdates.set_epoch('0000-01-01')
 
-    # use private method to clear the epoch and allow it to be set...
     mdates._reset_epoch_test_example()
     mdates.set_epoch('1970-01-01')
     dt = (date - np.datetime64('1970-01-01')).astype('datetime64[D]')


### PR DESCRIPTION
## PR Summary

The epoch is set by explicitly calling `mdates.set_epoch`, or implicitly set to the default by `mdates.get_epoch` (which is also called when converting datetimes.)

However, when running tests in parallel, there is no guarantee that any other call to `[gs]et_epoch` might have been made to lock it in, so we need to do that explicitly.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).