### PR TITLE
Small improvements to interactive examples

### DIFF
--- a/examples/animation/pause_resume.py
+++ b/examples/animation/pause_resume.py
@@ -7,6 +7,14 @@ This example showcases:
 
 - using the Animation.pause() method to pause an animation.
 - using the Animation.resume() method to resume an animation.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/event_handling/close_event.py
+++ b/examples/event_handling/close_event.py
@@ -4,6 +4,14 @@ Close Event
 ===========
 
 Example to show connecting events that occur when the figure closes.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/event_handling/coords_demo.py
+++ b/examples/event_handling/coords_demo.py
@@ -5,6 +5,14 @@ Mouse move and click events
 
 An example of how to interact with the plotting canvas by connecting to move
 and click events.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 from matplotlib.backend_bases import MouseButton

--- a/examples/event_handling/data_browser.py
+++ b/examples/event_handling/data_browser.py
@@ -8,6 +8,14 @@ Connecting data between multiple canvases.
 This example covers how to interact data with multiple canvases. This
 let's you select and highlight a point on one axis, and generating the
 data of that point on the other axis.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import numpy as np
 

--- a/examples/event_handling/figure_axes_enter_leave.py
+++ b/examples/event_handling/figure_axes_enter_leave.py
@@ -5,6 +5,14 @@ Figure/Axes enter and leave events
 
 Illustrate the figure and Axes enter and leave events by changing the
 frame colors on enter and leave.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import matplotlib.pyplot as plt
 

--- a/examples/event_handling/ginput_manual_clabel_sgskip.py
+++ b/examples/event_handling/ginput_manual_clabel_sgskip.py
@@ -6,10 +6,13 @@ Interactive functions
 This provides examples of uses of interactive functions, such as ginput,
 waitforbuttonpress and manual clabel placement.
 
-This script must be run interactively using a backend that has a
-graphical user interface (for example, using GTK3Agg backend, but not
-PS backend).
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
 
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import time

--- a/examples/event_handling/image_slices_viewer.py
+++ b/examples/event_handling/image_slices_viewer.py
@@ -4,6 +4,14 @@ Image Slices Viewer
 ===================
 
 Scroll through 2D image slices of a 3D array.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import numpy as np

--- a/examples/event_handling/keypress_demo.py
+++ b/examples/event_handling/keypress_demo.py
@@ -4,6 +4,14 @@ Keypress event
 ==============
 
 Show how to connect to keypress events.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import sys
 import numpy as np

--- a/examples/event_handling/lasso_demo.py
+++ b/examples/event_handling/lasso_demo.py
@@ -9,6 +9,14 @@ selected points
 
 This is currently a proof-of-concept implementation (though it is
 usable as is).  There will be some refinement of the API.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 from matplotlib import colors as mcolors, path

--- a/examples/event_handling/legend_picking.py
+++ b/examples/event_handling/legend_picking.py
@@ -4,6 +4,14 @@ Legend Picking
 ==============
 
 Enable picking on the legend to toggle the original line on and off
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import numpy as np

--- a/examples/event_handling/looking_glass.py
+++ b/examples/event_handling/looking_glass.py
@@ -4,6 +4,14 @@ Looking Glass
 =============
 
 Example using mouse events to simulate a looking glass for inspecting data.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/event_handling/path_editor.py
+++ b/examples/event_handling/path_editor.py
@@ -7,6 +7,14 @@ Sharing events across GUIs.
 
 This example demonstrates a cross-GUI application using Matplotlib event
 handling to interact with and modify objects on the canvas.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import numpy as np

--- a/examples/event_handling/pick_event_demo.py
+++ b/examples/event_handling/pick_event_demo.py
@@ -3,7 +3,6 @@
 Pick Event Demo
 ===============
 
-
 You can enable picking by setting the "picker" property of an artist
 (for example, a matplotlib Line2D, Text, Patch, Polygon, AxesImage,
 etc...)
@@ -59,6 +58,14 @@ the picker criteria (for example, all the points in the line that are within
 the specified epsilon tolerance)
 
 The examples below illustrate each of these methods.
