### PR TITLE
Refix for pyparsing compat.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -15,7 +15,7 @@ import numpy as np
 from pyparsing import (
     Combine, Empty, FollowedBy, Forward, Group, Literal, oneOf, OneOrMore,
     Optional, ParseBaseException, ParseFatalException, ParserElement,
-    ParseResults, QuotedString, Regex, StringEnd, Suppress, ZeroOrMore)
+    ParseResults, QuotedString, Regex, StringEnd, Suppress, White, ZeroOrMore)
 
 import matplotlib as mpl
 from . import _api, cbook
@@ -2060,6 +2060,7 @@ class Parser:
         p.accent        <<= Group(
             Suppress(p.bslash)
             + oneOf([*self._accent_map, *self._wide_accents])
+            + Suppress(Optional(White()))
             - p.placeable
         )
 

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -13,7 +13,6 @@ ipython
 ipywidgets
 numpydoc>=0.8
 packaging>=20
-pyparsing<3.0.0
 mpl-sphinx-theme
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -2,7 +2,6 @@
 
 certifi
 coverage
-pyparsing<3.0.0
 pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-rerunfailures


### PR DESCRIPTION
## PR Summary

cf https://github.com/matplotlib/matplotlib/pull/21489#issuecomment-954225531 (@ptmcg I'm not super certain about the expected semantics, but the need to explicitly skip whitespace here *looks* like a bug to me?)

For master, I think #21448 also fixes that.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
