### PR TITLE
Fix #21101 Add validator to errorbar method

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3294,7 +3294,7 @@ class Axes(_AxesBase):
 
         if has_negative_values(xerr) or has_negative_values(yerr):
             raise ValueError(
-                "'xerr' and 'yerr' must have non-negative numbers")
+                "'xerr' and 'yerr' must have non-negative values")
 
         if isinstance(errorevery, Integral):
             errorevery = (0, errorevery)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3180,7 +3180,7 @@ class Axes(_AxesBase):
               errors.
             - *None*: No errorbar.
 
-            Note that all error arrays should have *positive* values.
+            Note that all error arrays should have *non-negative* values.
 
             See :doc:`/gallery/statistics/errorbar_features`
             for an example on the usage of ``xerr`` and ``yerr``.
@@ -3284,17 +3284,21 @@ class Axes(_AxesBase):
         if len(x) != len(y):
             raise ValueError("'x' and 'y' must have the same size")
 
-        def check_if_negative(array):
+        def has_negative_values(array):
             if array is None:
                 return False
             try:
+                return np.any(array < 0)
+            except TypeError:
+                pass   # Don't fail on 'datetime.*' types
                 if np.any(array < 0):
                     return True
             except TypeError:   # Don't fail on 'datetime.*' types
                 pass
 
-        if check_if_negative(xerr) or check_if_negative(yerr):
-            raise ValueError("'xerr' and 'yerr' must have positive numbers")
+        if has_negative_values(xerr) or has_negative_values(yerr):
+            raise ValueError(
+                "'xerr' and 'yerr' must have non-negative numbers")
 
         if isinstance(errorevery, Integral):
             errorevery = (0, errorevery)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3285,20 +3285,16 @@ class Axes(_AxesBase):
             raise ValueError("'x' and 'y' must have the same size")
 
         def check_if_negative(array):
+            if array is None:
+                return False
             try:
                 if np.any(array < 0):
                     return True
             except TypeError:   # Don't fail on 'datetime.*' types
                 pass
 
-        if xerr is not None and check_if_negative(xerr):
-            if yerr is not None and check_if_negative(yerr):
-                raise ValueError(
-                    "'xerr' and 'yerr' must have positive numbers")
-            else:
-                raise ValueError("'xerr' must have positive numbers")
-        if check_if_negative(yerr):
-            raise ValueError("'yerr' must have positive numbers")
+        if check_if_negative(xerr) or check_if_negative(yerr):
+            raise ValueError("'xerr' and 'yerr' must have positive numbers")
 
         if isinstance(errorevery, Integral):
             errorevery = (0, errorevery)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3283,9 +3283,13 @@ class Axes(_AxesBase):
         x, y = np.atleast_1d(x, y)  # Make sure all the args are iterable.
         if len(x) != len(y):
             raise ValueError("'x' and 'y' must have the same size")
-        
+
         if xerr is not None and np.any(xerr < 0):
-            raise ValueError("'xerr' must have positive numbers")
+            if yerr is not None and np.any(yerr < 0):
+                raise ValueError(
+                    "'xerr' and 'yerr' must have positive numbers")
+            else:
+                raise ValueError("'xerr' must have positive numbers")
         if yerr is not None and np.any(yerr < 0):
             raise ValueError("'yerr' must have positive numbers")
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3,6 +3,7 @@ import itertools
 import logging
 import math
 from numbers import Integral, Number
+from datetime import timedelta
 
 import numpy as np
 from numpy import ma
@@ -3289,8 +3290,8 @@ class Axes(_AxesBase):
                 return False
             try:
                 return np.any(array < 0)