+
+.. note::
+    These examples exercises the interactive capabilities of Matplotlib, and
+    this will not appear in the static documentation. Please run this code on
+    your machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/event_handling/pick_event_demo.py
+++ b/examples/event_handling/pick_event_demo.py
@@ -81,114 +81,125 @@ from numpy.random import rand
 np.random.seed(19680801)
 
 
-def pick_simple():
-    # simple picking, lines, rectangles and text
-    fig, (ax1, ax2) = plt.subplots(2, 1)
-    ax1.set_title('click on points, rectangles or text', picker=True)
-    ax1.set_ylabel('ylabel', picker=True, bbox=dict(facecolor='red'))
-    line, = ax1.plot(rand(100), 'o', picker=True, pickradius=5)
+#############################################################################
+# Simple picking, lines, rectangles and text
+# ------------------------------------------
 
-    # pick the rectangle
-    ax2.bar(range(10), rand(10), picker=True)
-    for label in ax2.get_xticklabels():  # make the xtick labels pickable
-        label.set_picker(True)
+fig, (ax1, ax2) = plt.subplots(2, 1)
+ax1.set_title('click on points, rectangles or text', picker=True)
+ax1.set_ylabel('ylabel', picker=True, bbox=dict(facecolor='red'))
+line, = ax1.plot(rand(100), 'o', picker=True, pickradius=5)
 
-    def onpick1(event):
-        if isinstance(event.artist, Line2D):
-            thisline = event.artist
-            xdata = thisline.get_xdata()
-            ydata = thisline.get_ydata()
-            ind = event.ind
-            print('onpick1 line:', np.column_stack([xdata[ind], ydata[ind]]))
-        elif isinstance(event.artist, Rectangle):
-            patch = event.artist
-            print('onpick1 patch:', patch.get_path())
-        elif isinstance(event.artist, Text):
-            text = event.artist
-            print('onpick1 text:', text.get_text())
-
-    fig.canvas.mpl_connect('pick_event', onpick1)
+# Pick the rectangle.
+ax2.bar(range(10), rand(10), picker=True)
+for label in ax2.get_xticklabels():  # Make the xtick labels pickable.
+    label.set_picker(True)
 
 
-def pick_custom_hit():
-    # picking with a custom hit test function
-    # you can define custom pickers by setting picker to a callable
-    # function.  The function has the signature
-    #
-    #  hit, props = func(artist, mouseevent)
-    #
-    # to determine the hit test.  if the mouse event is over the artist,
-    # return hit=True and props is a dictionary of
-    # properties you want added to the PickEvent attributes
-
-    def line_picker(line, mouseevent):
-        """
-        Find the points within a certain distance from the mouseclick in
-        data coords and attach some extra attributes, pickx and picky
-        which are the data points that were picked.
-        """
-        if mouseevent.xdata is None:
-            return False, dict()
-        xdata = line.get_xdata()
-        ydata = line.get_ydata()
-        maxd = 0.05
-        d = np.sqrt(
-            (xdata - mouseevent.xdata)**2 + (ydata - mouseevent.ydata)**2)
-
-        ind, = np.nonzero(d <= maxd)
-        if len(ind):
-            pickx = xdata[ind]
-            picky = ydata[ind]
-            props = dict(ind=ind, pickx=pickx, picky=picky)
-            return True, props
-        else:
-            return False, dict()
-
-    def onpick2(event):
-        print('onpick2 line:', event.pickx, event.picky)
-
-    fig, ax = plt.subplots()
-    ax.set_title('custom picker for line data')
-    line, = ax.plot(rand(100), rand(100), 'o', picker=line_picker)
-    fig.canvas.mpl_connect('pick_event', onpick2)
-
-
-def pick_scatter_plot():
-    # picking on a scatter plot (matplotlib.collections.RegularPolyCollection)
-
-    x, y, c, s = rand(4, 100)
-
-    def onpick3(event):
+def onpick1(event):
+    if isinstance(event.artist, Line2D):
+        thisline = event.artist
+        xdata = thisline.get_xdata()
+        ydata = thisline.get_ydata()
         ind = event.ind
