### PR TITLE
Hide fully transparent latex text in PS output

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -593,6 +593,9 @@ translate
     @_log_if_debug_on
     def draw_tex(self, gc, x, y, s, prop, angle, *, mtext=None):
         # docstring inherited
+        if self._is_transparent(gc.get_rgb()):
+            return  # Special handling for fully transparent.
+
         if not hasattr(self, "psfrag"):
             self._logwarn_once(
                 "The PS backend determines usetex status solely based on "

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -118,6 +118,16 @@ def test_transparency():
     ax.text(.5, .5, "foo", color="r", alpha=0)
 
 
+@needs_usetex
+@image_comparison(["empty.eps"])
+def test_transparency_tex():
+    mpl.rcParams['text.usetex'] = True
+    fig, ax = plt.subplots()
+    ax.set_axis_off()
+    ax.plot([0, 1], color="r", alpha=0)
+    ax.text(.5, .5, "foo", color="r", alpha=0)
+
+
 def test_bbox():
     fig, ax = plt.subplots()
     with io.BytesIO() as buf:


### PR DESCRIPTION
## PR Summary
This PR closes #21466. It is a follow-up fix for #10166.

The PS backend initially rendered transparent text, which was not visible in other backends (e.g. PDF). #101166 fixed this for regular text but missed fixing this when using latex to render text. This PR fixes the problem for latex.

In #21466 @anntzer proposed to add a `@pytest.mark.parametrize()` decorator to `test_transparency()`. However, I think duplicating the test is the better approach here, as we also need the `@needs_usetex` decorator. this would result in the test not being run anymore when latex is missing which would be a step back.

However, if you think it is fine that the test is only run when latex is installed, we can change to `@pytest.mark.parametrize()`. I tried this already but had the additional problem that the test would be green regardless of the fix being applied (this is either me being stupid or `@image_comparison()` not working with additional decorators).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
