### PR TITLE
- added dependancy for wheel to setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -311,6 +311,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "numpy>=1.17",
         "setuptools_scm>=4",
         "setuptools_scm_git_archive",
+        "wheel",
     ],
     install_requires=[
         "cycler>=0.10",


### PR DESCRIPTION
## PR Summary
Dear all

py -m pip wheel git+https://github.com/matplotlib/matplotlib.git#egg=matplotlib

failed for me with the error.:

  error: invalid command 'bdist_wheel'

this is due to the lack of the wheel dependency for setup_requires

This request was previously bundled with a request to remove the setuptools requirements.

Thanks!
Franz 
