### PR TITLE
Rename `**kw` to `**kwargs`.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -54,29 +54,29 @@ class Tick(martist.Artist):
         The right/top tick label.
 
     """
-    def __init__(self, axes, loc, *,
-                 size=None,  # points
-                 width=None,
-                 color=None,
-                 tickdir=None,
-                 pad=None,
-                 labelsize=None,
-                 labelcolor=None,
-                 zorder=None,
-                 gridOn=None,  # defaults to axes.grid depending on
-                               # axes.grid.which
-                 tick1On=True,
-                 tick2On=True,
-                 label1On=True,
-                 label2On=False,
-                 major=True,
-                 labelrotation=0,
-                 grid_color=None,
-                 grid_linestyle=None,
-                 grid_linewidth=None,
-                 grid_alpha=None,
-                 **kw  # Other Line2D kwargs applied to gridlines.
-                 ):
+    def __init__(
+        self, axes, loc, *,
+        size=None,  # points
+        width=None,
+        color=None,
+        tickdir=None,
+        pad=None,
+        labelsize=None,
+        labelcolor=None,
+        zorder=None,
+        gridOn=None,  # defaults to axes.grid depending on axes.grid.which
+        tick1On=True,
+        tick2On=True,
+        label1On=True,
+        label2On=False,
+        major=True,
+        labelrotation=0,
+        grid_color=None,
+        grid_linestyle=None,
+        grid_linewidth=None,
+        grid_alpha=None,
+        **kwargs,  # Other Line2D kwargs applied to gridlines.
+    ):
         """
         bbox is the Bound2D bounding box in display coords of the Axes
         loc is the tick location in data coords
@@ -145,7 +145,7 @@ class Tick(martist.Artist):
             grid_linewidth = mpl.rcParams["grid.linewidth"]
         if grid_alpha is None:
             grid_alpha = mpl.rcParams["grid.alpha"]
