### PR TITLE
19195 rotated markers

### DIFF
--- a/doc/users/next_whats_new/extending_MarkerStyle.rst
+++ b/doc/users/next_whats_new/extending_MarkerStyle.rst
@@ -1,0 +1,19 @@
+New customization of MarkerStyle
+--------------------------------
+
+New MarkerStyle parameters allow control of join style and cap style. 
+The appearance of individual markers can be further controlled by 
+transform supplied during creation.
+
+.. plot::
+    :include-source:
+    import matplotlib.pyplot as plt
+    from matplotlib.markers import MarkerStyle
+    from matplotlib.transforms import Affine2D
+    fig, ax = plt.subplots(figsize=(6, 1))
+    fig.suptitle('New markers', fontsize=14)
+    for col, (size, rot) in enumerate(zip([2, 5, 10], [0, 45, 90])):
+        t = Affine2D().rotate_deg(rot).scale(size)
+        ax.plot(col, 0, marker=MarkerStyle("*", transform=t))
+    ax.axis("off")
+    ax.set_xlim(-0.1, 2.4)

--- a/doc/users/next_whats_new/extending_MarkerStyle.rst
+++ b/doc/users/next_whats_new/extending_MarkerStyle.rst
@@ -6,7 +6,8 @@ The appearance of individual markers can be further controlled by
 transform supplied during creation.
 
 .. plot::
-    :include-source:
+    :include-source: true
+    
     import matplotlib.pyplot as plt
     from matplotlib.markers import MarkerStyle
     from matplotlib.transforms import Affine2D

--- a/doc/users/next_whats_new/extending_MarkerStyle.rst
+++ b/doc/users/next_whats_new/extending_MarkerStyle.rst
@@ -1,9 +1,8 @@
 New customization of MarkerStyle
 --------------------------------
 
-New MarkerStyle parameters allow control of join style and cap style. 
-The appearance of individual markers can be further controlled by 
-transform supplied during creation.
+New MarkerStyle parameters allow control of join style and cap style, and for
+the user to supply a transformation to be applied to the marker (e.g. a rotation).
 
 .. plot::
     :include-source: true

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -166,8 +166,9 @@ plt.show()
 # Advanced marker modifications with transform
 # ============================================
 #
