### PR TITLE
fixed broken hyperlink in docs for contributing

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -129,8 +129,8 @@ A brief overview is:
       git clone https://github.com/<YOUR GITHUB USERNAME>/matplotlib.git
 
 4. Enter the directory and install the local version of Matplotlib.
-   See :ref:`installing_for_devs` for instructions
-
+   See :ref:`setting up Matplotlib for development <installing_for_devs>` for instructions
+ 
 5. Create a branch to hold your changes::
 
       git checkout -b my-feature origin/master


### PR DESCRIPTION
## PR Summary
A link on the [Contributing page](https://matplotlib.org/stable/devel/contributing.html) was displaying as :ref:`installing_for_devs`. This PR fixes the link and changes to display text to match to title of the linked page to reduce confusion when following the link.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ N/A] New features are documented, with examples if plot related.
- [ Yes] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
