### PR TITLE
Make figure target links relative

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.4.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.4.0.rst
@@ -166,7 +166,7 @@ New automatic labeling for bar charts
 A new `.Axes.bar_label` method has been added for auto-labeling bar charts.
 
 .. figure:: /gallery/lines_bars_and_markers/images/sphx_glr_bar_label_demo_001.png
-   :target: /gallery/lines_bars_and_markers/bar_label_demo.html
+   :target: ../../gallery/lines_bars_and_markers/bar_label_demo.html
 
    Example of the new automatic labeling.
 
@@ -396,7 +396,7 @@ style. This can be used to, e.g., distinguish the valid and invalid sides of
 the constraint boundaries in the solution space of optimizations.
 
 .. figure:: /gallery/misc/images/sphx_glr_tickedstroke_demo_002.png
-   :target: /gallery/misc/tickedstroke_demo.html
+   :target: ../../gallery/misc/tickedstroke_demo.html
 
 
 Colors and colormaps
@@ -702,7 +702,7 @@ The new `.Text` parameter ``transform_rotates_text`` now sets whether rotations
 of the transform affect the text direction.
 
 .. figure:: /gallery/text_labels_and_annotations/images/sphx_glr_text_rotation_relative_to_line_001.png
-   :target: /gallery/text_labels_and_annotations/text_rotation_relative_to_line.html
+   :target: ../../gallery/text_labels_and_annotations/text_rotation_relative_to_line.html
 
    Example of the new *transform_rotates_text* parameter
 
@@ -726,7 +726,7 @@ for each individual text element in a plot. If no parameter is set, the global
 value :rc:`mathtext.fontset` will be used.
 
 .. figure:: /gallery/text_labels_and_annotations/images/sphx_glr_mathtext_fontfamily_example_001.png
-   :target: /gallery/text_labels_and_annotations/mathtext_fontfamily_example.html
+   :target: ../../gallery/text_labels_and_annotations/mathtext_fontfamily_example.html
 
 ``TextArea``/``AnchoredText`` support *horizontalalignment*
 -----------------------------------------------------------
@@ -860,7 +860,7 @@ its entirety, supporting features such as custom styling for error lines and
 cap marks, control over errorbar spacing, upper and lower limit marks.
 
 .. figure:: /gallery/mplot3d/images/sphx_glr_errorbar3d_001.png
-   :target: /gallery/mplot3d/errorbar3d.html
+   :target: ../../gallery/mplot3d/errorbar3d.html
 
 Stem plots in 3D Axes
 ---------------------

--- a/doc/users/prev_whats_new/whats_new_3.5.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.5.0.rst
@@ -173,7 +173,7 @@ happens. The default is the current behaviour of "data", with the alternative
 being "rgba" for the newly-available behavior.
 
 .. figure:: /gallery/images_contours_and_fields/images/sphx_glr_image_antialiasing_001.png
-   :target: /gallery/images_contours_and_fields/image_antialiasing.html
+   :target: ../../gallery/images_contours_and_fields/image_antialiasing.html
 
    Example of the interpolation stage options.
 


### PR DESCRIPTION
## PR Summary

Sphinx embeds these verbatim, so if you link to `/foo`, then it will go to `matplotlib.org/foo`, which will pop up a redirect now. Using a relative link will go directly to `matplotlib.org/stable/foo`.

For example, on [this what's new entry](https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.5.0.html#image-interpolation-now-possible-at-rgba-stage), the image and the link after it should both point to the same place, but the former is at the toplevel while the latter is under `stable`.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).