### PR TITLE
TST: neither warned and pytest upstream deprecated this usage

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -180,8 +180,8 @@ def test_save_animation_smoketest(tmpdir, writer, frame_format, output, anim):
     with tmpdir.as_cwd():
         anim.save(output, fps=30, writer=writer, bitrate=500, dpi=dpi,
                   codec=codec)
-    with pytest.warns(None):
-        del anim
+
+    del anim
 
 
 @pytest.mark.parametrize('writer', [

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -437,6 +437,5 @@ def test_mathtext_cmr10_minus_sign():
     mpl.rcParams['axes.formatter.use_mathtext'] = True
     fig, ax = plt.subplots()
     ax.plot(range(-1, 1), range(-1, 1))
-    with pytest.warns(None) as record:
-        fig.canvas.draw()
-    assert len(record) == 0, "\n".join(str(e.message) for e in record)
+    # draw to make sure we have no warnings
+    fig.canvas.draw()


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

