### PR TITLE
DOC: explain too many ticks

### DIFF
--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -9,6 +9,68 @@ How-to
 .. contents::
    :backlinks: none
 
+
+_how-to-too-many-ticks
+
+Why do I have so many ticks, and/or why are they out of order?
+--------------------------------------------------------------
+
+Sometimes Matplotlib will unexpectedly plot with a tick for each data point,
+and/or the ticks will be out of numerical order. This is usually a sign that you
+have passed in a list of strings rather than a list or array of floats or
+datetime objects.  This will often happen when reading in a comma-delimited text
+file. Matplotlib treats lists of strings as "categorical" variables
+(:doc:`/gallery/lines_bars_and_markers/categorical_variables`), and by default
+puts one tick per "category", and plots them in the order in which they are
+supplied.
+
+In the example below, the upper row plots are plotted using strings for *x*;
+note that each string gets a tick, and they are in the order of the list passed
+to Matplotlib. In the lower row the data is converted to either floats or
+datetime64; note that the ticks are now ordered and spaced numerically.
+
+.. plot::
+    :include-source:
+    :align: center
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    fig, ax = plt.subplots(2, 2, constrained_layout=True, figsize=(6, 6))
+    x = ['1', '5', '2', '3']
+    y = [1, 4, 2, 3]
+    ax[0, 0].plot(x, y, 'd')
+    ax[0, 0].set_xlabel('Categories')
+    # convert to numbers:
+    x = np.asarray(x, dtype='float')
+    ax[1, 0].plot(x, y, 'd')
+    ax[1, 0].set_xlabel('Floats')
+
+    x = ['2021-10-01', '2021-11-02', '2021-12-03', '2021-10-04']
+    y = [0, 2, 3, 1]
+    ax[0, 1].plot(x, y, 'd')
+    ax[0, 1].tick_params(axis='x', labelrotation=45)
+    # convert to datetime64
+    x = np.asarray(x, dtype='datetime64[s]')
+    ax[1, 1].plot(x, y, 'd')
+    ax[1, 1].tick_params(axis='x', labelrotation=45)
+
+If *x* has 100 elements, all strings, then we would have 100 (unreadable)
+ticks:
+
+.. plot::
+    :include-source:
+    :align: center
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    fig, ax = plt.subplots(figsize=(6, 2.5))
+    x = [f'{xx}' for xx in np.arange(100)]
+    y = np.arange(100)
+    ax.plot(x, y)
+
+
 .. _howto-figure-empty:
 
 Check whether a figure is empty

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -15,11 +15,10 @@ _how-to-too-many-ticks
 Why do I have so many ticks, and/or why are they out of order?
 --------------------------------------------------------------
 
-Sometimes Matplotlib will unexpectedly plot with a tick for each data point,
-and/or the ticks will be out of numerical order. This is usually a sign that you
-have passed in a list of strings rather than a list or array of floats or
-datetime objects.  This will often happen when reading in a comma-delimited text
-file. Matplotlib treats lists of strings as "categorical" variables
+One common cause for unexpected tick behavior is passing a list of strings
+instead of numbers or datetime objects. This can easily happen without notice
+when reading in a comma-delimited text file. Matplotlib treats lists of strings
+as "categorical" variables
 (:doc:`/gallery/lines_bars_and_markers/categorical_variables`), and by default
 puts one tick per "category", and plots them in the order in which they are
 supplied.

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -10,7 +10,7 @@ How-to
    :backlinks: none
 
 
-_how-to-too-many-ticks
+.. _how-to-too-many-ticks:
 
 Why do I have so many ticks, and/or why are they out of order?
 --------------------------------------------------------------
@@ -25,50 +25,66 @@ supplied.
 
 In the example below, the upper row plots are plotted using strings for *x*;
 note that each string gets a tick, and they are in the order of the list passed
-to Matplotlib. In the lower row the data is converted to either floats or
-datetime64; note that the ticks are now ordered and spaced numerically.
+to Matplotlib.  If this is not desired, we need to change *x* to an array of
+numbers.
 
 .. plot::
     :include-source:
     :align: center
 
-    import matplotlib.pyplot as plt
-    import numpy as np
-
-    fig, ax = plt.subplots(2, 2, constrained_layout=True, figsize=(6, 6))
+    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2.5))
     x = ['1', '5', '2', '3']
     y = [1, 4, 2, 3]
