### PR TITLE
Use named groups in mathtext parser.

### DIFF
--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -255,13 +255,12 @@ def test_fontinfo():
         (r'$\left($', re.compile(r'Expected ("|\'\\)\\right["\']')),
         (r'$\dfrac$', r'Expected \dfrac{num}{den}'),
         (r'$\dfrac{}{}$', r'Expected \dfrac{num}{den}'),
-        (r'$\overset$', r'Expected \overset{body}{annotation}'),
-        (r'$\underset$', r'Expected \underset{body}{annotation}'),
+        (r'$\overset$', r'Expected \overset{annotation}{body}'),
+        (r'$\underset$', r'Expected \underset{annotation}{body}'),
         (r'$\foo$', r'Unknown symbol: \foo'),
         (r'$a^2^2$', r'Double superscript'),
         (r'$a_2_2$', r'Double subscript'),
-        (r'$a^2_a^2$', r'Subscript/superscript sequence is too long.'\
-            r' Use braces { } to remove ambiguity.'),
+        (r'$a^2_a^2$', r'Double superscript'),
     ],
     ids=[
         'hspace without value',


### PR DESCRIPTION
This makes the definitions much easier to read, by removing the need to
use Group() and Suppress(): previously, these would be used to nest the
parsed tokens and remove the unnecessary ones (e.g, braces), but such
tokens can also easily be ignored by giving names to the tokens we use
(instead of accessing them by position).  (See e.g. the implementation
of subsuper, which is also somewhat simplified.)

Also remove a few other pyparsing combinators that are not
needed: Combine (just concatenate the strings ourselves), FollowedBy
(use lookahead regexes), Literal (use plain strings, in particular
braces which are very common).

Also remove right_delim_safe, as self._right_delim already includes the
backslash-escaped closing brace rather than the unescaped one
(right_delim_safe dates back to when it didn't).

The error message for `a^2_2^2` now changed to "double superscript" as
we now simply check for subscripts and superscripts one at a time, and
fail when we see either two subscript or two superscripts, emitting the
corresponding error.

~~(I played a bit with the parser to try and see what's wrong with pyparsing 3
and got there; unfortunately this patch doesn't fix the incompatibility :-()~~
Edit: This seems to fix support with pyparsing 3.  It's not totally clear why, though...
A much more minimal fix would be
```patch
diff --git i/lib/matplotlib/_mathtext.py w/lib/matplotlib/_mathtext.py
index 73e6163944..fbf58b5df1 100644
--- i/lib/matplotlib/_mathtext.py
+++ w/lib/matplotlib/_mathtext.py
@@ -2046,7 +2046,7 @@ class Parser:
         p.accentprefixed <<= Suppress(p.bslash) + oneOf(self._accentprefixed)
         p.symbol_name   <<= (
             Combine(p.bslash + oneOf(list(tex2uni)))
-            + FollowedBy(Regex("[^A-Za-z]").leaveWhitespace() | StringEnd())
+            + Suppress(Regex("(?=[^A-Za-z]|$)").leaveWhitespace())
         )
         p.symbol        <<= (p.single_symbol | p.symbol_name).leaveWhitespace()
```
I still don't know whether that's a bug or an intended API change on pyparsing's side.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
