### PR TITLE
Raise when unknown signals are connected to CallbackRegistries.

### DIFF
--- a/doc/api/next_api_changes/behavior/21238-AL.rst
+++ b/doc/api/next_api_changes/behavior/21238-AL.rst
@@ -1,0 +1,6 @@
+``CallbackRegistry`` raises on unknown signals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When Matplotlib instantiates a `.CallbackRegistry`, it now limits callbacks
+to the signals that the registry knows about.  In practice, this means that
+calling `~.FigureCanvasBase.mpl_connect` with an invalid signal name now raises
+a `ValueError`.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -167,7 +167,7 @@ class Artist:
         # Normally, artist classes need to be queried for mouseover info if and
         # only if they override get_cursor_data.
         self._mouseover = type(self).get_cursor_data != Artist.get_cursor_data
-        self._callbacks = cbook.CallbackRegistry()
+        self._callbacks = cbook.CallbackRegistry(signals=["pchanged"])
         try:
             self.axes = None
         except AttributeError:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1199,7 +1199,8 @@ class _AxesBase(martist.Artist):
             spine.clear()
 
         self.ignore_existing_data_limits = True
-        self.callbacks = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry(
+            signals=["xlim_changed", "ylim_changed", "zlim_changed"])
 
         if self._sharex is not None:
             self.sharex(self._sharex)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -655,7 +655,8 @@ class Axis(martist.Artist):
         self.axes = axes
         self.major = Ticker()
         self.minor = Ticker()
-        self.callbacks = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry(
+            signals=["units", "units finalize"])
 
         self._autolabelpos = True
 
@@ -806,7 +807,8 @@ class Axis(martist.Artist):
         self._set_scale('linear')
 
         # Clear the callback registry for this axis, or it may "leak"
-        self.callbacks = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry(
+            signals=["units", "units finalize"])
 
         # whether the grids are on
         self._major_tick_kw['gridOn'] = (

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -359,7 +359,7 @@ class ScalarMappable:
         self.set_cmap(cmap)  # The Colormap instance of this ScalarMappable.
         #: The last colorbar associated with this ScalarMappable. May be None.
         self.colorbar = None
-        self.callbacks = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry(signals=["changed"])
 
     callbacksSM = _api.deprecated("3.5", alternative="callbacks")(
         property(lambda self: self.callbacks))

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1132,7 +1132,7 @@ class Normalize:
         self._vmax = _sanitize_extrema(vmax)
         self._clip = clip
         self._scale = None
-        self.callbacks = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry(signals=["changed"])
 
     @property
     def vmin(self):

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -18,7 +18,7 @@ class Container(tuple):
         return tuple.__new__(cls, args[0])
 
     def __init__(self, kl, label=None):
-        self._callbacks = cbook.CallbackRegistry()
+        self._callbacks = cbook.CallbackRegistry(signals=["pchanged"])
         self._remove_method = None
         self.set_label(label)
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2249,11 +2249,12 @@ class Figure(FigureBase):
             else:
                 _api.check_in_list(['constrained', 'tight'], layout=layout)
 
-        self.callbacks = cbook.CallbackRegistry()
+        self.callbacks = cbook.CallbackRegistry(signals=["dpi_changed"])
         # Callbacks traditionally associated with the canvas (and exposed with
         # a proxy property), but that actually need to be on the figure for
         # pickling.
-        self._canvas_callbacks = cbook.CallbackRegistry()
+        self._canvas_callbacks = cbook.CallbackRegistry(
+            signals=FigureCanvasBase.events)
         self._button_pick_id = self._canvas_callbacks.connect(
             'button_press_event', lambda event: self.canvas.pick(event))
         self._scroll_pick_id = self._canvas_callbacks.connect(

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -363,6 +363,19 @@ def test_callbackregistry_custom_exception_handler(monkeypatch, cb, excp):
         cb.process('foo')
 
 
+def test_callbackregistry_signals():
+    cr = cbook.CallbackRegistry(signals=["foo"])
+    results = []
+    def cb(x): results.append(x)
+    cr.connect("foo", cb)
+    with pytest.raises(ValueError):
+        cr.connect("bar", cb)
+    cr.process("foo", 1)
+    with pytest.raises(ValueError):
+        cr.process("bar", 1)
+    assert results == [1]
+
+
 def test_callbackregistry_blocking():
     # Needs an exception handler for interactive testing environments
     # that would only print this out instead of raising the exception

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -183,7 +183,7 @@ class Button(AxesWidget):
                              horizontalalignment='center',
                              transform=ax.transAxes)
 
-        self._observers = cbook.CallbackRegistry()
+        self._observers = cbook.CallbackRegistry(signals=["clicked"])
 
         self.connect_event('button_press_event', self._click)
         self.connect_event('button_release_event', self._release)
@@ -275,7 +275,7 @@ class SliderBase(AxesWidget):
         self.connect_event("button_release_event", self._update)
         if dragging:
             self.connect_event("motion_notify_event", self._update)
-        self._observers = cbook.CallbackRegistry()
+        self._observers = cbook.CallbackRegistry(signals=["changed"])
 
     def _stepped_value(self, val):
         """Return *val* coerced to closest number in the ``valstep`` grid."""
@@ -1031,7 +1031,7 @@ class CheckButtons(AxesWidget):
 
         self.connect_event('button_press_event', self._clicked)
 
-        self._observers = cbook.CallbackRegistry()
+        self._observers = cbook.CallbackRegistry(signals=["clicked"])
 
     def _clicked(self, event):
         if self.ignore(event) or event.button != 1 or event.inaxes != self.ax:
@@ -1160,7 +1160,7 @@ class TextBox(AxesWidget):
             verticalalignment='center', horizontalalignment=textalignment,
             parse_math=False)
 
-        self._observers = cbook.CallbackRegistry()
+        self._observers = cbook.CallbackRegistry(signals=["change", "submit"])
 
         ax.set(
             xlim=(0, 1), ylim=(0, 1),  # s.t. cursor appears from first click.
@@ -1447,7 +1447,7 @@ class RadioButtons(AxesWidget):
 
         self.connect_event('button_press_event', self._clicked)
 
-        self._observers = cbook.CallbackRegistry()
+        self._observers = cbook.CallbackRegistry(signals=["clicked"])
 
     cnt = _api.deprecated("3.4")(property(  # Not real, but close enough.
         lambda self: len(self._observers.callbacks['clicked'])))


### PR DESCRIPTION
I chose not to emit warnings during a deprecation period as otherwise
the semantics of the `signals` parameter would again have to change at
the end of the deprecation period (from warning to raising), which would
be another backcompatibility break...

Closes #8839.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
