### PR TITLE
FIX: remove colorbar from list of colorbars on axes

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -992,6 +992,12 @@ class Colorbar:
         If the colorbar was created with ``use_gridspec=True`` the previous
         gridspec is restored.
         """
+        if hasattr(self.ax, '_colorbar_info'):
+            parents = self.ax._colorbar_info['parents']
+            for a in parents:
+                if self.ax in a._colorbars:
+                    a._colorbars.remove(self.ax)
+
         self.ax.remove()
 
         self.mappable.callbacks.disconnect(self.mappable.colorbar_cid)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -221,7 +221,7 @@ def test_colorbar_single_scatter():
                          ids=['no gridspec', 'with gridspec'])
 def test_remove_from_figure(use_gridspec):
     """
-    Test `remove_from_figure` with the specified ``use_gridspec`` setting
+    Test `remove` with the specified ``use_gridspec`` setting
     """
     fig, ax = plt.subplots()
     sc = ax.scatter([1, 2], [3, 4], cmap="spring")
@@ -233,6 +233,23 @@ def test_remove_from_figure(use_gridspec):
     fig.subplots_adjust()
     post_position = ax.get_position()
     assert (pre_position.get_points() == post_position.get_points()).all()
+
+
+def test_remove_from_figure_cl():
+    """
+    Test `remove` with constrained_layout
+    """
+    fig, ax = plt.subplots(constrained_layout=True)
+    sc = ax.scatter([1, 2], [3, 4], cmap="spring")
+    sc.set_array(np.array([5, 6]))
+    fig.draw_without_rendering()
+    pre_position = ax.get_position()
+    cb = fig.colorbar(sc)
+    cb.remove()
+    fig.draw_without_rendering()
+    post_position = ax.get_position()
+    np.testing.assert_allclose(pre_position.get_points(),
+                               post_position.get_points())
 
 
 def test_colorbarbase():


### PR DESCRIPTION
Closes #20978

If a colorbar was removed it was not being removed from a list of colorbars associated with an axes.  This would confuse constrained_layout, as in #20978

### test:

This now works...

```python
import matplotlib.pyplot as plt
import numpy as np

figure, axes = plt.subplots(1, 1, constrained_layout=True)

data = np.random.normal(size=(10,10))
im = axes.imshow(data)
colorbar = figure.colorbar(im, ax=axes)
colorbar.remove()

plt.show()
```
