### PR TITLE
Fix format_cursor_data with nans.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1274,11 +1274,18 @@ class Artist:
             # Artist.format_cursor_data would always have precedence over
             # ScalarMappable.format_cursor_data.
             n = self.cmap.N
-            # Midpoints of neighboring color intervals.
-            neighbors = self.norm.inverse(
-                (int(self.norm(data) * n) + np.array([0, 1])) / n)
-            delta = abs(neighbors - data).max()
-            return "[{:-#.{}g}]".format(data, cbook._g_sig_digits(data, delta))
+            if np.ma.getmask(data):
+                return "[]"
+            normed = self.norm(data)
+            if np.isfinite(normed):
+                # Midpoints of neighboring color intervals.
+                neighbors = self.norm.inverse(
+                    (int(self.norm(data) * n) + np.array([0, 1])) / n)
+                delta = abs(neighbors - data).max()
+                g_sig_digits = cbook._g_sig_digits(data, delta)
+            else:
+                g_sig_digits = 3  # Consistent with default below.
+            return "[{:-#.{}g}]".format(data, g_sig_digits)
         else:
             try:
                 data[0]

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -340,6 +340,7 @@ def test_cursor_data():
     "data, text", [
         ([[10001, 10000]], "[10001.000]"),
         ([[.123, .987]], "[0.123]"),
+        ([[np.nan, 1, 2]], "[]"),
     ])
 def test_format_cursor_data(data, text):
     from matplotlib.backend_bases import MouseEvent
@@ -349,7 +350,6 @@ def test_format_cursor_data(data, text):
 
     xdisp, ydisp = ax.transData.transform([0, 0])
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
-    assert im.get_cursor_data(event) == data[0][0]
     assert im.format_cursor_data(im.get_cursor_data(event)) == text
 
 


### PR DESCRIPTION
Without this fix, hovering the mouse over a nan pixel in an imshow()
would result in `Warning: converting a masked element to nan.` and then
`ValueError: cannot convert float NaN to integer`.  Fix that.

The format_cursor_data test doesn't explicitly check the return value
of get_cursor_data anymore because np.ma.masked is returned for nan
inputs (this is expected from the general approach for handling invalid
data); checking that format_cursor_data gives the right string is
sufficient.

Regression coming from #20949.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