-# Markers can be modified by passing a transform to the MarkerStyle constructor.
-# Following example shows how a supplied rotation is applied to several marker shapes.
+# Markers can be modified by passing a transform to the MarkerStyle
+# constructor. Following example shows how a supplied rotation is applied to
+# several marker shapes.
 
 common_style = {k: v for k, v in filled_marker_style.items() if k != 'marker'}
 angles = [0, 10, 20, 30, 45, 60, 90]

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -19,8 +19,10 @@ For example usages see
 .. redirect-from:: /gallery/shapes_and_collections/marker_path
 """
 
+from matplotlib.markers import MarkerStyle
 import matplotlib.pyplot as plt
 from matplotlib.lines import Line2D
+from matplotlib.transforms import Affine2D
 
 
 text_style = dict(horizontalalignment='right', verticalalignment='center',
@@ -156,6 +158,101 @@ markers = {'star': star, 'circle': circle, 'cut_star': cut_star}
 for y, (name, marker) in enumerate(markers.items()):
     ax.text(-0.5, y, name, **text_style)
     ax.plot([y] * 3, marker=marker, **marker_style)
+format_axes(ax)
+
+plt.show()
+
+###############################################################################
+# Advanced marker modifications with transform
+# ============================================
+#
+# All markers can be modified by a user transform in MarkerStyle constructor.
+# Supplied transform is combined with the default transforms needed for
+# selected marker shape (e.g. caret up, caret down). Following example shows
+# how user supplied rotation applies to several marker shapes.
+
+common_style = {k: v for k, v in filled_marker_style.items() if v != 'marker'}
+angles = [0, 10, 20, 30, 45, 60, 90]
+
+fig, ax = plt.subplots()
+fig.suptitle('Rotated markers', fontsize=14)
+
+ax.text(-0.5, 0, 'Filled marker', **text_style)
+for x, theta in enumerate(angles):
+    t = Affine2D().rotate_deg(theta)
+    ax.plot(x, 0, marker=MarkerStyle('o', 'left', t), **common_style)
+
+ax.text(-0.5, 1, 'Un-filled marker', **text_style)
+for x, theta in enumerate(angles):
+    t = Affine2D().rotate_deg(theta)
+    ax.plot(x, 1, marker=MarkerStyle('1', 'left', t), **common_style)
+
+ax.text(-0.5, 2, 'Equation marker', **text_style)
+for x, theta in enumerate(angles):
+    t = Affine2D().rotate_deg(theta)
+    eq = r'$\frac{1}{x}$'
+    ax.plot(x, 2, marker=MarkerStyle(eq, 'left', t), **common_style)
+
+for x, theta in enumerate(angles):
+    ax.text(x, 2.5, f"{theta}°", horizontalalignment="center")
+format_axes(ax)
+
+plt.show()
+
+###############################################################################
+# Setting marker cap style and join style
+# =======================================
+#
+# All markers have predefined cap style and join style, but this can be
+# overriden during creation of MarkerStyle. Follwing example show how to
+# change the cap style and how different styles look.
+
+from matplotlib.markers import JoinStyle, CapStyle
+
+marker_inner = dict(markersize=35,
+                    markerfacecolor='tab:blue',
+                    markerfacecoloralt='lightsteelblue',
+                    markeredgecolor='brown',
+                    markeredgewidth=8,
+                    )
+
+marker_outer = dict(markersize=35,
+                    markerfacecolor='tab:blue',
+                    markerfacecoloralt='lightsteelblue',
+                    markeredgecolor='white',
+                    markeredgewidth=1,
+                    )
+
+fig, ax = plt.subplots()
+fig.suptitle('Marker CapStyle', fontsize=14)
+fig.subplots_adjust(left=0.1)
+
+for y, cap_style in enumerate([None, *CapStyle]):
+    ax.text(-0.5, y, cap_style.name, **text_style)
+    for x, theta in enumerate(angles):
+        t = Affine2D().rotate_deg(theta)
+        m = MarkerStyle('1', transform=t, capstyle=cap_style)
+        ax.plot(x, y, marker=m, **marker_inner)
+        ax.plot(x, y, marker=m, **marker_outer)
+        ax.text(x, len(CapStyle) - .5, f'{theta}°', ha='center')
+format_axes(ax)
+plt.show()
+
+###############################################################################
+# Follwing example show how to change the join style and how different styles
+# look.
+
+fig, ax = plt.subplots()
+fig.suptitle('Marker JoinStyle', fontsize=14)
+fig.subplots_adjust(left=0.05)
+
+for y, join_style in enumerate(JoinStyle):
+    ax.text(-0.5, y, join_style.name, **text_style)
+    for x, theta in enumerate(angles):
+        t = Affine2D().rotate_deg(theta)
+        m = MarkerStyle('*', transform=t, joinstyle=join_style)
+        ax.plot(x, y, marker=m, **marker_inner)
+        ax.text(x, len(JoinStyle) - .5, f'{theta}°', ha='center')
 format_axes(ax)
 
 plt.show()

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -197,6 +197,7 @@ for x, theta in enumerate(angles):
     ax.text(x, 2.5, f"{theta}°", horizontalalignment="center")
 format_axes(ax)
 
+fig.tight_layout()
 plt.show()
 
 ###############################################################################

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -166,10 +166,8 @@ plt.show()
 # Advanced marker modifications with transform
 # ============================================
 #
-# All markers can be modified by a user transform in MarkerStyle constructor.
-# Supplied transform is combined with the default transforms needed for
-# selected marker shape (e.g. caret up, caret down). Following example shows
-# how user supplied rotation applies to several marker shapes.
+# Markers can be modified by passing a transform to the MarkerStyle constructor.
+# Following example shows how a supplied rotation is applied to several marker shapes.
 
 common_style = {k: v for k, v in filled_marker_style.items() if k != 'marker'}
 angles = [0, 10, 20, 30, 45, 60, 90]
@@ -204,9 +202,8 @@ plt.show()
 # Setting marker cap style and join style
 # =======================================
 #
-# All markers have predefined cap style and join style, but this can be
-# overriden during creation of MarkerStyle. Follwing example show how to
-# change the cap style and how different styles look.
+# Markers have default cap and join styles, but these can be
+# customized when creating a MarkerStyle.
 
 from matplotlib.markers import JoinStyle, CapStyle
 
@@ -240,8 +237,7 @@ format_axes(ax)
 plt.show()
 
 ###############################################################################
-# Follwing example show how to change the join style and how different styles
-# looks like.
+# Modifying the join style:
 
 fig, ax = plt.subplots()
 fig.suptitle('Marker JoinStyle', fontsize=14)

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -171,7 +171,7 @@ plt.show()
 # selected marker shape (e.g. caret up, caret down). Following example shows
 # how user supplied rotation applies to several marker shapes.
 
-common_style = {k: v for k, v in filled_marker_style.items() if v != 'marker'}
+common_style = {k: v for k, v in filled_marker_style.items() if k != 'marker'}
 angles = [0, 10, 20, 30, 45, 60, 90]
 
 fig, ax = plt.subplots()
@@ -227,7 +227,7 @@ fig, ax = plt.subplots()
 fig.suptitle('Marker CapStyle', fontsize=14)
 fig.subplots_adjust(left=0.1)
 
-for y, cap_style in enumerate([None, *CapStyle]):
+for y, cap_style in enumerate(CapStyle):
     ax.text(-0.5, y, cap_style.name, **text_style)
     for x, theta in enumerate(angles):
         t = Affine2D().rotate_deg(theta)
@@ -240,7 +240,7 @@ plt.show()
 
 ###############################################################################
 # Follwing example show how to change the join style and how different styles
-# look.
+# looks like.
 
 fig, ax = plt.subplots()
 fig.suptitle('Marker JoinStyle', fontsize=14)

--- a/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -18,9 +18,9 @@ from matplotlib.textpath import TextPath
 from matplotlib.colors import Normalize
 
 SUCCESS_SYMBOLS = [
-    TextPath((0,0), "☹"), 
-    TextPath((0,0), "😒"), 
-    TextPath((0,0), "☺"), 
+    TextPath((0, 0), "☹"),
+    TextPath((0, 0), "😒"),
+    TextPath((0, 0), "☺"),
 ]
 
 N = 25
@@ -40,6 +40,6 @@ for skill, takeoff, thrust, mood, pos in data:
     m = MarkerStyle(SUCCESS_SYMBOLS[mood], transform=t)
     ax.plot(pos[0], pos[1], marker=m, color=cmap(thrust))
 fig.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap=cmap),
-    ax=ax, label="Normalized Thrust [a.u.]")
+             ax=ax, label="Normalized Thrust [a.u.]")
 ax.set_xlabel("X position [m]")
 ax.set_ylabel("Y position [m]")

--- a/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -4,9 +4,9 @@ Mapping marker properties to multivariate data
 ==============================================
 
 This example shows how to use different properties of markers to plot
-multivariate datasets. Here we represent a successful baseball throw as a smiley 
-face with marker size mapped to the skill of thrower, marker rotation to the take-off angle, 
-and thrust to the marker color.
+multivariate datasets. Here we represent a successful baseball throw as a
+smiley face with marker size mapped to the skill of thrower, marker rotation to
+the take-off angle, and thrust to the marker color.
 """
 
 import numpy as np

