### PR TITLE
Fix: axis, ticks are set to defaults fontsize after ax.clear()

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -895,7 +895,9 @@ class Axis(martist.Artist):
 
         This does not reset tick and tick label visibility.
         """
+        self.label.set_text('')
         self.label._reset_visual_defaults()
+        self.offsetText.set_text('')
         self.offsetText._reset_visual_defaults()
         self.labelpad = mpl.rcParams['axes.labelpad']
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -896,7 +896,11 @@ class Axis(martist.Artist):
         This does not reset tick and tick label visibility.
         """
 
-        self.label.set_text('')  # self.set_label_text would change isDefault_
+        self.label._reset_visual_defaults()
+        self.offsetText._reset_visual_defaults()
+        self.labelpad = mpl.rcParams['axes.labelpad']
+
+        self._set_default()
 
         self._set_scale('linear')
 
@@ -2193,6 +2197,9 @@ class XAxis(Axis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._set_default()
+
+    def _set_default(self):
         # x in axes coords, y in display coords (to be updated at draw time by
         # _update_label_positions and _update_offset_text_position).
         self.label.set(
@@ -2444,6 +2451,9 @@ class YAxis(Axis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._set_default()
+
+    def _set_default(self):
         # x in display coords, y in axes coords (to be updated at draw time by
         # _update_label_positions and _update_offset_text_position).
         self.label.set(

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -895,9 +895,7 @@ class Axis(martist.Artist):
 
         This does not reset tick and tick label visibility.
         """
-        self.label.set_text('')
         self.label._reset_visual_defaults()
-        self.offsetText.set_text('')
         self.offsetText._reset_visual_defaults()
         self.labelpad = mpl.rcParams['axes.labelpad']
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -895,12 +895,11 @@ class Axis(martist.Artist):
 
         This does not reset tick and tick label visibility.
         """
-
         self.label._reset_visual_defaults()
         self.offsetText._reset_visual_defaults()
         self.labelpad = mpl.rcParams['axes.labelpad']
 
-        self._set_default()
+        self._init()
 
         self._set_scale('linear')
 
@@ -2197,9 +2196,13 @@ class XAxis(Axis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._set_default()
+        self._init()
 
-    def _set_default(self):
+    def _init(self):
+        """
+        Initialize the label and offsetText instance values and
+        `label_position` / `offset_text_position`.
+        """
         # x in axes coords, y in display coords (to be updated at draw time by
         # _update_label_positions and _update_offset_text_position).
         self.label.set(
@@ -2209,6 +2212,7 @@ class XAxis(Axis):
                 self.axes.transAxes, mtransforms.IdentityTransform()),
         )
         self.label_position = 'bottom'
+
         self.offsetText.set(
             x=1, y=0,
             verticalalignment='top', horizontalalignment='right',
@@ -2451,9 +2455,13 @@ class YAxis(Axis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self._set_default()
+        self._init()
 
-    def _set_default(self):
+    def _init(self):
+        """
+        Initialize the label and offsetText instance values and
+        `label_position` / `offset_text_position`.
+        """
         # x in display coords, y in axes coords (to be updated at draw time by
         # _update_label_positions and _update_offset_text_position).
         self.label.set(

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -163,8 +163,9 @@ class Text(Artist):
         """
         super().__init__()
         self._x, self._y = x, y
+        self._text = ''
+        self.set_text(text)
         self._reset_visual_defaults(
-            text=text,
             color=color,
             fontproperties=fontproperties,
             usetex=usetex,
@@ -177,12 +178,11 @@ class Text(Artist):
             transform_rotates_text=transform_rotates_text,
             linespacing=linespacing,
             rotation_mode=rotation_mode,
-            **kwargs,
         )
+        self.update(kwargs)
 
     def _reset_visual_defaults(
         self,
-        text='',
         color=None,
         fontproperties=None,
         usetex=None,
@@ -195,10 +195,7 @@ class Text(Artist):
         transform_rotates_text=False,
         linespacing=None,
         rotation_mode=None,
-        **kwargs,
     ):
-        self._text = ''
-        self.set_text(text)
         self.set_color(
             color if color is not None else mpl.rcParams["text.color"])
         self.set_fontproperties(fontproperties)
@@ -217,7 +214,6 @@ class Text(Artist):
             linespacing = 1.2  # Maybe use rcParam later.
         self.set_linespacing(linespacing)
         self.set_rotation_mode(rotation_mode)
-        self.update(kwargs)
 
     def update(self, kwargs):
         # docstring inherited

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -163,6 +163,40 @@ class Text(Artist):
         """
         super().__init__()
         self._x, self._y = x, y
+        self._reset_visual_defaults(
+            text=text,
+            color=color,
+            fontproperties=fontproperties,
+            usetex=usetex,
+            parse_math=parse_math,
+            wrap=wrap,
+            verticalalignment=verticalalignment,
+            horizontalalignment=horizontalalignment,
+            multialignment=multialignment,
+            rotation=rotation,
+            transform_rotates_text=transform_rotates_text,
+            linespacing=linespacing,
+            rotation_mode=rotation_mode,
+            **kwargs,
+        )
+
+    def _reset_visual_defaults(
+        self,
+        text='',
+        color=None,
+        fontproperties=None,
+        usetex=None,
+        parse_math=None,
+        wrap=False,
+        verticalalignment='baseline',
+        horizontalalignment='left',
+        multialignment=None,
+        rotation=None,
+        transform_rotates_text=False,
+        linespacing=None,
+        rotation_mode=None,
+        **kwargs,
+    ):
         self._text = ''
         self.set_text(text)
         self.set_color(

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -164,8 +164,8 @@ class Text(Artist):
         super().__init__()
         self._x, self._y = x, y
         self._text = ''
-        self.set_text(text)
         self._reset_visual_defaults(
+            text=text,
             color=color,
             fontproperties=fontproperties,
             usetex=usetex,
@@ -183,6 +183,7 @@ class Text(Artist):
 
     def _reset_visual_defaults(
         self,
+        text='',
         color=None,
         fontproperties=None,
         usetex=None,
@@ -196,6 +197,7 @@ class Text(Artist):
         linespacing=None,
         rotation_mode=None,
     ):
+        self.set_text(text)
         self.set_color(
             color if color is not None else mpl.rcParams["text.color"])
         self.set_fontproperties(fontproperties)


### PR DESCRIPTION
## PR Summary
To solve [this issue](https://github.com/matplotlib/matplotlib/issues/21239),  not only content but its fontsize will be defaulted value in `clear` method.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