-        grid_kw = {k[5:]: v for k, v in kw.items()}
+        grid_kw = {k[5:]: v for k, v in kwargs.items()}
 
         self.tick1line = mlines.Line2D(
             [], [],
@@ -346,23 +346,23 @@ class Tick(martist.Artist):
         """
         raise NotImplementedError('Derived must override')
 
-    def _apply_params(self, **kw):
+    def _apply_params(self, **kwargs):
         for name, target in [("gridOn", self.gridline),
                              ("tick1On", self.tick1line),
                              ("tick2On", self.tick2line),
                              ("label1On", self.label1),
                              ("label2On", self.label2)]:
-            if name in kw:
-                target.set_visible(kw.pop(name))
-        if any(k in kw for k in ['size', 'width', 'pad', 'tickdir']):
-            self._size = kw.pop('size', self._size)
+            if name in kwargs:
+                target.set_visible(kwargs.pop(name))
+        if any(k in kwargs for k in ['size', 'width', 'pad', 'tickdir']):
+            self._size = kwargs.pop('size', self._size)
             # Width could be handled outside this block, but it is
             # convenient to leave it here.
-            self._width = kw.pop('width', self._width)
-            self._base_pad = kw.pop('pad', self._base_pad)
+            self._width = kwargs.pop('width', self._width)
+            self._base_pad = kwargs.pop('pad', self._base_pad)
             # _apply_tickdir uses _size and _base_pad to make _pad, and also
             # sets the ticklines markers.
-            self._apply_tickdir(kw.pop('tickdir', self._tickdir))
+            self._apply_tickdir(kwargs.pop('tickdir', self._tickdir))
             for line in (self.tick1line, self.tick2line):
                 line.set_markersize(self._size)
                 line.set_markeredgewidth(self._width)
@@ -371,25 +371,25 @@ class Tick(martist.Artist):
             self.label1.set_transform(trans)
             trans = self._get_text2_transform()[0]
             self.label2.set_transform(trans)
-        tick_kw = {k: v for k, v in kw.items() if k in ['color', 'zorder']}
-        if 'color' in kw:
-            tick_kw['markeredgecolor'] = kw['color']
+        tick_kw = {k: v for k, v in kwargs.items() if k in ['color', 'zorder']}
+        if 'color' in kwargs:
+            tick_kw['markeredgecolor'] = kwargs['color']
         self.tick1line.set(**tick_kw)
         self.tick2line.set(**tick_kw)
         for k, v in tick_kw.items():
             setattr(self, '_' + k, v)
 
-        if 'labelrotation' in kw:
-            self._set_labelrotation(kw.pop('labelrotation'))
+        if 'labelrotation' in kwargs:
+            self._set_labelrotation(kwargs.pop('labelrotation'))
             self.label1.set(rotation=self._labelrotation[1])
             self.label2.set(rotation=self._labelrotation[1])
 
-        label_kw = {k[5:]: v for k, v in kw.items()
+        label_kw = {k[5:]: v for k, v in kwargs.items()
                     if k in ['labelsize', 'labelcolor']}
         self.label1.set(**label_kw)
         self.label2.set(**label_kw)
 
-        grid_kw = {k[5:]: v for k, v in kw.items()
+        grid_kw = {k[5:]: v for k, v in kwargs.items()
                    if k in _gridline_param_names}
         self.gridline.set(**grid_kw)
 
@@ -847,7 +847,7 @@ class Axis(martist.Artist):
         except AttributeError:
             pass
 
-    def set_tick_params(self, which='major', reset=False, **kw):
+    def set_tick_params(self, which='major', reset=False, **kwargs):
         """
         Set appearance parameters for ticks, ticklabels, and gridlines.
 
@@ -855,7 +855,7 @@ class Axis(martist.Artist):
         :meth:`matplotlib.axes.Axes.tick_params`.
         """
         _api.check_in_list(['major', 'minor', 'both'], which=which)
-        kwtrans = self._translate_tick_kw(kw)
+        kwtrans = self._translate_tick_kw(kwargs)
 
         # the kwargs are stored in self._major/minor_tick_kw so that any
         # future new ticks will automatically get them

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -204,7 +204,7 @@ class __getattr__:
         lambda self: _make_axes_param_doc + _make_axes_other_param_doc))
 
 
-def _set_ticks_on_axis_warn(*args, **kw):
+def _set_ticks_on_axis_warn(*args, **kwargs):
     # a top level function which gets put in at the axes'
     # set_xticks and set_yticks by Colorbar.__init__.
     _api.warn_external("Use the colorbar set_ticks() method instead.")
@@ -1355,7 +1355,7 @@ def _normalize_location_orientation(location, orientation):
 
 @docstring.Substitution(_make_axes_param_doc, _make_axes_other_param_doc)
 def make_axes(parents, location=None, orientation=None, fraction=0.15,
-              shrink=1.0, aspect=20, **kw):
+              shrink=1.0, aspect=20, **kwargs):
     """
     Create an `~.axes.Axes` suitable for a colorbar.
 
@@ -1372,7 +1372,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     -------
     cax : `~.axes.Axes`
         The child axes.
-    kw : dict
+    kwargs : dict
         The reduced keyword dictionary to be passed when creating the colorbar
         instance.
 
@@ -1381,13 +1381,13 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     %s
     """
     loc_settings = _normalize_location_orientation(location, orientation)
-    # put appropriate values into the kw dict for passing back to
+    # put appropriate values into the kwargs dict for passing back to
     # the Colorbar class
-    kw['orientation'] = loc_settings['orientation']
-    location = kw['ticklocation'] = loc_settings['location']
+    kwargs['orientation'] = loc_settings['orientation']
+    location = kwargs['ticklocation'] = loc_settings['location']
 
-    anchor = kw.pop('anchor', loc_settings['anchor'])
-    panchor = kw.pop('panchor', loc_settings['panchor'])
+    anchor = kwargs.pop('anchor', loc_settings['anchor'])
+    panchor = kwargs.pop('panchor', loc_settings['panchor'])
     aspect0 = aspect
     # turn parents into a list if it is not already. We do this w/ np
     # because `plt.subplots` can return an ndarray and is natural to
@@ -1396,7 +1396,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     fig = parents[0].get_figure()
 
     pad0 = 0.05 if fig.get_constrained_layout() else loc_settings['pad']
-    pad = kw.pop('pad', pad0)
+    pad = kwargs.pop('pad', pad0)
 
     if not all(fig is ax.get_figure() for ax in parents):
         raise ValueError('Unable to create a colorbar axes as not all '
@@ -1453,12 +1453,12 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     cax.set_box_aspect(aspect)
     cax.set_aspect('auto')
 
-    return cax, kw
+    return cax, kwargs
 
 
 @docstring.Substitution(_make_axes_param_doc, _make_axes_other_param_doc)
 def make_axes_gridspec(parent, *, location=None, orientation=None,
-                       fraction=0.15, shrink=1.0, aspect=20, **kw):
+                       fraction=0.15, shrink=1.0, aspect=20, **kwargs):
     """
     Create a `.SubplotBase` suitable for a colorbar.
 
@@ -1488,7 +1488,7 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
     -------
     cax : `~.axes.SubplotBase`
         The child axes.
-    kw : dict
+    kwargs : dict
         The reduced keyword dictionary to be passed when creating the colorbar
         instance.
 
@@ -1498,13 +1498,13 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
     """
 
     loc_settings = _normalize_location_orientation(location, orientation)
-    kw['orientation'] = loc_settings['orientation']
-    location = kw['ticklocation'] = loc_settings['location']
+    kwargs['orientation'] = loc_settings['orientation']
+    location = kwargs['ticklocation'] = loc_settings['location']
 
     aspect0 = aspect
-    anchor = kw.pop('anchor', loc_settings['anchor'])
-    panchor = kw.pop('panchor', loc_settings['panchor'])
-    pad = kw.pop('pad', loc_settings["pad"])
+    anchor = kwargs.pop('anchor', loc_settings['anchor'])
+    panchor = kwargs.pop('panchor', loc_settings['panchor'])
+    pad = kwargs.pop('pad', loc_settings["pad"])
     wh_space = 2 * pad / (1 - pad)
 
     if location in ('left', 'right'):
@@ -1565,7 +1565,7 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
         fraction=fraction,
         aspect=aspect0,
         pad=pad)
-    return cax, kw
+    return cax, kwargs
 
 
 @_api.deprecated("3.4", alternative="Colorbar")

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1127,7 +1127,8 @@ default: %(va)s
         return text
 
     @docstring.dedent_interpd
-    def colorbar(self, mappable, cax=None, ax=None, use_gridspec=True, **kw):
+    def colorbar(
+            self, mappable, cax=None, ax=None, use_gridspec=True, **kwargs):
         """%(colorbar_doc)s"""
         if ax is None:
             ax = self.gca()
@@ -1146,16 +1147,16 @@ default: %(va)s
             userax = False
             if (use_gridspec and isinstance(ax, SubplotBase)
                     and not self.get_constrained_layout()):
-                cax, kw = cbar.make_axes_gridspec(ax, **kw)
+                cax, kwargs = cbar.make_axes_gridspec(ax, **kwargs)
             else:
-                cax, kw = cbar.make_axes(ax, **kw)
+                cax, kwargs = cbar.make_axes(ax, **kwargs)
         else:
             userax = True
 
         # need to remove kws that cannot be passed to Colorbar
         NON_COLORBAR_KEYS = ['fraction', 'pad', 'shrink', 'aspect', 'anchor',
                              'panchor']
-        cb_kw = {k: v for k, v in kw.items() if k not in NON_COLORBAR_KEYS}
+        cb_kw = {k: v for k, v in kwargs.items() if k not in NON_COLORBAR_KEYS}
 
         cb = cbar.Colorbar(cax, mappable, **cb_kw)
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2128,7 +2128,7 @@ class _Style:
     where actual styles are declared as subclass of it, and it
     provides some helper functions.
     """
-    def __new__(cls, stylename, **kw):
+    def __new__(cls, stylename, **kwargs):
         """Return the instance of the subclass with the given style name."""
 
         # The "class" should have the _style_list attribute, which is a mapping
@@ -2147,7 +2147,7 @@ class _Style:
         except ValueError as err:
             raise ValueError("Incorrect style argument : %s" %
                              stylename) from err
-        _args.update(kw)
+        _args.update(kwargs)
 
         return _cls(**_args)
 
@@ -4329,7 +4329,7 @@ default: 'arc3'
         self.patchB = patchB
         self.stale = True
 
-    def set_connectionstyle(self, connectionstyle, **kw):
+    def set_connectionstyle(self, connectionstyle, **kwargs):
         """
         Set the connection style. Old attributes are forgotten.
 
@@ -4356,14 +4356,14 @@ default: 'arc3'
                 callable(connectionstyle)):
             self._connector = connectionstyle
         else:
-            self._connector = ConnectionStyle(connectionstyle, **kw)
+            self._connector = ConnectionStyle(connectionstyle, **kwargs)
         self.stale = True
 
     def get_connectionstyle(self):
         """Return the `ConnectionStyle` used."""
         return self._connector
 
-    def set_arrowstyle(self, arrowstyle=None, **kw):
+    def set_arrowstyle(self, arrowstyle=None, **kwargs):
         """
         Set the arrow style. Old attributes are forgotten. Without arguments
         (or with ``arrowstyle=None``) returns available box styles as a list of
@@ -4389,7 +4389,7 @@ default: 'arc3'
         if isinstance(arrowstyle, ArrowStyle._Base):
             self._arrow_transmuter = arrowstyle
         else:
-            self._arrow_transmuter = ArrowStyle(arrowstyle, **kw)
+            self._arrow_transmuter = ArrowStyle(arrowstyle, **kwargs)
         self.stale = True
 
     def get_arrowstyle(self):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -284,9 +284,8 @@ class ThetaTick(maxis.XTick):
             rotation_mode='anchor',
             transform=self.label2.get_transform() + self._text2_translate)
 
