### PR TITLE
Factor out for_layout_only backcompat support in get_tightlayout.

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -17,7 +17,7 @@ import logging
 
 import numpy as np
 
-from matplotlib import _api
+from matplotlib import _api, artist as martist
 import matplotlib.transforms as mtransforms
 import matplotlib._layoutgrid as mlayoutgrid
 
@@ -534,17 +534,12 @@ def get_pos_and_bbox(ax, renderer):
         Position in figure coordinates.
     bbox : Bbox
         Tight bounding box in figure coordinates.
-
     """
     fig = ax.figure
     pos = ax.get_position(original=True)
     # pos is in panel co-ords, but we need in figure for the layout
     pos = pos.transformed(fig.transSubfigure - fig.transFigure)
-    try:
-        tightbbox = ax.get_tightbbox(renderer=renderer, for_layout_only=True)
-    except TypeError:
-        tightbbox = ax.get_tightbbox(renderer=renderer)
-
+    tightbbox = martist._get_tightbbox_for_layout_only(ax, renderer)
     if tightbbox is None:
         bbox = pos
     else:

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1301,6 +1301,18 @@ class Artist:
                 ax._mouseover_set.discard(self)
 
 
+def _get_tightbbox_for_layout_only(obj, *args, **kwargs):
+    """
+    Matplotlib's `.Axes.get_tightbbox` and `.Axis.get_tightbbox` support a
+    *for_layout_only* kwarg; this helper tries to uses the kwarg but skips it
+    when encountering third-party subclasses that do not support it.
+    """
+    try:
+        return obj.get_tightbbox(*args, **{**kwargs, "for_layout_only": True})
+    except TypeError:
+        return obj.get_tightbbox(*args, **kwargs)
+
+
 class ArtistInspector:
     """
     A helper class to inspect an `~matplotlib.artist.Artist` and return

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4582,21 +4582,13 @@ class _AxesBase(martist.Artist):
 
         if self.axison:
             if self.xaxis.get_visible():
-                try:
-                    bb_xaxis = self.xaxis.get_tightbbox(
-                        renderer, for_layout_only=for_layout_only)
-                except TypeError:
-                    # in case downstream library has redefined axis:
-                    bb_xaxis = self.xaxis.get_tightbbox(renderer)
+                bb_xaxis = martist._get_tightbbox_for_layout_only(
+                    self.xaxis, renderer)
                 if bb_xaxis:
                     bb.append(bb_xaxis)
             if self.yaxis.get_visible():
-                try:
-                    bb_yaxis = self.yaxis.get_tightbbox(
-                        renderer, for_layout_only=for_layout_only)
-                except TypeError:
-                    # in case downstream library has redefined axis:
-                    bb_yaxis = self.yaxis.get_tightbbox(renderer)
+                bb_yaxis = martist._get_tightbbox_for_layout_only(
+                    self.yaxis, renderer)
                 if bb_yaxis:
                     bb.append(bb_yaxis)
         self._update_title_position(renderer)

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -11,7 +11,7 @@ such cases as when left or right margin are affected by xlabel.
 
 import numpy as np
 
-from matplotlib import _api, rcParams
+from matplotlib import _api, artist as martist, rcParams
 from matplotlib.font_manager import FontProperties
 from matplotlib.transforms import Bbox
 
@@ -78,10 +78,7 @@ def _auto_adjust_subplotpars(
         bb = []
         for ax in subplots:
             if ax.get_visible():
-                try:
-                    bb += [ax.get_tightbbox(renderer, for_layout_only=True)]
-                except TypeError:
-                    bb += [ax.get_tightbbox(renderer)]
+                bb += [martist._get_tightbbox_for_layout_only(ax, renderer)]
 
         tight_bbox_raw = Bbox.union(bb)
         tight_bbox = fig.transFigure.inverted().transform_bbox(tight_bbox_raw)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3287,16 +3287,10 @@ pivot='tail', normalize=False, **kwargs)
         if self._axis3don:
             for axis in self._get_axis_list():
                 if axis.get_visible():
-                    try:
-                        axis_bb = axis.get_tightbbox(
-                            renderer,
-                            for_layout_only=for_layout_only
-                        )
-                    except TypeError:
-                        # in case downstream library has redefined axis:
-                        axis_bb = axis.get_tightbbox(renderer)
-                if axis_bb:
-                    batch.append(axis_bb)
+                    axis_bb = martist._get_tightbbox_for_layout_only(
+                        axis, renderer)
+                    if axis_bb:
+                        batch.append(axis_bb)
         return mtransforms.Bbox.union(batch)
 
     def stem(self, x, y, z, *, linefmt='C0-', markerfmt='C0o', basefmt='C3-',


### PR DESCRIPTION
This avoids duplicating try... except in a bunch of places, and also
gives a single centralized point if (possibly) we ever want to deprecate
support for subclasses that do *not* support for_layout_only.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
