### PR TITLE
legend_handler_map cleanups.

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -651,38 +651,24 @@ class Legend(Artist):
 
     @classmethod
     def get_default_handler_map(cls):
-        """
-        A class method that returns the default handler map.
-        """
+        """Return the global default handler map, shared by all legends."""
         return cls._default_handler_map
 
     @classmethod
     def set_default_handler_map(cls, handler_map):
-        """
-        A class method to set the default handler map.
-        """
+        """Set the global default handler map, shared by all legends."""
         cls._default_handler_map = handler_map
 
     @classmethod
     def update_default_handler_map(cls, handler_map):
-        """
-        A class method to update the default handler map.
-        """
+        """Update the global default handler map, shared by all legends."""
         cls._default_handler_map.update(handler_map)
 
     def get_legend_handler_map(self):
-        """
-        Return the handler map.
-        """
-
+        """Return this legend instance's handler map."""
         default_handler_map = self.get_default_handler_map()
-
-        if self._custom_handler_map:
-            hm = default_handler_map.copy()
-            hm.update(self._custom_handler_map)
-            return hm
-        else:
-            return default_handler_map
+        return ({**default_handler_map, **self._custom_handler_map}
+                if self._custom_handler_map else default_handler_map)
 
     @staticmethod
     def get_legend_handler(legend_handler_map, orig_handle):
@@ -1105,11 +1091,7 @@ class Legend(Artist):
 # Helper functions to parse legend arguments for both `figure.legend` and
 # `axes.legend`:
 def _get_legend_handles(axs, legend_handler_map=None):
-    """
-    Return a generator of artists that can be used as handles in
-    a legend.
-
-    """
+    """Yield artists that can be used as handles in a legend."""
     handles_original = []
     for ax in axs:
         handles_original += [
@@ -1124,14 +1106,9 @@ def _get_legend_handles(axs, legend_handler_map=None):
                       if isinstance(a, (Line2D, Patch, Collection))),
                     *axx.containers]
 
-    handler_map = Legend.get_default_handler_map()
-
-    if legend_handler_map is not None:
-        handler_map = handler_map.copy()
-        handler_map.update(legend_handler_map)
-
+    handler_map = {**Legend.get_default_handler_map(),
+                   **(legend_handler_map or {})}
     has_handler = Legend.get_legend_handler
-
     for handle in handles_original:
         label = handle.get_label()
         if label != '_nolegend_' and has_handler(handler_map, handle):
@@ -1139,13 +1116,9 @@ def _get_legend_handles(axs, legend_handler_map=None):
 
 
 def _get_legend_handles_labels(axs, legend_handler_map=None):
-    """
-    Return handles and labels for legend, internal method.
-
-    """
+    """Return handles and labels for legend."""
     handles = []
     labels = []
-
     for handle in _get_legend_handles(axs, legend_handler_map):
         label = handle.get_label()
         if label and not label.startswith('_'):
@@ -1201,7 +1174,7 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
     """
     log = logging.getLogger(__name__)
 
-    handlers = kwargs.get('handler_map', {}) or {}
+    handlers = kwargs.get('handler_map')
     extra_args = ()
 
     if (handles is not None or labels is not None) and args:


### PR DESCRIPTION
- Normalize legend_handler_map=None to {} in a single place (in
  _get_legend_handles).
- Use star-unpacking for dict merging.
- Cleanup various docstrings.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
