### PR TITLE
Reuse imsave()'s background-blending code in FigureCanvasAgg.print_jpeg.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -560,13 +560,11 @@ class FigureCanvasAgg(FigureCanvasBase):
 
     @_api.delete_parameter("3.5", "args")
     def print_jpg(self, filename_or_obj, *args, pil_kwargs=None):
-        # Remove transparency by alpha-blending on an assumed white background.
-        r, g, b, a = mcolors.to_rgba(self.figure.get_facecolor())
-        try:
-            self.figure.set_facecolor(a * np.array([r, g, b]) + 1 - a)
+        # savefig() has already applied savefig.facecolor; we now set it to
+        # white to make imsave() blend semi-transparent figures against an
+        # assumed white background.
+        with mpl.rc_context({"savefig.facecolor": "white"}):
             self._print_pil(filename_or_obj, "jpeg", pil_kwargs)
-        finally:
-            self.figure.set_facecolor((r, g, b, a))
 
     print_jpeg = print_jpg
 


### PR DESCRIPTION
We don't need to implement it twice, nor to mark the figure as stale by
temporarily switching its facecolor.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
