### PR TITLE
Remove plot_gallery setting from conf.py

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -189,7 +189,6 @@ sphinx_gallery_conf = {
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
 }
 
-plot_gallery = 'True'
 mathmpl_fontsize = 11.0
 mathmpl_srcset = ['2x']
 


### PR DESCRIPTION
The defined value is the [default](https://sphinx-gallery.github.io/stable/configuration.html#without-execution). If somebody wants to change that for their personal build, the recommended way is
[passing parameters to make](https://matplotlib.org/devdocs/devel/documenting_mpl.html#building-the-docs)

