### PR TITLE
DOC: Update style sheet reference

### DIFF
--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -109,26 +109,19 @@ def plot_figure(style_label=""):
     # across the different figures.
     prng = np.random.RandomState(96917002)
 
-    # Tweak the figure size to be better suited for a row of numerous plots:
-    # double the width and halve the height. NB: use relative changes because
-    # some styles may have a figure size different from the default one.
-    (fig_width, fig_height) = plt.rcParams['figure.figsize']
-    fig_size = [fig_width * 2, fig_height / 1.75]
-
     fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
-                            figsize=fig_size, constrained_layout=True)
+                            figsize=(14.8, 2.7), constrained_layout=True)
 
     # make a suptitle, in the same style for all subfigures,
-    # except those with dark backgrounds, which get a lighter
-    # color:
-    col = np.array([19, 6, 84])/256
-    back = mcolors.rgb_to_hsv(
+    # except those with dark backgrounds, which get a lighter color:
+    background_color = mcolors.rgb_to_hsv(
         mcolors.to_rgb(plt.rcParams['figure.facecolor']))[2]
-    if back < 0.5:
-        col = [0.8, 0.8, 1]
-    fig.suptitle(style_label, x=0.01, fontsize=14, ha='left',
-                 color=col, fontfamily='DejaVu Sans',
-                 fontweight='normal')
+    if background_color < 0.5:
+        title_color = [0.8, 0.8, 1]
+    else:
+        title_color = np.array([19, 6, 84]) / 256
+    fig.suptitle(style_label, x=0.01, ha='left', color=title_color,
+                 fontsize=14, fontfamily='DejaVu Sans', fontweight='normal')
 
     plot_scatter(axs[0], prng)
     plot_image_and_patch(axs[1], prng)

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -11,6 +11,7 @@ line plot and histogram,
 
 import numpy as np
 import matplotlib.pyplot as plt
+import matplotlib.colors as mcolors
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
@@ -26,15 +27,19 @@ def plot_scatter(ax, prng, nb_samples=100):
     return ax
 
 
-def plot_colored_sinusoidal_lines(ax):
-    """Plot sinusoidal lines with colors following the style color cycle."""
-    L = 2 * np.pi
-    x = np.linspace(0, L)
+def plot_colored_lines(ax):
+    """Plot lines with colors following the style color cycle."""
+    t = np.linspace(-10, 10, 100)
+
+    def sigmoid(t, t0):
+        return 1 / (1 + np.exp(-(t - t0)))
+
     nb_colors = len(plt.rcParams['axes.prop_cycle'])
-    shift = np.linspace(0, L, nb_colors, endpoint=False)
-    for s in shift:
-        ax.plot(x, np.sin(x + s), '-')
-    ax.set_xlim([x[0], x[-1]])
+    shifts = np.linspace(-5, 5, nb_colors)
+    amplitudes = np.linspace(1, 1.5, nb_colors)
+    for t0, a in zip(shifts, amplitudes):
+        ax.plot(t, a * sigmoid(t, t0), '-')
+    ax.set_xlim(-10, 10)
     return ax
 
 
@@ -108,22 +113,29 @@ def plot_figure(style_label=""):
     # double the width and halve the height. NB: use relative changes because
     # some styles may have a figure size different from the default one.
     (fig_width, fig_height) = plt.rcParams['figure.figsize']
-    fig_size = [fig_width * 2, fig_height / 2]
+    fig_size = [fig_width * 2, fig_height / 1.75]
 
     fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
-                            figsize=fig_size, squeeze=True)
-    axs[0].set_ylabel(style_label, fontsize=13, fontweight='bold')
+                            figsize=fig_size, constrained_layout=True)
+
+    # make a suptitle, in the same style for all subfigures,
+    # except those with dark backgrounds, which get a lighter
+    # color:
+    col = np.array([19, 6, 84])/256
+    back = mcolors.rgb_to_hsv(
+        mcolors.to_rgb(plt.rcParams['figure.facecolor']))[2]
+    if back < 0.5:
+        col = [0.8, 0.8, 1]
+    fig.suptitle(style_label, x=0.01, fontsize=14, ha='left',
+                 color=col, fontfamily='DejaVu Sans',
+                 fontweight='normal')
 
     plot_scatter(axs[0], prng)
     plot_image_and_patch(axs[1], prng)
     plot_bar_graphs(axs[2], prng)
     plot_colored_circles(axs[3], prng)
-    plot_colored_sinusoidal_lines(axs[4])
+    plot_colored_lines(axs[4])
     plot_histograms(axs[5], prng)
-
-    fig.tight_layout()
-
-    return fig
 
 
 if __name__ == "__main__":
@@ -141,6 +153,6 @@ if __name__ == "__main__":
     for style_label in style_list:
         with plt.rc_context({"figure.max_open_warning": len(style_list)}):
             with plt.style.context(style_label):
-                fig = plot_figure(style_label=style_label)
+                plot_figure(style_label=style_label)
 
     plt.show()

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -112,7 +112,7 @@ def plot_figure(style_label=""):
 
     fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
                             figsize=fig_size, squeeze=True)
-    axs[0].set_ylabel(style_label)
+    axs[0].set_ylabel(style_label, fontsize=13, fontweight='bold')
 
     plot_scatter(axs[0], prng)
     plot_image_and_patch(axs[1], prng)
@@ -131,8 +131,11 @@ if __name__ == "__main__":
     # Setup a list of all available styles, in alphabetical order but
     # the `default` and `classic` ones, which will be forced resp. in
     # first and second position.
+    # styles with leading underscores are for internal use such as testing
+    # and plot types gallery. These are excluded here.
     style_list = ['default', 'classic'] + sorted(
-        style for style in plt.style.available if style != 'classic')
+        style for style in plt.style.available
+        if style != 'classic' and not style.startswith('_'))
 
     # Plot a demonstration figure for every available style sheet.
     for style_label in style_list:


### PR DESCRIPTION
- Exclude internal styles (Closes #21838)
- Make style names a bit larger and bold for better readability
- Use a different curve than sin for the plot lines with colorcycle. - The sin curves have a lot of crossing which makes it hard to follow the colorcycle. - I've still one crossing section included to make it look a bit more interesting, but we could even remove that in case somebody thinks this is still too cluttered.