### PR TITLE
Add Python 3.10 testing.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -41,6 +41,11 @@ jobs:
             python-version: 3.9
             extra-requirements: '-r requirements/testing/extra.txt'
             XVFB_RUN: xvfb-run -a
+          - os: ubuntu-20.04
+            python-version: '3.10-dev'
+            # Re-add this when extra dependencies have wheels.
+            # extra-requirements: '-r requirements/testing/extra.txt'
+            XVFB_RUN: xvfb-run -a
           - os: macos-latest
             python-version: 3.8
             XVFB_RUN: ""

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -626,9 +626,9 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
     def __init__(self, canvas, parent, coordinates=True):
         """coordinates: should we show the coordinates on the right?"""
         QtWidgets.QToolBar.__init__(self, parent)
-        self.setAllowedAreas(
-            _enum("QtCore.Qt.ToolBarArea").TopToolBarArea
-            | _enum("QtCore.Qt.ToolBarArea").TopToolBarArea)
+        self.setAllowedAreas(QtCore.Qt.ToolBarArea(
+            _to_int(_enum("QtCore.Qt.ToolBarArea").TopToolBarArea) |
+            _to_int(_enum("QtCore.Qt.ToolBarArea").BottomToolBarArea)))
 
         self.coordinates = coordinates
         self._actions = {}  # mapping of toolitem method names to QActions.
@@ -651,9 +651,9 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         # will resize this label instead of the buttons.
         if self.coordinates:
             self.locLabel = QtWidgets.QLabel("", self)
-            self.locLabel.setAlignment(
-                _enum("QtCore.Qt.AlignmentFlag").AlignRight
-                | _enum("QtCore.Qt.AlignmentFlag").AlignVCenter)
+            self.locLabel.setAlignment(QtCore.Qt.AlignmentFlag(
+                _to_int(_enum("QtCore.Qt.AlignmentFlag").AlignRight) |
+                _to_int(_enum("QtCore.Qt.AlignmentFlag").AlignVCenter)))
             self.locLabel.setSizePolicy(QtWidgets.QSizePolicy(
                 _enum("QtWidgets.QSizePolicy.Policy").Expanding,
                 _enum("QtWidgets.QSizePolicy.Policy").Ignored,
@@ -883,13 +883,13 @@ class ToolbarQt(ToolContainerBase, QtWidgets.QToolBar):
     def __init__(self, toolmanager, parent):
         ToolContainerBase.__init__(self, toolmanager)
         QtWidgets.QToolBar.__init__(self, parent)
-        self.setAllowedAreas(
-            _enum("QtCore.Qt.ToolBarArea").TopToolBarArea
-            | _enum("QtCore.Qt.ToolBarArea").TopToolBarArea)
+        self.setAllowedAreas(QtCore.Qt.ToolBarArea(
+            _to_int(_enum("QtCore.Qt.ToolBarArea").TopToolBarArea) |
+            _to_int(_enum("QtCore.Qt.ToolBarArea").BottomToolBarArea)))
         message_label = QtWidgets.QLabel("")
-        message_label.setAlignment(
-            _enum("QtCore.Qt.AlignmentFlag").AlignRight
-            | _enum("QtCore.Qt.AlignmentFlag").AlignVCenter)
+        message_label.setAlignment(QtCore.Qt.AlignmentFlag(
+            _to_int(_enum("QtCore.Qt.AlignmentFlag").AlignRight) |
+            _to_int(_enum("QtCore.Qt.AlignmentFlag").AlignVCenter)))
         message_label.setSizePolicy(QtWidgets.QSizePolicy(
             _enum("QtWidgets.QSizePolicy.Policy").Expanding,
             _enum("QtWidgets.QSizePolicy.Policy").Ignored,

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -48,7 +48,7 @@ from numbers import Integral, Real
 
 from matplotlib import _api, colors as mcolors
 from .. import qt_compat
-from ..qt_compat import QtGui, QtWidgets, QtCore, _enum
+from ..qt_compat import QtGui, QtWidgets, QtCore, _enum, _to_int
 
 _log = logging.getLogger(__name__)
 
@@ -441,8 +441,12 @@ class FormDialog(QtWidgets.QDialog):
 
         # Button box
         self.bbox = bbox = QtWidgets.QDialogButtonBox(
-            _enum("QtWidgets.QDialogButtonBox.StandardButton").Ok
-            | _enum("QtWidgets.QDialogButtonBox.StandardButton").Cancel)
+            QtWidgets.QDialogButtonBox.StandardButton(
+                _to_int(
+                    _enum("QtWidgets.QDialogButtonBox.StandardButton").Ok) |
+                _to_int(
+                    _enum("QtWidgets.QDialogButtonBox.StandardButton").Cancel)
+            ))
         self.formwidget.update_buttons.connect(self.update_buttons)
         if self.apply_callback is not None:
             apply_btn = bbox.addButton(

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -21,6 +21,9 @@ def pytest_configure(config):
         ("filterwarnings", "error"),
         ("filterwarnings",
          "ignore:.*The py23 module has been deprecated:DeprecationWarning"),
+        ("filterwarnings",
+         r"ignore:DynamicImporter.find_spec\(\) not found; "
+         r"falling back to find_module\(\):ImportWarning"),
     ]:
         config.addinivalue_line(key, value)
 

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -10,7 +10,8 @@ import sys
 import pytest
 
 
-pytest.importorskip('sphinx')
+pytest.importorskip('sphinx',
+                    minversion=None if sys.version_info < (3, 10) else '4.1.3')
 
 
 def test_tinypages(tmpdir):

--- a/setup.py
+++ b/setup.py
@@ -304,6 +304,7 @@ setup(  # Finally, pass this all along to distutils to do the heavy lifting.
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: Visualization',
     ],
 


### PR DESCRIPTION
## PR Summary

Currently, pillow (https://github.com/python-pillow/Pillow/issues/5569) and kiwisolver (https://github.com/nucleic/kiwi/pull/103) do not have wheels, which slows down the build a bit, but it should pass anyway.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).