### PR TITLE
Improve `path.py` docstrings a bit

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -29,11 +29,11 @@ class Path:
     The underlying storage is made up of two parallel numpy arrays:
 
     - *vertices*: an Nx2 float array of vertices
-    - *codes*: an N-length uint8 array of vertex types, or None
+    - *codes*: an N-length uint8 array of path codes, or None
 
     These two arrays always have the same length in the first
     dimension.  For example, to represent a cubic curve, you must
-    provide three vertices as well as three codes ``CURVE4``.
+    provide three vertices and three ``CURVE4`` codes.
 
     The code types are:
 
@@ -109,7 +109,7 @@ class Path:
             handled correctly by the Agg PathIterator and other consumers of
             path data, such as :meth:`iter_segments`.
         codes : array-like or None, optional
-            n-length array integers representing the codes of the path.
+            N-length array of integers representing the codes of the path.
             If not None, codes must be the same length as vertices.
             If None, *vertices* will be treated as a series of line segments.
         _interpolation_steps : int, optional
@@ -288,7 +288,7 @@ class Path:
         Make a compound path object to draw a number
         of polygons with equal numbers of sides XY is a (numpolys x
         numsides x 2) numpy array of vertices.  Return object is a
-        :class:`Path`
+        :class:`Path`.
 
         .. plot:: gallery/misc/histogram_path.py
 
@@ -314,8 +314,8 @@ class Path:
     @classmethod
     def make_compound_path(cls, *args):
         """
-        Make a compound path from a list of Path objects. Blindly removes all
-        Path.STOP control points.
+        Make a compound path from a list of `Path` objects. Blindly removes
+        all `Path.STOP` control points.
         """
         # Handle an empty list in args (i.e. no args).
         if not args:
@@ -917,8 +917,8 @@ class Path:
     @classmethod
     def arc(cls, theta1, theta2, n=None, is_wedge=False):
         """
-        Return the unit circle arc from angles *theta1* to *theta2* (in
-        degrees).
+        Return a `Path` for the unit circle arc from angles *theta1* to
+        *theta2* (in degrees).
 
         *theta2* is unwrapped to produce the shortest arc within 360 degrees.
         That is, if *theta2* > *theta1* + 360, the arc will be from *theta1* to
@@ -996,8 +996,8 @@ class Path:
     @classmethod
     def wedge(cls, theta1, theta2, n=None):
         """
-        Return the unit circle wedge from angles *theta1* to *theta2* (in
-        degrees).
+        Return a `Path` for the unit circle wedge from angles *theta1* to
+        *theta2* (in degrees).
 
         *theta2* is unwrapped to produce the shortest wedge within 360 degrees.
         That is, if *theta2* > *theta1* + 360, the wedge will be from *theta1*


### PR DESCRIPTION
## PR Summary

This change fixes some wording in the `path.py` documentation, most substantively "vertex types" → "path codes". It is a follow-up to #20920 with some issues I noticed after that PR merged.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
