### PR TITLE
Don't use pixelDelta() on X11.

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -312,8 +312,10 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
     def wheelEvent(self, event):
         x, y = self.mouseEventCoords(self._get_position(event))
-        # from QWheelEvent::delta doc
-        if event.pixelDelta().x() == 0 and event.pixelDelta().y() == 0:
+        # from QWheelEvent::pixelDelta doc: pixelDelta is sometimes not
+        # provided (`isNull()`) and is unreliable on X11 ("xcb").
+        if (event.pixelDelta().isNull()
+                or QtWidgets.QApplication.instance().platformName() == "xcb"):
             steps = event.angleDelta().y() / 120
         else:
             steps = event.pixelDelta().y()


### PR DESCRIPTION
pixelDelta() is explicitly documented as "unreliable" and not-to-be-used
on X11 (https://doc.qt.io/qt-5/qwheelevent.html#pixelDelta);
locally, it reports the same value as angleDelta, but
because it isn't scaled, the value is 120x too big.  So add
a check that forces the use of angleDelta() on X11 (see also
https://doc.qt.io/qt-6/qguiapplication.html#platformName-prop).

This would be nice to have in 3.5 (I guess something recently changed in
the underlying X11 stack, exposing that bug).  I'll mark as release critical
just to get some attention :-) but am fine if this gets pushed back too.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
