### PR TITLE
Use bbox.{size,bounds,width,height,p0,...} where appropriate.

### DIFF
--- a/examples/shapes_and_collections/fancybox_demo.py
+++ b/examples/shapes_and_collections/fancybox_demo.py
@@ -44,7 +44,7 @@ for ax, (stylename, stylecls) in zip(axs[1:, :].T.flat, styles.items()):
 
 
 def add_fancy_patch_around(ax, bb, **kwargs):
-    fancy = FancyBboxPatch((bb.xmin, bb.ymin), bb.width, bb.height,
+    fancy = FancyBboxPatch(bb.p0, bb.width, bb.height,
                            fc=(1, 0.8, 1, 0.5), ec=(1, 0.5, 1, 0.5),
                            **kwargs)
     ax.add_patch(fancy)

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -30,11 +30,10 @@ class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
         self._renderer = RendererCairo(self.figure.dpi)
 
     def draw(self, drawDC=None):
-        width = int(self.figure.bbox.width)
-        height = int(self.figure.bbox.height)
-        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
+        size = self.figure.bbox.size.astype(int)
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, *size)
         self._renderer.set_ctx_from_surface(surface)
-        self._renderer.set_width_height(width, height)
+        self._renderer.set_width_height(*size)
         self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)
         self.bitmap = wxcairo.BitmapFromImageSurface(surface)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1627,7 +1627,7 @@ default: %(va)s
 
         for a in artists:
             bbox = a.get_tightbbox(renderer)
-            if bbox is not None and (bbox.width != 0 or bbox.height != 0):
+            if bbox is not None:
                 bb.append(bbox)
 
         for ax in self.axes:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -621,7 +621,7 @@ class Legend(Artist):
         # update the location and size of the legend. This needs to
         # be done in any case to clip the figure right.
         bbox = self._legend_box.get_window_extent(renderer)
-        self.legendPatch.set_bounds(bbox.x0, bbox.y0, bbox.width, bbox.height)
+        self.legendPatch.set_bounds(bbox.bounds)
         self.legendPatch.set_mutation_scale(fontsize)
 
         if self.shadow:

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -557,7 +557,7 @@ class PaddedBox(OffsetBox):
         self.stale = False
 
     def update_frame(self, bbox, fontsize=None):
-        self.patch.set_bounds(bbox.x0, bbox.y0, bbox.width, bbox.height)
+        self.patch.set_bounds(bbox.bounds)
         if fontsize:
             self.patch.set_mutation_scale(fontsize)
         self.stale = True
@@ -811,7 +811,7 @@ class TextArea(OffsetBox):
             ismath="TeX" if self._text.get_usetex() else False)
 
         bbox, info, yd = self._text._get_layout(renderer)
-        w, h = bbox.width, bbox.height
+        w, h = bbox.size
 
         self._baseline_transform.clear()
 
@@ -1111,7 +1111,7 @@ class AnchoredOffsetbox(OffsetBox):
         self.set_offset(_offset)
 
     def update_frame(self, bbox, fontsize=None):
-        self.patch.set_bounds(bbox.x0, bbox.y0, bbox.width, bbox.height)
+        self.patch.set_bounds(bbox.bounds)
         if fontsize:
             self.patch.set_mutation_scale(fontsize)
 
@@ -1146,8 +1146,7 @@ def _get_anchored_bbox(loc, bbox, parentbbox, borderpad):
     # validated.  If 0 (None), we just let ``bbox.anchored`` raise.
     c = [None, "NE", "NW", "SW", "SE", "E", "W", "E", "S", "N", "C"][loc]
     container = parentbbox.padded(-borderpad)
-    anchored_box = bbox.anchored(c, container=container)
-    return anchored_box.x0, anchored_box.y0
+    return bbox.anchored(c, container=container).p0
 
 
 class AnchoredText(AnchoredOffsetbox):
@@ -1487,8 +1486,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
 
         # update patch position
         bbox = self.offsetbox.get_window_extent(renderer)
