### PR TITLE
FIX: fix logic for FixedLocator set_ticklabels

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1706,10 +1706,12 @@ class Axis(martist.Artist):
         if isinstance(locator, mticker.FixedLocator):
             # Passing [] as a list of ticklabels is often used as a way to
             # remove all tick labels, so only error for > 0 ticklabels
-            if locator.nbins - 1 != len(ticklabels) and len(ticklabels) != 0:
+            nticks = (locator.nbins if locator.nbins is not None
+                                    else len(locator.locs))
+            if nticks != len(ticklabels) and len(ticklabels) != 0:
                 raise ValueError(
                     "The number of FixedLocator locations"
-                    f" ({locator.nbins}), usually from a call to"
+                    f" ({nticks}), usually from a call to"
                     " set_ticks, does not match"
                     f" the number of ticklabels ({len(ticklabels)}).")
             tickd = {loc: lab for loc, lab in zip(locator.locs, ticklabels)}


### PR DESCRIPTION
## PR Summary

Fixes an inconsistency noted in #20989

```python
fig, ax = plt.subplots()

ax.set_xlim(0, 1)
ax.xaxis.set_major_locator(FixedLocator(np.linspace(0, 1, 51), nbins=10))
ax.set_xticklabels(ax.get_xticklabels())
plt.show()
```

gives a value error currently because the number of ticks is actually set by nbins-1, not by the number of levels.  At the minimum the error message is confusing!




## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