-            except TypeError:
-                pass   # Don't fail on 'datetime.*' types
+            except TypeError:  # if array contains 'datetime.timedelta' types
+                return np.any(array < timedelta(0))
 
         if has_negative_values(xerr) or has_negative_values(yerr):
             raise ValueError(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3283,6 +3283,11 @@ class Axes(_AxesBase):
         x, y = np.atleast_1d(x, y)  # Make sure all the args are iterable.
         if len(x) != len(y):
             raise ValueError("'x' and 'y' must have the same size")
+        
+        if xerr is not None and np.any(xerr < 0):
+            raise ValueError("'xerr' must have positive numbers")
+        if yerr is not None and np.any(yerr < 0):
+            raise ValueError("'yerr' must have positive numbers")
 
         if isinstance(errorevery, Integral):
             errorevery = (0, errorevery)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3284,13 +3284,20 @@ class Axes(_AxesBase):
         if len(x) != len(y):
             raise ValueError("'x' and 'y' must have the same size")
 
-        if xerr is not None and np.any(xerr < 0):
-            if yerr is not None and np.any(yerr < 0):
+        def check_if_negative(array):
+            try:
+                if np.any(array < 0):
+                    return True
+            except:
+                pass
+
+        if xerr is not None and check_if_negative(xerr):
+            if yerr is not None and check_if_negative(yerr):
                 raise ValueError(
                     "'xerr' and 'yerr' must have positive numbers")
             else:
                 raise ValueError("'xerr' must have positive numbers")
-        if yerr is not None and np.any(yerr < 0):
+        if check_if_negative(yerr):
             raise ValueError("'yerr' must have positive numbers")
 
         if isinstance(errorevery, Integral):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3291,10 +3291,6 @@ class Axes(_AxesBase):
                 return np.any(array < 0)
             except TypeError:
                 pass   # Don't fail on 'datetime.*' types
-                if np.any(array < 0):
-                    return True
-            except TypeError:   # Don't fail on 'datetime.*' types
-                pass
 
         if has_negative_values(xerr) or has_negative_values(yerr):
             raise ValueError(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3288,7 +3288,7 @@ class Axes(_AxesBase):
             try:
                 if np.any(array < 0):
                     return True
-            except:
+            except TypeError:   # Don't fail on 'datetime.*' types
                 pass
 
         if xerr is not None and check_if_negative(xerr):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3524,6 +3524,12 @@ def test_xerr_yerr_positive():
         ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]])
     with pytest.raises(ValueError, match=error_message):
         ax.errorbar(x=[0], y=[0], yerr=[[-0.5], [1]])
+    with pytest.raises(ValueError, match=error_message):
+        x = np.arange(5)
+        y = [datetime.datetime(2021, 9, i * 2 + 1) for i in x]
+        ax.errorbar(x=x,
+                    y=y,
+                    yerr=datetime.timedelta(days=-10))
 
 
 @check_figures_equal()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3513,6 +3513,18 @@ def test_errorbar_every_invalid():
         ax.errorbar(x, y, yerr, errorevery='foobar')
 
 
+def test_xerr_yerr_positive():
+    ax = plt.figure().subplots()
+
+    with pytest.raises(ValueError,
+                       match="'xerr' and 'yerr' must have positive numbers"):
+        ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]], yerr=[[-0.5], [1]])
+    with pytest.raises(ValueError, match="'xerr' must have positive numbers"):
+        ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]])
+    with pytest.raises(ValueError, match="'yerr' must have positive numbers"):
+        ax.errorbar(x=[0], y=[0], yerr=[[-0.5], [1]])
+
+
 @check_figures_equal()
 def test_errorbar_every(fig_test, fig_ref):
     x = np.linspace(0, 1, 15)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3519,9 +3519,11 @@ def test_xerr_yerr_positive():
     with pytest.raises(ValueError,
                        match="'xerr' and 'yerr' must have positive numbers"):
         ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]], yerr=[[-0.5], [1]])
-    with pytest.raises(ValueError, match="'xerr' must have positive numbers"):
+    with pytest.raises(ValueError,
+                        match="'xerr' and 'yerr' must have positive numbers"):
         ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]])
-    with pytest.raises(ValueError, match="'yerr' must have positive numbers"):
+    with pytest.raises(ValueError,
+                        match="'xerr' and 'yerr' must have positive numbers"):
         ax.errorbar(x=[0], y=[0], yerr=[[-0.5], [1]])
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3516,7 +3516,7 @@ def test_errorbar_every_invalid():
 def test_xerr_yerr_positive():
     ax = plt.figure().subplots()
 
-    error_message = "'xerr' and 'yerr' must have non-negative numbers"
+    error_message = "'xerr' and 'yerr' must have non-negative values"
 
     with pytest.raises(ValueError, match=error_message):
         ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]], yerr=[[-0.5], [1]])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3516,14 +3516,13 @@ def test_errorbar_every_invalid():
 def test_xerr_yerr_positive():
     ax = plt.figure().subplots()
 
-    with pytest.raises(ValueError,
-                       match="'xerr' and 'yerr' must have positive numbers"):
+    error_message = "'xerr' and 'yerr' must have non-negative numbers"
+
+    with pytest.raises(ValueError, match=error_message):
         ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]], yerr=[[-0.5], [1]])
-    with pytest.raises(ValueError,
-                        match="'xerr' and 'yerr' must have positive numbers"):
+    with pytest.raises(ValueError, match=error_message):
         ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]])
-    with pytest.raises(ValueError,
-                        match="'xerr' and 'yerr' must have positive numbers"):
+    with pytest.raises(ValueError, match=error_message):
         ax.errorbar(x=[0], y=[0], yerr=[[-0.5], [1]])
 
 


### PR DESCRIPTION
## PR Summary

The PR adds a validator for `xerr` and `yerr` arguments in errorbar method to fix  #21101.

It brings implementation compliant with the documentation:
>Note that all error arrays should have *positive* values.

source: https://github.com/matplotlib/matplotlib/blob/master/lib/matplotlib/axes/_axes.py#L3183


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
