### PR TITLE
Add a PolygonSelector.verts setter

### DIFF
--- a/doc/users/next_whats_new/polygon_vert_setter.rst
+++ b/doc/users/next_whats_new/polygon_vert_setter.rst
@@ -1,0 +1,6 @@
+Setting PolygonSelector vertices
+--------------------------------
+The vertices of `~matplotlib.widgets.PolygonSelector` can now be set
+programmatically by using the `~matplotlib.widgets.PolygonSelector.verts`
+property. Setting the vertices this way will reset the selector, and create
+a new complete selector with the supplied vertices.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1442,6 +1442,28 @@ def test_polygon_selector_redraw():
     assert tool.verts == verts[0:2]
 
 
+@check_figures_equal()
+def test_polygon_selector_verts_setter(fig_test, fig_ref):
+    verts = [(0.1, 0.4), (0.5, 0.9), (0.3, 0.2)]
+    ax_test = fig_test.add_subplot()
+
+    def onselect(vertices):
+        pass
+
+    tool_test = widgets.PolygonSelector(ax_test, onselect)
+    tool_test.verts = verts
+    assert tool_test.verts == verts
+
+    ax_ref = fig_ref.add_subplot()
+    tool_ref = widgets.PolygonSelector(ax_ref, onselect)
+    event_sequence = (polygon_place_vertex(*verts[0]) +
+                      polygon_place_vertex(*verts[1]) +
+                      polygon_place_vertex(*verts[2]) +
+                      polygon_place_vertex(*verts[0]))
+    for (etype, event_args) in event_sequence:
+        do_event(tool_ref, etype, **event_args)
+
+
 @pytest.mark.parametrize(
     "horizOn, vertOn",
     [(True, True), (True, False), (False, True)],

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3786,6 +3786,22 @@ class PolygonSelector(_SelectorWidget):
         """The polygon vertices, as a list of ``(x, y)`` pairs."""
         return list(zip(self._xs[:-1], self._ys[:-1]))
 
+    @verts.setter
+    def verts(self, xys):
+        """
+        Set the polygon vertices.
+
+        This will remove any pre-existing vertices, creating a complete polygon
+        with the new vertices.
+        """
+        self._xs = [xy[0] for xy in xys]
+        self._xs.append(self._xs[0])
+        self._ys = [xy[1] for xy in xys]
+        self._ys.append(self._ys[0])
+        self._selection_completed = True
+        self.set_visible(True)
+        self._draw_polygon()
+
 
 class Lasso(AxesWidget):
     """


### PR DESCRIPTION
## PR Summary
This allows one to set up a `PolygonSelector` programmatically without having to click, and is similar to already-implemented functionality in `RectangleSelector`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
