### PR TITLE
Refactor common parts of ImageMagick{,File}Writer.

### DIFF
--- a/doc/api/next_api_changes/deprecations/21995-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21995-AL.rst
@@ -1,0 +1,3 @@
+``ImageMagickBase.delay`` and ``ImageMagickBase.output_args``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+are deprecated with no replacement.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -522,8 +522,8 @@ class FFMpegBase:
     """
     Mixin class for FFMpeg output.
 
-    To be useful this must be multiply-inherited from with a
-    `MovieWriterBase` sub-class.
+    This is a base class for the concrete `FFMpegWriter` and `FFMpegFileWriter`
+    classes.
     """
 
     _exec_key = 'animation.ffmpeg_path'
@@ -620,22 +620,41 @@ class ImageMagickBase:
     """
     Mixin class for ImageMagick output.
 
-    To be useful this must be multiply-inherited from with a
-    `MovieWriterBase` sub-class.
+    This is a base class for the concrete `ImageMagickWriter` and
+    `ImageMagickFileWriter` classes, which define an ``input_names`` attribute
+    (or property) specifying the input names passed to ImageMagick.
     """
 
     _exec_key = 'animation.convert_path'
     _args_key = 'animation.convert_args'
 
+    @_api.deprecated("3.6")
     @property
     def delay(self):
         return 100. / self.fps
 
+    @_api.deprecated("3.6")
     @property
     def output_args(self):
         extra_args = (self.extra_args if self.extra_args is not None
                       else mpl.rcParams[self._args_key])
         return [*extra_args, self.outfile]
+
+    def _args(self):
+        # ImageMagick does not recognize "raw".
+        fmt = "rgba" if self.frame_format == "raw" else self.frame_format
+        extra_args = (self.extra_args if self.extra_args is not None
+                      else mpl.rcParams[self._args_key])
+        return [
+            self.bin_path(),
+            "-size", "%ix%i" % self.frame_size,
+            "-depth", "8",
+            "-delay", str(100 / self.fps),
+            "-loop", "0",
+            f"{fmt}:{self.input_names}",
+            *extra_args,
+            self.outfile,
+        ]
 
     @classmethod
     def bin_path(cls):
@@ -662,14 +681,9 @@ class ImageMagickWriter(ImageMagickBase, MovieWriter):
 
     Frames are streamed directly to ImageMagick via a pipe and written
     in a single pass.
-
     """
-    def _args(self):
-        return ([self.bin_path(),
-                 '-size', '%ix%i' % self.frame_size, '-depth', '8',
-                 '-delay', str(self.delay), '-loop', '0',
-                 '%s:-' % self.frame_format]
-                + self.output_args)
+
+    input_names = "-"  # stdin
 
 
 # Combine ImageMagick options with temp file-based writing
@@ -683,15 +697,8 @@ class ImageMagickFileWriter(ImageMagickBase, FileMovieWriter):
     """
 
     supported_formats = ['png', 'jpeg', 'tiff', 'raw', 'rgba']
-
-    def _args(self):
-        # Force format: ImageMagick does not recognize 'raw'.
-        fmt = 'rgba:' if self.frame_format == 'raw' else ''
-        return ([self.bin_path(),
-                 '-size', '%ix%i' % self.frame_size, '-depth', '8',
-                 '-delay', str(self.delay), '-loop', '0',
-                 '%s%s*.%s' % (fmt, self.temp_prefix, self.frame_format)]
-                + self.output_args)
+    input_names = property(
+        lambda self: f'{self.temp_prefix}*.{self.frame_format}')
 
 
 # Taken directly from jakevdp's JSAnimation package at


### PR DESCRIPTION
ImageMagickWriter previously did not support frame_format = "raw",
unlike ImageMagickFileWriter, because it did not normalize it to "rgba".
(To test this, start e.g. with the simple_anim.py example, set the
writer to an ImageMagickWriter (or ImageMagickFileWriter) and
additionally set writer.frame_format = "raw".)

Also deprecate the ``delay`` and ``output_args``  properties which can
directly be handled by ``_args``, but add an ``input_names`` property
which allows the different customization between ImageMagickWriter and
ImageMagickFileWriter.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
