### PR TITLE
Fix METH_VARARGS method signatures 

### DIFF
--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -23,10 +23,10 @@ typedef struct
 
 
 /**********************************************************************
- * BufferRegion, PyObject *
+ * BufferRegion
  * */
 
-static PyObject *PyBufferRegion_new(PyTypeObject *type, PyObject *args)
+static PyObject *PyBufferRegion_new(PyTypeObject *type, PyObject *args, PyObject* kwds)
 {
     PyBufferRegion *self;
     self = (PyBufferRegion *)type->tp_alloc(type, 0);
@@ -154,7 +154,7 @@ static PyTypeObject *PyBufferRegion_init_type(PyObject *m, PyTypeObject *type)
  * RendererAgg
  * */
 
-static PyObject *PyRendererAgg_new(PyTypeObject *type, PyObject *args)
+static PyObject *PyRendererAgg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyRendererAgg *self;
     self = (PyRendererAgg *)type->tp_alloc(type, 0);
@@ -162,7 +162,7 @@ static PyObject *PyRendererAgg_new(PyTypeObject *type, PyObject *args)
     return (PyObject *)self;
 }
 
-static int PyRendererAgg_init(PyRendererAgg *self, PyObject *args)
+static int PyRendererAgg_init(PyRendererAgg *self, PyObject *args, PyObject *kwds)
 {
     unsigned int width;
     unsigned int height;

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -23,10 +23,10 @@ typedef struct
 
 
 /**********************************************************************
- * BufferRegion
+ * BufferRegion, PyObject *
  * */
 
-static PyObject *PyBufferRegion_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *PyBufferRegion_new(PyTypeObject *type, PyObject *args)
 {
     PyBufferRegion *self;
     self = (PyBufferRegion *)type->tp_alloc(type, 0);
@@ -40,7 +40,7 @@ static void PyBufferRegion_dealloc(PyBufferRegion *self)
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static PyObject *PyBufferRegion_to_string(PyBufferRegion *self, PyObject *args, PyObject *kwds)
+static PyObject *PyBufferRegion_to_string(PyBufferRegion *self, PyObject *args)
 {
     return PyBytes_FromStringAndSize((const char *)self->x->get_data(),
                                      self->x->get_height() * self->x->get_stride());
@@ -48,7 +48,7 @@ static PyObject *PyBufferRegion_to_string(PyBufferRegion *self, PyObject *args, 
 
 /* TODO: This doesn't seem to be used internally.  Remove? */
 
-static PyObject *PyBufferRegion_set_x(PyBufferRegion *self, PyObject *args, PyObject *kwds)
+static PyObject *PyBufferRegion_set_x(PyBufferRegion *self, PyObject *args)
 {
     int x;
     if (!PyArg_ParseTuple(args, "i:set_x", &x)) {
@@ -59,7 +59,7 @@ static PyObject *PyBufferRegion_set_x(PyBufferRegion *self, PyObject *args, PyOb
     Py_RETURN_NONE;
 }
 
-static PyObject *PyBufferRegion_set_y(PyBufferRegion *self, PyObject *args, PyObject *kwds)
+static PyObject *PyBufferRegion_set_y(PyBufferRegion *self, PyObject *args)
 {
     int y;
     if (!PyArg_ParseTuple(args, "i:set_y", &y)) {
@@ -70,14 +70,14 @@ static PyObject *PyBufferRegion_set_y(PyBufferRegion *self, PyObject *args, PyOb
     Py_RETURN_NONE;
 }
 
-static PyObject *PyBufferRegion_get_extents(PyBufferRegion *self, PyObject *args, PyObject *kwds)
+static PyObject *PyBufferRegion_get_extents(PyBufferRegion *self, PyObject *args)
 {
     agg::rect_i rect = self->x->get_rect();
 
     return Py_BuildValue("IIII", rect.x1, rect.y1, rect.x2, rect.y2);
 }
 
-static PyObject *PyBufferRegion_to_string_argb(PyBufferRegion *self, PyObject *args, PyObject *kwds)
+static PyObject *PyBufferRegion_to_string_argb(PyBufferRegion *self, PyObject *args)
 {
     PyObject *bufobj;
     uint8_t *buf;
@@ -154,7 +154,7 @@ static PyTypeObject *PyBufferRegion_init_type(PyObject *m, PyTypeObject *type)
  * RendererAgg
  * */
 
-static PyObject *PyRendererAgg_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_new(PyTypeObject *type, PyObject *args)
 {
     PyRendererAgg *self;
     self = (PyRendererAgg *)type->tp_alloc(type, 0);
@@ -162,7 +162,7 @@ static PyObject *PyRendererAgg_new(PyTypeObject *type, PyObject *args, PyObject 
     return (PyObject *)self;
 }
 
-static int PyRendererAgg_init(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static int PyRendererAgg_init(PyRendererAgg *self, PyObject *args)
 {
     unsigned int width;
     unsigned int height;
@@ -198,7 +198,7 @@ static void PyRendererAgg_dealloc(PyRendererAgg *self)
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static PyObject *PyRendererAgg_draw_path(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_draw_path(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     py::PathIterator path;
@@ -227,7 +227,7 @@ static PyObject *PyRendererAgg_draw_path(PyRendererAgg *self, PyObject *args, Py
     Py_RETURN_NONE;
 }
 
-static PyObject *PyRendererAgg_draw_text_image(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_draw_text_image(PyRendererAgg *self, PyObject *args)
 {
     numpy::array_view<agg::int8u, 2> image;
     double x;
@@ -252,7 +252,7 @@ static PyObject *PyRendererAgg_draw_text_image(PyRendererAgg *self, PyObject *ar
     Py_RETURN_NONE;
 }
 
-PyObject *PyRendererAgg_draw_markers(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+PyObject *PyRendererAgg_draw_markers(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     py::PathIterator marker_path;
@@ -288,7 +288,7 @@ PyObject *PyRendererAgg_draw_markers(PyRendererAgg *self, PyObject *args, PyObje
     Py_RETURN_NONE;
 }
 
-static PyObject *PyRendererAgg_draw_image(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_draw_image(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     double x;
@@ -316,7 +316,7 @@ static PyObject *PyRendererAgg_draw_image(PyRendererAgg *self, PyObject *args, P
 }
 
 static PyObject *
-PyRendererAgg_draw_path_collection(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+PyRendererAgg_draw_path_collection(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     agg::trans_affine master_transform;
@@ -377,7 +377,7 @@ PyRendererAgg_draw_path_collection(PyRendererAgg *self, PyObject *args, PyObject
     Py_RETURN_NONE;
 }
 
-static PyObject *PyRendererAgg_draw_quad_mesh(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_draw_quad_mesh(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     agg::trans_affine master_transform;
@@ -429,7 +429,7 @@ static PyObject *PyRendererAgg_draw_quad_mesh(PyRendererAgg *self, PyObject *arg
 }
 
 static PyObject *
-PyRendererAgg_draw_gouraud_triangle(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+PyRendererAgg_draw_gouraud_triangle(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     numpy::array_view<const double, 2> points;
@@ -470,7 +470,7 @@ PyRendererAgg_draw_gouraud_triangle(PyRendererAgg *self, PyObject *args, PyObjec
 }
 
 static PyObject *
-PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     numpy::array_view<const double, 3> points;
@@ -540,14 +540,14 @@ int PyRendererAgg_get_buffer(PyRendererAgg *self, Py_buffer *buf, int flags)
     return 1;
 }
 
-static PyObject *PyRendererAgg_clear(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_clear(PyRendererAgg *self, PyObject *args)
 {
     CALL_CPP("clear", self->x->clear());
 
     Py_RETURN_NONE;
 }
 
-static PyObject *PyRendererAgg_copy_from_bbox(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_copy_from_bbox(PyRendererAgg *self, PyObject *args)
 {
     agg::rect_d bbox;
     BufferRegion *reg;
@@ -565,7 +565,7 @@ static PyObject *PyRendererAgg_copy_from_bbox(PyRendererAgg *self, PyObject *arg
     return regobj;
 }
 
-static PyObject *PyRendererAgg_restore_region(PyRendererAgg *self, PyObject *args, PyObject *kwds)
+static PyObject *PyRendererAgg_restore_region(PyRendererAgg *self, PyObject *args)
 {
     PyBufferRegion *regobj;
     int xx1 = 0, yy1 = 0, xx2 = 0, yy2 = 0, x = 0, y = 0;

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -26,7 +26,7 @@ typedef struct
  * BufferRegion
  * */
 
-static PyObject *PyBufferRegion_new(PyTypeObject *type, PyObject *args, PyObject* kwds)
+static PyObject *PyBufferRegion_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
     PyBufferRegion *self;
     self = (PyBufferRegion *)type->tp_alloc(type, 0);

--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -81,7 +81,7 @@ const char* PyQuadContourGenerator_create_contour__doc__ =
     "--\n\n"
     "Create and return a non-filled contour.";
 
-static PyObject* PyQuadContourGenerator_create_contour(PyQuadContourGenerator* self, PyObject* args, PyObject* kwds)
+static PyObject* PyQuadContourGenerator_create_contour(PyQuadContourGenerator* self, PyObject* args)
 {
     double level;
     if (!PyArg_ParseTuple(args, "d:create_contour", &level)) {
@@ -98,7 +98,7 @@ const char* PyQuadContourGenerator_create_filled_contour__doc__ =
     "--\n\n"
     "Create and return a filled contour";
 
-static PyObject* PyQuadContourGenerator_create_filled_contour(PyQuadContourGenerator* self, PyObject* args, PyObject* kwds)
+static PyObject* PyQuadContourGenerator_create_filled_contour(PyQuadContourGenerator* self, PyObject* args)
 {
     double lower_level, upper_level;
     if (!PyArg_ParseTuple(args, "dd:create_filled_contour",

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -32,7 +32,7 @@ const char *Py_point_in_path__doc__ =
     "point_in_path(x, y, radius, path, trans)\n"
     "--\n\n";
 
-static PyObject *Py_point_in_path(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_point_in_path(PyObject *self, PyObject *args)
 {
     double x, y, r;
     py::PathIterator path;
@@ -64,7 +64,7 @@ const char *Py_points_in_path__doc__ =
     "points_in_path(points, radius, path, trans)\n"
     "--\n\n";
 
-static PyObject *Py_points_in_path(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_points_in_path(PyObject *self, PyObject *args)
 {
     numpy::array_view<const double, 2> points;
     double r;
@@ -95,7 +95,7 @@ const char *Py_point_on_path__doc__ =
     "point_on_path(x, y, radius, path, trans)\n"
     "--\n\n";
 
-static PyObject *Py_point_on_path(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_point_on_path(PyObject *self, PyObject *args)
 {
     double x, y, r;
     py::PathIterator path;
@@ -127,7 +127,7 @@ const char *Py_points_on_path__doc__ =
     "points_on_path(points, radius, path, trans)\n"
     "--\n\n";
 
-static PyObject *Py_points_on_path(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_points_on_path(PyObject *self, PyObject *args)
 {
     numpy::array_view<const double, 2> points;
     double r;
@@ -158,7 +158,7 @@ const char *Py_get_path_extents__doc__ =
     "get_path_extents(path, trans)\n"
     "--\n\n";
 
-static PyObject *Py_get_path_extents(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_get_path_extents(PyObject *self, PyObject *args)
 {
     py::PathIterator path;
     agg::trans_affine trans;
@@ -187,7 +187,7 @@ const char *Py_update_path_extents__doc__ =
     "update_path_extents(path, trans, rect, minpos, ignore)\n"
     "--\n\n";
 
-static PyObject *Py_update_path_extents(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_update_path_extents(PyObject *self, PyObject *args)
 {
     py::PathIterator path;
     agg::trans_affine trans;
@@ -266,7 +266,7 @@ const char *Py_get_path_collection_extents__doc__ =
     "master_transform, paths, transforms, offsets, offset_transform)\n"
     "--\n\n";
 
-static PyObject *Py_get_path_collection_extents(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_get_path_collection_extents(PyObject *self, PyObject *args)
 {
     agg::trans_affine master_transform;
     py::PathGenerator paths;
@@ -315,7 +315,7 @@ const char *Py_point_in_path_collection__doc__ =
     "offset_trans, filled)\n"
     "--\n\n";
 
-static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args)
 {
     double x, y, radius;
     agg::trans_affine master_transform;
@@ -370,7 +370,7 @@ const char *Py_path_in_path__doc__ =
     "path_in_path(path_a, trans_a, path_b, trans_b)\n"
     "--\n\n";
 
-static PyObject *Py_path_in_path(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_path_in_path(PyObject *self, PyObject *args)
 {
     py::PathIterator a;
     agg::trans_affine atrans;
@@ -404,7 +404,7 @@ const char *Py_clip_path_to_rect__doc__ =
     "clip_path_to_rect(path, rect, inside)\n"
     "--\n\n";
 
-static PyObject *Py_clip_path_to_rect(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_clip_path_to_rect(PyObject *self, PyObject *args)
 {
     py::PathIterator path;
     agg::rect_d rect;
@@ -431,7 +431,7 @@ const char *Py_affine_transform__doc__ =
     "affine_transform(points, trans)\n"
     "--\n\n";
 
-static PyObject *Py_affine_transform(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_affine_transform(PyObject *self, PyObject *args)
 {
     PyObject *vertices_obj;
     agg::trans_affine trans;
@@ -472,7 +472,7 @@ const char *Py_count_bboxes_overlapping_bbox__doc__ =
     "count_bboxes_overlapping_bbox(bbox, bboxes)\n"
     "--\n\n";
 
-static PyObject *Py_count_bboxes_overlapping_bbox(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_count_bboxes_overlapping_bbox(PyObject *self, PyObject *args)
 {
     agg::rect_d bbox;
     numpy::array_view<const double, 3> bboxes;
@@ -614,7 +614,7 @@ const char *Py_cleanup_path__doc__ =
     "return_curves, sketch)\n"
     "--\n\n";
 
-static PyObject *Py_cleanup_path(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_cleanup_path(PyObject *self, PyObject *args)
 {
     py::PathIterator path;
     agg::trans_affine trans;
@@ -721,7 +721,7 @@ const char *Py_convert_to_string__doc__ =
     "    Whether the opcode comes after the values (True) or before (False).\n"
     ;
 
-static PyObject *Py_convert_to_string(PyObject *self, PyObject *args, PyObject *kwds)
+static PyObject *Py_convert_to_string(PyObject *self, PyObject *args)
 {
     py::PathIterator path;
     agg::trans_affine trans;

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -66,7 +66,7 @@ const char *PyFT2Image_draw_rect__doc__ =
     "--\n\n"
     "Draw an empty rectangle to the image.\n";
 
-static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args
 {
     double x0, y0, x1, y1;
 
@@ -84,7 +84,7 @@ const char *PyFT2Image_draw_rect_filled__doc__ =
     "--\n\n"
     "Draw a filled rectangle to the image.\n";
 
-static PyObject *PyFT2Image_draw_rect_filled(PyFT2Image *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Image_draw_rect_filled(PyFT2Image *self, PyObject *args)
 {
     double x0, y0, x1, y1;
 
@@ -425,7 +425,7 @@ const char *PyFT2Font_clear__doc__ =
     "--\n\n"
     "Clear all the glyphs, reset for a new call to `.set_text`.\n";
 
-static PyObject *PyFT2Font_clear(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_clear(PyFT2Font *self, PyObject *args)
 {
     CALL_CPP("clear", (self->x->clear()));
 
@@ -437,7 +437,7 @@ const char *PyFT2Font_set_size__doc__ =
     "--\n\n"
     "Set the point size and dpi of the text.\n";
 
-static PyObject *PyFT2Font_set_size(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_set_size(PyFT2Font *self, PyObject *args)
 {
     double ptsize;
     double dpi;
@@ -456,7 +456,7 @@ const char *PyFT2Font_set_charmap__doc__ =
     "--\n\n"
     "Make the i-th charmap current.\n";
 
-static PyObject *PyFT2Font_set_charmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_set_charmap(PyFT2Font *self, PyObject *args)
 {
     int i;
 
@@ -474,7 +474,7 @@ const char *PyFT2Font_select_charmap__doc__ =
     "--\n\n"
     "Select a charmap by its FT_Encoding number.\n";
 
-static PyObject *PyFT2Font_select_charmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_select_charmap(PyFT2Font *self, PyObject *args)
 {
     unsigned long i;
 
@@ -496,7 +496,7 @@ const char *PyFT2Font_get_kerning__doc__ =
     "  KERNING_UNFITTED - Return scaled but un-grid-fitted kerning distances\n"
     "  KERNING_UNSCALED - Return the kerning vector in original font units\n";
 
-static PyObject *PyFT2Font_get_kerning(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_kerning(PyFT2Font *self, PyObject *args)
 {
     FT_UInt left, right, mode;
     int result;
@@ -587,7 +587,7 @@ const char *PyFT2Font_get_num_glyphs__doc__ =
     "--\n\n"
     "Return the number of loaded glyphs.\n";
 
-static PyObject *PyFT2Font_get_num_glyphs(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_num_glyphs(PyFT2Font *self, PyObject *args)
 {
     return PyLong_FromLong(self->x->get_num_glyphs());
 }
@@ -677,7 +677,7 @@ const char *PyFT2Font_get_width_height__doc__ =
     "The rotation of the string is accounted for.  To get width and height\n"
     "in pixels, divide these values by 64.\n";
 
-static PyObject *PyFT2Font_get_width_height(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_width_height(PyFT2Font *self, PyObject *args)
 {
     long width, height;
 
@@ -692,7 +692,7 @@ const char *PyFT2Font_get_bitmap_offset__doc__ =
     "Get the (x, y) offset in 26.6 subpixels for the bitmap if ink hangs left or below (0, 0).\n"
     "Since Matplotlib only supports left-to-right text, y is always 0.\n";
 
-static PyObject *PyFT2Font_get_bitmap_offset(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_bitmap_offset(PyFT2Font *self, PyObject *args)
 {
     long x, y;
 
@@ -708,7 +708,7 @@ const char *PyFT2Font_get_descent__doc__ =
     "The rotation of the string is accounted for.  To get the descent\n"
     "in pixels, divide this value by 64.\n";
 
-static PyObject *PyFT2Font_get_descent(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_descent(PyFT2Font *self, PyObject *args)
 {
     long descent;
 
@@ -809,7 +809,7 @@ const char *PyFT2Font_get_glyph_name__doc__ =
     "names (per FT_FACE_FLAG_GLYPH_NAMES), this returns a made-up name which\n"
     "does *not* roundtrip through `.get_name_index`.\n";
 
-static PyObject *PyFT2Font_get_glyph_name(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_glyph_name(PyFT2Font *self, PyObject *args)
 {
     unsigned int glyph_number;
     char buffer[128];
@@ -826,7 +826,7 @@ const char *PyFT2Font_get_charmap__doc__ =
     "Return a dict that maps the character codes of the selected charmap\n"
     "(Unicode by default) to their corresponding glyph indices.\n";
 
-static PyObject *PyFT2Font_get_charmap(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_charmap(PyFT2Font *self, PyObject *args)
 {
     PyObject *charmap;
     if (!(charmap = PyDict_New())) {
@@ -856,7 +856,7 @@ const char *PyFT2Font_get_char_index__doc__ =
     "--\n\n"
     "Return the glyph index corresponding to a character *codepoint*.\n";
 
-static PyObject *PyFT2Font_get_char_index(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_char_index(PyFT2Font *self, PyObject *args)
 {
     FT_UInt index;
     FT_ULong ccode;
@@ -878,7 +878,7 @@ const char *PyFT2Font_get_sfnt__doc__ =
     "(platform-ID, ISO-encoding-scheme, language-code, and description)\n"
     "tuples.\n";
 
-static PyObject *PyFT2Font_get_sfnt(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_sfnt(PyFT2Font *self, PyObject *args)
 {
     PyObject *names;
 
@@ -938,7 +938,7 @@ const char *PyFT2Font_get_name_index__doc__ =
     "Return the glyph index of a given glyph *name*.\n"
     "The glyph index 0 means 'undefined character code'.\n";
 
-static PyObject *PyFT2Font_get_name_index(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_name_index(PyFT2Font *self, PyObject *args)
 {
     char *glyphname;
     long name_index;
@@ -954,7 +954,7 @@ const char *PyFT2Font_get_ps_font_info__doc__ =
     "--\n\n"
     "Return the information in the PS Font Info structure.\n";
 
-static PyObject *PyFT2Font_get_ps_font_info(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_ps_font_info(PyFT2Font *self, PyObject *args)
 {
     PS_FontInfoRec fontinfo;
 
@@ -982,7 +982,7 @@ const char *PyFT2Font_get_sfnt_table__doc__ =
     "Return one of the following SFNT tables: head, maxp, OS/2, hhea, "
     "vhea, post, or pclt.\n";
 
-static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args)
 {
     char *tagname;
     if (!PyArg_ParseTuple(args, "s:get_sfnt_table", &tagname)) {
@@ -1284,7 +1284,7 @@ const char *PyFT2Font_get_path__doc__ =
     "Get the path data from the currently loaded glyph as a tuple of vertices, "
     "codes.\n";
 
-static PyObject *PyFT2Font_get_path(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_path(PyFT2Font *self, PyObject *args)
 {
     CALL_CPP("get_path", return self->x->get_path());
 }
@@ -1294,7 +1294,7 @@ const char *PyFT2Font_get_image__doc__ =
     "--\n\n"
     "Return the underlying image buffer for this font object.\n";
 
-static PyObject *PyFT2Font_get_image(PyFT2Font *self, PyObject *args, PyObject *kwds)
+static PyObject *PyFT2Font_get_image(PyFT2Font *self, PyObject *args)
 {
     FT2Image &im = self->x->get_image();
     npy_intp dims[] = {(npy_intp)im.get_height(), (npy_intp)im.get_width() };

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -66,7 +66,7 @@ const char *PyFT2Image_draw_rect__doc__ =
     "--\n\n"
     "Draw an empty rectangle to the image.\n";
 
-static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args
+static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args)
 {
     double x0, y0, x1, y1;
 

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -128,7 +128,7 @@ const char* PyTriangulation_get_edges__doc__ =
     "--\n\n"
     "Return edges array";
 
-static PyObject* PyTriangulation_get_edges(PyTriangulation* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTriangulation_get_edges(PyTriangulation* self, PyObject* args)
 {
     Triangulation::EdgeArray* result;
     CALL_CPP("get_edges", (result = &self->ptr->get_edges()));
@@ -145,7 +145,7 @@ const char* PyTriangulation_get_neighbors__doc__ =
     "--\n\n"
     "Return neighbors array";
 
-static PyObject* PyTriangulation_get_neighbors(PyTriangulation* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTriangulation_get_neighbors(PyTriangulation* self, PyObject* args)
 {
     Triangulation::NeighborArray* result;
     CALL_CPP("get_neighbors", (result = &self->ptr->get_neighbors()));
@@ -429,7 +429,7 @@ const char* PyTrapezoidMapTriFinder_get_tree_stats__doc__ =
     "\n"
     "Return statistics about the tree used by the trapezoid map";
 
-static PyObject* PyTrapezoidMapTriFinder_get_tree_stats(PyTrapezoidMapTriFinder* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTrapezoidMapTriFinder_get_tree_stats(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
     PyObject* result;
     CALL_CPP("get_tree_stats", (result = self->ptr->get_tree_stats()));
@@ -441,7 +441,7 @@ const char* PyTrapezoidMapTriFinder_initialize__doc__ =
     "\n"
     "Initialize this object, creating the trapezoid map from the triangulation";
 
-static PyObject* PyTrapezoidMapTriFinder_initialize(PyTrapezoidMapTriFinder* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTrapezoidMapTriFinder_initialize(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
     CALL_CPP("initialize", (self->ptr->initialize()));
     Py_RETURN_NONE;
@@ -452,7 +452,7 @@ const char* PyTrapezoidMapTriFinder_print_tree__doc__ =
     "\n"
     "Print the search tree as text to stdout; useful for debug purposes";
 
-static PyObject* PyTrapezoidMapTriFinder_print_tree(PyTrapezoidMapTriFinder* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTrapezoidMapTriFinder_print_tree(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
     CALL_CPP("print_tree", (self->ptr->print_tree()));
     Py_RETURN_NONE;

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -103,7 +103,7 @@ const char* PyTriangulation_calculate_plane_coefficients__doc__ =
     "--\n\n"
     "Calculate plane equation coefficients for all unmasked triangles";
 
-static PyObject* PyTriangulation_calculate_plane_coefficients(PyTriangulation* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTriangulation_calculate_plane_coefficients(PyTriangulation* self, PyObject* args)
 {
     Triangulation::CoordinateArray z;
     if (!PyArg_ParseTuple(args, "O&:calculate_plane_coefficients",
@@ -162,7 +162,7 @@ const char* PyTriangulation_set_mask__doc__ =
     "--\n\n"
     "Set or clear the mask array.";
 
-static PyObject* PyTriangulation_set_mask(PyTriangulation* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTriangulation_set_mask(PyTriangulation* self, PyObject* args)
 {
     Triangulation::MaskArray mask;
 
@@ -278,7 +278,7 @@ const char* PyTriContourGenerator_create_contour__doc__ =
     "\n"
     "Create and return a non-filled contour.";
 
-static PyObject* PyTriContourGenerator_create_contour(PyTriContourGenerator* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTriContourGenerator_create_contour(PyTriContourGenerator* self, PyObject* args)
 {
     double level;
     if (!PyArg_ParseTuple(args, "d:create_contour", &level)) {
@@ -295,7 +295,7 @@ const char* PyTriContourGenerator_create_filled_contour__doc__ =
     "\n"
     "Create and return a filled contour";
 
-static PyObject* PyTriContourGenerator_create_filled_contour(PyTriContourGenerator* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTriContourGenerator_create_filled_contour(PyTriContourGenerator* self, PyObject* args)
 {
     double lower_level, upper_level;
     if (!PyArg_ParseTuple(args, "dd:create_filled_contour",
@@ -404,7 +404,7 @@ const char* PyTrapezoidMapTriFinder_find_many__doc__ =
     "\n"
     "Find indices of triangles containing the point coordinates (x, y)";
 
-static PyObject* PyTrapezoidMapTriFinder_find_many(PyTrapezoidMapTriFinder* self, PyObject* args, PyObject* kwds)
+static PyObject* PyTrapezoidMapTriFinder_find_many(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
     TrapezoidMapTriFinder::CoordinateArray x, y;
     if (!PyArg_ParseTuple(args, "O&O&:find_many",


### PR DESCRIPTION
## PR Summary

A bunch of functions are declared with [`METH_VARARGS`](https://docs.python.org/3/c-api/structures.html?highlight=meth_varargs#METH_VARARGS) calling convention which should have signature [`PYCFunction`](https://docs.python.org/3/c-api/structures.html?highlight=meth_varargs#c.PyCFunction). However, they are declared instead with an extra `PyObject* kwds` argument as if they had `METH_VARARGS | METH_KEYWORDS` calling convention. They just ignore this argument.

I am coming from Pyodide. Web assembly has no native support for function pointer casting -- a function declared with a certain signature must be called with the same signature, or it will fail with `RuntimeError: function signature mismatch`. Emscripten has support for emulating function pointer casts which we are currently using, but it imposes a significant performance and stack space cost and we are trying to remove the pointer cast emulation https://github.com/pyodide/pyodide/pull/1677. To do this, we need to patch Python packages so that they have function signatures that match the calling conventions they declare.

## PR Checklist
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).