### PR TITLE
Support marker="none" to mean "no marker".

### DIFF
--- a/doc/users/next_whats_new/marker_none.rst
+++ b/doc/users/next_whats_new/marker_none.rst
@@ -1,0 +1,5 @@
+``marker`` can now be set to the string "none"
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... to mean *no-marker*, consistently with other APIs which support the
+lowercase version.  Using "none" is recommended over using "None", to avoid
+confusion with the None object.

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -566,7 +566,7 @@ class HandlerErrorbar(HandlerLine2D):
             self.update_prop(legline, plotlines, legend)
 
             legline.set_drawstyle('default')
-            legline.set_marker('None')
+            legline.set_marker('none')
 
             self.update_prop(legline_marker, plotlines, legend)
             legline_marker.set_linestyle('None')

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -45,7 +45,8 @@ marker                         symbol description
 ``9`` (``CARETRIGHTBASE``)     |m34|  caretright (centered at base)
 ``10`` (``CARETUPBASE``)       |m35|  caretup (centered at base)
 ``11`` (``CARETDOWNBASE``)     |m36|  caretdown (centered at base)
-``"None"``, ``" "`` or  ``""``        nothing
+``"none"`` or ``"None"``              nothing
+``" "`` or  ``""``                    nothing
 ``'$...$'``                    |m37|  Render the string using mathtext.
                                       E.g ``"$f$"`` for marker showing the
                                       letter ``f``.
@@ -200,6 +201,7 @@ class MarkerStyle:
         CARETUPBASE: 'caretupbase',
         CARETDOWNBASE: 'caretdownbase',
         "None": 'nothing',
+        "none": 'nothing',
         None: 'nothing',
         ' ': 'nothing',
         '': 'nothing'
@@ -227,7 +229,7 @@ class MarkerStyle:
             - Another instance of *MarkerStyle* copies the details of that
               ``marker``.
             - *None* means no marker.  This is the deprecated default.
-            - For other possible marker values see the module docstring
+            - For other possible marker values, see the module docstring
               `matplotlib.markers`.
 
         fillstyle : str, default: :rc:`markers.fillstyle`

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4117,8 +4117,9 @@ def test_eventplot_orientation(data, orientation):
 @image_comparison(['marker_styles.png'], remove_text=True)
 def test_marker_styles():
     fig, ax = plt.subplots()
-    for y, marker in enumerate(sorted(matplotlib.markers.MarkerStyle.markers,
-                                      key=lambda x: str(type(x))+str(x))):
+    for y, marker in enumerate(sorted(
+            {*matplotlib.markers.MarkerStyle.markers} - {"none"},
+            key=lambda x: str(type(x))+str(x))):
         ax.plot((y % 2)*5 + np.arange(10)*10, np.ones(10)*10*y, linestyle='',
                 marker=marker, markersize=10+y/5, label=marker)
 


### PR DESCRIPTION
As for other APIs (#19300), this is less likely to be confused with the None
object.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
