### PR TITLE
Add language about not assigning issues

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -40,6 +40,14 @@ difficulty. ``Difficulty: Easy`` is suited for people with little Python experie
 ``Difficulty: Medium`` and ``Difficulty: Hard`` are not trivial to solve and
 require more thought and programming experience.
 
+In general, the Matplotlib project does not assign issues. Issues are "assigned" or "claimed" by 
+opening a PR; there is no other assignment mechanism. If you have opened such a PR, please comment 
+on the issue thread to avoid duplication of work. Please check if there is an existing PR for 
+the issue you are addressing.  If there is, try to work with the author by submitting reviews of 
+their code or commenting on the PR rather than opening a new PR; duplicate PRs are subject to being closed.  
+However, if the existing PR is an outline, unlikely to work, or stalled, and the original author is unresponsive, 
+feel free to open a new PR referencing the old one. 
+
 .. _submitting-a-bug-report:
 
 Submitting a bug report
@@ -73,7 +81,7 @@ If you are reporting a bug, please do your best to include the following:
       >>> platform.python_version()
       '3.9.2'
 
-We have preloaded the issue creation page with a Markdown template that you can
+We have preloaded the issue creation page with a Markdown form that you can
 use to organize this information.
 
 Thank you for your help in keeping bug reports complete, targeted and descriptive.

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -40,14 +40,15 @@ difficulty. ``Difficulty: Easy`` is suited for people with little Python experie
 ``Difficulty: Medium`` and ``Difficulty: Hard`` are not trivial to solve and
 require more thought and programming experience.
 
-In general, the Matplotlib project does not assign issues. Issues are "assigned" 
-or "claimed" by opening a PR; there is no other assignment mechanism. If you have 
-opened such a PR, please comment on the issue thread to avoid duplication of work. 
-Please check if there is an existing PR for the issue you are addressing. If there 
-is, try to work with the author by submitting reviews of their code or commenting 
-on the PR rather than opening a new PR; duplicate PRs are subject to being closed.  
-However, if the existing PR is an outline, unlikely to work, or stalled, and the 
-original author is unresponsive, feel free to open a new PR referencing the old one. 
+In general, the Matplotlib project does not assign issues. Issues are 
+"assigned" or "claimed" by opening a PR; there is no other assignment 
+mechanism. If you have opened such a PR, please comment on the issue thread to 
+avoid duplication of work. Please check if there is an existing PR for the 
+issue you are addressing. If there is, try to work with the author by 
+submitting reviews of their code or commenting on the PR rather than opening 
+a new PR; duplicate PRs are subject to being closed.  However, if the existing 
+PR is an outline, unlikely to work, or stalled, and the original author is 
+unresponsive, feel free to open a new PR referencing the old one. 
 
 .. _submitting-a-bug-report:
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -40,13 +40,14 @@ difficulty. ``Difficulty: Easy`` is suited for people with little Python experie
 ``Difficulty: Medium`` and ``Difficulty: Hard`` are not trivial to solve and
 require more thought and programming experience.
 
-In general, the Matplotlib project does not assign issues. Issues are "assigned" or "claimed" by 
-opening a PR; there is no other assignment mechanism. If you have opened such a PR, please comment 
-on the issue thread to avoid duplication of work. Please check if there is an existing PR for 
-the issue you are addressing.  If there is, try to work with the author by submitting reviews of 
-their code or commenting on the PR rather than opening a new PR; duplicate PRs are subject to being closed.  
-However, if the existing PR is an outline, unlikely to work, or stalled, and the original author is unresponsive, 
-feel free to open a new PR referencing the old one. 
+In general, the Matplotlib project does not assign issues. Issues are "assigned" 
+or "claimed" by opening a PR; there is no other assignment mechanism. If you have 
+opened such a PR, please comment on the issue thread to avoid duplication of work. 
+Please check if there is an existing PR for the issue you are addressing. If there 
+is, try to work with the author by submitting reviews of their code or commenting 
+on the PR rather than opening a new PR; duplicate PRs are subject to being closed.  
+However, if the existing PR is an outline, unlikely to work, or stalled, and the 
+original author is unresponsive, feel free to open a new PR referencing the old one. 
 
 .. _submitting-a-bug-report:
 


### PR DESCRIPTION
This is a combination of @anntzer and @jklymak's language on issues not being assigned, though I put it under "new contributor issues"
* https://gitter.im/matplotlib/matplotlib?at=615aca48fb3dcd4e8808f439
* https://gitter.im/matplotlib/matplotlib?at=615acbf9f2cedf67f96662fd

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
