### PR TITLE
Support for forward/back mousebuttons on WX backend

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -772,8 +772,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             wx.MOUSE_BTN_LEFT: MouseButton.LEFT,
             wx.MOUSE_BTN_MIDDLE: MouseButton.MIDDLE,
             wx.MOUSE_BTN_RIGHT: MouseButton.RIGHT,
-            wx.MOUSE_BTN_AUX1: MouseButton.FORWARD,
-            wx.MOUSE_BTN_AUX2: MouseButton.BACK,
+            wx.MOUSE_BTN_AUX1: MouseButton.BACK,
+            wx.MOUSE_BTN_AUX2: MouseButton.FORWARD,
         }
         button = event.GetButton()
         button = button_map.get(button, button)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -515,6 +515,12 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         self.Bind(wx.EVT_RIGHT_DOWN, self._onMouseButton)
         self.Bind(wx.EVT_RIGHT_DCLICK, self._onMouseButton)
         self.Bind(wx.EVT_RIGHT_UP, self._onMouseButton)
+        self.Bind(wx.EVT_MOUSE_AUX1_DOWN, self._onMouseButton)
+        self.Bind(wx.EVT_MOUSE_AUX1_UP, self._onMouseButton)
+        self.Bind(wx.EVT_MOUSE_AUX2_DOWN, self._onMouseButton)
+        self.Bind(wx.EVT_MOUSE_AUX2_UP, self._onMouseButton)
+        self.Bind(wx.EVT_MOUSE_AUX1_DCLICK, self._onMouseButton)
+        self.Bind(wx.EVT_MOUSE_AUX2_DCLICK, self._onMouseButton)
         self.Bind(wx.EVT_MOUSEWHEEL, self._onMouseWheel)
         self.Bind(wx.EVT_MOTION, self._onMotion)
         self.Bind(wx.EVT_LEAVE_WINDOW, self._onLeave)
@@ -766,6 +772,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             wx.MOUSE_BTN_LEFT: MouseButton.LEFT,
             wx.MOUSE_BTN_MIDDLE: MouseButton.MIDDLE,
             wx.MOUSE_BTN_RIGHT: MouseButton.RIGHT,
+            wx.MOUSE_BTN_AUX1: MouseButton.FORWARD,
+            wx.MOUSE_BTN_AUX2: MouseButton.BACK,
         }
         button = event.GetButton()
         button = button_map.get(button, button)


### PR DESCRIPTION
## PR Summary
This PR adds the support for using the `MouseButton.FORWARD` and `MouseButton.BACKWARD` on the WX backend.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
