### PR TITLE
Ignore transOffset if no offsets passed to Collection

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
@@ -269,6 +269,10 @@ Miscellaneous deprecations
 - ``cm.LUTSIZE`` is deprecated. Use :rc:`image.lut` instead. This value only
   affects colormap quantization levels for default colormaps generated at
   module import time.
+- ``Collection.__init__`` previously ignored *transOffset* without *offsets* also
+  being specified. In the future, *transOffset* will begin having an effect
+  regardless of *offsets*. In the meantime, if you wish to set *transOffset*,
+  call `.Collection.set_offset_transform` explicitly.
 - ``Colorbar.patch`` is deprecated; this attribute is not correctly updated
   anymore.
 - ``ContourLabeler.get_label_width`` is deprecated.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -202,6 +202,18 @@ class Collection(artist.Artist, cm.ScalarMappable):
             if offsets.shape == (2,):
                 offsets = offsets[None, :]
             self._offsets = offsets
+        elif transOffset is not None:
+            _api.warn_deprecated(
+                '3.5',
+                removal='3.6',
+                message='Passing *transOffset* without *offsets* has no '
+                        'effect. This behavior is deprecated since %(since)s '
+                        'and %(removal)s, *transOffset* will begin having an '
+                        'effect regardless of *offsets*. In the meantime, if '
+                        'you wish to set *transOffset*, call '
+                        'collection.set_offset_transform(transOffset) '
+                        'explicitly.')
+            transOffset = None
 
         self._transOffset = transOffset
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1072,8 +1072,13 @@ def test_set_offsets_late():
 
 
 def test_set_offset_transform():
+    with pytest.warns(MatplotlibDeprecationWarning,
+                      match='.transOffset. without .offsets. has no effect'):
+        mcollections.Collection([],
+                                transOffset=mtransforms.IdentityTransform())
+
     skew = mtransforms.Affine2D().skew(2, 2)
-    init = mcollections.Collection([], transOffset=skew)
+    init = mcollections.Collection([], offsets=[], transOffset=skew)
 
     late = mcollections.Collection([])
     late.set_offset_transform(skew)


### PR DESCRIPTION
## PR Summary

This fixes a regression from #20717 in networkx (Fixes #21517), but we'll go forward with the change in a later release to give them time to fix it.

Since this will be reverted for 3.6, this is targeting v3.5.x directly.

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).