### PR TITLE
Less verbose install info on index page

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,29 +14,23 @@ and interactive visualizations in Python.
 Installation
 ============
 
-.. panels::
-    :card: + install-card
-    :column: col-lg-6 col-md-6 col-sm-12 col-xs-12 p-3
+.. container:: twocol
 
-    Installing using `conda <https://docs.continuum.io/anaconda/>`__
-    ^^^^^^^^^^^^^^^^^^^^^^
+    .. container::
 
+        Install using `pip <https://pypi.org/project/matplotlib>`__:
 
+        .. code-block:: bash
 
-    .. code-block:: bash
+            pip install matplotlib
 
-        conda install matplotlib
+    .. container::
 
-    ---
+        Install using `conda <https://docs.continuum.io/anaconda/>`__:
 
-    Installing using `pip <https://pypi.org/project/matplotlib>`__
-    ^^^^^^^^^^^^^^^^^^^^
+        .. code-block:: bash
 
-
-    .. code-block:: bash
-
-        pip install matplotlib
-
+            conda install matplotlib
 
 Further details are available in the :doc:`Installation Guide <users/installing/index>`.
 

--- a/doc/users/getting_started/index.rst
+++ b/doc/users/getting_started/index.rst
@@ -8,7 +8,7 @@ Installation quick-start
 
     .. container::
 
-        Install using pip:
+        Install using `pip <https://pypi.org/project/matplotlib>`__:
 
         .. code-block:: bash
 
@@ -16,7 +16,7 @@ Installation quick-start
 
     .. container::
 
-        Install using conda:
+        Install using `conda <https://docs.continuum.io/anaconda/>`__:
 
         .. code-block:: bash
 


### PR DESCRIPTION
Closes #21246.

This uses the same formatting as the install info in "getting started".
Also, add the conda and pip links to the "getting started" page.

before:
![grafik](https://user-images.githubusercontent.com/2836374/138603492-73650e56-3f8f-4635-8e29-4dc0c85021e5.png)

after:
![grafik](https://user-images.githubusercontent.com/2836374/138603542-09b2629b-04a2-4dd5-b6fe-6ed9a16ba4ea.png)

