### PR TITLE
Fix polar() regression on second call failure

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2193,14 +2193,12 @@ def polar(*args, **kwargs):
     # If an axis already exists, check if it has a polar projection
     if gcf().get_axes():
         ax = gca()
-        if isinstance(ax, PolarAxes):
-            return ax
-        else:
+        if not isinstance(ax, PolarAxes):
             _api.warn_external('Trying to create polar plot on an Axes '
                                'that does not have a polar projection.')
-    ax = axes(projection="polar")
-    ret = ax.plot(*args, **kwargs)
-    return ret
+    else:
+        ax = axes(projection="polar")
+    return ax.plot(*args, **kwargs)
 
 
 # If rcParams['backend_fallback'] is true, and an interactive backend is

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -314,9 +314,9 @@ def test_subplot_change_projection():
 
 def test_polar_second_call():
     # the first call creates the axes with polar projection
-    h1 = plt.polar(0., 1., 'ro')
-    assert isinstance(h1[0], mpl.lines.Line2D)
+    ln1, = plt.polar(0., 1., 'ro')
+    assert isinstance(ln1, mpl.lines.Line2D)
     # the second call should reuse the existing axes
-    h2 = plt.polar(1.57, .5, 'bo')
-    assert isinstance(h2[0], mpl.lines.Line2D)
-    assert h1[0].axes is h2[0].axes
+    ln2, = plt.polar(1.57, .5, 'bo')
+    assert isinstance(ln2, mpl.lines.Line2D)
+    assert ln1.axes is ln2.axes

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -310,3 +310,13 @@ def test_subplot_change_projection():
         assert ax_next.name == proj
         assert ax is not ax_next
         ax = ax_next
+
+
+def test_polar_second_call():
+    # the first call creates the axes with polar projection
+    h1 = plt.polar(0., 1., 'ro')
+    assert isinstance(h1[0], mpl.lines.Line2D)
+    # the second call should reuse the existing axes
+    h2 = plt.polar(1.57, .5, 'bo')
+    assert isinstance(h2[0], mpl.lines.Line2D)
+    assert h1[0].axes is h2[0].axes


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
