### PR TITLE
DOC: Fix selection of parameter names in HTML theme

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -245,3 +245,11 @@ div.twocol > div {
     padding: 0;
     margin: 0;
 }
+
+/* Fix selection of parameter names; remove when fixed in the theme
+ * https://github.com/sphinx-doc/sphinx/pull/9763
+ */
+.classifier:before {
+    display: inline-block;
+    margin: 0 0.5em;
+}


### PR DESCRIPTION
## PR Summary

Parameters are written in HTML as (leaving out some internal classes):
```
<strong>name</strong><span class="classifier"><a><code><span>TypeName</span></code></a></span>
```
but in rendered form there's a colon between the name and type. This colon is inserted virtually using CSS, but since it doesn't exist, the browser thinks both sides are part of the same word.

Styling the virtual text as inline block makes it be treated as a break, but also makes it apply vertical margins, so we need to set those to zero again.

See also https://github.com/sphinx-doc/sphinx/pull/9763
Fixes #21432.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).