### PR TITLE
Fix boundary norm negative

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1149,16 +1149,21 @@ class Colorbar:
             return (Y, X, extendlen)
 
     def _forward_boundaries(self, x):
+        # map boundaries equally between 0 and 1...
         b = self._boundaries
-        y = np.interp(x, b, np.linspace(0, b[-1], len(b)))
+        y = np.interp(x, b, np.linspace(0, 1, len(b)))
+        # the following avoids ticks in the extends:
         eps = (b[-1] - b[0]) * 1e-6
+        # map these _well_ out of bounds to keep any ticks out
+        # of the extends region...
         y[x < b[0]-eps] = -1
         y[x > b[-1]+eps] = 2
         return y
 
     def _inverse_boundaries(self, x):
+        # invert the above...
         b = self._boundaries
-        return np.interp(x, np.linspace(0, b[-1], len(b)), b)
+        return np.interp(x, np.linspace(0, 1, len(b)), b)
 
     def _reset_locator_formatter_scale(self):
         """

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -873,3 +873,32 @@ def test_proportional_colorbars():
             CS3 = axs[i, j].contourf(X, Y, Z, levels, cmap=cmap, norm=norm,
                                      extend=extends[i])
             fig.colorbar(CS3, spacing=spacings[j], ax=axs[i, j])
+
+
+def test_negative_boundarynorm():
+    fig, ax = plt.subplots(figsize=(1, 3))
+    cmap = plt.get_cmap("viridis")
+
+    clevs = np.arange(-94, -85)
+    norm = BoundaryNorm(clevs, cmap.N)
+    cb = fig.colorbar(cm.ScalarMappable(cmap=cmap, norm=norm), cax=ax)
+    np.testing.assert_allclose(cb.ax.get_ylim(), [clevs[0], clevs[-1]])
+    np.testing.assert_allclose(cb.ax.get_yticks(), clevs)
+
+    clevs = np.arange(85, 94)
+    norm = BoundaryNorm(clevs, cmap.N)
+    cb = fig.colorbar(cm.ScalarMappable(cmap=cmap, norm=norm), cax=ax)
+    np.testing.assert_allclose(cb.ax.get_ylim(), [clevs[0], clevs[-1]])
+    np.testing.assert_allclose(cb.ax.get_yticks(), clevs)
+
+    clevs = np.arange(-3, 3)
+    norm = BoundaryNorm(clevs, cmap.N)
+    cb = fig.colorbar(cm.ScalarMappable(cmap=cmap, norm=norm), cax=ax)
+    np.testing.assert_allclose(cb.ax.get_ylim(), [clevs[0], clevs[-1]])
+    np.testing.assert_allclose(cb.ax.get_yticks(), clevs)
+
+    clevs = np.arange(-8, 1)
+    norm = BoundaryNorm(clevs, cmap.N)
+    cb = fig.colorbar(cm.ScalarMappable(cmap=cmap, norm=norm), cax=ax)
+    np.testing.assert_allclose(cb.ax.get_ylim(), [clevs[0], clevs[-1]])
+    np.testing.assert_allclose(cb.ax.get_yticks(), clevs)

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -305,8 +305,12 @@ def test_clabel_zorder(use_clabeltext, contour_zorder, clabel_zorder):
         assert clabel.get_zorder() == expected_clabel_zorder
 
 
+# tol because ticks happen to fall on pixel boundaries so small
+# floating point changes in tick location flip which pixel gets
+# the tick.
 @image_comparison(['contour_log_extension.png'],
-                  remove_text=True, style='mpl20')
+                  remove_text=True, style='mpl20',
+                  tol=1.444)
 def test_contourf_log_extension():
     # Remove this line when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False


### PR DESCRIPTION
## PR Summary

Closes #21671 

Fixes an issue where the BoundaryNorm colorbar was broken if the boundaries were negative.  Added new test to make sure this doesn't break again.  

I'll be honest, I find this part of the colorbar code a bit inscrutable, and it doesn't have a lot of unit tests.  So more bug reports to help get all the combinations down would be helpful.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
