### PR TITLE
MNT: privatize colorbar attr

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -370,6 +370,7 @@ class Colorbar:
 
     n_rasterize = 50  # rasterize solids if number of colors >= n_rasterize
 
+    @_api.delete_parameter("3.6", "filled")
     def __init__(self, ax, mappable=None, *, cmap=None,
                  norm=None,
                  alpha=None,
@@ -450,7 +451,7 @@ class Colorbar:
         self.spacing = spacing
         self.orientation = orientation
         self.drawedges = drawedges
-        self.filled = filled
+        self._filled = filled
         self.extendfrac = extendfrac
         self.extendrect = extendrect
         self.solids = None
@@ -530,6 +531,8 @@ class Colorbar:
     # Also remove ._patch after deprecation elapses.
     patch = _api.deprecate_privatize_attribute("3.5", alternative="ax")
 
+    filled = _api.deprecate_privatize_attribute("3.6")
+
     def update_normal(self, mappable):
         """
         Update solid patches, lines, etc.
@@ -599,7 +602,7 @@ class Colorbar:
         # boundary norms + uniform spacing requires a manual locator.
         self.update_ticks()
 
-        if self.filled:
+        if self._filled:
             ind = np.arange(len(self._values))
             if self._extend_lower():
                 ind = ind[1:]
@@ -671,7 +674,7 @@ class Colorbar:
 
         # xyout is the path for the spine:
         self.outline.set_xy(xyout)
-        if not self.filled:
+        if not self._filled:
             return
 
         # Make extend triangles or rectangles filled patches.  These are

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -500,7 +500,7 @@ class Colorbar:
                 self.formatter = ticker.StrMethodFormatter(format)
         else:
             self.formatter = format  # Assume it is a Formatter or None
-        self.draw_all()
+        self._draw_all()
 
         if isinstance(mappable, contour.ContourSet) and not mappable.filled:
             self.add_lines(mappable)
@@ -554,14 +554,22 @@ class Colorbar:
             self.norm = mappable.norm
             self._reset_locator_formatter_scale()
 
-        self.draw_all()
+        self._draw_all()
         if isinstance(self.mappable, contour.ContourSet):
             CS = self.mappable
             if not CS.filled:
                 self.add_lines(CS)
         self.stale = True
 
+    @_api.deprecated("3.6", alternative="fig.draw_without_rendering()")
     def draw_all(self):
+        """
+        Calculate any free parameters based on the current cmap and norm,
+        and do all the drawing.
+        """
+        self._draw_all()
+
+    def _draw_all(self):
         """
         Calculate any free parameters based on the current cmap and norm,
         and do all the drawing.


### PR DESCRIPTION
## PR Summary

In partial response to #21932: we deprecated `filled` from clashing with the ContourSet mappable, but none of the other mappables can change *filled*, so we have basically made the argument useless.  This PR simply deprecates the useless kwarg.  

The *filled* kwarg doesn't directly do anything and filling is completely controlled by the mappable.

OTOH, maybe we want to reinstate the ability of *filled* to fill ContourSets that are not filled - that is what #21932 would like?

Also deprecates `draw_all` as a public method.  This doesn't draw anything, and its is not used as public API:

### Other potential attributes to make read-only:

- values
- boundaries
- solids 
- solids_patches 
- lines
- orientation
- cmap
- norm
- alpha
- outline

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
