### PR TITLE
FIX: put newline in matplotlibrc when setting default backend

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -225,6 +225,13 @@ jobs:
             fi
           fi
 
+          cat <<EOT >> mplsetup.cfg
+          [rc_options]
+          backend=Agg
+          EOT
+
+          cat mplsetup.cfg
+
           # All dependencies must have been pre-installed, so that the minver
           # constraints are held.
           python -m pip install --no-deps -e .

--- a/setup.py
+++ b/setup.py
@@ -205,7 +205,7 @@ def update_matplotlibrc(path):
         idx for idx, line in enumerate(template_lines)
         if "#backend:" in line]
     template_lines[backend_line_idx] = (
-        "#backend: {}".format(setupext.options["backend"])
+        "#backend: {}\n".format(setupext.options["backend"])
         if setupext.options["backend"]
         else "##backend: Agg")
     path.write_text("".join(template_lines))


### PR DESCRIPTION
Closes #21660

## PR Summary

We are missing a new line when formatting the matplotlibrc

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
