### PR TITLE
Deprecate some old globals in qt_compat.

### DIFF
--- a/doc/api/next_api_changes/deprecations/20881-AL.rst
+++ b/doc/api/next_api_changes/deprecations/20881-AL.rst
@@ -1,0 +1,3 @@
+``matplotlib.backends.qt_compat.ETS`` and ``matplotlib.backends.qt_compat.QT_RC_MAJOR_VERSION``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated, with no replacement.

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -23,6 +23,7 @@ import contextlib
 from packaging.version import parse as parse_version
 
 import matplotlib as mpl
+from matplotlib import _api
 
 
 QT_API_PYQT6 = "PyQt6"
@@ -138,11 +139,6 @@ if (sys.platform == 'darwin' and
         "QT_MAC_WANTS_LAYER" not in os.environ):
     os.environ["QT_MAC_WANTS_LAYER"] = "1"
 
-# These globals are only defined for backcompatibility purposes.
-ETS = dict(pyqt5=(QT_API_PYQT5, 5), pyside2=(QT_API_PYSIDE2, 5))
-
-QT_RC_MAJOR_VERSION = int(QtCore.qVersion().split(".")[0])
-
 
 # PyQt6 enum compat helpers.
 
@@ -253,3 +249,11 @@ def _maybe_allow_interrupt(qapp):
             signal.signal(signal.SIGINT, old_sigint_handler)
             if handler_args is not None:
                 old_sigint_handler(*handler_args)
+
+
+@_api.caching_module_getattr
+class __getattr__:
+    ETS = _api.deprecated("3.5")(property(lambda self: dict(
+        pyqt5=(QT_API_PYQT5, 5), pyside2=(QT_API_PYSIDE2, 5))))
+    QT_RC_MAJOR_VERSION = _api.deprecated("3.5")(property(
+        lambda self: int(QtCore.qVersion().split(".")[0])))


### PR DESCRIPTION
Especially, note that QT_RC_MAJOR_VERSION originally pointed to the qt
major version selected by the rcParams (qt4agg/qt5agg), which doesn't
even have an equivalent now that we moved to a single qtagg backend.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
