### PR TITLE
Fix ToolManager + TextBox support.

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -619,7 +619,11 @@ def test_CheckButtons():
     check.disconnect(cid)
 
 
-def test_TextBox():
+@pytest.mark.parametrize("toolbar", ["none", "toolbar2", "toolmanager"])
+def test_TextBox(toolbar):
+    # Avoid "toolmanager is provisional" warning.
+    dict.__setitem__(plt.rcParams, "toolbar", toolbar)
+
     from unittest.mock import Mock
     submit_event = Mock()
     text_change_event = Mock()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1287,7 +1287,7 @@ class TextBox(AxesWidget):
             # If using toolmanager, lock keypresses, and plan to release the
             # lock when typing stops.
             toolmanager.keypresslock(self)
-            stack.push(toolmanager.keypresslock.release, self)
+            stack.callback(toolmanager.keypresslock.release, self)
         else:
             # If not using toolmanager, disable all keypress-related rcParams.
             # Avoid spurious warnings if keymaps are getting deprecated.


### PR DESCRIPTION
Try running e.g. examples/widgets/textbox.py together with
`rcParams["toolbar"] = "toolmanager"`.  Before this fix, clicking on the
TextBox would result in "TypeError: push() takes 2 positional arguments
but 3 were given".

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
