### PR TITLE
Fix drawing animated artist updated in selector callback

### DIFF
--- a/examples/widgets/span_selector.py
+++ b/examples/widgets/span_selector.py
@@ -23,7 +23,7 @@ ax1.set_ylim(-2, 2)
 ax1.set_title('Press left mouse button and drag '
               'to select a region in the top graph')
 
-line2, = ax2.plot([], [])
+line2, = ax2.plot([], [], animated=True)
 
 
 def onselect(xmin, xmax):
@@ -58,6 +58,17 @@ span = SpanSelector(
     drag_from_anywhere=True
 )
 # Set useblit=True on most backends for enhanced performance.
+
+
+#############################################################################
+# .. note::
+#
+#    With useblit=True or when the callback update an animated artist, the
+#    artist needs to be added in the `depending_artists` list of the selector,
+#    otherwise it will not be drawn
+
+
+span.depending_artists.append(line2)
 
 
 plt.show()


### PR DESCRIPTION
## PR Summary

Fix drawing animated artists (external to selector artists itself), which are updated in selector callback - see changes in doc example: the animated line will not drawn if the selector doesn't draw it when updating itself.
I am not sure if it deserves a new feature entry.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [x] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [?] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [?] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
