### PR TITLE
Prefer "none" to "None" in docs, examples and comments.

### DIFF
--- a/examples/axes_grid1/inset_locator_demo.py
+++ b/examples/axes_grid1/inset_locator_demo.py
@@ -69,7 +69,7 @@ axins = inset_axes(ax, width="50%", height="75%",
                    bbox_transform=ax.transAxes, loc=3)
 
 # For visualization purposes we mark the bounding box by a rectangle
-ax.add_patch(plt.Rectangle((.2, .4), .6, .5, ls="--", ec="c", fc="None",
+ax.add_patch(plt.Rectangle((.2, .4), .6, .5, ls="--", ec="c", fc="none",
                            transform=ax.transAxes))
 
 # We set the axis limits to something other than the default, in order to not
@@ -89,9 +89,9 @@ axins3 = inset_axes(ax3, width="100%", height="100%",
                     bbox_transform=ax3.transAxes)
 
 # For visualization purposes we mark the bounding box by a rectangle
-ax2.add_patch(plt.Rectangle((0, 0), 1, 1, ls="--", lw=2, ec="c", fc="None"))
+ax2.add_patch(plt.Rectangle((0, 0), 1, 1, ls="--", lw=2, ec="c", fc="none"))
 ax3.add_patch(plt.Rectangle((.7, .5), .3, .5, ls="--", lw=2,
-                            ec="c", fc="None"))
+                            ec="c", fc="none"))
 
 # Turn ticklabels off
 for axi in [axins2, axins3, ax2, ax3]:

--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -117,7 +117,7 @@ fig, ax = plt.subplots()
 fig.suptitle('Mathtext markers', fontsize=14)
 fig.subplots_adjust(left=0.4)
 
-marker_style.update(markeredgecolor="None", markersize=15)
+marker_style.update(markeredgecolor="none", markersize=15)
 markers = ["$1$", r"$\frac{1}{2}$", "$f$", "$\u266B$", r"$\mathcal{A}$"]
 
 for y, marker in enumerate(markers):

--- a/examples/shapes_and_collections/compound_path.py
+++ b/examples/shapes_and_collections/compound_path.py
@@ -23,7 +23,7 @@ vertices += [(4, 4), (5, 5), (5, 4), (0, 0)]
 
 path = Path(vertices, codes)
 
-pathpatch = PathPatch(path, facecolor='None', edgecolor='green')
+pathpatch = PathPatch(path, facecolor='none', edgecolor='green')
 
 fig, ax = plt.subplots()
 ax.add_patch(pathpatch)

--- a/examples/statistics/errorbars_and_boxes.py
+++ b/examples/statistics/errorbars_and_boxes.py
@@ -40,7 +40,7 @@ yerr = np.random.rand(2, n) + 0.2
 
 
 def make_error_boxes(ax, xdata, ydata, xerror, yerror, facecolor='r',
-                     edgecolor='None', alpha=0.5):
+                     edgecolor='none', alpha=0.5):
 
     # Loop over data points; create box from errors at each point
     errorboxes = [Rectangle((x - xe[0], y - ye[0]), xe.sum(), ye.sum())
@@ -55,7 +55,7 @@ def make_error_boxes(ax, xdata, ydata, xerror, yerror, facecolor='r',
 
     # Plot errorbars
     artists = ax.errorbar(xdata, ydata, xerr=xerror, yerr=yerror,
-                          fmt='None', ecolor='k')
+                          fmt='none', ecolor='k')
 
     return artists
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3317,8 +3317,7 @@ class Axes(_AxesBase):
             %(Line2D:kwdoc)s
         """
         kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
-        # anything that comes in as 'None', drop so the default thing
-        # happens down stream
+        # Drop anything that comes in as None to use the default instead.
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         kwargs.setdefault('zorder', 2)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1291,7 +1291,7 @@ class _AxesBase(martist.Artist):
         self.patch = self._gen_axes_patch()
         self.patch.set_figure(self.figure)
         self.patch.set_facecolor(self._facecolor)
-        self.patch.set_edgecolor('None')
+        self.patch.set_edgecolor('none')
         self.patch.set_linewidth(0)
         self.patch.set_transform(self.transAxes)
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1093,15 +1093,15 @@ class Line2D(Artist):
 
             - A string:
 
-              ===============================   =================
-              Linestyle                         Description
-              ===============================   =================
-              ``'-'`` or ``'solid'``            solid line
-              ``'--'`` or  ``'dashed'``         dashed line
-              ``'-.'`` or  ``'dashdot'``        dash-dotted line
-              ``':'`` or ``'dotted'``           dotted line
-              ``'None'`` or ``' '`` or ``''``   draw nothing
-              ===============================   =================
+              ==========================================  =================
+              linestyle                                   description
+              ==========================================  =================
+              ``'-'`` or ``'solid'``                      solid line
+              ``'--'`` or  ``'dashed'``                   dashed line
+              ``'-.'`` or  ``'dashdot'``                  dash-dotted line
+              ``':'`` or ``'dotted'``                     dotted line
+              ``'none'``, ``'None'``, ``' '``, or ``''``  draw nothing
+              ==========================================  =================
 
             - Alternatively a dash tuple of the following form can be
               provided::

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -419,18 +419,15 @@ class Patch(artist.Artist):
         """
         Set the patch linestyle.
 
-        ===========================   =================
-        linestyle                     description
-        ===========================   =================
-        ``'-'`` or ``'solid'``        solid line
-        ``'--'`` or  ``'dashed'``     dashed line
-        ``'-.'`` or  ``'dashdot'``    dash-dotted line
-        ``':'`` or ``'dotted'``       dotted line
-        ``'None'``                    draw nothing
-        ``'none'``                    draw nothing
-        ``' '``                       draw nothing
-        ``''``                        draw nothing
-        ===========================   =================
+        ==========================================  =================
+        linestyle                                   description
+        ==========================================  =================
+        ``'-'`` or ``'solid'``                      solid line
+        ``'--'`` or  ``'dashed'``                   dashed line
+        ``'-.'`` or  ``'dashdot'``                  dash-dotted line
+        ``':'`` or ``'dotted'``                     dotted line
+        ``'none'``, ``'None'``, ``' '``, or ``''``  draw nothing
+        ==========================================  =================
 
         Alternatively a dash tuple of the following form can be provided::
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3033,8 +3033,7 @@ pivot='tail', normalize=False, **kwargs)
         had_data = self.has_data()
 
         kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
-        # anything that comes in as 'None', drop so the default thing
-        # happens down stream
+        # Drop anything that comes in as None to use the default instead.
         kwargs = {k: v for k, v in kwargs.items() if v is not None}
         kwargs.setdefault('zorder', 2)
 


### PR DESCRIPTION
(Markers are left untouched, as they don't support "none"; nor are
linestyles, for which the "canonical" version is still "None".)

See https://github.com/matplotlib/matplotlib/issues/19300.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
