### PR TITLE
_blit_draw function fix to correctly show the moving axis

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1166,13 +1166,13 @@ class Animation:
             view, bg = self._blit_cache.get(ax, (object(), None))
             if cur_view != view:
                 self._blit_cache[ax] = (
-                    cur_view, ax.figure.canvas.copy_from_bbox(ax.bbox))
+                    cur_view, ax.figure.canvas.copy_from_bbox(ax.figure.bbox))
         # Make a separate pass to draw foreground.
         for a in artists:
             a.axes.draw_artist(a)
         # After rendering all the needed artists, blit each axes individually.
         for ax in updated_ax:
-            ax.figure.canvas.blit(ax.bbox)
+            ax.figure.canvas.blit(ax.figure.bbox)
 
     def _blit_clear(self, artists):
         # Get a list of the axes that need clearing from the artists that


### PR DESCRIPTION
## PR Summary

Function _blit_draw in animation.py is not showing and not updating the labels of the axis in move. 
The bbox accessed directly as "ax.bbox" is not working. Using "ax.figure.bbox" solved the problem and the axes are plotted and updating correctly.

Is the first time I am contributing to this kind of project, sorry if something is incorrect. As far I can test this is working for me. I have been using this fix as a workaround for my personal use since 1.17. Even _blit_draw have been reworked and the same change still have a consistent behaviour fixing the problem.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