--- a/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -43,3 +43,5 @@ fig.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap=cmap),
              ax=ax, label="Normalized Thrust [a.u.]")
 ax.set_xlabel("X position [m]")
 ax.set_ylabel("Y position [m]")
+
+plt.show()

--- a/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -1,0 +1,45 @@
+"""
+==============================================
+Mapping marker properties to multivariate data
+==============================================
+
+This example shows how to use different properties of markers to plot
+multivariate datasets. Following example shows an illustrative case of
+plotting success of baseball throw as an smiley face with size mapped to
+the skill of thrower, rotation mapped to the take-off angle, and thrust
+to the color of the marker.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.markers import MarkerStyle
+from matplotlib.transforms import Affine2D
+from matplotlib.textpath import TextPath
+from matplotlib.colors import Normalize
+
+SUCCESS_SYMBOLS = [
+    TextPath((0,0), "☹"), 
+    TextPath((0,0), "😒"), 
+    TextPath((0,0), "☺"), 
+]
+
+N = 25
+np.random.seed(42)
+skills = np.random.uniform(5, 80, size=N) * 0.1 + 5
+takeoff_angles = np.random.normal(0, 90, N)
+thrusts = np.random.uniform(size=N)
+successfull = np.random.randint(0, 3, size=N)
+positions = np.random.normal(size=(N, 2)) * 5
+data = zip(skills, takeoff_angles, thrusts, successfull, positions)
+
+cmap = plt.cm.get_cmap("plasma")
+fig, ax = plt.subplots()
+fig.suptitle("Throwing success", size=14)
+for skill, takeoff, thrust, mood, pos in data:
+    t = Affine2D().scale(skill).rotate_deg(takeoff)
+    m = MarkerStyle(SUCCESS_SYMBOLS[mood], transform=t)
+    ax.plot(pos[0], pos[1], marker=m, color=cmap(thrust))
+fig.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap=cmap),
+    ax=ax, label="Normalized Thrust [a.u.]")
+ax.set_xlabel("X position [m]")
+ax.set_ylabel("Y position [m]")

--- a/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -4,10 +4,9 @@ Mapping marker properties to multivariate data
 ==============================================
 
 This example shows how to use different properties of markers to plot
-multivariate datasets. Following example shows an illustrative case of
-plotting success of baseball throw as an smiley face with size mapped to
-the skill of thrower, rotation mapped to the take-off angle, and thrust
-to the color of the marker.
+multivariate datasets. Here we represent a successful baseball throw as a smiley 
+face with marker size mapped to the skill of thrower, marker rotation to the take-off angle, 
+and thrust to the marker color.
 """
 
 import numpy as np

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -370,7 +370,10 @@ class Line2D(Artist):
         self.set_color(color)
         if marker is None:
             marker = 'none'  # Default.
-        self._marker = MarkerStyle(marker, fillstyle)
+        if not isinstance(marker, MarkerStyle):
+            self._marker = MarkerStyle(marker, fillstyle)
+        else:
+            self._marker = marker
 
         self._markevery = None
         self._markersize = None

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -419,7 +419,7 @@ class MarkerStyle:
         if self._user_transform is not None:
             return self._user_transform.frozen()
 
-    def transformed(self, transform:Affine2D):
+    def transformed(self, transform: Affine2D):
         """
         Return new marker with combined transformation.
 
@@ -442,22 +442,65 @@ class MarkerStyle:
         Parameters
         ----------
         deg : float, default: None
+            - use this parameter to specify rotation angle in degrees.
 
         rad : float, default: None
+            - use this parameter to specify rotation angle in radians.
+
+        Note: you must specify exactly one of deg or rad.
         """
         if not ((deg is None) ^ (rad is None)):
-            raise Exception("Only one of deg or rad shall be used.")
-        
-        _transform = self._user_transform or Affine2D()
-
-        if deg is not None: 
-            _transform = _transform.rotate_deg(deg)
-        
-        if rad is not None:
-            _transform = _transform.rotate(rad)
+            raise ValueError("Exactly one of deg or rad shall be used.")
 
         new_marker = MarkerStyle(self)
-        new_marker._user_transform = _transform
+        if new_marker._user_transform is None:
+            new_marker._user_transform = Affine2D()
+
+        if deg is not None:
+            new_marker._user_transform.rotate_deg(deg)
+        if rad is not None:
+            new_marker._user_transform.rotate(rad)
+
+        return new_marker
+
+    def scaled(self, sx, sy=None):
+        """
+        Return new marker scaled by specified scale factors.
+
+        If *sy* is None, the same scale is applied in both the *x*- and
+        *y*-directions.
+
+        Parameters
+        ----------
+        sx : float
+        - *x*-direction scaling factor.
+
+        sy : float, default: None
+        - *y*-direction scaling factor.
+        """
+        if sy is None:
+            sy = sx
+
+        new_marker = MarkerStyle(self)
+        _transform = new_marker._user_transform or Affine2D()
+        new_marker._user_transform = _transform.scale(sx, sy)
+        return new_marker
+
+    def translated(self, tx, ty):
+        """
+        Return new marker translated by tx and ty.
+
+        Parameters
+        ----------
+        tx : float
+
+        ty : float
+
+        """
+        new_marker = MarkerStyle(self)
+        _transform = new_marker._user_transform or Affine2D()
+        new_marker._user_transform = _transform.translate(tx, ty)
+        return new_marker
 
     def _set_nothing(self):
         self._filled = False

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -82,9 +82,11 @@ Hence the following are equivalent::
     plt.plot([1, 2, 3], marker=11)
     plt.plot([1, 2, 3], marker=matplotlib.markers.CARETDOWNBASE)
 
