### PR TITLE
DOC: Fix redirect to citing page

### DIFF
--- a/doc/users/project/citing.rst
+++ b/doc/users/project/citing.rst
@@ -1,4 +1,4 @@
-.. redirect-from:: /citing
+.. redirect-from:: /users/citing
 
 Citing Matplotlib
 =================


### PR DESCRIPTION
## PR Summary

cf https://github.com/matplotlib/mpl-brochure-site/pull/39

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