-    ax[0, 0].plot(x, y, 'd')
-    ax[0, 0].set_xlabel('Categories')
+    ax[0].plot(x, y, 'd')
+    ax[0].tick_params(axis='x', color='r', labelcolor='r')
+    ax[0].set_xlabel('Categories')
+    ax[0].set_title('Ticks seem out of order / misplaced')
+
     # convert to numbers:
     x = np.asarray(x, dtype='float')
-    ax[1, 0].plot(x, y, 'd')
-    ax[1, 0].set_xlabel('Floats')
-
-    x = ['2021-10-01', '2021-11-02', '2021-12-03', '2021-10-04']
-    y = [0, 2, 3, 1]
-    ax[0, 1].plot(x, y, 'd')
-    ax[0, 1].tick_params(axis='x', labelrotation=45)
-    # convert to datetime64
-    x = np.asarray(x, dtype='datetime64[s]')
-    ax[1, 1].plot(x, y, 'd')
-    ax[1, 1].tick_params(axis='x', labelrotation=45)
+    ax[1].plot(x, y, 'd')
+    ax[1].set_xlabel('Floats')
+    ax[1].set_title('Ticks as expected')
 
 If *x* has 100 elements, all strings, then we would have 100 (unreadable)
-ticks:
+ticks, and again the solution is to convert the strings to floats:
 
 .. plot::
     :include-source:
     :align: center
 
-    import matplotlib.pyplot as plt
-    import numpy as np
-
-    fig, ax = plt.subplots(figsize=(6, 2.5))
+    fig, ax = plt.subplots(1, 2, figsize=(6, 2.5))
     x = [f'{xx}' for xx in np.arange(100)]
     y = np.arange(100)
-    ax.plot(x, y)
+    ax[0].plot(x, y)
+    ax[0].tick_params(axis='x', color='r', labelcolor='r')
+    ax[0].set_title('Too many ticks')
+    ax[0].set_xlabel('Categories')
 
+    ax[1].plot(np.asarray(x, float), y)
+    ax[1].set_title('x converted to numbers')
+    ax[1].set_xlabel('Floats')
+
+A common case is when dates are read from a CSV file, they need to be
+converted from strings to datetime objects to get the proper date locators
+and formatters.
+
+.. plot::
+    :include-source:
+    :align: center
+
+    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 3.5))
+    x = ['2021-10-01', '2021-11-02', '2021-12-03', '2021-10-04']
+    y = [0, 2, 3, 1]
+    ax[0].plot(x, y, 'd')
+    ax[0].tick_params(axis='x', labelrotation=90, color='r', labelcolor='r')
+    ax[0].set_title('Dates out of order')
+
+    # convert to datetime64
+    x = np.asarray(x, dtype='datetime64[s]')
+    ax[1].plot(x, y, 'd')
+    ax[1].tick_params(axis='x', labelrotation=90)
+    ax[1].set_title('x converted to datetimes')
 
 .. _howto-determine-artist-extent:
 

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -15,12 +15,12 @@ How-to
 Why do I have so many ticks, and/or why are they out of order?
 --------------------------------------------------------------
 
-One common cause for unexpected tick behavior is passing a list of strings
-instead of numbers or datetime objects. This can easily happen without notice
+One common cause for unexpected tick behavior is passing a *list of strings
+instead of numbers or datetime objects*. This can easily happen without notice
 when reading in a comma-delimited text file. Matplotlib treats lists of strings
-as "categorical" variables
+as *categorical* variables
 (:doc:`/gallery/lines_bars_and_markers/categorical_variables`), and by default
-puts one tick per "category", and plots them in the order in which they are
+puts one tick per category, and plots them in the order in which they are
 supplied.
 
 .. plot::

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -23,68 +23,34 @@ as "categorical" variables
 puts one tick per "category", and plots them in the order in which they are
 supplied.
 
-In the example below, the upper row plots are plotted using strings for *x*;
-note that each string gets a tick, and they are in the order of the list passed
-to Matplotlib.  If this is not desired, we need to change *x* to an array of
-numbers.
-
 .. plot::
     :include-source:
     :align: center
 
-    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2.5))
-    x = ['1', '5', '2', '3']
-    y = [1, 4, 2, 3]
-    ax[0].plot(x, y, 'd')
-    ax[0].tick_params(axis='x', color='r', labelcolor='r')
-    ax[0].set_xlabel('Categories')
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2))
+
     ax[0].set_title('Ticks seem out of order / misplaced')
