### PR TITLE
Inherit many macos backend docstrings.

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -525,7 +525,7 @@ static PyMethodDef FigureCanvas_methods[] = {
     {"flush_events",
      (PyCFunction)FigureCanvas_flush_events,
      METH_NOARGS,
-     "Flush the GUI events for the figure."
+     NULL,  // docstring inherited.
     },
     {"set_rubberband",
      (PyCFunction)FigureCanvas_set_rubberband,
@@ -540,12 +540,12 @@ static PyMethodDef FigureCanvas_methods[] = {
     {"start_event_loop",
      (PyCFunction)FigureCanvas_start_event_loop,
      METH_KEYWORDS | METH_VARARGS,
-     "Runs the event loop until the timeout or until stop_event_loop is called.\n",
+     NULL,  // docstring inherited.
     },
     {"stop_event_loop",
      (PyCFunction)FigureCanvas_stop_event_loop,
      METH_NOARGS,
-     "Stops the event loop that was started by start_event_loop.\n",
+     NULL,  // docstring inherited.
     },
     {NULL}  /* Sentinel */
 };
@@ -768,27 +768,27 @@ static PyMethodDef FigureManager_methods[] = {
     {"show",
      (PyCFunction)FigureManager_show,
      METH_NOARGS,
-     "Shows the window associated with the figure manager."
+     NULL,  // docstring inherited.
     },
     {"destroy",
      (PyCFunction)FigureManager_destroy,
      METH_NOARGS,
-     "Closes the window associated with the figure manager."
+     NULL,  // docstring inherited.
     },
     {"set_window_title",
      (PyCFunction)FigureManager_set_window_title,
      METH_VARARGS,
-     "Sets the title of the window associated with the figure manager."
+     NULL,  // docstring inherited.
     },
     {"get_window_title",
      (PyCFunction)FigureManager_get_window_title,
      METH_NOARGS,
-     "Returns the title of the window associated with the figure manager."
+     NULL,  // docstring inherited.
     },
     {"resize",
      (PyCFunction)FigureManager_resize,
      METH_VARARGS,
-     "Resize the window (in pixels)."
+     NULL,  // docstring inherited.
     },
     {NULL}  /* Sentinel */
 };
@@ -1159,7 +1159,7 @@ static PyMethodDef NavigationToolbar2_methods[] = {
     {"set_message",
      (PyCFunction)NavigationToolbar2_set_message,
      METH_VARARGS,
-     "Set the message to be displayed on the toolbar."
+     NULL,  // docstring inherited.
     },
     {NULL}  /* Sentinel */
 };
@@ -2072,12 +2072,12 @@ static PyMethodDef Timer_methods[] = {
     {"_timer_start",
      (PyCFunction)Timer__timer_start,
      METH_VARARGS,
-     "Initialize and start the timer."
+     NULL,  // docstring inherited.
     },
     {"_timer_stop",
      (PyCFunction)Timer__timer_stop,
      METH_NOARGS,
-     "Stop the timer."
+     NULL,  // docstring inherited.
     },
     {NULL}  /* Sentinel */
 };


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
