### PR TITLE
Fix centre square rectangle selector part 1

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -118,6 +118,158 @@ def test_rectangle_selector_set_props_handle_props():
         assert artist.get_alpha() == 0.3
 
 
+def test_rectangle_resize():
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True)
+    # Create rectangle
+    do_event(tool, 'press', xdata=0, ydata=10, button=1)
+    do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
+    do_event(tool, 'release', xdata=100, ydata=120, button=1)
+    assert tool.extents == (0.0, 100.0, 10.0, 120.0)
+
+    # resize NE handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[3]
+    xdata_new, ydata_new = xdata + 10, ydata + 5
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    assert tool.extents == (0.0, xdata_new, 10.0, ydata_new)
+
+    # resize E handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdata_new, ydata_new = xdata + 10, ydata
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    assert tool.extents == (0.0, xdata_new, 10.0, 125.0)
+
+    # resize W handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdata_new, ydata_new = xdata + 15, ydata
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    assert tool.extents == (xdata_new, 120.0, 10.0, 125.0)
+
+    # resize SW handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2]
+    xdata_new, ydata_new = xdata + 20, ydata + 25
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    assert tool.extents == (xdata_new, 120.0, ydata_new, 125.0)
+
+
+@pytest.mark.parametrize('use_default_state', [True, False])
+def test_rectangle_resize_center(use_default_state):
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True)
+    # Create rectangle
+    do_event(tool, 'press', xdata=70, ydata=65, button=1)
+    do_event(tool, 'onmove', xdata=125, ydata=130, button=1)
+    do_event(tool, 'release', xdata=125, ydata=130, button=1)
+    assert tool.extents == (70.0, 125.0, 65.0, 130.0)
+
+    if use_default_state:
+        tool._default_state.add('center')
+
+    # resize NE handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[3]
+    xdiff, ydiff = 10, 5
+    xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_press', key='control')
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_release', key='control')
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    assert tool.extents == (70.0 - xdiff, xdata_new, 65.0 - ydiff, ydata_new)
+
+    # resize E handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = 10
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_press', key='control')
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_release', key='control')
+    assert tool.extents == (60.0 - xdiff, xdata_new, 60.0, 135.0)
+
+    # resize E handle negative diff
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = -20
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_press', key='control')
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_release', key='control')
+    assert tool.extents == (50.0 - xdiff, xdata_new, 60.0, 135.0)
+
+    # resize W handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = 15
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_press', key='control')
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_release', key='control')
+    assert tool.extents == (xdata_new, 125.0 - xdiff, 60.0, 135.0)
+
+    # resize W handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = -25
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_press', key='control')
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_release', key='control')
+    assert tool.extents == (xdata_new, 110.0 - xdiff, 60.0, 135.0)
+
+    # resize SW handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2]
+    xdiff, ydiff = 20, 25
+    xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_press', key='control')
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+    if not use_default_state:
+        do_event(tool, 'on_key_release', key='control')
+    assert tool.extents == (xdata_new, 135.0 - xdiff, ydata_new, 135.0 - ydiff)
+
+
 def test_ellipse():
     """For ellipse, test out the key modifiers"""
     ax = get_ax()

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -55,6 +55,19 @@ def test_rectangle_selector():
     check_rectangle(props=dict(fill=True))
 
 
+def _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new,
+                      use_key=None):
+    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
+    if use_key is not None:
+        do_event(tool, 'on_key_press', key=use_key)
+    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
+    if use_key is not None:
+        do_event(tool, 'on_key_release', key=use_key)
+    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
+
+    return tool
+
+
 @pytest.mark.parametrize('drag_from_anywhere, new_center',
                          [[True, (60, 75)],
                           [False, (30, 20)]])
@@ -126,46 +139,36 @@ def test_rectangle_resize():
 
     tool = widgets.RectangleSelector(ax, onselect, interactive=True)
     # Create rectangle
