### PR TITLE
Make _request_autoscale_view more generalizable to 3D.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -737,7 +737,8 @@ class Axes(_AxesBase):
         trans = self.get_yaxis_transform(which='grid')
         l = mlines.Line2D([xmin, xmax], [y, y], transform=trans, **kwargs)
         self.add_line(l)
-        self._request_autoscale_view(scalex=False, scaley=scaley)
+        if scaley:
+            self._request_autoscale_view("y")
         return l
 
     @docstring.dedent_interpd
@@ -804,7 +805,8 @@ class Axes(_AxesBase):
         trans = self.get_xaxis_transform(which='grid')
         l = mlines.Line2D([x, x], [ymin, ymax], transform=trans, **kwargs)
         self.add_line(l)
-        self._request_autoscale_view(scalex=scalex, scaley=False)
+        if scalex:
+            self._request_autoscale_view("x")
         return l
 
     @staticmethod
@@ -934,7 +936,7 @@ class Axes(_AxesBase):
         p = mpatches.Polygon(verts, **kwargs)
         p.set_transform(self.get_yaxis_transform(which="grid"))
         self.add_patch(p)
-        self._request_autoscale_view(scalex=False)
+        self._request_autoscale_view("y")
         return p
 
     @docstring.dedent_interpd
@@ -991,7 +993,7 @@ class Axes(_AxesBase):
         p.set_transform(self.get_xaxis_transform(which="grid"))
         p.get_path()._interpolation_steps = 100
         self.add_patch(p)
