### PR TITLE
set_dashes does not support offset=None anymore.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -914,15 +914,13 @@ class GraphicsContextBase:
 
         Parameters
         ----------
-        dash_offset : float or None
+        dash_offset : float
             The offset (usually 0).
         dash_list : array-like or None
-            The on-off sequence as points.
+            The on-off sequence as points.  None specifies a solid line.
 
         Notes
         -----
-        ``(None, None)`` specifies a solid line.
-
         See p. 107 of to PostScript `blue book`_ for more info.
 
         .. _blue book: https://www-cdf.fnal.gov/offline/PostScript/BLUEBOOK.PDF

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -212,31 +212,11 @@ int convert_dashes(PyObject *dashobj, void *dashesp)
 {
     Dashes *dashes = (Dashes *)dashesp;
 
-    if (dashobj == NULL && dashobj == Py_None) {
-        return 1;
-    }
-
-    PyObject *dash_offset_obj = NULL;
     double dash_offset = 0.0;
     PyObject *dashes_seq = NULL;
 
-    if (!PyArg_ParseTuple(dashobj, "OO:dashes", &dash_offset_obj, &dashes_seq)) {
+    if (!PyArg_ParseTuple(dashobj, "dO:dashes", &dash_offset, &dashes_seq)) {
         return 0;
-    }
-
-    if (dash_offset_obj != Py_None) {
-        dash_offset = PyFloat_AsDouble(dash_offset_obj);
-        if (PyErr_Occurred()) {
-            return 0;
-        }
-    } else {
-        if (PyErr_WarnEx(PyExc_FutureWarning,
-                         "Passing the dash offset as None is deprecated since "
-                         "Matplotlib 3.3 and will be removed in Matplotlib 3.5; "
-                         "pass it as zero instead.",
-                         1)) {
-            return 0;
-        }
     }
 
     if (dashes_seq == Py_None) {


### PR DESCRIPTION
This was deprecated in 3.3 (eb76378) and removed in most places in
c51ae6d5; this patch removes supports on the C side and mentions of it
in docs.

Also remove the `dashobj == NULL && dashobj == Py_None` check, which can
never be true.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
