### PR TITLE
Fix missing return value in closeButtonPressed.

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1291,7 +1291,11 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
     return suggested;
 }
 
-- (BOOL)closeButtonPressed { gil_call_method(manager, "close"); }
+- (BOOL)closeButtonPressed
+{
+    gil_call_method(manager, "close");
+    return YES;
+}
 
 - (void)close
 {


### PR DESCRIPTION
Accidentally removed in f7a432a.

Closes https://github.com/matplotlib/matplotlib/commit/f7a432a7523d4c99b19f0cd56b17e0310fcb3c20#r61013322.  Would be nice if we could run with -Werror instead, which would have caught this, but I assume @dopplershift had a good reason to only use -Werror=unguarded-availability in #17956?

It's also not completely clear to me why the only call to closeButtonPressed (in windowShouldClose) is protected by respondsToSelector, and whether it could just be inlined there instead, using something like
```patch
diff --git i/src/_macosx.m w/src/_macosx.m
index 64875fe7f1..cf84ef02fa 100755
--- i/src/_macosx.m
+++ w/src/_macosx.m
@@ -1519,12 +1519,8 @@ - (BOOL)windowShouldClose:(NSNotification*)notification
                                            data1: 0
                                            data2: 0];
     [NSApp postEvent: event atStart: true];
-    if ([window respondsToSelector: @selector(closeButtonPressed)]) {
-        BOOL closed = [((Window*) window) closeButtonPressed];
-        /* If closed, the window has already been closed via the manager. */
-        if (closed) { return NO; }
-    }
-    return YES;
+    gil_call_method(manager, "close");
+    return NO;  // the window has already been closed via the manager.
 }
 
 - (void)mouseEntered:(NSEvent *)event
```
Still, this patch should fix the main problem at hand...

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
