### PR TITLE
Make Line2D copy its inputs

### DIFF
--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -132,6 +132,9 @@ class TaggedValue(metaclass=TaggedValueMeta):
         self.unit = unit
         self.proxy_target = self.value
 
+    def __copy__(self):
+        return TaggedValue(self.value, self.unit)
+
     def __getattribute__(self, name):
         if name.startswith('__'):
             return object.__getattribute__(self, name)

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -16,6 +16,7 @@ from .markers import MarkerStyle
 from .path import Path
 from .transforms import Bbox, BboxTransformTo, TransformedPath
 from ._enums import JoinStyle, CapStyle
+import copy
 
 # Imported here for backward compatibility, even though they don't
 # really belong.
@@ -1230,7 +1231,7 @@ class Line2D(Artist):
         ----------
         x : 1D array
         """
-        self._xorig = x
+        self._xorig = copy.copy(x)
         self._invalidx = True
         self.stale = True
 
@@ -1242,7 +1243,7 @@ class Line2D(Artist):
         ----------
         y : 1D array
         """
-        self._yorig = y
+        self._yorig = copy.copy(y)
         self._invalidy = True
         self.stale = True
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -2,6 +2,8 @@
 2D lines with support for a variety of line styles, markers, colors, etc.
 """
 
+import copy
+
 from numbers import Integral, Number, Real
 import logging
 
@@ -16,7 +18,6 @@ from .markers import MarkerStyle
 from .path import Path
 from .transforms import Bbox, BboxTransformTo, TransformedPath
 from ._enums import JoinStyle, CapStyle
-import copy
 
 # Imported here for backward compatibility, even though they don't
 # really belong.

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -332,3 +332,14 @@ def test_picking():
     found, indices = l2.contains(mouse_event)
     assert found
     assert_array_equal(indices['ind'], [0])
+
+
+@check_figures_equal()
+def test_input_copy(fig_test, fig_ref):
+
+    t = np.arange(0, 6, 2)
+    l, = fig_test.add_subplot().plot(t, t, ".-")
+    t[:] = range(3)
+    # Trigger cache invalidation
+    l.set_drawstyle("steps")
+    fig_ref.add_subplot().plot([0, 2, 4], [0, 2, 4], ".-", drawstyle="steps")

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -26,6 +26,9 @@ class Quantity:
         else:
             return Quantity(self.magnitude, self.units)
 
+    def __copy__(self):
+        return Quantity(self.magnitude, self.units)
+
     def __getattr__(self, attr):
         return getattr(self.magnitude, attr)
 


### PR DESCRIPTION
## PR Summary

Fixes #21147

This fixes the earlier PR https://github.com/matplotlib/matplotlib/pull/21299 by @kinshukdua which was abandoned due to tricky problem with unit test failure



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
