### PR TITLE
FIX: Make sure a renderer gets attached to figure after draw

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -43,7 +43,7 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
 
     def draw(self):
         # docstring inherited
-        self.draw_idle()
+        self._draw()
         self.flush_events()
 
     # draw_idle is provided by _macosx.FigureCanvas

--- a/lib/matplotlib/tests/test_backend_macosx.py
+++ b/lib/matplotlib/tests/test_backend_macosx.py
@@ -1,0 +1,20 @@
+import pytest
+
+import matplotlib.pyplot as plt
+
+
+pytest.importorskip("matplotlib.backends.backend_macosx",
+                    reason="These are mac only tests")
+
+
+@pytest.mark.backend('macosx')
+def test_cached_renderer():
+    # Make sure that figures have an associated renderer after
+    # a fig.canvas.draw() call
+    fig = plt.figure(1)
+    fig.canvas.draw()
+    assert fig._cachedRenderer is not None
+
+    fig = plt.figure(2)
+    fig.draw_without_rendering()
+    assert fig._cachedRenderer is not None


### PR DESCRIPTION
## PR Summary
Make sure that a cached renderer gets added to the figure after calling fig.canvas.draw() on the macosx backend. This changes the draw path to go through adding a renderer to the figure first.

closes #19197
closes #13968
closes #7550

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
