### PR TITLE
Support pathological tmpdirs in TexManager.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -258,16 +258,19 @@ class TexManager:
         basefile = self.get_basefile(tex, fontsize)
         dvifile = '%s.dvi' % basefile
         if not os.path.exists(dvifile):
-            texfile = self.make_tex(tex, fontsize)
+            texfile = Path(self.make_tex(tex, fontsize))
             # Generate the dvi in a temporary directory to avoid race
             # conditions e.g. if multiple processes try to process the same tex
             # string at the same time.  Having tmpdir be a subdirectory of the
             # final output dir ensures that they are on the same filesystem,
-            # and thus replace() works atomically.
+            # and thus replace() works atomically.  It also allows referring to
+            # the texfile with a relative path (for pathological MPLCONFIGDIRs,
+            # the absolute path may contain characters (e.g. ~) that TeX does
+            # not support.)
             with TemporaryDirectory(dir=Path(dvifile).parent) as tmpdir:
                 self._run_checked_subprocess(
                     ["latex", "-interaction=nonstopmode", "--halt-on-error",
-                     texfile], tex, cwd=tmpdir)
+                     f"../{texfile.name}"], tex, cwd=tmpdir)
                 (Path(tmpdir) / Path(dvifile).name).replace(dvifile)
         return dvifile
 


### PR DESCRIPTION
tex does not support paths that contain tildes, and tmpdir may be such a
path.  Fortunately, we can arrange to refer to paths relatively instead.

No test, as that would involve setting up another MPLCONFIGDIR just for
that purpose, which is rather costly as we'd need to regen the font
cache for it.  But one can try e.g.
```
MPLCONFIGDIR=/tmp/has~tilde python -c 'from pylab import *; figtext(.5, .5, "a", usetex=True); show()'
```

Closes https://github.com/matplotlib/matplotlib/issues/21375#issuecomment-948268699.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
