### PR TITLE
Mac qt ctrl

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -171,37 +171,38 @@ jobs:
           # (sometimes, the install appears to be successful but shared
           # libraries cannot be loaded at runtime, so an actual import is a
           # better check).
-          if [[ "${{ runner.os }}" != 'macOS' ]]; then
-            # PyGObject, pycairo, and cariocffi do not install on OSX 10.12.
-             python -m pip install --upgrade pycairo 'cairocffi>=0.8' PyGObject &&
-               python -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' &&
-               echo 'PyGObject is available' ||
-               echo 'PyGObject is not available'
+          # PyGObject, pycairo, and cariocffi do not install on OSX 10.12.
+           python -m pip install --upgrade pycairo 'cairocffi>=0.8' PyGObject &&
+             python -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' &&
+             echo 'PyGObject is available' ||
+             echo 'PyGObject is not available'
 
-            # There are no functioning wheels available for OSX 10.12 (as of
-            # Sept 2020) for either pyqt5 (there are only wheels for 10.13+) or
-            # pyside2 (the latest version (5.13.2) with 10.12 wheels has a
-            # fatal to us bug, it was fixed in 5.14.0 which has 10.13 wheels)
-            python -mpip install --upgrade pyqt5${{ matrix.pyqt5-ver }} &&
-              python -c 'import PyQt5.QtCore' &&
-              echo 'PyQt5 is available' ||
-              echo 'PyQt5 is not available'
+          # There are no functioning wheels available for OSX 10.12 (as of
+          # Sept 2020) for either pyqt5 (there are only wheels for 10.13+) or
+          # pyside2 (the latest version (5.13.2) with 10.12 wheels has a
+          # fatal to us bug, it was fixed in 5.14.0 which has 10.13 wheels)
+          python -mpip install --upgrade pyqt5${{ matrix.pyqt5-ver }} &&
+            python -c 'import PyQt5.QtCore' &&
+            echo 'PyQt5 is available' ||
+            echo 'PyQt5 is not available'
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
             python -mpip install --upgrade pyside2 &&
               python -c 'import PySide2.QtCore' &&
               echo 'PySide2 is available' ||
               echo 'PySide2 is not available'
-            # Qt6 crashes on Github's ubuntu 18.04 runner.
-            if [[ "${{ matrix.os }}" = ubuntu-20.04 ]]; then
-              python -mpip install --upgrade pyqt6 &&
-                python -c 'import PyQt6.QtCore' &&
-                echo 'PyQt6 is available' ||
-                echo 'PyQt6 is not available'
-              python -mpip install --upgrade pyside6 &&
-                python -c 'import PySide6.QtCore' &&
-                echo 'PySide6 is available' ||
-                echo 'PySide6 is not available'
-            fi
           fi
+          # Qt6 crashes on Github's ubuntu 18.04 runner.
+          if [[ "${{ matrix.os }}" = ubuntu-20.04 ]]; then
+            python -mpip install --upgrade pyqt6 &&
+              python -c 'import PyQt6.QtCore' &&
+              echo 'PyQt6 is available' ||
+              echo 'PyQt6 is not available'
+            python -mpip install --upgrade pyside6 &&
+              python -c 'import PySide6.QtCore' &&
+              echo 'PySide6 is available' ||
+              echo 'PySide6 is not available'
+          fi
+
           python -mpip install --upgrade \
             -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}" \
             wxPython &&

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -166,24 +166,33 @@ def test_fig_sigint_override(qt_core):
 
 
 @pytest.mark.parametrize(
-    'qt_key, qt_mods, answer',
+    "qt_key, qt_mods, answer",
     [
-        ('Key_A', ['ShiftModifier'], 'A'),
-        ('Key_A', [], 'a'),
-        ('Key_A', ['ControlModifier'], 'ctrl+a'),
-        ('Key_Aacute', ['ShiftModifier'],
-         '\N{LATIN CAPITAL LETTER A WITH ACUTE}'),
-        ('Key_Aacute', [],
-         '\N{LATIN SMALL LETTER A WITH ACUTE}'),
-        ('Key_Control', ['AltModifier'], 'alt+control'),
-        ('Key_Alt', ['ControlModifier'], 'ctrl+alt'),
-        ('Key_Aacute', ['ControlModifier', 'AltModifier', 'MetaModifier'],
-         'ctrl+alt+meta+\N{LATIN SMALL LETTER A WITH ACUTE}'),
+        ("Key_A", ["ShiftModifier"], "A"),
+        ("Key_A", [], "a"),
+        ("Key_A", ["ControlModifier"], ("ctrl+a")),
+        (
+            "Key_Aacute",
+            ["ShiftModifier"],
+            "\N{LATIN CAPITAL LETTER A WITH ACUTE}",
+        ),
+        ("Key_Aacute", [], "\N{LATIN SMALL LETTER A WITH ACUTE}"),
+        ("Key_Control", ["AltModifier"], ("alt+control")),
+        ("Key_Alt", ["ControlModifier"], "ctrl+alt"),
+        (
+            "Key_Aacute",
+            ["ControlModifier", "AltModifier", "MetaModifier"],
+            ("ctrl+alt+meta+\N{LATIN SMALL LETTER A WITH ACUTE}"),
+        ),
         # We do not currently map the media keys, this may change in the
         # future.  This means the callback will never fire
-        ('Key_Play', [], None),
-        ('Key_Backspace', [], 'backspace'),
-        ('Key_Backspace', ['ControlModifier'], 'ctrl+backspace'),
+        ("Key_Play", [], None),
+        ("Key_Backspace", [], "backspace"),
+        (
+            "Key_Backspace",
+            ["ControlModifier"],
+            "ctrl+backspace",
+        ),
     ],
     ids=[
         'shift',
@@ -216,6 +225,11 @@ def test_correct_key(backend, qt_core, qt_key, qt_mods, answer):
     Assert sent and caught keys are the same.
     """
     from matplotlib.backends.qt_compat import _enum, _to_int
+
+    if sys.platform == "darwin" and answer is not None:
+        answer = answer.replace("ctrl", "cmd")
+        answer = answer.replace("control", "cmd")
+        answer = answer.replace("meta", "ctrl")
     result = None
     qt_mod = _enum("QtCore.Qt.KeyboardModifier").NoModifier
     for mod in qt_mods:

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -93,10 +93,10 @@ def test_other_signal_before_sigint(qt_core, platform_simulate_ctrl_c,
     def custom_sigpipe_handler(signum, frame):
         nonlocal sigcld_caught
         sigcld_caught = True
-    signal.signal(signal.SIGCLD, custom_sigpipe_handler)
+    signal.signal(signal.SIGCHLD, custom_sigpipe_handler)
 
     def fire_other_signal():
-        os.kill(os.getpid(), signal.SIGCLD)
+        os.kill(os.getpid(), signal.SIGCHLD)
 
     def fire_sigint():
         platform_simulate_ctrl_c()


### PR DESCRIPTION
## PR Summary

closes #21110

This fixes the QT tests to pass on OSX and tries to enable running them on GHA.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
