### PR TITLE
FIX: Reset label of axis to center

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3492,13 +3492,14 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
+        horizontalalignment = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
         kwargs.pop('ha', None)
         if loc == 'left':
-            kwargs.update(x=0, horizontalalignment='left')
+            kwargs.update(x=0, horizontalalignment=horizontalalignment or 'left')
         elif loc == 'center':
-            kwargs.update(x=0.5, horizontalalignment='center')
+            kwargs.update(x=0.5, horizontalalignment=horizontalalignment or 'center')
         elif loc == 'right':
-            kwargs.update(x=1, horizontalalignment='right')
+            kwargs.update(x=1, horizontalalignment=horizontalalignment or 'right')
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
     def invert_xaxis(self):
@@ -3839,13 +3840,14 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
+        horizontalalignment = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
         kwargs.pop('ha', None)
         if loc == 'bottom':
-            kwargs.update(y=0, horizontalalignment='left')
+            kwargs.update(y=0, horizontalalignment=horizontalalignment or 'left')
         elif loc == 'center':
-            kwargs.update(y=0.5, horizontalalignment='center')
+            kwargs.update(y=0.5, horizontalalignment=horizontalalignment or 'center')
         elif loc == 'top':
-            kwargs.update(y=1, horizontalalignment='right')
+            kwargs.update(y=1, horizontalalignment=horizontalalignment or 'right')
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def invert_yaxis(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3492,9 +3492,9 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
-        x = None or kwargs.get('x')
-        ha = None or kwargs.get('ha')
-        horizontalalignment = None or kwargs.get('horizontalalignment')
+        x = kwargs.get('x')
+        ha = kwargs.get('ha')
+        horizontalalignment = kwargs.get('horizontalalignment')
         ha_to_use = horizontalalignment or ha
 
         # Use ha_to_use under the ha alias moving forward
@@ -3853,9 +3853,9 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
-        y = None or kwargs.get('y')
-        ha = None or kwargs.get('ha')
-        horizontalalignment = None or kwargs.get('horizontalalignment')
+        y = kwargs.get('y')
+        ha = kwargs.get('ha')
+        horizontalalignment = kwargs.get('horizontalalignment')
         ha_to_use = horizontalalignment or ha
 
         # Use ha_to_use under the ha alias moving forward

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3487,24 +3487,18 @@ class _AxesBase(martist.Artist):
                                 f"its corresponding low level keyword "
                                 f"arguments ({protected_kw}) are also "
                                 f"supplied")
-            loc = 'center'
+
         else:
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
-        _api.check_in_list(('left', 'center', 'right'), loc=loc)
-        kwargs = cbook.normalize_kwargs(kwargs, mtext.Text)
+            _api.check_in_list(('left', 'center', 'right'), loc=loc)
 
-        if loc == 'left':
-            kwargs.setdefault('x', 0)
-            kwargs.setdefault('horizontalalignment', 'left')
-
-        elif loc == 'center':
-            kwargs.setdefault('x', 0.5)
-            kwargs.setdefault('horizontalalignment', 'center')
-
-        elif loc == 'right':
-            kwargs.setdefault('x', 1)
-            kwargs.setdefault('horizontalalignment', 'right')
+            if loc == 'left':
+                kwargs.update(x=0, horizontalalignment='left')
+            elif loc == 'center':
+                kwargs.update(x=0.5, horizontalalignment='center')
+            elif loc == 'right':
+                kwargs.update(x=1, horizontalalignment='right')
 
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
@@ -3841,24 +3835,18 @@ class _AxesBase(martist.Artist):
                                 f"its corresponding low level keyword "
                                 f"arguments ({protected_kw}) are also "
                                 f"supplied")
-            loc = 'center'
+
         else:
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
-        _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
-        kwargs = cbook.normalize_kwargs(kwargs, mtext.Text)
+            _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
 
