### PR TITLE
Fix typo in template of current dev-docs

### DIFF
--- a/doc/_templates/mpl_nav_bar.html
+++ b/doc/_templates/mpl_nav_bar.html
@@ -7,7 +7,7 @@
     <a class="reference internal nav-link" href="{{ pathto('gallery/index') }}">Examples</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ pathto('tutorials/index') }}">Tutoraials</a>
+    <a class="reference internal nav-link" href="{{ pathto('tutorials/index') }}">Tutorials</a>
   </li>
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ pathto('api/index') }}">Reference</a>


### PR DESCRIPTION
## PR Summary
I was recently working on some documentation and the new template took my attention, it looks great, good work. I found an typo in the main navigation bar `Tutoraials` -> `Tutorials`. Despite the fact that this is a single character PR I believe it has major impact and this will ease the process. I have not done any proof reading of the new documentation.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ N/A ] Has pytest style unit tests (and `pytest` passes).
- [ N/A ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ N/A ] New features are documented, with examples if plot related.
- [  ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ N/A ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ N/A ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
