### PR TITLE
Fix type1font docstring markup/punctuation.

### DIFF
--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -7,10 +7,10 @@ similarly to pdfTeX and friends. There is no support yet for subsetting.
 
 Usage::
 
-   >>> font = Type1Font(filename)
-   >>> clear_part, encrypted_part, finale = font.parts
-   >>> slanted_font = font.transform({'slant': 0.167})
-   >>> extended_font = font.transform({'extend': 1.2})
+    font = Type1Font(filename)
+    clear_part, encrypted_part, finale = font.parts
+    slanted_font = font.transform({'slant': 0.167})
+    extended_font = font.transform({'extend': 1.2})
 
 Sources:
 
@@ -38,18 +38,16 @@ _log = logging.getLogger(__name__)
 
 class _Token:
     """
-    A token in a PostScript stream
+    A token in a PostScript stream.
 
     Attributes
     ----------
     pos : int
-        position, i.e. offset from the beginning of the data
-
+        Position, i.e. offset from the beginning of the data.
     raw : str
-        the raw text of the token
-
+        Raw text of the token.
     kind : str
-        description of the token (for debugging or testing)
+        Description of the token (for debugging or testing).
     """
     __slots__ = ('pos', 'raw')
     kind = '?'
@@ -177,9 +175,8 @@ def _tokenize(data: bytes, skip_ws: bool):
     """
     A generator that produces _Token instances from Type-1 font code.
 
-    The consumer of the generator may send an integer to the tokenizer
-    to indicate that the next token should be _BinaryToken of the given
-    length.
+    The consumer of the generator may send an integer to the tokenizer to
+    indicate that the next token should be _BinaryToken of the given length.
 
     Parameters
     ----------
@@ -279,18 +276,16 @@ class _BalancedExpression(_Token):
 
 def _expression(initial, tokens, data):
     """
-    Consume some number of tokens and return a balanced PostScript expression
+    Consume some number of tokens and return a balanced PostScript expression.
 
     Parameters
     ----------
     initial : _Token
-        the token that triggered parsing a balanced expression
-
+        The token that triggered parsing a balanced expression.
     tokens : iterator of _Token
-        following tokens
-
+        Following tokens.
     data : bytes
-        underlying data that the token positions point to
+        Underlying data that the token positions point to.
 
     Returns
     -------
@@ -332,17 +327,20 @@ class Type1Font:
     parts : tuple
         A 3-tuple of the cleartext part, the encrypted part, and the finale of
         zeros.
+
     decrypted : bytes
-        The decrypted form of parts[1].
+        The decrypted form of ``parts[1]``.
+
     prop : dict[str, Any]
         A dictionary of font properties. Noteworthy keys include:
-          FontName - PostScript name of the font
-          Encoding - dict from numeric codes to glyph names
-          FontMatrix - bytes object encoding a matrix
-          UniqueID - optional font identifier, dropped when modifying the font
-          CharStrings - dict from glyph names to byte code
-          Subrs - array of byte code subroutines
-          OtherSubrs - bytes object encoding some PostScript code
+
+        - FontName: PostScript name of the font
+        - Encoding: dict from numeric codes to glyph names
+        - FontMatrix: bytes object encoding a matrix
+        - UniqueID: optional font identifier, dropped when modifying the font
+        - CharStrings: dict from glyph names to byte code
+        - Subrs: array of byte code subroutines
+        - OtherSubrs: bytes object encoding some PostScript code
     """
     __slots__ = ('parts', 'decrypted', 'prop', '_pos', '_abbr')
     # the _pos dict contains (begin, end) indices to parts[0] + decrypted
@@ -445,7 +443,7 @@ class Type1Font:
     @staticmethod
     def _decrypt(ciphertext, key, ndiscard=4):
         """
-        Decrypt ciphertext using the Type-1 font algorithm
+        Decrypt ciphertext using the Type-1 font algorithm.
 
         The algorithm is described in Adobe's "Adobe Type 1 Font Format".
         The key argument can be an integer, or one of the strings
@@ -467,7 +465,7 @@ class Type1Font:
     @staticmethod
     def _encrypt(plaintext, key, ndiscard=4):
         """
-        Encrypt plaintext using the Type-1 font algorithm
+        Encrypt plaintext using the Type-1 font algorithm.
 
         The algorithm is described in Adobe's "Adobe Type 1 Font Format".
         The key argument can be an integer, or one of the strings


### PR DESCRIPTION
## PR Summary

See misrendering currently at https://matplotlib.org/devdocs/api/type1font.html#matplotlib.type1font.Type1Font.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
