### PR TITLE
Fix make_norm_from_scale `__name__` when used inline.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1561,7 +1561,8 @@ def make_norm_from_scale(scale_cls, base_norm_cls=None, *, init=None):
                      .reshape(np.shape(value)))
             return value[0] if is_scalar else value
 
-    Norm.__name__ = base_norm_cls.__name__
+    Norm.__name__ = (f"{scale_cls.__name__}Norm" if base_norm_cls is Normalize
+                     else base_norm_cls.__name__)
     Norm.__qualname__ = base_norm_cls.__qualname__
     Norm.__module__ = base_norm_cls.__module__
     Norm.__doc__ = base_norm_cls.__doc__

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1475,3 +1475,9 @@ def test_norm_update_figs(fig_test, fig_ref):
     # Force initial draw to make sure it isn't already stale
     fig_test.canvas.draw()
     norm.vmin, norm.vmax = 10, 90
+
+
+def test_make_norm_from_scale_name():
+    logitnorm = mcolors.make_norm_from_scale(
+        mscale.LogitScale, mcolors.Normalize)
+    assert logitnorm.__name__ == "LogitScaleNorm"


### PR DESCRIPTION
`make_norm_from_scale` can be used "inline", rather than as a class
decorator, to dynamically create norm classes.  However, in that case,
the second parameter (`base_norm_cls`) would normally be set to the root
base norm class (`mcolors.Normalize`).  In that case, we should
generate a new `__name__` for the dynamically generated class, to avoid
the slightly confusing situation of having two different classes both
called `mcolors.Normalize`.

(See the "additional confusion" in the expected outcome section of https://github.com/matplotlib/matplotlib/issues/20755#issue-954604558.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
