### PR TITLE
Add label about workflow to new contributor PRs

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -9,6 +9,7 @@ jobs:
     steps:
     - uses: actions/first-interaction@v1
       with:
+        add-labels: "status: needs workflow approval"
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         pr-message: >+
           Thank you for opening your first PR into Matplotlib!


### PR DESCRIPTION
This modifies the new contributor bot workflow to add a "status: needs workflow approval" label. This is because new contributor PRs do not run through CI without approval from someone with commit rights, but it is not immediately clear which PRs are from new contributors. I'm using "status: needs workflow approval" over "new contributor" because it is tied to a specific actionable task.

**Edit**: I think I may have a chicken/egg problem here in that I think the bot won't run until the workflows are approved - is there any way to exclude it from the needs approval list?