### PR TITLE
Clarify coordinates for RectangleSelector properties

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3233,7 +3233,10 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def corners(self):
-        """Corners of rectangle from lower left, moving clockwise."""
+        """
+        Corners of rectangle from lower left in data coordinates,
+        moving clockwise.
+        """
         x0, y0, width, height = self._rect_bbox
         xc = x0, x0 + width, x0 + width, x0
         yc = y0, y0, y0 + height, y0 + height
@@ -3243,7 +3246,10 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def edge_centers(self):
-        """Midpoint of rectangle edges from left, moving anti-clockwise."""
+        """
+        Midpoint of rectangle edges in data coordiantes from left,
+        moving anti-clockwise.
+        """
         x0, y0, width, height = self._rect_bbox
         w = width / 2.
         h = height / 2.
@@ -3255,15 +3261,15 @@ class RectangleSelector(_SelectorWidget):
 
     @property
     def center(self):
-        """Center of rectangle."""
+        """Center of rectangle in data coordinates."""
         x0, y0, width, height = self._rect_bbox
         return x0 + width / 2., y0 + height / 2.
 
     @property
     def extents(self):
         """
-        Return (xmin, xmax, ymin, ymax) as defined by the bounding box before
-        rotation.
+        Return (xmin, xmax, ymin, ymax) in data coordinates as defined by the
+        bounding box before rotation.
         """
         x0, y0, width, height = self._rect_bbox
         xmin, xmax = sorted([x0, x0 + width])
@@ -3360,9 +3366,8 @@ class RectangleSelector(_SelectorWidget):
         """
         Return an array of shape (2, 5) containing the
         x (``RectangleSelector.geometry[1, :]``) and
-        y (``RectangleSelector.geometry[0, :]``) coordinates
-        of the four corners of the rectangle starting and ending
-        in the top left corner.
+        y (``RectangleSelector.geometry[0, :]``) data coordinates of the four
+        corners of the rectangle starting and ending in the top left corner.
         """
         if hasattr(self._selection_artist, 'get_verts'):
             xfm = self.ax.transData.inverted()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3234,7 +3234,7 @@ class RectangleSelector(_SelectorWidget):
     @property
     def corners(self):
         """
-        Corners of rectangle from lower left in data coordinates,
+        Corners of rectangle in data coordinates from lower left,
         moving clockwise.
         """
         x0, y0, width, height = self._rect_bbox


### PR DESCRIPTION
## PR Summary
Since https://github.com/matplotlib/matplotlib/pull/21945 is moving to using display coordinates internally, clarify the coordinates used in public facing API properties of `RectangleSelector`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
