### PR TITLE
Drop setuptools-scm requirement in wheels

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -322,9 +322,11 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "pyparsing>=2.2.1,<3.0.0",
         "python-dateutil>=2.7",
     ] + (
-        # Installing from a git checkout.
-        ["setuptools_scm>=4"] if Path(__file__).with_name(".git").exists()
-        else []
+        # Installing from a git checkout that is not producing a wheel.
+        ["setuptools_scm>=4"] if (
+            Path(__file__).with_name(".git").exists() and
+            os.environ.get("CIBUILDWHEEL", "0") != "1"
+        ) else []
     ),
     use_scm_version={
         "version_scheme": "release-branch-semver",


### PR DESCRIPTION
## PR Summary

Fixes #21783.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).