### PR TITLE
[Doc] FigureCanvasBase draw

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2041,10 +2041,10 @@ class FigureCanvasBase:
         """
         Render the `.Figure`.
 
-        This method must walk the artist tree, even if no output is produced, 
-        because it triggers deferred work that users may want to access before 
-        saving output to disk. For example computing limits, auto-limits, 
-        and tick values. 
+        This method must walk the artist tree, even if no output is produced,
+        because it triggers deferred work that users may want to access
+        before saving output to disk. For example computing limits,
+        auto-limits, and tick values.
         """
 
     def draw_idle(self, *args, **kwargs):


### PR DESCRIPTION
Started as a typo fix not->no, ended up rewriting/breaking up the paragraph.
