### PR TITLE
Change CircleCI job title to "Rendered docs"

### DIFF
--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -10,4 +10,4 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: docs-python38
-          job-title: Check the rendered docs here!
+          job-title: View the built docs


### PR DESCRIPTION
This was "Check the rendered docs here!" before. None of the other
job names is a full sentence.
