### PR TITLE
Use partialmethod for better signatures in backend_ps.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -838,17 +838,10 @@ class FigureCanvasPS(FigureCanvasBase):
     def get_default_filetype(self):
         return 'ps'
 
-    @_api.delete_parameter("3.5", "args")
-    def print_ps(self, outfile, *args, **kwargs):
-        return self._print_ps(outfile, 'ps', **kwargs)
-
-    @_api.delete_parameter("3.5", "args")
-    def print_eps(self, outfile, *args, **kwargs):
-        return self._print_ps(outfile, 'eps', **kwargs)
-
     @_api.delete_parameter("3.4", "dpi")
+    @_api.delete_parameter("3.5", "args")
     def _print_ps(
-            self, outfile, format, *,
+            self, fmt, outfile, *args,
             dpi=None, metadata=None, papertype=None, orientation='portrait',
             **kwargs):
 
@@ -885,12 +878,12 @@ class FigureCanvasPS(FigureCanvasBase):
         printer = (self._print_figure_tex
                    if mpl.rcParams['text.usetex'] else
                    self._print_figure)
-        printer(outfile, format, dpi=dpi, dsc_comments=dsc_comments,
+        printer(fmt, outfile, dpi=dpi, dsc_comments=dsc_comments,
                 orientation=orientation, papertype=papertype, **kwargs)
 
     @_check_savefig_extra_args
     def _print_figure(
-            self, outfile, format, *,
+            self, fmt, outfile, *,
             dpi, dsc_comments, orientation, papertype,
             bbox_inches_restore=None):
         """
@@ -900,7 +893,7 @@ class FigureCanvasPS(FigureCanvasBase):
         all string containing Document Structuring Convention comments,
         generated from the *metadata* parameter to `.print_figure`.
         """
-        is_eps = format == 'eps'
+        is_eps = fmt == 'eps'
         if not (isinstance(outfile, (str, os.PathLike))
                 or is_writable_file_like(outfile)):
             raise ValueError("outfile must be a path or a file-like object")
@@ -1028,7 +1021,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
     @_check_savefig_extra_args
     def _print_figure_tex(
-            self, outfile, format, *,
+            self, fmt, outfile, *,
             dpi, dsc_comments, orientation, papertype,
             bbox_inches_restore=None):
         """
@@ -1038,7 +1031,7 @@ class FigureCanvasPS(FigureCanvasBase):
 
         The rest of the behavior is as for `._print_figure`.
         """
-        is_eps = format == 'eps'
+        is_eps = fmt == 'eps'
 
         width, height = self.figure.get_size_inches()
         xo = 0
@@ -1120,6 +1113,9 @@ showpage
                              rotated=psfrag_rotated)
 
             _move_path_to_path_or_stream(tmpfile, outfile)
+
+    print_ps = functools.partialmethod(_print_ps, "ps")
+    print_eps = functools.partialmethod(_print_ps, "eps")
 
     def draw(self):
         self.figure.draw_without_rendering()


### PR DESCRIPTION
I missed this possibility in 26253f7a, but the idea is the same (see motivation there).

Move `format` to be the first parameter of `_print_ps` and friends, to
make the partialmethods easier to define.  Also rename `format` to `fmt`
while we're at it, to avoid shadowing the builtin `format` function.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
