### PR TITLE
Allow macosx thread safety test on macOS11

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -222,8 +222,14 @@ for param in _thread_safe_backends:
         param.marks.append(
             pytest.mark.xfail(raises=subprocess.CalledProcessError))
     elif backend == "macosx":
-        param.marks.append(
-            pytest.mark.xfail(raises=subprocess.TimeoutExpired, strict=True))
+        from packaging.version import parse
+        mac_ver = platform.mac_ver()[0]
+        # Note, macOS Big Sur is both 11 and 10.16, depending on SDK that
+        # Python was compiled against.
+        if mac_ver and parse(mac_ver) < parse('10.16'):
+            param.marks.append(
+                pytest.mark.xfail(raises=subprocess.TimeoutExpired,
+                                  strict=True))
     elif param.values[0].get("QT_API") == "PySide2":
         param.marks.append(
             pytest.mark.xfail(raises=subprocess.CalledProcessError))


### PR DESCRIPTION
## PR Summary

It appears to no longer timeout on that system, and is breaking CI, which just switched to it.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).