### PR TITLE
Fix Cairo backends on HiDPI screens

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2259,6 +2259,7 @@ class FigureCanvasBase:
         # Remove the figure manager, if any, to avoid resizing the GUI widget.
         with cbook._setattr_cm(self, manager=None), \
              cbook._setattr_cm(self.figure, dpi=dpi), \
+             cbook._setattr_cm(canvas, _device_pixel_ratio=1), \
              cbook._setattr_cm(canvas, _is_saving=True), \
              ExitStack() as stack:
 

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -245,7 +245,7 @@ class RendererCairo(RendererBase):
 
             ctx.save()
             ctx.select_font_face(*_cairo_font_args_from_font_prop(prop))
-            ctx.set_font_size(prop.get_size_in_points() * self.dpi / 72)
+            ctx.set_font_size(self.points_to_pixels(prop.get_size_in_points()))
             opts = cairo.FontOptions()
             opts.set_antialias(
                 cairo.ANTIALIAS_DEFAULT if mpl.rcParams["text.antialiased"]
@@ -271,7 +271,7 @@ class RendererCairo(RendererBase):
             ctx.move_to(ox, -oy)
             ctx.select_font_face(
                 *_cairo_font_args_from_font_prop(ttfFontProperty(font)))
-            ctx.set_font_size(fontsize * self.dpi / 72)
+            ctx.set_font_size(self.points_to_pixels(fontsize))
             ctx.show_text(chr(idx))
 
         for ox, oy, w, h in rects:
@@ -303,9 +303,7 @@ class RendererCairo(RendererBase):
         # save/restore prevents the problem
         ctx.save()
         ctx.select_font_face(*_cairo_font_args_from_font_prop(prop))
-        # Cairo (says it) uses 1/96 inch user space units, ref: cairo_gstate.c
-        # but if /96.0 is used the font is too small
-        ctx.set_font_size(prop.get_size_in_points() * self.dpi / 72)
+        ctx.set_font_size(self.points_to_pixels(prop.get_size_in_points()))
 
         y_bearing, w, h = ctx.text_extents(s)[1:4]
         ctx.restore()

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -28,6 +28,7 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
                 allocation.width, allocation.height)
             self._renderer.set_width_height(
                 allocation.width, allocation.height)
+            self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 
 

--- a/lib/matplotlib/backends/backend_gtk4cairo.py
+++ b/lib/matplotlib/backends/backend_gtk4cairo.py
@@ -27,6 +27,7 @@ class FigureCanvasGTK4Cairo(backend_gtk4.FigureCanvasGTK4,
                 allocation.width, allocation.height)
             self._renderer.set_width_height(
                 allocation.width, allocation.height)
+            self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 
 

--- a/lib/matplotlib/backends/backend_qtcairo.py
+++ b/lib/matplotlib/backends/backend_qtcairo.py
@@ -13,6 +13,7 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
 
     def draw(self):
         if hasattr(self._renderer.gc, "ctx"):
+            self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
         super().draw()
 
@@ -23,6 +24,7 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
             surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
             self._renderer.set_ctx_from_surface(surface)
             self._renderer.set_width_height(width, height)
+            self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
         buf = self._renderer.gc.ctx.get_target().get_data()
         if QT_API == "PyQt6":

--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -18,6 +18,7 @@ class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_ctx_from_surface(surface)
         self._renderer.set_width_height(width, height)
+        self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)
         buf = np.reshape(surface.get_data(), (height, width, 4))
         _backend_tk.blit(

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -35,6 +35,7 @@ class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_ctx_from_surface(surface)
         self._renderer.set_width_height(width, height)
+        self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)
         self.bitmap = wxcairo.BitmapFromImageSurface(surface)
         self._isDrawn = True


### PR DESCRIPTION
## PR Summary

Since Cairo renderers exist forever, we need to ensure they are using the correct DPI, or else physical sizes are incorrect.

Fixes #21024.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).