### PR TITLE
Re-order a widget test function

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1232,46 +1232,6 @@ def test_polygon_selector_set_props_handle_props():
         assert artist.get_alpha() == 0.3
 
 
-@pytest.mark.parametrize(
-    "horizOn, vertOn",
-    [(True, True), (True, False), (False, True)],
-)
-def test_MultiCursor(horizOn, vertOn):
-    fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
-
-    # useblit=false to avoid having to draw the figure to cache the renderer
-    multi = widgets.MultiCursor(
-        fig.canvas, (ax1, ax2), useblit=False, horizOn=horizOn, vertOn=vertOn
-    )
-
-    # Only two of the axes should have a line drawn on them.
-    if vertOn:
-        assert len(multi.vlines) == 2
-    if horizOn:
-        assert len(multi.hlines) == 2
-
-    # mock a motion_notify_event
-    # Can't use `do_event` as that helper requires the widget
-    # to have a single .ax attribute.
-    event = mock_event(ax1, xdata=.5, ydata=.25)
-    multi.onmove(event)
-
-    # the lines in the first two ax should both move
-    for l in multi.vlines:
-        assert l.get_xdata() == (.5, .5)
-    for l in multi.hlines:
-        assert l.get_ydata() == (.25, .25)
-
-    # test a move event in an axes not part of the MultiCursor
-    # the lines in ax1 and ax2 should not have moved.
-    event = mock_event(ax3, xdata=.75, ydata=.75)
-    multi.onmove(event)
-    for l in multi.vlines:
-        assert l.get_xdata() == (.5, .5)
-    for l in multi.hlines:
-        assert l.get_ydata() == (.25, .25)
-
-
 @check_figures_equal()
 def test_rect_visibility(fig_test, fig_ref):
     # Check that requesting an invisible selector makes it invisible
@@ -1338,3 +1298,43 @@ def test_polygon_selector_redraw():
     # After removing two verts, only one remains, and the
     # selector should be automatically resete
     assert tool.verts == verts[0:2]
+
+
+@pytest.mark.parametrize(
+    "horizOn, vertOn",
+    [(True, True), (True, False), (False, True)],
+)
+def test_MultiCursor(horizOn, vertOn):
+    fig, (ax1, ax2, ax3) = plt.subplots(3, sharex=True)
+
+    # useblit=false to avoid having to draw the figure to cache the renderer
+    multi = widgets.MultiCursor(
+        fig.canvas, (ax1, ax2), useblit=False, horizOn=horizOn, vertOn=vertOn
+    )
+
+    # Only two of the axes should have a line drawn on them.
+    if vertOn:
+        assert len(multi.vlines) == 2
+    if horizOn:
+        assert len(multi.hlines) == 2
+
+    # mock a motion_notify_event
+    # Can't use `do_event` as that helper requires the widget
+    # to have a single .ax attribute.
+    event = mock_event(ax1, xdata=.5, ydata=.25)
+    multi.onmove(event)
+
+    # the lines in the first two ax should both move
+    for l in multi.vlines:
+        assert l.get_xdata() == (.5, .5)
+    for l in multi.hlines:
+        assert l.get_ydata() == (.25, .25)
+
+    # test a move event in an axes not part of the MultiCursor
+    # the lines in ax1 and ax2 should not have moved.
+    event = mock_event(ax3, xdata=.75, ydata=.75)
+    multi.onmove(event)
+    for l in multi.vlines:
+        assert l.get_xdata() == (.5, .5)
+    for l in multi.hlines:
+        assert l.get_ydata() == (.25, .25)


### PR DESCRIPTION
This moves a MultiCursor test from within a block of PolygonSelector tests to the end of the file, making an uniterrupted block of all the PolygonSelector tests.

Eventually I want to split widget tests into one file per widget, but will wait until a number of ongoing widget PRs are merged to do that.