### PR TITLE
Skip some uses of packaging's PEP440 version for non-Python versions.

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -278,7 +278,7 @@ def _logged_cached(fmt, func=None):
     return wrapper
 
 
-_ExecInfo = namedtuple("_ExecInfo", "executable version")
+_ExecInfo = namedtuple("_ExecInfo", "executable raw_version version")
 
 
 class ExecutableNotFoundError(FileNotFoundError):
@@ -339,12 +339,13 @@ def _get_executable_info(name):
             raise ExecutableNotFoundError(str(_ose)) from _ose
         match = re.search(regex, output)
         if match:
-            version = parse_version(match.group(1))
+            raw_version = match.group(1)
+            version = parse_version(raw_version)
             if min_ver is not None and version < parse_version(min_ver):
                 raise ExecutableNotFoundError(
                     f"You have {args[0]} version {version} but the minimum "
                     f"version supported by Matplotlib is {min_ver}")
-            return _ExecInfo(args[0], version)
+            return _ExecInfo(args[0], raw_version, version)
         else:
             raise ExecutableNotFoundError(
                 f"Failed to determine the version of {args[0]} from "
@@ -401,7 +402,7 @@ def _get_executable_info(name):
         else:
             path = "convert"
         info = impl([path, "--version"], r"^Version: ImageMagick (\S*)")
-        if info.version == parse_version("7.0.10-34"):
+        if info.raw_version == "7.0.10-34":
             # https://github.com/ImageMagick/ImageMagick/issues/2720
             raise ExecutableNotFoundError(
                 f"You have ImageMagick {info.version}, which is unsupported")

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -134,9 +134,8 @@ else:  # We should not get there.
 # https://bugreports.qt.io/browse/QTBUG-87014, fixed in qt 5.15.2
 if (sys.platform == 'darwin' and
         parse_version(platform.mac_ver()[0]) >= parse_version("10.16") and
-        parse_version(QtCore.qVersion()) < parse_version("5.15.2") and
-        "QT_MAC_WANTS_LAYER" not in os.environ):
-    os.environ["QT_MAC_WANTS_LAYER"] = "1"
+        QtCore.QLibraryInfo.version().segments() <= [5, 15, 2]):
+    os.environ.setdefault("QT_MAC_WANTS_LAYER", "1")
 
 
 # PyQt6 enum compat helpers.

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -29,7 +29,6 @@ import subprocess
 from tempfile import TemporaryDirectory
 
 import numpy as np
-from packaging.version import parse as parse_version
 
 import matplotlib as mpl
 from matplotlib import _api, cbook, dviread, rcParams
@@ -291,9 +290,8 @@ class TexManager:
             # dvipng 1.16 has a bug (fixed in f3ff241) that breaks --freetype0
             # mode, so for it we keep FreeType enabled; the image will be
             # slightly off.
-            bad_ver = parse_version("1.16")
-            if (getattr(mpl, "_called_from_pytest", False)
-                    and mpl._get_executable_info("dvipng").version != bad_ver):
+            if (getattr(mpl, "_called_from_pytest", False) and
+                    mpl._get_executable_info("dvipng").raw_version != "1.16"):
                 cmd.insert(1, "--freetype0")
             self._run_checked_subprocess(cmd, tex)
         return pngfile


### PR DESCRIPTION
Version numbers from non-Python packages don't have to follow PEP440,
and there are at least a few cases where we can check for string
equality (when we don't need ordering) or rely on the library's own
version parsing (qt).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
