### PR TITLE
Slightly better positioning of subscripts and superscripts of fractions

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2207,15 +2207,15 @@ class Parser:
             result = Hlist([vlist])
             return [result]
 
-        # Set the minimum shifts for the superscript and subscript.
+        # Set the minimum shifts for the superscript and subscript (node756).
         constants = _get_font_constant_set(state)
         if isinstance(nucleus, Char):
             shift_up = 0
             shift_down = 0
         else:
-            # TODO Optimise and reduce line length.
-            shift_up = nucleus.height - constants.subdrop * xHeight * SHRINK_FACTOR
-            shift_down = nucleus.depth + constants.subdrop * xHeight * SHRINK_FACTOR
+            drop_amount = constants.subdrop * xHeight * SHRINK_FACTOR
+            shift_up = nucleus.height - drop_amount
+            shift_down = nucleus.depth + drop_amount
 
         # We remove kerning on the last character for consistency (otherwise
         # it will compute kerning based on non-shrunk characters and may put
@@ -2264,40 +2264,44 @@ class Parser:
                 subkern = 0
 
         if super is None:
-            # node757
+            # Align subscript without superscript (node757).
             x = Hlist([Kern(subkern), sub])
             x.shrink()
             if self.is_dropsub(last_char):
                 shift_down = lc_baseline + constants.subdrop * xHeight
             else:
-                # TODO Optimise.
-                if shift_down < constants.sub1 * xHeight:
-                    shift_down = constants.sub1 * xHeight
-                clr = x.height - xHeight * 4 / 5
-                if shift_down < clr:
-                    shift_down = clr
+                shift_down = max(shift_down, constants.sub1 * xHeight,
+                    x.height - xHeight * 4 / 5)
             x.shift_amount = shift_down
         else:
+            # Align superscript (node758).
             x = Hlist([Kern(superkern), super])
             x.shrink()
             if self.is_dropsub(last_char):
                 shift_up = lc_height - constants.subdrop * xHeight
             else:
-                shift_up = constants.sup1 * xHeight
+                shift_up = max(shift_up, constants.sup1 * xHeight,
+                    x.depth + xHeight / 4)
             if sub is None:
                 x.shift_amount = -shift_up
-            else:  # Both sub and superscript
+            else:
+                # Align subscript with superscript (node759).
                 y = Hlist([Kern(subkern), sub])
                 y.shrink()
                 if self.is_dropsub(last_char):
                     shift_down = lc_baseline + constants.subdrop * xHeight
                 else:
-                    shift_down = constants.sub2 * xHeight
-                # If sub and superscript collide, move super up
-                clr = (2.0 * rule_thickness -
+                    shift_down = max(shift_down, constants.sub2 * xHeight)
+                # If the subscript and superscript are too close to each other,
+                # move the subscript down.
+                clr = (4 * rule_thickness -
                        ((shift_up - x.depth) - (y.height - shift_down)))
                 if clr > 0.:
-                    shift_up += clr
+                    shift_down += clr
+                    clr = xHeight * 4 / 5 - shift_up + x.depth
+                    if clr > 0:
+                        shift_up += clr
+                        shift_down -= clr
                 x = Vlist([
                     x,
                     Kern((shift_up - x.depth) - (y.height - shift_down)),

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2271,7 +2271,7 @@ class Parser:
                 shift_down = lc_baseline + constants.subdrop * xHeight
             else:
                 shift_down = max(shift_down, constants.sub1 * xHeight,
-                    x.height - xHeight * 4 / 5)
+                                 x.height - xHeight * 4 / 5)
             x.shift_amount = shift_down
         else:
             # Align superscript (node758).
@@ -2281,7 +2281,7 @@ class Parser:
                 shift_up = lc_height - constants.subdrop * xHeight
             else:
                 shift_up = max(shift_up, constants.sup1 * xHeight,
-                    x.depth + xHeight / 4)
+                               x.depth + xHeight / 4)
             if sub is None:
                 x.shift_amount = -shift_up
             else:


### PR DESCRIPTION
## PR Summary
Tries to improve the positioning of sub- and superscripts attached to fractions (fix [#18086](https://github.com/matplotlib/matplotlib/issues/18086)).

## PR Checklist
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

## Details
```
import matplotlib.pyplot as plt
s = r'$\left(\dfrac{n}{d}\right)_p^q$ $\left(\dfrac{n}{d}\right)^q$ $\left(\dfrac{n}{d}\right)_p$'
fig = plt.figure()
fig.text(0.1, 0.5, s)
plt.show()
```

### Before
![before](https://user-images.githubusercontent.com/19171016/144579765-81b7f94f-6c69-4303-807f-1b077d137d78.png)

### After
![after](https://user-images.githubusercontent.com/19171016/144580065-e64610f3-2f16-434b-aea0-109baaaedaed.png)

## Notes
I added a new production rule for the tokenisation of expressions containing subscripts and superscripts.
```
        p.subsuper      <<= Group(
            (Optional(p.placeable)
             + OneOrMore(p.subsuperop - p.placeable)
             + Optional(p.apostrophe))
            | (p.placeable + Optional(p.apostrophe))
            | p.apostrophe
            | (p.auto_delim + OneOrMore(p.subsuperop - p.placeable))
        )
```
This should be considered suboptimal, but with my extremely limited knowledge of languages, grammars and parsing, this is the best idea I could come up with. This addition has the effect of making the nucleus (i.e. the expression to which a subscript and/or superscript are/is attached) available for the calculation of `shift_up` and `shift_down`.

I hate magic constants (`0.4` and `1.4`) as much as the next person, but can't think of anything better to differentiate nuclei which are and aren't fractions. This works for Dejavu Sans, but not for Computer Modern or STIX or Dejavu Serif. So, I'll leave this as a draft. Would appreciate experts weighing in.

LaTeX uses a wide assortment of font parameters (stored in `font_info`, an array) to calculate `shift_up` and `shift_down`, so the results of this will not exactly match what LaTeX gives us, but it will be close. Nevertheless, this will have to be tested extensively.

Needless to say, sub- and superscripts can be nested.
```
import matplotlib.pyplot as plt
s = r'$\left(\dfrac{\mathrm{Numerator}}{\mathrm{Denominator}}\right)_{y_{i^2}}^{\frac{y_k^{2^w}}{4^3}}$'
fig = plt.figure()
fig.text(0.1, 0.5, s, size=50)
plt.show()
```
![nesting](https://user-images.githubusercontent.com/19171016/144583277-f0b8b2df-38b6-46ca-a4f5-e28040712278.png)

Another point to note is that this will be affected by https://github.com/matplotlib/matplotlib/pull/20627, so a rebase may be required later.

