### PR TITLE
Various small fixes for streamplot().

### DIFF
--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -116,8 +116,8 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     if use_multicolor_lines:
         if color.shape != grid.shape:
             raise ValueError("If 'color' is given, it must match the shape of "
-                             "'Grid(x, y)'")
-        line_colors = []
+                             "the (x, y) grid")
+        line_colors = [[]]  # Empty entry allows concatenation of zero arrays.
         color = np.ma.masked_invalid(color)
     else:
         line_kw['color'] = color
@@ -126,7 +126,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     if isinstance(linewidth, np.ndarray):
         if linewidth.shape != grid.shape:
             raise ValueError("If 'linewidth' is given, it must match the "
-                             "shape of 'Grid(x, y)'")
+                             "shape of the (x, y) grid")
         line_kw['linewidth'] = []
     else:
         line_kw['linewidth'] = linewidth
@@ -137,7 +137,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
 
     # Sanity checks.
     if u.shape != grid.shape or v.shape != grid.shape:
-        raise ValueError("'u' and 'v' must match the shape of 'Grid(x, y)'")
+        raise ValueError("'u' and 'v' must match the shape of the (x, y) grid")
 
     u = np.ma.masked_invalid(u)
     v = np.ma.masked_invalid(v)
@@ -310,21 +310,22 @@ class Grid:
     """Grid of data."""
     def __init__(self, x, y):
 
-        if x.ndim == 1:
+        if np.ndim(x) == 1:
             pass
-        elif x.ndim == 2:
-            x_row = x[0, :]
+        elif np.ndim(x) == 2:
+            x_row = x[0]
             if not np.allclose(x_row, x):
                 raise ValueError("The rows of 'x' must be equal")
             x = x_row
         else:
             raise ValueError("'x' can have at maximum 2 dimensions")
 
-        if y.ndim == 1:
+        if np.ndim(y) == 1:
             pass
-        elif y.ndim == 2:
-            y_col = y[:, 0]
-            if not np.allclose(y_col, y.T):
+        elif np.ndim(y) == 2:
+            yt = np.transpose(y)  # Also works for nested lists.
+            y_col = yt[0]
+            if not np.allclose(y_col, yt):
                 raise ValueError("The columns of 'y' must be equal")
             y = y_col
         else:

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -144,3 +144,13 @@ def test_streamplot_grid():
 
     with pytest.raises(ValueError, match="'y' must be strictly increasing"):
         plt.streamplot(x, y, u, v)
+
+
+def test_streamplot_inputs():  # test no exception occurs.
+    # fully-masked
+    plt.streamplot(np.arange(3), np.arange(3),
+                   np.full((3, 3), np.nan), np.full((3, 3), np.nan),
+                   color=np.random.rand(3, 3))
+    # array-likes
+    plt.streamplot(range(3), range(3),
+                   np.random.rand(3, 3), np.random.rand(3, 3))


### PR DESCRIPTION
- Support array-like, but not array, x/y.
- Support fully masked inputs.  (Closes https://github.com/matplotlib/matplotlib/issues/19323.)
- Don't mention the Grid class (effectively internal) in error messages.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
