### PR TITLE
Fix GhostScript error handling types

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -136,9 +136,7 @@ class _GSConverter(_Converter):
         self._proc.stdin.flush()
         # GS> if nothing left on the stack; GS<n> if n items left on the stack.
         err = self._read_until((b"GS<", b"GS>"))
-        stack = ""
-        if err.endswith(b"GS<"):
-            stack = self._read_until(b">")
+        stack = self._read_until(b">") if err.endswith(b"GS<") else b""
         if stack or not os.path.exists(dest):
             stack_size = int(stack[:-1]) if stack else 0
             self._proc.stdin.write(b"pop\n" * stack_size)


### PR DESCRIPTION
## PR Summary

The `stack` variable should default to bytes, not str, which we can compress into a single statement for clarity.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).