### PR TITLE
Shorten PdfPages FAQ entry.

### DIFF
--- a/doc/faq/howto_faq.rst
+++ b/doc/faq/howto_faq.rst
@@ -110,33 +110,10 @@ on individual elements, e.g.::
 Save multiple plots to one pdf file
 -----------------------------------
 
-Many image file formats can only have one image per file, but some
-formats support multi-page files. Currently only the pdf backend has
-support for this. To make a multi-page pdf file, first initialize the
-file::
-
-    from matplotlib.backends.backend_pdf import PdfPages
-    pp = PdfPages('multipage.pdf')
-
-You can give the :class:`~matplotlib.backends.backend_pdf.PdfPages`
-object to :func:`~matplotlib.pyplot.savefig`, but you have to specify
-the format::
-
-    plt.savefig(pp, format='pdf')
-
-An easier way is to call
-:meth:`PdfPages.savefig <matplotlib.backends.backend_pdf.PdfPages.savefig>`::
-
-    pp.savefig()
-
-Finally, the multipage pdf object has to be closed::
-
-    pp.close()
-
-The same can be done using the pgf backend::
-
-    from matplotlib.backends.backend_pgf import PdfPages
-
+Many image file formats can only have one image per file, but some formats
+support multi-page files.  Currently, Matplotlib only provides multi-page
+output to pdf files, using either the pdf or pgf backends, via the
+`.backend_pdf.PdfPages` and `.backend_pgf.PdfPages` classes.
 
 .. _howto-auto-adjust:
 


### PR DESCRIPTION
The original wording was inaccurate as both the pdf and pgf backends
provide this functionality.  I tried fixing that, but duplicating all
links to both backends seemed unwieldy; additionally the "narrative"
version of the FAQ reads worse (we should just encourage `pp.savefig()`
instead of explaining that `plt.savefig()` needs workarounds, and also
prefer `with PdfPages(...) as pp:`).  Given that the docstring of both
classes have examples, I just got rid of most of the FAQ entry instead
(see also the next FAQ entries, which also have no code).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
