### PR TITLE
Fix check for manager presence in blocking_input.

### DIFF
--- a/lib/matplotlib/_blocking_input.py
+++ b/lib/matplotlib/_blocking_input.py
@@ -18,7 +18,7 @@ def blocking_input_loop(figure, event_names, timeout, handler):
         Function called for each event; it can force an early exit of the event
         loop by calling ``canvas.stop_event_loop()``.
     """
-    if hasattr(figure.canvas, "manager"):
+    if figure.canvas.manager:
         figure.show()  # Ensure that the figure is shown if we are managing it.
     # Connect the events to the on_event function call.
     cids = [figure.canvas.mpl_connect(name, handler) for name in event_names]

--- a/lib/matplotlib/blocking_input.py
+++ b/lib/matplotlib/blocking_input.py
@@ -83,7 +83,7 @@ class BlockingInput:
         self.n = n
         self.events = []
 
-        if hasattr(self.fig.canvas, "manager"):
+        if self.figure.canvas.manager:
             # Ensure that the figure is shown, if we are managing it.
             self.fig.show()
         # Connect the events to the on_event function call.


### PR DESCRIPTION
This was missed in 3ccc17b.  Closes #21548.
Milestoning as 3.5 as this is a regression in 3.3 and the fix seems simple enough, but feel free to push to 3.6.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
