### PR TITLE
FIX: re-instate ability to have position in axes

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1059,8 +1059,12 @@ def axes(arg=None, **kwargs):
         plt.axes((left, bottom, width, height), facecolor='w')
     """
     fig = gcf()
+    pos = kwargs.pop('position', None)
     if arg is None:
-        return fig.add_subplot(**kwargs)
+        if pos is None:
+            return fig.add_subplot(**kwargs)
+        else:
+            return fig.add_axes(pos, **kwargs)
     else:
         return fig.add_axes(arg, **kwargs)
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -1,4 +1,5 @@
 import difflib
+import numpy as np
 import subprocess
 import sys
 from pathlib import Path
@@ -320,3 +321,17 @@ def test_polar_second_call():
     ln2, = plt.polar(1.57, .5, 'bo')
     assert isinstance(ln2, mpl.lines.Line2D)
     assert ln1.axes is ln2.axes
+
+
+def test_fallback_position():
+    # check that position kwarg works if rect not supplied
+    axref = plt.axes([0.2, 0.2, 0.5, 0.5])
+    axtest = plt.axes(position=[0.2, 0.2, 0.5, 0.5])
+    np.testing.assert_allclose(axtest.bbox.get_points(),
+                               axref.bbox.get_points())
+
+    # check that position kwarg ignored if rect is supplied
+    axref = plt.axes([0.2, 0.2, 0.5, 0.5])
+    axtest = plt.axes([0.2, 0.2, 0.5, 0.5], position=[0.1, 0.1, 0.8, 0.8])
+    np.testing.assert_allclose(axtest.bbox.get_points(),
+                               axref.bbox.get_points())


### PR DESCRIPTION
## PR Summary

Closes #21441  

```
import matplotlib.pyplot as plt

fig = plt.figure()

pos1 = [0.1, 0.1, 0.3, 0.8]
pos2 = [0.5, 0.1, 0.4, 0.6]

ax1 = plt.axes(position = pos1)
ax1.plot([0,1], [0, 1], color = 'r', linewidth = 3)

ax2 = plt.axes(position = pos2)
ax2.plot([1, 0], [0, 1], color = 'b', linestyle = '--')
```

is documented to work, but position is silently ignored.  `position` is just redundant with `rect`, so go ahead and check for position if rect is None.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