-    do_event(tool, 'press', xdata=0, ydata=10, button=1)
-    do_event(tool, 'onmove', xdata=100, ydata=120, button=1)
-    do_event(tool, 'release', xdata=100, ydata=120, button=1)
+    _resize_rectangle(tool, 0, 10, 100, 120)
     assert tool.extents == (0.0, 100.0, 10.0, 120.0)
 
     # resize NE handle
     extents = tool.extents
     xdata, ydata = extents[1], extents[3]
     xdata_new, ydata_new = xdata + 10, ydata + 5
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    assert tool.extents == (0.0, xdata_new, 10.0, ydata_new)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (extents[0], xdata_new, extents[2], ydata_new)
 
     # resize E handle
     extents = tool.extents
     xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
     xdata_new, ydata_new = xdata + 10, ydata
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    assert tool.extents == (0.0, xdata_new, 10.0, 125.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (extents[0], xdata_new, extents[2], extents[3])
 
     # resize W handle
     extents = tool.extents
     xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
     xdata_new, ydata_new = xdata + 15, ydata
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    assert tool.extents == (xdata_new, 120.0, 10.0, 125.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (xdata_new, extents[1], extents[2], extents[3])
 
     # resize SW handle
     extents = tool.extents
     xdata, ydata = extents[0], extents[2]
     xdata_new, ydata_new = xdata + 20, ydata + 25
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    assert tool.extents == (xdata_new, 120.0, ydata_new, 125.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (xdata_new, extents[1], ydata_new, extents[3])
 
 
 @pytest.mark.parametrize('use_default_state', [True, False])
@@ -177,97 +180,209 @@ def test_rectangle_resize_center(use_default_state):
 
     tool = widgets.RectangleSelector(ax, onselect, interactive=True)
     # Create rectangle
-    do_event(tool, 'press', xdata=70, ydata=65, button=1)
-    do_event(tool, 'onmove', xdata=125, ydata=130, button=1)
-    do_event(tool, 'release', xdata=125, ydata=130, button=1)
+    _resize_rectangle(tool, 70, 65, 125, 130)
     assert tool.extents == (70.0, 125.0, 65.0, 130.0)
 
     if use_default_state:
         tool._default_state.add('center')
+        use_key = None
+    else:
+        use_key = 'control'
 
     # resize NE handle
     extents = tool.extents
     xdata, ydata = extents[1], extents[3]
     xdiff, ydiff = 10, 5
     xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_press', key='control')
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_release', key='control')
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    assert tool.extents == (70.0 - xdiff, xdata_new, 65.0 - ydiff, ydata_new)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0] - xdiff, xdata_new,
+                            extents[2] - ydiff, ydata_new)
 
     # resize E handle
     extents = tool.extents
     xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
     xdiff = 10
     xdata_new, ydata_new = xdata + xdiff, ydata
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_press', key='control')
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_release', key='control')
-    assert tool.extents == (60.0 - xdiff, xdata_new, 60.0, 135.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0] - xdiff, xdata_new,
+                            extents[2], extents[3])
 
     # resize E handle negative diff
     extents = tool.extents
     xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
     xdiff = -20
     xdata_new, ydata_new = xdata + xdiff, ydata
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_press', key='control')
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_release', key='control')
-    assert tool.extents == (50.0 - xdiff, xdata_new, 60.0, 135.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0] - xdiff, xdata_new,
+                            extents[2], extents[3])
 
     # resize W handle
     extents = tool.extents
     xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
     xdiff = 15
     xdata_new, ydata_new = xdata + xdiff, ydata
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_press', key='control')
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_release', key='control')
-    assert tool.extents == (xdata_new, 125.0 - xdiff, 60.0, 135.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (xdata_new, extents[1] - xdiff,
+                            extents[2], extents[3])
 
-    # resize W handle
+    # resize W handle negative diff
     extents = tool.extents
     xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
     xdiff = -25
     xdata_new, ydata_new = xdata + xdiff, ydata
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_press', key='control')
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_release', key='control')
-    assert tool.extents == (xdata_new, 110.0 - xdiff, 60.0, 135.0)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (xdata_new, extents[1] - xdiff,
+                            extents[2], extents[3])
 
     # resize SW handle
     extents = tool.extents
     xdata, ydata = extents[0], extents[2]
     xdiff, ydiff = 20, 25
     xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
-    do_event(tool, 'press', xdata=xdata, ydata=ydata, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_press', key='control')
-    do_event(tool, 'onmove', xdata=xdata_new, ydata=ydata_new, button=1)
-    do_event(tool, 'release', xdata=xdata_new, ydata=ydata_new, button=1)
-    if not use_default_state:
-        do_event(tool, 'on_key_release', key='control')
-    assert tool.extents == (xdata_new, 135.0 - xdiff, ydata_new, 135.0 - ydiff)
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (xdata_new, extents[1] - xdiff,
+                            ydata_new, extents[3] - ydiff)
+
+
+@pytest.mark.parametrize('use_default_state', [True, False])
+def test_rectangle_resize_square(use_default_state):
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True)
+    # Create rectangle
+    _resize_rectangle(tool, 70, 65, 120, 115)
+    assert tool.extents == (70.0, 120.0, 65.0, 115.0)
+
+    if use_default_state:
+        tool._default_state.add('square')
+        use_key = None
+    else:
+        use_key = 'shift'
+
+    # resize NE handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[3]
+    xdiff, ydiff = 10, 5
+    xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0], xdata_new,
+                            extents[2], extents[3] + xdiff)
+
+    # resize E handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = 10
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0], xdata_new,
+                            extents[2], extents[3] + xdiff)
+
+    # resize E handle negative diff
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = -20
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0], xdata_new,
+                            extents[2], extents[3] + xdiff)
+
+    # resize W handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = 15
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (xdata_new, extents[1],
+                            extents[2], extents[3] - xdiff)
+
+    # resize W handle negative diff
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = -25
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (xdata_new, extents[1],
+                            extents[2], extents[3] - xdiff)
+
+    # resize SW handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2]
+    xdiff, ydiff = 20, 25
+    xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new, use_key)
+    assert tool.extents == (extents[0] + ydiff, extents[1],
+                            ydata_new, extents[3])
+
+
+def test_rectangle_resize_square_center():
+    ax = get_ax()
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True)
+    # Create rectangle
+    _resize_rectangle(tool, 70, 65, 120, 115)
+    tool._default_state.add('square')
+    tool._default_state.add('center')
+    assert tool.extents == (70.0, 120.0, 65.0, 115.0)
+
+    # resize NE handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[3]
+    xdiff, ydiff = 10, 5
+    xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (extents[0] - xdiff, xdata_new,
+                            extents[2] - xdiff, extents[3] + xdiff)
+
+    # resize E handle
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = 10
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (extents[0] - xdiff, xdata_new,
+                            extents[2] - xdiff, extents[3] + xdiff)
+
+    # resize E handle negative diff
+    extents = tool.extents
+    xdata, ydata = extents[1], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = -20
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (extents[0] - xdiff, xdata_new,
+                            extents[2] - xdiff, extents[3] + xdiff)
+
+    # resize W handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = 5
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (xdata_new, extents[1] - xdiff,
+                            extents[2] + xdiff, extents[3] - xdiff)
+
+    # resize W handle negative diff
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2] + (extents[3] - extents[2]) / 2
+    xdiff = -25
+    xdata_new, ydata_new = xdata + xdiff, ydata
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (xdata_new, extents[1] - xdiff,
+                            extents[2] + xdiff, extents[3] - xdiff)
+
+    # resize SW handle
+    extents = tool.extents
+    xdata, ydata = extents[0], extents[2]
+    xdiff, ydiff = 20, 25
+    xdata_new, ydata_new = xdata + xdiff, ydata + ydiff
+    _resize_rectangle(tool, xdata, ydata, xdata_new, ydata_new)
+    assert tool.extents == (extents[0] + ydiff, extents[1] - ydiff,
+                            ydata_new, extents[3] - ydiff)
 
 
 def test_ellipse():

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2970,8 +2970,8 @@ class RectangleSelector(_SelectorWidget):
         # resize an existing shape
         if self._active_handle and self._active_handle != 'C':
             x0, x1, y0, y1 = self._extents_on_press
