### PR TITLE
Fix interrupting GTK on plain Python

### DIFF
--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -169,6 +169,13 @@ class _BackendGTK(_Backend):
 
         try:
             _application.run()  # Quits when all added windows close.
+        except KeyboardInterrupt:
+            # Ensure all windows can process their close event from
+            # _shutdown_application.
+            context = GLib.MainContext.default()
+            while context.pending():
+                context.iteration(True)
+            raise
         finally:
             # Running after quit is undefined, so create a new one next time.
             _application = None


### PR DESCRIPTION
## PR Summary

When the application is shut down, it's intended that all windows are closed. This shutdown event is also run if interrupted with Ctrl-C. But then the main loop is no longer running, and windows do not notice the close event sent to them.

In IPython, the input hook runs the loop and allows the windows to close down. But in plain Python, there is no input hook integration, and the windows sit around in limbo without accepting any events.

Absent any new input hook integrations, the workaround is to iterate the main loop on interrupt.

## PR Checklist

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).