-    def _apply_params(self, **kw):
-        super()._apply_params(**kw)
-
+    def _apply_params(self, **kwargs):
+        super()._apply_params(**kwargs)
         # Ensure transform is correct; sometimes this gets reset.
         trans = self.label1.get_transform()
         if not trans.contains_branch(self._text1_translate):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2073,7 +2073,7 @@ def _setup_pyplot_info_docstrings():
 
 
 @_copy_docstring_and_deprecators(Figure.colorbar)
-def colorbar(mappable=None, cax=None, ax=None, **kw):
+def colorbar(mappable=None, cax=None, ax=None, **kwargs):
     if mappable is None:
         mappable = gci()
         if mappable is None:
@@ -2081,7 +2081,7 @@ def colorbar(mappable=None, cax=None, ax=None, **kw):
                                'creation. First define a mappable such as '
                                'an image (with imshow) or a contour set ('
                                'with contourf).')
-    ret = gcf().colorbar(mappable, cax=cax, ax=ax, **kw)
+    ret = gcf().colorbar(mappable, cax=cax, ax=ax, **kwargs)
     return ret
 
 

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -33,7 +33,7 @@ Plot a 2D field of arrows.
 
 Call signature::
 
-  quiver([X, Y], U, V, [C], **kw)
+  quiver([X, Y], U, V, [C], **kwargs)
 
 *X*, *Y* define the arrow locations, *U*, *V* define the arrow directions, and
 *C* optionally sets the color.
