### PR TITLE
Doc fix colormap inaccuracy

### DIFF
--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -132,12 +132,14 @@ newcmp = ListedColormap(newcolors)
 plot_examples([viridis, newcmp])
 
 ##############################################################################
-# We can easily reduce the dynamic range of a colormap; here we choose the
-# middle 0.5 of the colormap.  However, we need to interpolate from a larger
-# colormap, otherwise the new colormap will have repeated values.
+# We can reduce the dynamic range of a colormap; here we choose the
+# middle half of the colormap.  Note, however, that because viridis is a
+# listed colormap, we will end up with 128 discrete values instead of the 256
+# values that were in the original colormap. This method does not interpolate
+# in color-space to add new colors.
 
-viridis_big = cm.get_cmap('viridis', 512)
-newcmp = ListedColormap(viridis_big(np.linspace(0.25, 0.75, 256)))
+viridis_big = cm.get_cmap('viridis')
+newcmp = ListedColormap(viridis_big(np.linspace(0.25, 0.75, 128)))
 plot_examples([viridis, newcmp])
 
 ##############################################################################


### PR DESCRIPTION
## PR Summary

This fixes an erroneous statement in the colormap tutorial;  closes #15884.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
