### PR TITLE
Fix broken QApplication init in a test.

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -379,8 +379,9 @@ def test_canvas_reinit():
 
 @pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_form_widget_get_with_datetime_and_date_fields():
-    if not QtWidgets.QApplication.instance():
-        QtWidgets.QApplication()
+    from matplotlib.backends.backend_qt import _create_qApp
+    _create_qApp()
+
     form = [
         ("Datetime field", datetime(year=2021, month=3, day=11)),
         ("Date field", date(year=2021, month=3, day=11))


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).