### PR TITLE
Fix centre and square state and add rotation for rectangle selector

### DIFF
--- a/doc/api/next_api_changes/deprecations/20839-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20839-EP.rst
@@ -1,4 +1,4 @@
 Selector widget state internals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*state_modifier_keys* now have to be defined when creating a selector widget.
-The *state_modifier_keys* attribute is deprecated.
+*state_modifier_keys* are immutable now. They can be set when creating the
+widget, but cannot be changed afterwards anymore.

--- a/doc/api/next_api_changes/deprecations/20839-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20839-EP.rst
@@ -1,4 +1,4 @@
 Selector widget state internals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*state_modifier_keys* have to be defined when creating the selector widget. The 
-*state_modifier_keys* attribute is deprecated.
+*state_modifier_keys* now have to be defined when creating a selector widget.
+The *state_modifier_keys* attribute is deprecated.

--- a/doc/api/next_api_changes/deprecations/20839-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20839-EP.rst
@@ -1,0 +1,4 @@
+Selector widget state internals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+*state_modifier_keys* have to be defined when creating the selector widget. The 
+*state_modifier_keys* attribute is deprecated.

--- a/doc/api/next_api_changes/deprecations/20839-EP.rst
+++ b/doc/api/next_api_changes/deprecations/20839-EP.rst
@@ -1,4 +1,4 @@
 Selector widget state internals
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-*state_modifier_keys* are immutable now. They can be set when creating the
-widget, but cannot be changed afterwards anymore.
+The *state_modifier_keys* attribute have been privatized and the modifier keys
+needs to be set when creating the widget.

--- a/doc/users/next_whats_new/rectangle_patch_rotation.rst
+++ b/doc/users/next_whats_new/rectangle_patch_rotation.rst
@@ -1,0 +1,5 @@
+Rectangle patch rotation point
+------------------------------
+
+The rotation point of the `~matplotlib.patches.Rectangle` can now be set to 'xy',
+'center' or a 2-tuple of numbers.

--- a/doc/users/next_whats_new/selector_improvement.rst
+++ b/doc/users/next_whats_new/selector_improvement.rst
@@ -1,16 +1,40 @@
-Rotating selectors and aspect ratio correction
-----------------------------------------------
+Selectors improvement: rotation, aspect ratio correction and add/remove state
+-----------------------------------------------------------------------------
 
 The `~matplotlib.widgets.RectangleSelector` and
 `~matplotlib.widgets.EllipseSelector` can now be rotated interactively.
-
-The rotation is enabled when *rotate* is added to
-:py:attr:`~matplotlib.widgets._SelectorWidget.state`, which can be done using
-:py:meth:`~matplotlib.widgets._SelectorWidget.add_state` or by striking
-the *state_modifier_keys* for *rotate* (default *r*).
+The rotation is enabled or disable by striking the *r* key
+(default value of 'rotate' in *state_modifier_keys*) or by calling
+*selector.add_state('rotate')*.
 
 The aspect ratio of the axes can now be taken into account when using the
-"square" state. When *data_coordinates* is added to
-:py:attr:`~matplotlib.widgets._SelectorWidget.state`, which can be done using
-:py:meth:`~matplotlib.widgets._SelectorWidget.add_state` or by striking
-the *state_modifier_keys* for *data_coordinates* (default *d*).
+"square" state. This can be enable or disable by striking the *d* key
+(default value of 'data_coordinates' in *state_modifier_keys*)
+or by calling *selector.add_state('rotate')*.
+
+In addition to changing selector state interactively using the modifier keys
+defined in *state_modifier_keys*, the selector state can now be changed
+programmatically using the *add_state* and *remove_state* method.
+
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+    from matplotlib.widgets import RectangleSelector
+    import numpy as np
+
+    values = np.arange(0, 100)
+
+    fig = plt.figure()
+    ax = fig.add_subplot()
+    ax.plot(values, values)
+
+    selector = RectangleSelector(ax, print, interactive=True, drag_from_anywhere=True)
+    selector.add_state('rotate') # alternatively press 'r' key
+    # rotate the selector interactively
+
+    selector.remove_state('rotate') # alternatively press 'r' key
+
+    selector.add_state('square')
+    # to keep the aspect ratio in data coordinates
+    selector.add_state('data_coordinates')

--- a/doc/users/next_whats_new/selector_improvement.rst
+++ b/doc/users/next_whats_new/selector_improvement.rst
@@ -1,8 +1,16 @@
-Selectors improvement
----------------------
+Rotating selectors and aspect ratio correction
+----------------------------------------------
 
 The `~matplotlib.widgets.RectangleSelector` and
-`~matplotlib.widgets.EllipseSelector` can now be rotated interactively. The rotation is
-enabled and disabled by pressing the 'r' key.
-The "square" shape can be defined in data or display coordinate system as defined
-by the *data_coordinates* modifier.
+`~matplotlib.widgets.EllipseSelector` can now be rotated interactively.
+
+The rotation is enabled when *rotate* is added to
+:py:attr:`~matplotlib.widgets._SelectorWidget.state`, which can be done using
+:py:meth:`~matplotlib.widgets._SelectorWidget.add_state` or by striking
+the *state_modifier_keys* for *rotate* (default *r*).
+
+The aspect ratio of the axes can now be taken into account when using the
+"square" state. When *data_coordinates* is added to
+:py:attr:`~matplotlib.widgets._SelectorWidget.state`, which can be done using
+:py:meth:`~matplotlib.widgets._SelectorWidget.add_state` or by striking
+the *state_modifier_keys* for *data_coordinates* (default *d*).

