### PR TITLE
Reduce do_3d_projection deprecation warnings in external artists

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -12,6 +12,7 @@ Module containing Axes3D, an object which can plot 3D objects on a
 
 from collections import defaultdict
 import functools
+import inspect
 import itertools
 import math
 from numbers import Integral
@@ -412,23 +413,26 @@ class Axes3D(Axes):
                 Call `do_3d_projection` on an *artist*, and warn if passing
                 *renderer*.
 
-                For our Artists, never pass *renderer*. For external Artists,
-                in lieu of more complicated signature parsing, always pass
-                *renderer* and raise a warning.
+                Attempt to bind the empty signature first, so external Artists
+                can avoid the deprecation warning if they support the new
+                calling convention.
                 """
-
-                if artist.__module__ == 'mpl_toolkits.mplot3d.art3d':
-                    # Our 3D Artists have deprecated the renderer parameter, so
-                    # avoid passing it to them; call this directly once the
-                    # deprecation has expired.
+                try:
+                    signature = inspect.signature(artist.do_3d_projection)
+                    signature.bind()
+                # ValueError if `inspect.signature` cannot provide a signature
+                # and TypeError if the binding fails or the object does not
+                # appear to be callable - the next call will then re-raise.
+                except (ValueError, TypeError):
+                    _api.warn_deprecated(
+                        "3.4",
+                        message="The 'renderer' parameter of "
+                        "do_3d_projection() was deprecated in Matplotlib "
+                        "%(since)s and will be removed %(removal)s.")
+                    return artist.do_3d_projection(renderer)
+                else:
+                    # Call this directly once the deprecation period expires.
                     return artist.do_3d_projection()
-
-                _api.warn_deprecated(
-                    "3.4",
-                    message="The 'renderer' parameter of "
-                    "do_3d_projection() was deprecated in Matplotlib "
-                    "%(since)s and will be removed %(removal)s.")
-                return artist.do_3d_projection(renderer)
 
             collections_and_patches = (
                 artist for artist in self._children

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1711,3 +1711,63 @@ def test_view_init_vertical_axis(
         tickdir_expected = tickdirs_expected[i]
         tickdir_actual = axis._get_tickdir()
         np.testing.assert_array_equal(tickdir_expected, tickdir_actual)
+
+
+def test_do_3d_projection_renderer_deprecation_warn_on_argument():
+    """
+    Test that an external artist with an old-style calling convention raises
+    a suitable deprecation warning.
+    """
+    class DummyPatch(art3d.Patch3D):
+        def do_3d_projection(self, renderer):
+            return 0
+
+        def draw(self, renderer):
+            pass
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    artist = DummyPatch()
+    ax.add_artist(artist)
+
+    match = r"The 'renderer' parameter of do_3d_projection\(\) was deprecated"
+    with pytest.warns(MatplotlibDeprecationWarning, match=match):
+        fig.canvas.draw()
+
+
+def test_do_3d_projection_renderer_deprecation_nowarn_on_optional_argument():
+    """
+    Test that an external artist with a calling convention compatible with
+    both v3.3 and v3.4 does not raise a deprecation warning.
+    """
+    class DummyPatch(art3d.Patch3D):
+        def do_3d_projection(self, renderer=None):
+            return 0
+
+        def draw(self, renderer):
+            pass
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    artist = DummyPatch()
+    ax.add_artist(artist)
+    fig.canvas.draw()
+
+
+def test_do_3d_projection_renderer_deprecation_nowarn_on_no_argument():
+    """
+    Test that an external artist with a calling convention compatible with
+    only v3.4 does not raise a deprecation warning.
+    """
+    class DummyPatch(art3d.Patch3D):
+        def do_3d_projection(self):
+            return 0
+
+        def draw(self, renderer):
+            pass
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    artist = DummyPatch()
+    ax.add_artist(artist)
+    fig.canvas.draw()


### PR DESCRIPTION
## PR Summary

Previously, when finding the 3D zorder, external artists were assumed to
use the calling convention of `Patch3D.do_3d_projection` from Matplotlib
3.3, where it took a positional `renderer` parameter.  This triggered
a deprecation warning, even if the artist could support the new
convention.  Now we attempt to bind the signature first, and only emit a
deprecation warning if the calling convention does not appear to work.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

Fix #21740.

The original logic this modifies was introduced in #18302, where there was a comment that this was deliberately avoiding signature parsing to make things simpler.  However, with the new calling convention only being used if the `Artist.__module__` is `mplot3d`-internal, this meant that library code (e.g. Qiskit/qiskit-terra#7301) could not avoid triggering the deprecation warning, even if downstream `Artist` did actually fulfill the convention.  Since the warnings are triggered during the drawing phase, which may well be outside library control, we couldn't suppress the warnings without changing global user filters.

If the performance hit from using `signature.bind` is too heavy, it could also do
```python
try:
    return artist.do_3d_projection()
except TypeError as exc:
    # - check the exception stack that the issue was the bind, not raised within the function
    # - do the deprecation warning
    return artist.do_3d_projection(renderer)
```