### PR TITLE
Make pywin32 optional in Ctrl+C Qt test.

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -39,8 +39,8 @@ def platform_simulate_ctrl_c(request):
     from functools import partial
 
     if hasattr(signal, "CTRL_C_EVENT"):
-        from win32api import GenerateConsoleCtrlEvent
-        return partial(GenerateConsoleCtrlEvent, 0, 0)
+        win32api = pytest.importorskip('win32api')
+        return partial(win32api.GenerateConsoleCtrlEvent, 0, 0)
     else:
         # we're not on windows
         return partial(os.kill, os.getpid(), signal.SIGINT)

--- a/requirements/testing/extra.txt
+++ b/requirements/testing/extra.txt
@@ -6,3 +6,4 @@ nbformat!=5.0.0,!=5.0.1
 pandas!=0.25.0
 pikepdf
 pytz
+pywin32; sys.platform == 'win32'


### PR DESCRIPTION
## PR Summary

From https://github.com/matplotlib/matplotlib/pull/13306/files/c3772ae037c5a2c7614013a9c36954675c5d9de0#diff-ee95644f45380b6c0cf91171c8c048ed673628bd67f14876ddd60abe0a3e0371

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).