### PR TITLE
Make gtk3 full_screen_toggle more robust against external changes.

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -395,12 +395,10 @@ class FigureManagerGTK3(FigureManagerBase):
                 _api.warn_external("Cannot raise window yet to be setup")
 
     def full_screen_toggle(self):
-        self._full_screen_flag = not self._full_screen_flag
-        if self._full_screen_flag:
-            self.window.fullscreen()
-        else:
+        if self.window.get_window().get_state() & Gdk.WindowState.FULLSCREEN:
             self.window.unfullscreen()
-    _full_screen_flag = False
+        else:
+            self.window.fullscreen()
 
     def _get_toolbar(self):
         # must be inited after the window, drawingArea and figure


### PR DESCRIPTION
The fullscreen state can also change via the window manager, so read the
state instead of trying to keep an internal flag.  All other backends
already use a similar strategy.

(`self.window` is a GtkWindow, whereas `self.window.get_window()` is a
GdkWindow...)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
