### PR TITLE
TST: Add future dependency tests as a weekly CI job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches-ignore:
       - v[0-9]+.[0-9]+.[0-9x]+-doc
+  schedule:
+    # 3:47 UTC on Saturdays
+    - cron: "47 3 * * 6"
 
 env:
   NO_AT_BRIDGE: 1  # Necessary for GTK3 interactive test.
@@ -209,6 +212,20 @@ jobs:
             echo 'wxPython is available' ||
             echo 'wxPython is not available'
 
+      - name: Install the nightly dependencies
+        # Only install the nightly dependencies during the scheduled event
+        if: ${{ github.event_name == 'schedule' && matrix.name-suffix != '(Minimum Versions)' }}
+        run: |
+          python -m pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple --upgrade numpy pandas
+
+          # Turn all warnings to errors, except ignore the distutils deprecations and the find_spec warning
+          cat >> pytest.ini << EOF
+          filterwarnings =
+              error
+              ignore:.*distutils:DeprecationWarning
+              ignore:DynamicImporter.find_spec\(\) not found; falling back to find_module\(\):ImportWarning
+          EOF
+
       - name: Install Matplotlib
         run: |
           ccache -s
@@ -266,3 +283,18 @@ jobs:
         with:
           name: "${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.name-suffix }} result images"
           path: ./result_images
+
+      - name: Create issue on failure
+        uses: imjohnbo/issue-bot@v3
+        if: ${{ failure() && github.event_name == 'schedule' }}
+        with:
+          title: "[TST] Upcoming dependency test failures"
+          body: |
+            The weekly build with nightly wheels from numpy and pandas
+            has failed. Check the logs for any updates that need to be
+            made in matplotlib.
+
+          pinned: false
+          close-previous: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3438,6 +3438,8 @@ def test_errorbar():
     ax.errorbar(x, y, yerr=[yerr_lower, 2*yerr], xerr=xerr,
                 fmt='o', ecolor='g', capthick=2)
     ax.set_title('Mixed sym., log y')
+    # Force limits due to floating point slop potentially expanding the range
+    ax.set_ylim(1e-2, 1e1)
 
     fig.suptitle('Variable errorbars')
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -568,14 +568,15 @@ def test_Normalize():
     # Don't lose precision on longdoubles (float128 on Linux):
     # for array inputs...
     vals = np.array([1.2345678901, 9.8765432109], dtype=np.longdouble)
-    norm = mcolors.Normalize(vals.min(), vals.max())
-    assert_array_equal(np.asarray(norm(vals)), [0, 1])
+    norm = mcolors.Normalize(vals[0], vals[1])
+    assert norm(vals).dtype == np.longdouble
+    assert_array_equal(norm(vals), [0, 1])
     # and for scalar ones.
     eps = np.finfo(np.longdouble).resolution
     norm = plt.Normalize(1, 1 + 100 * eps)
     # This returns exactly 0.5 when longdouble is extended precision (80-bit),
     # but only a value close to it when it is quadruple precision (128-bit).
-    assert 0 < norm(1 + 50 * eps) < 1
+    np.testing.assert_array_almost_equal_nulp(norm(1 + 50 * eps), 0.5)
 
 
 def test_FuncNorm():


### PR DESCRIPTION
## PR Summary

Test future numpy versions with Matplotlib to see if anything needs to be done in the future to address deprecations
or other pending changes.

* Currently will run once per week at 03:47 UTC on Saturdays.
* Only runs on Linux and for 3.9/3.10 currently as this is mostly just a smoke test for future issues.
* I think it will upload an issue on failure to notify the repo, but that is untested. Perhaps there is a better way here that someone knows about.

Link to a run on my branch (it should only run on matplotlib/matplotlib now)
https://github.com/greglucas/matplotlib/runs/4204821100?check_suite_focus=true

### 3.9 + numpy-1.22.dev failures

```bash
FAILED lib/matplotlib/tests/test_units.py::test_plot_masked_units[png] - matp...
= 1 failed, 8352 passed, 148 skipped, 13 xfailed, 4 xpassed in 537.93s (0:08:57) =
```

### 3.10 + numpy-1.22.dev failures

```bash
FAILED lib/matplotlib/tests/test_axes.py::test_errorbar[png] - matplotlib.tes...
FAILED lib/matplotlib/tests/test_axes.py::test_errorbar[svg] - matplotlib.tes...
FAILED lib/matplotlib/tests/test_axes.py::test_errorbar[pdf] - matplotlib.tes...
FAILED lib/matplotlib/tests/test_backends_interactive.py::test_webagg - Asser...
FAILED lib/matplotlib/tests/test_units.py::test_plot_masked_units[png] - matp...
FAILED lib/matplotlib/tests/test_streamplot.py::test_direction[png] - matplot...
FAILED lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py::test_axis_direction[png]
FAILED lib/mpl_toolkits/tests/test_mplot3d.py::test_trisurf3d[png] - matplotl...
FAILED lib/mpl_toolkits/tests/test_mplot3d.py::test_stem3d[png] - matplotlib....
= 9 failed, 8344 passed, 148 skipped, 13 xfailed, 4 xpassed, 4 warnings in 414.94s (0:06:54) =
```

### Additional things to consider
Perhaps we should also consider adding a nightly cibuildwheel to that repository for others to test out Matplotlib and report back to us easier?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
