### PR TITLE
Improve errorbar plot types example

### DIFF
--- a/plot_types/stats/README.rst
+++ b/plot_types/stats/README.rst
@@ -1,6 +1,6 @@
 .. _stats_plots:
 
-Specialized statistics plots
-----------------------------
+Statistics plots
+----------------
 
-Specialized plots for statistical analysis.
+Plots for statistical analysis.

--- a/plot_types/stats/errorbar_plot.py
+++ b/plot_types/stats/errorbar_plot.py
@@ -13,13 +13,13 @@ plt.style.use('mpl_plot_gallery')
 # make data:
 np.random.seed(1)
 x = [2, 4, 6]
-y = [4, 5, 4]
-yerr = np.random.uniform(0.5, 1.5, 3)
+y = [3.6, 5, 4.2]
+yerr = [0.9, 1.2, 0.5]
 
 # plot:
 fig, ax = plt.subplots()
 
-ax.errorbar(x, y, yerr, linewidth=2, capsize=6)
+ax.errorbar(x, y, yerr, fmt='o', linewidth=2, capsize=6)
 
 ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
        ylim=(0, 8), yticks=np.arange(1, 8))


### PR DESCRIPTION
## PR Summary

- use a marker and no line for the data points
- hard-code yerr instead of using random with a fixed seed
- Slightly move y so that the data points don't always fall on the grid
- Remove "specialized" from section title. There are no more special
  than any other plots.
