### PR TITLE
Use Bbox.unit() more.

### DIFF
--- a/examples/text_labels_and_annotations/angle_annotation.py
+++ b/examples/text_labels_and_annotations/angle_annotation.py
@@ -134,8 +134,7 @@ class AngleAnnotation(Arc):
         if self.unit == "points":
             factor = self.ax.figure.dpi / 72.
         elif self.unit[:4] == "axes":
-            b = TransformedBbox(Bbox.from_bounds(0, 0, 1, 1),
-                                self.ax.transAxes)
+            b = TransformedBbox(Bbox.unit(), self.ax.transAxes)
             dic = {"max": max(b.width, b.height),
                    "min": min(b.width, b.height),
                    "width": b.width, "height": b.height}

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1877,7 +1877,7 @@ class _AxesBase(martist.Artist):
             return
 
         trans = self.get_figure().transSubfigure
-        bb = mtransforms.Bbox.from_bounds(0, 0, 1, 1).transformed(trans)
+        bb = mtransforms.Bbox.unit().transformed(trans)
         # this is the physical aspect of the panel (or figure):
         fig_aspect = bb.height / bb.width
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2259,9 +2259,8 @@ class XAxis(Axis):
         self.stale = True
 
     def get_tick_space(self):
-        ends = mtransforms.Bbox.from_bounds(0, 0, 1, 1)
-        ends = ends.transformed(self.axes.transAxes -
-                                self.figure.dpi_scale_trans)
+        ends = mtransforms.Bbox.unit().transformed(
+            self.axes.transAxes - self.figure.dpi_scale_trans)
         length = ends.width * 72
         # There is a heuristic here that the aspect ratio of tick text
         # is no more than 3:1
@@ -2521,9 +2520,8 @@ class YAxis(Axis):
         self.stale = True
 
     def get_tick_space(self):
-        ends = mtransforms.Bbox.from_bounds(0, 0, 1, 1)
-        ends = ends.transformed(self.axes.transAxes -
-                                self.figure.dpi_scale_trans)
+        ends = mtransforms.Bbox.unit().transformed(
+            self.axes.transAxes - self.figure.dpi_scale_trans)
         length = ends.height * 72
         # Having a spacing of at least 2 just looks good.
         size = self._get_tick_label_size('y') * 2

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -363,7 +363,7 @@ class Axes3D(Axes):
         # scales and box/datalim. Those are all irrelevant - all we need to do
         # is make sure our coordinate system is square.
         trans = self.get_figure().transSubfigure
-        bb = mtransforms.Bbox.from_bounds(0, 0, 1, 1).transformed(trans)
+        bb = mtransforms.Bbox.unit().transformed(trans)
         # this is the physical aspect of the panel (or figure):
         fig_aspect = bb.height / bb.width
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
