### PR TITLE
Explicit registration of canvas-specific tool subclasses.

### DIFF
--- a/doc/api/next_api_changes/removals/20990-AL.rst
+++ b/doc/api/next_api_changes/removals/20990-AL.rst
@@ -1,0 +1,4 @@
+Support for passing tool names to ``ToolManager.add_tool``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... has been removed.  The second parameter to add_tool must now always be a
+tool class.

--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -277,6 +277,13 @@ def select_matching_signature(funcs, *args, **kwargs):
                 raise
 
 
+def recursive_subclasses(cls):
+    """Yield *cls* and direct and indirect subclasses of *cls*."""
+    yield cls
+    for subcls in cls.__subclasses__():
+        yield from recursive_subclasses(subcls)
+
+
 def warn_external(message, category=None):
     """
     `warnings.warn` wrapper that sets *stacklevel* to "outside Matplotlib".

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -1,5 +1,4 @@
-from matplotlib import _api, cbook, widgets
-import matplotlib.backend_tools as tools
+from matplotlib import _api, backend_tools, cbook, widgets
 
 
 class ToolEvent:
@@ -233,8 +232,9 @@ class ToolManager:
         ----------
         name : str
             Name of the tool, treated as the ID, has to be unique.
-        tool : class_like, i.e. str or type
-            Reference to find the class of the Tool to added.
+        tool : type
+            Class of the tool to be added.  A subclass will be used
+            instead if one was registered for the current canvas class.
 
         Notes
         -----
@@ -245,7 +245,7 @@ class ToolManager:
         matplotlib.backend_tools.ToolBase : The base class for tools.
         """
 
-        tool_cls = self._get_cls_to_instantiate(tool)
+        tool_cls = backend_tools._find_tool_class(type(self.canvas), tool)
         if not tool_cls:
             raise ValueError('Impossible to find class for %s' % str(tool))
 
@@ -254,7 +254,7 @@ class ToolManager:
                                'exists, not added')
             return self._tools[name]
 
