### PR TITLE
Speed up Tkagg blit with Tk_PhotoPutBlock

### DIFF
--- a/doc/api/next_api_changes/development/20840-RJS.rst
+++ b/doc/api/next_api_changes/development/20840-RJS.rst
@@ -1,8 +1,8 @@
 Increase to minimum supported optional dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For Maptlotlib 3.5, the :ref:`minimum supported versions of optional dependencies <optional_dependencies>`
-are being bumped:
+For Matplotlib 3.5, the :ref:`minimum supported versions of optional dependencies
+<optional_dependencies>` are being bumped:
 
 +------------+-----------------+---------------+
 | Dependency |  min in mpl3.4  | min in mpl3.5 |

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -60,15 +60,10 @@ def _blit(argsid):
 
     *argsid* is a unique string identifier to fetch the correct arguments from
     the ``_blit_args`` dict, since arguments cannot be passed directly.
-
-    photoimage blanking must occur in the same event and thread as blitting
-    to avoid flickering.
     """
     photoimage, dataptr, offsets, bboxptr, blank = _blit_args.pop(argsid)
-    if blank:
-        photoimage.blank()
     _tkagg.blit(
-        photoimage.tk.interpaddr(), str(photoimage), dataptr, offsets, bboxptr)
+        photoimage.tk.interpaddr(), str(photoimage), dataptr, blank, offsets, bboxptr)
 
 
 def blit(photoimage, aggimage, offsets, bbox=None):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -56,6 +56,7 @@ _blit_tcl_name = "mpl_blit_" + uuid.uuid4().hex
 TK_PHOTO_COMPOSITE_OVERLAY = 0  # apply transparency rules pixel-wise
 TK_PHOTO_COMPOSITE_SET = 1  # set image buffer directly
 
+
 def _blit(argsid):
     """
     Thin wrapper to blit called via tkapp.call.
