### PR TITLE
FIX: macosx animations

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -393,6 +393,9 @@ FigureCanvas_flush_events(FigureCanvas* self)
         PyErr_SetString(PyExc_RuntimeError, "NSView* is NULL");
         return NULL;
     }
+    // We need to interrupt the runloop very briefly to allow the view to be
+    // displayed when used in a fast updating animation
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.0]];
     [view displayIfNeeded];
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
The macosx backend would not update on flush_events calls due to the loop being run too fast for the view to update properly in the NSApp. Fix that by adding an unnoticeable RunLoop timer slowdown that allows the app to see the changes. Putting an `NSLog` into the drawRect loop before and after this produced identical results, taking 0.021 seconds per iteration, but with this addition, the draw update actually happens.

It doesn't feel super ideal, but this method is apparently used by others... [link to google book](https://books.google.com/books?id=XwWhCgAAQBAJ&pg=PA40&lpg=PA40&dq=%5B%5BNSRunLoop+currentRunLoop%5D+runUntilDate:%5BNSDate+dateWithTimeIntervalSinceNow:0.0%5D%5D&source=bl&ots=bNzNfYtwQV&sig=ACfU3U1TnW0urvc1102RAcLN2FYs2F3ZOw&hl=en&sa=X&ved=2ahUKEwjgg5a42rf0AhWBmmoFHaUYBjEQ6AF6BAgCEAM#v=onepage&q=%5B%5BNSRunLoop%20currentRunLoop%5D%20runUntilDate%3A%5BNSDate%20dateWithTimeIntervalSinceNow%3A0.0%5D%5D&f=false)

Example from #17642

```python
import matplotlib.pyplot as plt
import numpy as np

x = np.linspace(0, 2 * np.pi, 100)

fig, ax = plt.subplots()

# animated=True tells matplotlib to only draw the artist when we
# explicitly request it
(ln,) = ax.plot(x, np.sin(x), animated=True)

# make sure the window is raised, but the script keeps going
plt.show(block=False)

# stop to admire our empty window axes and ensure it is rendered at
# least once.
#
# We need to fully draw the figure at its final size on the screen
# before we continue on so that :
#  a) we have the correctly sized and drawn background to grab
#  b) we have a cached renderer so that ``ax.draw_artist`` works
# so we spin the event loop to let the backend process any pending operations
plt.pause(0.1)

# get copy of entire figure (everything inside fig.bbox) sans animated artist
bg = fig.canvas.copy_from_bbox(fig.bbox)
# draw the animated artist, this uses a cached renderer
ax.draw_artist(ln)
# show the result to the screen, this pushes the updated RGBA buffer from the
# renderer to the GUI framework so you can see it
fig.canvas.blit(fig.bbox)

for j in range(100):
    # reset the background back in the canvas state, screen unchanged
    fig.canvas.restore_region(bg)
    # update the artist, neither the canvas state nor the screen have changed
    ln.set_ydata(np.sin(x + (j / 100) * np.pi))
    # re-render the artist, updating the canvas state, but not the screen
    ax.draw_artist(ln)
    # copy the image to the GUI state, but screen might not changed yet
    fig.canvas.blit(fig.bbox)
    # flush any pending GUI events, re-painting the screen if needed
    fig.canvas.flush_events()
    # you can put a pause in if you want to slow things down
    # plt.pause(.1)
```

Closes #17642

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
