### PR TITLE
Fix decenter of image in gallery thumbnails

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -213,6 +213,10 @@ does not float with it.
     margin: 5px 2px;
 }
 
+/* workaround: the default padding decenters the image inside the frame */
+.sphx-glr-thumbcontainer .figure {
+    padding: 0;
+}
 
 table.property-table th,
 table.property-table td {


### PR DESCRIPTION
## PR Summary

When using the default padding and the pydata-sphinx-theme, the image
is shifted away from the center. While that should be fixed in
sphinx-gallery (and I will report it there), this serves as a workaround
on the matplotlib side, because I don't think they will have it fixed
ready for the 3.5 release.

Before:
![grafik](https://user-images.githubusercontent.com/2836374/133938894-c77f7ba5-29b6-4b1e-80dc-1258cae68f45.png)


After:
![grafik](https://user-images.githubusercontent.com/2836374/133938926-356fe44f-1cae-4537-9c78-690ce2a30d86.png)

