### PR TITLE
Switch transOffset to offset_transform.

### DIFF
--- a/doc/api/next_api_changes/deprecations/21965-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21965-AL.rst
@@ -1,0 +1,5 @@
+``transOffset`` parameter name
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``transOffset`` parameter of `.Collection.set_offset_transform` and the
+various ``create_collection`` methods of legend handlers has been renamed to
+``offset_transform`` (consistently with the property name).

--- a/examples/event_handling/lasso_demo.py
+++ b/examples/event_handling/lasso_demo.py
@@ -45,7 +45,7 @@ class LassoManager:
             6, sizes=(100,),
             facecolors=facecolors,
             offsets=self.xys,
-            transOffset=ax.transData)
+            offset_transform=ax.transData)
 
         ax.add_collection(self.collection)
 

--- a/examples/shapes_and_collections/collections.py
+++ b/examples/shapes_and_collections/collections.py
@@ -5,8 +5,8 @@ Line, Poly and RegularPoly Collection with autoscaling
 
 For the first two subplots, we will use spirals.  Their size will be set in
 plot units, not data units.  Their positions will be set in data units by using
-the *offsets* and *transOffset* keyword arguments of the `.LineCollection` and
-`.PolyCollection`.
+the *offsets* and *offset_transform* keyword arguments of the `.LineCollection`
+and `.PolyCollection`.
 
 The third subplot will make regular polygons, with the same
 type of scaling and positioning as in the first two.
@@ -46,8 +46,8 @@ fig.subplots_adjust(top=0.92, left=0.07, right=0.97,
                     hspace=0.3, wspace=0.3)
 
 
-col = collections.LineCollection([spiral], offsets=xyo,
-                                 transOffset=ax1.transData)
+col = collections.LineCollection(
+    [spiral], offsets=xyo, offset_transform=ax1.transData)
 trans = fig.dpi_scale_trans + transforms.Affine2D().scale(1.0/72.0)
 col.set_transform(trans)  # the points to pixels transform
 # Note: the first argument to the collection initializer
@@ -71,8 +71,8 @@ ax1.set_title('LineCollection using offsets')
 
 
 # The same data as above, but fill the curves.
-col = collections.PolyCollection([spiral], offsets=xyo,
-                                 transOffset=ax2.transData)
+col = collections.PolyCollection(
+    [spiral], offsets=xyo, offset_transform=ax2.transData)
 trans = transforms.Affine2D().scale(fig.dpi/72.0)
 col.set_transform(trans)  # the points to pixels transform
 ax2.add_collection(col, autolim=True)
@@ -85,7 +85,7 @@ ax2.set_title('PolyCollection using offsets')
 # 7-sided regular polygons
 
 col = collections.RegularPolyCollection(
-    7, sizes=np.abs(xx) * 10.0, offsets=xyo, transOffset=ax3.transData)
+    7, sizes=np.abs(xx) * 10.0, offsets=xyo, offset_transform=ax3.transData)
 trans = transforms.Affine2D().scale(fig.dpi / 72.0)
 col.set_transform(trans)  # the points to pixels transform
 ax3.add_collection(col, autolim=True)

