### PR TITLE
Use in-tree builds for PyPy wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -102,6 +102,7 @@ jobs:
           CIBW_BUILD: "pp37-*"
           CIBW_BEFORE_BUILD: pip install certifi numpy==${{ env.min-numpy-version }}
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          PIP_USE_FEATURE: in-tree-build
         if: matrix.cibw_archs != 'aarch64'
 
       - name: Validate that LICENSE files are included in wheels


### PR DESCRIPTION
## PR Summary

Doing out-of-tree builds makes a copy that breaks symlinks in the git tree on Windows, causing PyPy wheels to get a version that signifies a dirty tree when they shouldn't.

This will change in pip soon, but changing this will fix the version for our release now.

Fixes #20929

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).