### PR TITLE
Fix release notes typos.

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.5.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.5.0.rst
@@ -116,11 +116,11 @@ Image interpolation now possible at RGBA stage
 ----------------------------------------------
 
 Images in Matplotlib created via `~.axes.Axes.imshow` are resampled to match
-the resolution of the current canvas. It is useful to apply an anto-aliasing
+the resolution of the current canvas. It is useful to apply an auto-aliasing
 filter when downsampling to reduce Moiré effects. By default, interpolation is
 done on the data, a norm applied, and then the colormapping performed.
 
-However, it is often desireable for the anti-aliasing interpolation to happen
+However, it is often desirable for the anti-aliasing interpolation to happen
 in RGBA space, where the colors are interpolated rather than the data. This
 usually leads to colors outside the colormap, but visually blends adjacent
 colors, and is what browsers and other image processing software do.
@@ -208,7 +208,7 @@ user-friendly setup.
         "font.family": "Helvetica"
     })
 
-Type 42 Subsetting is now enabled for PDF/PS backends
+Type 42 subsetting is now enabled for PDF/PS backends
 -----------------------------------------------------
 
 `~matplotlib.backends.backend_pdf` and `~matplotlib.backends.backend_ps` now


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