--- a/examples/shapes_and_collections/ellipse_collection.py
+++ b/examples/shapes_and_collections/ellipse_collection.py
@@ -7,6 +7,7 @@ Drawing a collection of ellipses. While this would equally be possible using
 a `~.collections.EllipseCollection` or `~.collections.PathCollection`, the use
 of an `~.collections.EllipseCollection` allows for much shorter code.
 """
+
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.collections import EllipseCollection
@@ -25,7 +26,7 @@ aa = X * 9
 fig, ax = plt.subplots()
 
 ec = EllipseCollection(ww, hh, aa, units='x', offsets=XY,
-                       transOffset=ax.transData)
+                       offset_transform=ax.transData)
 ec.set_array((X + Y).ravel())
 ax.add_collection(ec)
 ax.autoscale_view()

--- a/examples/specialty_plots/mri_with_eeg.py
+++ b/examples/specialty_plots/mri_with_eeg.py
@@ -64,7 +64,7 @@ for i in range(n_rows):
 offsets = np.zeros((n_rows, 2), dtype=float)
 offsets[:, 1] = ticklocs
 
-lines = LineCollection(segs, offsets=offsets, transOffset=None)
+lines = LineCollection(segs, offsets=offsets, offset_transform=None)
 ax2.add_collection(lines)
 
 # Set the yticks to use axes coordinates on the y axis

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4463,14 +4463,14 @@ default: :rc:`scatter.edgecolors`
         offsets = np.ma.column_stack([x, y])
 
         collection = mcoll.PathCollection(
-                (path,), scales,
-                facecolors=colors,
-                edgecolors=edgecolors,
-                linewidths=linewidths,
-                offsets=offsets,
-                transOffset=kwargs.pop('transform', self.transData),
-                alpha=alpha
-                )
+            (path,), scales,
+            facecolors=colors,
+            edgecolors=edgecolors,
+            linewidths=linewidths,
+            offsets=offsets,
+            offset_transform=kwargs.pop('transform', self.transData),
+            alpha=alpha,
+        )
         collection.set_transform(mtransforms.IdentityTransform())
         if colors is None:
             collection.set_array(c)
@@ -4796,8 +4796,9 @@ default: :rc:`scatter.edgecolors`
                 edgecolors=edgecolors,
                 linewidths=linewidths,
                 offsets=offsets,
-                transOffset=mtransforms.AffineDeltaTransform(self.transData),
-                )
+                offset_transform=mtransforms.AffineDeltaTransform(
+                    self.transData),
+            )
 
         # Set normalizer if bins is 'log'
         if bins == 'log':

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -30,6 +30,7 @@ from ._enums import JoinStyle, CapStyle
     "facecolor": ["facecolors", "fc"],
     "linestyle": ["linestyles", "dashes", "ls"],
     "linewidth": ["linewidths", "lw"],
+    "offset_transform": ["transOffset"],
 })
 class Collection(artist.Artist, cm.ScalarMappable):
     r"""
@@ -84,7 +85,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                  joinstyle=None,
                  antialiaseds=None,
                  offsets=None,
-                 transOffset=None,
+                 offset_transform=None,
                  norm=None,  # optional for ScalarMappable
                  cmap=None,  # ditto
                  pickradius=5.0,
@@ -127,7 +128,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
             A vector by which to translate each patch after rendering (default
             is no translation). The translation is performed in screen (pixel)
             coordinates (i.e. after the Artist's transform is applied).
-        transOffset : `~.transforms.Transform`, default: `.IdentityTransform`
+        offset_transform : `~.Transform`, default: `.IdentityTransform`
             A single transform which will be applied to each *offsets* vector
             before it is used.
         norm : `~.colors.Normalize`, optional
@@ -202,7 +203,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 offsets = offsets[None, :]
             self._offsets = offsets
 
-        self._transOffset = transOffset
+        self._offset_transform = offset_transform
 
         self._path_effects = None
         self.update(kwargs)
@@ -219,22 +220,24 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
     def get_offset_transform(self):
         """Return the `.Transform` instance used by this artist offset."""
-        if self._transOffset is None:
-            self._transOffset = transforms.IdentityTransform()
-        elif (not isinstance(self._transOffset, transforms.Transform)
-              and hasattr(self._transOffset, '_as_mpl_transform')):
-            self._transOffset = self._transOffset._as_mpl_transform(self.axes)
-        return self._transOffset
+        if self._offset_transform is None:
+            self._offset_transform = transforms.IdentityTransform()
+        elif (not isinstance(self._offset_transform, transforms.Transform)
+              and hasattr(self._offset_transform, '_as_mpl_transform')):
+            self._offset_transform = \
+                self._offset_transform._as_mpl_transform(self.axes)
+        return self._offset_transform
 
-    def set_offset_transform(self, transOffset):
+    @_api.rename_parameter("3.6", "transOffset", "offset_transform")
+    def set_offset_transform(self, offset_transform):
         """
         Set the artist offset transform.
 
         Parameters
         ----------
-        transOffset : `.Transform`
+        offset_transform : `.Transform`
         """
-        self._transOffset = transOffset
+        self._offset_transform = offset_transform
 
     def get_datalim(self, transData):
         # Calculate the data limits and return them as a `.Bbox`.
@@ -254,9 +257,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         # 3. otherwise return a null Bbox.
 
         transform = self.get_transform()
-        transOffset = self.get_offset_transform()
-        hasOffsets = np.any(self._offsets)  # True if any non-zero offsets
-        if hasOffsets and not transOffset.contains_branch(transData):
+        offset_trf = self.get_offset_transform()
+        has_offsets = np.any(self._offsets)  # True if any non-zero offsets
+        if has_offsets and not offset_trf.contains_branch(transData):
             # if there are offsets but in some coords other than data,
             # then don't use them for autoscaling.
             return transforms.Bbox.null()
@@ -284,16 +287,16 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 return mpath.get_path_collection_extents(
                     transform.get_affine() - transData, paths,
                     self.get_transforms(),
-                    transOffset.transform_non_affine(offsets),
-                    transOffset.get_affine().frozen())
-            if hasOffsets:
+                    offset_trf.transform_non_affine(offsets),
+                    offset_trf.get_affine().frozen())
+            if has_offsets:
                 # this is for collections that have their paths (shapes)
                 # in physical, axes-relative, or figure-relative units
                 # (i.e. like scatter). We can't uniquely set limits based on
                 # those shapes, so we just set the limits based on their
                 # location.
 
