### PR TITLE
Deprecate MarkerStyle(None).

### DIFF
--- a/doc/api/next_api_changes/deprecations/21056-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21056-AL.rst
@@ -1,3 +1,3 @@
-Calling ``MarkerStyle()`` with no arguments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Calling ``MarkerStyle()`` with no arguments or ``MarkerStyle(None)``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ... is deprecated; use ``MarkerStyle("")`` to construct an empty marker style.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -368,6 +368,8 @@ class Line2D(Artist):
 
         self._color = None
         self.set_color(color)
+        if marker is None:
+            marker = 'none'  # Default.
         self._marker = MarkerStyle(marker, fillstyle)
 
         self._markevery = None

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -64,9 +64,10 @@ path                                  A `~matplotlib.path.Path` instance.
                                       rotated by ``angle``.
 ============================== ====== =========================================
 
-``None`` also means 'nothing' when directly constructing a `.MarkerStyle`, but
-note that there are other contexts where ``marker=None`` instead means "the
-default marker" (e.g. :rc:`scatter.marker` for `.Axes.scatter`).
+As a deprecated feature, ``None`` also means 'nothing' when directly
+constructing a `.MarkerStyle`, but note that there are other contexts where
+``marker=None`` instead means "the default marker" (e.g. :rc:`scatter.marker`
+for `.Axes.scatter`).
 
 Note that special symbols can be defined via the
 :doc:`STIX math font </tutorials/text/mathtext>`,
@@ -202,7 +203,6 @@ class MarkerStyle:
         CARETDOWNBASE: 'caretdownbase',
         "None": 'nothing',
         "none": 'nothing',
-        None: 'nothing',
         ' ': 'nothing',
         '': 'nothing'
     }
@@ -245,6 +245,12 @@ class MarkerStyle:
                 "deprecated since %(since)s; support will be removed "
                 "%(removal)s.  Use MarkerStyle('') to construct an empty "
                 "MarkerStyle.")
+        if marker is None:
+            marker = ""
+            _api.warn_deprecated(
+                "3.6", message="MarkerStyle(None) is deprecated since "
+                "%(since)s; support will be removed %(removal)s.  Use "
+                "MarkerStyle('') to construct an empty MarkerStyle.")
         self._set_marker(marker)
 
     __init__.__signature__ = inspect.signature(  # Only for deprecation period.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4117,9 +4117,15 @@ def test_eventplot_orientation(data, orientation):
 @image_comparison(['marker_styles.png'], remove_text=True)
 def test_marker_styles():
     fig, ax = plt.subplots()
-    for y, marker in enumerate(sorted(
-            {*matplotlib.markers.MarkerStyle.markers} - {"none"},
-            key=lambda x: str(type(x))+str(x))):
+    # Since generation of the test image, None was removed but 'none' was
+    # added. By moving 'none' to the front (=former sorted place of None)
+    # we can avoid regenerating the test image. This can be removed if the
+    # test image has to be regenerated for other reasons.
+    markers = sorted(matplotlib.markers.MarkerStyle.markers,
+                     key=lambda x: str(type(x))+str(x))
+    markers.remove('none')
+    markers = ['none', *markers]
+    for y, marker in enumerate(markers):
         ax.plot((y % 2)*5 + np.arange(10)*10, np.ones(10)*10*y, linestyle='',
                 marker=marker, markersize=10+y/5, label=marker)
 

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -19,7 +19,6 @@ def test_marker_fillstyle():
     'x',
     '',
     'None',
-    None,
     r'$\frac{1}{2}$',
     "$\u266B$",
     1,
@@ -40,9 +39,12 @@ def test_markers_valid(marker):
     markers.MarkerStyle(marker)
 
 
-def test_deprecated_marker_noargs():
+def test_deprecated_marker():
     with pytest.warns(MatplotlibDeprecationWarning):
         ms = markers.MarkerStyle()
+    markers.MarkerStyle(ms)  # No warning on copy.
+    with pytest.warns(MatplotlibDeprecationWarning):
+        ms = markers.MarkerStyle(None)
     markers.MarkerStyle(ms)  # No warning on copy.
 
 


### PR DESCRIPTION
See docstring change for the confusion that this resolves.
We can normalize None inputs on the caller side (and note that directly
constructing MarkerStyles is not something that most users need to do).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
