### PR TITLE
Build wheels for Apple Silicon.

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -15,6 +15,7 @@ jobs:
     env:
       min-numpy-version: "1.17.3"
       min-numpy-hash: "b6/d6/be8f975f5322336f62371c9abeb936d592c98c047ad63035f1b38ae08efe"
+      CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-latest]


### PR DESCRIPTION
## PR Summary

There are wheels available for kiwisolver, NumPy and Pillow already.

We cannot test because GitHub Actions don't support the M1 in hosted runners, and Apple is somewhat anti-developer CI for some reason.

## PR Checklist

- [?] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).