### PR TITLE
Ignore errors trying to delete make_release_tree.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,10 @@ import setuptools.command.sdist
 # The setuptools version of sdist adds a setup.cfg file to the tree.
 # We don't want that, so we simply remove it, and it will fall back to
 # vanilla distutils.
-del setuptools.command.sdist.sdist.make_release_tree
+try:
+    del setuptools.command.sdist.sdist.make_release_tree
+except AttributeError:
+    pass
 
 from distutils.errors import CompileError
 from distutils.dist import Distribution


### PR DESCRIPTION
## PR Summary

Which apparently happens in Fedora's automated build requirement generator.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).