### PR TITLE
Reword inset axes example.

### DIFF
--- a/examples/axes_grid1/demo_colorbar_with_inset_locator.py
+++ b/examples/axes_grid1/demo_colorbar_with_inset_locator.py
@@ -6,40 +6,37 @@ Controlling the position and size of colorbars with Inset Axes
 This example shows how to control the position, height, and width of
 colorbars using `~mpl_toolkits.axes_grid1.inset_locator.inset_axes`.
 
-Controlling the placement of the inset axes is done similarly as that of the
-legend: either by providing a location option ("upper right", "best", ...), or
-by providing a locator with respect to the parent bbox.
-
+Inset axes placement is controlled as for legends: either by providing a *loc*
+option ("upper right", "best", ...), or by providing a locator with respect to
+the parent bbox.  Parameters such as *bbox_to_anchor* and *borderpad* likewise
+work in the same way, and are also demonstrated here.
 """
-import matplotlib.pyplot as plt
 
+import matplotlib.pyplot as plt
 from mpl_toolkits.axes_grid1.inset_locator import inset_axes
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=[6, 3])
 
-axins1 = inset_axes(ax1,
-                    width="50%",  # width = 50% of parent_bbox width
-                    height="5%",  # height : 5%
-                    loc='upper right')
-
 im1 = ax1.imshow([[1, 2], [2, 3]])
-fig.colorbar(im1, cax=axins1, orientation="horizontal", ticks=[1, 2, 3])
+axins1 = inset_axes(
+    ax1,
+    width="50%",  # width: 50% of parent_bbox width
+    height="5%",  # height: 5%
+    loc="upper right",
+)
 axins1.xaxis.set_ticks_position("bottom")
-
-axins = inset_axes(ax2,
-                   width="5%",  # width = 5% of parent_bbox width
-                   height="50%",  # height : 50%
-                   loc='lower left',
-                   bbox_to_anchor=(1.05, 0., 1, 1),
-                   bbox_transform=ax2.transAxes,
-                   borderpad=0,
-                   )
-
-# Controlling the placement of the inset axes is basically same as that
-# of the legend.  you may want to play with the borderpad value and
-# the bbox_to_anchor coordinate.
+fig.colorbar(im1, cax=axins1, orientation="horizontal", ticks=[1, 2, 3])
 
 im = ax2.imshow([[1, 2], [2, 3]])
+axins = inset_axes(
+    ax2,
+    width="5%",  # width: 5% of parent_bbox width
+    height="50%",  # height: 50%
+    loc="lower left",
+    bbox_to_anchor=(1.05, 0., 1, 1),
+    bbox_transform=ax2.transAxes,
+    borderpad=0,
+)
 fig.colorbar(im, cax=axins, ticks=[1, 2, 3])
 
 plt.show()


### PR DESCRIPTION
Merge comment into header text, small relayout/reordering.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
