### PR TITLE
Drop labelling from PR welcome action

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -7,30 +7,29 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/first-interaction@v1
-      with:
-        add-labels: "status: needs workflow approval"
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-        pr-message: >+
-          Thank you for opening your first PR into Matplotlib!
+      - uses: actions/first-interaction@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          pr-message: >+
+            Thank you for opening your first PR into Matplotlib!
 
 
-          If you have not heard from us in a while, please feel free to
-          ping `@matplotlib/developers` or anyone who has commented on the
-          PR.  Most of our reviewers are volunteers and sometimes
-          things fall through the cracks.
+            If you have not heard from us in a while, please feel free to ping
+            `@matplotlib/developers` or anyone who has commented on the PR.
+            Most of our reviewers are volunteers and sometimes things fall
+            through the cracks.
 
 
-          You can also join us [on
-          gitter](https://gitter.im/matplotlib/matplotlib) for real-time
-          discussion.
+            You can also join us [on
+            gitter](https://gitter.im/matplotlib/matplotlib) for real-time
+            discussion.
 
 
-          For details on testing, writing docs, and our review process,
-          please see [the developer
-          guide](https://matplotlib.org/devdocs/devel/index.html)
+            For details on testing, writing docs, and our review process,
+            please see [the developer
+            guide](https://matplotlib.org/devdocs/devel/index.html)
 
 
-          We strive to be a welcoming and open project. Please follow our
-          [Code of
-          Conduct](https://github.com/matplotlib/matplotlib/blob/main/CODE_OF_CONDUCT.md).
+            We strive to be a welcoming and open project. Please follow our
+            [Code of
+            Conduct](https://github.com/matplotlib/matplotlib/blob/main/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
## PR Summary

The first-interaction GitHub Action doesn't appear to support adding labels and is broken with that config option.

See for example, [the error in this build](https://github.com/matplotlib/matplotlib/runs/4479637445?check_suite_focus=true)

I also silenced some linting by indenting the file consistently.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).