### PR TITLE
FIX: colorbars with NoNorm

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -839,7 +839,8 @@ class Colorbar:
                 # default locator:
                 nv = len(self._values)
                 base = 1 + int(nv / 10)
-                locator = ticker.IndexLocator(base=base, offset=0)
+                # put ticks on integers between the boundaries of NoNorm...
+                locator = ticker.IndexLocator(base=base, offset=.5)
 
         if minorlocator is None:
             minorlocator = ticker.NullLocator()
@@ -1097,6 +1098,9 @@ class Colorbar:
         # otherwise values are set from the boundaries
         if isinstance(self.norm, colors.BoundaryNorm):
             b = self.norm.boundaries
+        elif isinstance(self.norm, colors.NoNorm):
+            # NoNorm has N blocks, so N+1 boundaries, centered on integers:
+            b = np.arange(self.cmap.N + 1) - .5
         else:
             # otherwise make the boundaries from the size of the cmap:
             N = self.cmap.N + 1

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -824,6 +824,12 @@ class Colorbar:
             b = self.norm.boundaries
             if locator is None:
                 locator = ticker.FixedLocator(b, nbins=10)
+        elif isinstance(self.norm, colors.NoNorm):
+            if locator is None:
+                # put ticks on integers between the boundaries of NoNorm
+                nv = len(self._values)
+                base = 1 + int(nv / 10)
+                locator = ticker.IndexLocator(base=base, offset=.5)
         elif self.boundaries is not None:
             b = self._boundaries[self._inside]
             if locator is None:
@@ -835,12 +841,6 @@ class Colorbar:
                 locator = self._long_axis().get_major_locator()
             if minorlocator is None:
                 minorlocator = self._long_axis().get_minor_locator()
-            if isinstance(self.norm, colors.NoNorm):
-                # default locator:
-                nv = len(self._values)
-                base = 1 + int(nv / 10)
-                # put ticks on integers between the boundaries of NoNorm...
-                locator = ticker.IndexLocator(base=base, offset=.5)
 
         if minorlocator is None:
             minorlocator = ticker.NullLocator()

