### PR TITLE
fix y axis on 3d plot

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -130,6 +130,9 @@ class Axes3D(Axes):
         self.set_axis_on()
         self.M = None
 
+        # Change the y-axis ticks to be on the right side
+        self.yaxis.set_ticks_position("right")
+
         # func used to format z -- fall back on major formatters
         self.fmt_zdata = None
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -32,7 +32,7 @@ def tick_update_position(tick, tickxs, tickys, labelpos):
     tick.gridline.set_data(0, 0)
 
 
-class Axis(maxis.XAxis):
+class Axis(maxis.Axis):
     """An Axis class for the 3D plots."""
     # These points from the unit cube make up the x, y and z-planes
     _PLANES = (
@@ -516,21 +516,21 @@ class Axis(maxis.XAxis):
 # Use classes to look at different data limits
 
 
-class XAxis(Axis):
+class XAxis(Axis, maxis.XAxis):
     get_view_interval, set_view_interval = maxis._make_getset_interval(
         "view", "xy_viewLim", "intervalx")
     get_data_interval, set_data_interval = maxis._make_getset_interval(
         "data", "xy_dataLim", "intervalx")
 
 
-class YAxis(Axis):
+class YAxis(Axis, maxis.YAxis):
     get_view_interval, set_view_interval = maxis._make_getset_interval(
         "view", "xy_viewLim", "intervaly")
     get_data_interval, set_data_interval = maxis._make_getset_interval(
         "data", "xy_dataLim", "intervaly")
 
 
-class ZAxis(Axis):
+class ZAxis(Axis, maxis.XAxis):
     get_view_interval, set_view_interval = maxis._make_getset_interval(
         "view", "zz_viewLim", "intervalx")
     get_data_interval, set_data_interval = maxis._make_getset_interval(


### PR DESCRIPTION
This commit corrects the axis which the 3D y axis inherits from. The y-axis on 3D plots initially inherited from the x axis object, rather than a y axis object. This resulted in a bug where the x axis (instead of the y) was inverted for 3D plots when  was called. After inheritance correction, correct behavior was achieved with inversion, but the tick marks were incorrectly placed. The default location for tick marks on the y-axis is now
set to be right, rather than left.

Resolves #21369

## PR Summary
See commit message. This PR unfortunately causes failure of most tests in mplot3D at the moment.

## PR Checklist

- [x] correct axis inheritance
- [x] change y axis tick position
- [ ] Determine if corrections cause problems elsewhere in the code base
- [ ] Correct unit tests if necessary
- [ ] Add unit test to check for proper axis inversion.

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
