### PR TITLE
Disable blitting on GTK4 backends

### DIFF
--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -51,6 +51,7 @@ def _mpl_to_gtk_cursor(mpl_cursor):
 
 class FigureCanvasGTK4(Gtk.DrawingArea, FigureCanvasBase):
     required_interactive_framework = "gtk4"
+    supports_blit = False
     _timer_cls = TimerGTK4
     _context_is_scaled = False
 

--- a/lib/matplotlib/backends/backend_gtk4agg.py
+++ b/lib/matplotlib/backends/backend_gtk4agg.py
@@ -8,66 +8,34 @@ except ImportError as e:
 from . import backend_agg, backend_gtk4
 from .backend_cairo import cairo
 from .backend_gtk4 import Gtk, _BackendGTK4
-from matplotlib import transforms
 
 
 class FigureCanvasGTK4Agg(backend_gtk4.FigureCanvasGTK4,
                           backend_agg.FigureCanvasAgg):
     def __init__(self, figure):
         backend_gtk4.FigureCanvasGTK4.__init__(self, figure)
-        self._bbox_queue = []
 
     def on_draw_event(self, widget, ctx):
         scale = self.device_pixel_ratio
         allocation = self.get_allocation()
-        w = allocation.width * scale
-        h = allocation.height * scale
 
-        if not len(self._bbox_queue):
-            Gtk.render_background(
-                self.get_style_context(), ctx,
-                allocation.x, allocation.y,
-                allocation.width, allocation.height)
-            bbox_queue = [transforms.Bbox([[0, 0], [w, h]])]
-        else:
-            bbox_queue = self._bbox_queue
+        Gtk.render_background(
+            self.get_style_context(), ctx,
+            allocation.x, allocation.y,
+            allocation.width, allocation.height)
 
         ctx = backend_cairo._to_context(ctx)
 
-        for bbox in bbox_queue:
-            x = int(bbox.x0)
-            y = h - int(bbox.y1)
-            width = int(bbox.x1) - int(bbox.x0)
-            height = int(bbox.y1) - int(bbox.y0)
-
-            buf = cbook._unmultiplied_rgba8888_to_premultiplied_argb32(
-                np.asarray(self.copy_from_bbox(bbox)))
-            image = cairo.ImageSurface.create_for_data(
-                buf.ravel().data, cairo.FORMAT_ARGB32, width, height)
-            image.set_device_scale(scale, scale)
-            ctx.set_source_surface(image, x / scale, y / scale)
-            ctx.paint()
-
-        if len(self._bbox_queue):
-            self._bbox_queue = []
+        buf = cbook._unmultiplied_rgba8888_to_premultiplied_argb32(
+            np.asarray(self.renderer.buffer_rgba()))
+        height, width, _ = buf.shape
+        image = cairo.ImageSurface.create_for_data(
+            buf.ravel().data, cairo.FORMAT_ARGB32, width, height)
+        image.set_device_scale(scale, scale)
+        ctx.set_source_surface(image, 0, 0)
+        ctx.paint()
 
         return False
-
-    def blit(self, bbox=None):
-        # If bbox is None, blit the entire canvas to gtk. Otherwise
-        # blit only the area defined by the bbox.
-        if bbox is None:
-            bbox = self.figure.bbox
-
-        scale = self.device_pixel_ratio
-        allocation = self.get_allocation()
-        x = int(bbox.x0 / scale)
-        y = allocation.height - int(bbox.y1 / scale)
-        width = (int(bbox.x1) - int(bbox.x0)) // scale
-        height = (int(bbox.y1) - int(bbox.y0)) // scale
-
-        self._bbox_queue.append(bbox)
-        self.queue_draw_area(x, y, width, height)
 
     def draw(self):
         backend_agg.FigureCanvasAgg.draw(self)


### PR DESCRIPTION
## PR Summary

It is not possible to queue a draw for a subregion of a widget, so this crashes. Since 3.5 is feature frozen, disable blitting for now to make animations work.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).