### PR TITLE
Parametrize/simplify test_missing_psfont.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import matplotlib as mpl
-from matplotlib import dviread, pyplot as plt, checkdep_usetex, rcParams
+from matplotlib import pyplot as plt, checkdep_usetex, rcParams
 from matplotlib.cbook import _get_data_path
 from matplotlib.ft2font import FT2Font
 from matplotlib.backends._backend_pdf_ps import get_glyphs_subset
@@ -293,23 +293,6 @@ def test_grayscale_alpha():
     ax.imshow(dd, interpolation='none', cmap='gray_r')
     ax.set_xticks([])
     ax.set_yticks([])
-
-
-# This tests tends to hit a TeX cache lock on AppVeyor.
-@pytest.mark.flaky(reruns=3)
-@needs_usetex
-def test_missing_psfont(monkeypatch):
-    """An error is raised if a TeX font lacks a Type-1 equivalent"""
-    def psfont(*args, **kwargs):
-        return dviread.PsFont(texname='texfont', psname='Some Font',
-                              effects=None, encoding=None, filename=None)
-
-    monkeypatch.setattr(dviread.PsfontsMap, '__getitem__', psfont)
-    rcParams['text.usetex'] = True
-    fig, ax = plt.subplots()
-    ax.text(0.5, 0.5, 'hello')
-    with NamedTemporaryFile() as tmpfile, pytest.raises(ValueError):
-        fig.savefig(tmpfile, format='pdf')
 
 
 @mpl.style.context('default')

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -1,6 +1,5 @@
 import datetime
 from io import BytesIO
-import tempfile
 import xml.etree.ElementTree
 import xml.parsers.expat
 
@@ -8,7 +7,6 @@ import numpy as np
 import pytest
 
 import matplotlib as mpl
-from matplotlib import dviread
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
@@ -179,22 +177,6 @@ def test_count_bitmaps():
         ax5.plot([0, 20], [0, n], "b-", rasterized=True)
     assert count_tag(fig5, "image") == 5
     assert count_tag(fig5, "path") == 1  # axis patch
-
-
-@needs_usetex
-def test_missing_psfont(monkeypatch):
-    """An error is raised if a TeX font lacks a Type-1 equivalent"""
-
-    def psfont(*args, **kwargs):
-        return dviread.PsFont(texname='texfont', psname='Some Font',
-                              effects=None, encoding=None, filename=None)
-
-    monkeypatch.setattr(dviread.PsfontsMap, '__getitem__', psfont)
-    mpl.rc('text', usetex=True)
-    fig, ax = plt.subplots()
-    ax.text(0.5, 0.5, 'hello')
-    with tempfile.TemporaryFile() as tmpfile, pytest.raises(ValueError):
-        fig.savefig(tmpfile, format='svg')
 
 
 # Use Computer Modern Sans Serif, not Helvetica (which has no \textwon).


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
