### PR TITLE
[BUG in 3.5.0rc1] - Anatomy of a Figure has the legend in the wrong spot

### DIFF
--- a/examples/showcase/anatomy.py
+++ b/examples/showcase/anatomy.py
@@ -52,7 +52,7 @@ ax.set_title("Anatomy of a figure", fontsize=20, verticalalignment='bottom')
 ax.set_xlabel("X axis label")
 ax.set_ylabel("Y axis label")
 
-ax.legend()
+ax.legend(loc="upper right")
 
 
 def circle(x, y, radius=0.15):


### PR DESCRIPTION
## PR Summary
In 3.5.0rc1, the call to `ax.legend()` in the [Anatomy of a figure](https://matplotlib.org/3.5.0/gallery/showcase/anatomy.html) example is now placing the legend in the lower right corner:
![image](https://user-images.githubusercontent.com/24376333/141204976-57500e84-2d31-46c0-99fd-f94da7019f5d.png)

In [version 3.4.3](https://matplotlib.org/stable/gallery/showcase/anatomy.html), this call is determining that the "upper right" is the best location for the legend so the example works. I modified the call to `ax.legend()` to specify `loc="upper right"` to ensure we always have the legend in the correct spot.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [X] New features are documented, with examples if plot related.
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [X]Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [X] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [X] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
