### PR TITLE
Fix some typos in examples

### DIFF
--- a/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -27,9 +27,9 @@ np.random.seed(42)
 skills = np.random.uniform(5, 80, size=N) * 0.1 + 5
 takeoff_angles = np.random.normal(0, 90, N)
 thrusts = np.random.uniform(size=N)
-successfull = np.random.randint(0, 3, size=N)
+successful = np.random.randint(0, 3, size=N)
 positions = np.random.normal(size=(N, 2)) * 5
-data = zip(skills, takeoff_angles, thrusts, successfull, positions)
+data = zip(skills, takeoff_angles, thrusts, successful, positions)
 
 cmap = plt.cm.get_cmap("plasma")
 fig, ax = plt.subplots()

--- a/examples/misc/svg_filter_line.py
+++ b/examples/misc/svg_filter_line.py
@@ -3,9 +3,9 @@
 SVG Filter Line
 ===============
 
-Demonstrate SVG filtering effects which might be used with mpl.
+Demonstrate SVG filtering effects which might be used with Matplotlib.
 
-Note that the filtering effects are only effective if your svg renderer
+Note that the filtering effects are only effective if your SVG renderer
 support it.
 """
 

--- a/examples/misc/svg_filter_pie.py
+++ b/examples/misc/svg_filter_pie.py
@@ -3,10 +3,10 @@
 SVG Filter Pie
 ==============
 
-Demonstrate SVG filtering effects which might be used with mpl.
+Demonstrate SVG filtering effects which might be used with Matplotlib.
 The pie chart drawing code is borrowed from pie_demo.py
 
-Note that the filtering effects are only effective if your svg renderer
+Note that the filtering effects are only effective if your SVG renderer
 support it.
 """
 
@@ -26,7 +26,7 @@ fracs = [15, 30, 45, 10]
 explode = (0, 0.05, 0, 0)
 
 # We want to draw the shadow for each pie but we will not use "shadow"
-# option as it does'n save the references to the shadow patches.
+# option as it doesn't save the references to the shadow patches.
 pies = ax.pie(fracs, explode=explode, labels=labels, autopct='%1.1f%%')
 
 for w in pies[0]:
@@ -49,12 +49,11 @@ f = io.BytesIO()
 plt.savefig(f, format="svg")
 
 
-# filter definition for shadow using a gaussian blur
-# and lightening effect.
-# The lightening filter is copied from http://www.w3.org/TR/SVG/filters.html
+# Filter definition for shadow using a gaussian blur and lighting effect.
+# The lighting filter is copied from http://www.w3.org/TR/SVG/filters.html
 
 # I tested it with Inkscape and Firefox3. "Gaussian blur" is supported
-# in both, but the lightening effect only in the Inkscape. Also note
+# in both, but the lighting effect only in Inkscape. Also note
 # that, Inkscape's exporting also may not support it.
 
 filter_def = """

--- a/plot_types/arrays/barbs.py
+++ b/plot_types/arrays/barbs.py
@@ -1,7 +1,7 @@
 """
-================
-barbs(X, Y U, V)
-================
+=================
+barbs(X, Y, U, V)
+=================
 
 See `~matplotlib.axes.Axes.barbs`.
 """
@@ -26,7 +26,7 @@ V = amplitude * np.cos(angle)
 # plot:
 fig, ax = plt.subplots()
 
-ax.barbs(X, Y, U, V, barbcolor="C0", flagcolor="C0", length=7, linewidth=1.5)
+ax.barbs(X, Y, U, V, barbcolor='C0', flagcolor='C0', length=7, linewidth=1.5)
 
 ax.set(xlim=(0, 4.5), ylim=(0, 4.5))
 


### PR DESCRIPTION
## PR Summary

Mainly fixing the `barbs` typo I noticed in matplotlib/mpl-brochure-site#19.

## PR Checklist

- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).