@@ -214,8 +214,7 @@ class QuiverKey(martist.Artist):
 
     def __init__(self, Q, X, Y, U, label,
                  *, angle=0, coordinates='axes', color=None, labelsep=0.1,
-                 labelpos='N', labelcolor=None, fontproperties=None,
-                 **kw):
+                 labelpos='N', labelcolor=None, fontproperties=None, **kwargs):
         """
         Add a key to a quiver plot.
 
@@ -292,7 +291,7 @@ class QuiverKey(martist.Artist):
         self.labelpos = labelpos
         self.labelcolor = labelcolor
         self.fontproperties = fontproperties or dict()
-        self.kw = kw
+        self.kw = kwargs
         _fp = self.fontproperties
         # boxprops = dict(facecolor='red')
         self.text = mtext.Text(
@@ -326,13 +325,13 @@ class QuiverKey(martist.Artist):
                          else 'uv')
                 self.verts = self.Q._make_verts(
                     np.array([u]), np.array([v]), angle)
-            kw = self.Q.polykw
-            kw.update(self.kw)
+            kwargs = self.Q.polykw
+            kwargs.update(self.kw)
             self.vector = mcollections.PolyCollection(
                                         self.verts,
                                         offsets=[(self.X, self.Y)],
                                         transOffset=self.get_transform(),
-                                        **kw)
+                                        **kwargs)
             if self.color is not None:
                 self.vector.set_color(self.color)
             self.vector.set_transform(self.Q.get_transform())
@@ -472,7 +471,7 @@ class Quiver(mcollections.PolyCollection):
     def __init__(self, ax, *args,
                  scale=None, headwidth=3, headlength=5, headaxislength=4.5,
                  minshaft=1, minlength=1, units='width', scale_units=None,
-                 angles='uv', width=None, color='k', pivot='tail', **kw):
+                 angles='uv', width=None, color='k', pivot='tail', **kwargs):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -501,12 +500,12 @@ class Quiver(mcollections.PolyCollection):
         self.pivot = pivot.lower()
         _api.check_in_list(self._PIVOT_VALS, pivot=self.pivot)
 
-        self.transform = kw.pop('transform', ax.transData)
-        kw.setdefault('facecolors', color)
-        kw.setdefault('linewidths', (0,))
+        self.transform = kwargs.pop('transform', ax.transData)
+        kwargs.setdefault('facecolors', color)
+        kwargs.setdefault('linewidths', (0,))
         super().__init__([], offsets=self.XY, transOffset=self.transform,
-                         closed=False, **kw)
-        self.polykw = kw
+                         closed=False, **kwargs)
+        self.polykw = kwargs
         self.set_UVC(U, V, C)
         self._initialized = False
 
@@ -773,7 +772,7 @@ Plot a 2D field of barbs.
 
 Call signature::
 
-  barbs([X, Y], U, V, [C], **kw)
+  barbs([X, Y], U, V, [C], **kwargs)
 
 Where *X*, *Y* define the barb locations, *U*, *V* define the barb
 directions, and *C* optionally sets the color.
@@ -928,7 +927,7 @@ class Barbs(mcollections.PolyCollection):
     def __init__(self, ax, *args,
                  pivot='tip', length=7, barbcolor=None, flagcolor=None,
                  sizes=None, fill_empty=False, barb_increments=None,
-                 rounding=True, flip_barb=False, **kw):
+                 rounding=True, flip_barb=False, **kwargs):
         """
         The constructor takes one required argument, an Axes
         instance, followed by the args and kwargs described
