### PR TITLE
Fix copyright date with SOURCE_DATE_EPOCH set

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -230,9 +230,9 @@ html_context = {
 
 project = 'Matplotlib'
 copyright = (
-    '2002 - 2012 John Hunter, Darren Dale, Eric Firing, Michael Droettboom '
+    '2002–2012 John Hunter, Darren Dale, Eric Firing, Michael Droettboom '
     'and the Matplotlib development team; '
-    f'2012 - {sourceyear} The Matplotlib development team'
+    f'2012–{sourceyear} The Matplotlib development team'
 )
 
 


### PR DESCRIPTION
## PR Summary

When `SOURCE_DATE_EPOCH` is set, then Sphinx will attempt to 'fix' the year in the copyright:
https://github.com/sphinx-doc/sphinx/issues/3451#issuecomment-877801728
We already correctly understand that envvar, so this is unexpected and wrong.

Sphinx looks for a 4-digit year followed by a space or two 4-digit years separated by a dash. We can fix this by using an en-dash, which is the correct typographical symbol for date ranges anyway, and thwarts Sphinx.

Fixes #20854

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).