### PR TITLE
Deprecate support for no-args MarkerStyle().

### DIFF
--- a/doc/api/next_api_changes/deprecations/21056-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21056-AL.rst
@@ -1,0 +1,3 @@
+Calling ``MarkerStyle()`` with no arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated; use ``MarkerStyle("")`` to construct an empty marker style.

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -1,6 +1,7 @@
 import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib import markers
+from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 from matplotlib.path import Path
 from matplotlib.testing.decorators import check_figures_equal
 
@@ -32,12 +33,17 @@ def test_marker_fillstyle():
     (5, 0, 10),  # a pentagon, rotated by 10 degrees
     (7, 1, 10),  # a 7-pointed star, rotated by 10 degrees
     (5, 2, 10),  # asterisk, rotated by 10 degrees
-    markers.MarkerStyle(),
     markers.MarkerStyle('o'),
 ])
 def test_markers_valid(marker):
     # Checking this doesn't fail.
     markers.MarkerStyle(marker)
+
+
+def test_deprecated_marker_noargs():
+    with pytest.warns(MatplotlibDeprecationWarning):
+        ms = markers.MarkerStyle()
+    markers.MarkerStyle(ms)  # No warning on copy.
 
 
 @pytest.mark.parametrize('marker', [


### PR DESCRIPTION
As noted in the module docstring, there is a confusion between using a
generic default MarkerStyle (empty) and the artist-specific one (e.g.
scatter plots use `rcParams["scatter.marker"]`).  Fortunately, direct
construction of MarkerStyles (especially of empty ones) is hardly ever
needed, so we can just make the parameter required.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
