### PR TITLE
Raise correct exception out of Spines.__getattr__

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -550,7 +550,7 @@ class Spines(MutableMapping):
         try:
             return self._dict[name]
         except KeyError:
-            raise ValueError(
+            raise AttributeError(
                 f"'Spines' object does not contain a '{name}' spine")
 
     def __getitem__(self, key):

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -35,6 +35,8 @@ def test_spine_class():
     spines[:].set_val('y')
     assert all(spine.val == 'y' for spine in spines.values())
 
+    with pytest.raises(AttributeError, match='foo'):
+        spines.foo
     with pytest.raises(KeyError, match='foo'):
         spines['foo']
     with pytest.raises(KeyError, match='foo, bar'):


### PR DESCRIPTION
## PR Summary

If the name does not exist, then `__getattr__` should raise `AttributeError`, not `ValueError`.

Fixes #21554

## PR Checklist

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).