### PR TITLE
Cleanup index.rst sectioning

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -138,12 +138,27 @@ Formatting and style conventions
 It is useful to strive for consistency in the Matplotlib documentation.  Here
 are some formatting and style conventions that are used.
 
-Section name formatting
-~~~~~~~~~~~~~~~~~~~~~~~
+Section formatting
+~~~~~~~~~~~~~~~~~~
 
 For everything but top-level chapters,  use ``Upper lower`` for
 section titles, e.g., ``Possible hangups`` rather than ``Possible
 Hangups``
+
+We aim to follow the recommendations from the
+`Python documentation <https://devguide.python.org/documenting/#sections>`_
+and the `Sphinx reStructuredText documentation <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#sections>`_
+for section markup characters, i.e.:
+
+- ``#`` with overline, for parts. This is reserved for the main title in
+  ``index.rst``. All other pages should start with "chapter" or lower.
+- ``*`` with overline, for chapters
+- ``=``, for sections
+- ``-``, for subsections
+- ``^``, for subsubsections
+- ``"``, for paragraphs
+
+This may not yet be applied consistently in existing docs.
 
 Function arguments
 ~~~~~~~~~~~~~~~~~~

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -5,14 +5,16 @@
 .. module:: matplotlib
 
 
+##################################
 Matplotlib |release| documentation
-----------------------------------
+##################################
 
 Matplotlib is a comprehensive library for creating static, animated,
 and interactive visualizations in Python.
 
+************
 Installation
-============
+************
 
 .. container:: twocol
 
@@ -35,9 +37,9 @@ Installation
 Further details are available in the :doc:`Installation Guide <users/installing/index>`.
 
 
+******************
 Learning resources
-==================
-
+******************
 
 .. panels::
 
@@ -81,16 +83,18 @@ Learning resources
 
 
 
+********************
 Third-party packages
---------------------
+********************
 
 There are many `Third-party packages
 <https://matplotlib.org/mpl-third-party/>`_ built on top of and extending
 Matplotlib.
 
 
+************
 Contributing
-------------
+************
 
 Matplotlib is a community project maintained for and by its users.  There are many ways
 you can help!
@@ -98,9 +102,3 @@ you can help!
 - Help other users `on discourse <https://discourse.matplotlib.org>`__
 - report a bug or request a feature `on GitHub <https://github.com/matplotlib/matplotlib/issues>`__
 - or improve the :ref:`documentation and code <developers-guide-index>`
-
-
-Users guide
------------
-
-The `contents of the docs <users/index.html>`_.


### PR DESCRIPTION
- document a standard hierarchy of ReST section characters. Closes #20534
- Apply these to `index.html`
- Remove the "Users guide" section from `index.html`. Originally, this was the "Contents" page, which had no easily accessible link on the front page, so it got a section. "User guide" has replaced the "Contents" page, but it's accessible from the nav bar. Therefore, we do not need the section anymore.
