### PR TITLE
More (minor) plot types gallery fixes.

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -70,12 +70,12 @@ list_all = [
     # Basic
     "plot", "scatter_plot", "bar", "stem", "step", "pie", "fill_between",
     # Arrays
-    "imshow", "pcolormesh", "contourf", "quiver", "streamplot",
+    "imshow", "pcolormesh", "contour", "contourf", "quiver", "streamplot",
     # Stats
     "hist_plot", "boxplot_plot", "errorbar_plot", "violin",
     "barbs", "eventplot", "hist2d", "hexbin",
     # Unstructured
-    "tricontour", "tripcolor", "triplot",
+    "tricontour", "tricontourf", "tripcolor", "triplot",
     ]
 explicit_subsection_order = [item + ".py" for item in list_all]
 

--- a/lib/matplotlib/mpl-data/stylelib/_mpl-gallery-nogrid.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_mpl-gallery-nogrid.mplstyle
@@ -1,0 +1,19 @@
+# This style is used for the plot_types gallery. It is considered private.
+
+axes.grid: False
+axes.axisbelow: True
+
+figure.figsize: 2, 2
+# make it so the axes labels don't show up.  Obviously 
+# not good style for any quantitative analysis:
+figure.subplot.left: 0.01
+figure.subplot.right: 0.99
+figure.subplot.bottom: 0.01
+figure.subplot.top: 0.99
+
+xtick.major.size: 0.0
+ytick.major.size: 0.0
+
+# colors:
+image.cmap    : Blues
+# axes.prop_cycle: cycler('color', ['FF7F0E', '1F77B4', '2CA02C'])

--- a/lib/matplotlib/mpl-data/stylelib/_mpl-gallery.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_mpl-gallery.mplstyle
@@ -1,4 +1,4 @@
-# from the Matplotlib cheatsheet as used in our gallery:
+# This style is used for the plot_types gallery. It is considered private.
 
 axes.grid: True
 axes.axisbelow: True

--- a/lib/matplotlib/mpl-data/stylelib/_mpl-gallery.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_mpl-gallery.mplstyle
@@ -1,4 +1,4 @@
-# This style is used for the plot_types gallery. It is considered private.
+# This style is used for the plot_types gallery. It is considered part of the private API.
 
 axes.grid: True
 axes.axisbelow: True

--- a/plot_types/arrays/contour.py
+++ b/plot_types/arrays/contour.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.contour`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -17,7 +17,6 @@ levels = np.linspace(np.min(Z), np.max(Z), 7)
 
 # plot
 fig, ax = plt.subplots()
-ax.grid(False)
 
 ax.contour(X, Y, Z, levels=levels)
 

--- a/plot_types/arrays/contourf.py
+++ b/plot_types/arrays/contourf.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.contourf`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))

--- a/plot_types/arrays/imshow.py
+++ b/plot_types/arrays/imshow.py
@@ -13,7 +13,7 @@ plt.style.use('_mpl-gallery-nogrid')
 
 # make data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-Z = (1 - X/2. + X**5 + Y**3) * np.exp(-X**2 - Y**2)
+Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
 Z = Z[::16, ::16]
 
 # plot

--- a/plot_types/arrays/imshow.py
+++ b/plot_types/arrays/imshow.py
@@ -9,7 +9,7 @@ See `~matplotlib.axes.Axes.imshow`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -18,7 +18,6 @@ Z = Z[::16, ::16]
 
 # plot
 fig, ax = plt.subplots()
-ax.grid(False)
 
 ax.imshow(Z)
 

--- a/plot_types/arrays/pcolormesh.py
+++ b/plot_types/arrays/pcolormesh.py
@@ -10,7 +10,7 @@ the x and y vectors need not be equally spaced (indeed they can be skewed).
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make full-res data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -26,7 +26,6 @@ Z = Z[::8, :][:, xint]
 
 # plot
 fig, ax = plt.subplots()
-ax.grid(False)
 
 ax.pcolormesh(X, Y, Z, vmin=-0.5, vmax=1.0)
 

--- a/plot_types/arrays/pcolormesh.py
+++ b/plot_types/arrays/pcolormesh.py
@@ -14,7 +14,7 @@ plt.style.use('_mpl-gallery-nogrid')
 
 # make full-res data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-Z = (1 - X/2. + X**5 + Y**3) * np.exp(-X**2 - Y**2)
+Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
 
 # sample unevenly in x:
 dx = np.sqrt((np.arange(16) - 8)**2) + 6

