### PR TITLE
[ENH]: Use new style format strings for colorbar ticks

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -489,7 +489,7 @@ class Colorbar:
             self.locator = ticks    # Handle default in _ticker()
 
         if isinstance(format, str):
-            # Check format type between FormatStrFormatter and StrMethodFormatter
+            # Check format between FormatStrFormatter and StrMethodFormatter
             try:
                 self.formatter = ticker.FormatStrFormatter(format)
                 _ = self.formatter(0)

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -352,6 +352,8 @@ class Colorbar:
     ticks : `~matplotlib.ticker.Locator` or array-like of float
 
     format : str or `~matplotlib.ticker.Formatter`
+        If string, it supports '%' operator and `str.format` formats:
+        e.g. ``"%4.2e"`` or ``"{x:.2e}"``.
 
     drawedges : bool
 
@@ -487,7 +489,12 @@ class Colorbar:
             self.locator = ticks    # Handle default in _ticker()
 
         if isinstance(format, str):
-            self.formatter = ticker.FormatStrFormatter(format)
+            # Check format type between FormatStrFormatter and StrMethodFormatter
+            try:
+                self.formatter = ticker.FormatStrFormatter(format)
+                _ = self.formatter(0)
+            except TypeError:
+                self.formatter = ticker.StrMethodFormatter(format)
         else:
             self.formatter = format  # Assume it is a Formatter or None
         self.draw_all()

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -543,14 +543,15 @@ def test_colorbar_renorm():
     assert np.isclose(cbar.vmax, z.max() * 1000)
 
 
-def test_colorbar_format():
+@pytest.mark.parametrize('fmt', ['%4.2e', '{x:.2e}'])
+def test_colorbar_format(fmt):
     # make sure that format is passed properly
     x, y = np.ogrid[-4:4:31j, -4:4:31j]
     z = 120000*np.exp(-x**2 - y**2)
 
     fig, ax = plt.subplots()
     im = ax.imshow(z)
-    cbar = fig.colorbar(im, format='%4.2e')
+    cbar = fig.colorbar(im, format=fmt)
     fig.canvas.draw()
     assert cbar.ax.yaxis.get_ticklabels()[4].get_text() == '8.00e+04'
 


### PR DESCRIPTION
Fixes #21378

## PR Summary

This PR introduces `formatter` as property to fetch axis format and thus new style string formatter is used
If applying a similar logic to major and minor locators, we can end up with removing the code from `update_ticks`.
Tricky part is with `self.norm`.
If we are ok with this solution, I can work on doing the same for `locator` and `minorlocator`.

Context: PR from PyData Global 2021 mentored sprint

cc @tacaswell 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