-Markers join and cap styles can be customized by creating a new instance of MarkerStyle.
-A MarkerStyle can also have a custom
-`~matplotlib.transforms.Transform` allowing it to be arbitrarily rotated or offset.  
+Markers join and cap styles can be customized by creating a new instance of
+MarkerStyle.
+A MarkerStyle can also have a custom `~matplotlib.transforms.Transform`
+allowing it to be arbitrarily rotated or offset.
+
 Examples showing the use of markers:
 
 * :doc:`/gallery/lines_bars_and_markers/marker_reference`
@@ -148,14 +150,6 @@ from ._enums import JoinStyle, CapStyle
  CARETLEFTBASE, CARETRIGHTBASE, CARETUPBASE, CARETDOWNBASE) = range(12)
 
 _empty_path = Path(np.empty((0, 2)))
-
-
-def _fast_transform_combine(t1, t2):
-    """Combine two transformations where the second one can be None."""
-    if t2 is None:
-        return t1.frozen()
-    else:
-        return (t1 + t2).frozen()
 
 
 class MarkerStyle:
@@ -248,8 +242,9 @@ class MarkerStyle:
         fillstyle : str, default: :rc:`markers.fillstyle`
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
 
-        transform : Affine2D, default: None
-            Transform that will be combined with the native transform of the marker.
+        transform : transforms.Transform, default: None
+            Transform that will be combined with the native transform of the
+            marker.
 
         capstyle : CapStyle, default: None
             Cap style that will override the default cap style of the marker.
@@ -395,7 +390,10 @@ class MarkerStyle:
         Return the transform to be applied to the `.Path` from
         `MarkerStyle.get_path()`.
         """
-        return _fast_transform_combine(self._transform, self._user_transform)
+        if self._user_transform is None:
+            return self._transform.frozen()
+        else:
+            return (self._transform + self._user_transform).frozen()
 
     def get_alt_path(self):
         """
@@ -411,8 +409,10 @@ class MarkerStyle:
         Return the transform to be applied to the `.Path` from
         `MarkerStyle.get_alt_path()`.
         """
-        return _fast_transform_combine(self._alt_transform,
-                                       self._user_transform)
+        if self._user_transform is None:
+            return self._alt_transform.frozen()
+        else:
+            return (self._alt_transform + self._user_transform).frozen()
 
     def get_snap_threshold(self):
         return self._snap_threshold
@@ -424,7 +424,7 @@ class MarkerStyle:
 
     def transformed(self, transform: Affine2D):
         """
-        Return a new version of this marker with the transform applied. 
+        Return a new version of this marker with the transform applied.
 
         Parameters
         ----------

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -456,7 +456,7 @@ class MarkerStyle:
 
         .. note:: You must specify exactly one of deg or rad.
         """
-        if not ((deg is None) ^ (rad is None)):
+        if not (deg is None) ^ (rad is None):
             raise ValueError("Exactly one of deg or rad shall be used.")
 
         new_marker = MarkerStyle(self)

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -154,6 +154,14 @@ from ._enums import JoinStyle, CapStyle
 _empty_path = Path(np.empty((0, 2)))
 
 
+def _fast_transform_combine(t1, t2):
+    """Combine two transformations where the second one can be None."""
+    if t2 is None:
+        return t1.frozen()
+    else:
+        return (t1 + t2).frozen()
+
+
 class MarkerStyle:
     """
     A class representing marker types.
@@ -394,10 +402,7 @@ class MarkerStyle:
         Return the transform to be applied to the `.Path` from
         `MarkerStyle.get_path()`.
         """
-        if self._user_transform is not None:
-            return (self._transform + self._user_transform).frozen()
-        else:
-            return self._transform.frozen()
+        return _fast_transform_combine(self._transform, self._user_transform)
 
     def get_alt_path(self):
         """
@@ -413,10 +418,8 @@ class MarkerStyle:
         Return the transform to be applied to the `.Path` from
         `MarkerStyle.get_alt_path()`.
         """
-        if self._user_transform is not None:
-            return (self._alt_transform + self._user_transform).frozen()
-        else:
-            return self._alt_transform.frozen()
+        return _fast_transform_combine(self._alt_transform,
+                                       self._user_transform)
 
     def get_snap_threshold(self):
         return self._snap_threshold

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -426,7 +426,7 @@ class MarkerStyle:
         Parameters
         ----------
         transform : Affine2D, default: None
-            - transform will be combined with current user supplied transform.
+            Transform will be combined with current user supplied transform.
         """
         new_marker = MarkerStyle(self)
         if new_marker._user_transform is not None:
@@ -442,12 +442,12 @@ class MarkerStyle:
         Parameters
         ----------
         deg : float, default: None
-            - use this parameter to specify rotation angle in degrees.
+            Use this parameter to specify rotation angle in degrees.
 
         rad : float, default: None
-            - use this parameter to specify rotation angle in radians.
+            Use this parameter to specify rotation angle in radians.
 
-        Note: you must specify exactly one of deg or rad.
+        .. note:: You must specify exactly one of deg or rad.
         """
         if not ((deg is None) ^ (rad is None)):
             raise ValueError("Exactly one of deg or rad shall be used.")
@@ -473,10 +473,9 @@ class MarkerStyle:
         Parameters
         ----------
         sx : float
-        - *x*-direction scaling factor.
-
+            *X*-direction scaling factor.
         sy : float, default: None
-        - *y*-direction scaling factor.
+            *Y*-direction scaling factor.
         """
         if sy is None:
             sy = sx
@@ -493,9 +492,9 @@ class MarkerStyle:
         Parameters
         ----------
         tx : float
-
+            Coordinate for translation in *x*-direction.
         ty : float