--- a/doc/users/next_whats_new/selector_improvement.rst
+++ b/doc/users/next_whats_new/selector_improvement.rst
@@ -4,16 +4,16 @@ Selectors improvement: rotation, aspect ratio correction and add/remove state
 The `~matplotlib.widgets.RectangleSelector` and
 `~matplotlib.widgets.EllipseSelector` can now be rotated interactively.
 The rotation is enabled or disable by striking the *r* key
-(default value of 'rotate' in *state_modifier_keys*) or by calling
-*selector.add_state('rotate')*.
+('r' is the default key mapped to 'rotate' in *state_modifier_keys*) or by calling
+``selector.add_state('rotate')``.
 
 The aspect ratio of the axes can now be taken into account when using the
-"square" state. This is enable by specifying *use_data_coordinates='True'* when
+"square" state. This is enabled by specifying ``use_data_coordinates='True'`` when
 the selector is initialized.
 
 In addition to changing selector state interactively using the modifier keys
 defined in *state_modifier_keys*, the selector state can now be changed
-programmatically using the *add_state* and *remove_state* method.
+programmatically using the *add_state* and *remove_state* methods.
 
 
 .. code-block:: python

--- a/doc/users/next_whats_new/selector_improvement.rst
+++ b/doc/users/next_whats_new/selector_improvement.rst
@@ -1,0 +1,8 @@
+Selectors improvement
+---------------------
+
+The `~matplotlib.widgets.RectangleSelector` and
+`~matplotlib.widgets.EllipseSelector` can now be rotated interactively. The rotation is
+enabled and disabled by pressing the 'r' key.
+The "square" shape can be defined in data or display coordinate system as defined
+by the *data_coordinates* modifier.

--- a/doc/users/next_whats_new/selector_improvement.rst
+++ b/doc/users/next_whats_new/selector_improvement.rst
@@ -2,8 +2,9 @@ Selectors improvement: rotation, aspect ratio correction and add/remove state
 -----------------------------------------------------------------------------
 
 The `~matplotlib.widgets.RectangleSelector` and
-`~matplotlib.widgets.EllipseSelector` can now be rotated interactively.
-The rotation is enabled or disable by striking the *r* key
+`~matplotlib.widgets.EllipseSelector` can now be rotated interactively between
+-45° and 45°. The range limits are currently dictated by the implementation.
+The rotation is enabled or disabled by striking the *r* key
 ('r' is the default key mapped to 'rotate' in *state_modifier_keys*) or by calling
 ``selector.add_state('rotate')``.
 

--- a/doc/users/next_whats_new/selector_improvement.rst
+++ b/doc/users/next_whats_new/selector_improvement.rst
@@ -8,9 +8,8 @@ The rotation is enabled or disable by striking the *r* key
 *selector.add_state('rotate')*.
 
 The aspect ratio of the axes can now be taken into account when using the
-"square" state. This can be enable or disable by striking the *d* key
-(default value of 'data_coordinates' in *state_modifier_keys*)
-or by calling *selector.add_state('rotate')*.
+"square" state. This is enable by specifying *use_data_coordinates='True'* when
+the selector is initialized.
 
 In addition to changing selector state interactively using the modifier keys
 defined in *state_modifier_keys*, the selector state can now be changed
@@ -29,12 +28,12 @@ programmatically using the *add_state* and *remove_state* method.
     ax = fig.add_subplot()
     ax.plot(values, values)
 
-    selector = RectangleSelector(ax, print, interactive=True, drag_from_anywhere=True)
+    selector = RectangleSelector(ax, print, interactive=True,
+                                 drag_from_anywhere=True,
+                                 use_data_coordinates=True)
     selector.add_state('rotate') # alternatively press 'r' key
     # rotate the selector interactively
 
     selector.remove_state('rotate') # alternatively press 'r' key
 
     selector.add_state('square')
-    # to keep the aspect ratio in data coordinates
-    selector.add_state('data_coordinates')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8094,3 +8094,10 @@ such objects
     tricontourf = mtri.tricontourf
     tripcolor = mtri.tripcolor
     triplot = mtri.triplot
+
+    def _get_aspect_ratio(self):
+        """Convenience method to calculate aspect ratio of the axes."""
+        figure_size = self.get_figure().get_size_inches()
+        ll, ur = self.get_position() * figure_size
+        width, height = ur - ll
+        return height / (width * self.get_data_ratio())

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8096,7 +8096,10 @@ such objects
     triplot = mtri.triplot
 
     def _get_aspect_ratio(self):
-        """Convenience method to calculate aspect ratio of the axes."""
+        """
+        Convenience method to calculate the aspect ratio of the axes in
+        the display coordinate system.
+        """
         figure_size = self.get_figure().get_size_inches()
         ll, ur = self.get_position() * figure_size
         width, height = ur - ll

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -738,6 +738,10 @@ class Rectangle(Patch):
         self.angle = float(angle)
         self.rotate_around_center = rotate_around_center
         # Required for RectangleSelector with axes aspect ratio != 1
