### PR TITLE
DOC: Fix footnote that breaks PDF builds

### DIFF
--- a/examples/subplots_axes_and_figures/figure_size_units.py
+++ b/examples/subplots_axes_and_figures/figure_size_units.py
@@ -56,15 +56,15 @@ plt.show()
 # tedious for quick iterations.
 #
 # Because of the default ``rcParams['figure.dpi'] = 100``, one can mentally
-# divide the needed pixel value by 100 [*]_:
+# divide the needed pixel value by 100 [#]_:
 #
 plt.subplots(figsize=(6, 2))
 plt.text(0.5, 0.5, '600px x 200px', **text_kwargs)
 plt.show()
 
 #############################################################################
-# .. [*] Unfortunately, this does not work well for the ``matplotlib inline``
-#        backend in jupyter because that backend uses a different default of
+# .. [#] Unfortunately, this does not work well for the ``matplotlib inline``
+#        backend in Jupyter because that backend uses a different default of
 #        ``rcParams['figure.dpi'] = 72``. Additionally, it saves the figure
 #        with ``bbox_inches='tight'``, which crops the figure and makes the
 #        actual size unpredictable.


### PR DESCRIPTION
## PR Summary

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).