-
+            Coordinate for translation in *y*-direction.
         """
         new_marker = MarkerStyle(self)
         _transform = new_marker._user_transform or Affine2D()

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -82,13 +82,9 @@ Hence the following are equivalent::
     plt.plot([1, 2, 3], marker=11)
     plt.plot([1, 2, 3], marker=matplotlib.markers.CARETDOWNBASE)
 
-Markers have some reasonable default settings for join and cap styles.
-However, those can be overriden when creating a new instance of MarkerStyle.
-Furthermore, the marker shape can be modified by supplying
-`~matplotlib.transforms.Transform` during creation.
-Some markers are created as internally rotated shapes (e.g. triangles).
-For such cases, both internal and user supplied transforms are combined.
-
+Markers join and cap styles can be customized by creating a new instance of MarkerStyle.
+A MarkerStyle can also have a custom
+`~matplotlib.transforms.Transform` allowing it to be arbitrarily rotated or offset.  
 Examples showing the use of markers:
 
 * :doc:`/gallery/lines_bars_and_markers/marker_reference`
@@ -253,16 +249,13 @@ class MarkerStyle:
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
 
         transform : Affine2D, default: None
-            User supplied transformation that will be combined with the
-            native transformation of selected marker.
+            Transform that will be combined with the native transform of the marker.
 
         capstyle : CapStyle, default: None
-            User supplied cap style that will override the default cap
-            style of selected marker.
+            Cap style that will override the default cap style of the marker.
 
         joinstyle : JoinStyle, default: None
-            User supplied join style that will override the default cap
-            style of selected marker.
+            Join style that will override the default join style of the marker.
         """
         self._marker_function = None
         self._user_transform = transform
@@ -431,7 +424,7 @@ class MarkerStyle:
 
     def transformed(self, transform: Affine2D):
         """
-        Return new marker with combined transformation.
+        Return a new version of this marker with the transform applied. 
 
         Parameters
         ----------
@@ -447,15 +440,15 @@ class MarkerStyle:
 
     def rotated(self, deg=None, rad=None):
         """
-        Return new marker rotated by specified angle.
+        Return a new version of this marker rotated by specified angle.
 
         Parameters
         ----------
         deg : float, default: None
-            Use this parameter to specify rotation angle in degrees.
+            Rotation angle in degrees.
 
         rad : float, default: None
-            Use this parameter to specify rotation angle in radians.
+            Rotation angle in radians.
 
         .. note:: You must specify exactly one of deg or rad.
         """

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -85,7 +85,7 @@ Hence the following are equivalent::
 Markers have some reasonable default settings for join and cap styles.
 However, those can be overriden when creating a new instance of MarkerStyle.
 Furthermore, the marker shape can be modified by supplying
-`~matplotlib .transforms.Transform` during creation.
+`~matplotlib.transforms.Transform` during creation.
 Some markers are created as internally rotated shapes (e.g. triangles).
 For such cases, both internal and user supplied transforms are combined.
 

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -82,6 +82,13 @@ Hence the following are equivalent::
     plt.plot([1, 2, 3], marker=11)
     plt.plot([1, 2, 3], marker=matplotlib.markers.CARETDOWNBASE)
 
+Markers have some reasonable default settings for join and cap styles.
+However, those can be overriden when creating a new instance of MarkerStyle.
+Furthermore, the marker shape can be modified by supplying
+`~matplotlib .transforms.Transform` during creation.
+Some markers are created as internally rotated shapes (e.g. triangles).
+For such cases, both internal and user supplied transforms are combined.
+
 Examples showing the use of markers:
 
 * :doc:`/gallery/lines_bars_and_markers/marker_reference`

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -236,6 +236,18 @@ class MarkerStyle:
 
         fillstyle : str, default: :rc:`markers.fillstyle`
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
+        
+        transform : Affine2D, default: None
+            User supplied transformation that will be combined with the
+            native transformation of selected marker.
+
+        capstyle : CapStyle, default: None
+            User supplied cap style that will override the default cap
+            style of selected marker.
+
+        joinstyle : JoinStyle, default: None
+            User supplied join style that will override the default cap
+            style of selected marker.
         """
         self._marker_function = None
         self._user_transform = transform

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -495,22 +495,6 @@ class MarkerStyle:
         new_marker._user_transform = _transform.scale(sx, sy)
         return new_marker
 
-    def translated(self, tx, ty):
-        """
-        Return new marker translated by tx and ty.
-
-        Parameters
-        ----------
-        tx : float
-            Coordinate for translation in *x*-direction.
-        ty : float
-            Coordinate for translation in *y*-direction.
-        """
-        new_marker = MarkerStyle(self)
-        _transform = new_marker._user_transform or Affine2D()
-        new_marker._user_transform = _transform.translate(tx, ty)
-        return new_marker
-
     def _set_nothing(self):
         self._filled = False
 

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -93,7 +93,7 @@ Examples showing the use of markers:
 
 * :doc:`/gallery/lines_bars_and_markers/marker_reference`
 * :doc:`/gallery/lines_bars_and_markers/scatter_star_poly`
-
+* :doc:`/gallery/lines_bars_and_markers/multivariate_marker_plot`
 
 .. |m00| image:: /_static/markers/m00.png
 .. |m01| image:: /_static/markers/m01.png

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -236,7 +236,7 @@ class MarkerStyle:
 
         fillstyle : str, default: :rc:`markers.fillstyle`
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
-        
+
         transform : Affine2D, default: None
             User supplied transformation that will be combined with the
             native transformation of selected marker.
@@ -319,10 +319,10 @@ class MarkerStyle:
         self._recache()
 
     def get_joinstyle(self):
-        return self._joinstyle
+        return self._user_joinstyle or self._joinstyle
 
     def get_capstyle(self):
