### PR TITLE
Implement a consistent behavior in TkAgg backend for bad blit bbox

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -80,6 +80,8 @@ def blit(photoimage, aggimage, offsets, bbox=None):
 
     If *bbox* is passed, it defines the region that gets blitted. That region
     will be composed with the previous data according to the alpha channel.
+    Blitting will be clipped to pixels inside the canvas, including silently
+    doing nothing if the *bbox* region is entirely outside the canvas.
 
     Tcl events must be dispatched to trigger a blit from a non-Tcl thread.
     """
@@ -92,6 +94,8 @@ def blit(photoimage, aggimage, offsets, bbox=None):
         x2 = min(math.ceil(x2), width)
         y1 = max(math.floor(y1), 0)
         y2 = min(math.ceil(y2), height)
+        if (x1 > x2) or (y1 > y2):
+            return
         bboxptr = (x1, x2, y1, y2)
         comp_rule = TK_PHOTO_COMPOSITE_OVERLAY
     else:


### PR DESCRIPTION
## PR Summary
This PR seeks to make the failure modes more consistent and manageable when blitting on the `TkAgg` backend. Draft for now because I don't think it is release critical and some feedback is needed on design choices.

### Background
The thread safety changes of #18565 interact a bit awkwardly with the memory safety changes of #14478, namely when `_tkagg.blit` raises, it pops directly out of the tkinter `mainloop` call and poisons the current instance of tkapp so that pumping the event loop always raises the `ValueError` forever. This isn't a big deal for bad values of `comp_rule` or `photoimage` since those are matplotlib's responsibilities, however as a user-facing API this prevents a client application from gracefully handling bad bboxes; they are basically fatal.

Why, if this is so bad, did nobody notice?  In #14461 the bbox limits are clipped to a mostly-safe range, so only *very* bad bboxes that fall entirely outside the canvas trigger the issue.  (And only my app is crazy enough to generate such bboxes 🤦)

### Proposed fix(es)
#### Extend safe-clipping
The initial commit in this PR makes the most minimal possible change to existing behavior, extending the safe-clipping to boxes outside the canvas; they are simply dropped, and with a fast path optimization to boot. This way if `ValueErrors` are generated, they are 100% our fault. The `if` expression comes from the [check in `_tkagg.cpp`](https://github.com/matplotlib/matplotlib/blob/2f140ffb10f8f006778644562b47eb064f039553/src/_tkagg.cpp#L84-L87) but stripping the rules that are redundant to the clipping logic. The disadvantage is that the only way a user knows that their bbox is being clipped is by weird visual artifacts.

#### Raise aggressively
An alternative fix is to promote the [`_tkagg.cpp` check](https://github.com/matplotlib/matplotlib/blob/2f140ffb10f8f006778644562b47eb064f039553/src/_tkagg.cpp#L84-L87) into the first lines of `_backend_tk.blit`:

```python3
def blit(photoimage, aggimage, offsets, bbox=None):
    ...
    if bbox is not None:
        # Does anyone know why we are calling __array__ directly?
        (x1, y1), (x2, y2) = bbox.__array__().astype(int).tolist()
        if (0 > y1 or y1 > y2 or y2 > height or 0 > x1 or x1 > x2 or x2 > width):
            raise ValueError("Attempting to draw out of bounds")
        bboxptr = (x1, x2, y1, y2)
        comp_rule = TK_PHOTO_COMPOSITE_OVERLAY
    ...
```

This `raise` is now catchable and the check inside `_tkagg.blit` is redundant (though it is super cheap so it should remain in both places). Adding tests for this would finally cover this branch of the if statement. Also ALL bad bbox blits are errors now. 

I see two disadvantages to this alternative. The integer conversion has to be different (truncated) so that full-canvas blits are not liable to pick up an extra pixel and error out, however this floor rounding behavior is consistent with other backends. Some user code that worked by silently clipping will now raise.

### Open questions
Should we consider this alternative option as exposing latent bugs that should have been caught before, or as making `blit` "less robust"? Should we reconsider the current rounding/clipping rules? How strict are other backends to weird bboxes and can we make things consistent across all of them?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
