### PR TITLE
Fixing and adding a test for a problem when using twinx() and twiny() the Axes moves a little more than what they should

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4698,7 +4698,7 @@ class _AxesBase(martist.Artist):
 
         @ax2.set_axes_locator
         def axes_locator(_, renderer):
-            self_locator = self.get_axes_locator()
+            self_locator = self._TransformedBoundsLocator()
             if self_locator is not None:
                 return self_locator(self, renderer)
 
@@ -4734,7 +4734,7 @@ class _AxesBase(martist.Artist):
 
         @ax2.set_axes_locator
         def axes_locator(_, renderer):
-            self_locator = self.get_axes_locator()
+            self_locator = self._TransformedBoundsLocator()
             if self_locator is not None:
                 return self_locator(self, renderer)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4695,6 +4695,13 @@ class _AxesBase(martist.Artist):
         self.yaxis.tick_left()
         ax2.xaxis.set_visible(False)
         ax2.patch.set_visible(False)
+
+        @ax2.set_axes_locator
+        def axes_locator(_, renderer):
+            self_locator = self.get_axes_locator()
+            if self_locator is not None:
+                return self_locator(self, renderer)
+
         return ax2
 
     def twiny(self):
@@ -4724,6 +4731,13 @@ class _AxesBase(martist.Artist):
         self.xaxis.tick_bottom()
         ax2.yaxis.set_visible(False)
         ax2.patch.set_visible(False)
+
+        @ax2.set_axes_locator
+        def axes_locator(_, renderer):
+            self_locator = self.get_axes_locator()
+            if self_locator is not None:
+                return self_locator(self, renderer)
+
         return ax2
 
     def get_shared_x_axes(self):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -276,12 +276,12 @@ def test_twinning():
     ax1.set_position(pos2)
 
     # it gets the position, in a np.array, of ax1 after the twiny and the set_position
-    array1 = np.any(mtransforms.Bbox.get_points(ax1.get_position()))
+    array1 = np.all(mtransforms.Bbox.get_points(ax1.get_position()))
     # it gets the np.array of the point of pos2
-    array2 = np.any(mtransforms.Bbox.get_points(pos2))
+    array2 = np.all(mtransforms.Bbox.get_points(pos2))
 
     # Assert that the positions are the same, and the twinning don't change them
-    assert array1 == array2
+    assert np.array_equal(array1, array2)
 
 @image_comparison(["twin_axis_locators_formatters"])
 def test_twin_axis_locators_formatters():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -259,6 +259,19 @@ def test_strmethodformatter_auto_formatter():
 
     assert ax.yaxis.get_minor_formatter().fmt == targ_strformatter.fmt
 
+def test_twinning():
+    ax1 = plt.axes()
+
+    pos1 = ax1.get_position() # get the currently position
+    pos2 = [pos1.x0, pos1.y0,  pos1.width, pos1.height * 0.6]
+    # the line above changes pos1
+
+    ax2 = ax1.twiny()
+
+    ax2.set_position(pos2) # set a new position
+
+    # Assert that the positions are the same, and the twinning don't change them
+    assert ax2.get_position() == pos2
 
 @image_comparison(["twin_axis_locators_formatters"])
 def test_twin_axis_locators_formatters():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -259,19 +259,29 @@ def test_strmethodformatter_auto_formatter():
 
     assert ax.yaxis.get_minor_formatter().fmt == targ_strformatter.fmt
 
+
 def test_twinning():
+    # plot the axis
     ax1 = plt.axes()
 
-    pos1 = ax1.get_position() # get the currently position
-    pos2 = [pos1.x0, pos1.y0,  pos1.width, pos1.height * 0.6]
-    # the line above changes pos1
+    # get the currently position
+    pos1 = ax1.get_position()
+    # pos2 takes pos1 coords, and, alter the height by multiplying it by 0.6
+    pos2 = mtransforms.Bbox.from_extents([pos1.x0, pos1.y0,  pos1.width, pos1.height * 0.6])
+    
+    # twiny() ax1
+    ax1.twiny()
 
-    ax2 = ax1.twiny()
+    # set a new position
+    ax1.set_position(pos2)
 
-    ax2.set_position(pos2) # set a new position
+    # it gets the position, in a np.array, of ax1 after the twiny and the set_position
+    array1 = np.any(mtransforms.Bbox.get_points(ax1.get_position()))
+    # it gets the np.array of the point of pos2
+    array2 = np.any(mtransforms.Bbox.get_points(pos2))
 
     # Assert that the positions are the same, and the twinning don't change them
-    assert ax2.get_position() == pos2
+    assert array1 == array2
 
 @image_comparison(["twin_axis_locators_formatters"])
 def test_twin_axis_locators_formatters():


### PR DESCRIPTION
## PR Summary
This PR solve a problem where, if you used twiny() on your axis, this would dislocated the axes more than it should be. So using the patch that @QuLogic did and adding a test, that apparently was resolved.
- added a test for the case:
- Solution of the problem with twiny(), that dislocated the axe wrongly;
- Test added, to make sure this problem will not occur anymore, by failing if the bug happen.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->