### PR TITLE
DOC: fix stylesheet again

### DIFF
--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -11,6 +11,7 @@ line plot and histogram,
 
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
@@ -112,7 +113,13 @@ def plot_figure(axs, style_label=""):
     plot_colored_circles(axs[3], prng)
     plot_colored_sinusoidal_lines(axs[4])
     plot_histograms(axs[5], prng)
-
+    col = np.array([19, 6, 84])/256
+    back = mcolors.rgb_to_hsv(
+        mcolors.to_rgb(plt.rcParams['figure.facecolor']))[2]
+    if back < 0.5:
+        col = [0.8, 0.8, 1]
+    axs[0].figure.suptitle(style_label, x=0.03, fontsize=12,
+                           ha='left', color=col)
 
 if __name__ == "__main__":
 
@@ -133,5 +140,4 @@ if __name__ == "__main__":
             with plt.style.context(style_label):
                 ax = sfig.subplots(1, 6)
                 plot_figure(ax, style_label=style_label)
-                sfig.suptitle(style_label)
     plt.show()

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -104,6 +104,8 @@ def plot_figure(axs, style_label=""):
     # Use a dedicated RandomState instance to draw the same "random" values
     # across the different figures.
     prng = np.random.RandomState(96917002)
+    # the facecolor rcparam is not applied to subfigures, so
+    # do so manually here:
     axs[0].figure.set_facecolor(plt.rcParams['figure.facecolor'])
     axs[0].set_ylabel('ylabel')
 
@@ -113,13 +115,17 @@ def plot_figure(axs, style_label=""):
     plot_colored_circles(axs[3], prng)
     plot_colored_sinusoidal_lines(axs[4])
     plot_histograms(axs[5], prng)
+    # make a suptitle, in the same style for all subfigures,
+    # except those with dark backgrounds, which get a lighter
+    # color:
     col = np.array([19, 6, 84])/256
     back = mcolors.rgb_to_hsv(
         mcolors.to_rgb(plt.rcParams['figure.facecolor']))[2]
     if back < 0.5:
         col = [0.8, 0.8, 1]
-    axs[0].figure.suptitle(style_label, x=0.03, fontsize=12,
-                           ha='left', color=col)
+    axs[0].figure.suptitle(style_label, x=0.015, fontsize=14, ha='left',
+                           color=col, fontfamily='DejaVu Sans',
+                           fontweight='normal')
 
 if __name__ == "__main__":
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -98,21 +98,13 @@ def plot_histograms(ax, prng, nb_samples=10000):
     return ax
 
 
-def plot_figure(style_label=""):
+def plot_figure(axs, style_label=""):
     """Setup and plot the demonstration figure with a given style."""
     # Use a dedicated RandomState instance to draw the same "random" values
     # across the different figures.
     prng = np.random.RandomState(96917002)
-
-    # Tweak the figure size to be better suited for a row of numerous plots:
-    # double the width and halve the height. NB: use relative changes because
-    # some styles may have a figure size different from the default one.
-    (fig_width, fig_height) = plt.rcParams['figure.figsize']
-    fig_size = [fig_width * 2, fig_height / 2]
-
-    fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
-                            figsize=fig_size, squeeze=True)
-    axs[0].set_ylabel(style_label)
+    axs[0].figure.set_facecolor(plt.rcParams['figure.facecolor'])
+    axs[0].set_ylabel('ylabel')
 
     plot_scatter(axs[0], prng)
     plot_image_and_patch(axs[1], prng)
@@ -121,23 +113,25 @@ def plot_figure(style_label=""):
     plot_colored_sinusoidal_lines(axs[4])
     plot_histograms(axs[5], prng)
 
-    fig.tight_layout()
-
-    return fig
-
 
 if __name__ == "__main__":
 
     # Setup a list of all available styles, in alphabetical order but
-    # the `default` and `classic` ones, which will be forced resp. in
-    # first and second position.
+    # the `default`, `classic`, which will be forced
+    # resp. in first and second position.
     style_list = ['default', 'classic'] + sorted(
-        style for style in plt.style.available if style != 'classic')
+        style for style in plt.style.available if
+        ((style != 'classic') and (style[0] != '_')))
+    nstyles = len(style_list)
 
+    fig = plt.figure(figsize=(7, nstyles*2), constrained_layout=True)
+    subfigs = fig.subfigures(nstyles, 1)
     # Plot a demonstration figure for every available style sheet.
-    for style_label in style_list:
+    for sfig, style_label in zip(subfigs, style_list):
+
         with plt.rc_context({"figure.max_open_warning": len(style_list)}):
             with plt.style.context(style_label):
-                fig = plot_figure(style_label=style_label)
-
+                ax = sfig.subplots(1, 6)
+                plot_figure(ax, style_label=style_label)
+                sfig.suptitle(style_label)
     plt.show()


### PR DESCRIPTION
## PR Summary

This makes the stylesheet one figure (with subfigures) to allow us to better control the legibility (I hope)


## PR Checklist
![Styles](https://user-images.githubusercontent.com/1562854/143995266-5e1c204e-fc17-45f9-a4e4-a347f9f4f1bd.png)

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
