### PR TITLE
Add option of bounding box for PolygonSelector

### DIFF
--- a/doc/users/next_whats_new/polygon_selector_box.rst
+++ b/doc/users/next_whats_new/polygon_selector_box.rst
@@ -1,6 +1,6 @@
 PolygonSelector bounding boxes
 ------------------------------
-`~matplotlib.widgets.PolygonSelector` now has a *draw_box* argument, which
+`~matplotlib.widgets.PolygonSelector` now has a *draw_bounding_box* argument, which
 when set to `True` will draw a bounding box around the polygon once it is
 complete. The bounding box can be resized and moved, allowing the points of
 the polygon to be easily resized.

--- a/doc/users/next_whats_new/polygon_selector_box.rst
+++ b/doc/users/next_whats_new/polygon_selector_box.rst
@@ -1,0 +1,6 @@
+PolygonSelector bounding boxes
+------------------------------
+`~matplotlib.widgets.PolygonSelector` now has a *draw_box* argument, which
+when set to `True` will draw a bounding box around the polygon once it is
+complete. The bounding box can be resized and moved, allowing the points of
+the polygon to be easily resized.

--- a/examples/widgets/polygon_selector_demo.py
+++ b/examples/widgets/polygon_selector_demo.py
@@ -50,7 +50,7 @@ class SelectFromCollection:
         elif len(self.fc) == 1:
             self.fc = np.tile(self.fc, (self.Npts, 1))
 
-        self.poly = PolygonSelector(ax, self.onselect)
+        self.poly = PolygonSelector(ax, self.onselect, draw_box=True)
         self.ind = []
 
     def onselect(self, verts):

--- a/examples/widgets/polygon_selector_demo.py
+++ b/examples/widgets/polygon_selector_demo.py
@@ -50,7 +50,7 @@ class SelectFromCollection:
         elif len(self.fc) == 1:
             self.fc = np.tile(self.fc, (self.Npts, 1))
 
-        self.poly = PolygonSelector(ax, self.onselect, draw_box=True)
+        self.poly = PolygonSelector(ax, self.onselect, draw_bounding_box=True)
         self.ind = []
 
     def onselect(self, verts):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -617,6 +617,12 @@ class Line2D(Artist):
             self.pickradius = p
         self._picker = p
 
+    def get_bbox(self):
+        """Get the bounding box of this line."""
+        bbox = Bbox([[0, 0], [0, 0]])
+        bbox.update_from_data_xy(self.get_xydata())
+        return bbox
+
     def get_window_extent(self, renderer):
         bbox = Bbox([[0, 0], [0, 0]])
         trans_data_to_xy = self.get_transform().transform

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1164,10 +1164,10 @@ def polygon_remove_vertex(xdata, ydata):
             ('release', dict(xdata=xdata, ydata=ydata, button=3))]
 
 
-@pytest.mark.parametrize('draw_box', [False, True])
-def test_polygon_selector(draw_box):
+@pytest.mark.parametrize('draw_bounding_box', [False, True])
+def test_polygon_selector(draw_bounding_box):
     check_selector = functools.partial(
-        check_polygon_selector, draw_box=draw_box)
+        check_polygon_selector, draw_bounding_box=draw_bounding_box)
 
     # Simple polygon
     expected_result = [(50, 50), (150, 50), (50, 150)]
@@ -1264,8 +1264,8 @@ def test_polygon_selector(draw_box):
     check_selector(event_sequence, expected_result, 1)
 
 
-@pytest.mark.parametrize('draw_box', [False, True])
-def test_polygon_selector_set_props_handle_props(draw_box):
+@pytest.mark.parametrize('draw_bounding_box', [False, True])
+def test_polygon_selector_set_props_handle_props(draw_bounding_box):
     ax = get_ax()
 
     ax._selections_count = 0
