### PR TITLE
MNT: make print_figure kwarg wrapper support py311

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1601,7 +1601,12 @@ def _check_savefig_extra_args(func=None, extra_kwargs=()):
             r'^savefig|print_[A-Za-z0-9]+|_no_output_draw$'
         )
         seen_print_figure = False
-        for frame, line in traceback.walk_stack(None):
+        if sys.version_info < (3, 11):
+            current_frame = None
+        else:
+            import inspect
+            current_frame = inspect.currentframe()
+        for frame, line in traceback.walk_stack(current_frame):
             if frame is None:
                 # when called in embedded context may hit frame is None.
                 break

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1640,7 +1640,7 @@ def _check_savefig_extra_args(func=None, extra_kwargs=()):
             if arg in accepted_kwargs:
                 continue
             _api.warn_deprecated(
-                '3.3', name=name,
+                '3.3', name=name, removal='3.6',
                 message='%(name)s() got unexpected keyword argument "'
                         + arg + '" which is no longer supported as of '
                         '%(since)s and will become an error '


### PR DESCRIPTION

## PR Summary

Do not fully understand what changed, but without this change `walk_stack`
would start 2 frames higher (in the test module, not in backend_bases) which
would mean we never saw the frame with `print_figure` and hence was getting
warnings which we converted to failures on a vast majority of the tests.

I suspect that this is related to the fast-Python work and avoiding making
unneeded structures during the calls, but chased that theory down yet.

Discovered on a commit between py311a2 and py311a3.

This will need a followup PR to main that rips out almost all of this code.  We should have ripped it out in mpl35, but do not think we should do that in a patch release so also updated the deprecation date.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