--- a/lib/matplotlib/tests/baseline_images/test_colorbar/nonorm_colorbars.svg
+++ b/lib/matplotlib/tests/baseline_images/test_colorbar/nonorm_colorbars.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="432pt" height="72pt" viewBox="0 0 432 72" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <metadata>
+  <rdf:RDF xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+   <cc:Work>
+    <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+    <dc:date>2021-12-06T14:23:33.155376</dc:date>
+    <dc:format>image/svg+xml</dc:format>
+    <dc:creator>
+     <cc:Agent>
+      <dc:title>Matplotlib v3.6.0.dev954+ged9e9c2ef2.d20211206, https://matplotlib.org/</dc:title>
+     </cc:Agent>
+    </dc:creator>
+   </cc:Work>
+  </rdf:RDF>
+ </metadata>
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="patch_1">
+   <path d="M 0 72 
+L 432 72 
+L 432 0 
+L 0 0 
+z
+" style="fill: #ffffff"/>
+  </g>
+  <g id="axes_1">
+   <g id="patch_2">
+    <path d="M 54 36 
+L 388.8 36 
+L 388.8 8.64 
+L 54 8.64 
+z
+" style="fill: #ffffff"/>
+   </g>
+   <g id="patch_3">
+    <path clip-path="url(#pb535666b66)" style="fill: #ffffff; stroke: #ffffff; stroke-width: 0.01; stroke-linejoin: miter"/>
+   </g>
+   <g id="QuadMesh_1">
+    <path d="M 54 36 
+L 54 8.64 
+L 120.96 8.64 
+L 120.96 36 
+L 54 36 
+" clip-path="url(#pb535666b66)" style="fill: #440154"/>
+    <path d="M 120.96 36 
+L 120.96 8.64 
+L 187.92 8.64 
+L 187.92 36 
+L 120.96 36 
+" clip-path="url(#pb535666b66)" style="fill: #3b528b"/>
+    <path d="M 187.92 36 
+L 187.92 8.64 
+L 254.88 8.64 
+L 254.88 36 
+L 187.92 36 
+" clip-path="url(#pb535666b66)" style="fill: #21918c"/>
+    <path d="M 254.88 36 
+L 254.88 8.64 
+L 321.84 8.64 
+L 321.84 36 
+L 254.88 36 
+" clip-path="url(#pb535666b66)" style="fill: #5ec962"/>
+    <path d="M 321.84 36 
+L 321.84 8.64 
+L 388.8 8.64 
+L 388.8 36 
+L 321.84 36 
+" clip-path="url(#pb535666b66)" style="fill: #fde725"/>
+   </g>
+   <g id="matplotlib.axis_1">
+    <g id="xtick_1">
+     <g id="line2d_1">
+      <defs>
+       <path id="m11ebc9ebd0" d="M 0 0 
+L 0 3.5 
+" style="stroke: #000000; stroke-width: 0.8"/>
+      </defs>
+      <g>
+       <use xlink:href="#m11ebc9ebd0" x="87.48" y="36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_1">
+      <text style="font: 10px 'DejaVu Sans'; text-anchor: middle" x="87.48" y="50.598438" transform="rotate(-0 87.48 50.598438)">0</text>
+     </g>
+    </g>
+    <g id="xtick_2">
+     <g id="line2d_2">
+      <g>
+       <use xlink:href="#m11ebc9ebd0" x="154.44" y="36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_2">
+      <text style="font: 10px 'DejaVu Sans'; text-anchor: middle" x="154.44" y="50.598438" transform="rotate(-0 154.44 50.598438)">1</text>
+     </g>
+    </g>
+    <g id="xtick_3">
+     <g id="line2d_3">
+      <g>
+       <use xlink:href="#m11ebc9ebd0" x="221.4" y="36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_3">
+      <text style="font: 10px 'DejaVu Sans'; text-anchor: middle" x="221.4" y="50.598438" transform="rotate(-0 221.4 50.598438)">2</text>
+     </g>
+    </g>
+    <g id="xtick_4">
+     <g id="line2d_4">
+      <g>
+       <use xlink:href="#m11ebc9ebd0" x="288.36" y="36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_4">
+      <text style="font: 10px 'DejaVu Sans'; text-anchor: middle" x="288.36" y="50.598438" transform="rotate(-0 288.36 50.598438)">3</text>
+     </g>
+    </g>
+    <g id="xtick_5">
+     <g id="line2d_5">
+      <g>
+       <use xlink:href="#m11ebc9ebd0" x="355.32" y="36" style="stroke: #000000; stroke-width: 0.8"/>
+      </g>
+     </g>
+     <g id="text_5">
+      <text style="font: 10px 'DejaVu Sans'; text-anchor: middle" x="355.32" y="50.598438" transform="rotate(-0 355.32 50.598438)">4</text>
+     </g>
+    </g>
+   </g>
+   <g id="LineCollection_1"/>
+   <g id="patch_4">
+    <path d="M 54 36 
+L 54 22.32 
+L 54 8.64 
+L 388.8 8.64 
+L 388.8 22.32 
+L 388.8 36 
+L 54 36 
+z
+" style="fill: none; stroke: #000000; stroke-width: 0.8; stroke-linejoin: miter; stroke-linecap: square"/>
+   </g>
+  </g>
+ </g>
+ <defs>
+  <clipPath id="pb535666b66">
+   <rect x="54" y="8.64" width="334.8" height="27.36"/>
+  </clipPath>
+ </defs>
+</svg>

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -7,10 +7,11 @@ import matplotlib.colors as mcolors
 from matplotlib import rc_context
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
-from matplotlib.colors import BoundaryNorm, LogNorm, PowerNorm, Normalize
+from matplotlib.colors import (
+    BoundaryNorm, LogNorm, PowerNorm, Normalize, NoNorm
+)
 from matplotlib.colorbar import Colorbar
 from matplotlib.ticker import FixedLocator
-
 from matplotlib.testing.decorators import check_figures_equal
 
 
@@ -913,3 +914,18 @@ def test_negative_boundarynorm():
     cb = fig.colorbar(cm.ScalarMappable(cmap=cmap, norm=norm), cax=ax)
     np.testing.assert_allclose(cb.ax.get_ylim(), [clevs[0], clevs[-1]])
     np.testing.assert_allclose(cb.ax.get_yticks(), clevs)
+
+
+@image_comparison(['nonorm_colorbars.svg'], remove_text=False,
+                  style='mpl20')
+def test_nonorm():
+    plt.rcParams['svg.fonttype'] = 'none'
+    data = [1, 2, 3, 4, 5]
+
+    fig, ax = plt.subplots(figsize=(6, 1))
+    fig.subplots_adjust(bottom=0.5)
+
+    norm = NoNorm(vmin=min(data), vmax=max(data))
+    cmap = cm.get_cmap("viridis", len(data))
+    mappable = cm.ScalarMappable(norm=norm, cmap=cmap)
+    cbar = fig.colorbar(mappable, cax=ax, orientation="horizontal")


### PR DESCRIPTION
Closes #21870

This adds another special-case path for NoNorm and tweaks the contents of another.
These special-cases are required because NoNorm (like BoundaryNorm) has a
different return value than ever other Norm (it directly returns integers to
index into the LUT rather than [0, 1] that is later mapped into the LUT.

## PR Summary

I added this as an SVG because getting the text right is a critical part of this and SVG will not suffer from our free-type issues.

(I went through a minor panic when I was not seeing ticklabels in the svg, but luckily that was a viewer (emacs) bug 😌 but I did have 15 minutes of thinking we had stopped outputting _any_ text on SVGs!  This may be (another) rsvg bug....)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