-        if loc == 'bottom':
-            kwargs.setdefault('y', 0)
-            kwargs.setdefault('horizontalalignment', 'left')
-
-        elif loc == 'center':
-            kwargs.setdefault('y', 0.5)
-            kwargs.setdefault('horizontalalignment', 'center')
-
-        elif loc == 'top':
-            kwargs.setdefault('y', 1)
-            kwargs.setdefault('horizontalalignment', 'right')
+            if loc == 'bottom':
+                kwargs.update(y=0, horizontalalignment='left')
+            elif loc == 'center':
+                kwargs.update(y=0.5, horizontalalignment='center')
+            elif loc == 'top':
+                kwargs.update(y=1, horizontalalignment='right')
 
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3493,20 +3493,18 @@ class _AxesBase(martist.Artist):
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
         kwargs = cbook.normalize_kwargs(kwargs, mtext.Text)
-        x = kwargs.get('x')
-        ha = kwargs.get('horizontalalignment')
 
         if loc == 'left':
-            kwargs.update(x=0 if x is None else x,
-                          horizontalalignment='left' if ha is None else ha)
+            kwargs.setdefault('x', 0)
+            kwargs.setdefault('horizontalalignment', 'left')
 
         elif loc == 'center':
-            kwargs.update(x=0.5 if x is None else x,
-                          horizontalalignment='center' if ha is None else ha)
+            kwargs.setdefault('x', 0.5)
+            kwargs.setdefault('horizontalalignment', 'center')
 
         elif loc == 'right':
-            kwargs.update(x=1 if x is None else x,
-                          horizontalalignment='right' if ha is None else ha)
+            kwargs.setdefault('x', 1)
+            kwargs.setdefault('horizontalalignment', 'right')
 
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
@@ -3849,20 +3847,18 @@ class _AxesBase(martist.Artist):
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
         kwargs = cbook.normalize_kwargs(kwargs, mtext.Text)
-        y = kwargs.get('y')
-        ha = kwargs.get('horizontalalignment')
 
         if loc == 'bottom':
-            kwargs.update(y=0 if y is None else y,
-                          horizontalalignment='left' if ha is None else ha)
+            kwargs.setdefault('y', 0)
+            kwargs.setdefault('horizontalalignment', 'left')
 
         elif loc == 'center':
-            kwargs.update(y=0.5 if y is None else y,
-                          horizontalalignment='center' if ha is None else ha)
+            kwargs.setdefault('y', 0.5)
+            kwargs.setdefault('horizontalalignment', 'center')
 
         elif loc == 'top':
-            kwargs.update(y=1 if y is None else y,
-                          horizontalalignment='right' if ha is None else ha)
+            kwargs.setdefault('y', 1)
+            kwargs.setdefault('horizontalalignment', 'right')
 
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3492,21 +3492,26 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
-        ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
         x = None or kwargs.get('x')
-        kwargs.pop('horizontalalignment', None)
+        ha = None or kwargs.get('ha')
+        horizontalalignment = None or kwargs.get('horizontalalignment')
+        ha_to_use = horizontalalignment or ha
+
+        # Use ha_to_use under the ha alias moving forward
+        if not (ha and horizontalalignment):
+            kwargs.pop('horizontalalignment', None)
 
         if loc == 'left':
             kwargs.update(x=0 if x is None else x,
-                          ha='left' if ha is None else ha)
+                          ha='left' if ha_to_use is None else ha_to_use)
 
         elif loc == 'center':
             kwargs.update(x=0.5 if x is None else x,
-                          ha='center' if ha is None else ha)
+                          ha='center' if ha_to_use is None else ha_to_use)
 
         elif loc == 'right':
             kwargs.update(x=1 if x is None else x,
-                          ha='right' if ha is None else ha)
+                          ha='right' if ha_to_use is None else ha_to_use)
 
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
@@ -3848,21 +3853,26 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
-        ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
         y = None or kwargs.get('y')
-        kwargs.pop('horizontalalignment', None)
+        ha = None or kwargs.get('ha')
+        horizontalalignment = None or kwargs.get('horizontalalignment')
+        ha_to_use = horizontalalignment or ha
+
+        # Use ha_to_use under the ha alias moving forward
+        if not (ha and horizontalalignment):
+            kwargs.pop('horizontalalignment', None)
 
         if loc == 'bottom':
             kwargs.update(y=0 if y is None else y,
-                          ha='left' if ha is None else ha)
+                          ha='left' if ha_to_use is None else ha_to_use)
 
         elif loc == 'center':
             kwargs.update(y=0.5 if y is None else y,
-                          ha='center' if ha is None else ha)
+                          ha='center' if ha_to_use is None else ha_to_use)
 
         elif loc == 'top':
             kwargs.update(y=1 if y is None else y,
-                          ha='right' if ha is None else ha)
+                          ha='right' if ha_to_use is None else ha_to_use)
 
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3839,11 +3839,11 @@ class _AxesBase(martist.Artist):
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
         if loc == 'bottom':
