### PR TITLE
Turn mouseover into a mpl-style getset_property.

### DIFF
--- a/doc/api/artist_api.rst
+++ b/doc/api/artist_api.rst
@@ -35,6 +35,8 @@ Interactive
    Artist.pchanged
    Artist.get_cursor_data
    Artist.format_cursor_data
+   Artist.set_mouseover
+   Artist.get_mouseover
    Artist.mouseover
    Artist.contains
    Artist.pick

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1295,27 +1295,37 @@ class Artist:
                                  if isinstance(item, Number))
             return "[" + data_str + "]"
 
-    @property
-    def mouseover(self):
+    def get_mouseover(self):
         """
-        If this property is set to *True*, the artist will be queried for
-        custom context information when the mouse cursor moves over it.
-
-        See also :meth:`get_cursor_data`, :class:`.ToolCursorPosition` and
-        :class:`.NavigationToolbar2`.
+        Return whether this artist is queried for custom context information
+        when the mouse cursor moves over it.
         """
         return self._mouseover
 
-    @mouseover.setter
-    def mouseover(self, val):
-        val = bool(val)
-        self._mouseover = val
+    def set_mouseover(self, mouseover):
+        """
+        Set whether this artist is queried for custom context information when
+        the mouse cursor moves over it.
+
+        Parameters
+        ----------
+        mouseover : bool
+
+        See Also
+        --------
+        get_cursor_data
+        .ToolCursorPosition
+        .NavigationToolbar2
+        """
+        self._mouseover = bool(mouseover)
         ax = self.axes
         if ax:
-            if val:
+            if self._mouseover:
                 ax._mouseover_set.add(self)
             else:
                 ax._mouseover_set.discard(self)
+
+    mouseover = property(get_mouseover, set_mouseover)  # backcompat.
 
 
 def _get_tightbbox_for_layout_only(obj, *args, **kwargs):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1103,7 +1103,7 @@ class _AxesBase(martist.Artist):
             a.set_transform(self.transData)
 
         a.axes = self
-        if a.mouseover:
+        if a.get_mouseover():
             self._mouseover_set.add(a)
 
     def _gen_axes_patch(self):


### PR DESCRIPTION
This allows one to write e.g. `imshow(array, mouseover=False)` instead
of `im = imshow(array); im.mouseover = False`.

The Python property is kept for backcompat.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
