### PR TITLE
Test the rcParams deprecation machinery.

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -508,3 +508,39 @@ def test_backend_fallback_headful(tmpdir):
     # The actual backend will depend on what's installed, but at least tkagg is
     # present.
     assert backend.strip().lower() != "agg"
+
+
+def test_deprecation(monkeypatch):
+    monkeypatch.setitem(
+        mpl._deprecated_map, "patch.linewidth",
+        ("0.0", "axes.linewidth", lambda old: 2 * old, lambda new: new / 2))
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        assert mpl.rcParams["patch.linewidth"] \
+            == mpl.rcParams["axes.linewidth"] / 2
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        mpl.rcParams["patch.linewidth"] = 1
+    assert mpl.rcParams["axes.linewidth"] == 2
+
+    monkeypatch.setitem(
+        mpl._deprecated_ignore_map, "patch.edgecolor",
+        ("0.0", "axes.edgecolor"))
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        assert mpl.rcParams["patch.edgecolor"] \
+            == mpl.rcParams["axes.edgecolor"]
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        mpl.rcParams["patch.edgecolor"] = "#abcd"
+    assert mpl.rcParams["axes.edgecolor"] != "#abcd"
+
+    monkeypatch.setitem(
+        mpl._deprecated_ignore_map, "patch.force_edgecolor",
+        ("0.0", None))
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        assert mpl.rcParams["patch.force_edgecolor"] is None
+
+    monkeypatch.setitem(
+        mpl._deprecated_remain_as_none, "svg.hashsalt",
+        ("0.0",))
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        mpl.rcParams["svg.hashsalt"] = "foobar"
+    assert mpl.rcParams["svg.hashsalt"] == "foobar"  # Doesn't warn.
+    mpl.rcParams["svg.hashsalt"] = None  # Doesn't warn.


### PR DESCRIPTION
## PR Summary

Possibly in preparation of trying to fix (later) #13118/#20249.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
