### PR TITLE
Move installing FAQ to installing page.

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -6,6 +6,7 @@ Installation
    :hidden:
 
    installing_source.rst
+   ../faq/installing_faq.rst
 
 
 ==============================
@@ -90,3 +91,8 @@ Installing for development
 ==========================
 See :ref:`installing_for_devs`.
 
+==============
+Installing FAQ
+==============
+
+See :ref:`installing-faq`.

--- a/doc/faq/index.rst
+++ b/doc/faq/index.rst
@@ -14,7 +14,6 @@ The Matplotlib FAQ
 .. toctree::
    :maxdepth: 2
 
-   installing_faq.rst
    howto_faq.rst
    troubleshooting_faq.rst
    environment_variables_faq.rst

--- a/doc/faq/installing_faq.rst
+++ b/doc/faq/installing_faq.rst
@@ -1,8 +1,8 @@
 .. _installing-faq:
 
-*************
- Installation
-*************
+**************
+Installing FAQ
+**************
 
 .. contents::
    :backlinks: none


### PR DESCRIPTION
People with install problems will primarily look at the install page,
not the general FAQ page.

Question: Should we move the page in the file structure as well?
Con: External pages linking the FAQ will be broken. I wouldn't worry
     too much about this. Who links install FAQs anyway? And I trust
     that even with a broken Link people will look at Installing.
Pro: The file structure corresponds to the toc structure.
