### PR TITLE
Propose a less error-prone helper for module-level getattrs.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -176,16 +176,14 @@ def _get_version():
         return _version.version
 
 
-@functools.lru_cache(None)
-def __getattr__(name):
-    if name == "__version__":
-        return _get_version()
-    elif name == "__version_info__":
-        return _parse_to_version_info(__getattr__("__version__"))
-    elif name == "URL_REGEX":  # module-level deprecation.
-        _api.warn_deprecated("3.5", name=name)
-        return re.compile(r'^http://|^https://|^ftp://|^file:')
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+@_api.caching_module_getattr
+class __getattr__:
+    __version__ = property(lambda self: _get_version())
+    __version_info__ = property(
+        lambda self: _parse_to_version_info(self.__version__))
+    # module-level deprecations
+    URL_REGEX = _api.deprecated("3.5", obj_type="")(property(
+        lambda self: re.compile(r'^http://|^https://|^ftp://|^file:')))
 
 
 def _check_versions():

--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -10,6 +10,7 @@ This documentation is only relevant for Matplotlib developers, not for users.
 
 """
 
+import functools
 import itertools
 import re
 import sys
@@ -187,6 +188,41 @@ def check_getitem(_mapping, **kwargs):
         raise ValueError(
             "{!r} is not a valid value for {}; supported values are {}"
             .format(v, k, ', '.join(map(repr, mapping)))) from None
+
+
+def caching_module_getattr(cls):
+    """
+    Helper decorator for implementing module-level ``__getattr__`` as a class.
+
+    This decorator must be used at the module toplevel as follows::
+
+        @caching_module_getattr
+        class __getattr__:  # The class *must* be named ``__getattr__``.
+            @property  # Only properties are taken into account.
+            def name(self): ...
+
+    The ``__getattr__`` class will be replaced by a ``__getattr__``
+    function such that trying to access ``name`` on the module will
+    resolve the corresponding property (which may be decorated e.g. with
+    ``_api.deprecated`` for deprecating module globals).  The properties are
+    all implicitly cached.  Moreover, a suitable AttributeError is generated
+    and raised if no property with the given name exists.
+    """
+
+    assert cls.__name__ == "__getattr__"
+    # Don't accidentally export cls dunders.
+    props = {name: prop for name, prop in vars(cls).items()
+             if isinstance(prop, property)}
+    instance = cls()
+
+    @functools.lru_cache(None)
+    def __getattr__(name):
+        if name in props:
+            return props[name].__get__(instance)
+        raise AttributeError(
+            f"module {cls.__module__!r} has no attribute {name!r}")
+
+    return __getattr__
 
 
 def select_matching_signature(funcs, *args, **kwargs):

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -150,13 +150,14 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
                 return obj
 
         elif isinstance(obj, (property, classproperty)):
-            obj_type = "attribute"
+            if obj_type is None:
+                obj_type = "attribute"
             func = None
             name = name or obj.fget.__name__
             old_doc = obj.__doc__
 
             class _deprecated_property(type(obj)):
-                def __get__(self, instance, owner):
+                def __get__(self, instance, owner=None):
                     if instance is not None or owner is not None \
                             and isinstance(self, classproperty):
                         emit_warning()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -37,11 +37,11 @@ backend_version = "%s.%s.%s" % (
     Gtk.get_major_version(), Gtk.get_minor_version(), Gtk.get_micro_version())
 
 
-# module-level deprecations.
-@functools.lru_cache(None)
-def __getattr__(name):
-    if name == "cursord":
-        _api.warn_deprecated("3.5", name=name)
+@_api.caching_module_getattr  # module-level deprecations
+class __getattr__:
+    @_api.deprecated("3.5", obj_type="")
+    @property
+    def cursord(self):
         try:
             new_cursor = functools.partial(
                 Gdk.Cursor.new_from_name, Gdk.Display.get_default())
@@ -54,8 +54,6 @@ def __getattr__(name):
             }
         except TypeError as exc:
             return {}
-    else:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 # Placeholder

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -41,25 +41,19 @@ _log = logging.getLogger(__name__)
 PIXELS_PER_INCH = 75
 
 
-# module-level deprecations.
-@functools.lru_cache(None)
-def __getattr__(name):
-    if name == "IDLE_DELAY":
-        _api.warn_deprecated("3.1", name=name)
-        return 5
-    elif name == "cursord":
-        _api.warn_deprecated("3.5", name=name)
-        return {  # deprecated in Matplotlib 3.5.
-            cursors.MOVE: wx.CURSOR_HAND,
-            cursors.HAND: wx.CURSOR_HAND,
-            cursors.POINTER: wx.CURSOR_ARROW,
-            cursors.SELECT_REGION: wx.CURSOR_CROSS,
-            cursors.WAIT: wx.CURSOR_WAIT,
-            cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
-            cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
-        }
-    else:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+@_api.caching_module_getattr  # module-level deprecations
+class __getattr__:
+    IDLE_DELAY = _api.deprecated("3.1", obj_type="", removal="3.6")(property(
+        lambda self: 5))
+    cursord = _api.deprecated("3.5", obj_type="")(property(lambda self: {
+        cursors.MOVE: wx.CURSOR_HAND,
+        cursors.HAND: wx.CURSOR_HAND,
+        cursors.POINTER: wx.CURSOR_ARROW,
+        cursors.SELECT_REGION: wx.CURSOR_CROSS,
+        cursors.WAIT: wx.CURSOR_WAIT,
+        cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
+        cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
+    }))
 
 
 def error_msg_wx(msg, parent=None):

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -16,7 +16,6 @@ Builtin colormaps, colormap handling utilities, and the `ScalarMappable` mixin.
 """
 
 from collections.abc import Mapping, MutableMapping
