### PR TITLE
Include test notebooks in test package

### DIFF
--- a/lib/matplotlib/tests/test_backend_nbagg.py
+++ b/lib/matplotlib/tests/test_backend_nbagg.py
@@ -6,6 +6,8 @@ from tempfile import TemporaryDirectory
 import pytest
 
 nbformat = pytest.importorskip('nbformat')
+pytest.importorskip('nbconvert')
+pytest.importorskip('ipykernel')
 
 # From https://blog.thedataincubator.com/2016/06/testing-jupyter-notebooks/
 

--- a/setupext.py
+++ b/setupext.py
@@ -480,6 +480,7 @@ class Tests(OptionalPackage):
                 *_pkg_data_helper('matplotlib', 'tests/tinypages'),
                 'tests/cmr10.pfb',
                 'tests/mpltest.ttf',
+                'tests/test_*.ipynb',
             ],
             'mpl_toolkits': [
                 *_pkg_data_helper('mpl_toolkits', 'tests/baseline_images'),


### PR DESCRIPTION
## PR Summary

Additionally, the test requires `nbconvert` to execute, and `ipykernel` as the Python 3 kernel.

A redo of #21665.
Fixes #21654

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).