+        # The patch is defined in data coordinates and when changing the
+        # selector with square modifier and not in data coordinates, we need
+        # to correct for the aspect ratio difference between the data and
+        # display coordinate systems.
         self._aspect_ratio_correction = 1.0
         self._convert_units()  # Validate the inputs.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -721,7 +721,7 @@ class Rectangle(Patch):
             Rotation in degrees anti-clockwise about the rotation point.
         rotation_point : {'xy', 'center', (number, number)}, default: 'xy'
             If ``'xy'``, rotate around the anchor point. If ``'center'`` rotate
-            around the center. If 2-tuple of number, rotate around these
+            around the center. If 2-tuple of number, rotate around this
             coordinate.
 
         Other Parameters
@@ -740,7 +740,8 @@ class Rectangle(Patch):
         # The patch is defined in data coordinates and when changing the
         # selector with square modifier and not in data coordinates, we need
         # to correct for the aspect ratio difference between the data and
-        # display coordinate systems.
+        # display coordinate systems. Its value is typically provide by
+        # Axes._get_aspect_ratio()
         self._aspect_ratio_correction = 1.0
         self._convert_units()  # Validate the inputs.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -780,6 +780,7 @@ class Rectangle(Patch):
 
     @property
     def rotation_point(self):
+        """The rotation point of the patch."""
         return self._rotation_point
 
     @rotation_point.setter

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -706,7 +706,8 @@ class Rectangle(Patch):
         return fmt % pars
 
     @docstring.dedent_interpd
