### PR TITLE
Fix freetype wheel building

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -617,12 +617,15 @@ class FreeType(SetupPackage):
                 },
             }
             env["CFLAGS"] = env.get("CFLAGS", "") + " -fPIC"
-            subprocess.check_call(
-                ["./configure", "--with-zlib=no", "--with-bzip2=no",
-                 "--with-png=no", "--with-harfbuzz=no", "--enable-static",
-                 "--disable-shared",
-                 "--host=" + sysconfig.get_config_var('BUILD_GNU_TYPE')],
-                env=env, cwd=src_path)
+            configure = [
+                "./configure", "--with-zlib=no", "--with-bzip2=no",
+                "--with-png=no", "--with-harfbuzz=no", "--enable-static",
+                "--disable-shared"
+            ]
+            host = sysconfig.get_config_var('BUILD_GNU_TYPE')
+            if host is not None:  # May be unset on PyPy.
+                configure.append(f"--host={host}")
+            subprocess.check_call(configure, env=env, cwd=src_path)
             if 'GNUMAKE' in env:
                 make = env['GNUMAKE']
             elif 'MAKE' in env:


### PR DESCRIPTION
## PR Summary

The changes in #21263 caused wheel builds to fail, which we didn't see because they aren't run on pull requests. I've made sure that [wheel CI](https://github.com/QuLogic/matplotlib/actions/runs/1306485729) passes this time.

The problem is that setting `CC` only is incomplete, and we need to set the linker, etc. It is better to grab that from `sysconfig` rather than messing around with the `distutils` compiler that I originally did. Also, fix build on PyPy as well.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).