### PR TITLE
DOC: remove experimental tag from CL

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2212,22 +2212,22 @@ class Figure(FigureBase):
                 The use of this parameter is discouraged. Please use
                 ``layout='constrained'`` instead.
 
-        layout : {'constrained', 'tight'}, optional
-            The layout mechanism for positioning of plot elements.
-            Supported values:
+        layout : {'constrained', 'tight'}, optional, default: None
+            The layout mechanism for positioning of plot elements to avoid
+            overlapping Axes decorations (labels, ticks, etc). Note that
+            layout managers can have significant performance penalties.
 
-            - 'constrained': The constrained layout solver usually gives the
-              best layout results and is thus recommended. However, it is
-              computationally expensive and can be slow for complex figures
-              with many elements.
+            - 'constrained': The constrained layout solver adjusts axes sizes
+               to avoid overlapping axes decorations.  Can handle complex plot
+               layouts and colorbars, and is thus recommended.
 
               See :doc:`/tutorials/intermediate/constrainedlayout_guide`
               for examples.
 
             - 'tight': Use the tight layout mechanism. This is a relatively
-              simple algorithm, that adjusts the subplot parameters so that
-              decorations like tick labels, axis labels and titles have enough
-              space. See `.Figure.set_tight_layout` for further details.
+              simple algorithm that adjusts the subplot parameters so that
+              decorations do not overlap. See `.Figure.set_tight_layout` for
+              further details.
 
             If not given, fall back to using the parameters *tight_layout* and
             *constrained_layout*, including their config defaults

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -29,15 +29,6 @@ a figure. Two ways of doing so are
 
 Those are described in detail throughout the following sections.
 
-.. warning::
-
-    Currently Constrained Layout is **experimental**.  The
-    behaviour and API are subject to change, or the whole functionality
-    may be removed without a deprecation period.  If you *require* your
-    plots to be absolutely reproducible, get the Axes positions after
-    running Constrained Layout and use ``ax.set_position()`` in your code
-    with ``constrained_layout=False``.
-
 Simple Example
 ==============
 


### PR DESCRIPTION
## PR Summary

Constrained layout is not really experimental any more, and we probably should not break it at this point....


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