-            kwargs.update(y=0, verticalalignment='bottom')
+            kwargs.update(y=0, horizontalalignment='left')
         elif loc == 'center':
-            kwargs.update(y=0.5, verticalalignment='center')
+            kwargs.update(y=0.5, horizontalalignment='center')
         elif loc == 'top':
-            kwargs.update(y=1, verticalalignment='top')
+            kwargs.update(y=1, horizontalalignment='right')
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def invert_yaxis(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3492,14 +3492,14 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
-        horizontalalignment = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
-        kwargs.pop('ha', None)
+        ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
+        kwargs.pop('horizontalalignment', None)
         if loc == 'left':
-            kwargs.update(x=0, horizontalalignment=horizontalalignment or 'left')
+            kwargs.update(x=0, ha=ha or 'left')
         elif loc == 'center':
-            kwargs.update(x=0.5, horizontalalignment=horizontalalignment or 'center')
+            kwargs.update(x=0.5, ha=ha or 'center')
         elif loc == 'right':
-            kwargs.update(x=1, horizontalalignment=horizontalalignment or 'right')
+            kwargs.update(x=1, ha=ha or 'right')
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
     def invert_xaxis(self):
@@ -3840,14 +3840,14 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
-        horizontalalignment = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
-        kwargs.pop('ha', None)
+        ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
+        kwargs.pop('horizontalalignment', None)
         if loc == 'bottom':
-            kwargs.update(y=0, horizontalalignment=horizontalalignment or 'left')
+            kwargs.update(y=0, ha=ha or 'left')
         elif loc == 'center':
-            kwargs.update(y=0.5, horizontalalignment=horizontalalignment or 'center')
+            kwargs.update(y=0.5, ha=ha or 'center')
         elif loc == 'top':
-            kwargs.update(y=1, horizontalalignment=horizontalalignment or 'right')
+            kwargs.update(y=1, ha=ha or 'right')
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def invert_yaxis(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3492,26 +3492,21 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
+        kwargs = cbook.normalize_kwargs(kwargs, mtext.Text)
         x = kwargs.get('x')
-        ha = kwargs.get('ha')
-        horizontalalignment = kwargs.get('horizontalalignment')
-        ha_to_use = horizontalalignment or ha
-
-        # Use ha_to_use under the ha alias moving forward
-        if not (ha and horizontalalignment):
-            kwargs.pop('horizontalalignment', None)
+        ha = kwargs.get('horizontalalignment')
 
         if loc == 'left':
             kwargs.update(x=0 if x is None else x,
-                          ha='left' if ha_to_use is None else ha_to_use)
+                          horizontalalignment='left' if ha is None else ha)
 
         elif loc == 'center':
             kwargs.update(x=0.5 if x is None else x,
-                          ha='center' if ha_to_use is None else ha_to_use)
+                          horizontalalignment='center' if ha is None else ha)
 
         elif loc == 'right':
             kwargs.update(x=1 if x is None else x,
-                          ha='right' if ha_to_use is None else ha_to_use)
+                          horizontalalignment='right' if ha is None else ha)
 
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
@@ -3853,26 +3848,21 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
+        kwargs = cbook.normalize_kwargs(kwargs, mtext.Text)
         y = kwargs.get('y')
-        ha = kwargs.get('ha')
-        horizontalalignment = kwargs.get('horizontalalignment')
-        ha_to_use = horizontalalignment or ha
-
-        # Use ha_to_use under the ha alias moving forward
-        if not (ha and horizontalalignment):
-            kwargs.pop('horizontalalignment', None)
+        ha = kwargs.get('horizontalalignment')
 
         if loc == 'bottom':
             kwargs.update(y=0 if y is None else y,
-                          ha='left' if ha_to_use is None else ha_to_use)
+                          horizontalalignment='left' if ha is None else ha)
 
         elif loc == 'center':
             kwargs.update(y=0.5 if y is None else y,
-                          ha='center' if ha_to_use is None else ha_to_use)
+                          horizontalalignment='center' if ha is None else ha)
 
         elif loc == 'top':
             kwargs.update(y=1 if y is None else y,
-                          ha='right' if ha_to_use is None else ha_to_use)
+                          horizontalalignment='right' if ha is None else ha)
 
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3492,6 +3492,7 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
+        kwargs.pop('ha', None)
         if loc == 'left':
             kwargs.update(x=0, horizontalalignment='left')
         elif loc == 'center':
