### PR TITLE
Do not use space in directive calling.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4216,7 +4216,7 @@ class _AxesBase(martist.Artist):
         Set the navigation toolbar button status.
 
         .. warning::
-            this is not a user-API function.
+            This is not a user-API function.
 
         """
         self._navigate_mode = b

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4215,7 +4215,7 @@ class _AxesBase(martist.Artist):
         """
         Set the navigation toolbar button status.
 
-        .. warning ::
+        .. warning::
             this is not a user-API function.
 
         """

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -299,7 +299,7 @@ def unregister_cmap(name):
     If the named colormap is not registered, returns with no error, raises
     if you try to de-register a default colormap.
 
-    .. warning ::
+    .. warning::
 
       Colormap names are currently a shared namespace that may be used
       by multiple packages. Use `unregister_cmap` only if you know you

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1674,7 +1674,7 @@ default: %(va)s
 
         This is a helper function to build complex GridSpec layouts visually.
 
-        .. note ::
+        .. note::
 
            This API is provisional and may be revised in the future based on
            early user feedback.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1442,7 +1442,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
 
     This is a helper function to build complex GridSpec layouts visually.
 
-    .. note ::
+    .. note::
 
        This API is provisional and may be revised in the future based on
        early user feedback.

--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -111,7 +111,7 @@ small::
 
     r'$(\frac{5 - \frac{1}{x}}{4})$'
 
-.. math ::
+.. math::
 
     (\frac{5 - \frac{1}{x}}{4})
 
@@ -120,7 +120,7 @@ the parser that those brackets encompass the entire object.::
 
     r'$\left(\frac{5 - \frac{1}{x}}{4}\right)$'
 
-.. math ::
+.. math::
 
     \left(\frac{5 - \frac{1}{x}}{4}\right)
 
@@ -130,7 +130,7 @@ Radicals can be produced with the ``\sqrt[]{}`` command.  For example::
 
     r'$\sqrt{2}$'
 
-.. math ::
+.. math::
 
     \sqrt{2}
 
@@ -140,7 +140,7 @@ fractions or sub/superscripts::
 
     r'$\sqrt[3]{x}$'
 
-.. math ::
+.. math::
 
     \sqrt[3]{x}
 


### PR DESCRIPTION
This is non standard, and does not work with all rst parsers.
And those are the only few while there is approximatively 1200 directive
that don't use space in the codebase



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [N/A] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