--- a/plot_types/arrays/quiver.py
+++ b/plot_types/arrays/quiver.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.quiver`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data
 phi = np.linspace(0, 2 * np.pi, 8)

--- a/plot_types/arrays/streamplot.py
+++ b/plot_types/arrays/streamplot.py
@@ -12,7 +12,7 @@ plt.style.use('_mpl-gallery-nogrid')
 
 # make a stream function:
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-Z = (1 - X/2. + X**5 + Y**3) * np.exp(-X**2 - Y**2)
+Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
 # make U and V out of the streamfunction:
 V = np.diff(Z[1:, :], axis=1)
 U = -np.diff(Z[:, 1:], axis=0)
@@ -20,7 +20,6 @@ U = -np.diff(Z[:, 1:], axis=0)
 # plot:
 fig, ax = plt.subplots()
 
-# plot stream plot
 ax.streamplot(X[1:, 1:], Y[1:, 1:], U, V)
 
 plt.show()

--- a/plot_types/arrays/streamplot.py
+++ b/plot_types/arrays/streamplot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.streamplot`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make a stream function:
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -19,7 +19,6 @@ U = -np.diff(Z[:, 1:], axis=0)
 
 # plot:
 fig, ax = plt.subplots()
-ax.grid(False)
 
 # plot stream plot
 ax.streamplot(X[1:, 1:], Y[1:, 1:], U, V)

