### PR TITLE
Merge 3.5.x into main

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
@@ -269,6 +269,10 @@ Miscellaneous deprecations
 - ``cm.LUTSIZE`` is deprecated. Use :rc:`image.lut` instead. This value only
   affects colormap quantization levels for default colormaps generated at
   module import time.
+- ``Collection.__init__`` previously ignored *transOffset* without *offsets* also
+  being specified. In the future, *transOffset* will begin having an effect
+  regardless of *offsets*. In the meantime, if you wish to set *transOffset*,
+  call `.Collection.set_offset_transform` explicitly.
 - ``Colorbar.patch`` is deprecated; this attribute is not correctly updated
   anymore.
 - ``ContourLabeler.get_label_width`` is deprecated.

--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -1,140 +1,1299 @@
 .. _github-stats:
 
-GitHub statistics (Aug 12, 2021)
+GitHub statistics (Nov 15, 2021)
 ================================
 
-GitHub statistics for 2021/05/08 (tag: v3.4.2) - 2021/08/12
+GitHub statistics for 2021/03/26 (tag: v3.4.0) - 2021/11/15
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 22 issues and merged 69 pull requests.
-The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/64?closed=1>`__
+We closed 187 issues and merged 939 pull requests.
+The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/59?closed=1>`__
 
-The following 20 authors contributed 95 commits.
+The following 144 authors contributed 3406 commits.
 
+* Aaron Rogers
+* Abhinav Sagar
+* Adrian Price-Whelan
+* Adrien F. Vincent
+* ain-soph
+* Aitik Gupta
+* Akiomi Kamakura
+* AkM-2018
+* Andrea PIERRÉ
+* andthum
 * Antony Lee
+* Antti Soininen
+* apodemus
+* astromancer
+* Bruno Beltran
+* Carlos Cerqueira
+* Casper da Costa-Luis
+* ceelo777
+* Christian Baumann
+* dan
+* Dan Zimmerman
+* David Matos
+* David Poznik
 * David Stansby
-* Diego
+* dependabot[bot]
 * Diego Leal Petrola
-* Diego Petrola
+* Dmitriy Fishman
+* Ellert van der Velden
 * Elliott Sales de Andrade
+* Engjell Avdiu
 * Eric Firing
+* Eric Larson
+* Eric Prestat
+* Ewan Sutherland
+* Felix Nößler
+* Fernando
+* fourpoints
 * Frank Sauerburger
+* Gleb Fedorov
 * Greg Lucas
+* hannah
+* Hannes Breytenbach
+* Hans Meine
+* Harshal Prakash Patankar
+* harupy
+* Harutaka Kawamura
+* Hildo Guillardi Júnior
+* Holtz Yan
+* Hood
 * Ian Hunt-Isaak
+* Ian Thomas
+* ianhi
+* Illviljan
+* ImportanceOfBeingErnest
+* Isha Mehta
+* iury simoes-sousa
+* Jake Bowhay
+* Jakub Klus
+* Jan-Hendrik Müller
+* Janakarajan Natarajan
+* Jann Paul Mattern
 * Jash Shah
+* Jay Joshi
+* jayjoshi112711
+* jeffreypaul15
+* Jerome F. Villegas
+* Jerome Villegas
+* Jesus Briales
 * Jody Klymak
+* Jonathan Yong
+* Joschua Conrad
+* Joschua-Conrad
 * Jouni K. Seppänen
+* K-Monty
+* katrielester
+* kdpenner
+* Kent
+* Kent Gauen
+* kentcr
+* kir0ul
+* kislovskiy
+* KIU Shueng Chuan
+* KM Goh
+* Konstantin Popov
+* kyrogon
+* Leeh Peter
+* Leo Singer
+* lgfunderburk
+* Liam Toney
+* luz paz
+* luzpaz
+* Madhav Humagain
+* MalikIdreesHasa
+* Marat Kopytjuk
+* Marco Rigobello
+* Marco Salathe
+* Markus Wesslén
+* martinRenou
+* Matthias Bussonnier
+* MeeseeksMachine
 * Michał Górny
+* Mihai Anton
+* Navid C. Constantinou
+* Nico Schlömer
+* Phil Nagel
+* Philip Schiff
+* Philipp Nagel
+* pwohlhart
+* Péter Leéh
+* Quentin Peter
+* Ren Pang
+* rgbmrc
+* Richard Barnes
+* richardsheridan
+* Rike-Benjamin Schuppner
+* Roberto Toro
+* Ruth Comer
+* ryahern
+* Ryan May
+* Sam Van Kooten
 * sandipanpanda
+* Simon Hoxbro
 * Slava Ostroukh
+* Stefan Appelhoff
+* Stefanie Molin
+* takimata
+* tdpetrou
+* theOehrly
 * Thomas A Caswell
 * Tim Hoffmann
+* tohc1
+* Tom Charrett
+* Tom Neep
+* Tomas Hrnciar
+* Tortar
+* Tranquilled
+* Vagrant Cascadian
 * Viacheslav Ostroukh
+* Vishnu V K
 * Xianxiang Li
+* Yannic Schroeder
+* Yo Yehudi
+* Zexi
+* znstrider
 
 GitHub issues and pull requests:
 
-Pull Requests (69):
+Pull Requests (939):
 