-                offsets = (transOffset - transData).transform(offsets)
+                offsets = (offset_trf - transData).transform(offsets)
                 # note A-B means A B^{-1}
                 offsets = np.ma.masked_invalid(offsets)
                 if not offsets.mask.all():
@@ -311,7 +314,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         # Helper for drawing and hit testing.
 
         transform = self.get_transform()
-        transOffset = self.get_offset_transform()
+        offset_trf = self.get_offset_transform()
         offsets = self._offsets
         paths = self.get_paths()
 
@@ -332,17 +335,17 @@ class Collection(artist.Artist, cm.ScalarMappable):
             paths = [transform.transform_path_non_affine(path)
                      for path in paths]
             transform = transform.get_affine()
-        if not transOffset.is_affine:
-            offsets = transOffset.transform_non_affine(offsets)
+        if not offset_trf.is_affine:
+            offsets = offset_trf.transform_non_affine(offsets)
             # This might have changed an ndarray into a masked array.
-            transOffset = transOffset.get_affine()
+            offset_trf = offset_trf.get_affine()
 
         if isinstance(offsets, np.ma.MaskedArray):
             offsets = offsets.filled(np.nan)
             # Changing from a masked array to nan-filled ndarray
             # is probably most efficient at this point.
 
-        return transform, transOffset, offsets, paths
+        return transform, offset_trf, offsets, paths
 
     @artist.allow_rasterization
     def draw(self, renderer):
@@ -352,7 +355,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         self.update_scalarmappable()
 
-        transform, transOffset, offsets, paths = self._prepare_points()
+        transform, offset_trf, offsets, paths = self._prepare_points()
 
         gc = renderer.new_gc()
         self._set_gc_clip(gc)
@@ -408,11 +411,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
             gc.set_url(self._urls[0])
             renderer.draw_markers(
                 gc, paths[0], combined_transform.frozen(),
-                mpath.Path(offsets), transOffset, tuple(facecolors[0]))
+                mpath.Path(offsets), offset_trf, tuple(facecolors[0]))
         else:
             renderer.draw_path_collection(
                 gc, transform.frozen(), paths,
-                self.get_transforms(), offsets, transOffset,
+                self.get_transforms(), offsets, offset_trf,
                 self.get_facecolor(), self.get_edgecolor(),
                 self._linewidths, self._linestyles,
                 self._antialiaseds, self._urls,
@@ -459,7 +462,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if self.axes:
             self.axes._unstale_viewLim()
 
-        transform, transOffset, offsets, paths = self._prepare_points()
+        transform, offset_trf, offsets, paths = self._prepare_points()
 
         # Tests if the point is contained on one of the polygons formed
         # by the control points of each of the paths. A point is considered
@@ -469,7 +472,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         ind = _path.point_in_path_collection(
             mouseevent.x, mouseevent.y, pickradius,
             transform.frozen(), paths, self.get_transforms(),
-            offsets, transOffset, pickradius <= 0)
+            offsets, offset_trf, pickradius <= 0)
 
         return len(ind) > 0, dict(ind=ind)
 
