### PR TITLE
Also upload a subset of nightly wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -112,3 +112,8 @@ jobs:
         with:
           name: wheels
           path: ./dist/*.whl
+
+      - uses: actions/upload-artifact@v2
+        with:
+          name: manylinux_x86_64
+          path: ./dist/*x86_64.manylinux1*.whl


### PR DESCRIPTION
## PR Summary
Add a second artifact upload to the wheels that build on every merge to main. This is a subset of the `wheels` upload but should be significantly smaller to enable fast downloading for 3rd party tests in CI.

Closes: https://github.com/matplotlib/matplotlib/issues/21635