### PR TITLE
Fix error with pyparsing 3 for 3.5.x

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -13,7 +13,7 @@ import unicodedata
 
 import numpy as np
 from pyparsing import (
-    Combine, Empty, FollowedBy, Forward, Group, Literal, oneOf, OneOrMore,
+    Combine, Empty, Forward, Group, Literal, oneOf, OneOrMore,
     Optional, ParseBaseException, ParseFatalException, ParserElement,
     ParseResults, QuotedString, Regex, StringEnd, Suppress, ZeroOrMore)
 
@@ -2044,7 +2044,7 @@ class Parser:
         p.accentprefixed <<= Suppress(p.bslash) + oneOf(self._accentprefixed)
         p.symbol_name   <<= (
             Combine(p.bslash + oneOf(list(tex2uni)))
-            + FollowedBy(Regex("[^A-Za-z]").leaveWhitespace() | StringEnd())
+            + Suppress(Regex("(?=[^A-Za-z]|$)").leaveWhitespace())
         )
         p.symbol        <<= (p.single_symbol | p.symbol_name).leaveWhitespace()
 

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -250,7 +250,9 @@ def test_fontinfo():
         (r'$\leftF$', r'Expected a delimiter'),
         (r'$\rightF$', r'Unknown symbol: \rightF'),
         (r'$\left(\right$', r'Expected a delimiter'),
-        (r'$\left($', r'Expected "\right"'),
+        # PyParsing 2 uses double quotes, PyParsing 3 uses single quotes and an
+        # extra backslash.
+        (r'$\left($', re.compile(r'Expected ("|\'\\)\\right["\']')),
         (r'$\dfrac$', r'Expected \dfrac{num}{den}'),
         (r'$\dfrac{}{}$', r'Expected \dfrac{num}{den}'),
         (r'$\overset$', r'Expected \overset{body}{annotation}'),
@@ -281,8 +283,8 @@ def test_fontinfo():
 )
 def test_mathtext_exceptions(math, msg):
     parser = mathtext.MathTextParser('agg')
-
-    with pytest.raises(ValueError, match=re.escape(msg)):
+    match = re.escape(msg) if isinstance(msg, str) else msg
+    with pytest.raises(ValueError, match=match):
         parser.parse(math)
 
 

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -13,7 +13,6 @@ ipython
 ipywidgets
 numpydoc>=0.8
 packaging>=20
-pyparsing<3.0.0
 pydata-sphinx-theme>=0.6.0
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -2,7 +2,6 @@
 
 certifi
 coverage
-pyparsing<3.0.0
 pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-rerunfailures

--- a/setup.py
+++ b/setup.py
@@ -326,7 +326,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "numpy>=1.17",
         "packaging>=20.0",
         "pillow>=6.2.0",
-        "pyparsing>=2.2.1,<3.0.0",
+        "pyparsing>=2.2.1",
         "python-dateutil>=2.7",
     ] + (
         # Installing from a git checkout.


### PR DESCRIPTION
- This is the minimal fix suggestion taken from #21448
- This addresses the branch  `v3.5.x` directly. The main branch will be fixed through #21448 (and then only needs the unpinning as well).
- Removed all pyparsing pinning. If this runs through CI, the fix is proven to be working.

