### PR TITLE
BLD: limit support of pyparsing to <3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -326,7 +326,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "numpy>=1.17",
         "packaging>=20.0",
         "pillow>=6.2.0",
-        "pyparsing>=2.2.1",
+        "pyparsing>=2.2.1,<3",
         "python-dateutil>=2.7",
     ] + (
         # Installing from a git checkout.


### PR DESCRIPTION

## PR Summary

Due to a number of issues with the 3.0.x releases of pyparsing having issues,
we are going to for mpl3.5.0 limit to the 2.x series of pyparsing.  There is
ongoing work on both the Matplotlib and pyparsing sides and we anticipate that
we will be able to lift this constraint in the next patch release.

Due to one of our dependencies (packaging) also having issues with pyparsing and pinning it back to <3 we have been lulled into a false sense of security about if the v3.5.x branch is passing using pyparsing3 because it was actually testing with pyparsing 2.4.7.  Locally I see that on the v3.5.x branch we have:


| pyparsing version | v3.5.x | with Antony Patch | 
|-----------|------------|-----|
| 3.0.0  |   ✅  | ✅ 
| 3.0.1 | ✅ | ✅ 
| 3.0.2 | ❌ | ✅ 
| 3.0.3 | ❌ | ✅ 
| 3.0.4 | ❌ | ✅ 
| 3.0.5 | ❌ | ✅ |

The tests that fail are all of a dot moving from above a letter to in front of it.  If I cherry-pick the commit from #21501 (ec497ae) back to v3.5.x the tests pass.  However, given the discussion with @anntzer and @ptmcg I'm not sure if that that fix is "right" or not.  From https://github.com/matplotlib/matplotlib/pull/21501#discussion_r739563728

> Ok. There is a bug in pyparsing, but fixing it doesn't completely solve your problem.

I do not expect a future version of pyparsing to fix it for us so we will need some additional changes on our side

For mpl3.5.0 we need to merge either this PR or #21501.  On one hand, merging this PR is "safe" in that we are pretty confident that it won't break our users and buys more time to figure out what the right fix on our side is and in 3.5.1 we can exclude any version of pyparsing we do not want to / can not support (due to known bugs or performance versions).  On the other hand, if we merge #21501 we do not have to do any fancy pinning on pyparsing and if the solution there is not ideal we can fix it up in a patch release.

On balance, I think that merging #21501 and closing this PR is the right path forward.

<details>

```
===================================================================================================================================== short test summary info ======================================================================================================================================
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[png-mathtext-cm-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 2.308):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[png-mathtext-stix-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 16.782):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[png-mathtext-stixsans-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 17.033):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[png-mathtext-dejavusans-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 20.620):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[png-mathtext-dejavuserif-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 20.436):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[pdf-mathtext-cm-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 5.354):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[pdf-mathtext-stix-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 27.009):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[pdf-mathtext-stixsans-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 26.110):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[pdf-mathtext-dejavusans-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 31.526):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[pdf-mathtext-dejavuserif-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 32.275):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[svg-mathtext-cm-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 2.238):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[svg-mathtext-stix-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 16.225):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[svg-mathtext-stixsans-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 17.217):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[svg-mathtext-dejavusans-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 20.396):
FAILED lib/matplotlib/tests/test_mathtext.py::test_mathtext_rendering[svg-mathtext-dejavuserif-0] - matplotlib.testing.exceptions.ImageComparisonFailure: images not close (RMS 20.167):

```

</details>

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
