### PR TITLE
Avoid TransformedBbox where unneeded.

### DIFF
--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -57,11 +57,9 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
     tr = Affine2D().scale(fixed_dpi)
     dpi_scale = fixed_dpi / fig.dpi
 
-    _bbox = TransformedBbox(bbox_inches, tr)
-
     fig.bbox_inches = Bbox.from_bounds(0, 0,
                                        bbox_inches.width, bbox_inches.height)
-    x0, y0 = _bbox.x0, _bbox.y0
+    x0, y0 = tr.transform(bbox_inches.p0)
     w1, h1 = fig.bbox.width * dpi_scale, fig.bbox.height * dpi_scale
     fig.transFigure._boxout = Bbox.from_bounds(-x0, -y0, w1, h1)
     fig.transFigure.invalidate()

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from matplotlib import _api, rcParams
 from matplotlib.font_manager import FontProperties
-from matplotlib.transforms import TransformedBbox, Bbox
+from matplotlib.transforms import Bbox
 
 
 def _auto_adjust_subplotpars(
@@ -84,8 +84,7 @@ def _auto_adjust_subplotpars(
                     bb += [ax.get_tightbbox(renderer)]
 
         tight_bbox_raw = Bbox.union(bb)
-        tight_bbox = TransformedBbox(tight_bbox_raw,
-                                     fig.transFigure.inverted())
+        tight_bbox = fig.transFigure.inverted().transform_bbox(tight_bbox_raw)
 
         hspaces[rowspan, colspan.start] += ax_bbox.xmin - tight_bbox.xmin  # l
         hspaces[rowspan, colspan.stop] += tight_bbox.xmax - ax_bbox.xmax  # r

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -126,7 +126,7 @@ class AnchoredZoomLocator(AnchoredLocatorBase):
             bbox_transform=bbox_transform)
 
     def get_extent(self, renderer):
-        bb = TransformedBbox(self.axes.viewLim, self.parent_axes.transData)
+        bb = self.parent_axes.transData.transform_bbox(self.axes.viewLim)
         fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
         pad = self.pad * fontsize
         return (abs(bb.width * self.zoom) + 2 * pad,


### PR DESCRIPTION
transform_bbox is much faster when one does not need a TransformedBbox,
i.e. something that keeps track of later changes in the transform:
```
In [1]: from pylab import *
   ...: from matplotlib.transforms import *
   ...: tr = plt.gca().transAxes
   ...: bb = Bbox([[0, 0], [1, 1]])
   ...: %timeit TransformedBbox(bb, tr).x0
   ...: %timeit tr.transform_bbox(bb).x0
   ...: %timeit TransformedBbox(bb, tr).width
   ...: %timeit tr.transform_bbox(bb).width
11.8 µs ± 145 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
2.72 µs ± 31.5 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
11.9 µs ± 183 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
2.83 µs ± 16.6 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)
```

(I don't know if any of the places changed here are actually performance-critical, but this just seems good practice...)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
