### PR TITLE
DOC: Fix some lists in animation examples

### DIFF
--- a/examples/animation/animate_decay.py
+++ b/examples/animation/animate_decay.py
@@ -4,6 +4,7 @@ Decay
 =====
 
 This example showcases:
+
 - using a generator to drive an animation,
 - changing axes limits during an animation.
 """

--- a/examples/animation/pause_resume.py
+++ b/examples/animation/pause_resume.py
@@ -4,6 +4,7 @@ Pausing and Resuming an Animation
 =================================
 
 This example showcases:
+
 - using the Animation.pause() method to pause an animation.
 - using the Animation.resume() method to resume an animation.
 """


### PR DESCRIPTION
## PR Summary

Without a newline before lists, the text is crammed into one paragraph.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).