-    def __init__(self, xy, width, height, angle=0.0, **kwargs):
+    def __init__(self, xy, width, height, angle=0.0,
+                 rotate_around_center=False, **kwargs):
         """
         Parameters
         ----------
@@ -717,7 +718,12 @@ class Rectangle(Patch):
         height : float
             Rectangle height.
         angle : float, default: 0
-            Rotation in degrees anti-clockwise about *xy*.
+            Rotation in degrees anti-clockwise about *xy* if
+            *rotate_around_center* if False, otherwise rotate around the
+            center of the rectangle
+        rotate_around_center : bool, default: False
+            If True, the rotation is performed around the center of the
+            rectangle.
 
         Other Parameters
         ----------------
@@ -730,6 +736,7 @@ class Rectangle(Patch):
         self._width = width
         self._height = height
         self.angle = float(angle)
+        self.rotate_around_center = rotate_around_center
         self._convert_units()  # Validate the inputs.
 
     def get_path(self):
@@ -750,9 +757,14 @@ class Rectangle(Patch):
         # important to call the accessor method and not directly access the
         # transformation member variable.
         bbox = self.get_bbox()
+        if self.rotate_around_center:
+            width, height = bbox.x1 - bbox.x0, bbox.y1 - bbox.y0
+            rotation_point = bbox.x0 + width / 2., bbox.y0 + height / 2.
+        else:
+            rotation_point = bbox.x0, bbox.y0
         return (transforms.BboxTransformTo(bbox)
                 + transforms.Affine2D().rotate_deg_around(
-                    bbox.x0, bbox.y0, self.angle))
+                    *rotation_point, self.angle))
 
     def get_x(self):
         """Return the left coordinate of the rectangle."""

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -768,8 +768,7 @@ class Rectangle(Patch):
             rotation_point = bbox.x0 + width / 2., bbox.y0 + height / 2.
         elif self.rotation_point == 'xy':
             rotation_point = bbox.x0, bbox.y0
-        elif (isinstance(self.rotation_point[0], Number) and
-                  isinstance(self.rotation_point[1], Number)):
+        else:
             rotation_point = self.rotation_point
         return transforms.BboxTransformTo(bbox) \
                 + transforms.Affine2D() \
@@ -778,6 +777,21 @@ class Rectangle(Patch):
                 .rotate_deg(self.angle) \
                 .scale(1, 1 / self._aspect_ratio_correction) \
                 .translate(*rotation_point)
+
+    @property
+    def rotation_point(self):
+        return self._rotation_point
+
+    @rotation_point.setter
+    def rotation_point(self, value):
+        if value in ['center', 'xy'] or (
+                isinstance(value, tuple) and len(value) == 2 and
+                isinstance(value[0], Number) and isinstance(value[1], Number)
+                ):
+            self._rotation_point = value
+        else:
+            raise ValueError("`rotation_point` must be one of "
+                             "{'xy', 'center', (number, number)}.")
 
     def get_x(self):
         """Return the left coordinate of the rectangle."""

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -171,6 +171,26 @@ def test_rectangle_resize():
     assert tool.extents == (xdata_new, extents[1], ydata_new, extents[3])
 
 
+def test_rectangle_add_default_state():
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True)
+    # Create rectangle
+    _resize_rectangle(tool, 70, 65, 125, 130)
+
+    with pytest.raises(ValueError):
+        tool.add_default_state('unsupported_state')
+
+    with pytest.raises(ValueError):
+        tool.add_default_state('clear')
+    tool.add_default_state('move')
+    tool.add_default_state('square')
+    tool.add_default_state('center')
+
+
 @pytest.mark.parametrize('use_default_state', [True, False])
 def test_rectangle_resize_center(use_default_state):
     ax = get_ax()
@@ -184,7 +204,7 @@ def test_rectangle_resize_center(use_default_state):
     assert tool.extents == (70.0, 125.0, 65.0, 130.0)
 
     if use_default_state:
-        tool._default_state.add('center')
+        tool.add_default_state('center')
         use_key = None
     else:
         use_key = 'control'
@@ -257,7 +277,7 @@ def test_rectangle_resize_square(use_default_state):
     assert tool.extents == (70.0, 120.0, 65.0, 115.0)
 
     if use_default_state:
-        tool._default_state.add('square')
+        tool.add_default_state('square')
         use_key = None
     else:
         use_key = 'shift'
@@ -326,8 +346,8 @@ def test_rectangle_resize_square_center():
     tool = widgets.RectangleSelector(ax, onselect, interactive=True)
     # Create rectangle
     _resize_rectangle(tool, 70, 65, 120, 115)
-    tool._default_state.add('square')
-    tool._default_state.add('center')
+    tool.add_default_state('square')
+    tool.add_default_state('center')
     assert tool.extents == (70.0, 120.0, 65.0, 115.0)
 
     # resize NE handle
@@ -801,6 +821,24 @@ def test_selector_clear_method(selector):
     assert tool.visible
     if selector == 'span':
         assert tool.extents == (10, 50)
+
+
+def test_span_selector_add_default_state():
+    ax = get_ax()
+
+    def onselect(*args):
+        pass
+
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal', interactive=True)
+
+    with pytest.raises(ValueError):
+        tool.add_default_state('unsupported_state')
+    with pytest.raises(ValueError):
+        tool.add_default_state('center')
+    with pytest.raises(ValueError):
+        tool.add_default_state('square')
+
+    tool.add_default_state('move')
 
 
 def test_tool_line_handle():

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -350,7 +350,7 @@ def test_rectangle_resize_square_center():
     _resize_rectangle(tool, 70, 65, 120, 115)
     tool.add_default_state('square')
     tool.add_default_state('center')
-    assert tool.extents == (70.0, 120.0, 65.0, 115.0)
+    assert_allclose(tool.extents, (70.0, 120.0, 65.0, 115.0))
 
     # resize NE handle
     extents = tool.extents
@@ -358,8 +358,8 @@ def test_rectangle_resize_square_center():
     xdiff, ydiff = 10, 5
     xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
-    assert tool.extents == (extents[0] - xdiff, xdata_new,
-                            extents[2] - xdiff, extents[3] + xdiff)
+    assert_allclose(tool.extents, (extents[0] - xdiff, xdata_new,
+                                   extents[2] - xdiff, extents[3] + xdiff))
 
     # resize E handle
     extents = tool.extents
@@ -367,8 +367,8 @@ def test_rectangle_resize_square_center():
     xdiff = 10
     xdata_new, ydata_new = xdata + xdiff, ydata
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
-    assert tool.extents == (extents[0] - xdiff, xdata_new,
-                            extents[2] - xdiff, extents[3] + xdiff)
+    assert_allclose(tool.extents, (extents[0] - xdiff, xdata_new,
+                                   extents[2] - xdiff, extents[3] + xdiff))
 
     # resize E handle negative diff
     extents = tool.extents
@@ -376,8 +376,8 @@ def test_rectangle_resize_square_center():
     xdiff = -20
     xdata_new, ydata_new = xdata + xdiff, ydata
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
-    assert tool.extents == (extents[0] - xdiff, xdata_new,
-                            extents[2] - xdiff, extents[3] + xdiff)
+    assert_allclose(tool.extents, (extents[0] - xdiff, xdata_new,
+                                   extents[2] - xdiff, extents[3] + xdiff))
 
     # resize W handle
     extents = tool.extents
@@ -385,8 +385,8 @@ def test_rectangle_resize_square_center():
     xdiff = 5
     xdata_new, ydata_new = xdata + xdiff, ydata
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
-    assert tool.extents == (xdata_new, extents[1] - xdiff,
-                            extents[2] + xdiff, extents[3] - xdiff)
+    assert_allclose(tool.extents, (xdata_new, extents[1] - xdiff,
+                                   extents[2] + xdiff, extents[3] - xdiff))
 
     # resize W handle negative diff
     extents = tool.extents
@@ -394,8 +394,8 @@ def test_rectangle_resize_square_center():
     xdiff = -25
     xdata_new, ydata_new = xdata + xdiff, ydata
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
-    assert tool.extents == (xdata_new, extents[1] - xdiff,
-                            extents[2] + xdiff, extents[3] - xdiff)
+    assert_allclose(tool.extents, (xdata_new, extents[1] - xdiff,
+                                   extents[2] + xdiff, extents[3] - xdiff))
 
     # resize SW handle
     extents = tool.extents
@@ -403,8 +403,8 @@ def test_rectangle_resize_square_center():
     xdiff, ydiff = 20, 25
     xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
-    assert tool.extents == (extents[0] + ydiff, extents[1] - ydiff,
-                            ydata_new, extents[3] - ydiff)
+    assert_allclose(tool.extents, (extents[0] + ydiff, extents[1] - ydiff,
+                                   ydata_new, extents[3] - ydiff))
 
 
 @pytest.mark.parametrize('selector_class',
@@ -421,26 +421,35 @@ def test_rectangle_rotate(selector_class):
     do_event(tool, 'onmove', xdata=130, ydata=140)
     do_event(tool, 'release', xdata=130, ydata=140)
     assert tool.extents == (100, 130, 100, 140)
+    assert len(tool._default_state) == 0
+    assert len(tool._state) == 0
 
     # Rotate anticlockwise using top-right corner
     do_event(tool, 'on_key_press', key='r')
+    assert tool._default_state == set(['rotate'])
+    assert len(tool._state) == 0
     do_event(tool, 'press', xdata=130, ydata=140)
-    do_event(tool, 'onmove', xdata=110, ydata=145)
-    do_event(tool, 'release', xdata=110, ydata=145)
+    do_event(tool, 'onmove', xdata=120, ydata=145)
+    do_event(tool, 'release', xdata=120, ydata=145)
     do_event(tool, 'on_key_press', key='r')
+    assert len(tool._default_state) == 0
+    assert len(tool._state) == 0
     # Extents shouldn't change (as shape of rectangle hasn't changed)
     assert tool.extents == (100, 130, 100, 140)
+    assert_allclose(tool.rotation, 25.56, atol=0.01)
+    tool.rotation = 45
+    assert tool.rotation == 45
     # Corners should move
     # The third corner is at (100, 145)
     assert_allclose(tool.corners,
-                    np.array([[119.9, 139.9, 110.1, 90.1],
-                              [95.4, 117.8, 144.5, 122.2]]), atol=0.1)
+                    np.array([[118.53, 139.75, 111.46, 90.25],
+                              [95.25, 116.46, 144.75, 123.54]]), atol=0.01)
 
     # Scale using top-right corner
     do_event(tool, 'press', xdata=110, ydata=145)
     do_event(tool, 'onmove', xdata=110, ydata=160)
     do_event(tool, 'release', xdata=110, ydata=160)
-    assert_allclose(tool.extents, (100, 141.5, 100, 150.4), atol=0.1)
+    assert_allclose(tool.extents, (100, 139.75, 100, 151.82), atol=0.01)
 
 
 def test_rectangle_resize_square_center_aspect():
@@ -462,6 +471,7 @@ def test_rectangle_resize_square_center_aspect():
     xdata, ydata = extents[1], extents[3]
     xdiff = 10
     xdata_new, ydata_new = xdata + xdiff, ydata
+    ychange = xdiff * 1 / tool._aspect_ratio_correction
     _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
     assert_allclose(tool.extents, [extents[0] - xdiff, xdata_new,
                                    46.25, 133.75])

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -510,11 +510,10 @@ def test_rectangle_handles():
                                                    'markeredgecolor': 'b'})
     tool.extents = (100, 150, 100, 150)
 
-    assert tool.corners == (
-        (100, 150, 150, 100), (100, 100, 150, 150))
+    assert_allclose(tool.corners, ((100, 150, 150, 100), (100, 100, 150, 150)))
     assert tool.extents == (100, 150, 100, 150)
-    assert tool.edge_centers == (
-        (100, 125.0, 150, 125.0), (125.0, 100, 125.0, 150))
+    assert_allclose(tool.edge_centers,
+                    ((100, 125.0, 150, 125.0), (125.0, 100, 125.0, 150)))
     assert tool.extents == (100, 150, 100, 150)
 
     # grab a corner and move it

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -440,7 +440,6 @@ def test_rectangle_rotate(selector_class):
     tool.rotation = 45
     assert tool.rotation == 45
     # Corners should move
-    # The third corner is at (100, 145)
     assert_allclose(tool.corners,
                     np.array([[118.53, 139.75, 111.46, 90.25],
                               [95.25, 116.46, 144.75, 123.54]]), atol=0.01)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2074,37 +2074,34 @@ class _SelectorWidget(AxesWidget):
             self.update()
         self._handle_props.update(handle_props)
 
-    def _validate_state(self, value):
+    def _validate_state(self, state):
         supported_state = [
             key for key, value in self._state_modifier_keys.items()
             if key != 'clear' and value != 'not-applicable'
             ]
-        if value not in supported_state:
-            keys = ', '.join(supported_state)
-            raise ValueError('Setting default state must be one of the '
-                             f'following: {keys}.')
+        _api.check_in_list(supported_state, state=state)
 
-    def add_state(self, value):
+    def add_state(self, state):
         """
         Add a state to define the widget's behavior. See the
         `state_modifier_keys` parameters for details.
 
         Parameters
         ----------
