### PR TITLE
Defer enforcement of hatch validation

### DIFF
--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -188,6 +188,7 @@ def _validate_hatch_pattern(hatch):
             invalids = ''.join(sorted(invalids))
             _api.warn_deprecated(
                 '3.4',
+                removal='3.7',  # one release after custom hatches (#20690)
                 message=f'hatch must consist of a string of "{valid}" or '
                         'None, but found the following invalid values '
                         f'"{invalids}". Passing invalid values is deprecated '


### PR DESCRIPTION
We want to wait until an official API is available to define custom
hatches. One can currently add custom patches via monkeypatching, which
would be prevented by the hatch validation:
https://github.com/matplotlib/matplotlib/issues/20690#issuecomment-965638949

