### PR TITLE
Make HandlerLine2D{,Compound} inherit constructors from HandlerNpoints.

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -214,19 +214,6 @@ class HandlerLine2DCompound(HandlerNpoints):
     a line-only with a marker-only artist.  May be deprecated in the future.
     """
 
-    def __init__(self, marker_pad=0.3, numpoints=None, **kwargs):
-        """
-        Parameters
-        ----------
-        marker_pad : float
-            Padding between points in legend entry.
-        numpoints : int
-            Number of points to show in legend entry.
-        **kwargs
-            Keyword arguments forwarded to `.HandlerNpoints`.
-        """
-        super().__init__(marker_pad=marker_pad, numpoints=numpoints, **kwargs)
-
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
@@ -285,20 +272,6 @@ class HandlerLine2D(HandlerNpoints):
     HandlerLine2DCompound : An earlier handler implementation, which used one
                             artist for the line and another for the marker(s).
     """
-
-    def __init__(self, marker_pad=0.3, numpoints=None, **kw):
-        """
-        Parameters
-        ----------
-        marker_pad : float
-            Padding between points in legend entry.
-        numpoints : int
-            Number of points to show in legend entry.
-        **kwargs
-            Keyword arguments forwarded to `.HandlerNpoints`.
-        """
-        HandlerNpoints.__init__(self, marker_pad=marker_pad,
-                                numpoints=numpoints, **kw)
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,


### PR DESCRIPTION
The constructores are entirely identical (including wrt. defaults and
docstrings).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
