### PR TITLE
Update contributing guide.

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -290,12 +290,12 @@ prevent unexpected breaking of code that uses Matplotlib.
 - If possible, usage of an deprecated API should emit a
   `.MatplotlibDeprecationWarning`. There are a number of helper tools for this:
 
-  - Use ``cbook.warn_deprecated()`` for general deprecation warnings.
-  - Use the decorator ``@cbook.deprecated`` to deprecate classes, functions,
+  - Use ``_api.warn_deprecated()`` for general deprecation warnings.
+  - Use the decorator ``@_api.deprecated`` to deprecate classes, functions,
     methods, or properties.
   - To warn on changes of the function signature, use the decorators
-    ``@cbook._delete_parameter``, ``@cbook._rename_parameter``, and
-    ``@cbook._make_keyword_only``.
+    ``@_api.delete_parameter``, ``@_api.rename_parameter``, and
+    ``@_api.make_keyword_only``.
 
 - Deprecated API may be removed two point-releases after they were deprecated.
 
@@ -349,22 +349,22 @@ Keyword argument processing
 ---------------------------
 
 Matplotlib makes extensive use of ``**kwargs`` for pass-through customizations
-from one function to another. A typical example is in `matplotlib.pyplot.text`.
-The definition of the pylab text function is a simple pass-through to
-`matplotlib.axes.Axes.text`::
+from one function to another.  A typical example is
+`~matplotlib.axes.Axes.text`.  The definition of `matplotlib.pyplot.text` is a
+simple pass-through to `matplotlib.axes.Axes.text`::
 
-  # in pylab.py
-  def text(*args, **kwargs):
-      return gca().text(*args, **kwargs)
+  # in pyplot.py
+  def text(x, y, s, fontdict=None, **kwargs):
+      return gca().text(x, y, s, fontdict=fontdict, **kwargs)
 
-`~matplotlib.axes.Axes.text` in simplified form looks like this, i.e., it just
+`matplotlib.axes.Axes.text` (simplified for illustration) just
 passes all ``args`` and ``kwargs`` on to ``matplotlib.text.Text.__init__``::
 
   # in axes/_axes.py
-  def text(self, x, y, s, fontdict=None, withdash=False, **kwargs):
+  def text(self, x, y, s, fontdict=None, **kwargs):
       t = Text(x=x, y=y, text=s, **kwargs)
 
-and ``matplotlib.text.Text.__init__`` (again with liberties for illustration)
+and ``matplotlib.text.Text.__init__`` (again, simplified)
 just passes them on to the `matplotlib.artist.Artist.update` method::
 
   # in text.py


### PR DESCRIPTION
cbook->_api; pylab->pyplot.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
