### PR TITLE
use unused coords_flat

### DIFF
--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -783,7 +783,7 @@ def test_quadmesh_deprecated_positional(fig_test, fig_ref):
     ax = fig_ref.add_subplot()
     ax.set(xlim=(0, 5), ylim=(0, 4))
     with pytest.warns(MatplotlibDeprecationWarning):
-        qmesh = QuadMesh(4 - 1, 3 - 1, coords.copy().reshape(-1, 2),
+        qmesh = QuadMesh(4 - 1, 3 - 1, coords_flat,
                          False, 'gouraud')
     qmesh.set_array(C)
     ax.add_collection(qmesh)


### PR DESCRIPTION
## PR Summary
Use unused coords_flat, instead of reusing copy and resize method.
above variable coords_flat must have been assigned for this purpose, but somehow, never used.
This PR attempts to improve this, by using coords_flat in test quadmesh function

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
