### PR TITLE
Move label hiding rectilinear-only check into _label_outer_{x,y}axis.

### DIFF
--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -1,3 +1,4 @@
+import matplotlib as mpl
 from matplotlib import _api, cbook
 from matplotlib.axes._axes import Axes
 from matplotlib.gridspec import GridSpec, SubplotSpec
@@ -109,10 +110,13 @@ class SubplotBase:
         labels are on the top side); y-labels only for subplots on the first
         column (or last column, if labels are on the right side).
         """
-        self._label_outer_xaxis()
-        self._label_outer_yaxis()
+        self._label_outer_xaxis(check_patch=False)
+        self._label_outer_yaxis(check_patch=False)
 
-    def _label_outer_xaxis(self):
+    def _label_outer_xaxis(self, *, check_patch):
+        # see documentation in label_outer.
+        if check_patch and not isinstance(self.patch, mpl.patches.Rectangle):
+            return
         ss = self.get_subplotspec()
         label_position = self.xaxis.get_label_position()
         if not ss.is_first_row():  # Remove top label/ticklabels/offsettext.
@@ -128,7 +132,10 @@ class SubplotBase:
             if self.xaxis.offsetText.get_position()[1] == 0:
                 self.xaxis.offsetText.set_visible(False)
 
-    def _label_outer_yaxis(self):
+    def _label_outer_yaxis(self, *, check_patch):
+        # see documentation in label_outer.
+        if check_patch and not isinstance(self.patch, mpl.patches.Rectangle):
+            return
         ss = self.get_subplotspec()
         label_position = self.yaxis.get_label_position()
         if not ss.is_first_col():  # Remove left label/ticklabels/offsettext.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1910,10 +1910,10 @@ default: %(va)s
         for ax in ret.values():
             if sharex:
                 ax.sharex(ax0)
-                ax._label_outer_xaxis()
+                ax._label_outer_xaxis(check_patch=True)
             if sharey:
                 ax.sharey(ax0)
-                ax._label_outer_yaxis()
+                ax._label_outer_yaxis(check_patch=True)
         for k, ax in ret.items():
             if isinstance(k, str):
                 ax.set_label(k)

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -306,13 +306,12 @@ class GridSpecBase:
                     self[row, col], **subplot_kw)
 
         # turn off redundant tick labeling
-        if all(ax.name == "rectilinear" for ax in axarr.flat):
-            if sharex in ["col", "all"]:
-                for ax in axarr.flat:
-                    ax._label_outer_xaxis()
-            if sharey in ["row", "all"]:
-                for ax in axarr.flat:
-                    ax._label_outer_yaxis()
+        if sharex in ["col", "all"]:
+            for ax in axarr.flat:
+                ax._label_outer_xaxis(check_patch=True)
+        if sharey in ["row", "all"]:
+            for ax in axarr.flat:
+                ax._label_outer_yaxis(check_patch=True)
 
         if squeeze:
             # Discarding unneeded dimensions that equal 1.  If we only have one

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -396,10 +396,15 @@ def test_remove_shared_polar(fig_ref, fig_test):
 
 def test_shared_polar_keeps_ticklabels():
     fig, axs = plt.subplots(
-        2, 2, subplot_kw=dict(projection="polar"), sharex=True, sharey=True)
+        2, 2, subplot_kw={"projection": "polar"}, sharex=True, sharey=True)
     fig.canvas.draw()
     assert axs[0, 1].xaxis.majorTicks[0].get_visible()
     assert axs[0, 1].yaxis.majorTicks[0].get_visible()
+    fig, axs = plt.subplot_mosaic(
+        "ab\ncd", subplot_kw={"projection": "polar"}, sharex=True, sharey=True)
+    fig.canvas.draw()
+    assert axs["b"].xaxis.majorTicks[0].get_visible()
+    assert axs["b"].yaxis.majorTicks[0].get_visible()
 
 
 def test_axvline_axvspan_do_not_modify_rlims():


### PR DESCRIPTION
This allows having it both in subplots() (which had that check before)
and in subplot_mosaic (which didn't, see test).  (All Axes returned by
subplots() have the same projection, so `all(ax.name == "rectilinear")`
can be replaced by independently checking each Axes.)

xref #19994, again this may mess up some third-party axes (https://github.com/matplotlib/matplotlib/pull/19994#issuecomment-821595763) but the tradeoff seemed OK back then.  (We can always consider adding a "does this want to participate in label_outer" flag if there's demand for it, but let's not overengineer things for now.)

Edit, following review: Also improve the rectilinearity check by testing the shape of the axes
patch instead (so that e.g. skewT also participates in
outer-only-labels), and add an escape hatch so that Axes.label_outer
always does "what it says on, the tin".

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
