### PR TITLE
Shorten some inset_locator docstrings.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -168,24 +168,8 @@ class BboxConnector(Patch):
     @staticmethod
     def get_bbox_edge_pos(bbox, loc):
         """
-        Helper function to obtain the location of a corner of a bbox
-
-        Parameters
-        ----------
-        bbox : `matplotlib.transforms.Bbox`
-
-        loc : {1, 2, 3, 4}
-            Corner of *bbox*. Valid values are::
-
-                'upper right'  : 1,
-                'upper left'   : 2,
-                'lower left'   : 3,
-                'lower right'  : 4
-
-        Returns
-        -------
-        x, y : float
-            Coordinates of the corner specified by *loc*.
+        Return the ``(x, y)`` coordinates of corner *loc* of *bbox*; parameters
+        behave as documented for the `.BboxConnector` constructor.
         """
         x0, y0, x1, y1 = bbox.extents
         if loc == 1:
@@ -200,35 +184,9 @@ class BboxConnector(Patch):
     @staticmethod
     def connect_bbox(bbox1, bbox2, loc1, loc2=None):
         """
-        Helper function to obtain a Path from one bbox to another.
-
-        Parameters
-        ----------
-        bbox1, bbox2 : `matplotlib.transforms.Bbox`
-            Bounding boxes to connect.
-
-        loc1 : {1, 2, 3, 4}
-            Corner of *bbox1* to use. Valid values are::
-
-                'upper right'  : 1,
-                'upper left'   : 2,
-                'lower left'   : 3,
-                'lower right'  : 4
-
-        loc2 : {1, 2, 3, 4}, optional
-            Corner of *bbox2* to use. If None, defaults to *loc1*.
-            Valid values are::
-
-                'upper right'  : 1,
-                'upper left'   : 2,
-                'lower left'   : 3,
-                'lower right'  : 4
-
-        Returns
-        -------
-        path : `matplotlib.path.Path`
-            A line segment from the *loc1* corner of *bbox1* to the *loc2*
-            corner of *bbox2*.
+        Construct a `.Path` connecting corner *loc1* of *bbox1* to corner
+        *loc2* of *bbox2*, where parameters behave as documented as for the
+        `.BboxConnector` constructor.
         """
         if isinstance(bbox1, Rectangle):
             bbox1 = TransformedBbox(Bbox.unit(), bbox1.get_transform())
@@ -250,22 +208,15 @@ class BboxConnector(Patch):
         bbox1, bbox2 : `matplotlib.transforms.Bbox`
             Bounding boxes to connect.
 
-        loc1 : {1, 2, 3, 4}
-            Corner of *bbox1* to draw the line. Valid values are::
+        loc1, loc2 : {1, 2, 3, 4}
+            Corner of *bbox1* and *bbox2* to draw the line. Valid values are::
 
                 'upper right'  : 1,
                 'upper left'   : 2,
                 'lower left'   : 3,
                 'lower right'  : 4
 
-        loc2 : {1, 2, 3, 4}, optional
-            Corner of *bbox2* to draw the line. If None, defaults to *loc1*.
-            Valid values are::
-
-                'upper right'  : 1,
-                'upper left'   : 2,
-                'lower left'   : 3,
-                'lower right'  : 4
+            *loc2* is optional and defaults to *loc1*.
 
         **kwargs
             Patch properties for the line drawn. Valid arguments include:
@@ -308,18 +259,10 @@ class BboxConnectorPatch(BboxConnector):
         bbox1, bbox2 : `matplotlib.transforms.Bbox`
             Bounding boxes to connect.
 
-        loc1a, loc2a : {1, 2, 3, 4}
-            Corners of *bbox1* and *bbox2* to draw the first line.
-            Valid values are::
-
-                'upper right'  : 1,
-                'upper left'   : 2,
-                'lower left'   : 3,
-                'lower right'  : 4
-
-        loc1b, loc2b : {1, 2, 3, 4}
-            Corners of *bbox1* and *bbox2* to draw the second line.
-            Valid values are::
+        loc1a, loc2a, loc1b, loc2b : {1, 2, 3, 4}
+            The first line connects corners *loc1a* of *bbox1* and *loc2a* of
+            *bbox2*; the second line connects corners *loc1b* of *bbox1* and
+            *loc2b* of *bbox2*.  Valid values are::
 
                 'upper right'  : 1,
                 'upper left'   : 2,


### PR DESCRIPTION
We don't need to repeat the definition of `loc` again and again across
helper functions.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