@@ -64,8 +65,8 @@ def _blit(argsid):
     the ``_blit_args`` dict, since arguments cannot be passed directly.
     """
     photoimage, dataptr, offsets, bboxptr, comp_rule = _blit_args.pop(argsid)
-    _tkagg.blit(
-        photoimage.tk.interpaddr(), str(photoimage), dataptr, comp_rule, offsets, bboxptr)
+    _tkagg.blit(photoimage.tk.interpaddr(), str(photoimage), dataptr,
+                comp_rule, offsets, bboxptr)
 
 
 def blit(photoimage, aggimage, offsets, bbox=None):

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -80,7 +80,7 @@ def test_blit():  # pragma: no cover
     for bad_box in bad_boxes:
         try:
             _tkagg.blit(
-                photoimage.tk.interpaddr(), str(photoimage), dataptr,
+                photoimage.tk.interpaddr(), str(photoimage), dataptr, 0,
                 (0, 1, 2, 3), bad_box)
         except ValueError:
             print("success")

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -64,6 +64,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     int height, width;
     unsigned char *data_ptr;
     int comp_rule;
+    int put_retval;
     int o0, o1, o2, o3;
     int x1, x2, y1, y2;
     Tk_PhotoHandle photo;
@@ -99,9 +100,12 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     block.offset[1] = o1;
     block.offset[2] = o2;
     block.offset[3] = o3;
-    TK_PHOTO_PUT_BLOCK(
+    put_retval = TK_PHOTO_PUT_BLOCK(
         interp, photo, &block, x1, height - y2, x2 - x1, y2 - y1, comp_rule);
     Py_END_ALLOW_THREADS
+    if (put_retval) {
+        return PyErr_NoMemory();
+    }
 
 exit:
     if (PyErr_Occurred()) {

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -51,7 +51,6 @@ static int convert_voidptr(PyObject *obj, void *p)
 // extension module or loaded Tk libraries at run-time.
 static Tk_FindPhoto_t TK_FIND_PHOTO;
 static Tk_PhotoPutBlock_t TK_PHOTO_PUT_BLOCK;
-static Tk_PhotoPutBlock_NoComposite_t TK_PHOTO_PUT_BLOCK_NO_COMPOSITE;
 #ifdef WIN32_DLL
 // Global vars for Tcl functions.  We load these symbols from the tkinter
 // extension module or loaded Tcl libraries at run-time.
@@ -230,9 +229,7 @@ int load_tk(T lib)
         !!(TK_FIND_PHOTO =
             (Tk_FindPhoto_t)dlsym(lib, "Tk_FindPhoto")) +
         !!(TK_PHOTO_PUT_BLOCK =
-            (Tk_PhotoPutBlock_t)dlsym(lib, "Tk_PhotoPutBlock")) +
-        !!(TK_PHOTO_PUT_BLOCK_NO_COMPOSITE =
-            (Tk_PhotoPutBlock_NoComposite_t)dlsym(lib, "Tk_PhotoPutBlock_NoComposite"));
+            (Tk_PhotoPutBlock_t)dlsym(lib, "Tk_PhotoPutBlock"));
 }
 
 #ifdef WIN32_DLL
@@ -355,9 +352,6 @@ PyMODINIT_FUNC PyInit__tkagg(void)
         return NULL;
     } else if (!TK_PHOTO_PUT_BLOCK) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to load Tk_PhotoPutBlock");
-        return NULL;
-    } else if (!TK_PHOTO_PUT_BLOCK_NO_COMPOSITE) {
-        PyErr_SetString(PyExc_RuntimeError, "Failed to load Tk_PhotoPutBlock_NoComposite");
         return NULL;
     }
     return PyModule_Create(&_tkagg_module);

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -63,7 +63,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     char const *photo_name;
     int height, width;
     unsigned char *data_ptr;
-    int blank;
+    int comp_rule;
     int o0, o1, o2, o3;
     int x1, x2, y1, y2;
     Tk_PhotoHandle photo;
@@ -71,7 +71,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     if (!PyArg_ParseTuple(args, "O&s(iiO&)i(iiii)(iiii):blit",
                           convert_voidptr, &interp, &photo_name,
                           &height, &width, convert_voidptr, &data_ptr,
-                          &blank,
+                          &comp_rule,
                           &o0, &o1, &o2, &o3,
                           &x1, &x2, &y1, &y2)) {
         goto exit;
@@ -84,8 +84,8 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "Attempting to draw out of bounds");
         goto exit;
     }
-    if (blank != TK_PHOTO_COMPOSITE_OVERLAY && blank != TK_PHOTO_COMPOSITE_SET){
-        PyErr_SetString(PyExc_ValueError, "Invalid blank argument");
+    if (comp_rule != TK_PHOTO_COMPOSITE_OVERLAY && comp_rule != TK_PHOTO_COMPOSITE_SET){
+        PyErr_SetString(PyExc_ValueError, "Invalid comp_rule argument");
         goto exit;
     }
 
@@ -100,7 +100,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     block.offset[2] = o2;
     block.offset[3] = o3;
     TK_PHOTO_PUT_BLOCK(
-        interp, photo, &block, x1, height - y2, x2 - x1, y2 - y1, blank);
+        interp, photo, &block, x1, height - y2, x2 - x1, y2 - y1, comp_rule);
     Py_END_ALLOW_THREADS
 
 exit:

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -50,6 +50,7 @@ static int convert_voidptr(PyObject *obj, void *p)
 // Global vars for Tk functions.  We load these symbols from the tkinter
 // extension module or loaded Tk libraries at run-time.
 static Tk_FindPhoto_t TK_FIND_PHOTO;
+static Tk_PhotoPutBlock_t TK_PHOTO_PUT_BLOCK;
 static Tk_PhotoPutBlock_NoComposite_t TK_PHOTO_PUT_BLOCK_NO_COMPOSITE;
 #ifdef WIN32_DLL
 // Global vars for Tcl functions.  We load these symbols from the tkinter
@@ -219,6 +220,8 @@ int load_tk(T lib)
     return
         !!(TK_FIND_PHOTO =
             (Tk_FindPhoto_t)dlsym(lib, "Tk_FindPhoto")) +
+        !!(TK_PHOTO_PUT_BLOCK =
+            (Tk_PhotoPutBlock_t)dlsym(lib, "Tk_PhotoPutBlock")) +
         !!(TK_PHOTO_PUT_BLOCK_NO_COMPOSITE =
             (Tk_PhotoPutBlock_NoComposite_t)dlsym(lib, "Tk_PhotoPutBlock_NoComposite"));
 }
@@ -340,6 +343,9 @@ PyMODINIT_FUNC PyInit__tkagg(void)
 #endif
     } else if (!TK_FIND_PHOTO) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to load Tk_FindPhoto");
+        return NULL;
+    } else if (!TK_PHOTO_PUT_BLOCK) {
+        PyErr_SetString(PyExc_RuntimeError, "Failed to load Tk_PhotoPutBlock");
         return NULL;
     } else if (!TK_PHOTO_PUT_BLOCK_NO_COMPOSITE) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to load Tk_PhotoPutBlock_NoComposite");

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -85,7 +85,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
         PyErr_SetString(PyExc_ValueError, "Attempting to draw out of bounds");
         goto exit;
     }
-    if (comp_rule != TK_PHOTO_COMPOSITE_OVERLAY && comp_rule != TK_PHOTO_COMPOSITE_SET){
+    if (comp_rule != TK_PHOTO_COMPOSITE_OVERLAY && comp_rule != TK_PHOTO_COMPOSITE_SET) {
         PyErr_SetString(PyExc_ValueError, "Invalid comp_rule argument");
         goto exit;
     }

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -103,7 +103,7 @@ static PyObject *mpl_tk_blit(PyObject *self, PyObject *args)
     put_retval = TK_PHOTO_PUT_BLOCK(
         interp, photo, &block, x1, height - y2, x2 - x1, y2 - y1, comp_rule);
     Py_END_ALLOW_THREADS
-    if (put_retval) {
+    if (put_retval == TCL_ERROR) {
         return PyErr_NoMemory();
     }
 

--- a/src/_tkmini.h
+++ b/src/_tkmini.h
@@ -86,8 +86,8 @@ typedef struct Tk_PhotoImageBlock
     int offset[4];
 } Tk_PhotoImageBlock;
 
-#define TK_PHOTO_COMPOSITE_OVERLAY	0  // don't blank
-#define TK_PHOTO_COMPOSITE_SET		1  // blank
+#define TK_PHOTO_COMPOSITE_OVERLAY	0  // apply transparency rules pixel-wise
+#define TK_PHOTO_COMPOSITE_SET		1  // set image buffer directly
 
 /* Typedefs derived from function signatures in Tk header */
 /* Tk_FindPhoto typedef */

--- a/src/_tkmini.h
+++ b/src/_tkmini.h
@@ -88,6 +88,8 @@ typedef struct Tk_PhotoImageBlock
 
 #define TK_PHOTO_COMPOSITE_OVERLAY	0  // apply transparency rules pixel-wise
 #define TK_PHOTO_COMPOSITE_SET		1  // set image buffer directly
+#define TCL_OK     0
+#define TCL_ERROR  1
 
 /* Typedefs derived from function signatures in Tk header */
 /* Tk_FindPhoto typedef */

--- a/src/_tkmini.h
+++ b/src/_tkmini.h
@@ -86,10 +86,17 @@ typedef struct Tk_PhotoImageBlock
     int offset[4];
 } Tk_PhotoImageBlock;
 
+#define TK_PHOTO_COMPOSITE_OVERLAY	0
+#define TK_PHOTO_COMPOSITE_SET		1
+
 /* Typedefs derived from function signatures in Tk header */
 /* Tk_FindPhoto typedef */
 typedef Tk_PhotoHandle (*Tk_FindPhoto_t) (Tcl_Interp *interp, const char
         *imageName);
+/* Tk_PhotoPutBLock typedef */
+typedef int (*Tk_PhotoPutBlock_t) (Tcl_Interp *interp, Tk_PhotoHandle handle,
+        Tk_PhotoImageBlock *blockPtr, int x, int y,
+        int width, int height);
 /* Tk_PhotoPutBLock_NoComposite typedef */
 typedef void (*Tk_PhotoPutBlock_NoComposite_t) (Tk_PhotoHandle handle,
         Tk_PhotoImageBlock *blockPtr, int x, int y,

--- a/src/_tkmini.h
+++ b/src/_tkmini.h
@@ -97,10 +97,6 @@ typedef Tk_PhotoHandle (*Tk_FindPhoto_t) (Tcl_Interp *interp, const char
 typedef int (*Tk_PhotoPutBlock_t) (Tcl_Interp *interp, Tk_PhotoHandle handle,
         Tk_PhotoImageBlock *blockPtr, int x, int y,
         int width, int height, int compRule);
-/* Tk_PhotoPutBLock_NoComposite typedef */
-typedef void (*Tk_PhotoPutBlock_NoComposite_t) (Tk_PhotoHandle handle,
-        Tk_PhotoImageBlock *blockPtr, int x, int y,
-        int width, int height);
 
 #ifdef WIN32_DLL
 /* Typedefs derived from function signatures in Tcl header */

--- a/src/_tkmini.h
+++ b/src/_tkmini.h
@@ -86,8 +86,8 @@ typedef struct Tk_PhotoImageBlock
     int offset[4];
 } Tk_PhotoImageBlock;
 
-#define TK_PHOTO_COMPOSITE_OVERLAY	0
-#define TK_PHOTO_COMPOSITE_SET		1
+#define TK_PHOTO_COMPOSITE_OVERLAY	0  // don't blank
+#define TK_PHOTO_COMPOSITE_SET		1  // blank
 
 /* Typedefs derived from function signatures in Tk header */
 /* Tk_FindPhoto typedef */
@@ -96,7 +96,7 @@ typedef Tk_PhotoHandle (*Tk_FindPhoto_t) (Tcl_Interp *interp, const char
 /* Tk_PhotoPutBLock typedef */
 typedef int (*Tk_PhotoPutBlock_t) (Tcl_Interp *interp, Tk_PhotoHandle handle,
         Tk_PhotoImageBlock *blockPtr, int x, int y,
-        int width, int height);
+        int width, int height, int compRule);
 /* Tk_PhotoPutBLock_NoComposite typedef */
 typedef void (*Tk_PhotoPutBlock_NoComposite_t) (Tk_PhotoHandle handle,
         Tk_PhotoImageBlock *blockPtr, int x, int y,


### PR DESCRIPTION
## PR Summary
This PR releases the GIL while blitting, and chooses a slightly different but sometimes faster function to actually perform the blit.

In my usage, blitting can often be over 100 ms, which is a long time to hold the GIL... especially while not using the Python C API. I verified the safety of releasing the GIL back in 2ad422a78c3794ac5139364c0ea3d6a8d6de6030 but for some reason I took it back out when thread-based parallelism didn't work out. (#18565)

`_tkagg.blit` has been backed by `Tk_PhotoPutBlock_NoComposite` since #6442. This interface is deprecated, and on Tk 8.5 and later `Tk_PhotoPutBlock` gives the option to composite or not as a function argument, avoiding the need for an extra blanking step and permitting a [fast path](https://github.com/tcltk/tk/blob/5745147320011c82db86941f349d25a690cf914b/generic/tkImgPhoto.c#L3335-L3356) when the data are properly aligned, which seems to be the case on TkAgg. My profiling shows that the time spent specifically in `_tkagg.blit` drops by a factor of 2 to 10 (!?) in the naive use case of calling `fig.canvas.draw()`.  However, `FigureCanvasAgg.draw` is the main time sink in either case, so the FPS gains are limited, and for large canvases blitting still takes enough time to make dropping the GIL worthwhile. Nevertheless, I get a practical responsivity boost in a downstream application (100 ms -> 10 ms blit latency) so I think it is worth sharing.

If anyone can tell me why this speedup is only visible when `Figure.get_frameon()==True`, I will sleep much better at night. It would seem to have to do with the abundance or paucity of transparent pixels in the `PhotoImage`, but the Tk [source ](https://github.com/tcltk/tk/blob/5745147320011c82db86941f349d25a690cf914b/generic/tkImgPhoto.c#L3174-L3607) doesn't inspect that directly. Could it boil down to CPU branch prediction?

This change is backwards-incompatible with Tk < 8.5. I don't think that affects Python 3 or Matplotlib 3 users, but I would like confirmation.  Also I would like someone to check if this change is problematic in the TkCairo backend

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] ~~Has pytest style unit tests~~ (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- ~~[ ] New features are documented, with examples if plot related.~~
- ~~[x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).~~
- ~~[ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).~~
- ~~[ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).~~
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
