### PR TITLE
FIX: pre-composite animation frames to white background

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -39,7 +39,7 @@ import matplotlib as mpl
 from matplotlib._animation_data import (
     DISPLAY_TEMPLATE, INCLUDED_FRAMES, JS_INCLUDE, STYLE_INCLUDE)
 from matplotlib import _api, cbook
-
+import matplotlib.colors as mcolors
 
 _log = logging.getLogger(__name__)
 
@@ -1002,6 +1002,9 @@ class Animation:
 
         if savefig_kwargs is None:
             savefig_kwargs = {}
+        else:
+            # we are going to mutate this below
+            savefig_kwargs = dict(savefig_kwargs)
 
         if fps is None and hasattr(self, '_interval'):
             # Convert interval in ms to frames per second
@@ -1057,6 +1060,18 @@ class Animation:
             _log.info("Disabling savefig.bbox = 'tight', as it may cause "
                       "frame size to vary, which is inappropriate for "
                       "animation.")
+
+        facecolor = savefig_kwargs.get('facecolor',
+                                       mpl.rcParams['savefig.facecolor'])
+        if facecolor == 'auto':
+            facecolor = self._fig.get_facecolor()
+
+        def _pre_composite_to_white(color):
+            r, g, b, a = mcolors.to_rgba(color)
+            return a * np.array([r, g, b]) + 1 - a
+
+        savefig_kwargs['facecolor'] = _pre_composite_to_white(facecolor)
+        savefig_kwargs['transparent'] = False   # just to be safe!
         # canvas._is_saving = True makes the draw_event animation-starting
         # callback a no-op; canvas.manager = None prevents resizing the GUI
         # widget (both are likewise done in savefig()).

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -70,6 +70,7 @@ class NullMovieWriter(animation.AbstractMovieWriter):
 
 def test_null_movie_writer(anim):
     # Test running an animation with NullMovieWriter.
+    plt.rcParams["savefig.facecolor"] = "auto"
     filename = "unused.null"
     dpi = 50
     savefig_kwargs = dict(foo=0)
@@ -82,7 +83,10 @@ def test_null_movie_writer(anim):
     assert writer.outfile == filename
     assert writer.dpi == dpi
     assert writer.args == ()
-    assert writer.savefig_kwargs == savefig_kwargs
+    # we enrich the savefig kwargs to ensure we composite transparent
+    # output to an opaque background
+    for k, v in savefig_kwargs.items():
+        assert writer.savefig_kwargs[k] == v
     assert writer._count == anim.save_count
 
 


### PR DESCRIPTION
This fixes issues with encoding that do not support transparency and when the
Figure facecolor is transparent.

Closes #19040

## PR Summary

I'm not sure how to test this as it is a visual thing is h254 encoded output. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
