### PR TITLE
Drop retina images when building PDF docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -167,6 +167,21 @@ intersphinx_mapping = {
 
 # Sphinx gallery configuration
 
+def matplotlib_reduced_latex_scraper(block, block_vars, gallery_conf,
+                                     **kwargs):
+    """
+    Reduce srcset when creating a PDF.
+
+    Because sphinx-gallery runs *very* early, we cannot modify this even in the
+    earliest builder-inited signal. Thus we do it at scraping time.
+    """
+    from sphinx_gallery.scrapers import matplotlib_scraper
+
+    if gallery_conf['builder_name'] == 'latex':
+        gallery_conf['image_srcset'] = []
+    return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
+
+
 sphinx_gallery_conf = {
     'examples_dirs': ['../examples', '../tutorials', '../plot_types'],
     'filename_pattern': '^((?!sgskip).)*$',
@@ -183,6 +198,7 @@ sphinx_gallery_conf = {
     'remove_config_comments': True,
     'min_reported_time': 1,
     'thumbnail_size': (320, 224),
+    'image_scrapers': (matplotlib_reduced_latex_scraper, ),
     # Compression is a significant effort that we skip for local and CI builds.
     'compress_images': ('thumbnails', 'images') if is_release_build else (),
     'matplotlib_animations': True,


### PR DESCRIPTION
## PR Summary

This doubles the size of the PDF, and makes it impossible to upload to GitHub Pages.

In the future, I will make the images vectorized, but this requires work in sphinx-gallery or some rather large hacks.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).