### PR TITLE
FIX: Update blitting and drawing on the macosx backend

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -345,14 +345,7 @@ FigureCanvas_repr(FigureCanvas* self)
 }
 
 static PyObject*
-FigureCanvas_draw(FigureCanvas* self)
-{
-    [self->view display];
-    Py_RETURN_NONE;
-}
-
-static PyObject*
-FigureCanvas_draw_idle(FigureCanvas* self)
+FigureCanvas_update(FigureCanvas* self)
 {
     [self->view setNeedsDisplay: YES];
     Py_RETURN_NONE;
@@ -485,12 +478,8 @@ static PyTypeObject FigureCanvasType = {
     .tp_new = (newfunc)FigureCanvas_new,
     .tp_doc = "A FigureCanvas object wraps a Cocoa NSView object.",
     .tp_methods = (PyMethodDef[]){
-        {"draw",
-         (PyCFunction)FigureCanvas_draw,
-         METH_NOARGS,
-         NULL},  // docstring inherited
-        {"draw_idle",
-         (PyCFunction)FigureCanvas_draw_idle,
+        {"update",
+         (PyCFunction)FigureCanvas_update,
          METH_NOARGS,
          NULL},  // docstring inherited
         {"flush_events",
@@ -1263,7 +1252,7 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
 
     CGContextRef cr = [[NSGraphicsContext currentContext] CGContext];
 
-    if (!(renderer = PyObject_CallMethod(canvas, "_draw", ""))
+    if (!(renderer = PyObject_CallMethod(canvas, "get_renderer", ""))
         || !(renderer_buffer = PyObject_GetAttrString(renderer, "_renderer"))) {
         PyErr_Print();
         goto exit;

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -354,6 +354,9 @@ FigureCanvas_update(FigureCanvas* self)
 static PyObject*
 FigureCanvas_flush_events(FigureCanvas* self)
 {
+    // We need to allow the runloop to run very briefly
+    // to allow the view to be displayed when used in a fast updating animation
+    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.0]];
     [self->view displayIfNeeded];
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
## PR Summary

This moves some of the drawing and blitting code to the AGG canvas (instead of trying to use the objc routines) and leverages that to handle when a full AGG re-render should happen. The macosx code always grabs the full AGG buffer when drawing to the GUI window at the objc level (inside drawRect). I removed `_draw()` and added an `update()` routine in objc that requests a screen draw within the main run loop.

closes #10980
closes #17445 (Only does a full redraw once now!)
Fixes the example from #17642, but I'm not sure this is still feature-parity with what "flush_events" means on the other backends, so I guess it probably shouldn't be closed.

* I tried to draw on some of the logic in the QT backend. That portion would be good to have someone take a look at and provide suggestions for improvement.
* When creating the NavigationToolbar, there are two draw_idle calls that are made that I don't fully understand where they are coming from. I put some comments into the PR to show where that is happening.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
