### PR TITLE
Add ability to scale BBox with just x or y values

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -902,11 +902,51 @@ class Bbox(BboxBase):
                 self._points[:, 1] = points[:, 1]
                 self._minpos[1] = minpos[1]
 
+    def update_from_data_x(self, x, ignore=None):
+        """
+        Update the x-bounds of the `Bbox` based on the passed in data. After
+        updating, the bounds will have positive *width*, and *x0* will be the
+        minimal value.
+
+        Parameters
+        ----------
+        x : ndarray
+            Array of x-values.
+
+        ignore : bool, optional
+           - When ``True``, ignore the existing bounds of the `Bbox`.
+           - When ``False``, include the existing bounds of the `Bbox`.
+           - When ``None``, use the last value passed to :meth:`ignore`.
+        """
+        x = np.ravel(x)
+        self.update_from_data_xy(np.column_stack([x, np.ones(x.size)]),
+                                 ignore=ignore, updatey=False)
+
+    def update_from_data_y(self, y, ignore=None):
+        """
+        Update the y-bounds of the `Bbox` based on the passed in data. After
+        updating, the bounds will have positive *height*, and *y0* will be the
+        minimal value.
+
+        Parameters
+        ----------
+        y : ndarray
+            Array of y-values.
+
+        ignore : bool, optional
+           - When ``True``, ignore the existing bounds of the `Bbox`.
+           - When ``False``, include the existing bounds of the `Bbox`.
+           - When ``None``, use the last value passed to :meth:`ignore`.
+        """
+        y = np.array(y).ravel()
+        self.update_from_data_xy(np.column_stack([np.ones(y.size), y]),
+                                 ignore=ignore, updatex=False)
+
     def update_from_data_xy(self, xy, ignore=None, updatex=True, updatey=True):
         """
-        Update the bounds of the `Bbox` based on the passed in
-        data.  After updating, the bounds will have positive *width*
-        and *height*; *x0* and *y0* will be the minimal values.
+        Update the bounds of the `Bbox` based on the passed in data. After
+        updating, the bounds will have positive *width* and *height*;
+        *x0* and *y0* will be the minimal values.
 
         Parameters
         ----------

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -107,6 +107,7 @@ class Axes3D(Axes):
         self.xy_viewLim = Bbox.unit()
         self.zz_viewLim = Bbox.unit()
         self.xy_dataLim = Bbox.unit()
+        # z-limits are encoded in the x-component of the Bbox, y is un-used
         self.zz_dataLim = Bbox.unit()
 
         # inhibit autoscale_view until the axes are defined
@@ -643,14 +644,14 @@ class Axes3D(Axes):
     def auto_scale_xyz(self, X, Y, Z=None, had_data=None):
         # This updates the bounding boxes as to keep a record as to what the
         # minimum sized rectangular volume holds the data.
-        X = np.reshape(X, -1)
-        Y = np.reshape(Y, -1)
-        self.xy_dataLim.update_from_data_xy(
-            np.column_stack([X, Y]), not had_data)
+        if np.shape(X) == np.shape(Y):
+            self.xy_dataLim.update_from_data_xy(
+                np.column_stack([np.ravel(X), np.ravel(Y)]), not had_data)
+        else:
+            self.xy_dataLim.update_from_data_x(X, not had_data)
+            self.xy_dataLim.update_from_data_y(Y, not had_data)
         if Z is not None:
-            Z = np.reshape(Z, -1)
-            self.zz_dataLim.update_from_data_xy(
-                np.column_stack([Z, Z]), not had_data)
+            self.zz_dataLim.update_from_data_x(Z, not had_data)
         # Let autoscale_view figure out how to use this data.
         self.autoscale_view()
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -198,6 +198,17 @@ def test_tricontour():
     ax.tricontourf(x, y, z)
 
 
+def test_contour3d_1d_input():
+    # Check that 1D sequences of different length for {x, y} doesn't error
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    nx, ny = 30, 20
+    x = np.linspace(-10, 10, nx)
+    y = np.linspace(-10, 10, ny)
+    z = np.random.randint(0, 2, [ny, nx])
+    ax.contour(x, y, z, [0.5])
+
+
 @mpl3d_image_comparison(['lines3d.png'])
 def test_lines3d():
     fig = plt.figure()


### PR DESCRIPTION
## PR Summary
This is useful in `Axes3D`, when we are autoscaling with x and y values that are not always the same shape. As an example, see the contour code in https://github.com/matplotlib/matplotlib/issues/21310. Fixes https://github.com/matplotlib/matplotlib/issues/21310, and an alternative (with a nicer fix in my opinion) to https://github.com/matplotlib/matplotlib/issues/21312

If someone leaves a positive comment on this, I'll add a what's new entry and tests.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