@@ -940,7 +939,7 @@ class Barbs(mcollections.PolyCollection):
         self.barb_increments = barb_increments or dict()
         self.rounding = rounding
         self.flip = np.atleast_1d(flip_barb)
-        transform = kw.pop('transform', ax.transData)
+        transform = kwargs.pop('transform', ax.transData)
         self._pivot = pivot
         self._length = length
         barbcolor = barbcolor
@@ -952,22 +951,22 @@ class Barbs(mcollections.PolyCollection):
         # rest of the barb by default
 
         if None in (barbcolor, flagcolor):
-            kw['edgecolors'] = 'face'
+            kwargs['edgecolors'] = 'face'
             if flagcolor:
-                kw['facecolors'] = flagcolor
+                kwargs['facecolors'] = flagcolor
             elif barbcolor:
-                kw['facecolors'] = barbcolor
+                kwargs['facecolors'] = barbcolor
             else:
                 # Set to facecolor passed in or default to black
-                kw.setdefault('facecolors', 'k')
+                kwargs.setdefault('facecolors', 'k')
         else:
-            kw['edgecolors'] = barbcolor
-            kw['facecolors'] = flagcolor
+            kwargs['edgecolors'] = barbcolor
+            kwargs['facecolors'] = flagcolor
 
         # Explicitly set a line width if we're not given one, otherwise
         # polygons are not outlined and we get no barbs
-        if 'linewidth' not in kw and 'lw' not in kw:
-            kw['linewidth'] = 1
+        if 'linewidth' not in kwargs and 'lw' not in kwargs:
+            kwargs['linewidth'] = 1
 
         # Parse out the data arrays from the various configurations supported
         x, y, u, v, c = _parse_args(*args, caller_name='barbs()')
@@ -978,7 +977,7 @@ class Barbs(mcollections.PolyCollection):
         # Make a collection
         barb_size = self._length ** 2 / 4  # Empirically determined
         super().__init__([], (barb_size,), offsets=xy, transOffset=transform,
-                         **kw)
+                         **kwargs)
         self.set_transform(transforms.IdentityTransform())
 
         self.set_UVC(u, v, c)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -8,13 +8,13 @@ from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-def draw_quiver(ax, **kw):
+def draw_quiver(ax, **kwargs):
     X, Y = np.meshgrid(np.arange(0, 2 * np.pi, 1),
                        np.arange(0, 2 * np.pi, 1))
     U = np.cos(X)
     V = np.sin(Y)
 
-    Q = ax.quiver(U, V, **kw)
+    Q = ax.quiver(U, V, **kwargs)
     return Q
 
 

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -263,16 +263,16 @@ class GridFinder:
         return self._aux_transform.inverted().transform(
             np.column_stack([x, y])).T
 
-    def update(self, **kw):
-        for k in kw:
+    def update(self, **kwargs):
+        for k, v in kwargs.items():
             if k in ["extreme_finder",
                      "grid_locator1",
                      "grid_locator2",
                      "tick_formatter1",
                      "tick_formatter2"]:
-                setattr(self, k, kw[k])
+                setattr(self, k, v)
             else:
-                raise ValueError("Unknown update property '%s'" % k)
+                raise ValueError(f"Unknown update property {k!r}")
 
 
 class MaxNLocator(mticker.MaxNLocator):

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -278,10 +278,10 @@ class GridHelperCurveLinear(GridHelperBase):
                                       tick_formatter1,
                                       tick_formatter2)
 
-    def update_grid_finder(self, aux_trans=None, **kw):
+    def update_grid_finder(self, aux_trans=None, **kwargs):
         if aux_trans is not None:
             self.grid_finder.update_transform(aux_trans)
-        self.grid_finder.update(**kw)
+        self.grid_finder.update(**kwargs)
         self._old_limits = None  # Force revalidation.
 
     def new_fixed_axis(self, loc,


### PR DESCRIPTION
... and small local cleanups.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
