### PR TITLE
DOC: Fix source links to prereleases

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -635,7 +635,7 @@ if link_github:
             return None
 
         version = parse(matplotlib.__version__)
-        tag = 'master' if version.is_devrelease else f'v{version.base_version}'
+        tag = 'master' if version.is_devrelease else f'v{version.public}'
         return ("https://github.com/matplotlib/matplotlib/blob"
                 f"/{tag}/lib/{fn}{linespec}")
 else:


### PR DESCRIPTION
## PR Summary

We normally replace prerelease docs with final anyway, but until that time, the links using `Version.base_version` would point to the final tag, which won't exist yet. But `Version.public` includes the prerelease part and should point to the right tag.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).