### PR TITLE
Distinguish AbstractMovieWriter and MovieWriter in docs.

### DIFF
--- a/doc/api/animation_api.rst
+++ b/doc/api/animation_api.rst
@@ -59,9 +59,9 @@ supported.
 The inner workings of `FuncAnimation` is more-or-less::
 
   for d in frames:
-     artists = func(d, *fargs)
-     fig.canvas.draw_idle()
-     fig.canvas.start_event_loop(interval)
+      artists = func(d, *fargs)
+      fig.canvas.draw_idle()
+      fig.canvas.start_event_loop(interval)
 
 with details to handle 'blitting' (to dramatically improve the live
 performance), to be non-blocking, not repeatedly start/stop the GUI
@@ -211,16 +211,18 @@ debug.
    FFMpegFileWriter
    ImageMagickFileWriter
 
-Fundamentally, a `MovieWriter` provides a way to grab sequential frames
-from the same underlying `~matplotlib.figure.Figure` object.  The base
-class `MovieWriter` implements 3 methods and a context manager.  The
-only difference between the pipe-based and file-based writers is in the
-arguments to their respective ``setup`` methods.
+The writer classes provide a way to grab sequential frames from the same
+underlying `~matplotlib.figure.Figure`.  They all provide three methods that
+must be called in sequence:
 
-The ``setup()`` method is used to prepare the writer (possibly opening
-a pipe), successive calls to ``grab_frame()`` capture a single frame
-at a time and ``finish()`` finalizes the movie and writes the output
-file to disk.  For example ::
+- `~.AbstractMovieWriter.setup` prepares the writer (e.g. opening a pipe).
+  Pipe-based and file-based writers take different arguments to ``setup()``.
+- `~.AbstractMovieWriter.grab_frame` can then be called as often as
+  needed to capture a single frame at a time
+- `~.AbstractMovieWriter.finish` finalizes the movie and writes the output
+  file to disk.
+
+Example::
 
    moviewriter = MovieWriter(...)
    moviewriter.setup(fig, 'my_movie.ext', dpi=100)
@@ -230,14 +232,14 @@ file to disk.  For example ::
    moviewriter.finish()
 
 If using the writer classes directly (not through `Animation.save`), it is
-strongly encouraged to use the `~MovieWriter.saving` context manager ::
+strongly encouraged to use the `~.AbstractMovieWriter.saving` context manager::
 
   with moviewriter.saving(fig, 'myfile.mp4', dpi=100):
       for j in range(n):
           update_figure(j)
           moviewriter.grab_frame()
 
-to ensures that setup and cleanup are performed as necessary.
+to ensure that setup and cleanup are performed as necessary.
 
 Examples
 --------

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -156,19 +156,17 @@ writers = MovieWriterRegistry()
 
 class AbstractMovieWriter(abc.ABC):
     """
-    Abstract base class for writing movies. Fundamentally, what a MovieWriter
-    does is provide is a way to grab frames by calling grab_frame().
+    Abstract base class for writing movies, providing a way to grab frames by
+    calling `~AbstractMovieWriter.grab_frame`.
 
-    setup() is called to start the process and finish() is called afterwards.
-
-    This class is set up to provide for writing movie frame data to a pipe.
-    saving() is provided as a context manager to facilitate this process as::
+    `setup` is called to start the process and `finish` is called afterwards.
+    `saving` is provided as a context manager to facilitate this process as ::
 
         with moviewriter.saving(fig, outfile='myfile.mp4', dpi=100):
             # Iterate over frames
             moviewriter.grab_frame(**savefig_kwargs)
 
-    The use of the context manager ensures that setup() and finish() are
+    The use of the context manager ensures that `setup` and `finish` are
     performed as necessary.
 
     An instance of a concrete subclass of this class can be given as the


### PR DESCRIPTION
Some docs of AbstractMovieWriter are still written as if referring to
MovieWriter (which could be better named PipeMovieWriter, i.e. writers
that pipe frame data to a running subprocess).  This probably dates
back to when AbstractMovieWriter was not a thing yet.

Fix that.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
