### PR TITLE
Cleanup AnnotationBbox.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1314,7 +1314,9 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             *textcoords* in `.Annotation` for a detailed description.
 
         frameon : bool, default: True
-            Whether to draw a frame around the box.
+            By default, the text is surrounded by a white `.FancyBboxPatch`
+            (accessible as the ``patch`` attribute of the `.AnnotationBbox`).
+            If *frameon* is set to False, this patch is made invisible.
 
         pad : float, default: 0.4
             Padding around the offsetbox.
@@ -1329,10 +1331,9 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         """
 
         martist.Artist.__init__(self)
-        mtext._AnnotationBase.__init__(self,
-                                       xy,
-                                       xycoords=xycoords,
-                                       annotation_clip=annotation_clip)
+        mtext._AnnotationBase.__init__(
+            self, xy, xycoords=xycoords, annotation_clip=annotation_clip)
+
         self.offsetbox = offsetbox
         self.arrowprops = arrowprops
         self.set_fontsize(fontsize)
@@ -1418,34 +1419,17 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
 
     def get_window_extent(self, renderer):
         # docstring inherited
-        bboxes = [child.get_window_extent(renderer)
-                  for child in self.get_children()]
-
-        return Bbox.union(bboxes)
+        return Bbox.union([child.get_window_extent(renderer)
+                           for child in self.get_children()])
 
     def get_tightbbox(self, renderer):
         # docstring inherited
-        bboxes = [child.get_tightbbox(renderer)
-                  for child in self.get_children()]
-
-        return Bbox.union(bboxes)
+        return Bbox.union([child.get_tightbbox(renderer)
+                           for child in self.get_children()])
 
     def update_positions(self, renderer):
         """
-        Update the pixel positions of the annotated point and the text.
-        """
-        xy_pixel = self._get_position_xy(renderer)
-        self._update_position_xybox(renderer, xy_pixel)
-
-        mutation_scale = renderer.points_to_pixels(self.get_fontsize())
-        self.patch.set_mutation_scale(mutation_scale)
-
-        if self.arrow_patch:
-            self.arrow_patch.set_mutation_scale(mutation_scale)
-
-    def _update_position_xybox(self, renderer, xy_pixel):
-        """
-        Update the pixel positions of the annotation text and the arrow patch.
+        Update pixel positions for the annotated point, the text and the arrow.
         """
 
         x, y = self.xybox
@@ -1458,40 +1442,34 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             ox0, oy0 = self._get_xy(renderer, x, y, self.boxcoords)
 
         w, h, xd, yd = self.offsetbox.get_extent(renderer)
+        fw, fh = self._box_alignment
+        self.offsetbox.set_offset((ox0 - fw * w + xd, oy0 - fh * h + yd))
 
-        _fw, _fh = self._box_alignment
-        self.offsetbox.set_offset((ox0 - _fw * w + xd, oy0 - _fh * h + yd))
-
-        # update patch position
         bbox = self.offsetbox.get_window_extent(renderer)
         self.patch.set_bounds(bbox.bounds)
 
-        ox1, oy1 = xy_pixel
+        mutation_scale = renderer.points_to_pixels(self.get_fontsize())
+        self.patch.set_mutation_scale(mutation_scale)
 
         if self.arrowprops:
-            d = self.arrowprops.copy()
-
             # Use FancyArrowPatch if self.arrowprops has "arrowstyle" key.
 
             # Adjust the starting point of the arrow relative to the textbox.
             # TODO: Rotation needs to be accounted.
-            relpos = self._arrow_relpos
+            arrow_begin = bbox.p0 + bbox.size * self._arrow_relpos
+            arrow_end = self._get_position_xy(renderer)
+            # The arrow (from arrow_begin to arrow_end) will be first clipped
+            # by patchA and patchB, then shrunk by shrinkA and shrinkB (in
+            # points).  If patch A is not set, self.bbox_patch is used.
+            self.arrow_patch.set_positions(arrow_begin, arrow_end)
 
-            ox0 = bbox.x0 + bbox.width * relpos[0]
-            oy0 = bbox.y0 + bbox.height * relpos[1]
-
-            # The arrow will be drawn from (ox0, oy0) to (ox1, oy1).
-            # It will be first clipped by patchA and patchB.
-            # Then it will be shrunk by shrinkA and shrinkB (in points).
-            # If patch A is not set, self.bbox_patch is used.
-
-            self.arrow_patch.set_positions((ox0, oy0), (ox1, oy1))
-            fs = self.prop.get_size_in_points()
-            mutation_scale = d.pop("mutation_scale", fs)
-            mutation_scale = renderer.points_to_pixels(mutation_scale)
+            if "mutation_scale" in self.arrowprops:
+                mutation_scale = renderer.points_to_pixels(
+                    self.arrowprops["mutation_scale"])
+                # Else, use fontsize-based mutation_scale defined above.
             self.arrow_patch.set_mutation_scale(mutation_scale)
 
-            patchA = d.pop("patchA", self.patch)
+            patchA = self.arrowprops.get("patchA", self.patch)
             self.arrow_patch.set_patchA(patchA)
 
     def draw(self, renderer):


### PR DESCRIPTION
Inline _update_position_xybox into update_positions.  Avoid unpacking
x,y pairs where unnecessary.  Don't bother copying arrowprops, as we
don't actually modify it.  Reuse mutation scale for both patch and
arrow.  Clarify the doc for frameon (closes #17018).  Various small extra cleanups.

(re: #17018: I think the docs should only be added to AnnotationBbox, not to OffsetImage, which is only indirectly affected when associated with an AnnotationBbox.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
