### PR TITLE
Use mpl.colormaps in examples

### DIFF
--- a/examples/axes_grid1/demo_edge_colorbar.py
+++ b/examples/axes_grid1/demo_edge_colorbar.py
@@ -35,7 +35,7 @@ def demo_bottom_cbar(fig):
                     )
 
     Z, extent = get_demo_image()
-    cmaps = [plt.get_cmap("autumn"), plt.get_cmap("summer")]
+    cmaps = ["autumn", "summer"]
     for i in range(4):
         im = grid[i].imshow(Z, extent=extent, cmap=cmaps[i//2])
         if i % 2:
@@ -65,7 +65,7 @@ def demo_right_cbar(fig):
                     cbar_pad="2%",
                     )
     Z, extent = get_demo_image()
-    cmaps = [plt.get_cmap("spring"), plt.get_cmap("winter")]
+    cmaps = ["spring", "winter"]
     for i in range(4):
         im = grid[i].imshow(Z, extent=extent, cmap=cmaps[i//2])
         if i % 2:

--- a/examples/color/colormap_reference.py
+++ b/examples/color/colormap_reference.py
@@ -54,9 +54,9 @@ def plot_color_gradients(cmap_category, cmap_list):
 
     axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
 
-    for ax, name in zip(axs, cmap_list):
-        ax.imshow(gradient, aspect='auto', cmap=plt.get_cmap(name))
-        ax.text(-.01, .5, name, va='center', ha='right', fontsize=10,
+    for ax, cmap_name in zip(axs, cmap_list):
+        ax.imshow(gradient, aspect='auto', cmap=cmap_name)
+        ax.text(-.01, .5, cmap_name, va='center', ha='right', fontsize=10,
                 transform=ax.transAxes)
 
     # Turn off *all* ticks & spines, not just the ones with colormaps.

--- a/examples/color/custom_cmap.py
+++ b/examples/color/custom_cmap.py
@@ -69,6 +69,7 @@ never used.
 
 """
 import numpy as np
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.colors import LinearSegmentedColormap
 
@@ -167,11 +168,9 @@ blue_red1 = LinearSegmentedColormap('BlueRed1', cdict1)
 # of Colormap, not just
 # a LinearSegmentedColormap:
 
-blue_red2 = LinearSegmentedColormap('BlueRed2', cdict2)
-plt.register_cmap(cmap=blue_red2)
-
-plt.register_cmap(cmap=LinearSegmentedColormap('BlueRed3', cdict3))
-plt.register_cmap(cmap=LinearSegmentedColormap('BlueRedAlpha', cdict4))
+mpl.colormaps.register(LinearSegmentedColormap('BlueRed2', cdict2))
+mpl.colormaps.register(LinearSegmentedColormap('BlueRed3', cdict3))
+mpl.colormaps.register(LinearSegmentedColormap('BlueRedAlpha', cdict4))
 
 ###############################################################################
 # Make the figure:
@@ -184,8 +183,7 @@ fig.subplots_adjust(left=0.02, bottom=0.06, right=0.95, top=0.94, wspace=0.05)
 im1 = axs[0, 0].imshow(Z, cmap=blue_red1)
 fig.colorbar(im1, ax=axs[0, 0])
 
-cmap = plt.get_cmap('BlueRed2')
-im2 = axs[1, 0].imshow(Z, cmap=cmap)
+im2 = axs[1, 0].imshow(Z, cmap='BlueRed2')
 fig.colorbar(im2, ax=axs[1, 0])
 
 # Now we will set the third cmap as the default.  One would

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -6,6 +6,7 @@ Contourf Demo
 How to use the `.axes.Axes.contourf` method to create filled contour plots.
 """
 import numpy as np
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 origin = 'lower'
@@ -86,8 +87,7 @@ fig2.colorbar(CS3)
 
 # Illustrate all 4 possible "extend" settings:
 extends = ["neither", "both", "min", "max"]
-cmap = plt.cm.get_cmap("winter")
-cmap = cmap.with_extremes(under="magenta", over="yellow")
+cmap = mpl.colormaps["winter"].with_extremes(under="magenta", over="yellow")
 # Note: contouring simply excludes masked or nan regions, so
 # instead of using the "bad" colormap value for them, it draws
 # nothing at all in them.  Therefore the following would have

--- a/examples/images_contours_and_fields/demo_bboximage.py
+++ b/examples/images_contours_and_fields/demo_bboximage.py
@@ -7,6 +7,7 @@ A `~matplotlib.image.BboxImage` can be used to position an image according to
 a bounding box. This demo shows how to show an image inside a `.text.Text`'s
 bounding box as well as how to manually create a bounding box for the image.
 """
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.image import BboxImage
@@ -38,18 +39,18 @@ a = np.linspace(0, 1, 256).reshape(1, -1)
 a = np.vstack((a, a))
 
 # List of all colormaps; skip reversed colormaps.
-maps = sorted(m for m in plt.colormaps() if not m.endswith("_r"))
+cmap_names = sorted(m for m in mpl.colormaps if not m.endswith("_r"))
 
 ncol = 2
-nrow = len(maps)//ncol + 1
+nrow = len(cmap_names) // ncol + 1
 
 xpad_fraction = 0.3
-dx = 1./(ncol + xpad_fraction*(ncol - 1))
+dx = 1 / (ncol + xpad_fraction * (ncol - 1))
 
 ypad_fraction = 0.3
-dy = 1./(nrow + ypad_fraction*(nrow - 1))
+dy = 1 / (nrow + ypad_fraction * (nrow - 1))
 
-for i, m in enumerate(maps):
+for i, cmap_name in enumerate(cmap_names):
     ix, iy = divmod(i, nrow)
 
     bbox0 = Bbox.from_bounds(ix*dx*(1 + xpad_fraction),
@@ -58,7 +59,7 @@ for i, m in enumerate(maps):
     bbox = TransformedBbox(bbox0, ax2.transAxes)
 
     bbox_image = BboxImage(bbox,
-                           cmap=plt.get_cmap(m),
+                           cmap=cmap_name,
                            norm=None,
                            origin=None,
                            **kwargs

--- a/examples/images_contours_and_fields/quadmesh_demo.py
+++ b/examples/images_contours_and_fields/quadmesh_demo.py
@@ -9,7 +9,8 @@ a faster generalization of `~.axes.Axes.pcolor`, but with some restrictions.
 This demo illustrates a bug in quadmesh with masked data.
 """
 
-from matplotlib import cm, pyplot as plt
+import matplotlib as mpl
+from matplotlib import pyplot as plt
 import numpy as np
 
 n = 12
@@ -29,7 +30,7 @@ axs[0].pcolormesh(Qx, Qz, Z, shading='gouraud')
 axs[0].set_title('Without masked values')
 
 # You can control the color of the masked region.
-cmap = cm.get_cmap(plt.rcParams['image.cmap']).with_extremes(bad='y')
+cmap = mpl.colormaps[mpl.rcParams['image.cmap']].with_extremes(bad='y')
 axs[1].pcolormesh(Qx, Qz, Zm, shading='gouraud', cmap=cmap)
 axs[1].set_title('With masked values')
 

--- a/examples/images_contours_and_fields/tricontour_smooth_delaunay.py
+++ b/examples/images_contours_and_fields/tricontour_smooth_delaunay.py
@@ -25,7 +25,6 @@ a data set is the following:
 """
 from matplotlib.tri import Triangulation, TriAnalyzer, UniformTriRefiner
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import numpy as np
 
 
@@ -114,7 +113,6 @@ plot_expected = False    # plot of analytical function values for comparison
 
 # Graphical options for tricontouring
 levels = np.arange(0., 1., 0.025)
-cmap = cm.get_cmap(name='Blues', lut=None)
 
 fig, ax = plt.subplots()
 ax.set_aspect('equal')
@@ -122,11 +120,11 @@ ax.set_title("Filtering a Delaunay mesh\n"
              "(application to high-resolution tricontouring)")
 
 # 1) plot of the refined (computed) data contours:
-ax.tricontour(tri_refi, z_test_refi, levels=levels, cmap=cmap,
+ax.tricontour(tri_refi, z_test_refi, levels=levels, cmap='Blues',
               linewidths=[2.0, 0.5, 1.0, 0.5])
 # 2) plot of the expected (analytical) data contours (dashed):
 if plot_expected:
-    ax.tricontour(tri_refi, z_expected, levels=levels, cmap=cmap,
+    ax.tricontour(tri_refi, z_expected, levels=levels, cmap='Blues',
                   linestyles='--')
 # 3) plot of the fine mesh on which interpolation was done:
 if plot_refi_tri:

--- a/examples/images_contours_and_fields/tricontour_smooth_user.py
+++ b/examples/images_contours_and_fields/tricontour_smooth_user.py
@@ -8,7 +8,6 @@ with `matplotlib.tri.UniformTriRefiner`.
 """
 import matplotlib.tri as tri
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import numpy as np
 
 
@@ -66,8 +65,7 @@ ax.set_aspect('equal')
 ax.triplot(triang, lw=0.5, color='white')
 
 levels = np.arange(0., 1., 0.025)
-cmap = cm.get_cmap(name='terrain', lut=None)
-ax.tricontourf(tri_refi, z_test_refi, levels=levels, cmap=cmap)
+ax.tricontourf(tri_refi, z_test_refi, levels=levels, cmap='terrain')
 ax.tricontour(tri_refi, z_test_refi, levels=levels,
               colors=['0.25', '0.5', '0.5', '0.5', '0.5'],
               linewidths=[1.0, 0.5, 0.5, 0.5, 0.5])

--- a/examples/images_contours_and_fields/trigradient_demo.py
+++ b/examples/images_contours_and_fields/trigradient_demo.py
@@ -9,7 +9,6 @@ Demonstrates computation of gradient with
 from matplotlib.tri import (
     Triangulation, UniformTriRefiner, CubicTriInterpolator)
 import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import numpy as np
 
 
@@ -76,8 +75,7 @@ ax.margins(0.07)
 ax.triplot(triang, color='0.8')
 
 levels = np.arange(0., 1., 0.01)
-cmap = cm.get_cmap(name='hot', lut=None)
-ax.tricontour(tri_refi, z_test_refi, levels=levels, cmap=cmap,
+ax.tricontour(tri_refi, z_test_refi, levels=levels, cmap='hot',
               linewidths=[2.0, 1.0, 1.0, 1.0])
 # Plots direction of the electrical vector field
 ax.quiver(triang.x, triang.y, Ex/E_norm, Ey/E_norm,

--- a/examples/pie_and_polar_charts/nested_pie.py
+++ b/examples/pie_and_polar_charts/nested_pie.py
@@ -8,6 +8,7 @@ in Matplotlib. Such charts are often referred to as donut charts.
 
 """
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -30,7 +31,7 @@ fig, ax = plt.subplots()
 size = 0.3
 vals = np.array([[60., 32.], [37., 40.], [29., 10.]])
 
-cmap = plt.get_cmap("tab20c")
+cmap = mpl.colormaps["tab20c"]
 outer_colors = cmap(np.arange(3)*4)
 inner_colors = cmap([1, 2, 5, 6, 9, 10])
 
@@ -61,7 +62,7 @@ valsnorm = vals/np.sum(vals)*2*np.pi
 # Obtain the ordinates of the bar edges
 valsleft = np.cumsum(np.append(0, valsnorm.flatten()[:-1])).reshape(vals.shape)
 
-cmap = plt.get_cmap("tab20c")
+cmap = mpl.colormaps["tab20c"]
 outer_colors = cmap(np.arange(3)*4)
 inner_colors = cmap([1, 2, 5, 6, 9, 10])
 


### PR DESCRIPTION
Use the new ColormapRegistry `mpl.colormaps` in examples.

Also don't obtain the Colormap object if it only passed to a colormapping
function. Passing the name is sufficient in such cases.
