### PR TITLE
Label pylab as "discouraged" instead of "disapproved"

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -166,7 +166,7 @@ Further reading:
 - Most of the :ref:`examples <examples-index>` use the object-oriented approach
    (except for the pyplot section)
 
-The pylab API (disapproved)
+The pylab API (discouraged)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: pylab


### PR DESCRIPTION
Some native speaker please check, but I think *discouraged* is the better word.
