### PR TITLE
Small cleanups to colorbar.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1106,18 +1106,14 @@ class Colorbar:
         norm = copy.deepcopy(self.norm)
         norm.vmin = self.vmin
         norm.vmax = self.vmax
-        x = np.array([0.0, 1.0])
         y, extendlen = self._proportional_y()
         # invert:
-        if (isinstance(norm, (colors.BoundaryNorm, colors.NoNorm)) or
-                (self.__scale == 'manual')):
-            # if a norm doesn't have a named scale, or we are not using a norm:
-            dv = self.vmax - self.vmin
-            y = y * dv + self.vmin
+        if isinstance(norm, (colors.BoundaryNorm, colors.NoNorm)):
+            y = y * (self.vmax - self.vmin) + self.vmin  # not using a norm.
         else:
             y = norm.inverse(y)
         self._y = y
-        X, Y = np.meshgrid(x, y)
+        X, Y = np.meshgrid([0., 1.], y)
         if self.orientation == 'vertical':
             return (X, Y, extendlen)
         else:
@@ -1152,8 +1148,8 @@ class Colorbar:
                 self._set_scale('function', functions=funcs)
             elif self.spacing == 'proportional':
                 self._set_scale('linear')
-        elif hasattr(self.norm, '_scale') and self.norm._scale is not None:
-            # use the norm's scale:
+        elif getattr(self.norm, '_scale', None):
+            # use the norm's scale (if it exists and is not None):
             self._set_scale(self.norm._scale)
         elif type(self.norm) is colors.Normalize:
             # plain Normalize:


### PR DESCRIPTION
- `__scale = "manual"` doesn't exist anymore since d1c5a6a.
- Shorten Boundary/NoNorm inversion and norm._scale check.
- No need to define `x` well before its use point, and no need to make
  it an array explicitly.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