-
-    # convert to numbers:
-    x = np.asarray(x, dtype='float')
-    ax[1].plot(x, y, 'd')
-    ax[1].set_xlabel('Floats')
-    ax[1].set_title('Ticks as expected')
-
-If *x* has 100 elements, all strings, then we would have 100 (unreadable)
-ticks, and again the solution is to convert the strings to floats:
-
-.. plot::
-    :include-source:
-    :align: center
-
-    fig, ax = plt.subplots(1, 2, figsize=(6, 2.5))
-    x = [f'{xx}' for xx in np.arange(100)]
-    y = np.arange(100)
-    ax[0].plot(x, y)
-    ax[0].tick_params(axis='x', color='r', labelcolor='r')
-    ax[0].set_title('Too many ticks')
-    ax[0].set_xlabel('Categories')
-
-    ax[1].plot(np.asarray(x, float), y)
-    ax[1].set_title('x converted to numbers')
-    ax[1].set_xlabel('Floats')
-
-A common case is when dates are read from a CSV file, they need to be
-converted from strings to datetime objects to get the proper date locators
-and formatters.
-
-.. plot::
-    :include-source:
-    :align: center
-
-    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 3.5))
-    x = ['2021-10-01', '2021-11-02', '2021-12-03', '2021-10-04']
-    y = [0, 2, 3, 1]
+    x = ['5', '20', '1', '9']  # strings
+    y = [5, 20, 1, 9]
     ax[0].plot(x, y, 'd')
-    ax[0].tick_params(axis='x', labelrotation=90, color='r', labelcolor='r')
-    ax[0].set_title('Dates out of order')
+    ax[0].tick_params(axis='x', labelcolor='red', labelsize=14)
 
