### PR TITLE
Added _repr_html_ for fonts

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -395,7 +395,10 @@ FontEntry = dataclasses.make_dataclass(
     A class for storing Font properties.
 
     It is used when populating the font lookup dictionary.
-    """})
+    """,
+        '_repr_html_': lambda self: f"<span style='font-family:{self.name}'>{self.name}</span>",  # noqa: E501
+    }
+)
 
 
 def ttfFontProperty(font):

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 from matplotlib.font_manager import (
-    findfont, findSystemFonts, FontProperties, fontManager, json_dump,
+    findfont, findSystemFonts, FontEntry, FontProperties, fontManager, json_dump,
     json_load, get_font, is_opentype_cff_font, MSUserFontDirectories,
     _get_fontconfig_fonts)
 from matplotlib import pyplot as plt, rc_context
@@ -266,3 +266,10 @@ def test_fontcache_thread_safe():
     if proc.returncode:
         pytest.fail("The subprocess returned with non-zero exit status "
                     f"{proc.returncode}.")
+
+
+def test_fontentry_dataclass():
+    entry = FontEntry(name="font-name")
+
+    assert type(entry.__doc__) == str
+    assert entry._repr_html_() == "<span style='font-family:font-name'>font-name</span>"


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8]([](https://flake8.pycqa.org/en/latest/)) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
