### PR TITLE
FIX: spanning subfigures

### DIFF
--- a/lib/matplotlib/_layoutgrid.py
+++ b/lib/matplotlib/_layoutgrid.py
@@ -169,7 +169,8 @@ class LayoutGrid:
                 self.solver.addConstraint(c | 'required')
 
     def add_child(self, child, i=0, j=0):
-        self.children[i, j] = child
+        # np.ix_ returns the cross product of i and j indices
+        self.children[np.ix_(np.atleast_1d(i), np.atleast_1d(j))] = child
 
     def parent_constraints(self):
         # constraints that are due to the parent...

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -560,3 +560,10 @@ def test_suplabels():
     pos = ax.get_tightbbox(fig.canvas.get_renderer())
     assert pos.y0 > pos0.y0 + 10.0
     assert pos.x0 > pos0.x0 + 10.0
+
+
+def test_gridspec_addressing():
+    fig = plt.figure()
+    gs = fig.add_gridspec(3, 3)
+    sp = fig.add_subplot(gs[0:, 1:])
+    fig.draw_without_rendering()

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1073,6 +1073,7 @@ def test_subfigure_spanning():
         fig.add_subfigure(gs[0, 0]),
         fig.add_subfigure(gs[0:2, 1]),
         fig.add_subfigure(gs[2, 1:3]),
+        fig.add_subfigure(gs[0:, 1:])
     ]
 
     w = 640
@@ -1085,6 +1086,12 @@ def test_subfigure_spanning():
 
     np.testing.assert_allclose(sub_figs[2].bbox.min, [w / 3, 0])
     np.testing.assert_allclose(sub_figs[2].bbox.max, [w, h / 3])
+
+    # check here that slicing actually works.  Last sub_fig
+    # with open slices failed, but only on draw...
+    for i in range(4):
+        sub_figs[i].add_subplot()
+    fig.draw_without_rendering()
 
 
 @mpl.style.context('mpl20')


### PR DESCRIPTION
## PR Summary

Closes #21480

In that issue, gridspec indexing with open slices fails with constrained_layout for subfigures...




## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
