### PR TITLE
Try to install the Noto Sans CJK font

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,6 +59,7 @@ commands:
               fonts-crosextra-carlito \
               fonts-freefont-otf \
               fonts-humor-sans \
+              fonts-noto-cjk \
               optipng
 
   fonts-install:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,6 +65,7 @@ jobs:
               cm-super \
               dvipng \
               ffmpeg \
+              fonts-noto-cjk \
               gdb \
               gir1.2-gtk-3.0 \
               graphviz \
@@ -101,6 +102,8 @@ jobs:
             ;;
           macOS)
             brew install ccache
+            brew tap homebrew/cask-fonts
+            brew install font-noto-sans-cjk-sc
             ;;
           esac
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -82,6 +82,7 @@ stages:
               cm-super \
               dvipng \
               ffmpeg \
+              fonts-noto-cjk \
               gdb \
               gir1.2-gtk-3.0 \
               graphviz \
@@ -102,6 +103,8 @@ stages:
           darwin)
             brew install --cask xquartz
             brew install pkg-config ffmpeg imagemagick mplayer ccache
+            brew tap homebrew/cask-fonts
+            brew install font-noto-sans-cjk-sc
             ;;
           win32)
             ;;

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -101,7 +101,7 @@ def test_utf16m_sfnt():
         entry = next(entry for entry in fontManager.ttflist
                      if Path(entry.fname).name == "seguisbi.ttf")
     except StopIteration:
-        pytest.skip("Couldn't find font to test against.")
+        pytest.skip("Couldn't find seguisbi.ttf font to test against.")
     else:
         # Check that we successfully read "semibold" from the font's sfnt table
         # and set its weight accordingly.
@@ -111,10 +111,21 @@ def test_utf16m_sfnt():
 def test_find_ttc():
     fp = FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(findfont(fp)).name != "wqy-zenhei.ttc":
-        pytest.skip("Font may be missing")
-
+        pytest.skip("Font wqy-zenhei.ttc may be missing")
     fig, ax = plt.subplots()
     ax.text(.5, .5, "\N{KANGXI RADICAL DRAGON}", fontproperties=fp)
+    for fmt in ["raw", "svg", "pdf", "ps"]:
+        fig.savefig(BytesIO(), format=fmt)
+
+
+def test_find_noto():
+    fp = FontProperties(family=["Noto Sans CJK SC", "Noto Sans CJK JP"])
+    name = Path(findfont(fp)).name
+    if name not in ("NotoSansCJKsc-Regular.otf", "NotoSansCJK-Regular.ttc"):
+        pytest.skip(f"Noto Sans CJK SC font may be missing (found {name})")
+
+    fig, ax = plt.subplots()
+    ax.text(0.5, 0.5, 'Hello, 你好', fontproperties=fp)
     for fmt in ["raw", "svg", "pdf", "ps"]:
         fig.savefig(BytesIO(), format=fmt)
 


### PR DESCRIPTION
On Linux and Mac. Add a font_manager test that loads the font and uses it. This could be useful in testing the multi-font support (#20740 etc).

I couldn't get the font installed on Windows. There is a Chocolatey installer that installs all of the Noto fonts, which takes a really long time to run.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
