### PR TITLE
Removed the range parameter from the validate_whiskers function's err…

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -414,7 +414,7 @@ def validate_whiskers(s):
         try:
             return float(s)
         except ValueError as e:
-            raise ValueError("Not a valid whisker value ['range', float, "
+            raise ValueError("Not a valid whisker value [float, "
                              "(float, float)]") from e
 
 


### PR DESCRIPTION
#21514 @yy0931 @anntzer @masaaldosey @timhoffm

Until now, the ``validate_whiskers`` function in ``matplotlib/lib/matplotlib/rcsetup`` contains the following error message in line 417:

`raise ValueError("Not a valid whisker value ['range', float, "`

Since ``validate_whiskers`` does not accept the param "range" but it was still included in the ValueError raise, I removed it from that same message.