--- a/plot_types/basic/bar.py
+++ b/plot_types/basic/bar.py
@@ -7,7 +7,7 @@ See `~matplotlib.axes.Axes.bar` / `~matplotlib.axes.Axes.barh`.
 """
 import matplotlib.pyplot as plt
 import numpy as np
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data:
 np.random.seed(3)

--- a/plot_types/basic/pie.py
+++ b/plot_types/basic/pie.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.pie`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 
 # make data

--- a/plot_types/basic/plot.py
+++ b/plot_types/basic/plot.py
@@ -9,7 +9,7 @@ See `~matplotlib.axes.Axes.plot`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data
 x = np.linspace(0, 10, 100)

--- a/plot_types/basic/scatter_plot.py
+++ b/plot_types/basic/scatter_plot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.scatter`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make the data
 np.random.seed(3)

--- a/plot_types/basic/stem.py
+++ b/plot_types/basic/stem.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.stem`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data
 np.random.seed(3)

--- a/plot_types/basic/step.py
+++ b/plot_types/basic/step.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.step`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data
 np.random.seed(3)

--- a/plot_types/stats/barbs.py
+++ b/plot_types/stats/barbs.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.barbs`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data:
 np.random.seed(1)

--- a/plot_types/stats/boxplot_plot.py
+++ b/plot_types/stats/boxplot_plot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.boxplot`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data:
 np.random.seed(10)

--- a/plot_types/stats/errorbar_plot.py
+++ b/plot_types/stats/errorbar_plot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.errorbar`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data:
 np.random.seed(1)

--- a/plot_types/stats/eventplot.py
+++ b/plot_types/stats/eventplot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.eventplot`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data:
 np.random.seed(1)

--- a/plot_types/stats/hexbin.py
+++ b/plot_types/stats/hexbin.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.hexbin`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make data: correlated + noise
 np.random.seed(1)

--- a/plot_types/stats/hist2d.py
+++ b/plot_types/stats/hist2d.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.hist2d`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make data: correlated + noise
 np.random.seed(1)

--- a/plot_types/stats/hist_plot.py
+++ b/plot_types/stats/hist_plot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.hist`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data
 np.random.seed(1)

--- a/plot_types/stats/violin.py
+++ b/plot_types/stats/violin.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.violinplot`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery')
 
 # make data:
 np.random.seed(10)

--- a/plot_types/unstructured/tricontour.py
+++ b/plot_types/unstructured/tricontour.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.tricontour`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make structured data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -25,7 +25,6 @@ z = Z[ysamp, xsamp]
 
 # plot:
 fig, ax = plt.subplots()
-ax.grid(False)
 
 ax.plot(x, y, 'o', markersize=2, color='lightgrey')
 ax.tricontour(x, y, z, levels=levels)

--- a/plot_types/unstructured/tricontour.py
+++ b/plot_types/unstructured/tricontour.py
@@ -10,18 +10,12 @@ import numpy as np
 
 plt.style.use('_mpl-gallery-nogrid')
 
-# make structured data
-X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
-levels = np.linspace(Z.min(), Z.max(), 7)
-
-# sample it to make unstructured x, y, z
+# make data:
 np.random.seed(1)
-ysamp = np.random.randint(0, 256, size=250)
-xsamp = np.random.randint(0, 256, size=250)
-y = Y[:, 0][ysamp]
-x = X[0, :][xsamp]
-z = Z[ysamp, xsamp]
+x = np.random.uniform(-3, 3, 256)
+y = np.random.uniform(-3, 3, 256)
+z = (1 - x/2 + x**5 + y**3) * np.exp(-x**2 - y**2)
+levels = np.linspace(z.min(), z.max(), 7)
 
 # plot:
 fig, ax = plt.subplots()

--- a/plot_types/unstructured/tricontourf.py
+++ b/plot_types/unstructured/tricontourf.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.tricontourf`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make structured data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -25,7 +25,6 @@ z = Z[ysamp, xsamp]
 
 # plot:
 fig, ax = plt.subplots()
-ax.grid(False)
 
 ax.plot(x, y, 'o', markersize=2, color='grey')
 ax.tricontourf(x, y, z, levels=levels)

--- a/plot_types/unstructured/tricontourf.py
+++ b/plot_types/unstructured/tricontourf.py
@@ -10,18 +10,12 @@ import numpy as np
 
 plt.style.use('_mpl-gallery-nogrid')
 
-# make structured data
-X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
-levels = np.linspace(np.min(Z), np.max(Z), 7)
-
-# sample it to make unstructured x, y, z
+# make data:
 np.random.seed(1)
-ysamp = np.random.randint(0, 256, size=250)
-xsamp = np.random.randint(0, 256, size=250)
-y = Y[:, 0][ysamp]
-x = X[0, :][xsamp]
-z = Z[ysamp, xsamp]
+x = np.random.uniform(-3, 3, 256)
+y = np.random.uniform(-3, 3, 256)
+z = (1 - x/2 + x**5 + y**3) * np.exp(-x**2 - y**2)
+levels = np.linspace(z.min(), z.max(), 7)
 
 # plot:
 fig, ax = plt.subplots()

--- a/plot_types/unstructured/tripcolor.py
+++ b/plot_types/unstructured/tripcolor.py
@@ -10,17 +10,11 @@ import numpy as np
 
 plt.style.use('_mpl-gallery-nogrid')
 
-# make structured data
-X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
-
-# sample it to make unstructured x, y, z
+# make data:
 np.random.seed(1)
-ysamp = np.random.randint(0, 256, size=250)
-xsamp = np.random.randint(0, 256, size=250)
-y = Y[:, 0][ysamp]
-x = X[0, :][xsamp]
-z = Z[ysamp, xsamp]
+x = np.random.uniform(-3, 3, 256)
+y = np.random.uniform(-3, 3, 256)
+z = (1 - x/2 + x**5 + y**3) * np.exp(-x**2 - y**2)
 
 # plot:
 fig, ax = plt.subplots()

--- a/plot_types/unstructured/tripcolor.py
+++ b/plot_types/unstructured/tripcolor.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.tripcolor`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make structured data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))

--- a/plot_types/unstructured/triplot.py
+++ b/plot_types/unstructured/triplot.py
@@ -10,15 +10,11 @@ import numpy as np
 
 plt.style.use('_mpl-gallery-nogrid')
 
-# make structured data
-X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
-
-# sample it to make x, y, z
+# make data:
 np.random.seed(1)
-ysamp = np.random.randint(0, 256, size=250)
-xsamp = np.random.randint(0, 256, size=250)
-y = Y[:, 0][ysamp]
-x = X[0, :][xsamp]
+x = np.random.uniform(-3, 3, 256)
+y = np.random.uniform(-3, 3, 256)
+z = (1 - x/2 + x**5 + y**3) * np.exp(-x**2 - y**2)
 
 # plot:
 fig, ax = plt.subplots()

--- a/plot_types/unstructured/triplot.py
+++ b/plot_types/unstructured/triplot.py
@@ -8,7 +8,7 @@ See `~matplotlib.axes.Axes.triplot`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('mpl_plot_gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make structured data
 X, Y = np.meshgrid(np.linspace(-3, 3, 256), np.linspace(-3, 3, 256))
@@ -22,7 +22,6 @@ x = X[0, :][xsamp]
 
 # plot:
 fig, ax = plt.subplots()
-ax.grid(False)
 
 ax.triplot(x, y)
 


### PR DESCRIPTION
## PR Summary

All changes are small. I thought it's ok to put them in a single PR to not run CI that often.

- Include new plots into gallery ordering
- Use a second style for plot types gallery entries without grid - to declutter the actual plotting code more (removes `ax.grid(False)`
- Minor formatting fixes
- Simplify unstructured data generation: There is no need to generate a regular grid and statistically choose points from that. Instead, we can immediately choose random points.
