### PR TITLE
Docstring cleanups.

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -900,7 +900,7 @@ class ToolHelpBase(ToolBase):
     @staticmethod
     def format_shortcut(key_sequence):
         """
-        Converts a shortcut string from the notation used in rc config to the
+        Convert a shortcut string from the notation used in rc config to the
         standard notation for displaying shortcuts, e.g. 'ctrl+a' -> 'Ctrl+A'.
         """
         return (key_sequence if len(key_sequence) == 1 else

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -592,8 +592,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
     @_api.delete_parameter("3.4", "origin")
     def gui_repaint(self, drawDC=None, origin='WX'):
         """
-        Performs update of the displayed image on the GUI canvas, using the
-        supplied wx.PaintDC device context.
+        Update the displayed image on the GUI canvas, using the supplied
+        wx.PaintDC device context.
 
         The 'WXAgg' backend sets origin accordingly.
         """

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -2324,7 +2324,7 @@ class LightSource:
 
     def blend_overlay(self, rgb, intensity):
         """
-        Combines an rgb image with an intensity map using "overlay" blending.
+        Combine an rgb image with an intensity map using "overlay" blending.
 
         Parameters
         ----------

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -601,7 +601,7 @@ class Line2D(Artist):
 
     def set_picker(self, p):
         """
-        Sets the event picker details for the line.
+        Set the event picker details for the line.
 
         Parameters
         ----------
@@ -688,7 +688,7 @@ class Line2D(Artist):
 
     def _transform_path(self, subslice=None):
         """
-        Puts a TransformedPath instance at self._transformed_path;
+        Put a TransformedPath instance at self._transformed_path;
         all invalidation of the transform is then handled by the
         TransformedPath instance.
         """

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -162,7 +162,7 @@ class Path:
     @classmethod
     def _fast_from_codes_and_verts(cls, verts, codes, internals_from=None):
         """
-        Creates a Path instance without the expense of calling the constructor.
+        Create a Path instance without the expense of calling the constructor.
 
         Parameters
         ----------

--- a/lib/matplotlib/testing/widgets.py
+++ b/lib/matplotlib/testing/widgets.py
@@ -2,15 +2,16 @@
 ========================
 Widget testing utilities
 ========================
-Functions that are useful for testing widgets.
-See also matplotlib.tests.test_widgets
+
+See also :mod:`matplotlib.tests.test_widgets`.
 """
+
 import matplotlib.pyplot as plt
 from unittest import mock
 
 
 def get_ax():
-    """Creates plot and returns its axes"""
+    """Create a plot and return its axes."""
     fig, ax = plt.subplots(1, 1)
     ax.plot([0, 200], [0, 200])
     ax.set_aspect(1.0)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2710,7 +2710,7 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
 
         - "move": Move the existing shape, default: no modifier.
         - "clear": Clear the current shape, default: "escape".
-        - "square": Makes the shape square, default: "shift".
+        - "square": Make the shape square, default: "shift".
         - "center": Make the initial point the center of the shape,
           default: "ctrl".
 

--- a/lib/mpl_toolkits/axisartist/axisline_style.py
+++ b/lib/mpl_toolkits/axisartist/axisline_style.py
@@ -9,9 +9,7 @@ from matplotlib.path import Path
 
 class _FancyAxislineStyle:
     class SimpleArrow(FancyArrowPatch):
-        """
-        The artist class that will be returned for SimpleArrow style.
-        """
+        """The artist class that will be returned for SimpleArrow style."""
         _ARROW_STYLE = "->"
 
         def __init__(self, axis_artist, line_path, transform,
@@ -69,9 +67,7 @@ class _FancyAxislineStyle:
             FancyArrowPatch.draw(self, renderer)
 
     class FilledArrow(SimpleArrow):
-        """
-        The artist class that will be returned for SimpleArrow style.
-        """
+        """The artist class that will be returned for SimpleArrow style."""
         _ARROW_STYLE = "-|>"
 
 


### PR DESCRIPTION
Mostly D401 (imperative mood) fixes, and a few other things.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
