### PR TITLE
Fix rotation for aspect ratio of the axes values different from 1

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -452,6 +452,29 @@ def test_rectangle_rotate(selector_class):
             tool._selection_artist.rotation_point = 'unvalid_value'
 
 
+def test_rectangle_rotate_aspect_ratio():
+    _, ax = plt.subplots()
+    ax.plot([1, 2, 3], [10, 20, 30])
+
+    def onselect(epress, erelease):
+        pass
+
+    tool = widgets.RectangleSelector(ax, onselect=onselect, interactive=True)
+
+    # Draw rectangle
+    do_event(tool, 'press', xdata=1, ydata=10)
+    do_event(tool, 'onmove', xdata=1.5, ydata=14)
+    do_event(tool, 'release', xdata=1.5, ydata=14)
+    assert tool.extents == (1.0, 1.5, 10.0, 14.0)
+
+    # Rotate clockwise using bottom-right corner
+    do_event(tool, 'on_key_press', key='r')
+    do_event(tool, 'press', xdata=1.5, ydata=10)
+    do_event(tool, 'onmove', xdata=1.4, ydata=8.7)
+    do_event(tool, 'release', xdata=1.4, ydata=8.7)
+    assert_allclose(tool.rotation, -27.8, rtol=0.1)
+
+
 def test_rectange_add_remove_set():
     ax = get_ax()
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3087,8 +3087,9 @@ class RectangleSelector(_SelectorWidget):
             a = np.array([eventpress.xdata, eventpress.ydata])
             b = np.array(self.center)
             c = np.array([event.xdata, event.ydata])
-            angle = (np.arctan2(c[1]-b[1], c[0]-b[0]) -
-                     np.arctan2(a[1]-b[1], a[0]-b[0]))
+            ax_corr = self.ax._get_aspect_ratio()
+            angle = (np.arctan2((c[1]-b[1]) * ax_corr, c[0]-b[0]) -
+                     np.arctan2((a[1]-b[1]) * ax_corr, a[0]-b[0]))
             self.rotation = np.rad2deg(self._rotation_on_press + angle)
 
         # resize an existing shape


### PR DESCRIPTION
## PR Summary

Rotate counterclockwise to notice that the selector rotate too slowly because of the aspect ratio value difference

```python
import matplotlib.pyplot as plt
from matplotlib.widgets import RectangleSelector, PolygonSelector
import numpy as np

data = np.random.random(size=(24, 32))

fig, ax = plt.subplots()
ax.plot([10, 20, 30], [1, 2, 3])

def dummy(*args):
    pass
tool = RectangleSelector(ax, dummy, interactive=True, drag_from_anywhere=True)
tool.extents = (12, 20, 1.0, 1.6)
tool.add_state('rotate')
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