-        self.patch.set_bounds(bbox.x0, bbox.y0,
-                              bbox.width, bbox.height)
+        self.patch.set_bounds(bbox.bounds)
 
         x, y = xy_pixel
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2106,7 +2106,7 @@ def draw_bbox(bbox, renderer, color='k', trans=None):
     box returned by an artist's `.Artist.get_window_extent`
     to test whether the artist is returning the correct bbox.
     """
-    r = Rectangle(xy=(bbox.x0, bbox.y0), width=bbox.width, height=bbox.height,
+    r = Rectangle(xy=bbox.p0, width=bbox.width, height=bbox.height,
                   edgecolor=color, fill=False, clip_on=False)
     if trans is not None:
         r.set_transform(trans)

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -605,13 +605,9 @@ class Quiver(mcollections.PolyCollection):
             elif units == 'y':
                 dx0 = self.axes.viewLim.height
                 dx1 = self.axes.bbox.height
-            else:  # 'xy' is assumed
-                dxx0 = self.axes.viewLim.width
-                dxx1 = self.axes.bbox.width
-                dyy0 = self.axes.viewLim.height
-                dyy1 = self.axes.bbox.height
-                dx1 = np.hypot(dxx1, dyy1)
-                dx0 = np.hypot(dxx0, dyy0)
+            else:  # 'xy', i.e. hypot(x, y)
+                dx0 = np.hypot(*self.axes.viewLim.size)
+                dx1 = np.hypot(*self.axes.bbox.size)
             dx = dx1 / dx0
         else:
             if units == 'width':

--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -57,10 +57,9 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
     tr = Affine2D().scale(fixed_dpi)
     dpi_scale = fixed_dpi / fig.dpi
 
-    fig.bbox_inches = Bbox.from_bounds(0, 0,
-                                       bbox_inches.width, bbox_inches.height)
+    fig.bbox_inches = Bbox.from_bounds(0, 0, *bbox_inches.size)
     x0, y0 = tr.transform(bbox_inches.p0)
-    w1, h1 = fig.bbox.width * dpi_scale, fig.bbox.height * dpi_scale
+    w1, h1 = fig.bbox.size * dpi_scale
     fig.transFigure._boxout = Bbox.from_bounds(-x0, -y0, w1, h1)
     fig.transFigure.invalidate()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1207,12 +1207,12 @@ class TextBox(AxesWidget):
         bb_widthtext = self.text_disp.get_window_extent()
 
         if bb_text.y0 == bb_text.y1:  # Restoring the height if no text.
-            bb_text.y0 -= (bb_widthtext.y1-bb_widthtext.y0)/2
-            bb_text.y1 += (bb_widthtext.y1-bb_widthtext.y0)/2
+            bb_text.y0 -= bb_widthtext.height / 2
+            bb_text.y1 += bb_widthtext.height / 2
         elif not widthtext:  # Keep width to 0.
             bb_text.x1 = bb_text.x0
         else:  # Move the cursor using width of bb_widthtext.
-            bb_text.x1 = bb_text.x0 + (bb_widthtext.x1 - bb_widthtext.x0)
+            bb_text.x1 = bb_text.x0 + bb_widthtext.width
 
         self.cursor.set(
             segments=[[(bb_text.x1, bb_text.y0), (bb_text.x1, bb_text.y1)]],

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -205,8 +205,7 @@ class Divider:
             hh = (oy[-1] - oy[0]) / fig_h
             pb = mtransforms.Bbox.from_bounds(x, y, w, h)
             pb1 = mtransforms.Bbox.from_bounds(x, y, ww, hh)
-            pb1_anchored = pb1.anchored(self.get_anchor(), pb)
-            x0, y0 = pb1_anchored.x0, pb1_anchored.y0
+            x0, y0 = pb1.anchored(self.get_anchor(), pb).p0
 
         else:
             ox = self._calc_offsets(hsizes, k_h)
@@ -637,8 +636,7 @@ def _locate(x, y, w, h, summed_widths, equal_heights, fig_w, fig_h, anchor):
     hh = (karray[0]*h0_r + h0_a) / fig_h
     pb = mtransforms.Bbox.from_bounds(x, y, w, h)
     pb1 = mtransforms.Bbox.from_bounds(x, y, ww, hh)
-    pb1_anchored = pb1.anchored(anchor, pb)
-    x0, y0 = pb1_anchored.x0, pb1_anchored.y0
+    x0, y0 = pb1.anchored(anchor, pb).p0
 
     return x0, y0, ox, hh
 


### PR DESCRIPTION
Mostly for clarity, but also, these are all properties, so it should
even be (likely unnoticeably) faster to have fewer access attributes.

The change to Figure.get_tightbbox is slightly different: checking for
bbox.width/bbox.height is unnecessary because we already do the same
check a few lines later.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
