### PR TITLE
Added links to the mosaic docs in figure and pyplot module docstrings

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1680,7 +1680,7 @@ default: %(va)s
            early user feedback.
 
         See :doc:`/tutorials/provisional/mosaic`
-        for an examplary usage and provisional API documentation
+        for an example of its usage and provisional API documentation
 
         Parameters
         ----------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1679,7 +1679,7 @@ default: %(va)s
            This API is provisional and may be revised in the future based on
            early user feedback.
 
-        See :doc:`/tutorials/provisional/mosaic.py` 
+        See :doc:`/tutorials/provisional/mosaic`
         for an examplary usage and provisional API documentation
 
         Parameters

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1680,7 +1680,7 @@ default: %(va)s
            early user feedback.
 
         See :doc:`/tutorials/provisional/mosaic`
-        for an example of its usage and provisional API documentation
+        for an example and full API documentation
 
         Parameters
         ----------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1679,6 +1679,9 @@ default: %(va)s
            This API is provisional and may be revised in the future based on
            early user feedback.
 
+        See :doc:`/tutorials/provisional/mosaic.py` 
+        for an examplary usage and provisional API documentation
+
         Parameters
         ----------
         mosaic : list of list of {hashable or nested} or str

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1451,7 +1451,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        This API is provisional and may be revised in the future based on
        early user feedback.
 
-    See :doc:`/tutorials/provisional/mosaic.py` 
+    See :doc:`/tutorials/provisional/mosaic`
     for an examplary usage and provisional API documentation
 
     Parameters

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1452,7 +1452,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        early user feedback.
 
     See :doc:`/tutorials/provisional/mosaic`
-    for an examplary usage and provisional API documentation
+    for an example of its usage and provisional API documentation
 
     Parameters
     ----------

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1451,6 +1451,9 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        This API is provisional and may be revised in the future based on
        early user feedback.
 
+    See :doc:`/tutorials/provisional/mosaic.py` 
+    for an examplary usage and provisional API documentation
+
     Parameters
     ----------
     mosaic : list of list of {hashable or nested} or str

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1452,7 +1452,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        early user feedback.
 
     See :doc:`/tutorials/provisional/mosaic`
-    for an example of its usage and provisional API documentation
+    for an example and full API documentation
 
     Parameters
     ----------


### PR DESCRIPTION
#21532 @timhoffm

## PR Summary

Added links to the provisional API documentation for the subplot_mosaic function in both the ``figure`` and ``pyplot`` module docstrings

## PR Checklist

- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ N/A] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).