### PR TITLE
Adapt css so that galleries have four columns

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -207,6 +207,12 @@ does not float with it.
 
 }
 
+/* slightly reduce horizontal margin compared to gallery.css to
+ * get four columns of thumbnails in the pydata-sphinx-theme. */
+.sphx-glr-thumbcontainer {
+    margin: 5px 2px;
+}
+
 
 table.property-table th,
 table.property-table td {


### PR DESCRIPTION
The original thumbnail margin in gallery.css is 5px. We reduce the
horizontal margin to 2px so that four columns fit within the available
width in the pydata-sphinx-theme.

