### PR TITLE
Added get_font_names() to fontManager

### DIFF
--- a/.github/workflows/clean_pr.yml
+++ b/.github/workflows/clean_pr.yml
@@ -25,7 +25,7 @@ jobs:
           base="$(git merge-base "origin/$GITHUB_BASE_REF" 'HEAD^2')"
           am="$(git log "$base..HEAD^2" --pretty=tformat: --name-status --diff-filter=AM |
                 cut --fields 2 | sort | uniq --repeated |
-                grep -E '.(png|pdf|ps|eps|svg)' || true)"
+                grep -E '\.(png|pdf|ps|eps|svg)' || true)"
           if [[ -n "$am" ]]; then
             printf 'The following images were both added and modified in this PR:\n%s\n' "$am"
             exit 1

--- a/doc/users/next_whats_new/list_font_names.rst
+++ b/doc/users/next_whats_new/list_font_names.rst
@@ -1,0 +1,10 @@
+List of available font names
+------------------------------
+
+The list of available fonts are now easily accesible. Get a list of the
+available font names in matplotlib with:
+
+.. code-block:: python
+
+    from matplotlib import font_manager
+    font_manager.get_font_names()

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1309,6 +1309,10 @@ class FontManager:
             prop, fontext, directory, fallback_to_default, rebuild_if_missing,
             rc_params)
 
+    def get_font_names(self):
+        """Return the list of available fonts."""
+        return list(set([font.name for font in self.ttflist]))
+
     @lru_cache()
     def _findfont_cached(self, prop, fontext, directory, fallback_to_default,
                          rebuild_if_missing, rc_params):
@@ -1447,3 +1451,4 @@ def _load_fontmanager(*, try_read_cache=True):
 
 fontManager = _load_fontmanager()
 findfont = fontManager.findfont
+get_font_names = fontManager.get_font_names

--- a/tutorials/text/text_props.py
+++ b/tutorials/text/text_props.py
@@ -179,6 +179,11 @@ plt.show()
 # generic-family aliases like (``{'cursive', 'fantasy', 'monospace',
 # 'sans', 'sans serif', 'sans-serif', 'serif'}``).
 #
+# .. note::
+#    To access the full list of available fonts: ::
+#
+#       matplotlib.font_manager.get_font_names()
+#
 # The mapping between the generic family aliases and actual font families
 # (mentioned at :doc:`default rcParams </tutorials/introductory/customizing>`)
 # is controlled by the following rcParams:
@@ -208,6 +213,7 @@ plt.show()
 #
 #    # This is effectively translated to:
 #    matplotlib.rcParams['font.family'] = ['Family1', 'SerifFamily1', 'SerifFamily2', 'Family2']
+#
 #
 # Text with non-latin glyphs
 # ==========================


### PR DESCRIPTION
## PR Summary
Added list of available fonts. Changes in this PR allows the user to find a list of available fonts by running:
`matplotlib.font_manager.get_font_list()`. Edit: Fixes #21761.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

**Comments**
- About get_font_list()
I added get_font_list() as a method in FontManager. However, for convenience, I also added it as global function. In this way, although the method itself belongs to FontManager (`matplotlib.font_manager.fontManager.get_font_list()`) , is easily accessible one level up at  `matplotlib.font_manager.get_font_list()`. 

- Test Units
Although I was considering the use of a fixture to extract all the fonts from scratch but ended up skipping it. In the spirit of best practices, the addition of a fixture should be for usability across different unit tests, which in this case does not occur. The unit test is a bit long for my preference, but I tried my best to overcome the limitations. 

- Documentation
I added a note in the tutorial page `text_props.py` where there is a reference about fonts. I am not sure about adding plots here to illustrate the different font options. I could add a section if the reviewers consider it appropriate.  

- New features
Didn't add new features as I am not entirely sure this change is substantial enough to be added to the list of new features. I can add it later otherwise.

Finally, as a general comment, I would like to point out that the code in `font_manager.py` could be further improved as well as the unit tests associated with it. I guess because the last changes in this part of the library were added quite some time ago. I also understand the limitations when testing fonts across different platforms, though.  Anyway, If there is interest in the enhancement of this component of matplotlib I can offer some help, but that's another discussion. 

Let's start here, will be happy to improve/change whatever is necessary. Thanks.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