@@ -1317,7 +1320,7 @@ class RegularPolyCollection(_CollectionWithSizes):
                 edgecolors=("black",),
                 linewidths=(1,),
                 offsets=offsets,
-                transOffset=ax.transData,
+                offset_transform=ax.transData,
                 )
         """
         super().__init__(**kwargs)
@@ -2149,7 +2152,7 @@ class QuadMesh(Collection):
             return
         renderer.open_group(self.__class__.__name__, self.get_gid())
         transform = self.get_transform()
-        transOffset = self.get_offset_transform()
+        offset_trf = self.get_offset_transform()
         offsets = self._offsets
 
         if self.have_units():
@@ -2168,9 +2171,9 @@ class QuadMesh(Collection):
         else:
             coordinates = self._coordinates
 
-        if not transOffset.is_affine:
-            offsets = transOffset.transform_non_affine(offsets)
-            transOffset = transOffset.get_affine()
+        if not offset_trf.is_affine:
+            offsets = offset_trf.transform_non_affine(offsets)
+            offset_trf = offset_trf.get_affine()
 
         gc = renderer.new_gc()
         gc.set_snap(self.get_snap())
@@ -2185,7 +2188,7 @@ class QuadMesh(Collection):
             renderer.draw_quad_mesh(
                 gc, transform.frozen(),
                 coordinates.shape[1] - 1, coordinates.shape[0] - 1,
-                coordinates, offsets, transOffset,
+                coordinates, offsets, offset_trf,
                 # Backends expect flattened rgba arrays (n*m, 4) for fc and ec
                 self.get_facecolor().reshape((-1, 4)),
                 self._antialiased, self.get_edgecolors().reshape((-1, 4)))

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -829,8 +829,8 @@ class Legend(Artist):
                 bboxes.append(
                     artist.get_path().get_extents(artist.get_transform()))
             elif isinstance(artist, Collection):
-                _, transOffset, hoffsets, _ = artist._prepare_points()
-                for offset in transOffset.transform(hoffsets):
+                _, offset_trf, hoffsets, _ = artist._prepare_points()
+                for offset in offset_trf.transform(hoffsets):
                     offsets.append(offset)
         return bboxes, lines, offsets
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -464,14 +464,13 @@ class HandlerRegularPolyCollection(HandlerNpointsYoffsets):
         legend_handle.set_clip_box(None)
         legend_handle.set_clip_path(None)
 
-    def create_collection(self, orig_handle, sizes, offsets, transOffset):
-        p = type(orig_handle)(orig_handle.get_numsides(),
-                              rotation=orig_handle.get_rotation(),
-                              sizes=sizes,
-                              offsets=offsets,
-                              transOffset=transOffset,
-                              )
-        return p
+    @_api.rename_parameter("3.6", "transOffset", "offset_transform")
+    def create_collection(self, orig_handle, sizes, offsets, offset_transform):
+        return type(orig_handle)(
+            orig_handle.get_numsides(),
+            rotation=orig_handle.get_rotation(), sizes=sizes,
+            offsets=offsets, offset_transform=offset_transform,
+        )
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
@@ -485,34 +484,33 @@ class HandlerRegularPolyCollection(HandlerNpointsYoffsets):
         sizes = self.get_sizes(legend, orig_handle, xdescent, ydescent,
                                width, height, fontsize)
 
-        p = self.create_collection(orig_handle, sizes,
-                                   offsets=list(zip(xdata_marker, ydata)),
-                                   transOffset=trans)
+        p = self.create_collection(
+            orig_handle, sizes,
+            offsets=list(zip(xdata_marker, ydata)), offset_transform=trans)
 
         self.update_prop(p, orig_handle, legend)
-        p._transOffset = trans
+        p.set_offset_transform(trans)
         return [p]
 
 
 class HandlerPathCollection(HandlerRegularPolyCollection):
     r"""Handler for `.PathCollection`\s, which are used by `~.Axes.scatter`."""
-    def create_collection(self, orig_handle, sizes, offsets, transOffset):
-        p = type(orig_handle)([orig_handle.get_paths()[0]],
-                              sizes=sizes,
-                              offsets=offsets,
-                              transOffset=transOffset,
-                              )
-        return p
+
+    @_api.rename_parameter("3.6", "transOffset", "offset_transform")
+    def create_collection(self, orig_handle, sizes, offsets, offset_transform):
+        return type(orig_handle)(
+            [orig_handle.get_paths()[0]], sizes=sizes,
+            offsets=offsets, offset_transform=offset_transform,
+        )
 
 
 class HandlerCircleCollection(HandlerRegularPolyCollection):
     r"""Handler for `.CircleCollection`\s."""
-    def create_collection(self, orig_handle, sizes, offsets, transOffset):
-        p = type(orig_handle)(sizes,
-                              offsets=offsets,
-                              transOffset=transOffset,
-                              )
-        return p
+
+    @_api.rename_parameter("3.6", "transOffset", "offset_transform")
+    def create_collection(self, orig_handle, sizes, offsets, offset_transform):
+        return type(orig_handle)(
+            sizes, offsets=offsets, offset_transform=offset_transform)
 
 
 class HandlerErrorbar(HandlerLine2D):

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -328,10 +328,10 @@ class QuiverKey(martist.Artist):
             kwargs = self.Q.polykw
             kwargs.update(self.kw)
             self.vector = mcollections.PolyCollection(
-                                        self.verts,
-                                        offsets=[(self.X, self.Y)],
-                                        transOffset=self.get_transform(),
-                                        **kwargs)
+                self.verts,
+                offsets=[(self.X, self.Y)],
+                offset_transform=self.get_transform(),
+                **kwargs)
             if self.color is not None:
                 self.vector.set_color(self.color)
             self.vector.set_transform(self.Q.get_transform())
@@ -503,7 +503,7 @@ class Quiver(mcollections.PolyCollection):
         self.transform = kwargs.pop('transform', ax.transData)
         kwargs.setdefault('facecolors', color)
         kwargs.setdefault('linewidths', (0,))
-        super().__init__([], offsets=self.XY, transOffset=self.transform,
+        super().__init__([], offsets=self.XY, offset_transform=self.transform,
                          closed=False, **kwargs)
         self.polykw = kwargs
         self.set_UVC(U, V, C)
@@ -550,8 +550,8 @@ class Quiver(mcollections.PolyCollection):
 
     def get_datalim(self, transData):
         trans = self.get_transform()
-        transOffset = self.get_offset_transform()
-        full_transform = (trans - transData) + (transOffset - transData)
+        offset_trf = self.get_offset_transform()
+        full_transform = (trans - transData) + (offset_trf - transData)
         XY = full_transform.transform(self.XY)
         bbox = transforms.Bbox.null()
         bbox.update_from_data_xy(XY, ignore=True)
@@ -972,8 +972,8 @@ class Barbs(mcollections.PolyCollection):
 
         # Make a collection
         barb_size = self._length ** 2 / 4  # Empirically determined
-        super().__init__([], (barb_size,), offsets=xy, transOffset=transform,
-                         **kwargs)
+        super().__init__(
+            [], (barb_size,), offsets=xy, offset_transform=transform, **kwargs)
         self.set_transform(transforms.IdentityTransform())
 
         self.set_UVC(u, v, c)

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -90,7 +90,7 @@ def test_collection_transform_of_none():
                                      transform=mtransforms.IdentityTransform(),
                                      alpha=0.5)
     ax.add_collection(c)
-    assert isinstance(c._transOffset, mtransforms.IdentityTransform)
+    assert isinstance(c.get_offset_transform(), mtransforms.IdentityTransform)
 
 
 @image_comparison(["clip_path_clipping"], remove_text=True)
@@ -165,20 +165,18 @@ def test_hatching():
     rect1 = mpatches.Rectangle((0, 0), 3, 4, hatch='/')
     ax.add_patch(rect1)
 
-    rect2 = mcollections.RegularPolyCollection(4, sizes=[16000],
-                                               offsets=[(1.5, 6.5)],
-                                               transOffset=ax.transData,
-                                               hatch='/')
+    rect2 = mcollections.RegularPolyCollection(
+        4, sizes=[16000], offsets=[(1.5, 6.5)], offset_transform=ax.transData,
+        hatch='/')
     ax.add_collection(rect2)
 
     # Ensure edge color is not applied to hatching.
     rect3 = mpatches.Rectangle((4, 0), 3, 4, hatch='/', edgecolor='C1')
     ax.add_patch(rect3)
 
-    rect4 = mcollections.RegularPolyCollection(4, sizes=[16000],
-                                               offsets=[(5.5, 6.5)],
-                                               transOffset=ax.transData,
-                                               hatch='/', edgecolor='C1')
+    rect4 = mcollections.RegularPolyCollection(
+        4, sizes=[16000], offsets=[(5.5, 6.5)], offset_transform=ax.transData,
+        hatch='/', edgecolor='C1')
     ax.add_collection(rect4)
 
     ax.set_xlim(0, 7)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -374,11 +374,9 @@ def test_EllipseCollection():
     hh = Y / y[-1]
     aa = np.ones_like(ww) * 20  # first axis is 20 degrees CCW from x axis
 
-    ec = mcollections.EllipseCollection(ww, hh, aa,
-                                        units='x',
-                                        offsets=XY,
-                                        transOffset=ax.transData,
-                                        facecolors='none')
+    ec = mcollections.EllipseCollection(
+        ww, hh, aa, units='x', offsets=XY, offset_transform=ax.transData,
+        facecolors='none')
     ax.add_collection(ec)
     ax.autoscale_view()
 
@@ -430,7 +428,7 @@ def test_regularpolycollection_rotate():
     for xy, alpha in zip(xy_points, rotations):
         col = mcollections.RegularPolyCollection(
             4, sizes=(100,), rotation=alpha,
-            offsets=[xy], transOffset=ax.transData)
+            offsets=[xy], offset_transform=ax.transData)
         ax.add_collection(col, autolim=True)
     ax.autoscale_view()
 
@@ -458,8 +456,8 @@ def test_regularpolycollection_scale():
     xy = [(0, 0)]
     # Unit square has a half-diagonal of `1/sqrt(2)`, so `pi * r**2` equals...
     circle_areas = [np.pi / 2]
-    squares = SquareCollection(sizes=circle_areas, offsets=xy,
-                               transOffset=ax.transData)
+    squares = SquareCollection(
+        sizes=circle_areas, offsets=xy, offset_transform=ax.transData)
     ax.add_collection(squares, autolim=True)
     ax.axis([-1, 1, -1, 1])
 
@@ -487,10 +485,8 @@ def test_size_in_xy():
     widths = 10, 10
     coords = [(10, 10), (15, 15)]
     e = mcollections.EllipseCollection(
-        widths, heights, angles,
-        units='xy',
-        offsets=coords,
-        transOffset=ax.transData)
+        widths, heights, angles, units='xy',
+        offsets=coords, offset_transform=ax.transData)
 
     ax.add_collection(e)
 
@@ -1072,7 +1068,7 @@ def test_set_offsets_late():
 
 def test_set_offset_transform():
     skew = mtransforms.Affine2D().skew(2, 2)
-    init = mcollections.Collection([], transOffset=skew)
+    init = mcollections.Collection([], offset_transform=skew)
 
     late = mcollections.Collection([])
     late.set_offset_transform(skew)

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -166,7 +166,7 @@ fig, ax = plt.subplots()
 collection = mpl.collections.StarPolygonCollection(
     5, 0, [250, ],  # five point star, zero angle, size 250px
     offsets=np.column_stack([x, y]),  # Set the positions
-    transOffset=ax.transData,  # Propagate transformations of the Axes
+    offset_transform=ax.transData,  # Propagate transformations of the Axes
 )
 ax.add_collection(collection)
 ax.autoscale_view()


### PR DESCRIPTION
Note that most APIs *previously* already accepted *offset_transform* as
kwarg, due to the presence of the `set_offset_transform` setter.  Prefer
that name (shortening it to `offset_trf` for local variables).

Backcompat for the old `transOffset` name is kept in most places by
introducing a property alias.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
