### PR TITLE
Enable tests for text path based markers

### DIFF
--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -236,8 +236,8 @@ def test_marker_init_captyle():
         Affine2D().translate(1, 1)),
     (markers.MarkerStyle("o", transform=Affine2D().translate(1, 1)),
         Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
-    # (markers.MarkerStyle("$|||$", transform=Affine2D().translate(1, 1)),
-    #  Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
+    (markers.MarkerStyle("$|||$", transform=Affine2D().translate(1, 1)),
+     Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
     (markers.MarkerStyle(
         markers.TICKLEFT, transform=Affine2D().translate(1, 1)),
         Affine2D().translate(1, 1), Affine2D().translate(2, 2)),
@@ -264,8 +264,8 @@ def test_marker_rotated_invalid():
         10, None, Affine2D().translate(1, 1).rotate_deg(10)),
     (markers.MarkerStyle("o", transform=Affine2D().translate(1, 1)),
         None, 0.01, Affine2D().translate(1, 1).rotate(0.01)),
-    # (markers.MarkerStyle("$|||$", transform=Affine2D().translate(1, 1)),
-    #   10, None, Affine2D().translate(1, 1).rotate_deg(10)),
+    (markers.MarkerStyle("$|||$", transform=Affine2D().translate(1, 1)),
+      10, None, Affine2D().translate(1, 1).rotate_deg(10)),
     (markers.MarkerStyle(
         markers.TICKLEFT, transform=Affine2D().translate(1, 1)),
         10, None, Affine2D().translate(1, 1).rotate_deg(10)),


### PR DESCRIPTION
## PR Summary
This PR uncomments marker tests which required instances of TextPath. These tests were introduced (and unfortunately just commented out) in PR #20914, and can be used since #21280 is merged.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
