### PR TITLE
MAINT Fix signature qhull version function 

### DIFF
--- a/src/qhull_wrap.cpp
+++ b/src/qhull_wrap.cpp
@@ -295,7 +295,7 @@ delaunay(PyObject *self, PyObject *args)
 
 /* Return qhull version string for assistance in debugging. */
 static PyObject*
-version(void)
+version(PyObject *self, PyObject *arg)
 {
     return PyBytes_FromString(qh_version);
 }

--- a/src/qhull_wrap.cpp
+++ b/src/qhull_wrap.cpp
@@ -301,8 +301,8 @@ version(PyObject *self, PyObject *arg)
 }
 
 static PyMethodDef qhull_methods[] = {
-    {"delaunay", (PyCFunction)delaunay, METH_VARARGS, ""},
-    {"version", (PyCFunction)version, METH_NOARGS, ""},
+    {"delaunay", delaunay, METH_VARARGS, ""},
+    {"version", version, METH_NOARGS, ""},
     {NULL, NULL, 0, NULL}
 };
 


### PR DESCRIPTION
## PR Summary

This is more of the same function pointer cast removal maintenance, see #21628.
Now the problem is that the qhull version function is declared as taking no arguments, but is supposed to be a `METH_NOARGS` function. `METH_NOARGS` functions should take two `PyObject*` arguments. This tiny patch fixes that.