@@ -1277,7 +1277,7 @@ def test_polygon_selector_set_props_handle_props(draw_box):
     tool = widgets.PolygonSelector(ax, onselect,
                                    props=dict(color='b', alpha=0.2),
                                    handle_props=dict(alpha=0.5),
-                                   draw_box=draw_box)
+                                   draw_bounding_box=draw_bounding_box)
 
     event_sequence = (polygon_place_vertex(50, 50)
                       + polygon_place_vertex(150, 50)
@@ -1319,8 +1319,8 @@ def test_rect_visibility(fig_test, fig_ref):
 
 # Change the order that the extra point is inserted in
 @pytest.mark.parametrize('idx', [1, 2, 3])
-@pytest.mark.parametrize('draw_box', [False, True])
-def test_polygon_selector_remove(idx, draw_box):
+@pytest.mark.parametrize('draw_bounding_box', [False, True])
+def test_polygon_selector_remove(idx, draw_bounding_box):
     verts = [(50, 50), (150, 50), (50, 150)]
     event_sequence = [polygon_place_vertex(*verts[0]),
                       polygon_place_vertex(*verts[1]),
@@ -1333,22 +1333,24 @@ def test_polygon_selector_remove(idx, draw_box):
     event_sequence.append(polygon_remove_vertex(200, 200))
     # Flatten list of lists
     event_sequence = sum(event_sequence, [])
-    check_polygon_selector(event_sequence, verts, 2, draw_box=draw_box)
+    check_polygon_selector(event_sequence, verts, 2,
+                           draw_bounding_box=draw_bounding_box)
 
 
-@pytest.mark.parametrize('draw_box', [False, True])
-def test_polygon_selector_remove_first_point(draw_box):
+@pytest.mark.parametrize('draw_bounding_box', [False, True])
+def test_polygon_selector_remove_first_point(draw_bounding_box):
     verts = [(50, 50), (150, 50), (50, 150)]
     event_sequence = (polygon_place_vertex(*verts[0]) +
                       polygon_place_vertex(*verts[1]) +
                       polygon_place_vertex(*verts[2]) +
                       polygon_place_vertex(*verts[0]) +
                       polygon_remove_vertex(*verts[0]))
-    check_polygon_selector(event_sequence, verts[1:], 2, draw_box=draw_box)
+    check_polygon_selector(event_sequence, verts[1:], 2,
+                           draw_bounding_box=draw_bounding_box)
 
 
-@pytest.mark.parametrize('draw_box', [False, True])
-def test_polygon_selector_redraw(draw_box):
+@pytest.mark.parametrize('draw_bounding_box', [False, True])
+def test_polygon_selector_redraw(draw_bounding_box):
     verts = [(50, 50), (150, 50), (50, 150)]
     event_sequence = (polygon_place_vertex(*verts[0]) +
                       polygon_place_vertex(*verts[1]) +
@@ -1366,7 +1368,8 @@ def test_polygon_selector_redraw(draw_box):
     def onselect(vertices):
         pass
 
-    tool = widgets.PolygonSelector(ax, onselect, draw_box=draw_box)
+    tool = widgets.PolygonSelector(ax, onselect,
+                                   draw_bounding_box=draw_bounding_box)
     for (etype, event_args) in event_sequence:
         do_event(tool, etype, **event_args)
     # After removing two verts, only one remains, and the
@@ -1411,7 +1414,7 @@ def test_polygon_selector_box():
         pass
 
     # Create selector
-    tool = widgets.PolygonSelector(ax, onselect, draw_box=True)
+    tool = widgets.PolygonSelector(ax, onselect, draw_bounding_box=True)
     for (etype, event_args) in event_sequence:
         do_event(tool, etype, **event_args)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3576,7 +3576,7 @@ class PolygonSelector(_SelectorWidget):
         A vertex is selected (to complete the polygon or to move a vertex) if
         the mouse click is within *grab_range* pixels of the vertex.
 
-    draw_box : bool, optional
+    draw_bounding_box : bool, optional
         If `True`, a bounding box will be drawn around the polygon selector
         once it is complete. This box can be used to move and resize the
         selector.
@@ -3605,7 +3605,7 @@ class PolygonSelector(_SelectorWidget):
     @_api.rename_parameter("3.5", "vertex_select_radius", "grab_range")
     def __init__(self, ax, onselect, useblit=False,
                  props=None, handle_props=None, grab_range=10, *,
-                 draw_box=False, box_handle_props=None,
+                 draw_bounding_box=False, box_handle_props=None,
                  box_props=None):
         # The state modifiers 'move', 'square', and 'center' are expected by
         # _SelectorWidget but are not supported by PolygonSelector
@@ -3642,7 +3642,7 @@ class PolygonSelector(_SelectorWidget):
         self.grab_range = grab_range
 
         self.set_visible(True)
-        self._draw_box = draw_box
+        self._draw_box = draw_bounding_box
         self._box = None
 
         if box_handle_props is None:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -17,7 +17,7 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib import docstring
-from . import _api, backend_tools, cbook, colors, ticker
+from . import _api, backend_tools, cbook, colors, ticker, transforms
 from .lines import Line2D
 from .patches import Circle, Rectangle, Ellipse
 from .transforms import TransformedPatchPath, Affine2D
@@ -2877,6 +2877,11 @@ class RectangleSelector(_SelectorWidget):
         self._rotation = 0.0
         self._aspect_ratio_correction = 1.0
 
+        # State to allow the option of an interactive selector that can't be
+        # interactively drawn. This is used in PolygonSelector as an
+        # interactive bounding box to allow the polygon to be easily resized
+        self._allow_creation = True
+
         if drawtype == 'none':  # draw a line but make it invisible
             _api.warn_deprecated(
                 "3.5", message="Support for drawtype='none' is deprecated "
@@ -2979,12 +2984,13 @@ class RectangleSelector(_SelectorWidget):
         else:
             self._active_handle = None
 
-        if self._active_handle is None or not self._interactive:
+        if ((self._active_handle is None or not self._interactive) and
+                self._allow_creation):
             # Clear previous rectangle before drawing new rectangle.
             self.update()
 
-        if self._active_handle is None and not self.ignore_event_outside:
-            # Start drawing a new rectangle
+        if (self._active_handle is None and not self.ignore_event_outside and
+                self._allow_creation):
             x = event.xdata
             y = event.ydata
             self.visible = False
@@ -3170,7 +3176,8 @@ class RectangleSelector(_SelectorWidget):
             self._rotation = 0
             # Don't create a new rectangle if there is already one when
             # ignore_event_outside=True
-            if self.ignore_event_outside and self._selection_completed:
+            if ((self.ignore_event_outside and self._selection_completed) or
+                    not self._allow_creation):
                 return
             center = [eventpress.xdata, eventpress.ydata]
             dx = (event.xdata - center[0]) / 2.
@@ -3569,6 +3576,19 @@ class PolygonSelector(_SelectorWidget):
         A vertex is selected (to complete the polygon or to move a vertex) if
         the mouse click is within *grab_range* pixels of the vertex.
 
+    draw_box : bool, optional
+        If `True`, a bounding box will be drawn around the polygon selector
+        once it is complete. This box can be used to move and resize the
+        selector.
+
+    box_handle_props : dict, optional
+        Properties to set for the box handles. See the documentation for the
+        *handle_props* argument to `RectangleSelector` for more info.
+
+    box_props : dict, optional
+        Properties to set for the box. See the documentation for the *props*
+        argument to `RectangleSelector` for more info.
+
     Examples
     --------
     :doc:`/gallery/widgets/polygon_selector_demo`
@@ -3584,7 +3604,9 @@ class PolygonSelector(_SelectorWidget):
     @_api.rename_parameter("3.5", "markerprops", "handle_props")
     @_api.rename_parameter("3.5", "vertex_select_radius", "grab_range")
     def __init__(self, ax, onselect, useblit=False,
-                 props=None, handle_props=None, grab_range=10):
+                 props=None, handle_props=None, grab_range=10, *,
+                 draw_box=False, box_handle_props=None,
+                 box_props=None):
         # The state modifiers 'move', 'square', and 'center' are expected by
         # _SelectorWidget but are not supported by PolygonSelector
         # Note: could not use the existing 'move' state modifier in-place of
@@ -3620,6 +3642,75 @@ class PolygonSelector(_SelectorWidget):
         self.grab_range = grab_range
 
         self.set_visible(True)
+        self._draw_box = draw_box
+        self._box = None
+
+        if box_handle_props is None:
+            box_handle_props = {}
+        self._box_handle_props = self._handle_props.update(box_handle_props)
+        self._box_props = box_props
+
+    def _get_bbox(self):
+        return self._selection_artist.get_bbox()
+
+    def _add_box(self):
+        self._box = RectangleSelector(self.ax,
+                                      onselect=lambda *args, **kwargs: None,
+                                      useblit=self.useblit,
+                                      grab_range=self.grab_range,
+                                      handle_props=self._box_handle_props,
+                                      props=self._box_props,
+                                      interactive=True)
+        self._box._state_modifier_keys.pop('rotate')
+        self._box.connect_event('motion_notify_event', self._scale_polygon)
+        self._update_box()
+        # Set state that prevents the RectangleSelector from being created
+        # by the user
+        self._box._allow_creation = False
+        self._box._selection_completed = True
+        self._draw_polygon()
+
+    def _remove_box(self):
+        if self._box is not None:
+            self._box.set_visible(False)
+            self._box = None
+
+    def _update_box(self):
+        # Update selection box extents to the extents of the polygon
+        if self._box is not None:
+            bbox = self._get_bbox()
+            self._box.extents = [bbox.x0, bbox.x1, bbox.y0, bbox.y1]
+            # Save a copy
+            self._old_box_extents = self._box.extents
+
+    def _scale_polygon(self, event):
+        """
+        Scale the polygon selector points when the bounding box is moved or
+        scaled.
+
+        This is set as a callback on the bounding box RectangleSelector.
+        """
+        if not self._selection_completed:
+            return
+
+        if self._old_box_extents == self._box.extents:
+            return
+
+        # Create transform from old box to new box
+        x1, y1, w1, h1 = self._box._rect_bbox
+        old_bbox = self._get_bbox()
+        t = (transforms.Affine2D()
+             .translate(-old_bbox.x0, -old_bbox.y0)
+             .scale(1 / old_bbox.width, 1 / old_bbox.height)
+             .scale(w1, h1)
+             .translate(x1, y1))
+
+        # Update polygon verts
+        new_verts = t.transform(np.array(self.verts))
+        self._xs = list(np.append(new_verts[:, 0], new_verts[0, 0]))
+        self._ys = list(np.append(new_verts[:, 1], new_verts[0, 1]))
+        self._draw_polygon()
+        self._old_box_extents = self._box.extents
 
     line = _api.deprecated("3.5")(
         property(lambda self: self._selection_artist)
@@ -3661,6 +3752,7 @@ class PolygonSelector(_SelectorWidget):
             # If only one point left, return to incomplete state to let user
             # start drawing again
             self._selection_completed = False
+            self._remove_box()
 
     def _press(self, event):
         """Button press event handler."""
@@ -3688,6 +3780,8 @@ class PolygonSelector(_SelectorWidget):
               and self._xs[-1] == self._xs[0]
               and self._ys[-1] == self._ys[0]):
             self._selection_completed = True
+            if self._draw_box and self._box is None:
+                self._add_box()
 
         # Place new vertex.
         elif (not self._selection_completed
@@ -3776,11 +3870,13 @@ class PolygonSelector(_SelectorWidget):
             event = self._clean_event(event)
             self._xs, self._ys = [event.xdata], [event.ydata]
             self._selection_completed = False
+            self._remove_box()
             self.set_visible(True)
 
     def _draw_polygon(self):
         """Redraw the polygon based on the new vertex positions."""
         self._selection_artist.set_data(self._xs, self._ys)
+        self._update_box()
         # Only show one tool handle at the start and end vertex of the polygon
         # if the polygon is completed or the user is locked on to the start
         # vertex.


### PR DESCRIPTION
## PR Summary
This allows one to put a bounding box around a PolygonSelector, that can be used for resizing and moving (and eventually rotating) the selector points.

```python
import matplotlib.pyplot as plt
from matplotlib.widgets import PolygonSelector

fig, ax = plt.subplots()
sel = PolygonSelector(ax, lambda *args, **kwargs: None, draw_box=True)
plt.show()
```
https://user-images.githubusercontent.com/6197628/144757647-ca03dba5-2ab4-4812-a9dd-e80b294b286e.mov

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
