### PR TITLE
Hide note linking to the download section at the bottom of galleries

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -225,6 +225,18 @@ div.sphx-glr-download-link-note {
     visibility: hidden;
 }
 
+/* re-style the download button */
+div.sphx-glr-download a {
+    background-color: #E3F0F6;
+    background-image: none;
+    color: #11557c;
+    border: 0;
+}
+
+div.sphx-glr-download a:hover {
+    background-color: #BCD4DF;
+}
+
 table.property-table th,
 table.property-table td {
     padding: 4px 10px;


### PR DESCRIPTION
## 1. Hide note

sphinx-gallery puts this note at the top of each example:
![grafik](https://user-images.githubusercontent.com/2836374/138613597-d71f7b1e-a0e6-4276-93ba-45bdbecfe294.png)

I find this rather distracting and it only links to the download button at the bottom of the page. So let's remove this.

CSS is the recommended way for hiding this note:
https://github.com/sphinx-gallery/sphinx-gallery/issues/760


## 2. Re-style sphinx-gallery download buttons

to be more consistent with the new theme style.

The new text color is the matplotlib logo color. Backgrounds are lighter variations thereof.

before:
![grafik](https://user-images.githubusercontent.com/2836374/138616222-e2ac7674-f910-424a-8c09-535ef55a7ea6.png)

now:
![grafik](https://user-images.githubusercontent.com/2836374/138616205-7d3e85e0-4bb6-4c85-b1b4-047764fe9f37.png)