-        value : str
+        state : str
             Must be a supported state of the selector. See the
             `state_modifier_keys` parameters for details.
 
         Raises
         ------
         ValueError
-            When the value is not supported by the selector.
+            When the state is not supported by the selector.
 
         """
-        self._validate_state(value)
-        self._state.add(value)
+        self._validate_state(state)
+        self._state.add(state)
 
-    def remove_state(self, value):
+    def remove_state(self, state):
         """
         Remove a state to define the widget's behavior. See the
         `state_modifier_keys` parameters for details.
@@ -2118,11 +2115,11 @@ class _SelectorWidget(AxesWidget):
         Raises
         ------
         ValueError
-            When the value is not supported by the selector.
+            When the state is not supported by the selector.
 
         """
-        self._validate_state(value)
-        self._state.remove(value)
+        self._validate_state(state)
+        self._state.remove(state)
 
 
 class SpanSelector(_SelectorWidget):
@@ -2193,7 +2190,7 @@ class SpanSelector(_SelectorWidget):
 
     state_modifier_keys : dict, optional
         Keyboard modifiers which affect the widget's behavior.  Values
-        amend the defaults.
+        amend the defaults, which are:
 
         - "clear": Clear the current shape, default: "escape".
 
@@ -2800,7 +2797,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
 
     state_modifier_keys : dict, optional
         Keyboard modifiers which affect the widget's behavior.  Values
-        amend the defaults.
+        amend the defaults, which are:
 
         - "move": Move the existing shape, default: no modifier.
         - "clear": Clear the current shape, default: "escape".
@@ -2854,6 +2851,8 @@ class RectangleSelector(_SelectorWidget):
     >>> rect = mwidgets.RectangleSelector(ax, onselect, interactive=True,
                                           props=props)
     >>> fig.show()
+
+    >>> selector.add_state('square')
 
     See also: :doc:`/gallery/widgets/rectangle_selector`
     """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1947,9 +1947,8 @@ class _SelectorWidget(AxesWidget):
             key = event.key or ''
             key = key.replace('ctrl', 'control')
             # move state is locked in on a button press
