### PR TITLE
FIX: Remove the deepcopy override from transforms

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,3 +1,4 @@
+import copy
 from datetime import datetime
 import io
 from pathlib import Path
@@ -1261,3 +1262,28 @@ def test_kwargs_pass():
 
     assert fig.get_label() == 'whole Figure'
     assert sub_fig.get_label() == 'sub figure'
+
+
+def test_deepcopy():
+    fig1, ax = plt.subplots()
+    ax.plot([0, 1], [2, 3])
+    ax.set_yscale('log')
+
+    fig2 = copy.deepcopy(fig1)
+
+    # Make sure it is a new object
+    assert fig2.axes[0] is not ax
+    # And that the axis scale got propagated
+    assert fig2.axes[0].get_yscale() == 'log'
+    # Update the deepcopy and check the original isn't modified
+    fig2.axes[0].set_yscale('linear')
+    assert ax.get_yscale() == 'log'
+
+    # And test the limits of the axes don't get propagated
+    ax.set_xlim(1e-1, 1e2)
+    # Draw these to make sure limits are updated
+    fig1.draw_without_rendering()
+    fig2.draw_without_rendering()
+
+    assert ax.get_xlim() == (1e-1, 1e2)
+    assert fig2.axes[0].get_xlim() == (0, 1)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -151,22 +151,6 @@ class TransformNode:
                 other.set_children(val)  # val == getattr(other, key)
         return other
 
-    def __deepcopy__(self, memo):
-        # We could deepcopy the entire transform tree, but nothing except
-        # `self` is accessible publicly, so we may as well just freeze `self`.
-        other = self.frozen()
-        if other is not self:
-            return other
-        # Some classes implement frozen() as returning self, which is not
-        # acceptable for deepcopying, so we need to handle them separately.
-        other = copy.deepcopy(super(), memo)
-        # If `c = a + b; a1 = copy(a)`, then modifications to `a1` do not
-        # propagate back to `c`, i.e. we need to clear the parents of `a1`.
-        other._parents = {}
-        # If `c = a + b; c1 = copy(c)`, this creates a separate tree
-        # (`c1 = a1 + b1`) so nothing needs to be done.
-        return other
-
     def invalidate(self):
         """
         Invalidate this `TransformNode` and triggers an invalidation of its


### PR DESCRIPTION
## PR Summary
Currently, a deepcopy of a figure does not work because the transform tree does not get fully copied to the new state. I am not sure we actually need to override `__deepcopy__` on the transformNode, so just remove that and use the one that comes along with the class. I might be missing something obvious, but this does appear to work as I'd expect and not copy over any transform state to the new axes.

closes #21554

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
