### PR TITLE
DOC: Bump to the sphinx-gallery release

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -32,13 +32,10 @@ dependencies:
   - scipy
   - sphinx>=1.8.1,!=2.0.0
   - sphinx-copybutton
+  - sphinx-gallery>=0.10
   - pip
   - pip:
-    - sphinxcontrib-svg2pdfconverter
-    # b41e328 is PR 808 which adds the image_srcset directive.  When this is
-    # released with sphinx gallery, we can change to the last release w/o this feature:
-    # sphinx-gallery>0.9
-    - git+git://github.com/sphinx-gallery/sphinx-gallery@b41e328#egg=sphinx-gallery
+      - sphinxcontrib-svg2pdfconverter
   # testing
   - coverage
   - flake8>=3.8

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -15,11 +15,7 @@ numpydoc>=0.8
 packaging>=20
 pydata-sphinx-theme>=0.6.0
 sphinxcontrib-svg2pdfconverter>=1.1.0
-# sphinx-gallery>=0.7
-# b41e328 is PR 808 which adds the image_srcset directive.  When this is
-# released with sphinx gallery, we can change to the last release w/o this feature:
-# sphinx-gallery>0.90
-git+git://github.com/sphinx-gallery/sphinx-gallery@b41e328#egg=sphinx-gallery
+sphinx-gallery>=0.10
 sphinx-copybutton
 sphinx-panels
 scipy


### PR DESCRIPTION
## PR Summary

Now that it's out, we don't need to depend on a random commit.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).