### PR TITLE
Prepare for rcParams.copy() returning a new RcParams instance in the future

### DIFF
--- a/doc/api/next_api_changes/deprecations/YYYYY-AL.rst
+++ b/doc/api/next_api_changes/deprecations/YYYYY-AL.rst
@@ -1,0 +1,6 @@
+rcParams.copy() will return a new RcParams instance in the future
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+During the transition period, ``rcParams.copy()`` will emit a
+DeprecationWarning.  Either use ``dict.copy(rcParams)`` to copy rcParams as
+a plain dict, or ``copy.copy(rcParams)`` to copy rcParams as a new RcParams
+instance.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -708,6 +708,11 @@ class RcParams(MutableMapping, dict):
                         if pattern_re.search(key))
 
     def copy(self):
+        _api.warn_deprecated(
+            "3.6", message="In the future, rcParams.copy() will return a new "
+            "RcParams instance.  During the deprecation period, either use "
+            "dict.copy(rcParams) to copy rcParams as a plain dict, or "
+            "copy.copy(rcParams) to copy rcParams as a new RcParams instance.")
         return {k: dict.__getitem__(self, k) for k in self}
 
 
@@ -1076,7 +1081,8 @@ def rc_context(rc=None, fname=None):
              plt.plot(x, y)  # uses 'print.rc'
 
     """
-    orig = rcParams.copy()
+    with _api.suppress_matplotlib_deprecation_warning():
+        orig = rcParams.copy()
     try:
         if fname:
             rc_file(fname)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -613,7 +613,8 @@ class _xkcd:
     # work as a non-contextmanager too.
 
     def __init__(self, scale, length, randomness):
-        self._orig = rcParams.copy()
+        with _api.suppress_matplotlib_deprecation_warning():
+            self._orig = rcParams.copy()
 
         if rcParams['text.usetex']:
             raise RuntimeError(

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -154,7 +154,7 @@ def test_alias(equiv_styles):
     rc_dicts = []
     for sty in equiv_styles:
         with style.context(sty):
-            rc_dicts.append(mpl.rcParams.copy())
+            rc_dicts.append(dict.copy(mpl.rcParams))
 
     rc_base = rc_dicts[0]
     for nm, rc in zip(equiv_styles[1:], rc_dicts[1:]):


### PR DESCRIPTION
This would then allow
`rcParams.update(<previously-copied-rcParams-instance>)` to *not* emit
a deprecation warning (by checking the type of the input) even if the
copied RcParams instance contains a deprecated rc entry, because we'll
know that it will already have gone through the validator when being set
on the copied rcParams instance.

This is a proposed fix for (some use cases of) #13118/#15781/#20249, because looking at them and at linked issues from other repos, it looks like most relevant use cases are third-parties wanting to copy the state of all rcParams at a given point, and then later restore them (something like rc_context, but where `__enter__` and `__exit__` may be e.g. different functions).  This PR would then (together with typechecking in RcParams.update) allow them to use the normal `stashed_state = rcParams.copy(); <do whatever>; rcParams.update(stashed_state)` even in the presence of deprecated rcParams.  (Admittedly, the whole thing is a bit abstract right now because there are no deprecated rcParams currently.)

OTOH, perhaps a solution like this would also require #11509 being fixed first, because we wouldn't want assignments to the copied rcParams instance (not the global one) to affect the actual global state.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