-        print('onpick3 scatter:', ind, x[ind], y[ind])
-
-    fig, ax = plt.subplots()
-    ax.scatter(x, y, 100*s, c, picker=True)
-    fig.canvas.mpl_connect('pick_event', onpick3)
-
-
-def pick_image():
-    # picking images (matplotlib.image.AxesImage)
-    fig, ax = plt.subplots()
-    ax.imshow(rand(10, 5), extent=(1, 2, 1, 2), picker=True)
-    ax.imshow(rand(5, 10), extent=(3, 4, 1, 2), picker=True)
-    ax.imshow(rand(20, 25), extent=(1, 2, 3, 4), picker=True)
-    ax.imshow(rand(30, 12), extent=(3, 4, 3, 4), picker=True)
-    ax.set(xlim=(0, 5), ylim=(0, 5))
-
-    def onpick4(event):
-        artist = event.artist
-        if isinstance(artist, AxesImage):
-            im = artist
-            A = im.get_array()
-            print('onpick4 image', A.shape)
-
-    fig.canvas.mpl_connect('pick_event', onpick4)
+        print('onpick1 line:', np.column_stack([xdata[ind], ydata[ind]]))
+    elif isinstance(event.artist, Rectangle):
+        patch = event.artist
+        print('onpick1 patch:', patch.get_path())
+    elif isinstance(event.artist, Text):
+        text = event.artist
+        print('onpick1 text:', text.get_text())
 
 
-if __name__ == '__main__':
-    pick_simple()
-    pick_custom_hit()
-    pick_scatter_plot()
-    pick_image()
-    plt.show()
+fig.canvas.mpl_connect('pick_event', onpick1)
+
+
+#############################################################################
+# Picking with a custom hit test function
+# ---------------------------------------
+# You can define custom pickers by setting picker to a callable function. The
+# function has the signature::
+#
+#  hit, props = func(artist, mouseevent)
+#
+# to determine the hit test. If the mouse event is over the artist, return
+# ``hit=True`` and ``props`` is a dictionary of properties you want added to
+# the `.PickEvent` attributes.
+
+def line_picker(line, mouseevent):
+    """
+    Find the points within a certain distance from the mouseclick in
+    data coords and attach some extra attributes, pickx and picky
+    which are the data points that were picked.
+    """
+    if mouseevent.xdata is None:
+        return False, dict()
+    xdata = line.get_xdata()
+    ydata = line.get_ydata()
+    maxd = 0.05
+    d = np.sqrt(
+        (xdata - mouseevent.xdata)**2 + (ydata - mouseevent.ydata)**2)
+
+    ind, = np.nonzero(d <= maxd)
+    if len(ind):
+        pickx = xdata[ind]
+        picky = ydata[ind]
+        props = dict(ind=ind, pickx=pickx, picky=picky)
+        return True, props
+    else:
+        return False, dict()
+
+
+def onpick2(event):
+    print('onpick2 line:', event.pickx, event.picky)
+
+
+fig, ax = plt.subplots()
+ax.set_title('custom picker for line data')
+line, = ax.plot(rand(100), rand(100), 'o', picker=line_picker)
+fig.canvas.mpl_connect('pick_event', onpick2)
+
+
+#############################################################################
+# Picking on a scatter plot
+# -------------------------
+# A scatter plot is backed by a `~matplotlib.collections.PathCollection`.
+
+x, y, c, s = rand(4, 100)
+
+
+def onpick3(event):
+    ind = event.ind
+    print('onpick3 scatter:', ind, x[ind], y[ind])
+
+
+fig, ax = plt.subplots()
+ax.scatter(x, y, 100*s, c, picker=True)
+fig.canvas.mpl_connect('pick_event', onpick3)
+
+
+#############################################################################
+# Picking images
+# --------------
+# Images plotted using `.Axes.imshow` are `~matplotlib.image.AxesImage`
+# objects.
+
+fig, ax = plt.subplots()
+ax.imshow(rand(10, 5), extent=(1, 2, 1, 2), picker=True)
+ax.imshow(rand(5, 10), extent=(3, 4, 1, 2), picker=True)
+ax.imshow(rand(20, 25), extent=(1, 2, 3, 4), picker=True)
+ax.imshow(rand(30, 12), extent=(3, 4, 3, 4), picker=True)
+ax.set(xlim=(0, 5), ylim=(0, 5))
+
+
+def onpick4(event):
+    artist = event.artist
+    if isinstance(artist, AxesImage):
+        im = artist
+        A = im.get_array()
+        print('onpick4 image', A.shape)
+
+
+fig.canvas.mpl_connect('pick_event', onpick4)
+
+plt.show()

