### PR TITLE
Fix image testing decorator in pytest importlib mode

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -502,7 +502,7 @@ def _image_directories(func):
     ``$(pwd)/result_images/test_baz``.  The result directory is created if it
     doesn't exist.
     """
-    module_path = Path(sys.modules[func.__module__].__file__)
+    module_path = Path(inspect.getfile(func))
     baseline_dir = module_path.parent / "baseline_images" / module_path.stem
     result_dir = Path().resolve() / "result_images" / module_path.stem
     result_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## PR Summary

In [importlib mode](https://docs.pytest.org/en/latest/explanation/pythonpath.html#import-modes), files are not added to `sys.modules`, so we cannot use that to find the file path.

Fixes #21885

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).