### PR TITLE
Adding tutorial links for blitting in widgets.py

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1688,7 +1688,8 @@ class MultiCursor(Widget):
 
     useblit : bool, default: True
         Use blitting for faster drawing if supported by the backend.
-        See the tutorial :doc:`/tutorials/advanced/blitting` for details.
+        See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
 
     horizOn : bool, default: False
         Whether to draw the horizontal line.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1592,6 +1592,7 @@ class Cursor(AxesWidget):
         Whether to draw the vertical line.
     useblit : bool, default: False
         Use blitting for faster drawing if supported by the backend.
+        See the tutorial :doc:`/tutorials/advanced/blitting` for details.
 
     Other Parameters
     ----------------
@@ -1687,6 +1688,7 @@ class MultiCursor(Widget):
 
     useblit : bool, default: True
         Use blitting for faster drawing if supported by the backend.
+        See the tutorial :doc:`/tutorials/advanced/blitting` for details.
 
     horizOn : bool, default: False
         Whether to draw the horizontal line.
@@ -2093,7 +2095,8 @@ class SpanSelector(_SelectorWidget):
 
     useblit : bool, default: False
         If True, use the backend-dependent blitting features for faster
-        canvas updates.
+        canvas updates. See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
 
     props : dict, optional
         Dictionary of `matplotlib.patches.Patch` properties.
@@ -2502,7 +2505,8 @@ class ToolLineHandles:
         Additional line properties. See `matplotlib.lines.Line2D`.
     useblit : bool, default: True
         Whether to use blitting for faster drawing (if supported by the
-        backend).
+        backend). See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
     """
 
     def __init__(self, ax, positions, direction, line_props=None,
@@ -2609,7 +2613,8 @@ class ToolHandles:
         Additional marker properties. See `matplotlib.lines.Line2D`.
     useblit : bool, default: True
         Whether to use blitting for faster drawing (if supported by the
-        backend).
+        backend). See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
     """
 
     def __init__(self, ax, x, y, marker='o', marker_props=None, useblit=True):
@@ -2684,7 +2689,8 @@ _RECTANGLESELECTOR_PARAMETERS_DOCSTRING = \
 
     useblit : bool, default: False
         Whether to use blitting for faster drawing (if supported by the
-        backend).
+        backend). See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
 
     props : dict, optional
         Properties with which the __ARTIST_NAME__ is drawn. See
@@ -3240,7 +3246,8 @@ class LassoSelector(_SelectorWidget):
         passed the vertices of the selected path.
     useblit : bool, default: True
         Whether to use blitting for faster drawing (if supported by the
-        backend).
+        backend). See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
     props : dict, optional
         Properties with which the line is drawn, see `matplotlib.lines.Line2D`
         for valid properties. Default values are defined in ``mpl.rcParams``.
@@ -3322,7 +3329,8 @@ class PolygonSelector(_SelectorWidget):
 
     useblit : bool, default: False
         Whether to use blitting for faster drawing (if supported by the
-        backend).
+        backend). See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
 
     props : dict, optional
         Properties with which the line is drawn, see `matplotlib.lines.Line2D`
@@ -3589,7 +3597,8 @@ class Lasso(AxesWidget):
         Coordinates of the start of the lasso.
     useblit : bool, default: True
         Whether to use blitting for faster drawing (if supported by the
-        backend).
+        backend). See the tutorial :doc:`/tutorials/advanced/blitting`
+        for details.
     callback : callable
         Whenever the lasso is released, the *callback* function is called and
         passed the vertices of the selected path.


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
