### PR TITLE
DOC: link to cheatsheets site, not github repo

### DIFF
--- a/doc/_templates/cheatsheet_sidebar.html
+++ b/doc/_templates/cheatsheet_sidebar.html
@@ -1,7 +1,7 @@
 
 <div class="sidebar-cheatsheets">
   <h3>Matplotlib cheatsheets</h3>
-  <a href="https://github.com/matplotlib/cheatsheets#cheatsheets">
+  <a href="https://matplotlib.org/cheatsheets/">
     <img src="_static/mpl_cheatsheet1.png"
          alt="Matplotlib cheatsheets"
          srcset="_static/mpl_cheatsheet1.png 1x, _static/mpl_cheatsheet1_2x.png 2x"/>


### PR DESCRIPTION
## PR Summary

Cheatsheets now has a website (https://matplotlib.org/cheatsheets/) so link to that instead of the GitHub page.