-import functools
 
 import numpy as np
 from numpy import ma
@@ -27,14 +26,11 @@ from matplotlib._cm import datad
 from matplotlib._cm_listed import cmaps as cmaps_listed
 
 
-# module-level deprecations.
-@functools.lru_cache(None)
-def __getattr__(name):
-    if name == "LUTSIZE":
-        _api.warn_deprecated("3.5", name=name,
-                             alternative="rcParams['image.lut']")
-        return _LUTSIZE
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+@_api.caching_module_getattr  # module-level deprecations
+class __getattr__:
+    LUTSIZE = _api.deprecated(
+        "3.5", obj_type="", alternative="rcParams['image.lut']")(
+            property(lambda self: _LUTSIZE))
 
 
 _LUTSIZE = mpl.rcParams['image.lut']

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -12,7 +12,6 @@ In Matplotlib they are drawn into a dedicated `~.axes.Axes`.
 """
 
 import copy
-import functools
 import logging
 import textwrap
 
@@ -195,20 +194,14 @@ workaround is not used by default (see issue #1188).
        _colormap_kw_doc))
 
 
-# module-level deprecations.
-@functools.lru_cache(None)
-def __getattr__(name):
-    if name == "colorbar_doc":
-        _api.warn_deprecated("3.4", name=name)
-        return docstring.interpd.params["colorbar_doc"]
-    elif name == "colormap_kw_doc":
-        _api.warn_deprecated("3.4", name=name)
-        return _colormap_kw_doc
-    elif name == "make_axes_kw_doc":
-        _api.warn_deprecated("3.4", name=name)
-        return _make_axes_param_doc + _make_axes_other_param_doc
-    else:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+@_api.caching_module_getattr  # module-level deprecations
+class __getattr__:
+    colorbar_doc = _api.deprecated("3.4", obj_type="")(property(
+        lambda self: docstring.interpd.params["colorbar_doc"]))
+    colorbar_kw_doc = _api.deprecated("3.4", obj_type="")(property(
+        lambda self: _colormap_kw_doc))
+    make_axes_kw_doc = _api.deprecated("3.4", obj_type="")(property(
+        lambda self: _make_axes_param_doc + _make_axes_other_param_doc))
 
 
 def _set_ticks_on_axis_warn(*args, **kw):

--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -12,7 +12,6 @@ Core functions and attributes for the matplotlib style library:
 """
 
 import contextlib
-import functools
 import logging
 import os
 from pathlib import Path
@@ -27,13 +26,10 @@ _log = logging.getLogger(__name__)
 __all__ = ['use', 'context', 'available', 'library', 'reload_library']
 
 
-# module-level deprecations.
-@functools.lru_cache(None)
-def __getattr__(name):
-    if name == "STYLE_FILE_PATTERN":
-        _api.warn_deprecated("3.5", name=name)
-        return re.compile(r'([\S]+).%s$' % STYLE_EXTENSION)
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+@_api.caching_module_getattr  # module-level deprecations
+class __getattr__:
+    STYLE_FILE_PATTERN = _api.deprecated("3.5", obj_type="")(property(
+        lambda self: re.compile(r'([\S]+).%s$' % STYLE_EXTENSION)))
 
 
 BASE_LIBRARY_PATH = os.path.join(mpl.get_data_path(), 'stylelib')

--- a/lib/matplotlib/tests/test_getattr.py
+++ b/lib/matplotlib/tests/test_getattr.py
@@ -1,0 +1,28 @@
+from importlib import import_module
+from pkgutil import walk_packages
+
+import matplotlib
+import pytest
+
+# Get the names of all matplotlib submodules, except for the unit tests.
+module_names = [m.name for m in walk_packages(path=matplotlib.__path__,
+                                              prefix=f'{matplotlib.__name__}.')
+                if not m.name.startswith(__package__)]
+
+
+@pytest.mark.parametrize('module_name', module_names)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+def test_getattr(module_name):
+    """
+    Test that __getattr__ methods raise AttributeError for unknown keys.
+    See #20822, #20855.
+    """
+    try:
+        module = import_module(module_name)
+    except (ImportError, RuntimeError) as e:
+        # Skip modules that cannot be imported due to missing dependencies
+        pytest.skip(f'Cannot import {module_name} due to {e}')
+
+    key = 'THIS_SYMBOL_SHOULD_NOT_EXIST'
+    if hasattr(module, key):
+        delattr(module, key)


### PR DESCRIPTION
Apparently we always forget to generate the fallback AttributeError (#20822, #20855), so
introduce a helper to do so instead.  (I'm not wedded to the exact API...)

The changes in `deprecation.py` are (a) so that one can correctly
suppress the inferred type when deprecating properties (the new check is
coherent with the `if isinstance(obj, type)` and other cases) and (b) to
make single-argument `__get__` work on deprecated properties
(consistently with standard properties).

Would replace #20856.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
