### PR TITLE
skip QImage leak workaround for PySide2 >= 5.12

### DIFF
--- a/lib/matplotlib/backends/backend_qtagg.py
+++ b/lib/matplotlib/backends/backend_qtagg.py
@@ -61,7 +61,7 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
 
             if QT_API == "PyQt6":
                 from PyQt6 import sip
-                ptr = sip.voidptr(buf)
+                ptr = int(sip.voidptr(buf))
             else:
                 ptr = buf
             qimage = QtGui.QImage(
@@ -74,7 +74,8 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
             # Adjust the buf reference count to work around a memory
             # leak bug in QImage under PySide.
             if QT_API in ('PySide', 'PySide2'):
-                ctypes.c_long.from_address(id(buf)).value = 1
+                if QtCore.__version_info__ < (5, 12):
+                    ctypes.c_long.from_address(id(buf)).value = 1
 
             self._draw_rect_callback(painter)
         finally:

--- a/lib/matplotlib/backends/backend_qtcairo.py
+++ b/lib/matplotlib/backends/backend_qtcairo.py
@@ -29,7 +29,7 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
         buf = self._renderer.gc.ctx.get_target().get_data()
         if QT_API == "PyQt6":
             from PyQt6 import sip
-            ptr = sip.voidptr(buf)
+            ptr = int(sip.voidptr(buf))
         else:
             ptr = buf
         qimage = QtGui.QImage(
@@ -38,7 +38,8 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
         # Adjust the buf reference count to work around a memory leak bug in
         # QImage under PySide.
         if QT_API in ('PySide', 'PySide2'):
-            ctypes.c_long.from_address(id(buf)).value = 1
+            if QtCore.__version_info__ < (5, 12):
+                ctypes.c_long.from_address(id(buf)).value = 1
         _setDevicePixelRatio(qimage, self.device_pixel_ratio)
         painter = QtGui.QPainter(self)
         painter.eraseRect(event.rect())


### PR DESCRIPTION
## PR Summary
While testing out Matplotlib 3.5.0b1 with pyqtgraph, pyqtgraph CI pipelines were failing for PySide2 bindings.
https://github.com/pyqtgraph/pyqtgraph/pull/1999

The segfault was due to an old PySide2 QImage leak workaround. This leak was addressed in https://bugreports.qt.io/browse/PYSIDE-140 and versions of PySide2 >= 5.12 no longer need this workaround. 

This PR skips the workaround for PySide2 >= 5.12.

The other change of casting to int for PyQt6 avoids the following warning:
```
  c:\work\venv\allqt\lib\site-packages\matplotlib\backends\backend_qtagg.py:67: DeprecationWarning: an integer is required (got type PyQt6.sip.voidptr).  Implicit conversion to integers using __int__ is deprecated, and may be removed in a future version of Python.
```

Note: pyqtgraph only exercises the changes made to ```backend_qtagg.py```. The same changes made to ```backend_qtcairo.py``` were not tested.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A ] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
