### PR TITLE
FIX: manual colorbars and tight layout

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -280,6 +280,8 @@ class _ColorbarAxesLocator:
         # make tight_layout happy..
         ss = getattr(self._cbar.ax, 'get_subplotspec', None)
         if ss is None:
+            if self._orig_locator is None:
+                return None
             ss = self._orig_locator.get_subplotspec()
         else:
             ss = ss()

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -329,3 +329,16 @@ def test_non_agg_renderer(monkeypatch, recwarn):
     monkeypatch.setattr(mpl.backend_bases.RendererBase, "__init__", __init__)
     fig, ax = plt.subplots()
     fig.tight_layout()
+
+
+def test_manual_colorbar():
+    # This should warn, but not raise
+    fig, axes = plt.subplots(1, 2)
+    pts = axes[1].scatter([0, 1], [0, 1], c=[1, 5])
+    ax_rect = axes[1].get_position()
+    cax = fig.add_axes(
+        [ax_rect.x1 + 0.005, ax_rect.y0, 0.015, ax_rect.height]
+    )
+    fig.colorbar(pts, cax=cax)
+    with pytest.warns(UserWarning, match="This figure includes Axes"):
+        fig.tight_layout()

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -228,13 +228,14 @@ def get_subplotspec_list(axes_list, grid_spec=None):
 
         if hasattr(axes_or_locator, "get_subplotspec"):
             subplotspec = axes_or_locator.get_subplotspec()
-            subplotspec = subplotspec.get_topmost_subplotspec()
-            gs = subplotspec.get_gridspec()
-            if grid_spec is not None:
-                if gs != grid_spec:
+            if subplotspec is not None:
+                subplotspec = subplotspec.get_topmost_subplotspec()
+                gs = subplotspec.get_gridspec()
+                if grid_spec is not None:
+                    if gs != grid_spec:
+                        subplotspec = None
+                elif gs.locally_modified_subplot_params():
                     subplotspec = None
-            elif gs.locally_modified_subplot_params():
-                subplotspec = None
         else:
             subplotspec = None
 


### PR DESCRIPTION
## PR Summary

Closes #21749 

The subplotsepc logic was not correct for manually added colorbars so that tight_layout would raise instead of warn about the manual colorbar not being part of a layout.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
