### PR TITLE
MNT: Add modifier key press handling to macosx backend

### DIFF
--- a/doc/users/explain/event_handling.rst
+++ b/doc/users/explain/event_handling.rst
@@ -82,29 +82,28 @@ Event name             Class            Description
    you may encounter inconsistencies between the different user interface
    toolkits that Matplotlib works with. This is due to inconsistencies/limitations
    of the user interface toolkit. The following table shows some basic examples of
-   what you may expect to receive as key(s) from the different user interface toolkits,
-   where a comma separates different keys:
+   what you may expect to receive as key(s) (using a QWERTY keyboard layout)
+   from the different user interface toolkits, where a comma separates different keys:
 
-   ============== ============================= ============================== ============================== ============================== ==============================
-   Key(s) Pressed WxPython                      Qt                             WebAgg                         Gtk                            Tkinter
-   ============== ============================= ============================== ============================== ============================== ==============================
-   Shift+2        shift, shift+2                shift, "                       shift, "                       shift, "                       shift, "
-   Shift+F1       shift, shift+f1               shift, shift+f1                shift, shift+f1                shift, shift+f1                shift, shift+f1
-   Shift          shift                         shift                          shift                          shift                          shift
-   Control        control                       control                        control                        control                        control
-   Alt            alt                           alt                            alt                            alt                            alt
-   AltGr          Nothing                       Nothing                        alt                            iso_level3_shift               iso_level3_shift
-   CapsLock       caps_lock                     caps_lock                      caps_lock                      caps_lock                      caps_lock
-   A              a                             a                              A                              A                              A
-   a              a                             a                              a                              a                              a
-   Shift+a        shift, A                      shift, A                       shift, A                       shift, A                       shift, A
-   Shift+A        shift, A                      shift, A                       shift, a                       shift, a                       shift, a
-   Ctrl+Shift+Alt control, ctrl+shift, ctrl+alt control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta
-   Ctrl+Shift+a   control, ctrl+shift, ctrl+A   control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+a
-   Ctrl+Shift+A   control, ctrl+shift, ctrl+A   control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+a    control, ctrl+shift, ctrl+a    control, ctrl+shift, ctrl+a
-   F1             f1                            f1                             f1                             f1                             f1
-   Ctrl+F1        control, ctrl+f1              control, ctrl+f1               control, ctrl+f1               control, ctrl+f1               control, ctrl+f1
-   ============== ============================= ============================== ============================== ============================== ==============================
+   ================ ============================= ============================== ============================== ============================== ============================== ===================================
+   Key(s) Pressed   WxPython                      Qt                             WebAgg                         Gtk                            Tkinter                        macosx
+   ================ ============================= ============================== ============================== ============================== ============================== ===================================
+   Shift+2          shift, shift+2                shift, @                       shift, @                       shift, @                       shift, @                       shift, @
+   Shift+F1         shift, shift+f1               shift, shift+f1                shift, shift+f1                shift, shift+f1                shift, shift+f1                shift, shift+f1
+   Shift            shift                         shift                          shift                          shift                          shift                          shift
+   Control          control                       control                        control                        control                        control                        control
+   Alt              alt                           alt                            alt                            alt                            alt                            alt
+   AltGr            Nothing                       Nothing                        alt                            iso_level3_shift               iso_level3_shift
+   CapsLock         caps_lock                     caps_lock                      caps_lock                      caps_lock                      caps_lock                      caps_lock
+   CapsLock+a       caps_lock, a                  caps_lock, a                   caps_lock, A                   caps_lock, A                   caps_lock, A                   caps_lock, a
+   a                a                             a                              a                              a                              a                              a
+   Shift+a          shift, A                      shift, A                       shift, A                       shift, A                       shift, A                       shift, A
+   CapsLock+Shift+a caps_lock, shift, A           caps_lock, shift, A            caps_lock, shift, a            caps_lock, shift, a            caps_lock, shift, a            caps_lock, shift, A
+   Ctrl+Shift+Alt   control, ctrl+shift, ctrl+alt control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+alt+shift
+   Ctrl+Shift+a     control, ctrl+shift, ctrl+A   control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+a    control, ctrl+shift, ctrl+A
+   F1               f1                            f1                             f1                             f1                             f1                             f1
+   Ctrl+F1          control, ctrl+f1              control, ctrl+f1               control, ctrl+f1               control, ctrl+f1               control, ctrl+f1               control, Nothing
+   ================ ============================= ============================== ============================== ============================== ============================== ===================================
 
 Matplotlib attaches some keypress callbacks by default for interactivity; they
 are documented in the :ref:`key-event-handling` section.

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -247,7 +247,7 @@ static int wait_for_stdin(void)
 - (void)keyUp:(NSEvent*)event;
 - (void)scrollWheel:(NSEvent *)event;
 - (BOOL)acceptsFirstResponder;
