### PR TITLE
FIX: Make sure we do not over-write eps short cuts

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -429,7 +429,7 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
             key = (path, id(trf))
             custom_clip_cmd = self._clip_paths.get(key)
             if custom_clip_cmd is None:
-                custom_clip_cmd = "c%x" % len(self._clip_paths)
+                custom_clip_cmd = "c%d" % len(self._clip_paths)
                 self._pswriter.write(f"""\
 /{custom_clip_cmd} {{
 {self._convert_path(path, trf, simplify=False)}
@@ -570,7 +570,7 @@ grestore
         path_codes = []
         for i, (path, transform) in enumerate(self._iter_collection_raw_paths(
                 master_transform, paths, all_transforms)):
-            name = 'p%x_%x' % (self._path_collection_id, i)
+            name = 'p%d_%d' % (self._path_collection_id, i)
             path_bytes = self._convert_path(path, transform, simplify=False)
             self._pswriter.write(f"""\
 /{name} {{

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -247,7 +247,7 @@ def test_linedash():
     assert buf.tell() > 0
 
 
-def test_no_definintion():
+def test_no_duplicate_definition():
 
     fig = Figure()
     axs = fig.subplots(4, 4, subplot_kw=dict(projection="polar"))


### PR DESCRIPTION
## PR Summary

This tests that we have not re-defined a short-cut by checking that we do not
have two `/name` lines in the output file.

closes #21509

Co-authored-by: Antony Lee <anntzer.lee@gmail.com>


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

