### PR TITLE
Validate that input to Poly3DCollection is a list of 2D array-like

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -714,6 +714,12 @@ class Poly3DCollection(PolyCollection):
         and _edgecolors properties.
         """
         super().__init__(verts, *args, **kwargs)
+        if isinstance(verts, np.ndarray):
+            if verts.ndim != 3:
+                raise ValueError('verts must be a list of (N, 3) array-like')
+        else:
+            if any(len(np.shape(vert)) != 2 for vert in verts):
+                raise ValueError('verts must be a list of (N, 3) array-like')
         self.set_zsort(zsort)
         self._codes3d = None
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -704,6 +704,16 @@ def test_patch_collection_modification(fig_test, fig_ref):
     ax_ref.add_collection3d(c)
 
 
+def test_poly3dcollection_verts_validation():
+    poly = [[0, 0, 1], [0, 1, 1], [0, 1, 0], [0, 0, 0]]
+    with pytest.raises(ValueError, match=r'list of \(N, 3\) array-like'):
+        art3d.Poly3DCollection(poly)  # should be Poly3DCollection([poly])
+
+    poly = np.array(poly, dtype=float)
+    with pytest.raises(ValueError, match=r'list of \(N, 3\) array-like'):
+        art3d.Poly3DCollection(poly)  # should be Poly3DCollection([poly])
+
+
 @mpl3d_image_comparison(['poly3dcollection_closed.png'])
 def test_poly3dcollection_closed():
     fig = plt.figure()


### PR DESCRIPTION
A 2D array-like was accepted and only issued an obscure warning. This
can easily happen if one has only one polygon and forgets to warp it in
a list.

Closes #21652.

Note: I refrain from an additional check that each Polygon has shape
(N_i, 3) because that will reasonaly error out later, so we don't have
to blow up parameter checking too much.