-        return self._capstyle
+        return self._user_capstyle or self._capstyle
 
     def get_marker(self):
         return self._marker
@@ -413,6 +413,51 @@ class MarkerStyle:
 
     def get_snap_threshold(self):
         return self._snap_threshold
+
+    def get_user_transform(self):
+        """Return user supplied part of marker transform."""
+        if self._user_transform is not None:
+            return self._user_transform.frozen()
+
+    def transformed(self, transform:Affine2D):
+        """
+        Return new marker with combined transformation.
+
+        Parameters
+        ----------
+        transform : Affine2D, default: None
+            - transform will be combined with current user supplied transform.
+        """
+        new_marker = MarkerStyle(self)
+        if new_marker._user_transform is not None:
+            new_marker._user_transform += transform
+        else:
+            new_marker._user_transform = transform
+        return new_marker
+
+    def rotated(self, deg=None, rad=None):
+        """
+        Return new marker rotated by specified angle.
+
+        Parameters
+        ----------
+        deg : float, default: None
+
+        rad : float, default: None
+        """
+        if not ((deg is None) ^ (rad is None)):
+            raise Exception("Only one of deg or rad shall be used.")
+        
+        _transform = self._user_transform or Affine2D()
+
+        if deg is not None: 
+            _transform = _transform.rotate_deg(deg)
+        
+        if rad is not None:
+            _transform = _transform.rotate(rad)
+
+        new_marker = MarkerStyle(self)
+        new_marker._user_transform = _transform
 
     def _set_nothing(self):
         self._filled = False

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -322,10 +322,10 @@ class MarkerStyle:
         self._recache()
 
     def get_joinstyle(self):
-        return self._user_joinstyle or self._joinstyle
+        return self._joinstyle
 
     def get_capstyle(self):
-        return self._user_capstyle or self._capstyle
+        return self._capstyle
 
     def get_marker(self):
         return self._marker

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -438,7 +438,7 @@ class MarkerStyle:
             new_marker._user_transform = transform
         return new_marker
 
-    def rotated(self, deg=None, rad=None):
+    def rotated(self, *, deg=None, rad=None):
         """
         Return a new version of this marker rotated by specified angle.
 
@@ -452,9 +452,10 @@ class MarkerStyle:
 
         .. note:: You must specify exactly one of deg or rad.
         """
-        if not (deg is None) ^ (rad is None):
-            raise ValueError("Exactly one of deg or rad shall be used.")
-
+        if deg is None and rad is None:
+            raise ValueError('One of deg or rad is required')
+        if deg is not None and rad is not None:
+            raise ValueError('Only one of deg and rad can be supplied')
         new_marker = MarkerStyle(self)
         if new_marker._user_transform is None:
             new_marker._user_transform = Affine2D()

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -207,6 +207,30 @@ def test_marker_clipping(fig_ref, fig_test):
     ax_test.axis('off')
 
 
+def test_marker_init_transforms():
+    """Test that initializing marker with transform is a simple addition."""
+    marker = markers.MarkerStyle("o")
+    t = Affine2D().translate(1, 1)
+    t_marker = markers.MarkerStyle("o", transform=t)
+    assert marker.get_transform() + t == t_marker.get_transform()
+
+
+def test_marker_init_joinstyle():
+    marker = markers.MarkerStyle("*")
+    jstl = markers.JoinStyle.round
+    styled_marker = markers.MarkerStyle("*", joinstyle=jstl)
+    assert styled_marker.get_joinstyle() == jstl
+    assert marker.get_joinstyle() != jstl
+
+
+def test_marker_init_captyle():
+    marker = markers.MarkerStyle("*")
+    capstl = markers.CapStyle.round
+    styled_marker = markers.MarkerStyle("*", capstyle=capstl)
+    assert styled_marker.get_capstyle() == capstl
+    assert marker.get_capstyle() != capstl
+
+
 @pytest.mark.parametrize("marker,transform,expected", [
     (markers.MarkerStyle("o"), Affine2D().translate(1, 1),
         Affine2D().translate(1, 1)),

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -229,6 +229,7 @@ def test_marker_rotated_invalid():
     marker = markers.MarkerStyle("o")
     with pytest.raises(ValueError):
         new_marker = marker.rotated()
+    with pytest.raises(ValueError):    
         new_marker = marker.rotated(deg=10, rad=10)
 
 

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -271,3 +271,9 @@ def test_marker_scaled():
     expected = Affine2D().translate(1, 1).scale(2)
     assert new_marker.get_user_transform() == expected
     assert marker._user_transform is not new_marker._user_transform
+
+
+def test_alt_transform():
+    m1 = markers.MarkerStyle("o", "left")
+    m2 = markers.MarkerStyle("o", "left", Affine2D().rotate_deg(90))
+    assert m1.get_alt_transform().rotate_deg(90) == m2.get_alt_transform()

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -229,7 +229,7 @@ def test_marker_rotated_invalid():
     marker = markers.MarkerStyle("o")
     with pytest.raises(ValueError):
         new_marker = marker.rotated()
-    with pytest.raises(ValueError):    
+    with pytest.raises(ValueError):
         new_marker = marker.rotated(deg=10, rad=10)
 
 
@@ -246,8 +246,42 @@ def test_marker_rotated_invalid():
         markers.TICKLEFT, transform=Affine2D().translate(1, 1)),
         10, None, Affine2D().translate(1, 1).rotate_deg(10)),
 ])
-def test_marker_rotated_deg(marker, deg, rad, expected):
+def test_marker_rotated(marker, deg, rad, expected):
     new_marker = marker.rotated(deg=deg, rad=rad)
     assert new_marker is not marker
