### PR TITLE
Add a helper for directly output pdf streams.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -849,6 +849,11 @@ class PdfFile:
             self.currentstream.end()
             self.currentstream = None
 
+    def outputStream(self, ref, data, *, extra=None):
+        self.beginStream(ref.id, None, extra)
+        self.currentstream.write(data)
+        self.endStream()
+
     def _write_annotations(self):
         for annotsObject, annotations in self._annotations:
             self.writeObject(annotsObject, annotations)
@@ -1053,13 +1058,10 @@ class PdfFile:
 
         self.writeObject(fontdescObject, descriptor)
 
-        self.beginStream(fontfileObject.id, None,
-                         {'Length1': len(t1font.parts[0]),
-                          'Length2': len(t1font.parts[1]),
-                          'Length3': 0})
-        self.currentstream.write(t1font.parts[0])
-        self.currentstream.write(t1font.parts[1])
-        self.endStream()
+        self.outputStream(fontfileObject, b"".join(t1font.parts[:2]),
+                          extra={'Length1': len(t1font.parts[0]),
+                                 'Length2': len(t1font.parts[1]),
+                                 'Length3': 0})
 
         return fontdescObject
 
@@ -1182,13 +1184,13 @@ end"""
             charprocs = {}
             for charname in sorted(rawcharprocs):
                 stream = rawcharprocs[charname]
-                charprocDict = {'Length': len(stream)}
+                charprocDict = {}
                 # The 2-byte characters are used as XObjects, so they
                 # need extra info in their dictionary
                 if charname in multi_byte_chars:
-                    charprocDict['Type'] = Name('XObject')
-                    charprocDict['Subtype'] = Name('Form')
-                    charprocDict['BBox'] = bbox
+                    charprocDict = {'Type': Name('XObject'),
+                                    'Subtype': Name('Form'),
+                                    'BBox': bbox}
                     # Each glyph includes bounding box information,
                     # but xpdf and ghostscript can't handle it in a
                     # Form XObject (they segfault!!!), so we remove it
@@ -1197,9 +1199,7 @@ end"""
                     # value.
                     stream = stream[stream.find(b"d1") + 2:]
                 charprocObject = self.reserveObject('charProc')
-                self.beginStream(charprocObject.id, None, charprocDict)
-                self.currentstream.write(stream)
-                self.endStream()
+                self.outputStream(charprocObject, stream, extra=charprocDict)
 
                 # Send the glyphs with ccode > 255 to the XObject dictionary,
                 # and the others to the font itself
@@ -1267,12 +1267,9 @@ end"""
 
             # Make fontfile stream
             descriptor['FontFile2'] = fontfileObject
-            self.beginStream(
-                fontfileObject.id,
-                self.reserveObject('length of font stream'),
-                {'Length1': fontdata.getbuffer().nbytes})
-            self.currentstream.write(fontdata.getvalue())
-            self.endStream()
+            self.outputStream(
+                fontfileObject, fontdata.getvalue(),
+                extra={'Length1': fontdata.getbuffer().nbytes})
 
             # Make the 'W' (Widths) array, CidToGidMap and ToUnicode CMap
             # at the same time
@@ -1331,10 +1328,9 @@ end"""
             rawcharprocs = _get_pdf_charprocs(filename, glyph_ids)
             for charname in sorted(rawcharprocs):
                 stream = rawcharprocs[charname]
-                charprocDict = {'Length': len(stream)}
-                charprocDict['Type'] = Name('XObject')
-                charprocDict['Subtype'] = Name('Form')
-                charprocDict['BBox'] = bbox
+                charprocDict = {'Type': Name('XObject'),
+                                'Subtype': Name('Form'),
+                                'BBox': bbox}
                 # Each glyph includes bounding box information,
                 # but xpdf and ghostscript can't handle it in a
                 # Form XObject (they segfault!!!), so we remove it
@@ -1343,27 +1339,17 @@ end"""
                 # value.
                 stream = stream[stream.find(b"d1") + 2:]
                 charprocObject = self.reserveObject('charProc')
-                self.beginStream(charprocObject.id, None, charprocDict)
-                self.currentstream.write(stream)
-                self.endStream()
+                self.outputStream(charprocObject, stream, extra=charprocDict)
 
                 name = self._get_xobject_glyph_name(filename, charname)
                 self.multi_byte_charprocs[name] = charprocObject
 
             # CIDToGIDMap stream
             cid_to_gid_map = "".join(cid_to_gid_map).encode("utf-16be")
-            self.beginStream(cidToGidMapObject.id,
-                             None,
-                             {'Length': len(cid_to_gid_map)})
-            self.currentstream.write(cid_to_gid_map)
-            self.endStream()
+            self.outputStream(cidToGidMapObject, cid_to_gid_map)
 
             # ToUnicode CMap
-            self.beginStream(toUnicodeMapObject.id,
-                             None,
-                             {'Length': unicode_cmap})
-            self.currentstream.write(unicode_cmap)
-            self.endStream()
+            self.outputStream(toUnicodeMapObject, unicode_cmap)
 
             descriptor['MaxWidth'] = max_width
 


### PR DESCRIPTION
Also, such directly output streams don't need an explicitly set Length,
as the stream outputter will fill in that entry itself.  This is why
e.g. the invalid entry for toUnicodeMapObject (where Length was set to
unicode_cmap rather than len(unicode_cmap)) was not a problem: it was
overwritten in endStream().

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