--- a/examples/event_handling/pick_event_demo2.py
+++ b/examples/event_handling/pick_event_demo2.py
@@ -6,6 +6,14 @@ Pick Event Demo2
 Compute the mean (mu) and standard deviation (sigma) of 100 data sets and plot
 mu vs. sigma.  When you click on one of the (mu, sigma) points, plot the raw
 data from the dataset that generated this point.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/event_handling/poly_editor.py
+++ b/examples/event_handling/poly_editor.py
@@ -5,6 +5,14 @@ Poly Editor
 
 This is an example to show how to build cross-GUI applications using
 Matplotlib event handling to interact with objects on the canvas.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import numpy as np
 from matplotlib.lines import Line2D

--- a/examples/event_handling/pong_sgskip.py
+++ b/examples/event_handling/pong_sgskip.py
@@ -5,6 +5,14 @@ Pong
 
 A Matplotlib based game of Pong illustrating one way to write interactive
 animations that are easily ported to multiple backends.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import time

--- a/examples/event_handling/resample.py
+++ b/examples/event_handling/resample.py
@@ -6,6 +6,14 @@ Resampling Data
 Downsampling lowers the sample rate or sample size of a signal. In
 this tutorial, the signal is downsampled when the plot is adjusted
 through dragging and zooming.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import numpy as np

--- a/examples/event_handling/timers.py
+++ b/examples/event_handling/timers.py
@@ -5,6 +5,14 @@ Timers
 
 Simple example of using general timer objects. This is used to update
 the time placed in the title of the figure.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/examples/event_handling/trifinder_event_demo.py
+++ b/examples/event_handling/trifinder_event_demo.py
@@ -6,6 +6,14 @@ Trifinder Event Demo
 Example showing the use of a TriFinder object.  As the mouse is moved over the
 triangulation, the triangle under the cursor is highlighted and the index of
 the triangle is displayed in the plot title.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import matplotlib.pyplot as plt
 from matplotlib.tri import Triangulation

--- a/examples/event_handling/viewlims.py
+++ b/examples/event_handling/viewlims.py
@@ -5,6 +5,14 @@ Viewlims
 
 Creates two identical panels.  Zooming in on the right panel will show
 a rectangle in the first panel, denoting the zoomed region.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 import numpy as np
 import matplotlib.pyplot as plt

--- a/examples/event_handling/zoom_window.py
+++ b/examples/event_handling/zoom_window.py
@@ -29,8 +29,8 @@ import numpy as np
 # Fixing random state for reproducibility
 np.random.seed(19680801)
 
-figsrc, axsrc = plt.subplots()
-figzoom, axzoom = plt.subplots()
+figsrc, axsrc = plt.subplots(figsize=(3.7, 3.7))
+figzoom, axzoom = plt.subplots(figsize=(3.7, 3.7))
 axsrc.set(xlim=(0, 1), ylim=(0, 1), autoscale_on=False,
           title='Click to zoom')
 axzoom.set(xlim=(0.45, 0.55), ylim=(0.4, 0.6), autoscale_on=False,

--- a/examples/event_handling/zoom_window.py
+++ b/examples/event_handling/zoom_window.py
@@ -12,6 +12,14 @@ the (x, y) coordinates of the clicked point.
 
 Note the diameter of the circles in the scatter are defined in points**2, so
 their size is independent of the zoom.
+
+.. note::
+    This example exercises the interactive capabilities of Matplotlib, and this
+    will not appear in the static documentation. Please run this code on your
+    machine to see the interactivity.
+
+    You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## PR Summary

Adds a note about lack of interactivity in static docs, and tweaks some examples to look better once the multi-column sphinx-gallery CSS is removed.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).