### PR TITLE
Clarify set_parse_math documentation.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1232,7 +1232,8 @@ class Text(Artist):
         - If *self* is configured to use TeX, return *s* unchanged except that
           a single space gets escaped, and the flag "TeX".
         - Otherwise, if *s* is mathtext (has an even number of unescaped dollar
-          signs), return *s* and the flag True.
+          signs) and ``parse_math`` is not set to False, return *s* and the
+          flag True.
         - Otherwise, return *s* with dollar signs unescaped, and the flag
           False.
         """
@@ -1281,21 +1282,18 @@ class Text(Artist):
 
     def set_parse_math(self, parse_math):
         """
-        Override switch to enable/disable any mathtext
-        parsing for the given `Text` object.
+        Override switch to disable any mathtext parsing for this `Text`.
 
         Parameters
         ----------
         parse_math : bool
-            Whether to consider mathtext parsing for the string
+            If False, this `Text` will never use mathtext.  If True, mathtext
+            will be used if there is an even number of unescaped dollar signs.
         """
         self._parse_math = bool(parse_math)
 
     def get_parse_math(self):
-        """
-        Return whether mathtext parsing is considered
-        for this `Text` object.
-        """
+        """Return whether mathtext parsing is considered for this `Text`."""
         return self._parse_math
 
     def set_fontname(self, fontname):


### PR DESCRIPTION
In particular, even if set_parse_math(True), mathtext will not be used
if the string is not mathtext (this is not completely silly; one could
have expected to force the use of the math fontfamily rather than the
default text font by doing so).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
