### PR TITLE
Increase test timeouts to 60 s to aid slower architectures

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -456,7 +456,7 @@ def _get_testable_qt_backends():
         envs.append(pytest.param(env, marks=marks, id=str(env)))
     return envs
 
-_test_timeout = 10  # Empirically, 1s is not enough on CI.
+_test_timeout = 60  # A reasonably safe value for slower architectures.
 
 
 @pytest.mark.parametrize("env", _get_testable_qt_backends())

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -7,7 +7,7 @@ import sys
 
 import pytest
 
-_test_timeout = 10  # Empirically, 1s is not enough on CI.
+_test_timeout = 60  # A reasonably safe value for slower architectures.
 
 
 def _isolated_tk_test(success_count, func=None):

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -55,7 +55,7 @@ def _get_testable_interactive_backends():
     return envs
 
 
-_test_timeout = 10  # Empirically, 1s is not enough on CI.
+_test_timeout = 60  # A reasonably safe value for slower architectures.
 
 
 # The source of this function gets extracted and run in another process, so it


### PR DESCRIPTION
## PR Summary
Increase the test timeouts from 10 s to 60 s.  The Gentoo arch teams
have reported that the default timeout of 10 s is insufficient for
slower architectures (such as HPPA) and/or busy test systems.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] <del>Has pytest style unit tests (and `pytest` passes).</del>
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] <del>New features are documented, with examples if plot related.</del>
- [x] <del>Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).<del>
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] <del>New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).</del>
- [x] <del>API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).</del>

(this is a trivial test constant change, so most of the points above are irrelevant)