+    assert new_marker.get_user_transform() == expected
+    assert marker._user_transform is not new_marker._user_transform
+
+
+def test_marker_translated():
+    marker = markers.MarkerStyle("1")
+    new_marker = marker.translated(1, 1)
+    assert new_marker is not marker
+    assert new_marker.get_user_transform() == Affine2D().translate(1, 1)
+    assert marker._user_transform is not new_marker._user_transform
+
+    marker = markers.MarkerStyle("1", transform=Affine2D().translate(1, 1))
+    new_marker = marker.translated(1, 1)
+    assert new_marker is not marker
+    assert new_marker.get_user_transform() == Affine2D().translate(2, 2)
+    assert marker._user_transform is not new_marker._user_transform
+
+
+def test_marker_scaled():
+    marker = markers.MarkerStyle("1")
+    new_marker = marker.scaled(2)
+    assert new_marker is not marker
+    assert new_marker.get_user_transform() == Affine2D().scale(2)
+    assert marker._user_transform is not new_marker._user_transform
+
+    new_marker = marker.scaled(2, 3)
+    assert new_marker is not marker
+    assert new_marker.get_user_transform() == Affine2D().scale(2, 3)
+    assert marker._user_transform is not new_marker._user_transform
+
+    marker = markers.MarkerStyle("1", transform=Affine2D().translate(1, 1))
+    new_marker = marker.scaled(2)
+    assert new_marker is not marker
+    expected = Affine2D().translate(1, 1).scale(2)
     assert new_marker.get_user_transform() == expected
     assert marker._user_transform is not new_marker._user_transform

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -4,6 +4,7 @@ from matplotlib import markers
 from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 from matplotlib.path import Path
 from matplotlib.testing.decorators import check_figures_equal
+from matplotlib.transforms import Affine2D
 
 import pytest
 
@@ -204,3 +205,13 @@ def test_marker_clipping(fig_ref, fig_test):
     ax_test.set(xlim=(-0.5, ncol), ylim=(-0.5, 2 * nrow))
     ax_ref.axis('off')
     ax_test.axis('off')
+
+@pytest.mark.parametrize("marker,transform,expected", [
+    (markers.MarkerStyle("o"), Affine2D().translate(1,1), Affine2D().translate(1,1)),
+    (markers.MarkerStyle("o", transform=Affine2D().translate(1,1)), Affine2D().translate(1,1), Affine2D().translate(2,2)),
+])
+def test_marker_transformed(marker, transform, expected):
+    new_marker = marker.transformed(transform)
+    assert new_marker is not marker
+    assert new_marker.get_user_transform() == expected
+    assert marker.get_user_transform() is not new_marker.get_user_transform()

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -206,12 +206,47 @@ def test_marker_clipping(fig_ref, fig_test):
     ax_ref.axis('off')
     ax_test.axis('off')
 
