### PR TITLE
Fix format_cursor_data for values close to float resolution.

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2212,6 +2212,10 @@ def _g_sig_digits(value, delta):
     Return the number of significant digits to %g-format *value*, assuming that
     it is known with an error of *delta*.
     """
+    if delta == 0:
+        # delta = 0 may occur when trying to format values over a tiny range;
+        # in that case, replace it by the distance to the closest float.
+        delta = np.spacing(value)
     # If e.g. value = 45.67 and delta = 0.02, then we want to round to 2 digits
     # after the decimal point (floor(log10(0.02)) = -2); 45.67 contributes 2
     # digits before the decimal point (floor(log10(45.67)) + 1 = 2): the total

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -341,6 +341,7 @@ def test_cursor_data():
         ([[10001, 10000]], "[10001.000]"),
         ([[.123, .987]], "[0.123]"),
         ([[np.nan, 1, 2]], "[]"),
+        ([[1, 1+1e-15]], "[1.0000000000000000]"),
     ])
 def test_format_cursor_data(data, text):
     from matplotlib.backend_bases import MouseEvent


### PR DESCRIPTION
Previously, moving the cursor over
`plt.imshow(1 + np.random.randn(10, 10) * 1e-15)` would result in
`ValueError: math domain error` (when trying to compute
`math.log10(delta)` with `delta = 0`).  This is because the full range
of normalization implied by the image above (~1e-15) is representable
with float precision, but the spacing between individual colors (256x
less) is too small to be represented, and thus rounded to zero.

In general, I consider that such floating point errors should be fixed
on the user side, but this specific error seems worth fixing as the 1)
the image is still rendered correctly, 2) errors in the mouse event
handler (rendering the cursor text) are somewhat obscure for end users,
and 3) it used to work before Matplotlib 3.5.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
