### PR TITLE
Deprecate passing formatting parameters positionally to stem()

### DIFF
--- a/doc/api/next_api_changes/deprecations/21126-TH.rst
+++ b/doc/api/next_api_changes/deprecations/21126-TH.rst
@@ -1,0 +1,2 @@
+Passing formatting parameters positionally to ``stem()`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2849,6 +2849,12 @@ class Axes(_AxesBase):
             args = ()
         else:
             locs, heads, *args = args
+        if args:
+            _api.warn_deprecated(
+                "3.5",
+                message="Passing the linefmt parameter positionally is "
+                        "deprecated since Matplotlib %(since)s; the "
+                        "parameter will become keyword-only %(removal)s.")
 
         if orientation == 'vertical':
             locs, heads = self._process_unit_info([("x", locs), ("y", heads)])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3641,8 +3641,8 @@ def test_stem_args():
     # Test the call signatures
     ax.stem(y)
     ax.stem(x, y)
-    ax.stem(x, y, 'r--')
-    ax.stem(x, y, 'r--', basefmt='b--')
+    ax.stem(x, y, linefmt='r--')
+    ax.stem(x, y, linefmt='r--', basefmt='b--')
 
 
 def test_stem_dates():
@@ -3650,7 +3650,7 @@ def test_stem_dates():
     xs = [dateutil.parser.parse("2013-9-28 11:00:00"),
           dateutil.parser.parse("2013-9-28 12:00:00")]
     ys = [100, 200]
-    ax.stem(xs, ys, "*-")
+    ax.stem(xs, ys)
 
 
 @pytest.mark.parametrize("use_line_collection", [True, False],


### PR DESCRIPTION
## PR Summary

This will allow to simplify the implementation because, currently,
`stem(*args, linefmt=None, ...)` still tries to resolve excess
positionally passed args, to *linefmt* and following parameters, which
is quite a bit of logic (see `# fallback to positional argument` comments
in the implementation).

OTOH, since we have 3 formats, passing them positionally is already
difficult from a usability/readability perspective, because they can
easily be mixed up.
