### PR TITLE
Fix/add docstring signatures to many C++ methods.

### DIFF
--- a/src/_contour_wrapper.cpp
+++ b/src/_contour_wrapper.cpp
@@ -77,7 +77,7 @@ static void PyQuadContourGenerator_dealloc(PyQuadContourGenerator* self)
 }
 
 const char* PyQuadContourGenerator_create_contour__doc__ =
-    "create_contour(level)\n"
+    "create_contour(self, level)\n"
     "--\n\n"
     "Create and return a non-filled contour.";
 
@@ -94,7 +94,7 @@ static PyObject* PyQuadContourGenerator_create_contour(PyQuadContourGenerator* s
 }
 
 const char* PyQuadContourGenerator_create_filled_contour__doc__ =
-    "create_filled_contour(lower_level, upper_level)\n"
+    "create_filled_contour(self, lower_level, upper_level)\n"
     "--\n\n"
     "Create and return a filled contour";
 
@@ -123,13 +123,19 @@ static PyObject* PyQuadContourGenerator_create_filled_contour(PyQuadContourGener
 static PyTypeObject* PyQuadContourGenerator_init_type(PyObject* m, PyTypeObject* type)
 {
     static PyMethodDef methods[] = {
-        {"create_contour", (PyCFunction)PyQuadContourGenerator_create_contour, METH_VARARGS, PyQuadContourGenerator_create_contour__doc__},
-        {"create_filled_contour", (PyCFunction)PyQuadContourGenerator_create_filled_contour, METH_VARARGS, PyQuadContourGenerator_create_filled_contour__doc__},
+        {"create_contour",
+         (PyCFunction)PyQuadContourGenerator_create_contour,
+         METH_VARARGS,
+         PyQuadContourGenerator_create_contour__doc__},
+        {"create_filled_contour",
+         (PyCFunction)PyQuadContourGenerator_create_filled_contour,
+         METH_VARARGS,
+         PyQuadContourGenerator_create_filled_contour__doc__},
         {NULL}
     };
 
     memset(type, 0, sizeof(PyTypeObject));
-    type->tp_name = "matplotlib.QuadContourGenerator";
+    type->tp_name = "matplotlib._contour.QuadContourGenerator";
     type->tp_doc = PyQuadContourGenerator_init__doc__;
     type->tp_basicsize = sizeof(PyQuadContourGenerator);
     type->tp_dealloc = (destructor)PyQuadContourGenerator_dealloc;

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -9,7 +9,8 @@
  * */
 
 const char* image_resample__doc__ =
-"resample(input_array, output_array, matrix, interpolation=NEAREST, alpha=1.0, norm=False, radius=1)\n\n"
+"resample(input_array, output_array, matrix, interpolation=NEAREST, alpha=1.0, norm=False, radius=1)\n"
+"--\n\n"
 
 "Resample input_array, blending it in-place into output_array, using an\n"
 "affine transformation.\n\n"

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -62,7 +62,7 @@ static void PyFT2Image_dealloc(PyFT2Image *self)
 }
 
 const char *PyFT2Image_draw_rect__doc__ =
-    "draw_rect(x0, y0, x1, y1)\n"
+    "draw_rect(self, x0, y0, x1, y1)\n"
     "--\n\n"
     "Draw an empty rectangle to the image.\n";
 
@@ -80,7 +80,7 @@ static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args)
 }
 
 const char *PyFT2Image_draw_rect_filled__doc__ =
-    "draw_rect_filled(x0, y0, x1, y1)\n"
+    "draw_rect_filled(self, x0, y0, x1, y1)\n"
     "--\n\n"
     "Draw a filled rectangle to the image.\n";
 
@@ -421,7 +421,7 @@ static void PyFT2Font_dealloc(PyFT2Font *self)
 }
 
 const char *PyFT2Font_clear__doc__ =
-    "clear()\n"
+    "clear(self)\n"
     "--\n\n"
     "Clear all the glyphs, reset for a new call to `.set_text`.\n";
 
