### PR TITLE
Make rcParams.copy() return a new RcParams instance.

### DIFF
--- a/doc/api/next_api_changes/behavior/21042-AL.rst
+++ b/doc/api/next_api_changes/behavior/21042-AL.rst
@@ -1,0 +1,5 @@
+rcParams.copy() returns a new RcParams instance, rather than a dict
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This makes the copied instance still validate inputs, and additionally avoids
+emitting deprecation warnings when using a previously copied RcParams instance
+to update the global instance (even if some entries are deprecated).

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -699,7 +699,10 @@ class RcParams(MutableMapping, dict):
                         if pattern_re.search(key))
 
     def copy(self):
-        return {k: dict.__getitem__(self, k) for k in self}
+        rccopy = RcParams()
+        for k in self:  # Skip deprecations and revalidation.
+            dict.__setitem__(rccopy, k, dict.__getitem__(self, k))
+        return rccopy
 
 
 def rc_params(fail_on_error=False):
@@ -877,8 +880,8 @@ dict.setdefault(rcParamsDefault, "backend", rcsetup._auto_backend_sentinel)
 rcParams = RcParams()  # The global instance.
 dict.update(rcParams, dict.items(rcParamsDefault))
 dict.update(rcParams, _rc_params_in_file(matplotlib_fname()))
+rcParamsOrig = rcParams.copy()
 with _api.suppress_matplotlib_deprecation_warning():
-    rcParamsOrig = RcParams(rcParams.copy())
     # This also checks that all rcParams are indeed listed in the template.
     # Assigning to rcsetup.defaultParams is left only for backcompat.
     defaultParams = rcsetup.defaultParams = {

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -546,3 +546,8 @@ def test_deprecation(monkeypatch):
         mpl.rcParams["svg.hashsalt"] = "foobar"
     assert mpl.rcParams["svg.hashsalt"] == "foobar"  # Doesn't warn.
     mpl.rcParams["svg.hashsalt"] = None  # Doesn't warn.
+
+    mpl.rcParams.update(mpl.rcParams.copy())  # Doesn't warn.
+    # Note that the warning suppression actually arises from the
+    # iteration over the updater rcParams being protected by
+    # suppress_matplotlib_deprecation_warning, rather than any explicit check.


### PR DESCRIPTION
... so that `rcParams.update(<previously-copied-rcparams-instance>)`
doesn't emit DeprecationWarnings even if some entries are deprecated.
(See comment in tests.)

Supersedes #21015.

Closes #13118.  Closes #15781.  Closes #20249.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
