### PR TITLE
Convert macosx backend to use device_pixel_ratio

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -30,14 +30,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         FigureCanvasBase.__init__(self, figure)
         width, height = self.get_width_height()
         _macosx.FigureCanvas.__init__(self, width, height)
-        self._dpi_ratio = 1.0
-
-    def _set_device_scale(self, value):
-        if self._dpi_ratio != value:
-            # Need the new value in place before setting figure.dpi, which
-            # will trigger a resize
-            self._dpi_ratio, old_value = value, self._dpi_ratio
-            self.figure.dpi = self.figure.dpi / old_value * self._dpi_ratio
 
     def set_cursor(self, cursor):
         # docstring inherited
@@ -60,12 +52,11 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         self.draw_idle()
 
     def resize(self, width, height):
-        dpi = self.figure.dpi
-        width /= dpi
-        height /= dpi
-        self.figure.set_size_inches(width * self._dpi_ratio,
-                                    height * self._dpi_ratio,
-                                    forward=False)
+        # Size from macOS is logical pixels, dpi is physical.
+        scale = self.figure.dpi / self.device_pixel_ratio
+        width /= scale
+        height /= scale
+        self.figure.set_size_inches(width, height, forward=False)
         FigureCanvasBase.resize_event(self)
         self.draw_idle()
 


### PR DESCRIPTION
## PR Summary

This was not originally implemented in #19126, but causes some inconsistencies with other backends.

This also sets the initial scale as implemented in #18274.

I tested this out on MacStadium, but it only has a single display which isn't Retina. If you have a Retina display, you can check that the window is correctly double-sized.

If you have _two_ displays, with mixed DPI, then you can check the full functionality. If you create a window on one display, and move it to the other, it should shrink/grow accordingly. A test I do is to start an interpreter, go to interactive mode, and open a figure on each display (on mutter, where your mouse is determines where a window first appears; I don't know if that's the same on macOS). Then you can drag one to the other display, and if resized correctly, they should match each other. Additionally, call `fig.set_size_inches(3, 3)` on both _while on different displays_, and bringing them together should be the same size.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).