### PR TITLE
axis3d.py : new inheritance and overriden methods for Yaxis class

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -32,7 +32,7 @@ def tick_update_position(tick, tickxs, tickys, labelpos):
     tick.gridline.set_data(0, 0)
 
 
-class Axis(maxis.XAxis):
+class Axis(maxis.Axis):
     """An Axis class for the 3D plots."""
     # These points from the unit cube make up the x, y and z-planes
     _PLANES = (
@@ -516,21 +516,44 @@ class Axis(maxis.XAxis):
 # Use classes to look at different data limits
 
 
-class XAxis(Axis):
+class XAxis(Axis, maxis.XAxis):
     get_view_interval, set_view_interval = maxis._make_getset_interval(
         "view", "xy_viewLim", "intervalx")
     get_data_interval, set_data_interval = maxis._make_getset_interval(
         "data", "xy_dataLim", "intervalx")
 
 
-class YAxis(Axis):
+class YAxis(Axis, maxis.YAxis):
     get_view_interval, set_view_interval = maxis._make_getset_interval(
         "view", "xy_viewLim", "intervaly")
     get_data_interval, set_data_interval = maxis._make_getset_interval(
         "data", "xy_dataLim", "intervaly")
 
+    def get_tick_space(self):
+        ends = mtransforms.Bbox.from_bounds(0, 0, 1, 1)
+        ends = ends.transformed(self.axes.transAxes -
+                                self.figure.dpi_scale_trans)
+        length = ends.height * 72
+        # The spacing must be the same as in the XAxis method (3).
+        size = self._get_tick_label_size('y') * 3
+        if size > 0:
+            return int(np.floor(length / size))
+        else:
+            return 2**31 - 1
 
-class ZAxis(Axis):
+    def clear(self):
+        #The padding of the Yticks must be the same as for the XTicks.
+        super().clear()
+        self.majorTicks[0].label1.set(horizontalalignment='center',
+        verticalalignment='top')
+        self.minorTicks[0].label1.set(horizontalalignment='center',
+        verticalalignment='top')
+        self.majorTicks[0].label2.set(horizontalalignment='center',
+        verticalalignment='top')
+        self.minorTicks[0].label2.set(horizontalalignment='center',
+        verticalalignment='top')
+
+class ZAxis(Axis, maxis.XAxis):
     get_view_interval, set_view_interval = maxis._make_getset_interval(
         "view", "zz_viewLim", "intervalx")
     get_data_interval, set_data_interval = maxis._make_getset_interval(


### PR DESCRIPTION

## PR Summary

This pull request is a solution to [this](https://github.com/matplotlib/matplotlib/issues/21369) issue that seems to work. This issue is about the axes in a 3d plot.

In mplot3d/axis3d.py, because of a bad inheritance, as @QuLogic pointed out, methods like `invert.yaxis()` are affecting the X axis and not the Y axis.
He proposed a solution that I have copied here (changing inheritance in
the `[ X,Y,Z]Axis` classes).
But because of this change the ticks of the Y axis started to behave as if it was a 2D plot : this is what I tried to solve.
My contribution boils down to overriding two methods in the YAxis class in mplot3d/axis3d.py : 
- the `get_tick_space` method (the spacing must be of 3 as in the axis.XAxis method, and not just 2)
- the `clear` method (this method sets the padding of the Y ticks as in a 2D plot, and is called "at the last second". I found nothing better than fixing the padding right after this method is called)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
