### PR TITLE
Shorten various offsetbox implementations

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -585,8 +585,12 @@ class Legend(Artist):
 
     _loc = property(_get_loc, _set_loc)
 
-    def _findoffset(self, width, height, xdescent, ydescent, renderer):
+    def _findoffset(self):
         """Helper function to locate the legend."""
+        renderer = (self.figure._cachedRenderer
+                    or self._legend_box._cached_renderer)
+        width, height, xdescent, ydescent = self._legend_box.get_extent(
+            renderer)
 
         if self._loc == 0:  # "best".
             x, y = self._find_best_position(width, height, renderer)
@@ -883,6 +887,8 @@ class Legend(Artist):
         # docstring inherited
         if renderer is None:
             renderer = self.figure._cachedRenderer
+        # May not be cached on the figure, so cache it ourselves.
+        self._cached_renderer = renderer
         return self._legend_box.get_window_extent(renderer=renderer)
 
     def get_tightbbox(self, renderer):

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1034,27 +1034,19 @@ class AnchoredOffsetbox(OffsetBox):
 
     def get_window_extent(self, renderer):
         # docstring inherited
-        self._update_offset_func(renderer)
-        return super().get_window_extent(renderer)
-
-    def _update_offset_func(self, renderer, fontsize=None):
-        """
-        Update the offset func which depends on the dpi of the
-        renderer (because of the padding).
-        """
-        if fontsize is None:
-            fontsize = renderer.points_to_pixels(
-                self.prop.get_size_in_points())
+        # Update the offset func, which depends on the dpi of the renderer
+        # (because of the padding).
+        fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
 
         def _offset(w, h, xd, yd, renderer):
             bbox = Bbox.from_bounds(0, 0, w, h)
-            borderpad = self.borderpad * fontsize
+            pad = self.borderpad * fontsize
             bbox_to_anchor = self.get_bbox_to_anchor()
-            x0, y0 = _get_anchored_bbox(
-                self.loc, bbox, bbox_to_anchor, borderpad)
+            x0, y0 = _get_anchored_bbox(self.loc, bbox, bbox_to_anchor, pad)
             return x0 + xd, y0 + yd
 
         self.set_offset(_offset)
+        return super().get_window_extent(renderer)
 
     def update_frame(self, bbox, fontsize=None):
         self.patch.set_bounds(bbox.bounds)
@@ -1066,11 +1058,9 @@ class AnchoredOffsetbox(OffsetBox):
         if not self.get_visible():
             return
 
-        fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
-        self._update_offset_func(renderer, fontsize)
-
         # update the location and size of the legend
         bbox = self.get_window_extent(renderer)
+        fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
         self.update_frame(bbox, fontsize)
         self.patch.draw(renderer)
 

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -70,18 +70,11 @@ class AnchoredLocatorBase(AnchoredOffsetbox):
 
     def __call__(self, ax, renderer):
         self.axes = ax
-
-        fontsize = renderer.points_to_pixels(self.prop.get_size_in_points())
-        self._update_offset_func(renderer, fontsize)
-
-        width, height, xdescent, ydescent = self.get_extent(renderer)
-
-        px, py = self.get_offset(width, height, 0, 0, renderer)
-        bbox_canvas = Bbox.from_bounds(px, py, width, height)
+        bbox = self.get_window_extent(renderer)
+        px, py = self.get_offset(bbox.width, bbox.height, 0, 0, renderer)
+        bbox_canvas = Bbox.from_bounds(px, py, bbox.width, bbox.height)
         tr = ax.figure.transFigure.inverted()
-        bb = TransformedBbox(bbox_canvas, tr)
-
-        return bb
+        return TransformedBbox(bbox_canvas, tr)
 
 
 class AnchoredSizeLocator(AnchoredLocatorBase):

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -71,7 +71,7 @@ class AnchoredLocatorBase(AnchoredOffsetbox):
     def __call__(self, ax, renderer):
         self.axes = ax
         bbox = self.get_window_extent(renderer)
-        px, py = self.get_offset(bbox.width, bbox.height, 0, 0, renderer)
+        px, py = self.get_offset()
         bbox_canvas = Bbox.from_bounds(px, py, bbox.width, bbox.height)
         tr = ax.figure.transFigure.inverted()
         return TransformedBbox(bbox_canvas, tr)


### PR DESCRIPTION
## PR Summary

1st commit: Inherit OffsetBox.{get_offset,get_window_extent}.

By making the parameters of OffsetBox.get_offset optional (which matches
the fact that there are currently subclasses for which get_offset does
*not* take any parameters), and adjusting OffsetBox.get_window_extent to
use get_extent (which is typically redefined in subclasses) instead of
get_extent_offsets (which is not), we can inherit the implementation of
OffsetBox.get_window_extent across most subclasses instead of having to
copy-paste it again and again.

2nd commit: Inline AnchoredOffsetBox._update_offset_func.

It is only called in `get_window_extent` -- and in `draw`, but *that*
call is immediately followed by a call to `get_window_extent`, so it is
redundant.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
