### PR TITLE
Add a Figure._get_cachedRenderer() method

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2376,6 +2376,13 @@ class Figure(FigureBase):
 
     get_axes = axes.fget
 
+    def _get_cachedRenderer(self, error_if_none=True):
+        # Get the cached renderer, raising an error if it doesn't exist yet
+        if error_if_none and self._cachedRenderer is None:
+            raise RuntimeError("This code can only be used after an "
+                               "initial draw which caches the renderer.")
+        return self._cachedRenderer
+
     def _get_dpi(self):
         return self._dpi
 
@@ -2829,10 +2836,7 @@ class Figure(FigureBase):
         This method can only be used after an initial draw of the figure,
         because that creates and caches the renderer needed here.
         """
-        if self._cachedRenderer is None:
-            raise AttributeError("draw_artist can only be used after an "
-                                 "initial draw which caches the renderer")
-        a.draw(self._cachedRenderer)
+        a.draw(self._get_cachedRenderer())
 
     def __getstate__(self):
         state = super().__getstate__()

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -881,7 +881,7 @@ class Legend(Artist):
     def get_window_extent(self, renderer=None):
         # docstring inherited
         if renderer is None:
-            renderer = self.figure._cachedRenderer
+            renderer = self.figure._get_cachedRenderer()
         return self._legend_box.get_window_extent(renderer=renderer)
 
     def get_tightbbox(self, renderer):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -880,3 +880,11 @@ def test_subfigure_legend():
     ax.plot([0, 1], [0, 1], label="line")
     leg = subfig.legend()
     assert leg.figure is subfig
+
+
+def test_no_renderer_error():
+    leg = plt.legend()
+    with pytest.raises(
+            RuntimeError,
+            match='This code can only be used after an initial draw'):
+        leg.get_window_extent()


### PR DESCRIPTION
## PR Summary
Adds `Figure._get_cachedRenderer()` which can be used to get the cached renderer, but error if it's not present. This can be used in one existing place, and is also now used in a legend method, which probably fixes https://github.com/matplotlib/matplotlib/issues/21285

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