@@ -3838,6 +3839,7 @@ class _AxesBase(martist.Artist):
             loc = (loc if loc is not None
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
+        kwargs.pop('ha', None)
         if loc == 'bottom':
             kwargs.update(y=0, horizontalalignment='left')
         elif loc == 'center':

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3493,13 +3493,14 @@ class _AxesBase(martist.Artist):
                    else mpl.rcParams['xaxis.labellocation'])
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
         ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
+        x = None or kwargs.get('x')
         kwargs.pop('horizontalalignment', None)
         if loc == 'left':
-            kwargs.update(x=0, ha=ha or 'left')
+            kwargs.update(x=x or 0, ha=ha or 'left')
         elif loc == 'center':
-            kwargs.update(x=0.5, ha=ha or 'center')
+            kwargs.update(x=x or 0.5, ha=ha or 'center')
         elif loc == 'right':
-            kwargs.update(x=1, ha=ha or 'right')
+            kwargs.update(x=x or 1, ha=ha or 'right')
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
     def invert_xaxis(self):
@@ -3841,13 +3842,14 @@ class _AxesBase(martist.Artist):
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
         ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
+        y = None or kwargs.get('y')
         kwargs.pop('horizontalalignment', None)
         if loc == 'bottom':
-            kwargs.update(y=0, ha=ha or 'left')
+            kwargs.update(y=y or 0, ha=ha or 'left')
         elif loc == 'center':
-            kwargs.update(y=0.5, ha=ha or 'center')
+            kwargs.update(y=y or 0.5, ha=ha or 'center')
         elif loc == 'top':
-            kwargs.update(y=1, ha=ha or 'right')
+            kwargs.update(y=y or 1, ha=ha or 'right')
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def invert_yaxis(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3494,6 +3494,8 @@ class _AxesBase(martist.Artist):
         _api.check_in_list(('left', 'center', 'right'), loc=loc)
         if loc == 'left':
             kwargs.update(x=0, horizontalalignment='left')
+        elif loc == 'center':
+            kwargs.update(x=0.5, horizontalalignment='center')
         elif loc == 'right':
             kwargs.update(x=1, horizontalalignment='right')
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
@@ -3837,9 +3839,11 @@ class _AxesBase(martist.Artist):
                    else mpl.rcParams['yaxis.labellocation'])
         _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
         if loc == 'bottom':
-            kwargs.update(y=0, horizontalalignment='left')
+            kwargs.update(y=0, verticalalignment='bottom')
+        elif loc == 'center':
+            kwargs.update(y=0.5, verticalalignment='center')
         elif loc == 'top':