+
 @pytest.mark.parametrize("marker,transform,expected", [
-    (markers.MarkerStyle("o"), Affine2D().translate(1,1), Affine2D().translate(1,1)),
-    (markers.MarkerStyle("o", transform=Affine2D().translate(1,1)), Affine2D().translate(1,1), Affine2D().translate(2,2)),
+    (markers.MarkerStyle("o"), Affine2D().translate(1, 1),
+        Affine2D().translate(1, 1)),
+    (markers.MarkerStyle("o", transform=Affine2D().translate(1, 1)),
+        Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
+    # (markers.MarkerStyle("$|||$", transform=Affine2D().translate(1, 1)),
+    #  Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
+    (markers.MarkerStyle(
+        markers.TICKLEFT, transform=Affine2D().translate(1, 1)),
+        Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
 ])
 def test_marker_transformed(marker, transform, expected):
     new_marker = marker.transformed(transform)
     assert new_marker is not marker
     assert new_marker.get_user_transform() == expected
-    assert marker.get_user_transform() is not new_marker.get_user_transform()
+    assert marker._user_transform is not new_marker._user_transform
+
+
+def test_marker_rotated_invalid():
+    marker = markers.MarkerStyle("o")
+    with pytest.raises(ValueError):
+        new_marker = marker.rotated()
+        new_marker = marker.rotated(deg=10, rad=10)
+
+
+@pytest.mark.parametrize("marker,deg,rad,expected", [
+    (markers.MarkerStyle("o"), 10, None, Affine2D().rotate_deg(10)),
+    (markers.MarkerStyle("o"), None, 0.01, Affine2D().rotate(0.01)),
+    (markers.MarkerStyle("o", transform=Affine2D().translate(1, 1)),
+        10, None, Affine2D().translate(1, 1).rotate_deg(10)),
+    (markers.MarkerStyle("o", transform=Affine2D().translate(1, 1)),
+        None, 0.01, Affine2D().translate(1, 1).rotate(0.01)),
+    # (markers.MarkerStyle("$|||$", transform=Affine2D().translate(1, 1)),
+    #   10, None, Affine2D().translate(1, 1).rotate_deg(10)),
+    (markers.MarkerStyle(
+        markers.TICKLEFT, transform=Affine2D().translate(1, 1)),
+        10, None, Affine2D().translate(1, 1).rotate_deg(10)),
+])
+def test_marker_rotated_deg(marker, deg, rad, expected):
+    new_marker = marker.rotated(deg=deg, rad=rad)
+    assert new_marker is not marker
+    assert new_marker.get_user_transform() == expected
+    assert marker._user_transform is not new_marker._user_transform

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -253,20 +253,6 @@ def test_marker_rotated(marker, deg, rad, expected):
     assert marker._user_transform is not new_marker._user_transform
 
 
-def test_marker_translated():
-    marker = markers.MarkerStyle("1")
-    new_marker = marker.translated(1, 1)
-    assert new_marker is not marker
-    assert new_marker.get_user_transform() == Affine2D().translate(1, 1)
-    assert marker._user_transform is not new_marker._user_transform
-
-    marker = markers.MarkerStyle("1", transform=Affine2D().translate(1, 1))
-    new_marker = marker.translated(1, 1)
-    assert new_marker is not marker
-    assert new_marker.get_user_transform() == Affine2D().translate(2, 2)
-    assert marker._user_transform is not new_marker._user_transform
-
-
 def test_marker_scaled():
     marker = markers.MarkerStyle("1")
     new_marker = marker.scaled(2)


### PR DESCRIPTION
## PR Summary
Add user supplied transforms and join/cap styles …

Improvement was done in instantiating new instance utilizing deep copy should preserve immutability of MarkerStyle members (e.g. Path, or Transform). However deepcopy of MarkerStyle(r"$|||$") fails. Originally it was needed in lines.py, but I think it can be optimized out to avoid multiple re-instantiation of MarkerStyle.

I followed the discussion for issue #19195 and tried several cases:
```python
from matplotlib import transforms
import matplotlib.pyplot as plt
import matplotlib.pyplot as plt
from matplotlib.lines import Line2D
from matplotlib.transforms import Affine2D
from matplotlib.markers import MarkerStyle, JoinStyle, CapStyle

text_style = dict(horizontalalignment='right', verticalalignment='center',
                  fontsize=12, fontfamily='monospace')
marker_style = dict(linestyle=':', color='0.8', markersize=10,
                    markerfacecolor="tab:blue", markeredgecolor="tab:blue")

def format_axes(ax):
    ax.margins(0.2)
    ax.set_axis_off()
    ax.invert_yaxis()

fig, ax = plt.subplots()
fig.suptitle('Marker fillstyle', fontsize=14)
fig.subplots_adjust(left=0.4)

marker_colors = dict(markersize=15,
                    markerfacecolor='tab:blue',
                    markerfacecoloralt='lightsteelblue',
                    markeredgecolor='brown')

for y, fill_style in enumerate(Line2D.fillStyles[1:-1]):
    ax.text(-0.5, y, repr(fill_style), **text_style)
    ax.plot([0,5],[y]*2, linestyle=":", color='darkgrey')
    for x, theta in enumerate([0, 10, 15, 20, 30, 45]):
        ax.plot(x, y, marker=MarkerStyle("o", fill_style, transform=Affine2D().rotate_deg(theta)), **marker_colors)
        ax.text(x, 4, f"{theta}°", **text_style)
format_axes(ax)

plt.show()
```
![fillstyle](https://user-images.githubusercontent.com/48711526/131022506-27ba9a2d-9f37-4f4f-b0fa-c914dd67b865.png)

```python
fig, ax = plt.subplots()
fig.suptitle('Marker CapStyle', fontsize=14)
fig.subplots_adjust(left=0.1)

marker_inner = dict(markersize=35,
                    markerfacecolor='tab:blue',
                    markerfacecoloralt='lightsteelblue',
                    markeredgecolor='brown',
                    markeredgewidth=8,
                    )

marker_outer = dict(markersize=35,
                    markerfacecolor='tab:blue',
                    markerfacecoloralt='lightsteelblue',
                    markeredgecolor='white',
                    markeredgewidth=1,
                    )

for y, cap_style in enumerate(CapStyle):
    ax.text(-0.5, y, cap_style.name, **text_style)
    ax.plot([0,5],[y]*2, linestyle=":", color='darkgrey')
    for x, theta in enumerate([0, 10, 15, 20, 30, 45]):
        ax.plot(x, y, marker=MarkerStyle("1", transform=Affine2D().rotate_deg(theta), capstyle=cap_style), **marker_inner)
        ax.plot(x, y, marker=MarkerStyle("1", transform=Affine2D().rotate_deg(theta), capstyle=cap_style), **marker_outer)
        ax.text(x, 3, f"{theta}°", **text_style)
format_axes(ax)

plt.show()
```
![capstyle](https://user-images.githubusercontent.com/48711526/131022778-3b5fdce5-9aae-4ec1-b4d1-a292c0e89fc7.png)

```python
fig, ax = plt.subplots()
fig.suptitle('Marker JoinStyle', fontsize=14)
fig.subplots_adjust(left=0.1)

marker_colors = dict(markersize=35,
                    markerfacecolor='tab:blue',
                    markerfacecoloralt='lightsteelblue',
                    markeredgecolor='brown',
                    markeredgewidth=8)

for y, join_style in enumerate(JoinStyle):
    ax.text(-0.5, y, join_style.name, **text_style)
    ax.plot([0,5],[y]*2, linestyle=":", color='darkgrey')
    for x, theta in enumerate([0, 10, 15, 20, 30, 45]):
        ax.plot(x, y, marker=MarkerStyle("*", transform=Affine2D().rotate_deg(theta), joinstyle=join_style), **marker_colors)
        ax.text(x, 3, f"{theta}°", **text_style)
format_axes(ax)

plt.show()
```
![joinstyle](https://user-images.githubusercontent.com/48711526/131022798-2f522320-4d76-441e-a6ae-cd9a60c9a0e1.png)

```
list1 = [0, 1] #| x coordinates
list2 = [0, 0] #| y coordinates

p1 = [.5, 0] #| p1 stands for point1, the marker will be placed in this point
marker1 = MarkerStyle(r'$|||$', transform=Affine2D().rotate_deg(45))

plt.plot(list1, list2, 'o-k', linewidth = 1)
plt.plot(p1[0], p1[1], 'k', marker = marker1)

#T# show the results
plt.show()
```
![reproductor](https://user-images.githubusercontent.com/48711526/131022807-2f188796-5e4c-4655-9e8c-671053ef4d13.png)

Things that needs to be done:

- [x] Add modifiers such as (rotated -> returns new rotated instance, and other primitive transformations)
- [x] Add tests
- [x] Improve documentation

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
