### PR TITLE
Use _api.check_shape more.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -504,9 +504,7 @@ def _create_lookup_table(N, data, gamma=1.0):
         adata = np.array(data)
     except Exception as err:
         raise TypeError("data must be convertible to an array") from err
-    shape = adata.shape
-    if len(shape) != 2 or shape[1] != 3:
-        raise ValueError("data must be nx3 format")
+    _api.check_shape((None, 3), data=adata)
 
     x = adata[:, 0]
     y0 = adata[:, 1]

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1656,11 +1656,10 @@ class Transform(TransformNode):
             raise NotImplementedError('Only defined in 2D')
         angles = np.asarray(angles)
         pts = np.asarray(pts)
-        if angles.ndim != 1 or angles.shape[0] != pts.shape[0]:
-            raise ValueError("'angles' must be a column vector and have same "
-                             "number of rows as 'pts'")
-        if pts.shape[1] != 2:
-            raise ValueError("'pts' must be array with 2 columns for x, y")
+        _api.check_shape((None, 2), pts=pts)
+        _api.check_shape((None,), angles=angles)
+        if len(angles) != len(pts):
+            raise ValueError("There must be as many 'angles' as 'pts'")
         # Convert to radians if desired
         if not radians:
             angles = np.deg2rad(angles)

--- a/lib/matplotlib/tri/triinterpolate.py
+++ b/lib/matplotlib/tri/triinterpolate.py
@@ -1406,8 +1406,7 @@ def _safe_inv22_vectorized(M):
 
     *M* : array of (2, 2) matrices to inverse, shape (n, 2, 2)
     """
-    assert M.ndim == 3
-    assert M.shape[-2:] == (2, 2)
+    _api.check_shape((None, 2, 2), M=M)
     M_inv = np.empty_like(M)
     prod1 = M[:, 0, 0]*M[:, 1, 1]
     delta = prod1 - M[:, 0, 1]*M[:, 1, 0]
@@ -1441,8 +1440,7 @@ def _pseudo_inv22sym_vectorized(M):
 
     *M* : array of (2, 2) matrices to inverse, shape (n, 2, 2)
     """
-    assert M.ndim == 3
-    assert M.shape[-2:] == (2, 2)
+    _api.check_shape((None, 2, 2), M=M)
     M_inv = np.empty_like(M)
     prod1 = M[:, 0, 0]*M[:, 1, 1]
     delta = prod1 - M[:, 0, 1]*M[:, 1, 0]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -893,11 +893,8 @@ class RangeSlider(SliderBase):
         ----------
         val : tuple or array-like of float
         """
-        val = np.sort(np.asanyarray(val))
-        if val.shape != (2,):
-            raise ValueError(
-                f"val must have shape (2,) but has shape {val.shape}"
-            )
+        val = np.sort(val)
+        _api.check_shape((2,), val=val)
         val[0] = self._min_in_bounds(val[0])
         val[1] = self._max_in_bounds(val[1])
         xy = self.poly.xy

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -343,13 +343,8 @@ class Axes3D(Axes):
         if aspect is None:
             aspect = np.asarray((4, 4, 3), dtype=float)
         else:
-            orig_aspect = aspect
             aspect = np.asarray(aspect, dtype=float)
-            if aspect.shape != (3,):
-                raise ValueError(
-                    "You must pass a 3-tuple that can be cast to floats. "
-                    f"You passed {orig_aspect!r}"
-                )
+            _api.check_shape((3,), aspect=aspect)
         # default scale tuned to match the mpl32 appearance.
         aspect *= 1.8294640721620434 * zoom / np.linalg.norm(aspect)
 


### PR DESCRIPTION
Note that the warning in transform_angles was poorly worded: `angles` is
1D, and thus not a "column vector" and doesn't have "rows".

In RangeSlider.set_val we don't need to explicitly cast to arrays as
np.sort will do that for us anyways.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