-            for state in ['move']:
-                if key == self._state_modifier_keys[state]:
-                    self._state.add(state)
+            if key == self._state_modifier_keys['move']:
+                self._state.add('move')
             self._press(event)
             return True
         return False
@@ -2000,14 +1999,10 @@ class _SelectorWidget(AxesWidget):
                 self.clear()
                 return
             for (state, modifier) in self._state_modifier_keys.items():
-                if modifier in key.split('+'):
-                    # rotate and data_coordinates are enable/disable
-                    # on key press
-                    if (state in ['rotate', 'data_coordinates'] and
-                            state in self._state):
-                        self._state.discard(state)
-                    else:
-                        self._state.add(state)
+                # 'rotate' and 'data_coordinates' are added in _default_state
+                if (modifier in key.split('+') and
+                        state not in ['rotate', 'data_coordinates']):
+                    self._state.add(state)
             self._on_key_press(event)
 
     def _on_key_press(self, event):
@@ -2017,9 +2012,9 @@ class _SelectorWidget(AxesWidget):
         """Key release event handler and validator."""
         if self.active:
             key = event.key or ''
+            key = key.replace('ctrl', 'control')
             for (state, modifier) in self._state_modifier_keys.items():
-                if (modifier in key.split('+') and
-                        state not in ['rotate', 'data_coordinates']):
+                if modifier in key.split('+'):
                     self._state.discard(state)
             self._on_key_release(event)
 
@@ -2858,7 +2853,8 @@ class RectangleSelector(_SelectorWidget):
         self._interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
         self.ignore_event_outside = ignore_event_outside