-//- (void)flagsChanged:(NSEvent*)event;
+- (void)flagsChanged:(NSEvent*)event;
 @end
 
 /* ---------------------------- Python classes ---------------------------- */
@@ -1711,21 +1711,24 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     return YES;
 }
 
-/* This is all wrong. Address of pointer is being passed instead of pointer, keynames don't
-   match up with what the front-end and does the front-end even handle modifier keys by themselves?
-
-- (void)flagsChanged:(NSEvent*)event
+// flagsChanged gets called on single modifier keypresses
+// The modifier + second key gets handled in convertKeyEvent in KeyUp/KeyDown
+- (void)flagsChanged:(NSEvent *)event
 {
     const char *s = NULL;
-    if (([event modifierFlags] & NSControlKeyMask) == NSControlKeyMask)
+    if ([event modifierFlags] & NSEventModifierFlagControl)
         s = "control";
-    else if (([event modifierFlags] & NSShiftKeyMask) == NSShiftKeyMask)
+    else if ([event modifierFlags] & NSEventModifierFlagShift)
         s = "shift";
-    else if (([event modifierFlags] & NSAlternateKeyMask) == NSAlternateKeyMask)
+    else if ([event modifierFlags] & NSEventModifierFlagOption)
         s = "alt";
+    else if ([event modifierFlags] & NSEventModifierFlagCommand)
+        s = "cmd";
+    else if ([event modifierFlags] & NSEventModifierFlagCapsLock)
+        s = "caps_lock";
     else return;
     PyGILState_STATE gstate = PyGILState_Ensure();
-    PyObject* result = PyObject_CallMethod(canvas, "key_press_event", "s", &s);
+    PyObject* result = PyObject_CallMethod(canvas, "key_press_event", "s", s);
     if (result)
         Py_DECREF(result);
     else
@@ -1733,7 +1736,6 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
 
     PyGILState_Release(gstate);
 }
- */
 @end
 
 static PyObject*

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1727,73 +1727,51 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
 // so we need to handle both cases here
 - (void)flagsChanged:(NSEvent *)event
 {
-    bool keypress = false;
-    bool keyrelease = false;
-    if (([event modifierFlags] & NSEventModifierFlagCommand) && !lastCommand) {
-        // Command pressed
-        lastCommand = true;
+    bool isPress = false; // true if key is pressed, false is released
+    if ((([event modifierFlags] & NSEventModifierFlagCommand) && !lastCommand) ||
+        (!([event modifierFlags] & NSEventModifierFlagCommand) && lastCommand)) {
+        // Command pressed/released
+        lastCommand = !lastCommand;
         keyChangeCommand = true;
-        keypress = true;
+        isPress = lastCommand;
     }
-    else if (!([event modifierFlags] & NSEventModifierFlagCommand) && lastCommand) {
-        // Command released
-        lastCommand = false;
-        keyChangeCommand = true;
-        keyrelease = true;
-    }
-    else if (([event modifierFlags] & NSEventModifierFlagControl) && !lastControl) {
-        // Control pressed
-        lastControl = true;
+    else if ((([event modifierFlags] & NSEventModifierFlagControl) && !lastControl) ||
+             (!([event modifierFlags] & NSEventModifierFlagControl) && lastControl)) {
+        // Control pressed/released
+        lastControl = !lastControl;
         keyChangeControl = true;
-        keypress = true;
+        isPress = lastControl;
     }
-    else if (!([event modifierFlags] & NSEventModifierFlagControl) && lastControl) {
-        // Control released
-        lastControl = false;
-        keyChangeControl = true;
-        keyrelease = true;
-    }
-    else if (([event modifierFlags] & NSEventModifierFlagShift) && !lastShift) {
-        // Shift pressed
-        lastShift = true;
+    else if ((([event modifierFlags] & NSEventModifierFlagShift) && !lastShift) ||
+             (!([event modifierFlags] & NSEventModifierFlagShift) && lastShift)) {
+        // Shift pressed/released
+        lastShift = !lastShift;
         keyChangeShift = true;
-        keypress = true;
+        isPress = lastShift;
     }
-    else if (!([event modifierFlags] & NSEventModifierFlagShift) && lastShift) {
-        // Shift released
-        lastShift = false;
-        keyChangeShift = true;
-        keyrelease = true;
-    }
-    else if (([event modifierFlags] & NSEventModifierFlagOption) && !lastOption) {
-        // Option pressed
-        lastOption = true;
+    else if ((([event modifierFlags] & NSEventModifierFlagOption) && !lastOption) ||
+             (!([event modifierFlags] & NSEventModifierFlagOption) && lastOption)) {
+        // Option pressed/released
+        lastOption = !lastOption;
         keyChangeOption = true;
-        keypress = true;
+        isPress = lastOption;
     }
-    else if (!([event modifierFlags] & NSEventModifierFlagOption) && lastOption) {
-        // Option released
-        lastOption = false;
-        keyChangeOption = true;
-        keyrelease = true;
-    }
-    else if (([event modifierFlags] & NSEventModifierFlagCapsLock) && !lastCapsLock) {
-        // Capslock pressed
-        lastCapsLock = true;
+    else if ((([event modifierFlags] & NSEventModifierFlagCapsLock) && !lastCapsLock) ||
+             (!([event modifierFlags] & NSEventModifierFlagCapsLock) && lastCapsLock)) {
+        // Capslock pressed/released
+        lastCapsLock = !lastCapsLock;
         keyChangeCapsLock = true;
-        keypress = true;
+        isPress = lastCapsLock;
     }
-    else if (!([event modifierFlags] & NSEventModifierFlagCapsLock) && lastCapsLock) {
-        // Capslock released
-        lastCapsLock = false;
-        keyChangeCapsLock = true;
-        keyrelease = true;
+    else{
+        // flag we don't handle
+        return;
     }
 
-    if (keypress) {
+    if (isPress) {
         [self keyDown: event];
     }
-    else if (keyrelease) {
+    else {
         [self keyUp: event];
     }
 


### PR DESCRIPTION
## PR Summary

The flagsChanged event handles single presses of modifier keys, so we need to send the corresponding string to our key press handlers from within that routine. Modifier + second key is handled within the KeyUp/KeyDown routines already, so leave those alone.

Taking the example from issue #20486
```python
import matplotlib.pyplot as plt
fig = plt.figure()

def on_key(event):
    print('you pressed', event.key, event.xdata, event.ydata)
def on_key_release(event):
    print('you released', event.key, event.xdata, event.ydata)

fig.canvas.mpl_connect('key_press_event', on_key)
fig.canvas.mpl_connect('key_release_event', on_key_release)
plt.show()
```
this adds the single modifier key presses back in. Before this, the (modifier + key) "cmd+a" would show up, but there wasn't a single "cmd" (modifier) preceding it.

```bash
you pressed cmd None None
you pressed cmd+a None None
```

I'm not sure how to send key press events through the terminal natively, so there are no automated tests.

closes #20486
closes #9837

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
