### PR TITLE
Cleanup some dviread docstrings.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -84,8 +84,6 @@ def _arg(nbytes, signed, dvi, _):
 
 def _arg_slen(dvi, delta):
     """
-    Signed, length *delta*
-
     Read *delta* bytes, returning None if *delta* is zero, and the bytes
     interpreted as a signed integer otherwise.
     """
@@ -96,26 +94,20 @@ def _arg_slen(dvi, delta):
 
 def _arg_slen1(dvi, delta):
     """
-    Signed, length *delta*+1
-
     Read *delta*+1 bytes, returning the bytes interpreted as signed.
     """
-    return dvi._arg(delta+1, True)
+    return dvi._arg(delta + 1, True)
 
 
 def _arg_ulen1(dvi, delta):
     """
-    Unsigned length *delta*+1
-
     Read *delta*+1 bytes, returning the bytes interpreted as unsigned.
     """
-    return dvi._arg(delta+1, False)
+    return dvi._arg(delta + 1, False)
 
 
 def _arg_olen1(dvi, delta):
     """
-    Optionally signed, length *delta*+1
-
     Read *delta*+1 bytes, returning the bytes interpreted as
     unsigned integer for 0<=*delta*<3 and signed if *delta*==3.
     """
@@ -139,30 +131,30 @@ def _dispatch(table, min, max=None, state=None, args=('raw',)):
     matches *state* if not None, reads arguments from the file according
     to *args*.
 
-    *table*
-        the dispatch table to be filled in
+    Parameters
+    ----------
+    table : dict[int, callable]
+        The dispatch table to be filled in.
 
-    *min*
-        minimum opcode for calling this function
+    min, max : int
+        Range of opcodes that calls the registered function; *max* defaults to
+        *min*.
 
-    *max*
-        maximum opcode for calling this function, None if only *min* is allowed
+    state : _dvistate, optional
+        State of the Dvi object in which these opcodes are allowed.
 
-    *state*
-        state of the Dvi object in which these opcodes are allowed
+    args : list[str], default: ['raw']
+        Sequence of argument specifications:
 
-    *args*
-        sequence of argument specifications:
-
-        ``'raw'``: opcode minus minimum
-        ``'u1'``: read one unsigned byte
-        ``'u4'``: read four bytes, treat as an unsigned number
-        ``'s4'``: read four bytes, treat as a signed number
-        ``'slen'``: read (opcode - minimum) bytes, treat as signed
-        ``'slen1'``: read (opcode - minimum + 1) bytes, treat as signed
-        ``'ulen1'``: read (opcode - minimum + 1) bytes, treat as unsigned
-        ``'olen1'``: read (opcode - minimum + 1) bytes, treat as unsigned
-                     if under four bytes, signed if four bytes
+        - 'raw': opcode minus minimum
+        - 'u1': read one unsigned byte
+        - 'u4': read four bytes, treat as an unsigned number
+        - 's4': read four bytes, treat as a signed number
+        - 'slen': read (opcode - minimum) bytes, treat as signed
+        - 'slen1': read (opcode - minimum + 1) bytes, treat as signed
+        - 'ulen1': read (opcode - minimum + 1) bytes, treat as unsigned
+        - 'olen1': read (opcode - minimum + 1) bytes, treat as unsigned
+          if under four bytes, signed if four bytes
     """
     def decorate(method):
         get_args = [_arg_mapping[x] for x in args]
@@ -185,6 +177,7 @@ def _dispatch(table, min, max=None, state=None, args=('raw',)):
 class Dvi:
     """
     A reader for a dvi ("device-independent") file, as produced by TeX.
+
     The current implementation can only iterate through pages in order,
     and does not even attempt to verify the postamble.
 
@@ -956,8 +949,9 @@ class PsfontsMap:
 
 def _parse_enc(path):
     r"""
-    Parses a \*.enc file referenced from a psfonts.map style file.
-    The format this class understands is a very limited subset of PostScript.
+    Parse a \*.enc file referenced from a psfonts.map style file.
+
+    The format supported by this function is a tiny subset of PostScript.
 
     Parameters
     ----------


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
