### PR TITLE
Remove the index and module index pages

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -354,9 +354,12 @@ html_sidebars = {
     # '**': ['localtoc.html', 'pagesource.html']
 }
 
-# If false, no module index is generated.
-# html_use_modindex = True
-html_domain_indices = ["py-modindex"]
+# If true, add an index to the HTML documents.
+html_use_index = False
+
+# If true, generate domain-specific indices in addition to the general index.
+# For e.g. the Python domain, this is the global module index.
+html_domain_index = False
 
 # If true, the reST sources are included in the HTML build as _sources/<name>.
 # html_copy_source = True

--- a/doc/contents.rst
+++ b/doc/contents.rst
@@ -22,6 +22,4 @@ Contents
 
 .. only:: html
 
-  * :ref:`genindex`
-  * :ref:`modindex`
   * :ref:`search`


### PR DESCRIPTION
Index and module index are currently linked at the very bottom at:
https://matplotlib.org/devdocs/contents.html#complete-sitemap

The index is not really helpful. Search is better for all practical purposes.

The module index is redundant to the [module list on the reference page](https://matplotlib.org/devdocs/api/index.html#modules).
And the latter is better because we can control what to show; e.g. we
leave out the specific backend modules.


