### PR TITLE
Rework plot types quiver

### DIFF
--- a/plot_types/arrays/quiver.py
+++ b/plot_types/arrays/quiver.py
@@ -8,20 +8,21 @@ See `~matplotlib.axes.Axes.quiver`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('_mpl-gallery')
+plt.style.use('_mpl-gallery-nogrid')
 
 # make data
-phi = np.linspace(0, 2 * np.pi, 8)
-x, y = 4 + 1 * np.cos(phi), 4 + 1 * np.sin(phi)
-u, v = 1.5 * np.cos(phi), 1.5 * np.sin(phi)
+x = np.linspace(-4, 4, 6)
+y = np.linspace(-4, 4, 6)
+X, Y = np.meshgrid(x, y)
+U = X + Y
+V = Y - X
 
 # plot
 fig, ax = plt.subplots()
 
-ax.quiver(x, y, u, v, color="C0", angles='xy',
-          scale_units='xy', scale=0.5, width=.05)
+ax.quiver(X, Y, U, V, color="C0", angles='xy',
+          scale_units='xy', scale=5, width=.015)
 
-ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
-       ylim=(0, 8), yticks=np.arange(1, 8))
+ax.set(xlim=(-5, 5), ylim=(-5, 5))
 
 plt.show()


### PR DESCRIPTION
While quiver can be used on individual points, the most common use case
is gridded data. We should use the common use case as the example.
Another reason is that, `quiver()` is assigned to the arrays category
in plot types.
