### PR TITLE
FIX: logic of title repositioning

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2981,13 +2981,13 @@ class _AxesBase(martist.Artist):
                     axs = axs + [ax]
             top = -np.Inf
             for ax in axs:
+                bb = None
                 if (ax.xaxis.get_ticks_position() in ['top', 'unknown']
                         or ax.xaxis.get_label_position() == 'top'):
                     bb = ax.xaxis.get_tightbbox(renderer)
-                else:
+                if bb is None:
                     bb = ax.get_window_extent(renderer)
-                if bb is not None:
-                    top = max(top, bb.ymax)
+                top = max(top, bb.ymax)
             if top < 0:
                 # the top of Axes is not even on the figure, so don't try and
                 # automatically place it.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5627,6 +5627,17 @@ def test_title_location_roundtrip():
         ax.set_title('fail', loc='foo')
 
 
+@pytest.mark.parametrize('sharex', [True, False])
+def test_title_location_shared(sharex):
+    fig, axs = plt.subplots(2, 1, sharex=sharex)
+    axs[0].set_title('A', pad=-40)
+    axs[1].set_title('B', pad=-40)
+    fig.draw_without_rendering()
+    x, y1 = axs[0].title.get_position()
+    x, y2 = axs[1].title.get_position()
+    assert y1 == y2 == 1.0
+
+
 @image_comparison(["loglog.png"], remove_text=True, tol=0.02)
 def test_loglog():
     fig, ax = plt.subplots()


### PR DESCRIPTION
## PR Summary

Addresses #21394 so that the padding is consistent, if not exactly what the user wants.  

```
fig, axs = plt.subplots(2, 1, sharex=sharex)
axs[0].set_title(f'A sharex={sharex}', pad=-40)
axs[1].set_title('B', pad=-40)
```

## Old

Note how when we sharex the title is displaced downwards, but only in the first plot, not the last one.  This is inconsistent with the sharex=False behaviour, which is to manually move the axes outside the axes bounds (regardless of the users' pad argument).

We did discuss this behaviour, and decided it was OK, if less than great.  Users can get around this by specifying `y` manually (i.e. `y=1.0001` works fine).   We probably should deprecate the `pad` argument in favour of just asking folks to specify the title position using `y`.  

![Old_sharex_False](https://user-images.githubusercontent.com/1562854/138121284-0afa6347-dc21-46f5-bbdf-9cbe71f28d0f.png)

![Old_sharex_True](https://user-images.githubusercontent.com/1562854/138121297-96337b98-b6fc-4ee5-bf39-69661b57e248.png)

## New
![New_sharex_False](https://user-images.githubusercontent.com/1562854/138121318-d48d8592-029e-4f69-83d1-57ff85c9a5cb.png)
![New_sharex_True](https://user-images.githubusercontent.com/1562854/138121332-e9c62892-5e89-4f32-bf34-7d5513811a43.png)




## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
