### PR TITLE
Fix compiler configuration priority for FreeType build

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -609,13 +609,13 @@ class FreeType(SetupPackage):
         print(f"Building freetype in {src_path}")
         if sys.platform != 'win32':  # compilation on non-windows
             env = {
-                **env,
                 **{
                     var: value
                     for var, value in sysconfig.get_config_vars().items()
                     if var in {"CC", "CFLAGS", "CXX", "CXXFLAGS", "LD",
                                "LDFLAGS"}
                 },
+                **env,
             }
             env["CFLAGS"] = env.get("CFLAGS", "") + " -fPIC"
             configure = [


### PR DESCRIPTION
## PR Summary

The `CC`/`CFLAGS`/etc flags from the Python config should be our default, but we should always listen to an existing `CC` set in the environment.

Fixes https://github.com/conda-forge/matplotlib-feedstock/pull/312#issuecomment-973902767

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).