### PR TITLE
Allow SubFigure legends

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -360,7 +360,7 @@ class Legend(Artist):
         """
         # local import only to avoid circularity
         from matplotlib.axes import Axes
-        from matplotlib.figure import Figure
+        from matplotlib.figure import FigureBase
 
         super().__init__()
 
@@ -434,11 +434,13 @@ class Legend(Artist):
             self.isaxes = True
             self.axes = parent
             self.set_figure(parent.figure)
-        elif isinstance(parent, Figure):
+        elif isinstance(parent, FigureBase):
             self.isaxes = False
             self.set_figure(parent)
         else:
-            raise TypeError("Legend needs either Axes or Figure as parent")
+            raise TypeError(
+                "Legend needs either Axes or FigureBase as parent"
+            )
         self.parent = parent
 
         self._loc_used_default = loc is None

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -871,3 +871,12 @@ def test_handlerline2d():
     handles = [mlines.Line2D([0], [0], marker="v")]
     leg = ax.legend(handles, ["Aardvark"], numpoints=1)
     assert handles[0].get_marker() == leg.legendHandles[0].get_marker()
+
+
+def test_subfigure_legend():
+    # Test that legend can be added to subfigure (#20723)
+    subfig = plt.figure().subfigures()
+    ax = subfig.subplots()
+    ax.plot([0, 1], [0, 1], label="line")
+    leg = subfig.legend()
+    assert leg.figure is subfig


### PR DESCRIPTION
## PR Summary

- Closes #20723

As reported in #20723, this changes the `isinstance` check in `Legend` to check against `FigureBase` instead of `Figure`

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- N/A: API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).