### PR TITLE
Move gui_support.macosx option to packages section.

### DIFF
--- a/doc/api/next_api_changes/development/21415-AL.rst
+++ b/doc/api/next_api_changes/development/21415-AL.rst
@@ -1,0 +1,2 @@
+``gui_support.macosx`` setup option has been renamed to ``packages.macosx``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/mplsetup.cfg.template
+++ b/mplsetup.cfg.template
@@ -3,26 +3,26 @@
 [libs]
 # By default, Matplotlib builds with LTO, which may be slow if you re-compile
 # often, and don't need the space saving/speedup.
+#
 #enable_lto = True
+#
 # By default, Matplotlib downloads and builds its own copies of FreeType and of
 # Qhull.  You may set the following to True to instead link against a system
 # FreeType/Qhull.  As an exception, Matplotlib defaults to the system version
 # of FreeType on AIX.
+#
 #system_freetype = False
 #system_qhull = False
 
 [packages]
-# There are a number of data subpackages from Matplotlib that are
-# considered optional. All except 'tests' data (meaning the baseline
-# image files) are installed by default, but that can be changed here.
-#tests = False
-
-[gui_support]
-# Matplotlib supports multiple GUI toolkits, known as backends.
-# The MacOSX backend requires the Cocoa headers included with XCode.
-# You can select whether to build it by uncommenting the following line.
-# It is never built on Linux or Windows, regardless of the config value.
+# Some of Matplotlib's components are optional: the MacOSX backend (installed
+# by default on MacOSX; requires the Cocoa headers included with XCode), and
+# the test data (i.e., the baseline image files; not installed by default).
+# You can control whether they are installed by uncommenting the following
+# lines.  Note that the MacOSX backend is never built on Linux or Windows,
+# regardless of the config value.
 #
+#tests = False
 #macosx = True
 
 [rc_options]

--- a/setupext.py
+++ b/setupext.py
@@ -321,7 +321,6 @@ class SetupPackage:
 
 
 class OptionalPackage(SetupPackage):
-    config_category = "packages"
     default_config = True
 
     def check(self):
@@ -330,7 +329,7 @@ class OptionalPackage(SetupPackage):
 
         May be overridden by subclasses for additional checks.
         """
-        if config.getboolean(self.config_category, self.name,
+        if config.getboolean("packages", self.name,
                              fallback=self.default_config):
             return "installing"
         else:  # Configuration opt-out by user
@@ -717,7 +716,6 @@ class Qhull(SetupPackage):
 
 
 class BackendMacOSX(OptionalPackage):
-    config_category = 'gui_support'
     name = 'macosx'
 
     def check(self):
@@ -726,10 +724,10 @@ class BackendMacOSX(OptionalPackage):
         return super().check()
 
     def get_extensions(self):
-        sources = [
-            'src/_macosx.m'
-            ]
-        ext = Extension('matplotlib.backends._macosx', sources)
+        ext = Extension(
+            'matplotlib.backends._macosx', [
+                'src/_macosx.m'
+            ])
         ext.extra_compile_args.extend(['-Werror=unguarded-availability'])
         ext.extra_link_args.extend(['-framework', 'Cocoa'])
         if platform.python_implementation().lower() == 'pypy':


### PR DESCRIPTION
Currently, packages and gui_support only have one entry each, and are
conceptually close enough to be merged.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
