### PR TITLE
Fix problem with (deep)copy of TextPath

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -276,7 +276,7 @@ class Path:
             codes = self.codes.copy()
         except AttributeError:
             codes = None
-        return self.__class__(
+        return Path(
             self.vertices.copy(), codes,
             _interpolation_steps=self._interpolation_steps)
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -276,7 +276,7 @@ class Path:
             codes = self.codes.copy()
         except AttributeError:
             codes = None
-        return Path(
+        return self.__class__(
             self.vertices.copy(), codes,
             _interpolation_steps=self._interpolation_steps)
 

--- a/lib/matplotlib/tests/test_textpath.py
+++ b/lib/matplotlib/tests/test_textpath.py
@@ -5,6 +5,7 @@ from matplotlib.textpath import TextPath
 
 
 def test_set_size():
+    """Set size with zero offset should scale vertices and retain codes."""
     path = TextPath((0, 0), ".")
     _size = path.get_size()
     verts = path.vertices.copy()

--- a/lib/matplotlib/tests/test_textpath.py
+++ b/lib/matplotlib/tests/test_textpath.py
@@ -18,6 +18,7 @@ def test_deepcopy():
     # Should not raise any error
     path = TextPath((0, 0), ".")
     path_copy = deepcopy(path)
+    assert isinstance(path_copy, TextPath)
     assert path is not path_copy
     assert path.vertices is not path_copy.vertices
     assert path.codes is not path_copy.codes

--- a/lib/matplotlib/tests/test_textpath.py
+++ b/lib/matplotlib/tests/test_textpath.py
@@ -1,0 +1,37 @@
+from copy import copy, deepcopy
+
+from numpy.testing import assert_array_equal
+from matplotlib.textpath import TextPath
+
+
+def test_set_size():
+    path = TextPath((0, 0), ".")
+    _size = path.get_size()
+    verts = path.vertices.copy()
+    codes = path.codes.copy()
+    path.set_size(20)
+    assert_array_equal(verts/_size*path.get_size(), path.vertices)
+    assert_array_equal(codes, path.codes)
+
+
+def test_deepcopy():
+    # Should not raise any error
+    path = TextPath((0, 0), ".")
+    path_copy = deepcopy(path)
+    assert path is not path_copy
+    assert path.vertices is not path_copy.vertices
+    assert path.codes is not path_copy.codes
+
+
+def test_copy():
+    # Should not raise any error
+    path = TextPath((0, 0), ".")
+    path_copy = copy(path)
+    assert path is not path_copy
+    assert path.vertices is path_copy.vertices
+    assert path.codes is path_copy.codes
+    path = TextPath((0, 0), ".")
+    path_copy = path.copy()
+    assert path is not path_copy
+    assert path.vertices is path_copy.vertices
+    assert path.codes is path_copy.codes

--- a/lib/matplotlib/tests/test_textpath.py
+++ b/lib/matplotlib/tests/test_textpath.py
@@ -15,9 +15,14 @@ def test_set_size():
 
 
 def test_deepcopy():
-    # Should not raise any error
     path = TextPath((0, 0), ".")
     path_copy = deepcopy(path)
+    assert isinstance(path_copy, TextPath)
+    assert path is not path_copy
+    assert path.vertices is not path_copy.vertices
+    assert path.codes is not path_copy.codes
+    path = TextPath((0, 0), ".")
+    path_copy = path.deepcopy({})
     assert isinstance(path_copy, TextPath)
     assert path is not path_copy
     assert path.vertices is not path_copy.vertices
@@ -25,7 +30,6 @@ def test_deepcopy():
 
 
 def test_copy():
-    # Should not raise any error
     path = TextPath((0, 0), ".")
     path_copy = copy(path)
     assert path is not path_copy

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from collections import OrderedDict
 import functools
 import logging
@@ -429,3 +430,23 @@ class TextPath(Path):
             self._cached_vertices = tr.transform(self._vertices)
             self._cached_vertices.flags.writeable = False
             self._invalid = False
+
+    def __deepcopy__(self, memo):
+        # taken from https://stackoverflow.com/a/15774013
+        self._revalidate_path()
+        cls = self.__class__
+        new_instance = cls.__new__(cls)
+        memo[id(self)] = new_instance
+        for k, v in self.__dict__.items():
+            setattr(new_instance, k, deepcopy(v, memo))
+        return new_instance
+
+    deepcopy = __deepcopy__
+
+    def __copy__(self):
+        # taken from https://stackoverflow.com/a/15774013
+        self._revalidate_path()
+        cls = self.__class__
+        new_instance = cls.__new__(cls)
+        new_instance.__dict__.update(self.__dict__)
+        return new_instance

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -381,7 +381,6 @@ class TextPath(Path):
             size = prop.get_size_in_points()
 
         self._xy = xy
-        self.set_size(size)
 
         self._cached_vertices = None
         s, ismath = Text(usetex=usetex)._preprocess_math(s)
@@ -390,11 +389,12 @@ class TextPath(Path):
             _interpolation_steps=_interpolation_steps,
             readonly=True)
         self._should_simplify = False
+        self.set_size(size)
 
     def set_size(self, size):
         """Set the text size."""
         self._size = size
-        self._invalid = True
+        self._recache_path()
 
     def get_size(self):
         """Get the text size."""
@@ -403,9 +403,8 @@ class TextPath(Path):
     @property
     def vertices(self):
         """
-        Return the cached path after updating it if necessary.
+        Return the cached path.
         """
-        self._revalidate_path()
         return self._cached_vertices
 
     @property
@@ -415,17 +414,15 @@ class TextPath(Path):
         """
         return self._codes
 
-    def _revalidate_path(self):
+    def _recache_path(self):
         """
-        Update the path if necessary.
+        Update the path.
 
-        The path for the text is initially create with the font size of
+        The path for the text is initially created with the font size of
         `.FONT_SCALE`, and this path is rescaled to other size when necessary.
         """
-        if self._invalid or self._cached_vertices is None:
-            tr = (Affine2D()
-                  .scale(self._size / text_to_path.FONT_SCALE)
-                  .translate(*self._xy))
-            self._cached_vertices = tr.transform(self._vertices)
-            self._cached_vertices.flags.writeable = False
-            self._invalid = False
+        tr = (Affine2D()
+                .scale(self._size / text_to_path.FONT_SCALE)
+                .translate(*self._xy))
+        self._cached_vertices = tr.transform(self._vertices)
+        self._cached_vertices.flags.writeable = False

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -432,7 +432,7 @@ class TextPath(Path):
             self._invalid = False
 
     def __deepcopy__(self, memo):
-        # taken from https://stackoverflow.com/a/15774013
+        """Update path and create deep copy."""
         self._revalidate_path()
         cls = self.__class__
         new_instance = cls.__new__(cls)
@@ -444,7 +444,7 @@ class TextPath(Path):
     deepcopy = __deepcopy__
 
     def __copy__(self):
-        # taken from https://stackoverflow.com/a/15774013
+        """Update path and create shallow copy."""
         self._revalidate_path()
         cls = self.__class__
         new_instance = cls.__new__(cls)


### PR DESCRIPTION
## PR Summary
The problem is that deepcopy of TextPath calls deepcopy of Path. In turn `Path` utilizes `super().__init__` for creating a new
instance. However, `Path.__init__` and `TextPath.__init__` are completely different.

Related to Issue #20943
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