-        self._rotation = 0
+        self._rotation = 0.0
+        self._aspect_ratio_correction = 1.0
 
         if drawtype == 'none':  # draw a line but make it invisible
             _api.warn_deprecated(
@@ -2892,6 +2888,7 @@ class RectangleSelector(_SelectorWidget):
             self.ax.add_line(to_draw)
 
         self._selection_artist = to_draw
+        self._set_aspect_ratio_correction()
 
         self.minspanx = minspanx
         self.minspany = minspany
@@ -2975,6 +2972,8 @@ class RectangleSelector(_SelectorWidget):
             self.set_visible(True)
 
         self._extents_on_press = self.extents
+        self._rotation_on_press = self._rotation
+        self._set_aspect_ratio_correction()
 
         return False
 
@@ -3050,13 +3049,8 @@ class RectangleSelector(_SelectorWidget):
         dy = event.ydata - eventpress.ydata
         refmax = None
         if 'data_coordinates' in state:
-            aspect_ratio = 1
             refx, refy = dx, dy
         else:
-            figure_size = self.ax.get_figure().get_size_inches()
-            ll, ur = self.ax.get_position() * figure_size
-            width, height = ur - ll
-            aspect_ratio = height / width * self.ax.get_data_ratio()
             refx = event.xdata / (eventpress.xdata + 1e-6)
             refy = event.ydata / (eventpress.ydata + 1e-6)
 
@@ -3067,8 +3061,9 @@ class RectangleSelector(_SelectorWidget):
             a = np.array([eventpress.xdata, eventpress.ydata])
             b = np.array(self.center)
             c = np.array([event.xdata, event.ydata])
-            self._rotation = (np.arctan2(c[1]-b[1], c[0]-b[0]) -
-                              np.arctan2(a[1]-b[1], a[0]-b[0]))
+            angle = (np.arctan2(c[1]-b[1], c[0]-b[0]) -
+                     np.arctan2(a[1]-b[1], a[0]-b[0]))
+            self.rotation = np.rad2deg(self._rotation_on_press + angle)
 
         # resize an existing shape
         elif self._active_handle and self._active_handle != 'C':
@@ -3083,10 +3078,10 @@ class RectangleSelector(_SelectorWidget):
                         refmax = max(refx, refy, key=abs)
                     if self._active_handle in ['E', 'W'] or refmax == refx:
                         hw = event.xdata - center[0]
-                        hh = hw / aspect_ratio
+                        hh = hw / self._aspect_ratio_correction
                     else:
                         hh = event.ydata - center[1]
-                        hw = hh * aspect_ratio
+                        hw = hh * self._aspect_ratio_correction
                 else:
                     hw = size_on_press[0] / 2
                     hh = size_on_press[1] / 2
@@ -3119,10 +3114,12 @@ class RectangleSelector(_SelectorWidget):
                         refmax = max(refx, refy, key=abs)
                     if self._active_handle in ['E', 'W'] or refmax == refx:
                         sign = np.sign(event.ydata - y0)
-                        y1 = y0 + sign * abs(x1 - x0) / aspect_ratio
+                        y1 = y0 + sign * abs(x1 - x0) / \
+                            self._aspect_ratio_correction
                     else:
                         sign = np.sign(event.xdata - x0)
-                        x1 = x0 + sign * abs(y1 - y0) * aspect_ratio
+                        x1 = x0 + sign * abs(y1 - y0) * \
+                            self._aspect_ratio_correction
 
         # move existing shape
         elif self._active_handle == 'C':
@@ -3149,9 +3146,9 @@ class RectangleSelector(_SelectorWidget):
             if 'square' in state:
                 refmax = max(refx, refy, key=abs)
                 if refmax == refx:
-                    dy = dx / aspect_ratio
+                    dy = np.sign(dy) * abs(dx) / self._aspect_ratio_correction
                 else:
-                    dx = dy * aspect_ratio
+                    dx = np.sign(dx) * abs(dy) * self._aspect_ratio_correction
 
             # from center
             if 'center' in state:
@@ -3168,6 +3165,18 @@ class RectangleSelector(_SelectorWidget):
 
         self.extents = x0, x1, y0, y1
 
+    def _on_key_press(self, event):
+        key = event.key or ''
+        key = key.replace('ctrl', 'control')
+        for (state, modifier) in self._state_modifier_keys.items():
+            if modifier in key.split('+'):
+                if state in ['rotate', 'data_coordinates']:
+                    if state in self._default_state:
+                        self._default_state.discard(state)
+                    else:
+                        self._default_state.add(state)
+                    self._set_aspect_ratio_correction()
+
     @property
     def _rect_bbox(self):
         if self._drawtype == 'box':
@@ -3178,8 +3187,27 @@ class RectangleSelector(_SelectorWidget):
             y0, y1 = min(y), max(y)
             return x0, y0, x1 - x0, y1 - y0
 
+    def _set_aspect_ratio_correction(self):
+        aspect_ratio = self.ax._get_aspect_ratio()
+        if not hasattr(self._selection_artist, '_aspect_ratio_correction'):
+            # Aspect ratio correction is not supported with deprecated
+            # drawtype='line'. Remove this block in matplotlib 3.7
+            self._aspect_ratio_correction = 1
+            return
+
+        self._selection_artist._aspect_ratio_correction = aspect_ratio
+        if 'data_coordinates' in self._state | self._default_state:
+            self._aspect_ratio_correction = 1
+        else:
+            self._aspect_ratio_correction = aspect_ratio
+
     def _get_rotation_transform(self):
-        return Affine2D().rotate_around(*self.center, self._rotation)
+        aspect_ratio = self.ax._get_aspect_ratio()
+        return Affine2D().translate(-self.center[0], -self.center[1]) \
+                .scale(1, aspect_ratio) \
+                .rotate(self._rotation) \
+                .scale(1, 1 / aspect_ratio) \
+                .translate(*self.center)
 
     @property
     def corners(self):
@@ -3234,14 +3262,17 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def rotation(self):
-        """Rotation in degree."""
+        """Rotation in degree in interval [0, 45]."""
         return np.rad2deg(self._rotation)
 
     @rotation.setter
     def rotation(self, value):
-        self._rotation = np.deg2rad(value)
-        # call extents setter to draw shape and update handles positions
-        self.extents = self.extents
+        # Restrict to a limited range of rotation [0, 45] to avoid changing
+        # order of handles
+        if 0 <= value and value <= 45:
+            self._rotation = np.deg2rad(value)
+            # call extents setter to draw shape and update handles positions
+            self.extents = self.extents
 
     draw_shape = _api.deprecate_privatize_attribute('3.5')
 
@@ -3352,7 +3383,7 @@ class EllipseSelector(RectangleSelector):
             self._selection_artist.center = center
             self._selection_artist.width = 2 * a
             self._selection_artist.height = 2 * b
-            self._selection_artist.set_angle(self.rotation)
+            self._selection_artist.angle = self.rotation
         else:
             rad = np.deg2rad(np.arange(31) * 12)
             x = a * np.cos(rad) + center[0]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3048,10 +3048,13 @@ class RectangleSelector(_SelectorWidget):
 
         dx = event.xdata - eventpress.xdata
         dy = event.ydata - eventpress.ydata
+        # refmax is used when moving the corner handle with the square state
+        # and is the maximum between refx and refy
         refmax = None
         if 'data_coordinates' in state:
             refx, refy = dx, dy
         else:
+            # Add 1e-6 to avoid divided by zero error
             refx = event.xdata / (eventpress.xdata + 1e-6)
             refy = event.ydata / (eventpress.ydata + 1e-6)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2103,6 +2103,7 @@ class _SelectorWidget(AxesWidget):
                              f'following: {keys}.')
         self._default_state.add(value)
 
