### PR TITLE
Make hexbin mincnt consistently inclusive of lower bound

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4696,14 +4696,14 @@ default: :rc:`scatter.edgecolors`
             for i in range(nx1):
                 for j in range(ny1):
                     vals = lattice1[i, j]
-                    if len(vals) > mincnt:
+                    if len(vals) >= mincnt:
                         lattice1[i, j] = reduce_C_function(vals)
                     else:
                         lattice1[i, j] = np.nan
             for i in range(nx2):
                 for j in range(ny2):
                     vals = lattice2[i, j]
-                    if len(vals) > mincnt:
+                    if len(vals) >= mincnt:
                         lattice2[i, j] = reduce_C_function(vals)
                     else:
                         lattice2[i, j] = np.nan

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4507,7 +4507,7 @@ default: :rc:`scatter.edgecolors`
             Use a linear or log10 scale on the vertical axis.
 
         mincnt : int > 0, default: *None*
-            If not *None*, only display cells with more than *mincnt*
+            If not *None*, only display cells with at least *mincnt*
             number of points in the cell.
 
         marginals : bool, default: *False*

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -793,6 +793,27 @@ def test_hexbin_log_clim():
     assert h.get_clim() == (2, 100)
 
 
+def test_hexbin_mincnt_withC():
+    # Issue #20877: Tests mincnt working the same with/without weights C
+    np.random.seed(19680801)
+    n = 20000
+
+    x = np.random.normal(loc=0, scale=2, size=n)
+    y = np.random.randint(0, 100, n)
+
+    fig, axes = plt.subplots(2, 1)
+
+    ax = axes[0]
+    res1 = ax.hexbin(x, y, mincnt=1, extent=[-8, 8, 0, 100], gridsize=150)
+
+    ax = axes[1]
+    res2 = ax.hexbin(x, y, mincnt=1, extent=[-8, 8, 0, 100], gridsize=150,
+                     C=5*np.ones(len(x)), reduce_C_function=np.sum)
+
+    assert len(res1.get_array()) == len(res2.get_array())
+    assert 5*sum(res1.get_array()) == sum(res2.get_array())
+
+
 def test_inverted_limits():
     # Test gh:1553
     # Calling invert_xaxis prior to plotting should not disable autoscaling


### PR DESCRIPTION
## PR Summary
This addresses #20877. I dug into the root cause and found that "mincnt" is documented as being **exclusive**, sometimes behaves as **inclusive** (default when you don't provide C), and sometimes behaves as **exclusive** (when you do provide C). In this PR, I make three small changes to standardize on mincnt being **inclusive**.

Prior to the fix:
- If the user _does not_ provide input C, then mincount is _inclusive_; mincount=1 displays hexagons with 1 or more points. I believe this is the expected behavior.
- If the user _does_ provide input C, then mincount is _exclusive_; mincount=1 displays hexagons with >1 points

After the fix:
- mincount is treated as inclusive whether or not the user supplies C, docstring reflects this

Expected behavior is for both of these plots to be identical (adapted from example in #20877). The number of points reported by the print statements should be identical as well.:

```
import numpy as np
import matplotlib.pyplot as plt

npts = int(2e4)

# Create a random distribution and another one as it perturbation
y = np.random.randint(0, 100, npts)
# Y axis variable
x = np.random.normal(loc=0, scale=2, size=npts)

# Plot
fig, axes = plt.subplots(2,1)

#C not specified
ax = axes[0]
res1 = ax.hexbin(x, y, mincnt=1, extent=[-8,8,0,100], gridsize=150)

#adding weights of 1 and specifying reduce as sum should be identical to no weights
ax = axes[1]
res2 = ax.hexbin(x, y, C=np.ones(len(x)), mincnt=1, extent=[-8,8,0,100], gridsize=150,
                 reduce_C_function = np.sum)

c1 = res1.get_array()                
c2 = res2.get_array()

print('points binned in plot1: ', sum(c1))
print('points binned in plot2: ', sum(c2))

fig.savefig(f"hexbin_weights.png")
plt.show()
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
