### PR TITLE
Clip slider init marker to slider track.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -20,6 +20,7 @@ from matplotlib import docstring
 from . import _api, backend_tools, cbook, colors, ticker
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
+from .transforms import TransformedPatchPath
 
 
 class LockDraw:
@@ -439,7 +440,10 @@ class Slider(SliderBase):
             )
             ax.add_patch(self.track)
             self.poly = ax.axhspan(valmin, valinit, .25, .75, **kwargs)
-            self.hline = ax.axhline(valinit, .15, .85, color=initcolor, lw=1)
+            # Drawing a longer line and clipping it to the track avoids
+            # pixellization-related asymmetries.
+            self.hline = ax.axhline(valinit, 0, 1, color=initcolor, lw=1,
+                                    clip_path=TransformedPatchPath(self.track))
             handleXY = [[0.5], [valinit]]
         else:
             self.track = Rectangle(
@@ -449,12 +453,8 @@ class Slider(SliderBase):
             )
             ax.add_patch(self.track)
             self.poly = ax.axvspan(valmin, valinit, .25, .75, **kwargs)
-            # These asymmetric limits (.2, .9) minimize the asymmetry
-            # above and below the *poly* when rendered to pixels.
-            # This seems to be different for Horizontal and Vertical lines.
-            # For discussion see:
-            # https://github.com/matplotlib/matplotlib/pull/19265
-            self.vline = ax.axvline(valinit, .2, .9, color=initcolor, lw=1)
+            self.vline = ax.axvline(valinit, 0, 1, color=initcolor, lw=1,
+                                    clip_path=TransformedPatchPath(self.track))
             handleXY = [[valinit], [0.5]]
         self._handle, = ax.plot(
             *handleXY,


### PR DESCRIPTION
This avoids pixelization-related asymmetries, e.g. with the subplot
params tool.

I'm not sure why self.track needs to be wrapped in a
TransformedPatchPath (clip_path seems supposed to also directly support
rectangles), but in any case this works...

See discussion starting at https://github.com/matplotlib/matplotlib/pull/19265#discussion_r559249661 for the original problem.

before:
![old](https://user-images.githubusercontent.com/1322974/138680123-097ed2a4-ddef-4b19-a383-082238e6f05f.png)
after:
![new](https://user-images.githubusercontent.com/1322974/138680111-fe8a476a-9611-4895-a5f4-4143c4847c9c.png)

Not really release-critical for 3.5, but I'll still milestone it there as it goes with #19265.  Feel free to remilestone.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
