### PR TITLE
Deprecate mlab.stride_windows.

### DIFF
--- a/doc/api/next_api_changes/deprecations/ZZZZZ-AL.rst
+++ b/doc/api/next_api_changes/deprecations/ZZZZZ-AL.rst
@@ -1,0 +1,4 @@
+``mlab.stride_windows``
+~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.  Use ``np.lib.stride_tricks.sliding_window_view`` instead
+(or ``np.lib.stride_tricks.as_strided`` on numpy<1.20).

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -3,7 +3,7 @@ from numpy.testing import (assert_allclose, assert_almost_equal,
 import numpy as np
 import pytest
 
-import matplotlib.mlab as mlab
+from matplotlib import mlab, _api
 
 
 class TestStride:
@@ -12,6 +12,11 @@ class TestStride:
         while y.base is not None:
             y = y.base
         return y
+
+    @pytest.fixture(autouse=True)
+    def stride_is_deprecated(self):
+        with _api.suppress_matplotlib_deprecation_warning():
+            yield
 
     def calc_window_target(self, x, NFFT, noverlap=0, axis=0):
         """


### PR DESCRIPTION
The functionality is directly provided by numpy>=1.20 (it will be a
while before we can rely on that version of numpy, but we can still
deprecate stride_windows as public API in the meantime, as we don't want
to encourage users to rely on mlab for that).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
