### PR TITLE
FIX: Don't subslice lines if non-standard transform

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -664,7 +664,8 @@ class Line2D(Artist):
                 self.axes.name == 'rectilinear' and
                 self.axes.get_xscale() == 'linear' and
                 self._markevery is None and
-                self.get_clip_on()):
+                self.get_clip_on() and
+                self.get_transform() == self.axes.transData):
             self._subslice = True
             nanmask = np.isnan(x)
             if nanmask.any():

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -16,6 +16,7 @@ import matplotlib.lines as mlines
 from matplotlib.markers import MarkerStyle
 from matplotlib.path import Path
 import matplotlib.pyplot as plt
+import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
@@ -129,6 +130,17 @@ def test_drawstyle_variants():
     for ax, ds in zip(axs.flat, dss):
         ax.plot(range(2000), drawstyle=ds)
         ax.set(xlim=(0, 2), ylim=(0, 2))
+
+
+@check_figures_equal(extensions=('png',))
+def test_no_subslice_with_transform(fig_ref, fig_test):
+    ax = fig_ref.add_subplot()
+    x = np.arange(2000)
+    ax.plot(x + 2000, x)
+
+    ax = fig_test.add_subplot()
+    t = mtransforms.Affine2D().translate(2000.0, 0.0)
+    ax.plot(x, x, transform=t+ax.transData)
 
 
 def test_valid_drawstyles():


### PR DESCRIPTION
## PR Summary

`Line2D` objects are "sub sliced" if they are well-ordered, and their view window is smaller than the actual data extents. However, if someone applies a transform, in particular a lateral translation, then the data all ends up out of view.  This adds a check to only apply the subslice algorithm if the transform is `ax.transData`.   

Closes #21008

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
