### PR TITLE
Set macOS icon when using Qt backend

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -1,7 +1,6 @@
 import functools
 import operator
 import os
-import signal
 import sys
 import traceback
 
@@ -121,6 +120,10 @@ def _create_qApp():
             except AttributeError:  # Only for Qt>=5.14.
                 pass
             qApp = QtWidgets.QApplication(["matplotlib"])
+            if sys.platform == "darwin":
+                image = str(cbook._get_data_path('images/matplotlib.svg'))
+                icon = QtGui.QIcon(image)
+                qApp.setWindowIcon(icon)
             qApp.lastWindowClosed.connect(qApp.quit)
             cbook._setup_new_guiapp()
         else:
@@ -519,8 +522,10 @@ class FigureManagerQT(FigureManagerBase):
         self.window.closing.connect(canvas.close_event)
         self.window.closing.connect(self._widgetclosed)
 
-        image = str(cbook._get_data_path('images/matplotlib.svg'))
-        self.window.setWindowIcon(QtGui.QIcon(image))
+        if sys.platform != "darwin":
+            image = str(cbook._get_data_path('images/matplotlib.svg'))
+            icon = QtGui.QIcon(image)
+            self.window.setWindowIcon(icon)
 
         self.window._destroying = False
 


### PR DESCRIPTION
## PR Summary

On most platforms, windows have their own icons that are displayed in conjunction with windows. On macOS, icons are used differently. Individual windows should not have an icon unless they are associated with a file. On the other hand, processes ("Apps") have icons that can be set.

@greglucas suggested applying these fixes within derivations of FigureManagerBase. FigureManagerBase should only be instantiated when Matplotlib is responsible for running the GUI and its event loop. In this case, it makes sense for Matplotlib to control the App icon. (see https://github.com/matplotlib/matplotlib/pull/14930#issuecomment-980795349)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).