@@ -433,7 +433,7 @@ static PyObject *PyFT2Font_clear(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_set_size__doc__ =
-    "set_size(ptsize, dpi)\n"
+    "set_size(self, ptsize, dpi)\n"
     "--\n\n"
     "Set the point size and dpi of the text.\n";
 
@@ -452,7 +452,7 @@ static PyObject *PyFT2Font_set_size(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_set_charmap__doc__ =
-    "set_charmap(i)\n"
+    "set_charmap(self, i)\n"
     "--\n\n"
     "Make the i-th charmap current.\n";
 
@@ -470,7 +470,7 @@ static PyObject *PyFT2Font_set_charmap(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_select_charmap__doc__ =
-    "select_charmap(i)\n"
+    "select_charmap(self, i)\n"
     "--\n\n"
     "Select a charmap by its FT_Encoding number.\n";
 
@@ -488,7 +488,7 @@ static PyObject *PyFT2Font_select_charmap(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_kerning__doc__ =
-    "get_kerning(left, right, mode)\n"
+    "get_kerning(self, left, right, mode)\n"
     "--\n\n"
     "Get the kerning between *left* and *right* glyph indices.\n"
     "*mode* is a kerning mode constant:\n"
@@ -511,7 +511,7 @@ static PyObject *PyFT2Font_get_kerning(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_set_text__doc__ =
-    "set_text(string, angle, flags=32)\n"
+    "set_text(self, string, angle, flags=32)\n"
     "--\n\n"
     "Set the text *string* and *angle*.\n"
     "*flags* can be a bitwise-or of the LOAD_XXX constants;\n"
@@ -583,7 +583,7 @@ static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *k
 }
 
 const char *PyFT2Font_get_num_glyphs__doc__ =
-    "get_num_glyphs()\n"
+    "get_num_glyphs(self)\n"
     "--\n\n"
     "Return the number of loaded glyphs.\n";
 
@@ -593,7 +593,7 @@ static PyObject *PyFT2Font_get_num_glyphs(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_load_char__doc__ =
-    "load_char(charcode, flags=32)\n"
+    "load_char(self, charcode, flags=32)\n"
     "--\n\n"
     "Load character with *charcode* in current fontfile and set glyph.\n"
     "*flags* can be a bitwise-or of the LOAD_XXX constants;\n"
@@ -632,7 +632,7 @@ static PyObject *PyFT2Font_load_char(PyFT2Font *self, PyObject *args, PyObject *
 }
 
 const char *PyFT2Font_load_glyph__doc__ =
-    "load_glyph(glyphindex, flags=32)\n"
+    "load_glyph(self, glyphindex, flags=32)\n"
     "--\n\n"
     "Load character with *glyphindex* in current fontfile and set glyph.\n"
     "*flags* can be a bitwise-or of the LOAD_XXX constants;\n"
@@ -671,7 +671,7 @@ static PyObject *PyFT2Font_load_glyph(PyFT2Font *self, PyObject *args, PyObject 
 }
 
 const char *PyFT2Font_get_width_height__doc__ =
-    "get_width_height()\n"
+    "get_width_height(self)\n"
     "--\n\n"
     "Get the width and height in 26.6 subpixels of the current string set by `.set_text`.\n"
     "The rotation of the string is accounted for.  To get width and height\n"
@@ -687,7 +687,7 @@ static PyObject *PyFT2Font_get_width_height(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_bitmap_offset__doc__ =
-    "get_bitmap_offset()\n"
+    "get_bitmap_offset(self)\n"
     "--\n\n"
     "Get the (x, y) offset in 26.6 subpixels for the bitmap if ink hangs left or below (0, 0).\n"
     "Since Matplotlib only supports left-to-right text, y is always 0.\n";
@@ -702,7 +702,7 @@ static PyObject *PyFT2Font_get_bitmap_offset(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_descent__doc__ =
-    "get_descent()\n"
+    "get_descent(self)\n"
     "--\n\n"
     "Get the descent in 26.6 subpixels of the current string set by `.set_text`.\n"
     "The rotation of the string is accounted for.  To get the descent\n"
@@ -718,7 +718,7 @@ static PyObject *PyFT2Font_get_descent(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_draw_glyphs_to_bitmap__doc__ =
-    "draw_glyphs_to_bitmap()\n"
+    "draw_glyphs_to_bitmap(self, antialiased=True)\n"
     "--\n\n"
     "Draw the glyphs that were loaded by `.set_text` to the bitmap.\n"
     "The bitmap size will be automatically set to include the glyphs.\n";
@@ -739,7 +739,7 @@ static PyObject *PyFT2Font_draw_glyphs_to_bitmap(PyFT2Font *self, PyObject *args
 }
 
 const char *PyFT2Font_get_xys__doc__ =
-    "get_xys()\n"
+    "get_xys(self, antialiased=True)\n"
     "--\n\n"
     "Get the xy locations of the current glyphs.\n";
 
@@ -760,7 +760,7 @@ static PyObject *PyFT2Font_get_xys(PyFT2Font *self, PyObject *args, PyObject *kw
 }
 
 const char *PyFT2Font_draw_glyph_to_bitmap__doc__ =
-    "draw_glyph_to_bitmap(bitmap, x, y, glyph)\n"
+    "draw_glyph_to_bitmap(self, image, x, y, glyph, antialiased=True)\n"
     "--\n\n"
     "Draw a single glyph to the bitmap at pixel locations x, y\n"
     "Note it is your responsibility to set up the bitmap manually\n"
@@ -801,7 +801,7 @@ static PyObject *PyFT2Font_draw_glyph_to_bitmap(PyFT2Font *self, PyObject *args,
 }
 
 const char *PyFT2Font_get_glyph_name__doc__ =
-    "get_glyph_name(index)\n"
+    "get_glyph_name(self, index)\n"
     "--\n\n"
     "Retrieve the ASCII name of a given glyph *index* in a face.\n"
     "\n"
@@ -821,7 +821,7 @@ static PyObject *PyFT2Font_get_glyph_name(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_charmap__doc__ =
-    "get_charmap()\n"
+    "get_charmap(self)\n"
     "--\n\n"
     "Return a dict that maps the character codes of the selected charmap\n"
     "(Unicode by default) to their corresponding glyph indices.\n";
@@ -852,7 +852,7 @@ static PyObject *PyFT2Font_get_charmap(PyFT2Font *self, PyObject *args)
 
 
 const char *PyFT2Font_get_char_index__doc__ =
-    "get_char_index(codepoint)\n"
+    "get_char_index(self, codepoint)\n"
     "--\n\n"
     "Return the glyph index corresponding to a character *codepoint*.\n";
 
@@ -872,7 +872,7 @@ static PyObject *PyFT2Font_get_char_index(PyFT2Font *self, PyObject *args)
 
 
 const char *PyFT2Font_get_sfnt__doc__ =
-    "get_sfnt()\n"
+    "get_sfnt(self)\n"
     "--\n\n"
     "Load the entire SFNT names table, as a dict whose keys are\n"
     "(platform-ID, ISO-encoding-scheme, language-code, and description)\n"
@@ -933,7 +933,7 @@ static PyObject *PyFT2Font_get_sfnt(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_name_index__doc__ =
-    "get_name_index(name)\n"
+    "get_name_index(self, name)\n"
     "--\n\n"
     "Return the glyph index of a given glyph *name*.\n"
     "The glyph index 0 means 'undefined character code'.\n";
@@ -950,7 +950,7 @@ static PyObject *PyFT2Font_get_name_index(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_ps_font_info__doc__ =
-    "get_ps_font_info()\n"
+    "get_ps_font_info(self)\n"
     "--\n\n"
     "Return the information in the PS Font Info structure.\n";
 
@@ -977,7 +977,7 @@ static PyObject *PyFT2Font_get_ps_font_info(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_sfnt_table__doc__ =
-    "get_sfnt_table(name)\n"
+    "get_sfnt_table(self, name)\n"
     "--\n\n"
     "Return one of the following SFNT tables: head, maxp, OS/2, hhea, "
     "vhea, post, or pclt.\n";
@@ -1279,7 +1279,7 @@ static PyObject *PyFT2Font_get_sfnt_table(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_path__doc__ =
-    "get_path()\n"
+    "get_path(self)\n"
     "--\n\n"
     "Get the path data from the currently loaded glyph as a tuple of vertices, "
     "codes.\n";
@@ -1290,7 +1290,7 @@ static PyObject *PyFT2Font_get_path(PyFT2Font *self, PyObject *args)
 }
 
 const char *PyFT2Font_get_image__doc__ =
-    "get_image()\n"
+    "get_image(self)\n"
     "--\n\n"
     "Return the underlying image buffer for this font object.\n";
 

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -24,7 +24,7 @@ static PyObject* PyTriangulation_new(PyTypeObject* type, PyObject* args, PyObjec
 const char* PyTriangulation_init__doc__ =
     "Triangulation(x, y, triangles, mask, edges, neighbors)\n"
     "--\n\n"
-    "Create a new C++ Triangulation object\n"
+    "Create a new C++ Triangulation object.\n"
     "This should not be called directly, instead use the python class\n"
     "matplotlib.tri.Triangulation instead.\n";
 
@@ -99,9 +99,9 @@ static void PyTriangulation_dealloc(PyTriangulation* self)
 }
 
 const char* PyTriangulation_calculate_plane_coefficients__doc__ =
-    "calculate_plane_coefficients(z, plane_coefficients)\n"
+    "calculate_plane_coefficients(self, z, plane_coefficients)\n"
     "--\n\n"
-    "Calculate plane equation coefficients for all unmasked triangles";
+    "Calculate plane equation coefficients for all unmasked triangles.";
 
 static PyObject* PyTriangulation_calculate_plane_coefficients(PyTriangulation* self, PyObject* args)
 {
@@ -124,9 +124,9 @@ static PyObject* PyTriangulation_calculate_plane_coefficients(PyTriangulation* s
 }
 
 const char* PyTriangulation_get_edges__doc__ =
-    "get_edges()\n"
+    "get_edges(self)\n"
     "--\n\n"
-    "Return edges array";
+    "Return edges array.";
 
 static PyObject* PyTriangulation_get_edges(PyTriangulation* self, PyObject* args)
 {
@@ -141,9 +141,9 @@ static PyObject* PyTriangulation_get_edges(PyTriangulation* self, PyObject* args
 }
 
 const char* PyTriangulation_get_neighbors__doc__ =
-    "get_neighbors()\n"
+    "get_neighbors(self)\n"
     "--\n\n"
-    "Return neighbors array";
+    "Return neighbors array.";
 
 static PyObject* PyTriangulation_get_neighbors(PyTriangulation* self, PyObject* args)
 {
@@ -158,7 +158,7 @@ static PyObject* PyTriangulation_get_neighbors(PyTriangulation* self, PyObject* 
 }
 
 const char* PyTriangulation_set_mask__doc__ =
-    "set_mask(mask)\n"
+    "set_mask(self, mask)\n"
     "--\n\n"
     "Set or clear the mask array.";
 
@@ -183,10 +183,22 @@ static PyObject* PyTriangulation_set_mask(PyTriangulation* self, PyObject* args)
 static PyTypeObject* PyTriangulation_init_type(PyObject* m, PyTypeObject* type)
 {
     static PyMethodDef methods[] = {
-        {"calculate_plane_coefficients", (PyCFunction)PyTriangulation_calculate_plane_coefficients, METH_VARARGS, PyTriangulation_calculate_plane_coefficients__doc__},
-        {"get_edges", (PyCFunction)PyTriangulation_get_edges, METH_NOARGS, PyTriangulation_get_edges__doc__},
-        {"get_neighbors", (PyCFunction)PyTriangulation_get_neighbors, METH_NOARGS, PyTriangulation_get_neighbors__doc__},
-        {"set_mask", (PyCFunction)PyTriangulation_set_mask, METH_VARARGS, PyTriangulation_set_mask__doc__},
+        {"calculate_plane_coefficients",
+         (PyCFunction)PyTriangulation_calculate_plane_coefficients,
+         METH_VARARGS,
+         PyTriangulation_calculate_plane_coefficients__doc__},
+        {"get_edges",
+         (PyCFunction)PyTriangulation_get_edges,
+         METH_NOARGS,
+         PyTriangulation_get_edges__doc__},
+        {"get_neighbors",
+         (PyCFunction)PyTriangulation_get_neighbors,
+         METH_NOARGS,
+         PyTriangulation_get_neighbors__doc__},
+        {"set_mask",
+         (PyCFunction)PyTriangulation_set_mask,
+         METH_VARARGS,
+         PyTriangulation_set_mask__doc__},
         {NULL}
     };
 
@@ -235,7 +247,7 @@ static PyObject* PyTriContourGenerator_new(PyTypeObject* type, PyObject* args, P
 const char* PyTriContourGenerator_init__doc__ =
     "TriContourGenerator(triangulation, z)\n"
     "--\n\n"
-    "Create a new C++ TriContourGenerator object\n"
+    "Create a new C++ TriContourGenerator object.\n"
     "This should not be called directly, instead use the functions\n"
     "matplotlib.axes.tricontour and tricontourf instead.\n";
 
@@ -274,8 +286,8 @@ static void PyTriContourGenerator_dealloc(PyTriContourGenerator* self)
 }
 
 const char* PyTriContourGenerator_create_contour__doc__ =
-    "create_contour(level)\n"
-    "\n"
+    "create_contour(self, level)\n"
+    "--\n\n"
     "Create and return a non-filled contour.";
 
 static PyObject* PyTriContourGenerator_create_contour(PyTriContourGenerator* self, PyObject* args)
@@ -291,9 +303,9 @@ static PyObject* PyTriContourGenerator_create_contour(PyTriContourGenerator* sel
 }
 
 const char* PyTriContourGenerator_create_filled_contour__doc__ =
-    "create_filled_contour(lower_level, upper_level)\n"
-    "\n"
-    "Create and return a filled contour";
+    "create_filled_contour(self, lower_level, upper_level)\n"
+    "--\n\n"
+    "Create and return a filled contour.";
 
 static PyObject* PyTriContourGenerator_create_filled_contour(PyTriContourGenerator* self, PyObject* args)
 {
@@ -370,7 +382,7 @@ static PyObject* PyTrapezoidMapTriFinder_new(PyTypeObject* type, PyObject* args,
 const char* PyTrapezoidMapTriFinder_init__doc__ =
     "TrapezoidMapTriFinder(triangulation)\n"
     "--\n\n"
-    "Create a new C++ TrapezoidMapTriFinder object\n"
+    "Create a new C++ TrapezoidMapTriFinder object.\n"
     "This should not be called directly, instead use the python class\n"
     "matplotlib.tri.TrapezoidMapTriFinder instead.\n";
 
@@ -400,9 +412,9 @@ static void PyTrapezoidMapTriFinder_dealloc(PyTrapezoidMapTriFinder* self)
 }
 
 const char* PyTrapezoidMapTriFinder_find_many__doc__ =
-    "find_many(x, y)\n"
-    "\n"
-    "Find indices of triangles containing the point coordinates (x, y)";
+    "find_many(self, x, y)\n"
+    "--\n\n"
+    "Find indices of triangles containing the point coordinates (x, y).";
 
 static PyObject* PyTrapezoidMapTriFinder_find_many(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
@@ -425,9 +437,9 @@ static PyObject* PyTrapezoidMapTriFinder_find_many(PyTrapezoidMapTriFinder* self
 }
 
 const char* PyTrapezoidMapTriFinder_get_tree_stats__doc__ =
-    "get_tree_stats()\n"
-    "\n"
-    "Return statistics about the tree used by the trapezoid map";
+    "get_tree_stats(self)\n"
+    "--\n\n"
+    "Return statistics about the tree used by the trapezoid map.";
 
 static PyObject* PyTrapezoidMapTriFinder_get_tree_stats(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
@@ -437,9 +449,9 @@ static PyObject* PyTrapezoidMapTriFinder_get_tree_stats(PyTrapezoidMapTriFinder*
 }
 
 const char* PyTrapezoidMapTriFinder_initialize__doc__ =
-    "initialize()\n"
-    "\n"
-    "Initialize this object, creating the trapezoid map from the triangulation";
+    "initialize(self)\n"
+    "--\n\n"
+    "Initialize this object, creating the trapezoid map from the triangulation.";
 
 static PyObject* PyTrapezoidMapTriFinder_initialize(PyTrapezoidMapTriFinder* self, PyObject* args)
 {
@@ -448,9 +460,9 @@ static PyObject* PyTrapezoidMapTriFinder_initialize(PyTrapezoidMapTriFinder* sel
 }
 
 const char* PyTrapezoidMapTriFinder_print_tree__doc__ =
-    "print_tree()\n"
-    "\n"
-    "Print the search tree as text to stdout; useful for debug purposes";
+    "print_tree(self)\n"
+    "--\n\n"
+    "Print the search tree as text to stdout; useful for debug purposes.";
 
 static PyObject* PyTrapezoidMapTriFinder_print_tree(PyTrapezoidMapTriFinder* self, PyObject* args)
 {


### PR DESCRIPTION
In particular, all methods were missing the self arg in the documented
signature (one can check that this matters e.g. by inspecting
`inspect.signature(matplotlib.ft2font.FT2Image.draw_rect)`).

(xref #15009)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
