### PR TITLE
BUG: Fix f_back is None handling

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -333,7 +333,8 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
     def resizeEvent(self, event):
         frame = sys._getframe()
-        if frame.f_code is frame.f_back.f_code:  # Prevent PyQt6 recursion.
+        # Prevent PyQt6 recursion, but sometimes frame.f_back is None
+        if frame.f_code is getattr(frame.f_back, 'f_code', None):
             return
         w = event.size().width() * self.device_pixel_ratio
         h = event.size().height() * self.device_pixel_ratio


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

On anything after #19255, when resizing some plots (on PyQt5 5.15.4) I get:
```
>>> Traceback (most recent call last):
  File "/home/larsoner/python/matplotlib/lib/matplotlib/backends/backend_qt.py", line 336, in resizeEvent
    if frame.f_code is frame.f_back.f_code:  # Prevent PyQt6 recursion.
AttributeError: 'NoneType' object has no attribute 'f_code'
```
This PR fixes this problem using `getatttr`. I'm not sure how to make a good unit-test for this...