### PR TITLE
Enforce backport conditions on v*-doc branches

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,7 +104,15 @@ commands:
     steps:
       - run:
           name: Install Matplotlib
-          command: python -m pip install --user -ve .
+          command: |
+            if [[ "$CIRCLE_BRANCH" == v*-doc ]]; then
+              # The v*-doc branches must build against the specified release.
+              version=${CIRCLE_BRANCH%-doc}
+              version=${version#v}
+              python -m pip install matplotlib==${version}
+            else
+              python -m pip install --user -ve .
+            fi
       - save_cache:
           key: build-deps-1
           paths:

--- a/.github/workflows/clean_pr.yml
+++ b/.github/workflows/clean_pr.yml
@@ -30,3 +30,14 @@ jobs:
             printf 'The following images were both added and modified in this PR:\n%s\n' "$am"
             exit 1
           fi
+      - name: Check for invalid backports to -doc branches
+        if: endsWith(github.base_ref, '-doc')
+        run: |
+          git fetch --quiet origin "$GITHUB_BASE_REF"
+          base="$(git merge-base "origin/$GITHUB_BASE_REF" 'HEAD^2')"
+          lib="$(git log "$base..HEAD^2" --pretty=tformat: --name-status -- lib src |
+                 cut --fields 2 | sort || true)"
+          if [[ -n "$lib" ]]; then
+            printf 'Changes to the following files have no effect and should not be backported:\n%s\n' "$lib"
+            exit 1
+          fi


### PR DESCRIPTION
## PR Summary

The `v*-doc` backport branches build docs against the released version. This is not enforced in the CI, and PRs can be backported that have no effect (e.e.g, #21631).

This PR adds a check that `lib` files are not modified on backports, and also attempts to run CircleCI with the right version.

Also fixes the added-and-modified check which was incorrectly failing in #21799, as noted on gitter.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).