### PR TITLE
Deprecate error_msg_foo helpers.

### DIFF
--- a/doc/api/next_api_changes/deprecations/21187-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21187-AL.rst
@@ -1,0 +1,3 @@
+``backend_gtk3.error_msg_gtk`` and ``backend_wx.error_msg_wx``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -526,7 +526,11 @@ class NavigationToolbar2GTK3(_NavigationToolbar2GTK, Gtk.Toolbar):
         try:
             self.canvas.figure.savefig(fname, format=fmt)
         except Exception as e:
-            error_msg_gtk(str(e), parent=self)
+            dialog = Gtk.MessageDialog(
+                parent=self.canvas.get_toplevel(), message_format=str(e),
+                type=Gtk.MessageType.ERROR, buttons=Gtk.ButtonsType.OK)
+            dialog.run()
+            dialog.destroy()
 
 
 class ToolbarGTK3(ToolContainerBase, Gtk.Box):
@@ -722,6 +726,7 @@ class ToolCopyToClipboardGTK3(backend_tools.ToolCopyToClipboardBase):
         clipboard.set_image(pb)
 
 
+@_api.deprecated("3.6")
 def error_msg_gtk(msg, parent=None):
     if parent is not None:  # find the toplevel Gtk.Window
         parent = parent.get_toplevel()

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -56,6 +56,7 @@ class __getattr__:
     }))
 
 
+@_api.deprecated("3.6")
 def error_msg_wx(msg, parent=None):
     """Signal an error condition with a popup error dialog."""
     dialog = wx.MessageDialog(parent=parent,
@@ -1153,15 +1154,15 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         # Fetch the required filename and file type.
         filetypes, exts, filter_index = self.canvas._get_imagesave_wildcards()
         default_file = self.canvas.get_default_filename()
-        dlg = wx.FileDialog(
+        dialog = wx.FileDialog(
             self.canvas.GetParent(), "Save to file",
             mpl.rcParams["savefig.directory"], default_file, filetypes,
             wx.FD_SAVE | wx.FD_OVERWRITE_PROMPT)
-        dlg.SetFilterIndex(filter_index)
-        if dlg.ShowModal() == wx.ID_OK:
-            path = pathlib.Path(dlg.GetPath())
+        dialog.SetFilterIndex(filter_index)
+        if dialog.ShowModal() == wx.ID_OK:
+            path = pathlib.Path(dialog.GetPath())
             _log.debug('%s - Save file path: %s', type(self), path)
-            fmt = exts[dlg.GetFilterIndex()]
+            fmt = exts[dialog.GetFilterIndex()]
             ext = path.suffix[1:]
             if ext in self.canvas.get_supported_filetypes() and fmt != ext:
                 # looks like they forgot to set the image type drop
@@ -1176,7 +1177,11 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             try:
                 self.canvas.figure.savefig(str(path), format=fmt)
             except Exception as e:
-                error_msg_wx(str(e))
+                dialog = wx.MessageDialog(
+                    parent=self.canvas.GetParent(), message=str(e),
+                    caption='Matplotlib error')
+                dialog.ShowModal()
+                dialog.Destroy()
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         height = self.canvas.figure.bbox.height


### PR DESCRIPTION
They are clearly intended for Matplotlib's internal use (e.g.
error_msg_wx sets the title of the message dialog to "Matplotlib backend
error"), and similar helpers have already been removed from other
backends.

Also correctly set the parents on the message dialogs, don't bother
setting the button on wx.MessageDialog (which already defaults to
CENTRE|OK), make the wx title also apply to other wxfoo backends, and
rename a variable in backend_wx for consistency.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
