### PR TITLE
Snap selectors

### DIFF
--- a/doc/users/next_whats_new/snap_selector.rst
+++ b/doc/users/next_whats_new/snap_selector.rst
@@ -1,0 +1,4 @@
+SpanSelector widget can now be snapped to specified values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The SpanSelector widget can now be snapped to values specified by the *snap_values*
+argument.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -67,8 +67,7 @@ def test_rectangle_selector():
 @pytest.mark.parametrize('spancoords', ['data', 'pixels'])
 @pytest.mark.parametrize('minspanx, x1', [[0, 10], [1, 10.5], [1, 11]])
 @pytest.mark.parametrize('minspany, y1', [[0, 10], [1, 10.5], [1, 11]])
-def test_rectangle_minspan(spancoords, minspanx, x1, minspany, y1):
-    ax = get_ax()
+def test_rectangle_minspan(ax, spancoords, minspanx, x1, minspany, y1):
     # attribute to track number of onselect calls
     ax._n_onselect = 0
 
@@ -922,6 +921,37 @@ def test_span_selector_animated_artists_callback():
     do_event(span, 'release', xdata=release_data[0],
              ydata=release_data[1], button=1)
     assert ln2.stale is False
+
+
+def test_snapping_values_span_selector(ax):
+    def onselect(*args):
+        pass
+
+    tool = widgets.SpanSelector(ax, onselect, direction='horizontal',)
+    snap_function = tool._snap
+
+    snap_values = np.linspace(0, 5, 11)
+    values = np.array([-0.1, 0.1, 0.2, 0.5, 0.6, 0.7, 0.9, 4.76, 5.0, 5.5])
+    expect = np.array([00.0, 0.0, 0.0, 0.5, 0.5, 0.5, 1.0, 5.00, 5.0, 5.0])
+    values = snap_function(values, snap_values)
+    assert_allclose(values, expect)
+
+
+def test_span_selector_snap(ax):
+    def onselect(vmin, vmax):
+        ax._got_onselect = True
+
+    snap_values = np.arange(50) * 4
+
+    tool = widgets.SpanSelector(ax, onselect, direction='horizontal',
+                                snap_values=snap_values)
+    tool.extents = (17, 35)
+    assert tool.extents == (16, 36)
+
+    tool.snap_values = None
+    assert tool.snap_values is None
+    tool.extents = (17, 35)
+    assert tool.extents == (17, 35)
 
 
 def check_lasso_selector(**kwargs):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2238,9 +2238,8 @@ class SpanSelector(_SelectorWidget):
         If `True`, the event triggered outside the span selector will be
         ignored.
 
-    snap_values : 1D array-like, default: None
-        Snap the extents of the selector to the values defined in
-        ``snap_values``.
+    snap_values : 1D array-like, optional
+        Snap the selector edges to the given values.
 
     Examples
     --------
@@ -2585,12 +2584,11 @@ class SpanSelector(_SelectorWidget):
     @staticmethod
     def _snap(values, snap_values):
         """Snap values to a given array values (snap_values)."""
-        indices = np.empty_like(values, dtype="uint")
         # take into account machine precision
         eps = np.min(np.abs(np.diff(snap_values))) * 1e-12
-        for i, v in enumerate(values):
-            indices[i] = np.abs(snap_values - v + np.sign(v) * eps).argmin()
-        return snap_values[indices]
+        return tuple(
+            snap_values[np.abs(snap_values - v + np.sign(v) * eps).argmin()]
+            for v in values)
 
     @property
     def extents(self):
@@ -2874,7 +2872,6 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
     use_data_coordinates : bool, default: False
         If `True`, the "square" shape of the selector is defined in
         data coordinates instead of display coordinates.
-
     """
 
 


### PR DESCRIPTION
## PR Summary

Snap SpanSelector position to specific values.

```python

import matplotlib.pyplot as plt
from matplotlib.widgets import SpanSelector, RectangleSelector
import numpy as np

y = np.arange(25)
snap_values = np.append(y-0.5, [y[-1] + 0.5])
snap_values_2D = np.array([y]*2)

fig, ax = plt.subplots()
ax.plot(y, 'o')

span = SpanSelector(ax, print, direction='horizontal',
                    interactive=True,
                    drag_from_anywhere=True,
                    snap_values=snap_values)
```

