### PR TITLE
Correct the default for fillstyle parameter in MarkerStyle()

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -227,7 +227,7 @@ class MarkerStyle:
             - For other possible marker values see the module docstring
               `matplotlib.markers`.
 
-        fillstyle : str, default: 'full'
+        fillstyle : str, default: :rc:`markers.fillstyle`
             One of 'full', 'left', 'right', 'bottom', 'top', 'none'.
         """
         self._marker_function = None


### PR DESCRIPTION
## PR Summary

See https://github.com/matplotlib/matplotlib/blob/23f1da49f6ebdacbf51252b0066f7ac804612f5d/lib/matplotlib/markers.py#L277

