### PR TITLE
Make Axis3D constructor signature closer to the one of 2D axis.

### DIFF
--- a/doc/api/next_api_changes/deprecations/21425-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21425-AL.rst
@@ -1,0 +1,15 @@
+3D Axis
+~~~~~~~
+The previous constructor of `.axis3d.Axis`, with signature
+``(self, adir, v_intervalx, d_intervalx, axes, *args, rotate_label=None, **kwargs)``
+is deprecated in favor of a new signature closer to the one of 2D Axis; it
+is now ``(self, axes, *, rotate_label=None, **kwargs)`` where ``kwargs`` are
+forwarded to the 2D Axis constructor.  The axis direction is now inferred from
+the axis class' ``axis_name`` attribute (as in the 2D case); the ``adir``
+attribute is deprecated.
+
+The ``init3d`` method of 3D Axis is also deprecated; all the relevant
+initialization is done as part of the constructor.
+
+The ``d_interval`` and ``v_interval`` attributes of 3D Axis are deprecated; use
+``get_data_interval`` and ``get_view_interval`` instead.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -194,14 +194,9 @@ class Axes3D(Axes):
 
     def _init_axis(self):
         """Init 3D axes; overrides creation of regular X/Y axes."""
-        self.xaxis = axis3d.XAxis('x', self.xy_viewLim.intervalx,
-                                  self.xy_dataLim.intervalx, self)
-        self.yaxis = axis3d.YAxis('y', self.xy_viewLim.intervaly,
-                                  self.xy_dataLim.intervaly, self)
-        self.zaxis = axis3d.ZAxis('z', self.zz_viewLim.intervalx,
-                                  self.zz_dataLim.intervalx, self)
-        for ax in self.xaxis, self.yaxis, self.zaxis:
-            ax.init3d()
+        self.xaxis = axis3d.XAxis(self)
+        self.yaxis = axis3d.YAxis(self)
+        self.zaxis = axis3d.ZAxis(self)
 
     def get_zaxis(self):
         """Return the ``ZAxis`` (`~.axis3d.Axis`) instance."""


### PR DESCRIPTION
Setting `adir` to a direction not matching the specific axis class
doesn't make sense anyways; the viewlims and datalims properties
previously got init'ed to their preexisting values; and init3d doesn't
warrant being a separate public API.

Also deprecate the 3D-specific d_interval and v_interval attributes, as
they have direct replacements compatible with 2D.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
