### PR TITLE
Fix nav link for "Usage guide" and remove release/date info from that page

### DIFF
--- a/doc/_templates/mpl_nav_bar.html
+++ b/doc/_templates/mpl_nav_bar.html
@@ -13,7 +13,7 @@
     <a class="reference internal nav-link" href="{{ pathto('api/index') }}">Reference</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ pathto('contents') }}">Usage guide</a>
+    <a class="reference internal nav-link" href="{{ pathto('users/index') }}">Usage guide</a>
   </li>
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ pathto('devel/index') }}">Develop</a>

--- a/doc/users/index.rst
+++ b/doc/users/index.rst
@@ -4,14 +4,6 @@
 Usage guide
 ###########
 
-.. only:: html
-
-    :Release: |version|
-    :Date: |today|
-
-
-
-
 .. toctree::
    :maxdepth: 2
 


### PR DESCRIPTION
## PR Summary

- Nav link closes #21161.
- The release and date are already shown on the new top-level https://matplotlib.org/devdocs/contents.html page.