-            sizepress = [x1 - x0, y1 - y0]
-            center = [x0 + sizepress[0] / 2, y0 + sizepress[1] / 2]
+            size_on_press = [x1 - x0, y1 - y0]
+            center = [x0 + size_on_press[0] / 2, y0 + size_on_press[1] / 2]
             dx = event.xdata - self._eventpress.xdata
             dy = event.ydata - self._eventpress.ydata
 
@@ -2987,9 +2987,10 @@ class RectangleSelector(_SelectorWidget):
                 dy *= y_factor
                 y0 = y1
 
-            # from center
+            # Keeping the center fixed
             if 'center' in state:
                 if 'square' in state:
+                    # Force the same change in dx and dy
                     if self._active_handle in ['E', 'W']:
                         # using E, W handle we need to update dy accordingly
                         dy = dx
@@ -2999,24 +3000,26 @@ class RectangleSelector(_SelectorWidget):
                     else:
                         dx = dy = max(dx, dy, key=abs)
 
-                dw = sizepress[0] / 2 + dx
-                dh = sizepress[1] / 2 + dy
+                # new half-width and half-height
+                hw = size_on_press[0] / 2 + dx
+                hh = size_on_press[1] / 2 + dy
 
                 if 'square' not in state:
                     # cancel changes in perpendicular direction
                     if self._active_handle in ['E', 'W']:
-                        dh = sizepress[1] / 2
+                        hh = size_on_press[1] / 2
                     if self._active_handle in ['N', 'S']:
-                        dw = sizepress[0] / 2
+                        hw = size_on_press[0] / 2
 
-                x0, x1, y0, y1 = (center[0] - dw, center[0] + dw,
-                                  center[1] - dh, center[1] + dh)
+                x0, x1, y0, y1 = (center[0] - hw, center[0] + hw,
+                                  center[1] - hh, center[1] + hh)
 
             else:
+                # Keeping the opposite corner/edge fixed
                 if 'square' in state:
                     dx = dy = max(dx, dy, key=abs)
-                    x1 = x0 + x_factor * (dx + sizepress[0])
-                    y1 = y0 + y_factor * (dy + sizepress[1])
+                    x1 = x0 + x_factor * (dx + size_on_press[0])
+                    y1 = y0 + y_factor * (dy + size_on_press[1])
                 else:
                     if self._active_handle in ['E', 'W'] + self._corner_order:
                         x1 = event.xdata


### PR DESCRIPTION
@dstansby, as mentioned in https://github.com/matplotlib/matplotlib/pull/20839#issuecomment-966512282, this is the first part of #20839.

## PR Summary
- Fix centre and square state of rectangle selector in interactive mode. These states were working only when creating the selector.
- Fix name coordinate handle: N and S were swapped.
- Rebased on latest main branch.

```python
import matplotlib.pyplot as plt
from matplotlib.widgets import RectangleSelector
import numpy as np

values = np.arange(0, 100)

fig = plt.figure()
ax = fig.add_subplot()
ax.plot(values, values)

selector = RectangleSelector(ax, print, interactive=True, drag_from_anywhere=True)

# change the size of selector interactively
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [n/a] New features are documented, with examples if plot related.
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.