### PR TITLE
ENH: Add support to save images in WebP format

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -69,6 +69,7 @@ _default_filetypes = {
     'svgz': 'Scalable Vector Graphics',
     'tif': 'Tagged Image File Format',
     'tiff': 'Tagged Image File Format',
+    'webp': 'WebP Image Format',
 }
 _default_backends = {
     'eps': 'matplotlib.backends.backend_ps',
@@ -84,6 +85,7 @@ _default_backends = {
     'svgz': 'matplotlib.backends.backend_svg',
     'tif': 'matplotlib.backends.backend_agg',
     'tiff': 'matplotlib.backends.backend_agg',
+    'webp': 'matplotlib.backends.backend_agg',
 }
 
 

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -594,6 +594,29 @@ class FigureCanvasAgg(FigureCanvasBase):
 
     print_tiff = print_tif
 
+    @_check_savefig_extra_args
+    def print_webp(self, filename_or_obj, *, pil_kwargs=None):
+        """
+        Write the figure to a WebP file.
+
+        Parameters
+        ----------
+        filename_or_obj : str or path-like or file-like
+            The file to write to.
+
+        Other Parameters
+        ----------------
+        pil_kwargs : dict, optional
+            Additional keyword arguments that are passed to
+            `PIL.Image.Image.save` when saving the figure.
+        """
+        FigureCanvasAgg.draw(self)
+        if pil_kwargs is None:
+            pil_kwargs = {}
+        pil_kwargs.setdefault("dpi", (self.figure.dpi, self.figure.dpi))
+        return (Image.fromarray(np.asarray(self.buffer_rgba()))
+                .save(filename_or_obj, format='webp', **pil_kwargs))
+
 
 @_Backend.export
 class _BackendAgg(_Backend):


### PR DESCRIPTION
## PR Summary
Fixes #21162
This adds support to save images in WebP format. 
This works fine without any problem since Pillow supports WebP and the code is analogous to the support for tiff images added in PR #15193.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
