### PR TITLE
Uncamelcase some internal variables in axis.py; rename _get_tick_bboxes.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1018,24 +1018,18 @@ class Axis(martist.Artist):
         a.set_figure(self.figure)
 
     def get_ticklabel_extents(self, renderer):
-        """
-        Get the extents of the tick labels on either side
-        of the axes.
-        """
-
+        """Get the extents of the tick labels on either side of the axes."""
         ticks_to_draw = self._update_ticks()
-        ticklabelBoxes, ticklabelBoxes2 = self._get_tick_bboxes(ticks_to_draw,
-                                                                renderer)
-
-        if len(ticklabelBoxes):
-            bbox = mtransforms.Bbox.union(ticklabelBoxes)
+        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
+        if len(tlb1):
+            bbox1 = mtransforms.Bbox.union(tlb1)
         else:
-            bbox = mtransforms.Bbox.from_extents(0, 0, 0, 0)
-        if len(ticklabelBoxes2):
-            bbox2 = mtransforms.Bbox.union(ticklabelBoxes2)
+            bbox1 = mtransforms.Bbox.from_extents(0, 0, 0, 0)
+        if len(tlb2):
+            bbox2 = mtransforms.Bbox.union(tlb2)
         else:
             bbox2 = mtransforms.Bbox.from_extents(0, 0, 0, 0)
-        return bbox, bbox2
+        return bbox1, bbox2
 
     def _update_ticks(self):
         """
@@ -1080,7 +1074,7 @@ class Axis(martist.Artist):
 
         return ticks_to_draw
 
-    def _get_tick_bboxes(self, ticks, renderer):
+    def _get_ticklabel_bboxes(self, ticks, renderer):
         """Return lists of bboxes for ticks' label1's and label2's."""
         return ([tick.label1.get_window_extent(renderer)
                  for tick in ticks if tick.label1.get_visible()],
@@ -1105,18 +1099,16 @@ class Axis(martist.Artist):
         self._update_label_position(renderer)
 
         # go back to just this axis's tick labels
-        ticklabelBoxes, ticklabelBoxes2 = self._get_tick_bboxes(
-                    ticks_to_draw, renderer)
+        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
 
-        self._update_offset_text_position(ticklabelBoxes, ticklabelBoxes2)
+        self._update_offset_text_position(tlb1, tlb2)
         self.offsetText.set_text(self.major.formatter.get_offset())
 
         bboxes = [
             *(a.get_window_extent(renderer)
               for a in [self.offsetText]
               if a.get_visible()),
-            *ticklabelBoxes,
-            *ticklabelBoxes2,
+            *tlb1, *tlb2,
         ]
         # take care of label
         if self.label.get_visible():
@@ -1156,22 +1148,20 @@ class Axis(martist.Artist):
         renderer.open_group(__name__, gid=self.get_gid())
 
         ticks_to_draw = self._update_ticks()
-        ticklabelBoxes, ticklabelBoxes2 = self._get_tick_bboxes(ticks_to_draw,
-                                                                renderer)
+        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
 
         for tick in ticks_to_draw:
             tick.draw(renderer)
 
-        # scale up the axis label box to also find the neighbors, not
-        # just the tick labels that actually overlap note we need a
-        # *copy* of the axis label box because we don't want to scale
-        # the actual bbox
+        # Scale up the axis label box to also find the neighbors, not just the
+        # tick labels that actually overlap.  We need a *copy* of the axis
+        # label box because we don't want to scale the actual bbox.
 
         self._update_label_position(renderer)
 
         self.label.draw(renderer)
 
-        self._update_offset_text_position(ticklabelBoxes, ticklabelBoxes2)
+        self._update_offset_text_position(tlb1, tlb2)
         self.offsetText.set_text(self.major.formatter.get_offset())
         self.offsetText.draw(renderer)
 
@@ -1878,7 +1868,7 @@ class Axis(martist.Artist):
         for ax in grouper.get_siblings(self.axes):
             axis = getattr(ax, f"{axis_name}axis")
             ticks_to_draw = axis._update_ticks()
-            tlb, tlb2 = axis._get_tick_bboxes(ticks_to_draw, renderer)
+            tlb, tlb2 = axis._get_ticklabel_bboxes(ticks_to_draw, renderer)
             bboxes.extend(tlb)
             bboxes2.extend(tlb2)
         return bboxes, bboxes2
@@ -2144,19 +2134,19 @@ class XAxis(Axis):
         """
         bbox, bbox2 = self.get_ticklabel_extents(renderer)
         # MGDTODO: Need a better way to get the pad
-        padPixels = self.majorTicks[0].get_pad_pixels()
+        pad_pixels = self.majorTicks[0].get_pad_pixels()
 
         above = 0.0
         if bbox2.height:
-            above += bbox2.height + padPixels
+            above += bbox2.height + pad_pixels
         below = 0.0
         if bbox.height:
-            below += bbox.height + padPixels
+            below += bbox.height + pad_pixels
 
         if self.get_label_position() == 'top':
-            above += self.label.get_window_extent(renderer).height + padPixels
+            above += self.label.get_window_extent(renderer).height + pad_pixels
         else:
-            below += self.label.get_window_extent(renderer).height + padPixels
+            below += self.label.get_window_extent(renderer).height + pad_pixels
         return above, below
 
     def set_ticks_position(self, position):
@@ -2408,19 +2398,19 @@ class YAxis(Axis):
     def get_text_widths(self, renderer):
         bbox, bbox2 = self.get_ticklabel_extents(renderer)
         # MGDTODO: Need a better way to get the pad
-        padPixels = self.majorTicks[0].get_pad_pixels()
+        pad_pixels = self.majorTicks[0].get_pad_pixels()
 
         left = 0.0
         if bbox.width:
-            left += bbox.width + padPixels
+            left += bbox.width + pad_pixels
         right = 0.0
         if bbox2.width:
-            right += bbox2.width + padPixels
+            right += bbox2.width + pad_pixels
 
         if self.get_label_position() == 'left':
-            left += self.label.get_window_extent(renderer).width + padPixels
+            left += self.label.get_window_extent(renderer).width + pad_pixels
         else:
-            right += self.label.get_window_extent(renderer).width + padPixels
+            right += self.label.get_window_extent(renderer).width + pad_pixels
         return left, right
 
     def set_ticks_position(self, position):

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -485,7 +485,7 @@ class Axis(maxis.XAxis):
 
         ticks = ticks_to_draw
 
-        bb_1, bb_2 = self._get_tick_bboxes(ticks, renderer)
+        bb_1, bb_2 = self._get_ticklabel_bboxes(ticks, renderer)
         other = []
 
         if self.line.get_visible():


### PR DESCRIPTION
It's actually returning the ticklabel bboxes, not including the
tickmarks themselves.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
