### PR TITLE
Improve formatting of imshow() cursor data independently of colorbar.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -12,6 +12,7 @@ import contextlib
 import functools
 import gzip
 import itertools
+import math
 import operator
 import os
 from pathlib import Path
@@ -2199,6 +2200,23 @@ def _format_approx(number, precision):
     Remove trailing zeros and possibly the decimal point.
     """
     return f'{number:.{precision}f}'.rstrip('0').rstrip('.') or '0'
+
+
+def _g_sig_digits(value, delta):
+    """
+    Return the number of significant digits to %g-format *value*, assuming that
+    it is known with an error of *delta*.
+    """
+    # If e.g. value = 45.67 and delta = 0.02, then we want to round to 2 digits
+    # after the decimal point (floor(log10(0.02)) = -2); 45.67 contributes 2
+    # digits before the decimal point (floor(log10(45.67)) + 1 = 2): the total
+    # is 4 significant digits.  A value of 0 contributes 1 "digit" before the
+    # decimal point.
+    # For inf or nan, the precision doesn't matter.
+    return max(
+        0,
+        (math.floor(math.log10(abs(value))) + 1 if value else 1)
+        - math.floor(math.log10(delta))) if math.isfinite(value) else 0
 
 
 def _unikey_or_keysym_to_mplkey(unikey, keysym):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1399,16 +1399,10 @@ class PolarAxes(Axes):
         # (as for linear axes), but for theta, use f-formatting as scientific
         # notation doesn't make sense and the trailing dot is ugly.
         def format_sig(value, delta, opt, fmt):
-            digits_post_decimal = math.floor(math.log10(delta))
-            digits_offset = (
-                # For "f", only count digits after decimal point.
-                0 if fmt == "f"
-                # For "g", offset by digits before the decimal point.
-                else math.floor(math.log10(abs(value))) + 1 if value
-                # For "g", 0 contributes 1 "digit" before the decimal point.
-                else 1)
-            fmt_prec = max(0, digits_offset - digits_post_decimal)
-            return f"{value:-{opt}.{fmt_prec}{fmt}}"
+            # For "f", only count digits after decimal point.
+            prec = (max(0, -math.floor(math.log10(delta))) if fmt == "f" else
+                    cbook._g_sig_digits(value, delta))
+            return f"{value:-{opt}.{prec}{fmt}}"
 
         return ('\N{GREEK SMALL LETTER THETA}={}\N{GREEK SMALL LETTER PI} '
                 '({}\N{DEGREE SIGN}), r={}').format(

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -337,11 +337,11 @@ def test_cursor_data():
 
 
 @pytest.mark.parametrize(
-    "data, text_without_colorbar, text_with_colorbar", [
-        ([[10001, 10000]], "[1e+04]", "[10001]"),
-        ([[.123, .987]], "[0.123]", "[0.123]"),
+    "data, text", [
+        ([[10001, 10000]], "[10001.000]"),
+        ([[.123, .987]], "[0.123]"),
     ])
-def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
+def test_format_cursor_data(data, text):
     from matplotlib.backend_bases import MouseEvent
 
     fig, ax = plt.subplots()
@@ -350,15 +350,7 @@ def test_format_cursor_data(data, text_without_colorbar, text_with_colorbar):
     xdisp, ydisp = ax.transData.transform([0, 0])
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.get_cursor_data(event) == data[0][0]
-    assert im.format_cursor_data(im.get_cursor_data(event)) \
-        == text_without_colorbar
-
-    fig.colorbar(im)
-    fig.canvas.draw()  # This is necessary to set up the colorbar formatter.
-
-    assert im.get_cursor_data(event) == data[0][0]
-    assert im.format_cursor_data(im.get_cursor_data(event)) \
-        == text_with_colorbar
+    assert im.format_cursor_data(im.get_cursor_data(event)) == text
 
 
 @image_comparison(['image_clip'], style='mpl20')

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -655,16 +655,7 @@ class ScalarFormatter(Formatter):
                 # Rough approximation: no more than 1e4 divisions.
                 a, b = self.axis.get_view_interval()
                 delta = (b - a) / 1e4
-            # If e.g. value = 45.67 and delta = 0.02, then we want to round to
-            # 2 digits after the decimal point (floor(log10(0.02)) = -2);
-            # 45.67 contributes 2 digits before the decimal point
-            # (floor(log10(45.67)) + 1 = 2): the total is 4 significant digits.
-            # A value of 0 contributes 1 "digit" before the decimal point.
-            sig_digits = max(
-                0,
-                (math.floor(math.log10(abs(value))) + 1 if value else 1)
-                - math.floor(math.log10(delta)))
-            fmt = f"%-#.{sig_digits}g"
+            fmt = "%-#.{}g".format(cbook._g_sig_digits(value, delta))
         return self._format_maybe_minus_and_locale(fmt, value)
 
     def format_data(self, value):


### PR DESCRIPTION
Currently (since #12459), when a colorbar is present, the cursor data under imshow() is
formatted using the colorbar's cursor formatter (the idea being that
that formatter should be able to "smartly" take normalization limits
into account); if no colorbar is present a fixed format string ("%0.3g")
is used (see #12473 for a stalled attempt to work around that).

In fact, there is a better scale that defines the number of significant
digits one should display in an imshow cursor data: it arises because
colormaps are discrete (usually with 256 colors, but in any case the
value is available as `cmap.N`).  This quantization tells us, for a
given value, by how much one needs to move before the underlying color
changes (at all); that step size can be used to to determine a number
of significant digits to display.  (Even if that's not necessarily
always the best number, it should at least be reasonable *given the
user's choice of normalization*.)

Also, note that because ScalarFormatter has now changed to take pixel
size into account when determining *its* number of significant digits (#16776),
the previous approach of relying on the colorbar formatter has become
a less good approximation, as that means that the number of digits
displayed for an imshow() cursor could depend on the physical size of
the associated colorbar (if present).

Also factor out and reuse some logic to compute the number of
significant digits to use in format strings for given value/error pairs,
already used by the linear and polar tickers.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
