### PR TITLE
mark_inset should manually unstale axes limits before drawing itself.

### DIFF
--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -8,7 +8,7 @@ from matplotlib.backend_bases import MouseEvent
 from matplotlib.colors import LogNorm
 from matplotlib.transforms import Bbox, TransformedBbox
 from matplotlib.testing.decorators import (
-    image_comparison, remove_ticks_and_titles)
+    check_figures_equal, image_comparison, remove_ticks_and_titles)
 
 from mpl_toolkits.axes_grid1 import (
     axes_size as Size,
@@ -494,3 +494,19 @@ def test_grid_axes_position(direction):
     assert loc[1]._nx > loc[0]._nx and loc[2]._ny < loc[0]._ny
     assert loc[0]._nx == loc[2]._nx and loc[0]._ny == loc[1]._ny
     assert loc[3]._nx == loc[1]._nx and loc[3]._ny == loc[2]._ny
+
+
+@check_figures_equal(extensions=["png"])
+def test_mark_inset_unstales_viewlim(fig_test, fig_ref):
+    inset, full = fig_test.subplots(1, 2)
+    full.plot([0, 5], [0, 5])
+    inset.set(xlim=(1, 2), ylim=(1, 2))
+    # Check that mark_inset unstales full's viewLim before drawing the marks.
+    mark_inset(full, inset, 1, 4)
+
+    inset, full = fig_ref.subplots(1, 2)
+    full.plot([0, 5], [0, 5])
+    inset.set(xlim=(1, 2), ylim=(1, 2))
+    mark_inset(full, inset, 1, 4)
+    # Manually unstale the full's viewLim.
+    fig_ref.canvas.draw()


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/17711; see description there.  Milestoning as 3.6, but I guess 3.5 would be good too.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
