### PR TITLE
Cache build dependencies on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,13 @@ commands:
       - run:
           name: Install Matplotlib
           command: python -m pip install --user -ve .
+      - save_cache:
+          key: build-deps-1
+          paths:
+            # FreeType 2.6.1 tarball.
+            - ~/.cache/matplotlib/0a3c7dfbda6da1e8fce29232e8e96d987ababbbf71ebc8c75659e4132c367014
+            # Qhull 2020.2 tarball.
+            - ~/.cache/matplotlib/b5c2d7eb833278881b952c8a52d20179eab87766b00b865000469a45c1838b7e
 
   doc-build:
     steps:

--- a/setupext.py
+++ b/setupext.py
@@ -168,14 +168,16 @@ _freetype_hashes = {
     '2.10.1':
         '3a60d391fd579440561bf0e7f31af2222bc610ad6ce4d9d7bd2165bca8669110',
 }
-# This is the version of FreeType to use when building a local
-# version.  It must match the value in
-# lib/matplotlib.__init__.py and also needs to be changed below in the
-# embedded windows build script (grep for "REMINDER" in this file)
+# This is the version of FreeType to use when building a local version.  It
+# must match the value in lib/matplotlib.__init__.py and also needs to be
+# changed below in the embedded windows build script (grep for "REMINDER" in
+# this file). Also update the cache path in `.circleci/config.yml`.
 LOCAL_FREETYPE_VERSION = '2.6.1'
 LOCAL_FREETYPE_HASH = _freetype_hashes.get(LOCAL_FREETYPE_VERSION, 'unknown')
 
+# Also update the cache path in `.circleci/config.yml`.
 LOCAL_QHULL_VERSION = '2020.2'
+LOCAL_QHULL_HASH = 'b5c2d7eb833278881b952c8a52d20179eab87766b00b865000469a45c1838b7e'
 
 
 # Matplotlib build options, which can be altered using mplsetup.cfg
@@ -688,7 +690,7 @@ class Qhull(SetupPackage):
 
         toplevel = get_and_extract_tarball(
             urls=["http://www.qhull.org/download/qhull-2020-src-8.0.2.tgz"],
-            sha="b5c2d7eb833278881b952c8a52d20179eab87766b00b865000469a45c1838b7e",
+            sha=LOCAL_QHULL_HASH,
             dirname=f"qhull-{LOCAL_QHULL_VERSION}",
         )
         shutil.copyfile(toplevel / "COPYING.txt", "LICENSE/LICENSE_QHULL")


### PR DESCRIPTION
## PR Summary

This seems to be failing a bit more often today, so hopefully this will help a little.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).