+
 class SpanSelector(_SelectorWidget):
     """
     Visually select a min/max range on a single axis and call a function with

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2948,7 +2948,7 @@ class RectangleSelector(_SelectorWidget):
 
     def _init_shape(self, **props):
         return Rectangle((0, 0), 0, 1, visible=False,
-                         rotate_around_center=True, **props)
+                         rotation_point='center', **props)
 
     def _press(self, event):
         """Button press event handler."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1809,9 +1809,9 @@ class _SelectorWidget(AxesWidget):
         self.useblit = useblit and self.canvas.supports_blit
         self.connect_default_events()
 
-        self.state_modifier_keys = dict(move=' ', clear='escape',
-                                        square='shift', center='control')
-        self.state_modifier_keys.update(state_modifier_keys or {})
+        self._state_modifier_keys = dict(move=' ', clear='escape',
+                                         square='shift', center='control')
+        self._state_modifier_keys.update(state_modifier_keys or {})
 
         self.background = None
 
@@ -1834,6 +1834,7 @@ class _SelectorWidget(AxesWidget):
     eventpress = _api.deprecate_privatize_attribute("3.5")
     eventrelease = _api.deprecate_privatize_attribute("3.5")
     state = _api.deprecate_privatize_attribute("3.5")
+    state_modifier_keys = _api.deprecate_privatize_attribute("3.5")
 
     def set_active(self, active):
         super().set_active(active)
@@ -1944,7 +1945,7 @@ class _SelectorWidget(AxesWidget):
             key = event.key or ''
             key = key.replace('ctrl', 'control')
             # move state is locked in on a button press
-            if key == self.state_modifier_keys['move']:
+            if key == self._state_modifier_keys['move']:
                 self._state.add('move')
             self._press(event)
             return True
@@ -1992,10 +1993,10 @@ class _SelectorWidget(AxesWidget):
         if self.active:
             key = event.key or ''
             key = key.replace('ctrl', 'control')
-            if key == self.state_modifier_keys['clear']:
+            if key == self._state_modifier_keys['clear']:
                 self.clear()
                 return
-            for (state, modifier) in self.state_modifier_keys.items():
+            for (state, modifier) in self._state_modifier_keys.items():
                 if modifier in key:
                     self._state.add(state)
             self._on_key_press(event)
@@ -2007,7 +2008,7 @@ class _SelectorWidget(AxesWidget):
         """Key release event handler and validator."""
         if self.active:
             key = event.key or ''
-            for (state, modifier) in self.state_modifier_keys.items():
+            for (state, modifier) in self._state_modifier_keys.items():
                 if modifier in key:
                     self._state.discard(state)
             self._on_key_release(event)
@@ -2088,7 +2089,7 @@ class _SelectorWidget(AxesWidget):
 
         """
         supported_default_state = [
-            key for key, value in self.state_modifier_keys.items()
+            key for key, value in self._state_modifier_keys.items()
             if key != 'clear' and value != 'not-applicable'
             ]
         if value not in supported_default_state:
@@ -3635,13 +3636,13 @@ class PolygonSelector(_SelectorWidget):
         # 'move_all' mode (by checking the released key)
         if (not self._selection_completed
                 and
-                (event.key == self.state_modifier_keys.get('move_vertex')
-                 or event.key == self.state_modifier_keys.get('move_all'))):
+                (event.key == self._state_modifier_keys.get('move_vertex')
+                 or event.key == self._state_modifier_keys.get('move_all'))):
             self._xs.append(event.xdata)
             self._ys.append(event.ydata)
             self._draw_polygon()
         # Reset the polygon if the released key is the 'clear' key.
-        elif event.key == self.state_modifier_keys.get('clear'):
+        elif event.key == self._state_modifier_keys.get('clear'):
             event = self._clean_event(event)
             self._xs, self._ys = [event.xdata], [event.ydata]
             self._selection_completed = False


### PR DESCRIPTION
## PR Summary
- Fix centre and square state of rectangle selector in interactive mode. These states were working only when creating the selector.
- Fix name coordinate handle: N and S were swapped
- Add method to add a default state
- Privatize state_modifier_keys
- Add `data_coordinates` state to define if the square ratio should be calculated in data or figure coordinates
- Add rotation of `RectangleSelector` and `EllipseSelector` taking into account aspect ratio of the axes and using the center of the shape as rotation center.

```python
import matplotlib.pyplot as plt
from matplotlib.widgets import RectangleSelector
import numpy as np

values = np.arange(0, 100)

fig = plt.figure()
ax = fig.add_subplot()
ax.plot(values, values)

selector = RectangleSelector(ax, print, interactive=True,
                             drag_from_anywhere=True,
                             use_data_coordinates=True)
selector.add_state('rotate') # alternatively press 'r' key
# rotate the selector interactively

selector.remove_state('rotate') # alternatively press 'r' key

selector.add_state('square')
```

~I would expect that this PR conflicts with https://github.com/matplotlib/matplotlib/pull/19864 and I would be interested to take over #19864 to rebase and fix the outstanding issues.~ The selector rotation is added in this PR.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