-    # convert to datetime64
-    x = np.asarray(x, dtype='datetime64[s]')
-    ax[1].plot(x, y, 'd')
-    ax[1].tick_params(axis='x', labelrotation=90)
-    ax[1].set_title('x converted to datetimes')
+    ax[1].set_title('Many ticks')
+    x = [str(xx) for xx in np.arange(100)]  # strings
+    y = np.arange(100)
+    ax[1].plot(x, y)
+    ax[1].tick_params(axis='x', labelcolor='red', labelsize=14)
+
+The solution is to convert the list of strings to numbers or
+datetime objects (often ``np.asarray(['2', '5', '1'], dtype='float')`` or::
+
+    np.asarray(['2021-10-01', '2021-11-02', '2021-12-03'],
+               dtype='datetime64[s]')
+
+For more information see :doc:`/gallery/ticks/ticks_too_many`.
 
 .. _howto-determine-artist-extent:
 

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -71,6 +71,18 @@ ticks:
     ax.plot(x, y)
 
 
+.. _howto-determine-artist-extent:
+
+Determine the extent of Artists on the Figure
+---------------------------------------------
+
+Sometimes we want to know the extent of an Artist.  Matplotlib `.Artist` objects
+have a method `.Artist.get_window_extent` that will usually return the extent of
+the artist in pixels.  However, some artists, in particular text, must be
+rendered at least once before their extent is known.  Matplotlib supplies
+`.Figure.draw_without_rendering`, which should be called before calling
+``get_window_extent``.
+
 .. _howto-figure-empty:
 
 Check whether a figure is empty

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -72,7 +72,7 @@ ticks:
 
 .. _howto-determine-artist-extent:
 
-Determine the extent of Artists on the Figure
+Determine the extent of Artists in the Figure
 ---------------------------------------------
 
 Sometimes we want to know the extent of an Artist.  Matplotlib `.Artist` objects

--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -45,10 +45,8 @@ supplied.
     ax[1].tick_params(axis='x', labelcolor='red', labelsize=14)
 
 The solution is to convert the list of strings to numbers or
-datetime objects (often ``np.asarray(['2', '5', '1'], dtype='float')`` or::
-
-    np.asarray(['2021-10-01', '2021-11-02', '2021-12-03'],
-               dtype='datetime64[s]')
+datetime objects (often ``np.asarray(numeric_strings, dtype='float')`` or
+``np.asarray(datetime_strings, dtype='datetime64[s]')``).
 
 For more information see :doc:`/gallery/ticks/ticks_too_many`.
 

--- a/examples/ticks/ticks_too_many.py
+++ b/examples/ticks/ticks_too_many.py
@@ -1,0 +1,68 @@
+"""
+=====================
+Fixing too many ticks
+=====================
+
+One common cause for unexpected tick behavior is passing a list of strings
+instead of numbers or datetime objects. This can easily happen without notice
+when reading in a comma-delimited text file. Matplotlib treats lists of strings
+as "categorical" variables
+(:doc:`/gallery/lines_bars_and_markers/categorical_variables`), and by default
+puts one tick per "category", and plots them in the order in which they are
+supplied.  If this is not desired, the solution is to convert the strings to
+a numeric type as in the following examples.
+
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2.5))
+x = ['1', '5', '2', '3']
+y = [1, 4, 2, 3]
+ax[0].plot(x, y, 'd')
+ax[0].tick_params(axis='x', color='r', labelcolor='r')
+ax[0].set_xlabel('Categories')
+ax[0].set_title('Ticks seem out of order / misplaced')
+
+# convert to numbers:
+x = np.asarray(x, dtype='float')
+ax[1].plot(x, y, 'd')
+ax[1].set_xlabel('Floats')
+ax[1].set_title('Ticks as expected')
+
+############################################################################
+# If *x* has 100 elements, all strings, then we would have 100 (unreadable)
+# ticks, and again the solution is to convert the strings to floats:
+
+fig, ax = plt.subplots(1, 2, figsize=(6, 2.5))
+x = [f'{xx}' for xx in np.arange(100)]
+y = np.arange(100)
+ax[0].plot(x, y)
+ax[0].tick_params(axis='x', color='r', labelcolor='r')
+ax[0].set_title('Too many ticks')
+ax[0].set_xlabel('Categories')
+
+ax[1].plot(np.asarray(x, float), y)
+ax[1].set_title('x converted to numbers')
+ax[1].set_xlabel('Floats')
+
+############################################################################
+# A common case is when dates are read from a CSV file, they need to be
+# converted from strings to datetime objects to get the proper date locators
+# and formatters.
+
+fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2.75))
+x = ['2021-10-01', '2021-11-02', '2021-12-03', '2021-09-01']
+y = [0, 2, 3, 1]
+ax[0].plot(x, y, 'd')
+ax[0].tick_params(axis='x', labelrotation=90, color='r', labelcolor='r')
+ax[0].set_title('Dates out of order')
+
+# convert to datetime64
+x = np.asarray(x, dtype='datetime64[s]')
+ax[1].plot(x, y, 'd')
+ax[1].tick_params(axis='x', labelrotation=90)
+ax[1].set_title('x converted to datetimes')
+
+plt.show()

--- a/examples/ticks/ticks_too_many.py
+++ b/examples/ticks/ticks_too_many.py
@@ -6,13 +6,17 @@ Fixing too many ticks
 One common cause for unexpected tick behavior is passing a list of strings
 instead of numbers or datetime objects. This can easily happen without notice
 when reading in a comma-delimited text file. Matplotlib treats lists of strings
-as "categorical" variables
+as *categorical* variables
 (:doc:`/gallery/lines_bars_and_markers/categorical_variables`), and by default
-puts one tick per "category", and plots them in the order in which they are
+puts one tick per category, and plots them in the order in which they are
 supplied.  If this is not desired, the solution is to convert the strings to
 a numeric type as in the following examples.
 
 """
+
+############################################################################
+# Example 1: Strings can lead to an unexpected order of number ticks
+# ------------------------------------------------------------------
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -32,6 +36,8 @@ ax[1].set_xlabel('Floats')
 ax[1].set_title('Ticks as expected')
 
 ############################################################################
+# Example 2: Strings can lead to very many ticks
+# ----------------------------------------------
 # If *x* has 100 elements, all strings, then we would have 100 (unreadable)
 # ticks, and again the solution is to convert the strings to floats:
 
@@ -48,6 +54,8 @@ ax[1].set_title('x converted to numbers')
 ax[1].set_xlabel('Floats')
 
 ############################################################################
+# Example 3: Strings can lead to an unexpected order of datetime ticks
+# --------------------------------------------------------------------
 # A common case is when dates are read from a CSV file, they need to be
 # converted from strings to datetime objects to get the proper date locators
 # and formatters.


### PR DESCRIPTION
## PR Summary

Users _often_ get confused when they get too many ticks or those that are out of order, because we plot lists of strings as categoricals.  This PR seeks to at least have a FAQ entry to address that problem and encourage them to convert to numbers of some sort.



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
