### PR TITLE
Return minorticks as array, not as list.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1269,19 +1269,19 @@ class Axis(martist.Artist):
     def get_minorticklocs(self):
         """Return this Axis' minor tick locations in data coordinates."""
         # Remove minor ticks duplicating major ticks.
-        major_locs = self.major.locator()
-        minor_locs = self.minor.locator()
-        transform = self._scale.get_transform()
-        tr_minor_locs = transform.transform(minor_locs)
-        tr_major_locs = transform.transform(major_locs)
-        lo, hi = sorted(transform.transform(self.get_view_interval()))
-        # Use the transformed view limits as scale.  1e-5 is the default rtol
-        # for np.isclose.
-        tol = (hi - lo) * 1e-5
+        minor_locs = np.asarray(self.minor.locator())
         if self.remove_overlapping_locs:
-            minor_locs = [
-                loc for loc, tr_loc in zip(minor_locs, tr_minor_locs)
-                if ~np.isclose(tr_loc, tr_major_locs, atol=tol, rtol=0).any()]
+            major_locs = self.major.locator()
+            transform = self._scale.get_transform()
+            tr_minor_locs = transform.transform(minor_locs)
+            tr_major_locs = transform.transform(major_locs)
+            lo, hi = sorted(transform.transform(self.get_view_interval()))
+            # Use the transformed view limits as scale.  1e-5 is the default
+            # rtol for np.isclose.
+            tol = (hi - lo) * 1e-5
+            mask = np.isclose(tr_minor_locs[:, None], tr_major_locs[None, :],
+                              atol=tol, rtol=0).any(axis=1)
+            minor_locs = minor_locs[~mask]
         return minor_locs
 
     def get_ticklocs(self, *, minor=False):

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -608,6 +608,7 @@ def test_colorbar_inverted_ticks():
     cbar.minorticks_on()
     ticks = cbar.get_ticks()
     minorticks = cbar.get_ticks(minor=True)
+    assert isinstance(minorticks, np.ndarray)
     cbar.ax.invert_yaxis()
     np.testing.assert_allclose(ticks, cbar.get_ticks())
     np.testing.assert_allclose(minorticks, cbar.get_ticks(minor=True))


### PR DESCRIPTION
The return type changed accidentally when remove_overlapping_locs was
introduced (except for NullLocator, which always returned a plain list).
Make the API consistent with majorticks, which are (mostly) always
returned as an array.

Modifying the test in test_colorbar is so-so, but that's the only place,
AFAICT, that currently tests anything with get_ticklocs(minor=True),
so...

Closes https://github.com/matplotlib/matplotlib/issues/19559.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
