### PR TITLE
Deleted 'range' in the validate_whiskers function's ValueError raising

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1680,7 +1680,7 @@ default: %(va)s
            early user feedback.
 
         See :doc:`/tutorials/provisional/mosaic`
-        for an examplary usage and provisional API documentation
+        for an example of its usage and provisional API documentation
 
         Parameters
         ----------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1679,7 +1679,7 @@ default: %(va)s
            This API is provisional and may be revised in the future based on
            early user feedback.
 
-        See :doc:`/tutorials/provisional/mosaic.py` 
+        See :doc:`/tutorials/provisional/mosaic`
         for an examplary usage and provisional API documentation
 
         Parameters

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1680,7 +1680,7 @@ default: %(va)s
            early user feedback.
 
         See :doc:`/tutorials/provisional/mosaic`
-        for an example of its usage and provisional API documentation
+        for an example and full API documentation
 
         Parameters
         ----------

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1679,6 +1679,9 @@ default: %(va)s
            This API is provisional and may be revised in the future based on
            early user feedback.
 
+        See :doc:`/tutorials/provisional/mosaic.py` 
+        for an examplary usage and provisional API documentation
+
         Parameters
         ----------
         mosaic : list of list of {hashable or nested} or str

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1451,7 +1451,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        This API is provisional and may be revised in the future based on
        early user feedback.
 
-    See :doc:`/tutorials/provisional/mosaic.py` 
+    See :doc:`/tutorials/provisional/mosaic`
     for an examplary usage and provisional API documentation
 
     Parameters

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1452,7 +1452,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        early user feedback.
 
     See :doc:`/tutorials/provisional/mosaic`
-    for an examplary usage and provisional API documentation
+    for an example of its usage and provisional API documentation
 
     Parameters
     ----------

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1451,6 +1451,9 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        This API is provisional and may be revised in the future based on
        early user feedback.
 
+    See :doc:`/tutorials/provisional/mosaic.py` 
+    for an examplary usage and provisional API documentation
+
     Parameters
     ----------
     mosaic : list of list of {hashable or nested} or str

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1452,7 +1452,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
        early user feedback.
 
     See :doc:`/tutorials/provisional/mosaic`
-    for an example of its usage and provisional API documentation
+    for an example and full API documentation
 
     Parameters
     ----------

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -414,7 +414,7 @@ def validate_whiskers(s):
         try:
             return float(s)
         except ValueError as e:
-            raise ValueError("Not a valid whisker value ['range', float, "
+            raise ValueError("Not a valid whisker value [float, "
                              "(float, float)]") from e
 
 


### PR DESCRIPTION
#21514 @yy0931

## PR Summary

``validate_whiskers`` does not accept "range" but it was still included in the error message, so I deleted it.