-* :ghpull:`20830`: Backport PR #20826 on branch v3.4.x (Fix clear of Axes that are shared.)
-* :ghpull:`20826`: Fix clear of Axes that are shared.
-* :ghpull:`20823`: Backport PR #20817 on branch v3.4.x (Make test_change_epoch more robust.)
-* :ghpull:`20817`: Make test_change_epoch more robust.
-* :ghpull:`20820`: Backport PR #20771 on branch v3.4.x (FIX: tickspacing for subfigures)
-* :ghpull:`20771`: FIX: tickspacing for subfigures
-* :ghpull:`20777`: FIX: dpi and scatter for subfigures now correct
-* :ghpull:`20787`: Backport PR #20786 on branch v3.4.x (Fixed typo in _constrained_layout.py (#20782))
-* :ghpull:`20786`: Fixed typo in _constrained_layout.py (#20782)
-* :ghpull:`20763`: Backport PR #20761 on branch v3.4.x (Fix suplabel autopos)
-* :ghpull:`20761`: Fix suplabel autopos
-* :ghpull:`20751`: Backport PR #20748 on branch v3.4.x (Ensure _static directory exists before copying CSS.)
-* :ghpull:`20748`: Ensure _static directory exists before copying CSS.
-* :ghpull:`20713`: Backport PR #20710 on branch v3.4.x (Fix tests with Inkscape 1.1.)
-* :ghpull:`20687`: Enable PyPy wheels for v3.4.x
-* :ghpull:`20710`: Fix tests with Inkscape 1.1.
-* :ghpull:`20696`: Backport PR #20662 on branch v3.4.x (Don't forget to disable autoscaling after interactive zoom.)
-* :ghpull:`20662`: Don't forget to disable autoscaling after interactive zoom.
-* :ghpull:`20683`: Backport PR #20645 on branch v3.4.x (Fix leak if affine_transform is passed invalid vertices.)
-* :ghpull:`20645`: Fix leak if affine_transform is passed invalid vertices.
-* :ghpull:`20642`: Backport PR #20629 on branch v3.4.x (Add protection against out-of-bounds read in ttconv)
-* :ghpull:`20643`: Backport PR #20597 on branch v3.4.x
-* :ghpull:`20629`: Add protection against out-of-bounds read in ttconv
-* :ghpull:`20597`: Fix TTF headers for type 42 stix font
-* :ghpull:`20624`: Backport PR #20609 on branch v3.4.x (FIX: fix figbox deprecation)
-* :ghpull:`20609`: FIX: fix figbox deprecation
-* :ghpull:`20594`: Backport PR #20590 on branch v3.4.x (Fix class docstrings for Norms created from Scales.)
-* :ghpull:`20590`: Fix class docstrings for Norms created from Scales.
-* :ghpull:`20587`: Backport PR #20584: FIX: do not simplify path in LineCollection.get_s…
-* :ghpull:`20584`: FIX: do not simplify path in LineCollection.get_segments
-* :ghpull:`20578`: Backport PR #20511 on branch v3.4.x (Fix calls to np.ma.masked_where)
-* :ghpull:`20511`: Fix calls to np.ma.masked_where
-* :ghpull:`20568`: Backport PR #20565 on branch v3.4.x (FIX: PILLOW asarray bug)
-* :ghpull:`20566`: Backout pillow=8.3.0 due to a crash
-* :ghpull:`20565`: FIX: PILLOW asarray bug
-* :ghpull:`20503`: Backport PR #20488 on branch v3.4.x (FIX: Include 0 when checking lognorm vmin)
-* :ghpull:`20488`: FIX: Include 0 when checking lognorm vmin
-* :ghpull:`20483`: Backport PR #20480 on branch v3.4.x (Fix str of empty polygon.)
-* :ghpull:`20480`: Fix str of empty polygon.
-* :ghpull:`20478`: Backport PR #20473 on branch v3.4.x (_GSConverter: handle stray 'GS' in output gracefully)
-* :ghpull:`20473`: _GSConverter: handle stray 'GS' in output gracefully
-* :ghpull:`20456`: Backport PR #20453 on branch v3.4.x (Remove ``Tick.apply_tickdir`` from 3.4 deprecations.)
-* :ghpull:`20441`: Backport PR #20416 on branch v3.4.x (Fix missing Patch3DCollection._z_markers_idx)
-* :ghpull:`20416`: Fix missing Patch3DCollection._z_markers_idx
-* :ghpull:`20417`: Backport PR #20395 on branch v3.4.x (Pathing issue)
-* :ghpull:`20395`: Pathing issue
-* :ghpull:`20404`: Backport PR #20403: FIX: if we have already subclassed mixin class ju…
-* :ghpull:`20403`: FIX: if we have already subclassed mixin class just return
-* :ghpull:`20383`: Backport PR #20381 on branch v3.4.x (Prevent corrections and completions in search field)
-* :ghpull:`20307`: Backport PR #20154 on branch v3.4.x (ci: Bump Ubuntu to 18.04 LTS.)
-* :ghpull:`20285`: Backport PR #20275 on branch v3.4.x (Fix some examples that are skipped in docs build)
-* :ghpull:`20275`: Fix some examples that are skipped in docs build
-* :ghpull:`20267`: Backport PR #20265 on branch v3.4.x (Legend edgecolor face)
-* :ghpull:`20265`: Legend edgecolor face
-* :ghpull:`20260`: Fix legend edgecolor face
-* :ghpull:`20259`: Backport PR #20248 on branch v3.4.x (Replace pgf image-streaming warning by error.)
-* :ghpull:`20248`: Replace pgf image-streaming warning by error.
-* :ghpull:`20241`: Backport PR #20212 on branch v3.4.x (Update span_selector.py)
-* :ghpull:`20212`: Update span_selector.py
-* :ghpull:`19980`: Tidy up deprecation messages in ``_subplots.py``
-* :ghpull:`20234`: Backport PR #20225 on branch v3.4.x (FIX: correctly handle ax.legend(..., legendcolor='none'))
-* :ghpull:`20225`: FIX: correctly handle ax.legend(..., legendcolor='none')
-* :ghpull:`20232`: Backport PR #19636 on branch v3.4.x (Correctly check inaxes for multicursor)
-* :ghpull:`20228`: Backport PR #19849 on branch v3.4.x (FIX DateFormatter for month names when usetex=True)
-* :ghpull:`19849`: FIX DateFormatter for month names when usetex=True
-* :ghpull:`20154`: ci: Bump Ubuntu to 18.04 LTS.
-* :ghpull:`20186`: Backport PR #19975 on branch v3.4.x (CI: remove workflow to push commits to macpython/matplotlib-wheels)
-* :ghpull:`19975`: CI: remove workflow to push commits to macpython/matplotlib-wheels
-* :ghpull:`19636`: Correctly check inaxes for multicursor
+* :ghpull:`21645`: Backport PR #21628 on branch v3.5.x (Fix METH_VARARGS method signatures )
+* :ghpull:`21644`: Backport PR #21640 on branch v3.5.x (DOC: remove sample_plots from tutorials)
+* :ghpull:`21628`: Fix METH_VARARGS method signatures
+* :ghpull:`21640`: DOC: remove sample_plots from tutorials
+* :ghpull:`21636`: Backport PR #21604 on branch v3.5.x (Fix centre square rectangle selector part 1)
+* :ghpull:`21604`: Fix centre square rectangle selector part 1
+* :ghpull:`21633`: Backport PR #21501 on branch v3.5.x (Refix for pyparsing compat.)
+* :ghpull:`21606`: BLD: limit support of pyparsing to <3
+* :ghpull:`21501`: Refix for pyparsing compat.
+* :ghpull:`21624`: Backport PR #21621 on branch v3.5.x (Fix GhostScript error handling types)
+* :ghpull:`21625`: Backport PR #21568 on branch v3.5.x (Enhancing support for tex and datetimes)
+* :ghpull:`21568`: Enhancing support for tex and datetimes
+* :ghpull:`21621`: Fix GhostScript error handling types
+* :ghpull:`21623`: Backport PR #21619 on branch v3.5.x (Revert "Pin sphinx to fix sphinx-gallery")
+* :ghpull:`21619`: Revert "Pin sphinx to fix sphinx-gallery"
+* :ghpull:`21618`: Backport PR #21617 on branch v3.5.x (FIX: Make sure we do not over-write eps short cuts)
+* :ghpull:`21622`: Backport PR #21350 on branch v3.5.x (Remove plot_gallery setting from conf.py)
+* :ghpull:`21617`: FIX: Make sure we do not over-write eps short cuts
+* :ghpull:`21616`: Backport PR #21613 on branch v3.5.x (SEC/DOC update supported versions)
+* :ghpull:`21615`: Backport PR #21607 on branch v3.5.x (DOC: link to cheatsheets site, not github repo)
+* :ghpull:`21614`: Backport PR #21609 on branch v3.5.x (Fix documentation link with renaming ``voxels`` to ``voxelarray``)
+* :ghpull:`21613`: SEC/DOC update supported versions
+* :ghpull:`21607`: DOC: link to cheatsheets site, not github repo
+* :ghpull:`21609`: Fix documentation link with renaming ``voxels`` to ``voxelarray``
+* :ghpull:`21605`: Backport PR #21317 on branch v3.5.x (Move label hiding rectilinear-only check into _label_outer_{x,y}axis.)
+* :ghpull:`21317`: Move label hiding rectilinear-only check into _label_outer_{x,y}axis.
+* :ghpull:`21602`: Backport PR #21586 on branch v3.5.x (Defer enforcement of hatch validation)
+* :ghpull:`21601`: Backport PR #21530 on branch v3.5.x (Fix interrupting GTK on plain Python)
+* :ghpull:`21603`: Backport PR #21596 on branch v3.5.x (Pin sphinx to fix sphinx-gallery)
+* :ghpull:`21586`: Defer enforcement of hatch validation
+* :ghpull:`21530`: Fix interrupting GTK on plain Python
+* :ghpull:`21397`: Support for pre 2.7.1 freetype savannah versions
+* :ghpull:`21599`: Backport PR #21592 on branch v3.5.x ([BUG in 3.5.0rc1] - Anatomy of a Figure has the legend in the wrong spot)
+* :ghpull:`21587`: Backport PR #21581 on branch v3.5.x (Fix RangeSlider.reset)
+* :ghpull:`21592`: [BUG in 3.5.0rc1] - Anatomy of a Figure has the legend in the wrong spot
+* :ghpull:`21596`: Pin sphinx to fix sphinx-gallery
+* :ghpull:`21577`: Backport PR #21527 on branch v3.5.x (Add more 3.5 release notes)
+* :ghpull:`21527`: Add more 3.5 release notes
+* :ghpull:`21573`: Backport PR #21570 on branch v3.5.x (Raise correct exception out of Spines.__getattr__)
+* :ghpull:`21563`: Backport PR #21559 on branch v3.5.x (Fix eventplot units)
+* :ghpull:`21560`: Backport PR #21553 on branch v3.5.x (Fix check for manager presence in blocking_input.)
+* :ghpull:`21561`: Backport PR #21555 on branch v3.5.x (MNT: reject more possibly unsafe strings in validate_cycler)
+* :ghpull:`21555`: MNT: reject more possibly unsafe strings in validate_cycler
+* :ghpull:`21553`: Fix check for manager presence in blocking_input.
+* :ghpull:`21559`: Fix eventplot units
+* :ghpull:`21543`: Backport PR #21443 on branch v3.5.x (FIX: re-instate ability to have position in axes)
+* :ghpull:`21550`: Ignore transOffset if no offsets passed to Collection
+* :ghpull:`21443`: FIX: re-instate ability to have position in axes
+* :ghpull:`21531`: Backport PR #21491 on branch v3.5.x (Relocate inheritance diagram to the top of the document)
+* :ghpull:`21491`: Relocate inheritance diagram to the top of the document
+* :ghpull:`21504`: Backport PR #21481 on branch v3.5.x (FIX: spanning subfigures)
+* :ghpull:`21481`: FIX: spanning subfigures
+* :ghpull:`21483`: Backport PR #21387 on branch v3.5.x (Fix path simplification of closed loops)
+* :ghpull:`21486`: Backport PR #21478 on branch v3.5.x (Fix GTK4 embedding example)
+* :ghpull:`21497`: Backport PR #21484 on branch v3.5.x (Replacement for imread should return an array)
+* :ghpull:`21484`: Replacement for imread should return an array
+* :ghpull:`21495`: Backport PR #21492 on branch v3.5.x (added parameter documentation for MultiCursor)
+* :ghpull:`21493`: Backport PR #21488 on branch v3.5.x (Added to contour docs)
+* :ghpull:`21492`: added parameter documentation for MultiCursor
+* :ghpull:`21488`: Added to contour docs
+* :ghpull:`21478`: Fix GTK4 embedding example
+* :ghpull:`21387`: Fix path simplification of closed loops
+* :ghpull:`21479`: Backport PR #21472 on branch v3.5.x (Clarify set_parse_math documentation.)
+* :ghpull:`21472`: Clarify set_parse_math documentation.
+* :ghpull:`21471`: Backport PR #21470 on branch v3.5.x (Hide fully transparent latex text in PS output)
+* :ghpull:`21470`: Hide fully transparent latex text in PS output
+* :ghpull:`21469`: Backport PR #21468 on branch v3.5.x (Fix some typos in examples)
+* :ghpull:`21468`: Fix some typos in examples
+* :ghpull:`21461`: Backport #21429 from jklymak/doc-use-mpl-sphinx
+* :ghpull:`21464`: Backport PR #21460 on branch v3.5.x (Clip slider init marker to slider track.)
+* :ghpull:`21460`: Clip slider init marker to slider track.
+* :ghpull:`21458`: Backport:  #21429 from jklymak/doc-use-mpl-sphinx
+* :ghpull:`21454`: Fix error with pyparsing 3 for 3.5.x
+* :ghpull:`21459`: Backport PR #21423 on branch v3.5.x (Change CircleCI job title to "Rendered docs")
+* :ghpull:`21423`: Change CircleCI job title to "Rendered docs"
+* :ghpull:`21457`: Backport PR #21455 on branch v3.5.x (Hide note linking to the download section at the bottom of galleries)
+* :ghpull:`21456`: Backport PR #21453 on branch v3.5.x (Cleanup index.rst sectioning)
+* :ghpull:`21455`: Hide note linking to the download section at the bottom of galleries
+* :ghpull:`21453`: Cleanup index.rst sectioning
+* :ghpull:`21224`: DOC: Nav-bar: Add icon linking to contents
+* :ghpull:`21451`: Backport PR #21445 on branch v3.5.x (Mnt pin pyparsing)
+* :ghpull:`21429`: DOC: use mpl-sphinx-theme for navbar, social, logo
+* :ghpull:`21450`: Backport PR #21449 on branch v3.5.x (Less verbose install info on index page)
+* :ghpull:`21449`: Less verbose install info on index page
+* :ghpull:`21446`: Also exclude pyparsing 3.0.0 in setup.py.
+* :ghpull:`21445`: Mnt pin pyparsing
+* :ghpull:`21439`: Backport PR #21420 on branch v3.5.x (Enable Python 3.10 wheel building on all systems)
+* :ghpull:`21438`: Backport PR #21427 on branch v3.5.x (Update docstrings of get_{view,data}_interval.)
+* :ghpull:`21437`: Backport PR #21435 on branch v3.5.x (DOC: Fix selection of parameter names in HTML theme)
+* :ghpull:`21420`: Enable Python 3.10 wheel building on all systems
+* :ghpull:`21427`: Update docstrings of get_{view,data}_interval.
+* :ghpull:`21435`: DOC: Fix selection of parameter names in HTML theme
+* :ghpull:`21428`: Backport PR #21422 on branch v3.5.x (More doc reorganization)
+* :ghpull:`21422`: More doc reorganization
+* :ghpull:`21421`: Backport PR #21411 on branch v3.5.x (Document webagg in docs.)
+* :ghpull:`21419`: Backport PR #21251 on branch v3.5.x (DOC: more site re-org)
+* :ghpull:`21411`: Document webagg in docs.
+* :ghpull:`21251`: DOC: more site re-org
+* :ghpull:`21416`: Backport PR #21326 on branch v3.5.x (Add ability to scale BBox with just x or y values)
+* :ghpull:`21418`: Backport PR #21414 on branch v3.5.x (Support pathological tmpdirs in TexManager.)
+* :ghpull:`21410`: Backport PR #20591 on branch v3.5.x (Webagg backend: get rid of tornado)
+* :ghpull:`21414`: Support pathological tmpdirs in TexManager.
+* :ghpull:`21326`: Add ability to scale BBox with just x or y values
+* :ghpull:`20591`: Webagg backend: get rid of tornado
+* :ghpull:`21406`: Backport PR #21212 on branch v3.5.x (Fix set_size_inches on HiDPI and also GTK4)
+* :ghpull:`21405`: Backport PR #21365 on branch v3.5.x (Convert macosx backend to use device_pixel_ratio)
+* :ghpull:`18274`: Improve initial macosx device scale
+* :ghpull:`21212`: Fix set_size_inches on HiDPI and also GTK4
+* :ghpull:`21365`: Convert macosx backend to use device_pixel_ratio
+* :ghpull:`21372`: Backport PR #20708 on branch v3.5.x (Describe possible need for loading the 'lmodern' package when using PGF files)
+* :ghpull:`20708`: Describe possible need for loading the 'lmodern' package when using PGF files
+* :ghpull:`21359`: Add GHA testing whether files were added and deleted in the same PR.
+* :ghpull:`21360`: Backport PR #21335 on branch v3.5.x (DOC: move usage tutorial info to Users guide rst)
+* :ghpull:`21363`: Backport PR #21287 on branch v3.5.x (Inherit more docstrings.)
+* :ghpull:`21361`: Fix flake8 from #21335
+* :ghpull:`21287`: Inherit more docstrings.
+* :ghpull:`21335`: DOC: move usage tutorial info to Users guide rst
+* :ghpull:`21358`: Backport PR #21357 on branch v3.5.x (DOC: remove test from README.rst)
+* :ghpull:`21357`: DOC: remove test from README.rst
+* :ghpull:`21350`: Remove plot_gallery setting from conf.py
+* :ghpull:`21340`: Backport PR #21332 on branch v3.5.x (Fix default value for ``shading`` in``pyplot.pcolormesh`` docstring)
+* :ghpull:`21332`: Fix default value for ``shading`` in``pyplot.pcolormesh`` docstring
+* :ghpull:`21334`: Backport PR #21330 on branch v3.5.x (Fix medical image caption in tutorial)
+* :ghpull:`21329`: Backport PR #21321 on branch v3.5.x (DOC Update description of ax.contour method, resolves #21310)
+* :ghpull:`21330`: Fix medical image caption in tutorial
+* :ghpull:`21321`: DOC Update description of ax.contour method, resolves #21310
+* :ghpull:`21327`: Backport PR #21313 on branch v3.5.x (DOC: Minimal getting started page)
+* :ghpull:`21313`: DOC: Minimal getting started page
+* :ghpull:`21316`: Backport PR #21312 on branch v3.5.x (Update link to Agg website)
+* :ghpull:`21312`: Update link to Agg website
+* :ghpull:`21308`: Backport PR #21307 on branch v3.5.x (Use in-tree builds for PyPy wheels)
+* :ghpull:`21307`: Use in-tree builds for PyPy wheels
+* :ghpull:`21306`: Backport PR #21303 on branch v3.5.x (Pin macOS to 10.15 for wheels)
+* :ghpull:`21305`: Backport PR #21286 on branch v3.5.x (Clarify FigureBase.tight_bbox as different from all other artists.)
+* :ghpull:`21286`: Clarify FigureBase.tight_bbox as different from all other artists.
+* :ghpull:`21302`: Backport PR #21291 on branch v3.5.x (DOC: Bump to the sphinx-gallery release)
+* :ghpull:`21304`: Backport PR #21294 on branch v3.5.x (Disable blitting on GTK4 backends)
+* :ghpull:`21294`: Disable blitting on GTK4 backends
+* :ghpull:`21277`: Backport PR #21263 on branch v3.5.x (Ensure internal FreeType matches Python compile)
+* :ghpull:`21291`: DOC: Bump to the sphinx-gallery release
+* :ghpull:`21296`: Backport PR #21288 on branch v3.5.x (Allow macosx thread safety test on macOS11)
+* :ghpull:`21297`: Backport PR #21293 on branch v3.5.x (Fix snap argument to pcolormesh)
+* :ghpull:`21293`: Fix snap argument to pcolormesh
+* :ghpull:`21288`: Allow macosx thread safety test on macOS11
+* :ghpull:`21279`: Fix freetype wheel building
+* :ghpull:`21292`: Backport PR #21290 on branch v3.5.x (DOC: Fix some lists in animation examples)
+* :ghpull:`21290`: DOC: Fix some lists in animation examples
+* :ghpull:`21284`: Backport PR #21282 on branch v3.5.x (Fix incorrect markup in example.)
+* :ghpull:`21282`: Fix incorrect markup in example.
+* :ghpull:`21281`: Backport PR #21275 on branch v3.5.x (Fix format_cursor_data for values close to float resolution.)
+* :ghpull:`21275`: Fix format_cursor_data for values close to float resolution.
+* :ghpull:`21263`: Ensure internal FreeType matches Python compile
+* :ghpull:`21273`: Backport PR #21269 on branch v3.5.x (Don't use pixelDelta() on X11.)
+* :ghpull:`21269`: Don't use pixelDelta() on X11.
+* :ghpull:`21268`: Backport PR #21236: DOC: Update interactive colormap example
+* :ghpull:`21265`: Backport PR #21264 on branch v3.5.x (DOC: Fix footnote that breaks PDF builds)
+* :ghpull:`21264`: DOC: Fix footnote that breaks PDF builds
+* :ghpull:`21236`: DOC: Update interactive colormap example
+* :ghpull:`21262`: Backport PR #21250 on branch v3.5.x (DOC: Remove examples/README)
+* :ghpull:`21260`: DOC: Fix source links to prereleases
+* :ghpull:`21261`: Backport PR #21240: DOC: Fix source links and flake8 cleanup
+* :ghpull:`21248`: Backport PR #21247 on branch v3.5.x (Fix release notes typos.)
+* :ghpull:`21254`: Backport PR #21249 on branch v3.5.x (Fix some syntax highlights in coding and contributing guide.)
+* :ghpull:`21250`: DOC: Remove examples/README
+* :ghpull:`21249`: Fix some syntax highlights in coding and contributing guide.
+* :ghpull:`20652`: Fixed Comments and Clarification
+* :ghpull:`21240`: DOC: Fix source links and flake8 cleanup
+* :ghpull:`21247`: Fix release notes typos.
+* :ghpull:`21244`: Backport PR #20907 on branch v3.5.x (Move sigint tests into subprocesses)
+* :ghpull:`21245`: Backport PR #21226 on branch v3.5.x (DOC: Adapt some colors in examples)
+* :ghpull:`21226`: DOC: Adapt some colors in examples
+* :ghpull:`20907`: Move sigint tests into subprocesses
+* :ghpull:`21241`: Backport PR #21237 on branch v3.5.x (DOC: Add fill_between to plot_types)
+* :ghpull:`21237`: DOC: Add fill_between to plot_types
+* :ghpull:`21235`: Backport PR #20852 on branch v3.5.x (Prepare docs for 3.5)
+* :ghpull:`20852`: Prepare docs for 3.5
+* :ghpull:`21234`: Backport PR #21221 on branch v3.5.x (Updates to plot types)
+* :ghpull:`21232`: Backport PR #21228 on branch v3.5.x (Small doc nits.)
+* :ghpull:`21233`: Backport PR #21229 on branch v3.5.x (Shorten PdfPages FAQ entry.)
+* :ghpull:`21221`: Updates to plot types
+* :ghpull:`21229`: Shorten PdfPages FAQ entry.
+* :ghpull:`21228`: Small doc nits.
+* :ghpull:`21227`: Backport PR #20730 on branch v3.5.x (DOC: Add a release mode tag)
+* :ghpull:`20730`: DOC: Add a release mode tag
+* :ghpull:`21225`: Backport PR #21223 on branch v3.5.x (Fix nav link for "Usage guide" and remove release/date info from that page)
+* :ghpull:`21223`: Fix nav link for "Usage guide" and remove release/date info from that page
+* :ghpull:`21222`: Backport PR #21211 on branch v3.5.x (updated resources)
+* :ghpull:`21211`: updated resources
+* :ghpull:`21219`: Backport PR #21216 on branch v3.5.x (Use correct confidence interval)
+* :ghpull:`21216`: Use correct confidence interval
+* :ghpull:`21217`: Backport PR #21215 on branch v3.5.x (Fix more edge cases in psd, csd.)
+* :ghpull:`21215`: Fix more edge cases in psd, csd.
+* :ghpull:`21210`: Backport PR #21191 on branch v3.5.x (Fix very-edge case in csd(), plus small additional cleanups.)
+* :ghpull:`21209`: Backport PR #21188 on branch v3.5.x (Rework headers for individual backend docs.)
+* :ghpull:`21191`: Fix very-edge case in csd(), plus small additional cleanups.
+* :ghpull:`21188`: Rework headers for individual backend docs.
+* :ghpull:`21208`: Backport PR #21203 on branch v3.5.x (Rework plot types quiver)
+* :ghpull:`21203`: Rework plot types quiver
+* :ghpull:`21207`: Backport PR #21198 on branch v3.5.x (Update coding_guide.rst)
+* :ghpull:`21206`: Backport PR #21201 on branch v3.5.x (Fix signature of barh() in plot types)
+* :ghpull:`21204`: Backport PR #21193 on branch v3.5.x (Update contributing guide.)
+* :ghpull:`21198`: Update coding_guide.rst
+* :ghpull:`21201`: Fix signature of barh() in plot types
+* :ghpull:`21200`: Backport PR #21196 on branch v3.5.x (Update fonts.rst)
+* :ghpull:`21199`: Backport PR #21026 on branch v3.5.x (Place 3D contourf patches between levels)
+* :ghpull:`21197`: Backport PR #21186 on branch v3.5.x (Fixed typos using codespell. (previous pull request was told not to change the agg files) )
+* :ghpull:`21196`: Update fonts.rst
+* :ghpull:`21026`: Place 3D contourf patches between levels
+* :ghpull:`21186`: Fixed typos using codespell. (previous pull request was told not to change the agg files)
+* :ghpull:`21195`: Backport PR #21189 on branch v3.5.x (Small doc fixes.)
+* :ghpull:`21194`: Backport PR #21192 on branch v3.5.x (Discourage making style changes to extern/.)
+* :ghpull:`21189`: Small doc fixes.
+* :ghpull:`21192`: Discourage making style changes to extern/.
+* :ghpull:`21193`: Update contributing guide.
+* :ghpull:`21184`: Backport PR #21172 on branch v3.5.x (skip QImage leak workaround for PySide2 >= 5.12)
+* :ghpull:`21183`: Backport PR #21081 on branch v3.5.x (Improve docs for to_jshtml())
+* :ghpull:`21172`: skip QImage leak workaround for PySide2 >= 5.12
+* :ghpull:`21181`: Backport PR #21166 on branch v3.5.x (Cleanup contour(f)3d examples.)
+* :ghpull:`21182`: Backport PR #21180 on branch v3.5.x (Remove uninformative ``.. figure::`` titles in docs.)
+* :ghpull:`21081`: Improve docs for to_jshtml()
+* :ghpull:`21180`: Remove uninformative ``.. figure::`` titles in docs.
+* :ghpull:`21166`: Cleanup contour(f)3d examples.
+* :ghpull:`21174`: Backport PR #19343 on branch v3.5.x (Enh improve agg chunks error)
+* :ghpull:`19343`: Enh improve agg chunks error
+* :ghpull:`21171`: Backport PR #20951 on branch v3.5.x ([ENH]: data kwarg support for mplot3d #20912)
+* :ghpull:`21169`: Backport PR #21126 on branch v3.5.x (Deprecate passing formatting parameters positionally to stem())
+* :ghpull:`21126`: Deprecate passing formatting parameters positionally to stem()
+* :ghpull:`21164`: Backport PR #21039 on branch v3.5.x (Fix ``hexbin`` marginals and log scaling)
+* :ghpull:`21039`: Fix ``hexbin`` marginals and log scaling
+* :ghpull:`21160`: Backport PR #21136 on branch v3.5.x (More (minor) plot types gallery fixes.)
+* :ghpull:`21136`: More (minor) plot types gallery fixes.
+* :ghpull:`21158`: Backport PR #21140 on branch v3.5.x (Docstring cleanups around DATA_PARAMETER_PLACEHOLDER.)
+* :ghpull:`21159`: Backport PR #21127 on branch v3.5.x (Simplify argument parsing in stem().)
+* :ghpull:`21157`: Backport PR #21153 on branch v3.5.x (Improve curve_error_band example.)
+* :ghpull:`21156`: Backport PR #21154 on branch v3.5.x (Increase marker size in double_pendulum example.)
+* :ghpull:`21127`: Simplify argument parsing in stem().
+* :ghpull:`21140`: Docstring cleanups around DATA_PARAMETER_PLACEHOLDER.
+* :ghpull:`21153`: Improve curve_error_band example.
+* :ghpull:`21154`: Increase marker size in double_pendulum example.
+* :ghpull:`21149`: Backport PR #21146 on branch v3.5.x (Fix clim handling for pcolor{,mesh}.)
+* :ghpull:`21151`: Backport PR #21141 on branch v3.5.x (Fix DATA_PARAMETER_PLACEHOLDER interpolation for quiver&contour{,f}.)
+* :ghpull:`21150`: Backport PR #21145 on branch v3.5.x (Fix format_cursor_data with nans.)
+* :ghpull:`21141`: Fix DATA_PARAMETER_PLACEHOLDER interpolation for quiver&contour{,f}.
+* :ghpull:`21145`: Fix format_cursor_data with nans.
+* :ghpull:`21146`: Fix clim handling for pcolor{,mesh}.
+* :ghpull:`21148`: Backport PR #21142 on branch v3.5.x (Mac qt ctrl)
+* :ghpull:`21142`: Mac qt ctrl
+* :ghpull:`21144`: Backport PR #21122 on branch v3.5.x (CTRL does not fix aspect in zoom-to-rect mode.)
+* :ghpull:`21143`: Backport PR #19515 on branch v3.5.x (Colorbar axis zoom and pan)
+* :ghpull:`21122`: CTRL does not fix aspect in zoom-to-rect mode.
+* :ghpull:`19515`: Colorbar axis zoom and pan
+* :ghpull:`21138`: Backport PR #21131 on branch v3.5.x (Fix polar() regression on second call failure)
+* :ghpull:`21134`: Backport PR #21124 on branch v3.5.x (Tweak streamplot plot_types example.)
+* :ghpull:`21133`: Backport PR #21114 on branch v3.5.x (Add contour and tricontour plots to plot types)
+* :ghpull:`21132`: Backport PR #21093 on branch v3.5.x (DOC: clarify what we mean by object oriented in pyplot api)
+* :ghpull:`21124`: Tweak streamplot plot_types example.
+* :ghpull:`21114`: Add contour and tricontour plots to plot types
+* :ghpull:`21130`: Backport PR #21129 on branch v3.5.x (Fix decenter of image in gallery thumbnails)
+* :ghpull:`21093`: DOC: clarify what we mean by object oriented in pyplot api
+* :ghpull:`21129`: Fix decenter of image in gallery thumbnails
+* :ghpull:`21125`: Backport PR #21086 on branch v3.5.x (Capitalization fixes in example section titles.)
+* :ghpull:`21128`: Backport PR #21123 on branch v3.5.x (Simplify/uniformize sample data setup in plot_types examples.)
+* :ghpull:`21123`: Simplify/uniformize sample data setup in plot_types examples.
+* :ghpull:`21121`: Backport PR #21111 on branch v3.5.x (Rename section title Gallery -> Examples)
+* :ghpull:`21086`: Capitalization fixes in example section titles.
+* :ghpull:`21120`: Backport PR #21115 on branch v3.5.x (Improve errorbar plot types example)
+* :ghpull:`21119`: Backport PR #21116 on branch v3.5.x (Adapt css so that galleries have four columns)
+* :ghpull:`21116`: Adapt css so that galleries have four columns
+* :ghpull:`21118`: Backport PR #21112 on branch v3.5.x (Fix make_norm_from_scale ``__name__`` when used inline.)
+* :ghpull:`21111`: Rename section title Gallery -> Examples
+* :ghpull:`21112`: Fix make_norm_from_scale ``__name__`` when used inline.
+* :ghpull:`20951`: [ENH]: data kwarg support for mplot3d #20912
+* :ghpull:`21115`: Improve errorbar plot types example
+* :ghpull:`21109`: Backport PR #21104 on branch v3.5.x (Remove the index and module index pages)
+* :ghpull:`21104`: Remove the index and module index pages
+* :ghpull:`21102`: Backport PR #21100 on branch v3.5.x (Cleanup demo_tight_layout.)
+* :ghpull:`21106`: Backport PR #21034 on branch v3.5.x (Make rcParams["backend"] backend fallback check rcParams identity first.)
+* :ghpull:`21105`: Backport PR #21083 on branch v3.5.x (Fix capitalizations)
+* :ghpull:`21103`: Backport PR #21089 on branch v3.5.x (Update sticky_edges docstring to new behavior.)
+* :ghpull:`21034`: Make rcParams["backend"] backend fallback check rcParams identity first.
+* :ghpull:`21083`: Fix capitalizations
+* :ghpull:`21099`: Backport PR #20935 on branch v3.5.x (Add ColormapsRegistry as experimental and add it to pyplot)
+* :ghpull:`21100`: Cleanup demo_tight_layout.
+* :ghpull:`21098`: Backport PR #20903 on branch v3.5.x (Use release-branch version scheme )
+* :ghpull:`20935`: Add ColormapsRegistry as experimental and add it to pyplot
+* :ghpull:`20903`: Use release-branch version scheme
+* :ghpull:`21089`: Update sticky_edges docstring to new behavior.
+* :ghpull:`21084`: Backport PR #20988 on branch v3.5.x (Add HiDPI support in GTK.)
+* :ghpull:`21085`: Backport PR #21082 on branch v3.5.x (Fix layout of sidebar entries)
+* :ghpull:`20345`: ENH: call update_ticks before we return them to the user
+* :ghpull:`21082`: Fix layout of sidebar entries
+* :ghpull:`20988`: Add HiDPI support in GTK.
+* :ghpull:`21080`: Backport PR #19619 on branch v3.5.x (Fix bug in shape assignment)
+* :ghpull:`19619`: Fix bug in shape assignment
+* :ghpull:`21079`: Backport PR #21078 on branch v3.5.x (Cache build dependencies on Circle)
+* :ghpull:`21078`: Cache build dependencies on Circle
+* :ghpull:`21077`: Backport PR #21076 on branch v3.5.x (Break links between twinned axes when removing)
+* :ghpull:`21076`: Break links between twinned axes when removing
+* :ghpull:`21073`: Backport PR #21072 on branch v3.5.x (Use sysconfig directly instead of through distutils)
+* :ghpull:`21072`: Use sysconfig directly instead of through distutils
+* :ghpull:`21071`: Backport PR #21061 on branch v3.5.x (Remove most visible dependencies on distutils.)
+* :ghpull:`21061`: Remove most visible dependencies on distutils.
+* :ghpull:`21070`: Backport PR #21025 on branch v3.5.x (Fix Cairo backends on HiDPI screens)
+* :ghpull:`21065`: Backport PR #20819 on branch v3.5.x (Add CPython 3.10 wheels)
+* :ghpull:`21069`: Backport PR #21051 on branch v3.5.x (set_dashes does not support offset=None anymore.)
+* :ghpull:`21068`: Backport PR #21067 on branch v3.5.x (Remove generated file accidentally added in #20867)
+* :ghpull:`21025`: Fix Cairo backends on HiDPI screens
+* :ghpull:`21051`: set_dashes does not support offset=None anymore.
+* :ghpull:`21067`: Remove generated file accidentally added in #20867
+* :ghpull:`21066`: Backport PR #21060 on branch v3.5.x (Correct the default for fillstyle parameter in MarkerStyle())
+* :ghpull:`20819`: Add CPython 3.10 wheels
+* :ghpull:`21064`: Backport PR #20913 on branch v3.5.x ([Doc] colors.to_hex input & output)
+* :ghpull:`20913`: [Doc] colors.to_hex input & output
+* :ghpull:`21063`: Backport PR #21062 on branch v3.5.x (Fix typo in template of current dev-docs)
+* :ghpull:`21062`: Fix typo in template of current dev-docs
+* :ghpull:`21060`: Correct the default for fillstyle parameter in MarkerStyle()
+* :ghpull:`21058`: Backport PR #21053 on branch v3.5.x (Fix validate_markevery docstring markup.)
+* :ghpull:`21053`: Fix validate_markevery docstring markup.
+* :ghpull:`21052`: Backport PR #20867 on branch v3.5.x ("inner" index reorganization)
+* :ghpull:`21047`: Backport PR #21040 on branch v3.5.x (Document ``handleheight`` parameter of ``Legend`` constructor)
+* :ghpull:`21048`: Backport PR #21044 on branch v3.5.x (Support for forward/back mousebuttons on WX backend)
+* :ghpull:`20867`: "inner" index reorganization
+* :ghpull:`21044`: Support for forward/back mousebuttons on WX backend
+* :ghpull:`21040`: Document ``handleheight`` parameter of ``Legend`` constructor
+* :ghpull:`21045`: Backport PR #21041 on branch v3.5.x (Prefer "none" to "None" in docs, examples and comments.)
+* :ghpull:`21041`: Prefer "none" to "None" in docs, examples and comments.
+* :ghpull:`21037`: Backport PR #20949 on branch v3.5.x (Improve formatting of imshow() cursor data independently of colorbar.)
+* :ghpull:`21035`: Backport PR #21031 on branch v3.5.x (Make date.{converter,interval_multiples} rcvalidators side-effect free.)
+* :ghpull:`20949`: Improve formatting of imshow() cursor data independently of colorbar.
+* :ghpull:`21031`: Make date.{converter,interval_multiples} rcvalidators side-effect free.
+* :ghpull:`21032`: Backport PR #21017 on branch v3.5.x (FIX: Don't subslice lines if non-standard transform)
+* :ghpull:`21030`: Backport PR #20980 on branch v3.5.x (FIX: remove colorbar from list of colorbars on axes)
+* :ghpull:`21029`: Backport PR #21028 on branch v3.5.x (Minor homogeneization of markup for MEP titles.)
+* :ghpull:`21028`: Minor homogeneization of markup for MEP titles.
+* :ghpull:`21022`: Backport PR #20518 on branch v3.5.x ( Support sketch_params in pgf backend)
+* :ghpull:`20518`:  Support sketch_params in pgf backend
+* :ghpull:`21018`: Backport PR #20976 on branch v3.5.x (Separate tick and spine examples)
+* :ghpull:`20976`: Separate tick and spine examples
+* :ghpull:`21014`: Backport PR #20994 on branch v3.5.x (Remove unused icon_filename, window_icon globals.)
+* :ghpull:`21013`: Backport PR #21012 on branch v3.5.x (Use numpydoc for GridSpecFromSubplotSpec.__init__)
+* :ghpull:`20994`: Remove unused icon_filename, window_icon globals.
+* :ghpull:`21012`: Use numpydoc for GridSpecFromSubplotSpec.__init__
+* :ghpull:`21011`: Backport PR #21003 on branch v3.5.x (Deemphasize mpl_toolkits in API docs.)
+* :ghpull:`21003`: Deemphasize mpl_toolkits in API docs.
+* :ghpull:`21002`: Backport PR #20987 on branch v3.5.x (FIX: colorbar with boundary norm, proportional, extend)
+* :ghpull:`20987`: FIX: colorbar with boundary norm, proportional, extend
+* :ghpull:`21000`: Backport PR #20997 on branch v3.5.x (Fix ToolManager + TextBox support.)
+* :ghpull:`20997`: Fix ToolManager + TextBox support.
+* :ghpull:`20985`: Backport PR #20942 on branch v3.5.x (DOC Use 'Axes' instead of 'axes' in axes._base.py)
+* :ghpull:`20983`: Backport PR #20973 on branch v3.5.x (Docstring cleanups.)
+* :ghpull:`20982`: Backport PR #20972 on branch v3.5.x (Cleanup some dviread docstrings.)
+* :ghpull:`20942`: DOC Use 'Axes' instead of 'axes' in axes._base.py
+* :ghpull:`20981`: Backport PR #20975 on branch v3.5.x (Clarify support for 2D coordinate inputs to streamplot.)
+* :ghpull:`20972`: Cleanup some dviread docstrings.
+* :ghpull:`20975`: Clarify support for 2D coordinate inputs to streamplot.
+* :ghpull:`20973`: Docstring cleanups.
+* :ghpull:`20971`: Backport PR #20970 on branch v3.5.x (Build wheels for Apple Silicon.)
+* :ghpull:`20970`: Build wheels for Apple Silicon.
+* :ghpull:`20969`: Backport PR #20321 on branch v3.5.x (Add a GTK4 backend.)
+* :ghpull:`20321`: Add a GTK4 backend.
+* :ghpull:`20966`: Backport PR #19553 on branch v3.5.x (ENH: Adding callbacks to Norms for update signals)
+* :ghpull:`20967`: Backport PR #20965 on branch v3.5.x (BUG: Fix f_back is None handling)
+* :ghpull:`20965`: BUG: Fix f_back is None handling
+* :ghpull:`19553`: ENH: Adding callbacks to Norms for update signals
+* :ghpull:`20960`: Backport PR #20745 on branch v3.5.x (Clean up some Event class docs.)
+* :ghpull:`20745`: Clean up some Event class docs.
+* :ghpull:`20959`: Backport PR #20952 on branch v3.5.x (Redirect to new 3rd party packages page)
+* :ghpull:`20952`: Redirect to new 3rd party packages page
+* :ghpull:`20958`: Backport PR #20956 on branch v3.5.x (Make warning for no-handles legend more explicit.)
+* :ghpull:`20956`: Make warning for no-handles legend more explicit.
+* :ghpull:`20954`: Backport PR #20931 on branch v3.5.x (API: rename draw_no_output to draw_without_rendering)
+* :ghpull:`20931`: API: rename draw_no_output to draw_without_rendering
+* :ghpull:`20934`: Backport PR #20919 on branch v3.5.x (Improve various release notes)"
+* :ghpull:`20948`: Backport PR #20944 on branch v3.5.x (Switch documented deprecations in mathtext by ``__getattr__`` deprecations)
+* :ghpull:`20944`: Switch documented deprecations in mathtext by ``__getattr__`` deprecations
+* :ghpull:`20947`: Backport PR #20941 on branch v3.5.x (Fix variable capitalization in plot types headings)
+* :ghpull:`20941`: Fix variable capitalization in plot types headings
+* :ghpull:`20939`: Backport PR #20937 on branch v3.5.x (Fix documented allowed values for Patch.set_edgecolor.)
+* :ghpull:`20940`: Backport PR #20938 on branch v3.5.x (Fix missorted changelog entry.)
+* :ghpull:`20938`: Fix missorted changelog entry.
+* :ghpull:`20937`: Fix documented allowed values for Patch.set_edgecolor.
+* :ghpull:`20933`: Backport PR #20916 on branch v3.5.x (Improve deleted Animation warning)
+* :ghpull:`20916`: Improve deleted Animation warning
+* :ghpull:`20919`: Improve various release notes
+* :ghpull:`20928`: Backport PR #20889 on branch v3.5.x (Fix clearing selector)
+* :ghpull:`20927`: Backport PR #20924 on branch v3.5.x (Improve ``path.py`` docstrings a bit)
+* :ghpull:`20889`: Fix clearing selector
+* :ghpull:`20922`: Backport PR #20920 on branch v3.5.x (Fix cubic curve code in ``Path.__doc__``)
+* :ghpull:`20925`: Backport PR #20917 on branch v3.5.x (Move installing FAQ to installing page.)
+* :ghpull:`20924`: Improve ``path.py`` docstrings a bit
+* :ghpull:`20917`: Move installing FAQ to installing page.
+* :ghpull:`20920`: Fix cubic curve code in ``Path.__doc__``
+* :ghpull:`20918`: Backport PR #20915 on branch v3.5.x ([Doc] boxplot typo)
+* :ghpull:`20915`: [Doc] boxplot typo
+* :ghpull:`20908`: [Doc] FigureCanvasBase draw
+* :ghpull:`20899`: Backport PR #20885 on branch v3.5.x (Fix broken QApplication init in a test.)
+* :ghpull:`20885`: Fix broken QApplication init in a test.
+* :ghpull:`20894`: Backport PR #20891 on branch v3.5.x (Add dependency link for 3.5)
+* :ghpull:`20893`: Backport PR #20892 on branch v3.5.x (Label pylab as "discouraged" instead of "disapproved")
+* :ghpull:`20891`: Add dependency link for 3.5
+* :ghpull:`20888`: Backport PR #20864 on branch v3.5.x (Add Python 3.10 testing.)
+* :ghpull:`20890`: Backport PR #20693 on branch v3.5.x (Fix setting artists properties of selectors)
+* :ghpull:`20892`: Label pylab as "discouraged" instead of "disapproved"
+* :ghpull:`20693`: Fix setting artists properties of selectors
+* :ghpull:`20864`: Add Python 3.10 testing.
+* :ghpull:`20886`: Backport PR #20884 on branch v3.5.x (Ensure full environment is passed to headless test.)
+* :ghpull:`20884`: Ensure full environment is passed to headless test.
+* :ghpull:`20883`: Make pywin32 optional in Ctrl+C Qt test.
+* :ghpull:`20874`: Add additional external resource.
+* :ghpull:`20875`: Use mpl.colormaps in examples
+* :ghpull:`20586`: Deprecate matplotlib.test()
+* :ghpull:`19892`: Add Figure parameter layout and discourage tight_layout / constrained_layout
+* :ghpull:`20882`: Don't add QtNetwork to the API exported by qt_compat.
+* :ghpull:`20881`: Deprecate some old globals in qt_compat.
+* :ghpull:`13306`: Qt5: SIGINT kills just the mpl window and not the process itself
+* :ghpull:`20876`: DOC: Fix dependency link.
+* :ghpull:`20878`: Use tables for Locator and Formatter docs
+* :ghpull:`20873`: Remove mplutils.cpp; shorten mplutils.h.
+* :ghpull:`20872`: Remove some boilerplate from C extension inits.
+* :ghpull:`20871`: Move setup.cfg to mplsetup.cfg.
+* :ghpull:`20869`: Ignore errors trying to delete make_release_tree.
+* :ghpull:`20868`: Fix qt key mods
+* :ghpull:`20856`: TST: Add unit test to catch recurrences of #20822, #20855
+* :ghpull:`20857`: Propose a less error-prone helper for module-level getattrs.
+* :ghpull:`20840`: Speed up Tkagg blit with Tk_PhotoPutBlock
+* :ghpull:`20805`: Ensure all params are restored after ``reset_ticks``.
+* :ghpull:`20863`: new github citation format
+* :ghpull:`20859`: Allow SubFigure legends
+* :ghpull:`20848`: Fix PyPy wheels and tests
+* :ghpull:`20862`: Fix minor typo in setupext.py
+* :ghpull:`20814`: FIX: Avoid copying source script when ``plot_html_show_source_link`` is False in plot directive
+* :ghpull:`20855`: BUG: __getattr__ must raise AttributeError if name not found (again)
+* :ghpull:`20079`: Prepare axes_divider for simpler(?) indexing-based API.
+* :ghpull:`20444`: Delete _Bracket and update the _Curve to be able to ']->' and '<-['
+* :ghpull:`20812`: Clarify tutorial "Customizing Matplotlib with style sheets and rcParams"
+* :ghpull:`20806`: Deprecate matplotlib.cm.LUTSIZE
+* :ghpull:`20818`: Swap Cap/Cup glyphs when using STIX font.
+* :ghpull:`20849`: Add external resources to devdoc landing page
+* :ghpull:`20846`: Re-re-remove deprecated Qt globals.
+* :ghpull:`18503`: Add a dedicated ColormapRegistry class
+* :ghpull:`20603`: Deprecate unused LassoSelector event handlers.
+* :ghpull:`20679`: Fix selector onselect call when the selector is removed by an "empty" click and add ``ignore_event_outside`` argument
+* :ghpull:`11358`: FIX/ENH: Introduce a monolithic legend handler for Line2D
+* :ghpull:`20699`: FIX/ENH: Introduce a monolithic legend handler for Line2D
+* :ghpull:`20837`: Merge branch v3.4.x
+* :ghpull:`18782`: ENH: allow image to interpolate post RGBA
+* :ghpull:`20829`: TST: neither warned and pytest upstream deprecated this usage
+* :ghpull:`20828`: Increase test timeouts to 60 s to aid slower architectures
+* :ghpull:`20816`: ENH: Add the ability to block callback signals
+* :ghpull:`20646`: Handle NaN values in ``plot_surface`` zsort
+* :ghpull:`20725`: ``Axes3D.plot_surface``: Allow masked arrays and ``NaN`` values
+* :ghpull:`20825`: Fix image triage tool with Qt6
+* :ghpull:`20229`: ENH: Only do constrained layout at draw...
+* :ghpull:`20822`: BUG: __getattr__ must raise AttributeError if name not found
+* :ghpull:`20815`: circle: Switch to next-gen image.
+* :ghpull:`20813`: add doc-link to dufte
+* :ghpull:`20799`: MNT: Rename callbacksSM to callbacks
+* :ghpull:`20803`: Re-remove deprecated Qt globals.
+* :ghpull:`17810`: FIX: don't fail on first show if animation already exhausted
+* :ghpull:`20733`: Deprecate globals using module-level ``__getattr__``.
+* :ghpull:`20788`: FIX: Check for colorbar creation with multi-dimensional alpha
+* :ghpull:`20115`: ENH: pass extra kwargs in FigureBase, SubFigure, Figure to set
+* :ghpull:`20795`: TST/MNT: deprecate unused fixture
+* :ghpull:`20792`: Change legend guide to object oriented approach
+* :ghpull:`20717`: Fix collection offsets
+* :ghpull:`20673`: Point [SOURCE] documents to github
+* :ghpull:`19255`: Support for PyQt6/PySide6.
+* :ghpull:`20772`: Implement remove_rubberband rather than release_zoom.
+* :ghpull:`20783`: Document how to check for the existence of current figure/axes.
+* :ghpull:`20778`: Dedupe handling of mouse buttons in macos backend.
+* :ghpull:`20749`: Cleanup font subsetting code
+* :ghpull:`20775`: Remove some remnants of qt4 support.
+* :ghpull:`20659`: Add HiDPI-related config for mathmpl
+* :ghpull:`20767`: Factor out latex ifpackageloaded pattern.
+* :ghpull:`20769`: Simplify backend_ps._nums_to_str.
+* :ghpull:`20768`: Avoid using gca() in examples.
+* :ghpull:`20766`: Fix line dash offset format in PS output
+* :ghpull:`20706`: Include ``underscore.sty``
+* :ghpull:`20729`: Support vmin/vmax with bins='log' in hexbin
+* :ghpull:`20753`: Deprecate support for case-insensitive scales.
+* :ghpull:`20602`: Merge EllipseSelector example together with RectangleSelector.
+* :ghpull:`20744`: Add an example showing alternate mouse cursors.
+* :ghpull:`20758`: FIX: pass colorbar.set_ticklabels down to long_axis
+* :ghpull:`20759`: Modernize mathtext examples
+* :ghpull:`20739`: Small simplifications to streamplot.
+* :ghpull:`20756`: Add new external resource: Python Graph Gallery
+* :ghpull:`20330`: Fix cla colorbar
+* :ghpull:`20688`: issue form files
+* :ghpull:`20743`: Set the canvas cursor when using a SpanSelector
+* :ghpull:`20391`: Type42 subsetting in PS/PDF
+* :ghpull:`20737`: DOC: new index page
+* :ghpull:`20686`: Fix interaction between make_keyword_only and pyplot generation.
+* :ghpull:`20731`: Improved implementation of Path.copy and deepcopy
+* :ghpull:`20732`: Fix style in ``assert(x)``.
+* :ghpull:`20620`: Move set_cursor from the toolbar to FigureCanvas.
+* :ghpull:`20728`: Fix broken link in 'Contributing' docs
+* :ghpull:`20727`: DOC/TST make circle faster
+* :ghpull:`20726`: DOC: Provide alternative to cbar.patch
+* :ghpull:`20719`: Fix color normalization in plot types scatter
+* :ghpull:`20634`: Implement Type-1 decryption
+* :ghpull:`20633`: Emit non BMP chars as XObjects in PDF
+* :ghpull:`20709`: Fix Circle merge on master branch.
+* :ghpull:`20701`: Small cleanup to GTK backend
+* :ghpull:`20670`: Support markevery on figure-level lines.
+* :ghpull:`20707`: Rename a confusingly named variable in backend_pdf.
+* :ghpull:`20680`: CI: Build merged version on CircleCI
+* :ghpull:`20471`: add interactive colorbar example to gallery
+* :ghpull:`20692`: Small cleanups to hatch.py.
+* :ghpull:`20702`: DOC: add note about contouring algorithm
+* :ghpull:`18869`: Add __version_info__ as a tuple-based version identifier
+* :ghpull:`20689`: Fix some very unlikely leaks in extensions.
+* :ghpull:`20254`: Define FloatingAxes boundary patch in data coordinates.
+* :ghpull:`20682`: Bump codecov/codecov-action from 1 to 2
+* :ghpull:`20544`: Support of different locations for the text fixing cursor of TextBox
+* :ghpull:`20648`: Simplify barchart_demo
+* :ghpull:`20606`: Dynamically generate CbarAxes.
+* :ghpull:`20405`: ENH: expose make_norm_from_scale
+* :ghpull:`20555`: Fix the way to get xs length in set_3d_properties()
+* :ghpull:`20546`: Improve tutorial figures in the new theme
+* :ghpull:`20676`: Fix bounds when initialising ``SpanSelector``
+* :ghpull:`20678`: Clarify comment about backend_pgf.writeln.
+* :ghpull:`20675`: Shorten the ``@deprecated`` docs.
+* :ghpull:`20585`: Rename parameter selectors
+* :ghpull:`20672`: Remove outdated parts of MatplotlibDeprecationWarning docs.
+* :ghpull:`20671`: Standardize description of kwargs in legend_handler.
+* :ghpull:`20669`: Cleanup related to usage of axs
+* :ghpull:`20664`: Reword docs about fallbacks on headless linux.
+* :ghpull:`20663`: Document $MPLSETUPCFG.
+* :ghpull:`20638`: Small simplifications to FixedAxisArtistHelper.
+* :ghpull:`20626`: Simplify curvilinear grid examples.
+* :ghpull:`20088`: fix some http: -> https: URLs
+* :ghpull:`20654`: Remove some usages of plt.setp()
+* :ghpull:`20615`: Font 42 kerning
+* :ghpull:`20636`: Use set_xticks(ticks, labels) instead of a separate set_xticklabels()
+* :ghpull:`20450`: [Doc] Font Types and Font Subsetting
+* :ghpull:`20582`: Fix twoslopenorm colorbar
+* :ghpull:`20632`: Use ticklabels([]) instead of ticklabels('')
+* :ghpull:`20608`: doc/conf.py: if set, use SOURCE_DATE_EPOCH to set copyright year.
+* :ghpull:`20605`: Add \dddot and \ddddot as accents in mathtext
+* :ghpull:`20621`: TST/DOC: just run circle once...
+* :ghpull:`20498`: Adapt the release guide to the new release notes structure
+* :ghpull:`20601`: Hide some ``_SelectorWidget`` state internals.
+* :ghpull:`20600`: Inline _print_svg into its only call site (print_svg).
+* :ghpull:`20589`: Add directional sizing cursors
+* :ghpull:`20481`: Deprecate Colorbar.patch.
+* :ghpull:`20598`: Don't forget to propagate kwargs from print_svgz to print_svg.
+* :ghpull:`19495`: Move svg basename detection down to RendererSVG.
+* :ghpull:`20501`: Colorbar redo again!
+* :ghpull:`20407`: Turn shared_axes, stale_viewlims into {axis_name: value} dicts.
+* :ghpull:`18966`: PR: Remove modality of figure options
+* :ghpull:`19265`: Change styling of slider widgets
+* :ghpull:`20593`: DOC: fix various typos
+* :ghpull:`20374`: Check modification times of included RST files
+* :ghpull:`20569`: Better signature and docstring for Artist.set
+* :ghpull:`20574`: Add tricontourf hatching example
+* :ghpull:`18666`: Remove unused/deprecated ``AVConv`` classes
+* :ghpull:`20514`: Fix example for rcParams['autolimit_mode']
+* :ghpull:`20571`: Switch default ArrowStyle angle values from None to zero.
+* :ghpull:`20510`: Consistent capitalization of section headers
+* :ghpull:`20573`: Move the marker path example into the marker reference
+* :ghpull:`20572`: Clarify allowable backend switches in matplotlib.use().
+* :ghpull:`20538`: Show box/arrowstyle parameters in reference examples.
+* :ghpull:`20515`: Shorten the implementation of bxp().
+* :ghpull:`20562`: More concise how to for subplot adjustment
+* :ghpull:`20570`: Reduce vertical margins in property tables
+* :ghpull:`20563`: Expire deprecation of passing nbins to MaxNLocator in two ways
+* :ghpull:`20561`: Fix limits in plot types example hist(x)
+* :ghpull:`20559`: Fix deprecation of encoding in plot_directive.
+* :ghpull:`20547`: Raise if passed invalid kwargs to set_constrained_layout_pads.
+* :ghpull:`20527`: Factor out DEBUG_TRUETYPE checks in ttconv, & removals of unused defs.
+* :ghpull:`20465`: Remove remaining 3.3 deprecations
+* :ghpull:`20558`: Rename recently introduced parameters in SpanSelector
+* :ghpull:`20535`: Improve the documentation guide
+* :ghpull:`20113`: Interactive span selector improvement
+* :ghpull:`20524`: Dedupe some box anchoring code between legend.py and offsetbox.py.
+* :ghpull:`20451`: Add initial TextBox widget testing
+* :ghpull:`20543`: Deprecate ``@pytest.mark.style(...)``.
+* :ghpull:`20530`: Plot nothing for incompatible 0 shape in x,y data
+* :ghpull:`20367`: Add parse_math in Text and default it False for TextBox
+* :ghpull:`20509`: Cleanup plot types
+* :ghpull:`20537`: Don't sort boxstyles/arrowstyles/etc. alphabetically.
+* :ghpull:`20542`: Fix ScalarFormatter.format_ticks for non-ordered tick locations.
+* :ghpull:`20533`: Rename (N, M) -> (M, N) array-like
+* :ghpull:`20540`: Deprecate :encoding: option to .. plot::, which has no effect since 2011
+* :ghpull:`20541`: Minor fix
+* :ghpull:`20539`: Document defaults in plot_directive.
+* :ghpull:`20536`: Make most of annotation tutorial a comment, and remove figure titles.
+* :ghpull:`20439`: Remove dead code from LGTM alerts.
+* :ghpull:`20528`: Merge subplot_demo into subplot example.
+* :ghpull:`20493`: Cleanup AnchoredOffsetbox-related demos.
+* :ghpull:`20513`: Shorten the bxp docstring.
+* :ghpull:`20507`: Merge subplot_toolbar example into subplots_adjust.
+* :ghpull:`20505`: Add rc_context to customizing tutorial
+* :ghpull:`20449`: Suppress repeated logwarns in postscript output.
+* :ghpull:`20500`: DOC: Add twitter icon and fix logo link
+* :ghpull:`20499`: Simplify plot types pie()
+* :ghpull:`20495`: Fix shape of Z in contour docs
+* :ghpull:`20497`: Remove obsolete footnote on pyside
+* :ghpull:`20485`: DOC: hexbin 'extent' must be 4-tuple of float, not float
+* :ghpull:`20466`: Various cleanups to pgf backend.
+* :ghpull:`20474`: Make lack of support more explicit for non-postscript fonts + usetex.
+* :ghpull:`20476`: give Font a root widget
+* :ghpull:`20477`: remove _master attribute from FigureCanvasTk
+* :ghpull:`19731`: DOC: first pass at switching to pydata theme
+* :ghpull:`20475`: Less pyplot, more OO in docs.
+* :ghpull:`20467`: Small cleanups to sphinxext.plot_directive.
+* :ghpull:`20437`: Use packaging to do version comparisons.
+* :ghpull:`20354`: Merge Colorbar and ColorbarBase.
+* :ghpull:`20464`: tinypages/conf.py doesn't need to manipulate sys.path.
+* :ghpull:`20420`: Add a select_overload helper for signature-overloaded functions.
+* :ghpull:`20460`: Shorten the AnchoredOffsetbox docstring.
+* :ghpull:`20458`: Set the axes of legend text
+* :ghpull:`20438`: Fix deprecation of ``Tick.apply_tickdir``.
+* :ghpull:`20457`: Rename data variables in histogram example.
+* :ghpull:`20442`: Fix dvi baseline detector when ``\usepackage{chemformula}`` is used.
+* :ghpull:`20454`: Tell LGTM to use Python 3 explicitly.
+* :ghpull:`20446`: Make used tex packages consistent between ps and other backends.
+* :ghpull:`20447`: Remove Figure/Axes/Axis deprecations from 3.3
+* :ghpull:`20414`: ENH: add colorbar info to gridspec cbar
+* :ghpull:`20436`: Add missing super __init__ in subclasses
+* :ghpull:`20284`: Use a GtkApplication in GTK backend.
+* :ghpull:`20400`: Make pdftex.map parsing stricter
+* :ghpull:`20292`: Cleanup plot types docs
+* :ghpull:`20445`: Small cleanups to backend_ps.
+* :ghpull:`20399`: Improve example for 3D polygons
+* :ghpull:`20432`: Small doc cleanups.
+* :ghpull:`20398`: Document Axes.get_aspect()
+* :ghpull:`20428`: Deprecate public use of get_path_in_displaycoord.
+* :ghpull:`20397`: Improve hexbin() documentation
+* :ghpull:`20430`: Improve fancyarrow_demo.
+* :ghpull:`20431`: Fix indentation of Arrow/Box/Connection styles tables.
+* :ghpull:`20427`: Fix references in ArrowStyle docstring.
+* :ghpull:`20346`: Clarify/Improve docs on family-names vs generic-families
+* :ghpull:`20410`: PGF: Clip lines/markers to maximum LaTeX dimensions.
+* :ghpull:`20363`: Don't disable path clipping on paths with codes.
+* :ghpull:`20244`: Inline and simplify SubplotToolQt.
+* :ghpull:`20165`: Slightly improve output of dvi debug utilities, and tiny cleanups.
+* :ghpull:`20390`: Cleanup arrow_demo.
+* :ghpull:`20408`: Remove mention of now-removed Encoding class.
+* :ghpull:`20327`: FIX: fix colorbars with no scales
+* :ghpull:`20215`: Quadmesh.set_array validates dimensions
+* :ghpull:`20293`: Simplify font setting in usetex mode
+* :ghpull:`20386`: Merge arrow_simple_demo into arrow_guide.
+* :ghpull:`20348`: codecs.getwriter has simpler lifetime semantics than TextIOWrapper.
+* :ghpull:`20132`: Create release notes page
+* :ghpull:`20331`: Remove Axis, Tick, and Axes deprecations from 3.3
+* :ghpull:`20373`: Handle direction="column" in axes_grid.Grid
+* :ghpull:`20394`: Remove separate section for support of 3d subplots.
+* :ghpull:`20393`: Remove non-informative figure captions.
+* :ghpull:`17453`: Displaying colorbars with specified boundaries correctly
+* :ghpull:`20369`: Switch version scheme to release-branch-semver.
+* :ghpull:`20377`: Cleanup some examples titles & texts.
+* :ghpull:`20378`: Redirect agg_buffer{,_to_array} examples to canvasagg.
+* :ghpull:`20376`: Small improvements to canvasagg example.
+* :ghpull:`20365`: Reorganize a bit text-related rcs in matplotlibrc.
+* :ghpull:`20362`: Add research notice
+* :ghpull:`20353`: Remove incorrect statement about data-kwarg interface.
+* :ghpull:`20343`: Fix exception handling when constructing C-level PathGenerator.
+* :ghpull:`20349`: Fix missing write in TTStreamWriter::printf.
+* :ghpull:`20347`: Fix possible refleak in PathGenerator.
+* :ghpull:`20339`: Cleanup autoscale-related docstrings.
+* :ghpull:`20338`: Fix some indent-related style lints.
+* :ghpull:`20337`: Small unit-related cleanups.
+* :ghpull:`20168`: FIX: clean up re-limiting hysteresis
+* :ghpull:`20336`: Deduplicate color format specification
+* :ghpull:`20334`: Remove need for ConversionInterface to support unitless values.
+* :ghpull:`20020`: For polar plots, report cursor position with correct precision.
+* :ghpull:`20319`: DOC: Tweaks to module API pages
+* :ghpull:`20332`: Quadmesh's default value of shading is now set to 'flat' instead of False
+* :ghpull:`20333`: Better align param comments in ``Legend.__init__`` signature.
+* :ghpull:`20323`: Adding cla and remove to ColorbarAxes
+* :ghpull:`20320`: Fix remaining E265 exceptions.
+* :ghpull:`20318`: DOC: Fix missing refs in what's new pages
+* :ghpull:`20315`: Fix spelling.
+* :ghpull:`20291`: Write data parameter docs as regular parameter not as note (v2)
+* :ghpull:`19908`: Implement get_cursor_data for QuadMesh.
+* :ghpull:`20314`: MAINT: Removing deprecated colorbar functions.
+* :ghpull:`20310`: Add test for font selection by texmanager.
+* :ghpull:`19348`: Make YearLocator a subclass of RRuleLocator
+* :ghpull:`20208`: Rewrite blocking_input to something much simpler.
+* :ghpull:`19033`: Templatize class factories.
+* :ghpull:`20309`: DOC: Spell out args/kwargs in examples/tutorials
+* :ghpull:`20305`: Merge two axisartist examples and point to standard methods.
+* :ghpull:`20306`: Document legend(handles=handles) signature
+* :ghpull:`20311`: Warn if a non-str is passed to an rcParam requiring a str.
+* :ghpull:`18472`: Adding a get_coordinates() method to Quadmesh collections
+* :ghpull:`20032`: axvline()/axvspan() should not update r limits in polar plots.
+* :ghpull:`20304`: Don't mention dviread in the PsfontsMap "missing entry" error message.
+* :ghpull:`20308`: Remove outdated comment re: pgf/windows.
+* :ghpull:`20302`: Further remove use of meshWidth, meshHeight in QuadMesh.
+* :ghpull:`20101`: Fix ``Text`` class bug when ``font`` argument is provided without ``math_fontfamily``
+* :ghpull:`15436`: Allow imshow from float16 data
+* :ghpull:`20299`: Simplify tfm parsing.
+* :ghpull:`20290`: Support imshow(<float16 array>).
+* :ghpull:`20303`: Remove tilde in code links where not necessary
+* :ghpull:`19873`: Allow changing the vertical axis in 3d plots
+* :ghpull:`19558`: Use luatex in --luaonly mode to query kpsewhich.
+* :ghpull:`20301`: Clarify the effect of PolygonCollection properties on Quiver
+* :ghpull:`20235`: Warn user when mathtext font is used for ticks
+* :ghpull:`20237`: Make QuadMesh arguments with defaults keyword_only
+* :ghpull:`20054`: Enh better colorbar axes
+* :ghpull:`20164`: Auto-generate required kwdoc entries into docstring.interpd.
+* :ghpull:`19677`: Convert axis limit units in Qt plot options widget
+* :ghpull:`14913`: Reimplement NonUniformImage, PcolorImage in Python, not C.
+* :ghpull:`20295`: Replace text._wrap_text by _cm_set().
+* :ghpull:`19859`: Write data parameter docs as regular parameter not as note
+* :ghpull:`20273`: Fix cursor with toolmanager on GTK3.
+* :ghpull:`20288`: Small markup fixes in api docs.
+* :ghpull:`20276`: Tiny fixes to mathtext/usetex tutorials.
+* :ghpull:`20084`: Add legend.labelcolor in rcParams
+* :ghpull:`19253`: Improve font spec for SVG font referencing.
+* :ghpull:`20278`: Deprecate public access to certain texmanager attributes.
+* :ghpull:`19375`: Don't composite path-clipped image; forward suppressComposite as needed.
+* :ghpull:`20190`: Simplify handling of uncomparable formats in tests.
+* :ghpull:`20277`: Fix ordering of tex font usepackages.
+* :ghpull:`20279`: Slightly reword intros of mpl_toolkits API docs.
+* :ghpull:`20272`: De-duplicate fonts in LaTeX preamble.
+* :ghpull:`15604`: Deprecate auto-removal of grid by pcolor/pcolormesh.
+* :ghpull:`20193`: Simplify HostAxes.draw and its interaction with ParasiteAxes.
+* :ghpull:`19441`: Make backend_gtk3foo importable on headless environments.
+* :ghpull:`20126`: Simplify font_manager font enumeration logic.
+* :ghpull:`19869`: Factor out x/y lo/hi handling in errorbar.
+* :ghpull:`20173`: Rename (with deprecation) first parameter of grid() from b to visible.
+* :ghpull:`19499`: Fully fold overset/underset into _genset.
+* :ghpull:`20268`: Api pcolorargs deprecation
+* :ghpull:`20264`: Fix blitting selector
+* :ghpull:`20081`: Limit documenting special members to __call__
+* :ghpull:`20245`: MAINT: Removing deprecated ``offset_position`` from Collection
+* :ghpull:`20218`: Update Axes showcase in "Embedding in Tk" example
+* :ghpull:`20019`: Example: Cursor widget with text
+* :ghpull:`20242`: Add comments and format Axis._get_coord_info
+* :ghpull:`20207`: Move axisartist towards using standard Transforms.
+* :ghpull:`20247`: Explicitly reject black autoformatting.
+* :ghpull:`20217`: ci: Export sphinx-gallery run results to CircleCI.
+* :ghpull:`20238`: Clarify docstring of ScalarMappable.set/get_array()
+* :ghpull:`20239`: Style tables in style guide
+* :ghpull:`19894`: Remove deprecated Qt4 backends
+* :ghpull:`19937`: Add washing machine to Axes3D
+* :ghpull:`20233`: Add a Ubuntu 20.04 / Python 3.9 CI run
+* :ghpull:`20227`: Adding an equals method to colormaps
+* :ghpull:`20216`: Documentation Style Guide for contributors
+* :ghpull:`20222`: Fix C coverage
+* :ghpull:`20221`: DOC: clarify that savefig(..., transparent=False) has no effect
+* :ghpull:`20047`: Add labels parameter to set_ticks()
+* :ghpull:`20118`: Convert FontEntry to a data class
+* :ghpull:`19167`: Add support for HiDPI in TkAgg on Windows
+* :ghpull:`18397`: fix cmr10 negative sign in cmsy10 (RuntimeWarning: Glyph 8722 missing)
+* :ghpull:`20170`: SubplotParams.validate-associated fixes.
+* :ghpull:`19467`: Shorten the implementation of violin().
+* :ghpull:`12226`: FIX: pcolor/pcolormesh honour edgecolors kwarg when facecolors is set 'none'
+* :ghpull:`18870`: Expand ScalarMappable.set_array to accept array-like inputs
+* :ghpull:`20073`: Support SubFigures in AxesDivider.
+* :ghpull:`20209`: Deprecate cbook.report_memory.
+* :ghpull:`20211`: Use check_getitem in legend location resolution.
+* :ghpull:`20206`: Cleanup axisartist in preparation for future changes.
+* :ghpull:`20191`: Small simplifications to FloatingAxesBase.
+* :ghpull:`20189`: Add tests for ginput and waitforbuttonpress.
+* :ghpull:`20199`: Make set_marker{edge,face}color(None) more consistent.
+* :ghpull:`16943`: Changing get_cmap to return copies of the registered colormaps.
+* :ghpull:`19483`: MNT: deprecate epoch2num/num2epoch
+* :ghpull:`20201`: Simplify _process_plot_var_args.set_prop_cycle.
+* :ghpull:`20197`: Speedup Line2D marker color setting.
+* :ghpull:`20194`: Fix markup on MEP22.
+* :ghpull:`20198`: Fix validation of Line2D color.
+* :ghpull:`20046`: Deprecation warning
+* :ghpull:`20144`: More tight_layout cleanups
+* :ghpull:`20105`: Shorten Curve arrowstyle implementations.
+* :ghpull:`19401`: Simplify axisartist line clipping.
+* :ghpull:`19260`: Update round fix
+* :ghpull:`20196`: Replaced links to colormap packages with link to third-party packages list in MPL docs
+* :ghpull:`18819`: Usage guide edit
+* :ghpull:`18346`: Soft-deprecate Axes.plot_date()
+* :ghpull:`20187`: Merge v3.4.x up into master
+* :ghpull:`15333`: Enh: DivergingNorm Fair
+* :ghpull:`20188`: Remove 3.3 deprecations in cbook.
+* :ghpull:`20177`: Fix broken test re: polar tick visibility.
+* :ghpull:`20026`: DOC: move third-party packages to new page
+* :ghpull:`19994`: Don't hide shared "x/y"ticklabels for grids of non-rectilinear axes.
+* :ghpull:`20150`: Rename mosaic layout
+* :ghpull:`19369`: Add Artist._cm_set for temporarily setting an Artist property.
+* :ghpull:`15889`: Add svg logo icon
+* :ghpull:`20140`: DOC: make 2x versions of all gallery figures
+* :ghpull:`20155`: Fix wheel builds on CI
+* :ghpull:`19951`: Convert Qhull wrapper to C++ and array_view
+* :ghpull:`19918`: Cleanup some consistency in contour extensions
+* :ghpull:`20153`: Fix wheel builds on CI
+* :ghpull:`19363`: Create box3d example
+* :ghpull:`20129`: Cleanup some "variable assigned but not used" lints.
+* :ghpull:`20107`: Support full-sharex/y in subplot_mosaic.
+* :ghpull:`20094`: Switch _auto_adjust_subplotpars to take rowspan/colspan as input.
+* :ghpull:`16368`: Improve warning for unsupported scripts.
+* :ghpull:`19660`: Allow PolygonSelector points to be removed
+* :ghpull:`16291`: Split Norm and LinearNorm up
+* :ghpull:`20119`: Cleanup flake8 exceptions for examples
+* :ghpull:`20109`: Fix trailing text in doctest-syntax plot_directive.
+* :ghpull:`19538`: Speedup pdftex.map parsing.
+* :ghpull:`20003`: Bump minimum NumPy to 1.17
+* :ghpull:`20074`: Copy-edit axes_grid tutorial.
+* :ghpull:`20124`: Remove workaround unneeded on Py3.7+, which we require now.
+* :ghpull:`20120`: Cleanup subsetting tool.
+* :ghpull:`20108`: Skip back-and-forth between pixels and points in contour code.
+* :ghpull:`20106`: Shorten bracket arrowstyle docs.
+* :ghpull:`20090`: Cleanup anchored_artists, inset_locator docstrings.
+* :ghpull:`20097`: Use nullcontext more as do-nothing context manager.
+* :ghpull:`20095`: Remove 3.3 ticker deprecations
+* :ghpull:`20064`: Expire deprecation of AxesDivider defaulting to zero pads.
+* :ghpull:`20091`: Cleanup tight_layout.
+* :ghpull:`20069`: Don't make VBoxDivider inherit from HBoxDivider.
+* :ghpull:`20078`: Remove some usages of OrderedDict
+* :ghpull:`20077`: Expire Artist.set() property reordering
+* :ghpull:`20070`: Harmonize descriptions of the 'anchor' parameter.
+* :ghpull:`20011`: Move development dependencies to dependencies page
+* :ghpull:`20072`: Improve labeling in simple_axes_divider1 example.
+* :ghpull:`20063`: Deprecate some untested, never used axes_grid1 methods.
+* :ghpull:`20065`: Deprecate AxesDivider.append_axes(..., add_to_figure=True).
+* :ghpull:`20066`: Cleanup axes_divider docstrings, and detail calculations.
+* :ghpull:`20059`: Include left and right titles for labeling axes in qt axes selector.
+* :ghpull:`20052`: Remove axes_grid/axisartist APIs deprecated in Matplotlib 3.3.
+* :ghpull:`18807`: make FancyArrow animatable
+* :ghpull:`15281`: Don't use ImageGrid in demo_text_rotation_mode.
+* :ghpull:`20051`: Remove offsetbox APIs deprecated in Matplotlib 3.3.
+* :ghpull:`14854`: Improved dev installation documentation
+* :ghpull:`18900`: Enh better colorbar axes
+* :ghpull:`20042`: DOC: fix typos
+* :ghpull:`13860`: Deprecate {Locator,Formatter}.set_{{view,data}_interval,bounds}.
+* :ghpull:`20028`: Shorten the repr of scaling transforms.
+* :ghpull:`20027`: Fix axvspan for drawing slices on polar plots.
+* :ghpull:`20024`: Small fixes to latex-related docs.
+* :ghpull:`20023`: Simplify _redo_transform_rel_fig.
+* :ghpull:`20012`: Fix default theta tick locations for non-full-circle polar plots.
+* :ghpull:`20021`: DOC: fix typos
+* :ghpull:`20013`: Move restriction of polar theta scales to ThetaAxis._set_scale.
+* :ghpull:`20010`: DOC: fix heading level for plot_types/stats
+* :ghpull:`20000`: Remove ax fixture from category tests.
+* :ghpull:`20007`: Correct minor typos in legend.py and autoscale.py
+* :ghpull:`20005`: DOC: Fix numpydoc syntax, and parameters names.
+* :ghpull:`19996`: Small simplification to RadialLocator.
+* :ghpull:`19968`: ENH: draw no output
+* :ghpull:`19657`: Allow Selectors to be dragged from anywhere within their patch
+* :ghpull:`19304`: Add legend title font properties
+* :ghpull:`19977`: Fix doc build
+* :ghpull:`19974`: CI: update the ssh key used to push the devdocs
+* :ghpull:`9888`: Add an Annulus patch class
+* :ghpull:`13680`: Update seaborn style
+* :ghpull:`19967`: ENH: add user-facing no-output draw
+* :ghpull:`19765`: ENH: use canvas renderer in draw
+* :ghpull:`19525`: Don't create page transparency group in pdf output (for pdftex compat).
+* :ghpull:`19952`: avoid implicit np.array -> float conversion
+* :ghpull:`19931`: Remove now unused patches to ttconv.
+* :ghpull:`19934`: Deprecate drawtype to RectangleSelector
+* :ghpull:`19941`: Simplify 3D random walk example
+* :ghpull:`19926`: Move custom scales/custom projections docs to module docstrings.
+* :ghpull:`19898`: Remove 3.3 backend deprecations
+* :ghpull:`19901`: Remove 3.3 rcParam deprecations
+* :ghpull:`19900`: Remove 3.3 text deprecations
+* :ghpull:`19922`: Remove 3.3 deprecated modules
+* :ghpull:`19925`: Include projections.geo in api docs.
+* :ghpull:`19924`: Discourage use of imread & improve its docs.
+* :ghpull:`19866`: Switch to asciiart for boxplot illustration.
+* :ghpull:`19912`: Add symlog to figureoptions scalings
+* :ghpull:`19564`: Micro-optimize type1font loading
+* :ghpull:`19623`: FIX: Contour lines rendered incorrectly when closed loops
+* :ghpull:`19902`: Implement ``ArtistList.__[r]add__``.
+* :ghpull:`19904`: Don't set zoom/pan cursor for non-navigatable axes.
+* :ghpull:`19909`: Use unicode when interactively displaying 3d azim/elev.
+* :ghpull:`19905`: pyplot: do not apply kwargs twice in to x/yticklabels
+* :ghpull:`19126`: Move pixel ratio handling into FigureCanvasBase
+* :ghpull:`19897`: DOC/MNT fix make clean for plot_types
+* :ghpull:`19858`: Move Line2D units handling to Axes & deprecate "units finalize" signal.
+* :ghpull:`19889`: Include length in ArtistList repr.
+* :ghpull:`19887`: Fix E265 in test files.
+* :ghpull:`19882`: Use ax.set() for a more compact notation of styling in plot types docs
+* :ghpull:`17231`: Fix errobar order
+* :ghpull:`19703`: DOC:  new plot gallery
+* :ghpull:`19825`: Factor out machinery for running subprocess tk tests.
+* :ghpull:`19872`: Fix unit handling in errorbar for astropy.
+* :ghpull:`19526`: Apply unit conversion early in errorbar().
+* :ghpull:`19855`: Correct handle default backend.
+* :ghpull:`18216`: Combine Axes.{lines,images,collections,patches,text,tables} into single list
+* :ghpull:`19853`: Consistent corner variables names in widgets.py
+* :ghpull:`19575`: Deprecate Text.get_prop_tup.
+* :ghpull:`19810`: Remove JPEG-specific parameters and rcParams.
+* :ghpull:`19666`: Change dictionary to list of tuples to permit duplicate keys
+* :ghpull:`19400`: Fix tk event coordinates in the presence of scrollbars.
+* :ghpull:`19603`: Remove matplotlibrc.template.
+* :ghpull:`19835`: Merge v3.4.x into master
+* :ghpull:`19821`: Hide stderr output from subprocess call in test suite.
+* :ghpull:`19819`: Correct small typos in _axes.py and legend.py
+* :ghpull:`19795`: Remove usetex-related APIs deprecated in Matplotlib 3.3.
+* :ghpull:`19789`: Fix zorder handling for OffsetBoxes and subclasses.
+* :ghpull:`19796`: Expire ````keymap.all_axes````-related deprecations.
+* :ghpull:`19806`: Remove outdated api changes notes.
+* :ghpull:`19801`: Expire deprecation of mathtext.fallback_to_cm.
+* :ghpull:`12744`: Explicit plotorder
+* :ghpull:`19681`: Merge branch 'v3.4.x' into master
+* :ghpull:`18971`: Switch to setuptools_scm.
+* :ghpull:`19727`: DOC: simplify API index
+* :ghpull:`19760`: Speed up _delete_parameter.
+* :ghpull:`19756`: Minor cleanup of documentation guide
+* :ghpull:`19752`: Cleanup backend_tools docstrings, and minor refactorings.
+* :ghpull:`19552`: Remove scalarmappable private update attributes
+* :ghpull:`19728`: Factor out clip-path attr handling in backend_svg.
+* :ghpull:`19540`: Share subplots() label visibility handling with label_outer().
+* :ghpull:`19753`: Cleanup string formatting in backend_pgf.
+* :ghpull:`19750`: Simplify maxdict implementation.
+* :ghpull:`19749`: Remove unused _find_dedent_regex & _dedent_regex.
+* :ghpull:`19751`: Update some matplotlib.lines docstrings.
+* :ghpull:`13072`: ENH: add figure.legend; outside kwarg for better layout outside subplots
+* :ghpull:`19740`: Minor backend docstring fixes.
+* :ghpull:`19734`: Remove unused _fonts attribute in RendererSVG.
+* :ghpull:`19733`: Reword AutoDateFormatter docs.
+* :ghpull:`19718`: Small style fixes to matplotlibrc.template.
+* :ghpull:`19679`: Add inheritance diagram to patches docs
+* :ghpull:`19717`: Don't sort lexicographially entries in SVG output.
+* :ghpull:`19716`: Fix colon placement in issue template.
+* :ghpull:`19704`: Cleanup license page in docs
+* :ghpull:`19487`: Deprecate unused \*args to print_<foo>.
+* :ghpull:`19654`: Dedupe various method implementations using functools.partialmethod.
+* :ghpull:`19655`: Deprecate Tick.apply_tickdir.
+* :ghpull:`19653`: deprecate_privatize_attribute also works for privatizing methods.
+* :ghpull:`19646`: Add angle setter/getter to Rectangle
+* :ghpull:`19659`: Improve docs for rgba conversion
+* :ghpull:`19641`: Fix Bbox.frozen() not copying minposx/minposy
+* :ghpull:`19626`: Clean up E265 in examples.
+* :ghpull:`19622`: Prefer Axes.remove() over Figure.delaxes() in docs.
+* :ghpull:`19621`: Dedupe docstrings of Figure.{get_axes,axes}.
+* :ghpull:`19600`: DOC: better intro for dates.py
+* :ghpull:`19606`: Remove versionadded notes; correct doc link
+* :ghpull:`19620`: Remove suggestion to remove rk4/rk45 integrators from streamplot.
+* :ghpull:`19586`: DOC: more improve date example
+* :ghpull:`19566`: add docstring to ax.quiver
+* :ghpull:`19601`: Handle None entries in sys.modules.
+* :ghpull:`19517`: Deprecate toplevel is_url, URL_REGEX helpers.
+* :ghpull:`19570`: Dedupe part of error message in check_in_list.
+* :ghpull:`14508`: Add force_zorder parameter
+* :ghpull:`19585`: Deprecate trivial helpers in style.core.
+* :ghpull:`19534`: BUG: fill_between with interpolate=True and NaN.
+* :ghpull:`18887`: FIX: Generalize Colorbar Scale Handling
+* :ghpull:`16788`: Adding png image return for inline backend figures with _repr_html_
 
-Issues (22):
+Issues (187):
 
-* :ghissue:`20219`: Regression: undocumented change of behaviour in mpl 3.4.2 with axis ticks direction
-* :ghissue:`20721`: ax.clear() adds extra ticks, un-hides shared-axis tick labels
-* :ghissue:`20765`: savefig re-scales xticks and labels of some (but not all) subplots
-* :ghissue:`20782`: [Bug]: _supylabel get_in_layout() typo?
-* :ghissue:`20747`: [Bug]: _copy_css_file assumes that the _static directory already exists
-* :ghissue:`20617`: tests fail with new inkscape
-* :ghissue:`20519`: Toolbar zoom doesn't change autoscale status for versions 3.2.0 and above
-* :ghissue:`20628`: Out-of-bounds read leads to crash or broken TrueType fonts
-* :ghissue:`20612`: Broken EPS for Type 42 STIX
-* :ghissue:`19982`: regression for 3.4.x - ax.figbox replacement incompatible to all version including 3.3.4
-* :ghissue:`19938`: unuseful deprecation warning figbox
-* :ghissue:`16400`: Inconsistent behavior between Normalizers when input is Dataframe
-* :ghissue:`20583`: Lost class descriptions since 3.4 docs
-* :ghissue:`20551`: set_segments(get_segments()) makes lines coarse
-* :ghissue:`20560`: test_png is failing
-* :ghissue:`20487`: test_huge_range_log is failing...
-* :ghissue:`20472`: test_backend_pgf.py::test_xelatex[pdf] - ValueError: invalid literal for int() with base 10: b'ate missing from Resources. [...]
-* :ghissue:`20328`: Path.intersects_path sometimes returns incorrect values
-* :ghissue:`20258`: Using edgecolors='face' with stackplot causes value error when using plt.legend()
-* :ghissue:`20200`: examples/widgets/span_selector.py is brittle
-* :ghissue:`20231`: MultiCursor bug
-* :ghissue:`19836`: Month names not set as text when using usetex
+* :ghissue:`21518`: [Bug]: Datetime axis with usetex is unclear
+* :ghissue:`21509`: [Bug]: Text sometimes is missing when figure saved to EPS
+* :ghissue:`21569`: [Bug]: AttributeError: 'NoneType' object has no attribute 'dpi' after drawing and removing contours inside artist
+* :ghissue:`21612`: [Bug]: Security.md out of date
+* :ghissue:`21608`: [Doc]: ``ax.voxels`` links to wrong method.
+* :ghissue:`21528`: [Doc]: Outdated QT_API docs
+* :ghissue:`21517`: [Bug]: this example shows ok on matplotlib-3.4.3, but not in matplotlib-3.5.0 master of october 30th
+* :ghissue:`21548`: [Bug]: blocking_input
+* :ghissue:`21552`: [Bug]: eventplot cannot handle multiple datetime-based series
+* :ghissue:`21441`: [Bug]: axes(position = [...]) behavior
+* :ghissue:`10346`: Passing clim as keyword argument to pcolormesh does not change limits.
+* :ghissue:`21480`: [Bug]: Subfigure breaks for some ``Gridspec`` slices when using ``constrained_layout``
+* :ghissue:`20989`: [Bug]: regression with setting ticklabels for colorbars in matplotlib 3.5.0b1
+* :ghissue:`21474`: [Doc]: Suggestion to use PIL.image.open is not a 1:1 replacement for imread
+* :ghissue:`19634`: Multicursor docstring missing a Parameters Section
+* :ghissue:`20847`: [Bug]: Contourf not filling contours.
+* :ghissue:`21300`: [Bug]: zooming in on contour plot gives false extra contour lines
+* :ghissue:`21466`: [Bug]: EPS export shows hidden tick labels when using tex for text rendering
+* :ghissue:`21463`: [Bug]: Plotting lables with Greek latters in math mode produces Parsing error when plt.show() runs
+* :ghissue:`20534`: Document formatting for for sections
+* :ghissue:`21246`: [Doc]: Install info takes up too much room on new front page
+* :ghissue:`21432`: [Doc]: Double clicking parameter name also highlights next item of text
+* :ghissue:`21310`: [Bug]: contour on 3d plot fails if x and y are 1d and different lengths
+* :ghissue:`18213`: Figure out why test_interactive_backend fails on Travis macOS
+* :ghissue:`21090`: [MNT]: Should set_size_inches be updated to use device_pixel_ratio?
+* :ghissue:`13948`: Allow colorbar.ax.set_ylim to set the colorbar limits?
+* :ghissue:`21314`: Inconsistensy in ``pyplot.pcolormesh`` docstring regarding default value for ``shading``
+* :ghissue:`21320`: [Doc]: Incorrect image caption in imshow() example
+* :ghissue:`21311`: [Doc]: dead link for agg
+* :ghissue:`20929`: [Bug]: PyPy Win64 wheels use incorrect version
+* :ghissue:`21202`: [Bug]: python3.7/site-packages/matplotlib/ft2font.so: Undefined symbol "FT_Done_Glyph"
+* :ghissue:`20932`: Qt Ctrl-C broken on windows
+* :ghissue:`21230`: [Doc]: [source] links is devdocs are broken
+* :ghissue:`20906`: 3.5.0b1: ax.contour generates different artists
+* :ghissue:`21161`: [Doc]: In new docs, "Usage guide" entry in the top menu does not link to the "Usage guide"
+* :ghissue:`21016`: [Bug] Error: 'PathCollection' object has no attribute 'do_3d_projection' when doing contourf in 3d with extend = 'both'
+* :ghissue:`21135`: [Doc]: Data parameter description is not always replaced
+* :ghissue:`4132`: Support clim kwarg in pcolor-type plots
+* :ghissue:`21110`: Qt swapping ctrl and cmd on OSX
+* :ghissue:`20912`: [ENH]: data kwarg support for mplot3d
+* :ghissue:`15005`: Cleanup API for setting ticks
+* :ghissue:`21095`: [ENH]: A data-type check is missed in cm.ScalarMappable.set_array()
+* :ghissue:`7711`: Colorbar: changing the norm does not update the Formatter
+* :ghissue:`18925`: Removing axes created by twiny() leads to an error
+* :ghissue:`21057`: [Bug]: distutils deprecation
+* :ghissue:`21024`: [ENH]: Cairo backends do not fully support HiDPI
+* :ghissue:`20811`: Python 3.10 manylinux wheels
+* :ghissue:`11509`: On making the rc-validators function know the rcParam affected instance
+* :ghissue:`20516`: Sketch params ignored when using PGF backend
+* :ghissue:`20963`: [Bug]: broken 'proportional' colorbar when using contourf+cmap+norm+extend
+* :ghissue:`13974`: [DOC] Undocumented behavior in streamplot
+* :ghissue:`16251`: API changes are too hard to find in the rendered docs
+* :ghissue:`20770`: [Doc]: How to replicate behaviour of ``plt.gca(projection=...)``?
+* :ghissue:`17052`: Colorbar update error with clim change in multi_image.py example
+* :ghissue:`4387`: make ``Normalize`` objects notifiy scalar-mappables on changes
+* :ghissue:`20001`: rename fig.draw_no_output
+* :ghissue:`20936`: [Bug]: edgecolor 'auto' doesn't work properly
+* :ghissue:`20909`: [Bug]: Animation error message
+* :ghissue:`6864`: Add release dates to what's new page
+* :ghissue:`20905`: [Bug]: error plotting z-axis array with np.nan -- does not plot with cmap option (surface plot)
+* :ghissue:`20618`: BUG: Lost functionality of interactive selector update
+* :ghissue:`20791`: [Bug]: spines and ticklabels
+* :ghissue:`20723`: Adding a legend to a ``SubFigure`` doesn't work
+* :ghissue:`20637`: PyPy wheels are pinned to v3.3, so pypy-based wheels for latest versions are not available
+* :ghissue:`19160`: pypy failures
+* :ghissue:`20385`: Add ']->' , '<-[' arrowstyles
+* :ghissue:`19016`: Move away from set_ticklabels()
+* :ghissue:`20800`: [Bug]: Setting backend in custom style sheet raises UserWarning
+* :ghissue:`20809`: [Bug]: \Cap and \Cup in mathtext are inconsistent
+* :ghissue:`20762`: [Doc]: Add external resources to devdoc landing page
+* :ghissue:`18490`: Add a method to access the list of registered colormaps
+* :ghissue:`20666`: Interactive SpanSelector no longer notifies when the selector is removed by an "empty" click
+* :ghissue:`20552`: Expose legend's line: ``legline._legmarker`` as public
+* :ghissue:`18391`: Bug? Legend Picking Not Working on Marker
+* :ghissue:`11357`: Unable to retrieve marker from legend handle
+* :ghissue:`2035`: legend marker update bug
+* :ghissue:`19748`: Incorrect & inconsistent coloring in .imshow() with LogNorm
+* :ghissue:`18735`: imshow padding around NaN values
+* :ghissue:`7928`: [Bug] backend_bases.key_press_handler sneakily uses digit keys
+* :ghissue:`20802`: Add ability to disable callbacks temporarily
+* :ghissue:`16470`: Inconsistent Corner Masking w/ plot_surface
+* :ghissue:`12395`: Rendering issue occurs when plotting 3D surfaces at a discontinuity
+* :ghissue:`8222`: matplotlib 3D surface - gaps / holes in surface
+* :ghissue:`4941`: Axes3d plot_surface not supporting masked arrays?
+* :ghissue:`487`: Plotting masked arrays with plot_surface()
+* :ghissue:`20794`: [Doc]: "Bachelor's degrees by gender" example is more or less dufte
+* :ghissue:`20557`: Have ``[Source]`` in api docs link to github
+* :ghissue:`20754`: [Doc]: legend guide should be OO
+* :ghissue:`17770`: animation.save and fig.savefig interfere with each other and raise StopIteration
+* :ghissue:`20785`: [Bug]: Colorbar creation from pcolormesh with cell specific alpha values
+* :ghissue:`19843`: collection with alpha + colorer
+* :ghissue:`20698`: collections.Collections offset improvements
+* :ghissue:`17774`: Cannot make Latex plots when Pandas dataframe has underscore in variable name
+* :ghissue:`19884`: Better document Axes.set()
+* :ghissue:`20760`: [Bug]: subfigure position shifts on y-axis when x kwarg added to supxlabel
+* :ghissue:`20296`: colorbar set_ticklabels - text properties not working
+* :ghissue:`18191`: PostScript Type42 embedding is broken in various ways
+* :ghissue:`11303`: Using fonttype 42 will make the produced PDF size considerably larger when the image has Chinese characters
+* :ghissue:`20735`: The top level of the docs needs modification
+* :ghissue:`20684`: make_keyword_only doesn't work for pyplot-wrapped methods
+* :ghissue:`20635`: DOC: Document patch deprecation
+* :ghissue:`17473`: Issue with appearance of RectangleSelector
+* :ghissue:`20616`: Type 42 chars beyond BMP not displayed in PDF
+* :ghissue:`20658`: MAINT: CircleCI build merged PRs
+* :ghissue:`18312`: Add easily comparable version info to toplevel
+* :ghissue:`20665`: interactive SpanSelector incorrectly forces axes limits to include 0
+* :ghissue:`20614`: Missing kerning in PDFs with Type 42 font
+* :ghissue:`20640`: Column direction breaks label mode L for AxesGrid.
+* :ghissue:`20581`: Change in custom norm colour map display
+* :ghissue:`20595`: Triple and quadruple dot Mathtext accents don't stack or align.
+* :ghissue:`19755`: Avoid showing a black background before the plot is ready with Qt5agg backend
+* :ghissue:`10235`: Why not get the same clear image on a high-resolution screen?
+* :ghissue:`20479`: ColorbarAxes is an imperfect proxy for the Axes passed to Colorbar
+* :ghissue:`18965`: Figure options with qt backend breaks
+* :ghissue:`19256`: New Styling for Sliders
+* :ghissue:`14148`: zorder ignored in mplot3d
+* :ghissue:`20523`: plot_directive is confused by include directives, part 2 (context option)
+* :ghissue:`17860`: Plot directive may be confused by ``..include::``
+* :ghissue:`19431`: Tricontour documentation and examples should be updated in line with contour
+* :ghissue:`20508`: rcParams['axes.autolimit_mode'] = 'round_numbers' is broken
+* :ghissue:`20289`: Simplify font setting in usetex mode
+* :ghissue:`20370`: Test Coverage for TextBox
+* :ghissue:`20522`: Improve 'Writing ReST Pages' section on docs
+* :ghissue:`19259`: Set legend title font properties
+* :ghissue:`20049`: add legend.labelcolor "argument" to mplstyle stylesheet
+* :ghissue:`20452`: Wrong/not useful error message when plotting incompatible x and y
+* :ghissue:`20266`: "$$" can not be displayed by ax.text()
+* :ghissue:`20517`: Wrong shape of Z in documentation of contour
+* :ghissue:`19423`: Switch to pydata-sphinx-theme
+* :ghissue:`20435`: Legend Text's ``axes`` attribute is ``None``
+* :ghissue:`20379`: Change name of variables in histogram example
+* :ghissue:`20440`: Wrong text vertical position with LaTeX enabled
+* :ghissue:`10042`: Inconsistent use of graphicx and color packages in LaTeX preambles
+* :ghissue:`4482`: PGF Backend: "Dimension too large" error while processing log-scale plot
+* :ghissue:`20324`: New colorbar doesn't handle norms without a scale properly...
+* :ghissue:`17508`: Quadmesh.set_array should validate dimensions
+* :ghissue:`20372`: Incorrect axes positioning in axes_grid.Grid with direction='column'
+* :ghissue:`19419`: Dev version hard to check
+* :ghissue:`17310`: Matplotlib git master version fails to pass serveral pytest's tests.
+* :ghissue:`7742`: plot_date() after axhline() doesn't rescale axes
+* :ghissue:`20322`: QuadMesh default for shading inadvertently changed.
+* :ghissue:`9653`: SVG savefig + LaTeX extremely slow on macOS
+* :ghissue:`20099`: ``fontset`` from ``mathtext`` throwing error after setting Text ``font=``
+* :ghissue:`18399`: How to get Quadmesh coordinates
+* :ghissue:`15432`: Add support in matplotlib.pyplot.imshow for float16
+* :ghissue:`20298`: plt.quiver linestyle option doesn't work?.....
+* :ghissue:`19075`: Qt backend's Figure options to support axis units
+* :ghissue:`15039`: NonUniformImage wrong image when using large values for axis
+* :ghissue:`18499`: Saving as a pdf ignores ``set_clip_path`` when there is more than one of them.
+* :ghissue:`15600`: Grid disappear after pcolormesh apply
+* :ghissue:`20080`: API docs currently include entries for class ``__dict__``, ``__module__``, ``__weakref__``
+* :ghissue:`20159`: Zoom in NavigationToolbar2Tk stops working after updating the canvas figure.
+* :ghissue:`17007`: Computer Modern Glyph Error
+* :ghissue:`19494`: Update azure ubuntu images to 18.04, or update texlive in CI
+* :ghissue:`18841`: ScalarMappable should copy its input and allow non-arrays
+* :ghissue:`20121`: Adding cmocean and CMasher to the colormaps tutorial
+* :ghissue:`18154`: Deprecate plot_date()
+* :ghissue:`7413`: Autoscaling has fundamental problems
+* :ghissue:`19627`: Replace use of Python/C API with numpy::array_view in _tri.cpp and qhull_wrap.c
+* :ghissue:`19111`: plot_directive errantly tries to run code
+* :ghissue:`11007`: BUG: Plot directive fails if its content ends with a normal text line (sphinxext)
+* :ghissue:`19929`: Selecting axes when customizing gives <anonymous AxesSubplot>
+* :ghissue:`19578`: bisect very hard with rcParam changes
+* :ghissue:`19506`: Allow saving PDF files without a page group
+* :ghissue:`19906`: symlog is not in scale setting
+* :ghissue:`19568`: Contour lines are rendered incorrectly when closed loops
+* :ghissue:`19890`: Should ArtistList implement ``__add__``?
+* :ghissue:`14405`: ENH: Add HiDPI physical to logical pixel ratio property
+* :ghissue:`17139`: errorbar doesn't follow plot order
+* :ghissue:`18277`: Create new sphinx gallery page for "Chart Types"
+* :ghissue:`15446`: the python script in Catalina dock icon display wrong
+* :ghissue:`19848`: ValueError: Key backend: '' is not a valid value for backend
+* :ghissue:`1622`: zorder is not respected by all parts of ``errorbar``
+* :ghissue:`17247`: Move towards making Axes.lines, Axes.patches, ... read-only views of a single child list.
+* :ghissue:`19842`: UserWarning: "Trying to register the cmap '...' which already exists" is not very helpful.
+* :ghissue:`7962`: pip interprets Matplotlib dev version as stable
+* :ghissue:`19607`: Curves with same label not appearing in Figure options (only the last one)
+* :ghissue:`17584`: NavigationToolbar2Tk behave unexpected when using it in with Tkinter Canvas
+* :ghissue:`19838`: Unexpected behaviour of imshow default interpolation
+* :ghissue:`7650`: anchored_artists don't support zorder argument
+* :ghissue:`19687`: License doc cleanup
+* :ghissue:`19635`: Multicursor updates to events for any axis
+* :ghissue:`17967`: Document how to use mathtext to obtain unicode minus instead of dashes for negative numbers
+* :ghissue:`8519`: Closed figures linger in memory
+* :ghissue:`14175`: RFC: Allow users to force zorder in 3D plots
+* :ghissue:`19464`: Quiver docs don't have a return section
+* :ghissue:`18986`: fill_between issue with interpolation & NaN
 
 
-Previous GitHub Stats
----------------------
+Previous GitHub statistics
+--------------------------
 
 
 .. toctree::

--- a/doc/users/prev_whats_new/github_stats_3.4.3.rst
+++ b/doc/users/prev_whats_new/github_stats_3.4.3.rst
@@ -1,0 +1,133 @@
+.. _github-stats-3-4-3:
+
+GitHub statistics for Matpltlib 3.4.3
+=====================================
+
+GitHub statistics for 2021/05/08 - 2021/08/12 (tag: v3.4.2)
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+We closed 22 issues and merged 69 pull requests.
+The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/64?closed=1>`__
+
+The following 20 authors contributed 95 commits.
+
+* Antony Lee
+* David Stansby
+* Diego
+* Diego Leal Petrola
+* Diego Petrola
+* Elliott Sales de Andrade
+* Eric Firing
+* Frank Sauerburger
+* Greg Lucas
+* Ian Hunt-Isaak
+* Jash Shah
+* Jody Klymak
+* Jouni K. Seppänen
+* Michał Górny
+* sandipanpanda
+* Slava Ostroukh
+* Thomas A Caswell
+* Tim Hoffmann
+* Viacheslav Ostroukh
+* Xianxiang Li
+
+GitHub issues and pull requests:
+
+Pull Requests (69):
+
+* :ghpull:`20830`: Backport PR #20826 on branch v3.4.x (Fix clear of Axes that are shared.)
+* :ghpull:`20826`: Fix clear of Axes that are shared.
+* :ghpull:`20823`: Backport PR #20817 on branch v3.4.x (Make test_change_epoch more robust.)
+* :ghpull:`20817`: Make test_change_epoch more robust.
+* :ghpull:`20820`: Backport PR #20771 on branch v3.4.x (FIX: tickspacing for subfigures)
+* :ghpull:`20771`: FIX: tickspacing for subfigures
+* :ghpull:`20777`: FIX: dpi and scatter for subfigures now correct
+* :ghpull:`20787`: Backport PR #20786 on branch v3.4.x (Fixed typo in _constrained_layout.py (#20782))
+* :ghpull:`20786`: Fixed typo in _constrained_layout.py (#20782)
+* :ghpull:`20763`: Backport PR #20761 on branch v3.4.x (Fix suplabel autopos)
+* :ghpull:`20761`: Fix suplabel autopos
+* :ghpull:`20751`: Backport PR #20748 on branch v3.4.x (Ensure _static directory exists before copying CSS.)
+* :ghpull:`20748`: Ensure _static directory exists before copying CSS.
+* :ghpull:`20713`: Backport PR #20710 on branch v3.4.x (Fix tests with Inkscape 1.1.)
+* :ghpull:`20687`: Enable PyPy wheels for v3.4.x
+* :ghpull:`20710`: Fix tests with Inkscape 1.1.
+* :ghpull:`20696`: Backport PR #20662 on branch v3.4.x (Don't forget to disable autoscaling after interactive zoom.)
+* :ghpull:`20662`: Don't forget to disable autoscaling after interactive zoom.
+* :ghpull:`20683`: Backport PR #20645 on branch v3.4.x (Fix leak if affine_transform is passed invalid vertices.)
+* :ghpull:`20645`: Fix leak if affine_transform is passed invalid vertices.
+* :ghpull:`20642`: Backport PR #20629 on branch v3.4.x (Add protection against out-of-bounds read in ttconv)
+* :ghpull:`20643`: Backport PR #20597 on branch v3.4.x
+* :ghpull:`20629`: Add protection against out-of-bounds read in ttconv
+* :ghpull:`20597`: Fix TTF headers for type 42 stix font
+* :ghpull:`20624`: Backport PR #20609 on branch v3.4.x (FIX: fix figbox deprecation)
+* :ghpull:`20609`: FIX: fix figbox deprecation
+* :ghpull:`20594`: Backport PR #20590 on branch v3.4.x (Fix class docstrings for Norms created from Scales.)
+* :ghpull:`20590`: Fix class docstrings for Norms created from Scales.
+* :ghpull:`20587`: Backport PR #20584: FIX: do not simplify path in LineCollection.get_s…
+* :ghpull:`20584`: FIX: do not simplify path in LineCollection.get_segments
+* :ghpull:`20578`: Backport PR #20511 on branch v3.4.x (Fix calls to np.ma.masked_where)
+* :ghpull:`20511`: Fix calls to np.ma.masked_where
+* :ghpull:`20568`: Backport PR #20565 on branch v3.4.x (FIX: PILLOW asarray bug)
+* :ghpull:`20566`: Backout pillow=8.3.0 due to a crash
+* :ghpull:`20565`: FIX: PILLOW asarray bug
+* :ghpull:`20503`: Backport PR #20488 on branch v3.4.x (FIX: Include 0 when checking lognorm vmin)
+* :ghpull:`20488`: FIX: Include 0 when checking lognorm vmin
+* :ghpull:`20483`: Backport PR #20480 on branch v3.4.x (Fix str of empty polygon.)
+* :ghpull:`20480`: Fix str of empty polygon.
+* :ghpull:`20478`: Backport PR #20473 on branch v3.4.x (_GSConverter: handle stray 'GS' in output gracefully)
+* :ghpull:`20473`: _GSConverter: handle stray 'GS' in output gracefully
+* :ghpull:`20456`: Backport PR #20453 on branch v3.4.x (Remove ``Tick.apply_tickdir`` from 3.4 deprecations.)
+* :ghpull:`20441`: Backport PR #20416 on branch v3.4.x (Fix missing Patch3DCollection._z_markers_idx)
+* :ghpull:`20416`: Fix missing Patch3DCollection._z_markers_idx
+* :ghpull:`20417`: Backport PR #20395 on branch v3.4.x (Pathing issue)
+* :ghpull:`20395`: Pathing issue
+* :ghpull:`20404`: Backport PR #20403: FIX: if we have already subclassed mixin class ju…
+* :ghpull:`20403`: FIX: if we have already subclassed mixin class just return
+* :ghpull:`20383`: Backport PR #20381 on branch v3.4.x (Prevent corrections and completions in search field)
+* :ghpull:`20307`: Backport PR #20154 on branch v3.4.x (ci: Bump Ubuntu to 18.04 LTS.)
+* :ghpull:`20285`: Backport PR #20275 on branch v3.4.x (Fix some examples that are skipped in docs build)
+* :ghpull:`20275`: Fix some examples that are skipped in docs build
+* :ghpull:`20267`: Backport PR #20265 on branch v3.4.x (Legend edgecolor face)
+* :ghpull:`20265`: Legend edgecolor face
+* :ghpull:`20260`: Fix legend edgecolor face
+* :ghpull:`20259`: Backport PR #20248 on branch v3.4.x (Replace pgf image-streaming warning by error.)
+* :ghpull:`20248`: Replace pgf image-streaming warning by error.
+* :ghpull:`20241`: Backport PR #20212 on branch v3.4.x (Update span_selector.py)
+* :ghpull:`20212`: Update span_selector.py
+* :ghpull:`19980`: Tidy up deprecation messages in ``_subplots.py``
+* :ghpull:`20234`: Backport PR #20225 on branch v3.4.x (FIX: correctly handle ax.legend(..., legendcolor='none'))
+* :ghpull:`20225`: FIX: correctly handle ax.legend(..., legendcolor='none')
+* :ghpull:`20232`: Backport PR #19636 on branch v3.4.x (Correctly check inaxes for multicursor)
+* :ghpull:`20228`: Backport PR #19849 on branch v3.4.x (FIX DateFormatter for month names when usetex=True)
+* :ghpull:`19849`: FIX DateFormatter for month names when usetex=True
+* :ghpull:`20154`: ci: Bump Ubuntu to 18.04 LTS.
+* :ghpull:`20186`: Backport PR #19975 on branch v3.4.x (CI: remove workflow to push commits to macpython/matplotlib-wheels)
+* :ghpull:`19975`: CI: remove workflow to push commits to macpython/matplotlib-wheels
+* :ghpull:`19636`: Correctly check inaxes for multicursor
+
+Issues (22):
+
+* :ghissue:`20219`: Regression: undocumented change of behaviour in mpl 3.4.2 with axis ticks direction
+* :ghissue:`20721`: ax.clear() adds extra ticks, un-hides shared-axis tick labels
+* :ghissue:`20765`: savefig re-scales xticks and labels of some (but not all) subplots
+* :ghissue:`20782`: [Bug]: _supylabel get_in_layout() typo?
+* :ghissue:`20747`: [Bug]: _copy_css_file assumes that the _static directory already exists
+* :ghissue:`20617`: tests fail with new inkscape
+* :ghissue:`20519`: Toolbar zoom doesn't change autoscale status for versions 3.2.0 and above
+* :ghissue:`20628`: Out-of-bounds read leads to crash or broken TrueType fonts
+* :ghissue:`20612`: Broken EPS for Type 42 STIX
+* :ghissue:`19982`: regression for 3.4.x - ax.figbox replacement incompatible to all version including 3.3.4
+* :ghissue:`19938`: unuseful deprecation warning figbox
+* :ghissue:`16400`: Inconsistent behavior between Normalizers when input is Dataframe
+* :ghissue:`20583`: Lost class descriptions since 3.4 docs
+* :ghissue:`20551`: set_segments(get_segments()) makes lines coarse
+* :ghissue:`20560`: test_png is failing
+* :ghissue:`20487`: test_huge_range_log is failing...
+* :ghissue:`20472`: test_backend_pgf.py::test_xelatex[pdf] - ValueError: invalid literal for int() with base 10: b'ate missing from Resources. [...]
+* :ghissue:`20328`: Path.intersects_path sometimes returns incorrect values
+* :ghissue:`20258`: Using edgecolors='face' with stackplot causes value error when using plt.legend()
+* :ghissue:`20200`: examples/widgets/span_selector.py is brittle
+* :ghissue:`20231`: MultiCursor bug
+* :ghissue:`19836`: Month names not set as text when using usetex

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -16,6 +16,7 @@ Version 3.5
 
     prev_whats_new/whats_new_3.5.0.rst
     ../api/prev_api_changes/api_changes_3.5.0.rst
+    github_stats.rst
 
 Version 3.4
 ===========

--- a/doc/users/release_notes_next.rst
+++ b/doc/users/release_notes_next.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 Next version
 ============
 .. toctree::

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -13,7 +13,7 @@ import unicodedata
 
 import numpy as np
 from pyparsing import (
-    Combine, Empty, FollowedBy, Forward, Group, Literal, oneOf, OneOrMore,
+    Combine, Empty, Forward, Group, Literal, oneOf, OneOrMore,
     Optional, ParseBaseException, ParseFatalException, ParserElement,
     ParseResults, QuotedString, Regex, StringEnd, Suppress, White, ZeroOrMore)
 
@@ -2046,7 +2046,7 @@ class Parser:
         p.accentprefixed <<= Suppress(p.bslash) + oneOf(self._accentprefixed)
         p.symbol_name   <<= (
             Combine(p.bslash + oneOf(list(tex2uni)))
-            + FollowedBy(Regex("[^A-Za-z]").leaveWhitespace() | StringEnd())
+            + Suppress(Regex("(?=[^A-Za-z]|$)").leaveWhitespace())
         )
         p.symbol        <<= (p.single_symbol | p.symbol_name).leaveWhitespace()
 

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -250,7 +250,9 @@ def test_fontinfo():
         (r'$\leftF$', r'Expected a delimiter'),
         (r'$\rightF$', r'Unknown symbol: \rightF'),
         (r'$\left(\right$', r'Expected a delimiter'),
-        (r'$\left($', r'Expected "\right"'),
+        # PyParsing 2 uses double quotes, PyParsing 3 uses single quotes and an
+        # extra backslash.
+        (r'$\left($', re.compile(r'Expected ("|\'\\)\\right["\']')),
         (r'$\dfrac$', r'Expected \dfrac{num}{den}'),
         (r'$\dfrac{}{}$', r'Expected \dfrac{num}{den}'),
         (r'$\overset$', r'Expected \overset{body}{annotation}'),
@@ -281,8 +283,8 @@ def test_fontinfo():
 )
 def test_mathtext_exceptions(math, msg):
     parser = mathtext.MathTextParser('agg')
-
-    with pytest.raises(ValueError, match=re.escape(msg)):
+    match = re.escape(msg) if isinstance(msg, str) else msg
+    with pytest.raises(ValueError, match=match):
         parser.parse(math)
 
 

--- a/setupext.py
+++ b/setupext.py
@@ -591,7 +591,9 @@ class FreeType(SetupPackage):
                 (f'https://downloads.sourceforge.net/project/freetype'
                  f'/freetype2/{LOCAL_FREETYPE_VERSION}/{tarball}'),
                 (f'https://download.savannah.gnu.org/releases/freetype'
-                 f'/{tarball}')
+                 f'/{tarball}'),
+                (f'https://download.savannah.gnu.org/releases/freetype'
+                 f'/freetype-old/{tarball}')
             ],
             sha=LOCAL_FREETYPE_HASH,
             dirname=f'freetype-{LOCAL_FREETYPE_VERSION}',


### PR DESCRIPTION
## PR Summary

Also reverts #21550, which was not intended for 3.6.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).