### PR TITLE
Fix qt key mods

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -106,7 +106,7 @@ def test_fig_signals(qt_core):
         ('Key_Control', ['AltModifier'], 'alt+control'),
         ('Key_Alt', ['ControlModifier'], 'ctrl+alt'),
         ('Key_Aacute', ['ControlModifier', 'AltModifier', 'MetaModifier'],
-         'ctrl+alt+super+\N{LATIN SMALL LETTER A WITH ACUTE}'),
+         'ctrl+alt+meta+\N{LATIN SMALL LETTER A WITH ACUTE}'),
         # We do not currently map the media keys, this may change in the
         # future.  This means the callback will never fire
         ('Key_Play', [], None),

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -107,6 +107,8 @@ def test_fig_signals(qt_core):
         ('Key_Alt', ['ControlModifier'], 'ctrl+alt'),
         ('Key_Aacute', ['ControlModifier', 'AltModifier', 'MetaModifier'],
          'ctrl+alt+super+\N{LATIN SMALL LETTER A WITH ACUTE}'),
+        # We do not currently map the media keys, this may change in the
+        # future.  This means the callback will never fire
         ('Key_Play', [], None),
         ('Key_Backspace', [], 'backspace'),
         ('Key_Backspace', ['ControlModifier'], 'ctrl+backspace'),
@@ -142,6 +144,7 @@ def test_correct_key(backend, qt_core, qt_key, qt_mods, answer):
     Assert sent and caught keys are the same.
     """
     from matplotlib.backends.qt_compat import _enum, _to_int
+    result = None
     qt_mod = _enum("QtCore.Qt.KeyboardModifier").NoModifier
     for mod in qt_mods:
         qt_mod |= getattr(_enum("QtCore.Qt.KeyboardModifier"), mod)
@@ -152,11 +155,13 @@ def test_correct_key(backend, qt_core, qt_key, qt_mods, answer):
         def modifiers(self): return qt_mod
 
     def on_key_press(event):
-        assert event.key == answer
+        nonlocal result
+        result = event.key
 
     qt_canvas = plt.figure().canvas
     qt_canvas.mpl_connect('key_press_event', on_key_press)
     qt_canvas.keyPressEvent(_Event())
+    assert result == answer
 
 
 @pytest.mark.backend('QtAgg', skip_on_importerror=True)


### PR DESCRIPTION
## PR Summary

Fixes a Qt test.  It looks like we had a test that never actually worked (the assert happened in a callback so the failure was ignored) which meant that the parameterized tests always passed.  When the test was fixed to raise on error this brought to light a miss-match between the computed and expected results which is also fixed.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
