### PR TITLE
Drop non-significant zeros from ps output.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -385,7 +385,7 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
 
      /PaintProc {{
         pop
-        {linewidth:f} setlinewidth
+        {linewidth:g} setlinewidth
 {self._convert_path(
     Path.hatch(hatch), Affine2D().scale(sidelen), simplify=False)}
         gsave
@@ -395,7 +395,7 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
      }} bind
    >>
    matrix
-   0.0 {pageheight:f} translate
+   0 {pageheight:g} translate
    makepattern
    /{name} exch def
 """)
@@ -472,9 +472,9 @@ newpath
         self._pswriter.write(f"""\
 gsave
 {self._get_clip_cmd(gc)}
-{x:f} {y:f} translate
+{x:g} {y:g} translate
 [{matrix}] concat
-{xscale:f} {yscale:f} scale
+{xscale:g} {yscale:g} scale
 /DataString {w:d} string def
 {w:d} {h:d} 8 [ {w:d} 0 0 -{h:d} 0 {h:d} ]
 {{
@@ -674,13 +674,13 @@ grestore
         ps_name = (font.postscript_name
                    .encode("ascii", "replace").decode("ascii"))
         self.set_font(ps_name, prop.get_size_in_points())
-        thetext = "\n".join(f"{x:f} 0 m /{name:s} glyphshow"
+        thetext = "\n".join(f"{x:g} 0 m /{name:s} glyphshow"
                             for x, name in xs_names)
         self._pswriter.write(f"""\
 gsave
 {self._get_clip_cmd(gc)}
-{x:f} {y:f} translate
-{angle:f} rotate
+{x:g} {y:g} translate
+{angle:g} rotate
 {thetext}
 grestore
 """)
@@ -695,8 +695,8 @@ grestore
         self.set_color(*gc.get_rgb())
         self._pswriter.write(
             f"gsave\n"
-            f"{x:f} {y:f} translate\n"
-            f"{angle:f} rotate\n")
+            f"{x:g} {y:g} translate\n"
+            f"{angle:g} rotate\n")
         lastfont = None
         for font, fontsize, num, ox, oy in glyphs:
             self._character_tracker.track_glyph(font, num)
@@ -708,7 +708,7 @@ grestore
                 font.get_name_char(chr(num)) if isinstance(font, AFM) else
                 font.get_glyph_name(font.get_char_index(num)))
             self._pswriter.write(
-                f"{ox:f} {oy:f} moveto\n"
+                f"{ox:g} {oy:g} moveto\n"
                 f"/{glyph_name} glyphshow\n")
         for ox, oy, w, h in rects:
             self._pswriter.write(f"{ox} {oy} {w} {h} rectfill\n")
@@ -756,7 +756,7 @@ gsave
    /BitsPerComponent 8
    /BitsPerFlag 8
    /AntiAlias true
-   /Decode [ {xmin:f} {xmax:f} {ymin:f} {ymax:f} 0 1 0 1 0 1 ]
+   /Decode [ {xmin:g} {xmax:g} {ymin:g} {ymax:g} 0 1 0 1 0 1 ]
    /DataSource ({stream})
 >>
 shfill


### PR DESCRIPTION
`:g` format drops non significant zeros, and also uses scientific
notation as appropriate; PostScript explicitly supports scientific
notation (PostScript Language Reference section 3.2).

The point is mostly to improve the legibility of the PostScript output.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
