### PR TITLE
Ensure internal FreeType matches Python compile

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -618,7 +618,8 @@ class FreeType(SetupPackage):
             subprocess.check_call(
                 ["./configure", "--with-zlib=no", "--with-bzip2=no",
                  "--with-png=no", "--with-harfbuzz=no", "--enable-static",
-                 "--disable-shared"],
+                 "--disable-shared",
+                 "--host=" + sysconfig.get_config_var('BUILD_GNU_TYPE')],
                 env=env, cwd=src_path)
             if 'GNUMAKE' in env:
                 make = env['GNUMAKE']

--- a/setupext.py
+++ b/setupext.py
@@ -605,9 +605,16 @@ class FreeType(SetupPackage):
         if (src_path / 'objs' / '.libs' / libfreetype).is_file():
             return  # Bail out because we have already built FreeType.
 
+        cc = get_ccompiler()
+
         print(f"Building freetype in {src_path}")
         if sys.platform != 'win32':  # compilation on non-windows
-            env = {**env, "CFLAGS": "{} -fPIC".format(env.get("CFLAGS", ""))}
+            env = {
+                **env,
+                "CC": (shlex.join(cc.compiler) if sys.version_info >= (3, 8)
+                       else " ".join(shlex.quote(x) for x in cc.compiler)),
+                "CFLAGS": "{} -fPIC".format(env.get("CFLAGS", "")),
+            }
             subprocess.check_call(
                 ["./configure", "--with-zlib=no", "--with-bzip2=no",
                  "--with-png=no", "--with-harfbuzz=no", "--enable-static",
@@ -660,7 +667,6 @@ class FreeType(SetupPackage):
                 f.truncate()
                 f.write(vcxproj)
 
-            cc = get_ccompiler()
             cc.initialize()  # Get msbuild in the %PATH% of cc.spawn.
             cc.spawn(["msbuild", str(sln_path),
                       "/t:Clean;Build",


### PR DESCRIPTION
## PR Summary

Pass along a few options to ensure that FreeType doesn't end up with a mixed compiler or bit-ness compared to the rest of the compiled `ft2font` extension.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).