### PR TITLE
Fix transparency when exporting to png via pgf backend.

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -312,10 +312,12 @@ def test_bbox_inches_tight():
 
 @needs_xelatex
 @needs_ghostscript
-def test_png():
-    # Just a smoketest.
-    fig, ax = plt.subplots()
-    fig.savefig(BytesIO(), format="png", backend="pgf")
+def test_png_transparency():  # Actually, also just testing that png works.
+    buf = BytesIO()
+    plt.figure().savefig(buf, format="png", backend="pgf", transparent=True)
+    buf.seek(0)
+    t = plt.imread(buf)
+    assert (t[..., 3] == 0).all()  # fully transparent.
 
 
 @needs_xelatex


### PR DESCRIPTION
... and add a private mechanism ($_MPLHIDEEXECUTABLES) to allow manually
testing both pdftocairo and ghostscript.  No automation for that, sorry.

Closes https://github.com/matplotlib/matplotlib/issues/11738.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