-            kwargs.update(y=1, horizontalalignment='right')
+            kwargs.update(y=1, verticalalignment='top')
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def invert_yaxis(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3495,12 +3495,19 @@ class _AxesBase(martist.Artist):
         ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
         x = None or kwargs.get('x')
         kwargs.pop('horizontalalignment', None)
+
         if loc == 'left':
-            kwargs.update(x=x or 0, ha=ha or 'left')
+            kwargs.update(x=0 if x is None else x,
+                          ha='left' if ha is None else ha)
+
         elif loc == 'center':
-            kwargs.update(x=x or 0.5, ha=ha or 'center')
+            kwargs.update(x=0.5 if x is None else x,
+                          ha='center' if ha is None else ha)
+
         elif loc == 'right':
-            kwargs.update(x=x or 1, ha=ha or 'right')
+            kwargs.update(x=1 if x is None else x,
+                          ha='right' if ha is None else ha)
+
         return self.xaxis.set_label_text(xlabel, fontdict, **kwargs)
 
     def invert_xaxis(self):
@@ -3844,12 +3851,19 @@ class _AxesBase(martist.Artist):
         ha = None or kwargs.get('horizontalalignment') or kwargs.get('ha')
         y = None or kwargs.get('y')
         kwargs.pop('horizontalalignment', None)
+
         if loc == 'bottom':
-            kwargs.update(y=y or 0, ha=ha or 'left')
+            kwargs.update(y=0 if y is None else y,
+                          ha='left' if ha is None else ha)
+
         elif loc == 'center':
-            kwargs.update(y=y or 0.5, ha=ha or 'center')
+            kwargs.update(y=0.5 if y is None else y,
+                          ha='center' if ha is None else ha)
+
         elif loc == 'top':
-            kwargs.update(y=y or 1, ha=ha or 'right')
+            kwargs.update(y=1 if y is None else y,
+                          ha='right' if ha is None else ha)
+
         return self.yaxis.set_label_text(ylabel, fontdict, **kwargs)
 
     def invert_yaxis(self):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -105,6 +105,30 @@ def test_label_loc_rc(fig_test, fig_ref):
     cbar.set_label("Z Label", x=1, ha='right')
 
 
+def test_label_shift():
+    fig, ax = plt.subplots()
+
+    # Test label re-centering on x-axis
+    ax.set_xlabel("Test label", loc="left")
+    ax.set_xlabel("Test label", loc="center")
+    assert ax.xaxis.get_label()._x == 0.5
+    ax.set_xlabel("Test label", loc="right")
+    assert ax.xaxis.get_label()._x == 1.0
+    ax.set_xlabel("Test label", loc="center")
+    assert ax.xaxis.get_label()._x == 0.5
+
+    # Test label re-centering on y-axis
+    ax.set_ylabel("Test label", loc="top")
+    ax.set_ylabel("Test label", loc="center")
+    assert ax.yaxis.get_label()._y == 0.5
+    ax.set_ylabel("Test label", loc="bottom")
+    assert ax.yaxis.get_label()._y == 0.0
+    ax.set_ylabel("Test label", loc="center")
+    assert ax.yaxis.get_label()._y == 0.5
+
+    plt.close()
+
+
 @check_figures_equal(extensions=["png"])
 def test_acorr(fig_test, fig_ref):
     np.random.seed(19680801)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -126,8 +126,6 @@ def test_label_shift():
     ax.set_ylabel("Test label", loc="center")
     assert ax.yaxis.get_label().get_horizontalalignment() == "center"
 
-    plt.close()
-
 
 @check_figures_equal(extensions=["png"])
 def test_acorr(fig_test, fig_ref):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -111,20 +111,20 @@ def test_label_shift():
     # Test label re-centering on x-axis
     ax.set_xlabel("Test label", loc="left")
     ax.set_xlabel("Test label", loc="center")
-    assert ax.xaxis.get_label()._x == 0.5
+    assert ax.xaxis.get_label().get_horizontalalignment() == "center"
     ax.set_xlabel("Test label", loc="right")
-    assert ax.xaxis.get_label()._x == 1.0
+    assert ax.xaxis.get_label().get_horizontalalignment() == "right"
     ax.set_xlabel("Test label", loc="center")
-    assert ax.xaxis.get_label()._x == 0.5
+    assert ax.xaxis.get_label().get_horizontalalignment() == "center"
 
     # Test label re-centering on y-axis
     ax.set_ylabel("Test label", loc="top")
     ax.set_ylabel("Test label", loc="center")
-    assert ax.yaxis.get_label()._y == 0.5
+    assert ax.yaxis.get_label().get_horizontalalignment() == "center"
     ax.set_ylabel("Test label", loc="bottom")
-    assert ax.yaxis.get_label()._y == 0.0
+    assert ax.yaxis.get_label().get_horizontalalignment() == "left"
     ax.set_ylabel("Test label", loc="center")
-    assert ax.yaxis.get_label()._y == 0.5
+    assert ax.yaxis.get_label().get_horizontalalignment() == "center"
 
     plt.close()
 


### PR DESCRIPTION
## PR Summary
Fixes #21772 
1) Added elif blocks to center `xlabel` and `ylabel`
2) Added a test for the same in `test_axes.py`
3) Additionally, in `set_ylabel`, the `horizontalalignment` was getting reset instead of `verticalalignment`

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).