### PR TITLE
Addition of numticks=N in LogLocator

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1124,7 +1124,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator()
+                self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1124,7 +1124,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator(numticksN)
+                self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1124,7 +1124,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator(numticks=N)
+                self.locator = ticker.LogLocator(numticksN)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -24,17 +24,25 @@ import types
 import numpy as np
 from PIL import Image
 
-from matplotlib import _api, colors as mcolors, rcParams, _mathtext
+from matplotlib import (
+    _api, colors as mcolors, rcParams, _mathtext, _mathtext_data)
 from matplotlib.ft2font import FT2Image, LOAD_NO_HINTING
 from matplotlib.font_manager import FontProperties
-# Backcompat imports, all are deprecated as of 3.4.
-from matplotlib._mathtext import (  # noqa: F401
-    SHRINK_FACTOR, GROW_FACTOR, NUM_SIZE_LEVELS)
-from matplotlib._mathtext_data import (  # noqa: F401
-    latex_to_bakoma, latex_to_cmex, latex_to_standard, stix_virtual_fonts,
-    tex2uni)
 
 _log = logging.getLogger(__name__)
+
+
+@_api.caching_module_getattr
+class __getattr__:
+    locals().update({
+        name: _api.deprecated("3.4")(
+            property(lambda self, _mod=mod, _name=name: getattr(_mod, _name)))
+        for mod, names in [
+            (_mathtext, ["SHRINK_FACTOR", "GROW_FACTOR", "NUM_SIZE_LEVELS"]),
+            (_mathtext_data, [
+                "latex_to_bakoma", "latex_to_cmex", "latex_to_standard",
+                "stix_virtual_fonts", "tex2uni"])]
+        for name in names})
 
 
 get_unicode_index = _mathtext.get_unicode_index


### PR DESCRIPTION
# Addition of numticks=N in LogLocator in def _autolev(self, N):
## PR Summary


 "closes #19856"
Contour plots don't interact nicely with matplotlib.colors.LogNorm. Level=N doesn't work with LogNorm.
Added numticks=N in LogLocator in def _autolev(self, N):
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ N/A] New features are documented, with examples if plot related.
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
