### PR TITLE
Un-pin pyparsing to see if pyparsing 3.0.3 works on main

### DIFF
--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -13,7 +13,6 @@ ipython
 ipywidgets
 numpydoc>=0.8
 packaging>=20
-pyparsing<3.0.0
 mpl-sphinx-theme
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -2,7 +2,6 @@
 
 certifi
 coverage
-pyparsing<3.0.0
 pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-rerunfailures

--- a/setup.py
+++ b/setup.py
@@ -319,7 +319,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "numpy>=1.17",
         "packaging>=20.0",
         "pillow>=6.2.0",
-        "pyparsing>=2.2.1,<3.0.0",
+        "pyparsing>=2.2.1,!=3.0.0,!=3.0.1",
         "python-dateutil>=2.7",
     ] + (
         # Installing from a git checkout.


### PR DESCRIPTION
## PR Summary

Pyparsing 3.0.0 introduced some backward-incompatible changes. As a result, we pinned it in #21445 + #21446.

Let's see if this is fixed in the more recent versions of pyparsing.