-        self._request_autoscale_view(scaley=False)
+        self._request_autoscale_view("x")
         return p
 
     @_preprocess_data(replace_names=["y", "xmin", "xmax", "colors"],
@@ -1627,7 +1629,10 @@ class Axes(_AxesBase):
         lines = [*self._get_lines(*args, data=data, **kwargs)]
         for line in lines:
             self.add_line(line)
-        self._request_autoscale_view(scalex=scalex, scaley=scaley)
+        if scalex:
+            self._request_autoscale_view("x")
+        if scaley:
+            self._request_autoscale_view("y")
         return lines
 
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
@@ -4045,8 +4050,7 @@ class Axes(_AxesBase):
                 axis.set_major_formatter(formatter)
             formatter.seq = [*formatter.seq, *datalabels]
 
-            self._request_autoscale_view(
-                scalex=self._autoscaleXon, scaley=self._autoscaleYon)
+            self._request_autoscale_view()
 
         return dict(whiskers=whiskers, caps=caps, boxes=boxes,
                     medians=medians, fliers=fliers, means=means)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -781,24 +781,26 @@ class _AxesBase(martist.Artist):
         self._unstale_viewLim()
         return self._viewLim
 
-    # API could be better, right now this is just to match the old calls to
-    # autoscale_view() after each plotting method.
-    def _request_autoscale_view(self, tight=None, **kwargs):
-        # kwargs are "scalex", "scaley" (& "scalez" for 3D) and default to True
-        want_scale = {name: True for name in self._axis_names}
-        for k, v in kwargs.items():  # Validate args before changing anything.
-            if k.startswith("scale"):
-                name = k[5:]
-                if name in want_scale:
-                    want_scale[name] = v
-                    continue
-            raise TypeError(
-                f"_request_autoscale_view() got an unexpected argument {k!r}")
+    def _request_autoscale_view(self, axis="all", tight=None):
+        """
+        Mark a single axis, or all of them, as stale wrt. autoscaling.
+
+        No computation is performed until the next autoscaling; thus, separate
+        calls to control individual axises incur negligible performance cost.
+
+        Parameters
+        ----------
+        axis : str, default: "all"
+            Either an element of ``self._axis_names``, or "all".
+        tight : bool or None, default: None
+        """
+        axis_names = _api.check_getitem(
+            {**{k: [k] for k in self._axis_names}, "all": self._axis_names},
+            axis=axis)
+        for name in axis_names:
+            self._stale_viewlims[name] = True
         if tight is not None:
             self._tight = tight
-        for k, v in want_scale.items():
-            if v:
-                self._stale_viewlims[k] = True  # Else keep old state.
 
     def _set_lim_and_transforms(self):
         """
@@ -2425,8 +2427,7 @@ class _AxesBase(martist.Artist):
         for line in self.lines:
             line.recache_always()
         self.relim()
-        self._request_autoscale_view(scalex=(axis_name == "x"),
-                                     scaley=(axis_name == "y"))
+        self._request_autoscale_view(axis_name)
 
     def relim(self, visible_only=False):
         """
@@ -2634,7 +2635,7 @@ class _AxesBase(martist.Artist):
         if m <= -0.5:
             raise ValueError("margin must be greater than -0.5")
         self._xmargin = m
-        self._request_autoscale_view(scalex=True, scaley=False)
+        self._request_autoscale_view("x")
         self.stale = True
 
     def set_ymargin(self, m):
@@ -2657,7 +2658,7 @@ class _AxesBase(martist.Artist):
         if m <= -0.5:
             raise ValueError("margin must be greater than -0.5")
         self._ymargin = m
-        self._request_autoscale_view(scalex=False, scaley=True)
+        self._request_autoscale_view("y")
         self.stale = True
 
     def margins(self, *margins, x=None, y=None, tight=True):
@@ -2774,7 +2775,8 @@ class _AxesBase(martist.Artist):
             True turns autoscaling on, False turns it off.
             None leaves the autoscaling state unchanged.
         axis : {'both', 'x', 'y'}, default: 'both'
-            Which axis to operate on.
+            The axis on which to operate.  (For 3D axes, *axis* can also be set
+            to 'z', and 'both' refers to all three axes.)
         tight : bool or None, default: None
             If True, first set the margins to zero.  Then, this argument is
             forwarded to `autoscale_view` (regardless of its value); see the
@@ -2796,7 +2798,10 @@ class _AxesBase(martist.Artist):
             self._xmargin = 0
         if tight and scaley:
             self._ymargin = 0
-        self._request_autoscale_view(tight=tight, scalex=scalex, scaley=scaley)
+        if scalex:
+            self._request_autoscale_view("x", tight=tight)
+        if scaley:
+            self._request_autoscale_view("y", tight=tight)
 
     def autoscale_view(self, tight=None, scalex=True, scaley=True):
         """
@@ -3312,8 +3317,8 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
         axis : {'both', 'x', 'y'}, default: 'both'
-            The axis on which to operate.
-
+            The axis on which to operate.  (For 3D axes, *axis* can also be
+            set to 'z', and 'both' refers to all three axes.)
         tight : bool or None, optional
             Parameter passed to `~.Axes.autoscale_view`.
             Default is None, for no change.
@@ -3335,15 +3340,12 @@ class _AxesBase(martist.Artist):
             ax.locator_params(tight=True, nbins=4)
 
         """
-        _api.check_in_list(['x', 'y', 'both'], axis=axis)
-        update_x = axis in ['x', 'both']
-        update_y = axis in ['y', 'both']
-        if update_x:
-            self.xaxis.get_major_locator().set_params(**kwargs)
-        if update_y:
-            self.yaxis.get_major_locator().set_params(**kwargs)
-        self._request_autoscale_view(tight=tight,
-                                     scalex=update_x, scaley=update_y)
+        _api.check_in_list([*self._axis_names, "both"], axis=axis)
+        for name in self._axis_names:
+            if axis in [name, "both"]:
+                loc = self._get_axis_map()[name].get_major_locator()
+                loc.set_params(**kwargs)
+                self._request_autoscale_view(name, tight=tight)
         self.stale = True
 
     def tick_params(self, axis='both', **kwargs):


### PR DESCRIPTION
The API of _request_autoscale_view() was originally modelled to
match the one of autoscale_view() -- hence the scalex/scaley/scalez
kwargs -- but just taking an axis name (or "all") as single arg makes
generalization to 3D easier.

(In bxp(), the autoscale request does not need to be protected by
checking whether the autoscale state is on, as autoscale_view is a noop
for non-autoscaling axises.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
