### PR TITLE
Move sigint tests into subprocesses

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -60,6 +60,8 @@ install:
   # pull pywin32 from conda because on py38 there is something wrong with finding
   # the dlls when insalled from pip
   - conda install -c conda-forge pywin32
+  # install pyqt from conda-forge
+  - conda install -c conda-forge pyqt
   - echo %PYTHON_VERSION% %TARGET_ARCH%
   # Install dependencies from PyPI.
   - python -m pip install --upgrade -r requirements/testing/all.txt %EXTRAREQS% %PINNEDVERS%

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -228,8 +228,14 @@ def _maybe_allow_interrupt(qapp):
             rsock.fileno(), _enum('QtCore.QSocketNotifier.Type').Read
         )
 
+        rsock.setblocking(False)
         # Clear the socket to re-arm the notifier.
-        sn.activated.connect(lambda *args: rsock.recv(1))
+        @sn.activated.connect
+        def _may_clear_sock(*args):
+            try:
+                rsock.recv(1)
+            except BlockingIOError:
+                pass
 
         def handle(*args):
             nonlocal handler_args

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -228,6 +228,12 @@ def _maybe_allow_interrupt(qapp):
             rsock.fileno(), _enum('QtCore.QSocketNotifier.Type').Read
         )
 
+        # We do not actually care about this value other than running some
+        # Python code to ensure that the interpreter has a chance to handle the
+        # signal in Python land.  We also need to drain the socket because it
+        # will be written to as part of the wakeup!  There are some cases where
+        # this may fire too soon / more than once on Windows so we should be
+        # forgiving about reading an empty socket.
         rsock.setblocking(False)
         # Clear the socket to re-arm the notifier.
         @sn.activated.connect

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -214,29 +214,31 @@ def test_fig_sigint_override(qt_core):
 
     signal.signal(signal.SIGINT, custom_handler)
 
-    # mainloop() sets SIGINT, starts Qt event loop (which triggers timer and
-    # exits) and then mainloop() resets SIGINT
-    matplotlib.backends.backend_qt._BackendQT.mainloop()
+    try:
+        # mainloop() sets SIGINT, starts Qt event loop (which triggers timer
+        # and exits) and then mainloop() resets SIGINT
+        matplotlib.backends.backend_qt._BackendQT.mainloop()
 
-    # Assert: signal handler during loop execution is changed
-    # (can't test equality with func)
-    assert event_loop_handler != custom_handler
+        # Assert: signal handler during loop execution is changed
+        # (can't test equality with func)
+        assert event_loop_handler != custom_handler
 
-    # Assert: current signal handler is the same as the one we set before
-    assert signal.getsignal(signal.SIGINT) == custom_handler
-
-    # Repeat again to test that SIG_DFL and SIG_IGN will not be overridden
-    for custom_handler in (signal.SIG_DFL, signal.SIG_IGN):
-        qt_core.QTimer.singleShot(0, fire_signal_and_quit)
-        signal.signal(signal.SIGINT, custom_handler)
-
-        _BackendQT5.mainloop()
-
-        assert event_loop_handler == custom_handler
+        # Assert: current signal handler is the same as the one we set before
         assert signal.getsignal(signal.SIGINT) == custom_handler
 
-    # Reset SIGINT handler to what it was before the test
-    signal.signal(signal.SIGINT, original_handler)
+        # Repeat again to test that SIG_DFL and SIG_IGN will not be overridden
+        for custom_handler in (signal.SIG_DFL, signal.SIG_IGN):
+            qt_core.QTimer.singleShot(0, fire_signal_and_quit)
+            signal.signal(signal.SIGINT, custom_handler)
+
+            _BackendQT5.mainloop()
+
+            assert event_loop_handler == custom_handler
+            assert signal.getsignal(signal.SIGINT) == custom_handler
+
+    finally:
+        # Reset SIGINT handler to what it was before the test
+        signal.signal(signal.SIGINT, original_handler)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## PR Summary

This prevents them accidentally breaking the test runner itself, depending on platform. Also, enable Qt tests on AppVeyor. A followup to #20883.

~~I haven't converted `test_fig_sigint_override` yet, as I want to see if this works on Windows.~~ `test_fig_sigint_override` doesn't actually fire any signals, but I modified it to ensure it doesn't leave broken global state.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).