-        if name == 'cursor' and tool_cls != tools.SetCursorBase:
+        if name == 'cursor' and tool_cls != backend_tools.SetCursorBase:
             _api.warn_deprecated("3.5",
                                  message="Overriding ToolSetCursor with "
                                  f"{tool_cls.__qualname__} was only "
@@ -271,7 +271,7 @@ class ToolManager:
             self.update_keymap(name, tool_cls.default_keymap)
 
         # For toggle tools init the radio_group in self._toggled
-        if isinstance(tool_obj, tools.ToolToggleBase):
+        if isinstance(tool_obj, backend_tools.ToolToggleBase):
             # None group is not mutually exclusive, a set is used to keep track
             # of all toggled tools in this group
             if tool_obj.radio_group is None:
@@ -337,23 +337,6 @@ class ToolManager:
         # Keep track of the toggled tool in the radio_group
         self._toggled[radio_group] = toggled
 
-    def _get_cls_to_instantiate(self, callback_class):
-        # Find the class that corresponds to the tool
-        if isinstance(callback_class, str):
-            # FIXME: make more complete searching structure
-            if callback_class in globals():
-                callback_class = globals()[callback_class]
-            else:
-                mod = 'backend_tools'
-                current_module = __import__(mod,
-                                            globals(), locals(), [mod], 1)
-
-                callback_class = getattr(current_module, callback_class, False)
-        if callable(callback_class):
-            return callback_class
-        else:
-            return None
-
     def trigger_tool(self, name, sender=None, canvasevent=None, data=None):
         """
         Trigger a tool and emit the ``tool_trigger_{name}`` event.
@@ -376,7 +359,7 @@ class ToolManager:
         if sender is None:
             sender = self
 
-        if isinstance(tool, tools.ToolToggleBase):
+        if isinstance(tool, backend_tools.ToolToggleBase):
             self._handle_toggle(tool, sender, canvasevent, data)
 
         tool.trigger(sender, canvasevent, data)  # Actually trigger Tool.
@@ -418,7 +401,8 @@ class ToolManager:
         `.ToolBase` or None
             The tool or None if no tool with the given name exists.
         """
-        if isinstance(name, tools.ToolBase) and name.name in self._tools:
+        if (isinstance(name, backend_tools.ToolBase)
+                and name.name in self._tools):
             return name
         if name not in self._tools:
             if warn:

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -774,6 +774,7 @@ class ToolTip:
             tw.destroy()
 
 
+@backend_tools._register_tool_class(FigureCanvasTk)
 class RubberbandTk(backend_tools.RubberbandBase):
     def draw_rubberband(self, x0, y0, x1, y1):
         self.remove_rubberband()
@@ -859,12 +860,14 @@ class ToolbarTk(ToolContainerBase, tk.Frame):
         self._message.set(s)
 
 
+@backend_tools._register_tool_class(FigureCanvasTk)
 class SaveFigureTk(backend_tools.SaveFigureBase):
     def trigger(self, *args):
         NavigationToolbar2Tk.save_figure(
             self._make_classic_style_pseudo_toolbar())
 
 
+@backend_tools._register_tool_class(FigureCanvasTk)
 class ConfigureSubplotsTk(backend_tools.ConfigureSubplotsBase):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -894,6 +897,7 @@ class ConfigureSubplotsTk(backend_tools.ConfigureSubplotsBase):
             self.window = None
 
 
+@backend_tools._register_tool_class(FigureCanvasTk)
 class HelpTk(backend_tools.ToolHelpBase):
     def trigger(self, *args):
         dialog = SimpleDialog(
@@ -901,11 +905,6 @@ class HelpTk(backend_tools.ToolHelpBase):
         dialog.done = lambda num: dialog.frame.master.withdraw()
 
 
-backend_tools.ToolSaveFigure = SaveFigureTk
-backend_tools.ToolConfigureSubplots = ConfigureSubplotsTk
-backend_tools.ToolRubberband = RubberbandTk
-backend_tools.ToolHelp = HelpTk
-backend_tools.ToolCopyToClipboard = backend_tools.ToolCopyToClipboardBase
 Toolbar = ToolbarTk
 
 

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -29,12 +29,11 @@ except ValueError as e:
     raise ImportError from e
 
 from gi.repository import Gio, GLib, GObject, Gtk, Gdk
+from . import _backend_gtk
 from ._backend_gtk import (
     _create_application, _shutdown_application,
     backend_version, _BackendGTK, _NavigationToolbar2GTK,
     TimerGTK as TimerGTK3,
-    ConfigureSubplotsGTK as ConfigureSubplotsGTK3,
-    RubberbandGTK as RubberbandGTK3,
 )
 
 
@@ -597,6 +596,7 @@ class ToolbarGTK3(ToolContainerBase, Gtk.Box):
         self._message.set_label(s)
 
 
+@backend_tools._register_tool_class(FigureCanvasGTK3)
 class SaveFigureGTK3(backend_tools.SaveFigureBase):
     def trigger(self, *args, **kwargs):
 
@@ -613,6 +613,7 @@ class SetCursorGTK3(backend_tools.SetCursorBase):
             self._make_classic_style_pseudo_toolbar(), cursor)
 
 
+@backend_tools._register_tool_class(FigureCanvasGTK3)
 class HelpGTK3(backend_tools.ToolHelpBase):
     def _normalize_shortcut(self, key):
         """
@@ -698,6 +699,7 @@ class HelpGTK3(backend_tools.ToolHelpBase):
             self._show_shortcuts_dialog()
 
 
+@backend_tools._register_tool_class(FigureCanvasGTK3)
 class ToolCopyToClipboardGTK3(backend_tools.ToolCopyToClipboardBase):
     def trigger(self, *args, **kwargs):
         clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
@@ -721,13 +723,11 @@ def error_msg_gtk(msg, parent=None):
     dialog.destroy()
 
 
-backend_tools.ToolSaveFigure = SaveFigureGTK3
-backend_tools.ToolConfigureSubplots = ConfigureSubplotsGTK3
-backend_tools.ToolRubberband = RubberbandGTK3
-backend_tools.ToolHelp = HelpGTK3
-backend_tools.ToolCopyToClipboard = ToolCopyToClipboardGTK3
-
 Toolbar = ToolbarGTK3
+backend_tools._register_tool_class(
+    FigureCanvasGTK3, _backend_gtk.ConfigureSubplotsGTK)
+backend_tools._register_tool_class(
+    FigureCanvasGTK3, _backend_gtk.RubberbandGTK)
 
 
 @_Backend.export

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -29,12 +29,11 @@ except ValueError as e:
     raise ImportError from e
 
 from gi.repository import Gio, GLib, GObject, Gtk, Gdk, GdkPixbuf
+from . import _backend_gtk
 from ._backend_gtk import (
     _create_application, _shutdown_application,
     backend_version, _BackendGTK, _NavigationToolbar2GTK,
     TimerGTK as TimerGTK4,
-    ConfigureSubplotsGTK as ConfigureSubplotsGTK4,
-    RubberbandGTK as RubberbandGTK4,
 )
 
 
@@ -564,6 +563,7 @@ class ToolbarGTK4(ToolContainerBase, Gtk.Box):
         self._message.set_label(s)
 
 
+@backend_tools._register_tool_class(FigureCanvasGTK4)
 class SaveFigureGTK4(backend_tools.SaveFigureBase):
     def trigger(self, *args, **kwargs):
 
@@ -573,6 +573,7 @@ class SaveFigureGTK4(backend_tools.SaveFigureBase):
         return NavigationToolbar2GTK4.save_figure(PseudoToolbar())
 
 
+@backend_tools._register_tool_class(FigureCanvasGTK4)
 class HelpGTK4(backend_tools.ToolHelpBase):
     def _normalize_shortcut(self, key):
         """
@@ -646,6 +647,7 @@ class HelpGTK4(backend_tools.ToolHelpBase):
         window.show()
 
 
+@backend_tools._register_tool_class(FigureCanvasGTK4)
 class ToolCopyToClipboardGTK4(backend_tools.ToolCopyToClipboardBase):
     def trigger(self, *args, **kwargs):
         with io.BytesIO() as f:
@@ -658,12 +660,10 @@ class ToolCopyToClipboardGTK4(backend_tools.ToolCopyToClipboardBase):
         clipboard.set(pb)
 
 
-backend_tools.ToolSaveFigure = SaveFigureGTK4
-backend_tools.ToolConfigureSubplots = ConfigureSubplotsGTK4
-backend_tools.ToolRubberband = RubberbandGTK4
-backend_tools.ToolHelp = HelpGTK4
-backend_tools.ToolCopyToClipboard = ToolCopyToClipboardGTK4
-
+backend_tools._register_tool_class(
+    FigureCanvasGTK4, _backend_gtk.ConfigureSubplotsGTK)
+backend_tools._register_tool_class(
+    FigureCanvasGTK4, _backend_gtk.RubberbandGTK)
 Toolbar = ToolbarGTK4
 
 

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -952,12 +952,14 @@ class ToolbarQt(ToolContainerBase, QtWidgets.QToolBar):
         self.widgetForAction(self._message_action).setText(s)
 
 
+@backend_tools._register_tool_class(FigureCanvasQT)
 class ConfigureSubplotsQt(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
         NavigationToolbar2QT.configure_subplots(
             self._make_classic_style_pseudo_toolbar())
 
 
+@backend_tools._register_tool_class(FigureCanvasQT)
 class SaveFigureQt(backend_tools.SaveFigureBase):
     def trigger(self, *args):
         NavigationToolbar2QT.save_figure(
@@ -971,6 +973,7 @@ class SetCursorQt(backend_tools.SetCursorBase):
             self._make_classic_style_pseudo_toolbar(), cursor)
 
 
+@backend_tools._register_tool_class(FigureCanvasQT)
 class RubberbandQt(backend_tools.RubberbandBase):
     def draw_rubberband(self, x0, y0, x1, y1):
         NavigationToolbar2QT.draw_rubberband(
@@ -981,22 +984,17 @@ class RubberbandQt(backend_tools.RubberbandBase):
             self._make_classic_style_pseudo_toolbar())
 
 
+@backend_tools._register_tool_class(FigureCanvasQT)
 class HelpQt(backend_tools.ToolHelpBase):
     def trigger(self, *args):
         QtWidgets.QMessageBox.information(None, "Help", self._get_help_html())
 
 
+@backend_tools._register_tool_class(FigureCanvasQT)
 class ToolCopyToClipboardQT(backend_tools.ToolCopyToClipboardBase):
     def trigger(self, *args, **kwargs):
         pixmap = self.canvas.grab()
         qApp.clipboard().setPixmap(pixmap)
-
-
-backend_tools.ToolSaveFigure = SaveFigureQt
-backend_tools.ToolConfigureSubplots = ConfigureSubplotsQt
-backend_tools.ToolRubberband = RubberbandQt
-backend_tools.ToolHelp = HelpQt
-backend_tools.ToolCopyToClipboard = ToolCopyToClipboardQT
 
 
 @_Backend.export

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1287,12 +1287,14 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
         self._label_text.SetLabel(s)
 
 
+@backend_tools._register_tool_class(_FigureCanvasWxBase)
 class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
         NavigationToolbar2Wx.configure_subplots(
             self._make_classic_style_pseudo_toolbar())
 
 
+@backend_tools._register_tool_class(_FigureCanvasWxBase)
 class SaveFigureWx(backend_tools.SaveFigureBase):
     def trigger(self, *args):
         NavigationToolbar2Wx.save_figure(
@@ -1306,6 +1308,7 @@ class SetCursorWx(backend_tools.SetCursorBase):
             self._make_classic_style_pseudo_toolbar(), cursor)
 
 
+@backend_tools._register_tool_class(_FigureCanvasWxBase)
 class RubberbandWx(backend_tools.RubberbandBase):
     def draw_rubberband(self, x0, y0, x1, y1):
         NavigationToolbar2Wx.draw_rubberband(
@@ -1361,12 +1364,14 @@ class _HelpDialog(wx.Dialog):
         cls._instance.Show()
 
 
+@backend_tools._register_tool_class(_FigureCanvasWxBase)
 class HelpWx(backend_tools.ToolHelpBase):
     def trigger(self, *args):
         _HelpDialog.show(self.figure.canvas.GetTopLevelParent(),
                          self._get_help_entries())
 
 
+@backend_tools._register_tool_class(_FigureCanvasWxBase)
 class ToolCopyToClipboardWx(backend_tools.ToolCopyToClipboardBase):
     def trigger(self, *args, **kwargs):
         if not self.canvas._isDrawn:
@@ -1377,13 +1382,6 @@ class ToolCopyToClipboardWx(backend_tools.ToolCopyToClipboardBase):
             wx.TheClipboard.SetData(wx.BitmapDataObject(self.canvas.bitmap))
         finally:
             wx.TheClipboard.Close()
-
-
-backend_tools.ToolSaveFigure = SaveFigureWx
-backend_tools.ToolConfigureSubplots = ConfigureSubplotsWx
-backend_tools.ToolRubberband = RubberbandWx
-backend_tools.ToolHelp = HelpWx
-backend_tools.ToolCopyToClipboard = ToolCopyToClipboardWx
 
 
 @_Backend.export

--- a/lib/matplotlib/docstring.py
+++ b/lib/matplotlib/docstring.py
@@ -1,5 +1,7 @@
 import inspect
 
+from . import _api
+
 
 class Substitution:
     """
@@ -45,12 +47,6 @@ class Substitution:
         self.params.update(*args, **kwargs)
 
 
-def _recursive_subclasses(cls):
-    yield cls
-    for subcls in cls.__subclasses__():
-        yield from _recursive_subclasses(subcls)
-
-
 class _ArtistKwdocLoader(dict):
     def __missing__(self, key):
         if not key.endswith(":kwdoc"):
@@ -58,7 +54,7 @@ class _ArtistKwdocLoader(dict):
         name = key[:-len(":kwdoc")]
         from matplotlib.artist import Artist, kwdoc
         try:
-            cls, = [cls for cls in _recursive_subclasses(Artist)
+            cls, = [cls for cls in _api.recursive_subclasses(Artist)
                     if cls.__name__ == name]
         except ValueError as e:
             raise KeyError(key) from e


### PR DESCRIPTION
Don't mess up with overwriting backend_tools globals, which would fail if multiple backend modules are imported.

This proposes an API to fix #17986 (and therefore unblock https://github.com/matplotlib/matplotlib/pull/20273#issuecomment-845703009).  I had tried another approach back in #9941, but that PR did many more cleanups at the same time and therefore got bogged down in side discussions; this one solely implements canvas-specific tool subclass registration.  That registration mechanism is private for now, but we can always consider making it public if there's demand for it.  (I actually guess there would not be that much demand for third-party tool implementers because even if the tool really required some backend-specific logic, it could just use a plain old if-switch instead (https://github.com/anntzer/mplinorm/blob/dbd0b34ab4b2ad3799410565ec6ad31f992b7576/lib/mplinorm.py#L162) because a single module/package would provide the tools; the dispatch problem on Matplotlib's side mostly comes from the fact that each backend implements its own tools in its own module.  The only case where this would really be necessary for third parties is for integration into a new event loop.)

(See the linked PRs and issues for more details about the problem this is solving.)

attn @fariza, I guess.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
