### PR TITLE
Significantly improve tight layout performance for cartopy axes

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -320,23 +320,6 @@ class Artist:
         """
         return Bbox([[0, 0], [0, 0]])
 
-    def _get_clipping_extent_bbox(self):
-        """
-        Return a bbox with the extents of the intersection of the clip_path
-        and clip_box for this artist, or None if both of these are
-        None, or ``get_clip_on`` is False.
-        """
-        bbox = None
-        if self.get_clip_on():
-            clip_box = self.get_clip_box()
-            if clip_box is not None:
-                bbox = clip_box
-            clip_path = self.get_clip_path()
-            if clip_path is not None and bbox is not None:
-                clip_path = clip_path.get_fully_transformed_path()
-                bbox = Bbox.intersection(bbox, clip_path.get_extents())
-        return bbox
-
     def get_tightbbox(self, renderer):
         """
         Like `.Artist.get_window_extent`, but includes any clipping.
@@ -358,7 +341,7 @@ class Artist:
             if clip_box is not None:
                 bbox = Bbox.intersection(bbox, clip_box)
             clip_path = self.get_clip_path()
-            if clip_path is not None and bbox is not None:
+            if clip_path is not None:
                 clip_path = clip_path.get_fully_transformed_path()
                 bbox = Bbox.intersection(bbox, clip_path.get_extents())
         return bbox
@@ -843,6 +826,30 @@ class Artist:
         ``fig.savefig(fname, bbox_inches='tight')``.
         """
         return self._in_layout
+
+    def _fully_clipped_to_axes(self):
+        """
+        Return a boolean flag, ``True`` if the artist is clipped to the axes
+        and can thus be skipped in layout calculations. Requires `get_clip_on`
+        is True, one of `clip_box` or `clip_path` is set, ``clip_box.extents``
+        is equivalent to ``ax.bbox.extents`` (if set), and ``clip_path._patch``
+        is equivalent to ``ax.patch`` (if set).
+        """
+        # Note that ``clip_path.get_fully_transformed_path().get_extents()``
+        # cannot be directly compared to ``axes.bbox.extents`` because the
+        # extents may be undefined (i.e. equivalent to ``Bbox.null()``)
+        # before the associated artist is drawn, and this method is meant
+        # to determine whether ``axes.get_tightbbox()`` may bypass drawing
+        clip_box = self.get_clip_box()
+        clip_path = self.get_clip_path()
+        return (self.axes is not None
+                and self.get_clip_on()
+                and (clip_box is not None or clip_path is not None)
+                and (clip_box is None
+                     or np.all(clip_box.extents == self.axes.bbox.extents))
+                and (clip_path is None
+                     or isinstance(clip_path, TransformedPatchPath)
+                     and clip_path._patch is self.axes.patch))
 
     def get_clip_on(self):
         """Return whether the artist uses clipping."""


### PR DESCRIPTION
This PR is adapted from SciTools/cartopy#1956 following our discussion there.

## Summary

This PR significantly improves the speed of `Axes.get_tightbbox()` for non-rectilinear axes (in particular, matplotlib's PolarAxes and cartopy's GeoAxes) by preventing unnecessary and expensive `get_window_extent()` computations. In the presence of complex, high-resolution artists, it can result in a **2x improvement** to the draw time when "tight layout" is enabled (since artists are effectively only drawn once instead of twice).

There may be a better way to implement this -- looking forward to everyone's thoughts.

## Details

To prevent unnecessary and expensive `get_window_extent()` computations, `Axes.get_tightbbox()` skips artists with `clip_on` set to True and whose `clip_box.extents` are equivalent to `ax.bbox.extents`. However, while all axes artists are clipped by `TransformedPatchPath(ax.patch)` by default, only artists drawn inside rectilinear projections are clipped by `ax.bbox` (see the below example).

This PR replaces `Artist._get_clipping_extent_bbox()` with `Artist._is_axes_clipped()`. Now,`Axes.get_tightbbox()` includes `ax.patch.get_window_extent()` in its computation, and skips all artists clipped by **either** `ax.bbox` or `ax.patch` (i.e., artists for which `Artist._is_axes_clipped()` returns True).

This PR also removes the computation of the intersection of `clip_box` and `clip_path`, under the assumption that the independent test of `clip_path` covers those instances, but perhaps that should be added back.

## Example

Here is an example with a cartopy `GeoAxes`:

```python
import numpy as np
import matplotlib.pyplot as plt
import cartopy.crs as ccrs
fig, ax = plt.subplots(subplot_kw={'projection': ccrs.Robinson()})
N = 5000  # large dataset
lon = np.linspace(-180, 180, N)
lat = np.linspace(-90, 90, N)
data = np.random.rand(N, N)
m = ax.pcolormesh(lon, lat, data, transform=ccrs.PlateCarree())
print(m.get_clip_box() is None)  # returns True
%timeit fig.tight_layout()
```

Performance before:

```
638 ms ± 67.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

Performance after:

```
2.37 ms ± 60.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

And of course the performance difference is larger the larger the dataset.

## Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] (n/a?) New features are documented, with examples if plot related.
- [x] (n/a?) New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] (n/a?) API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
