### PR TITLE
Add corner coordinate helper methods to Ellipse/Rectangle

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -806,6 +806,18 @@ class Rectangle(Patch):
         """Return the left and bottom coords of the rectangle as a tuple."""
         return self._x0, self._y0
 
+    def get_corners(self):
+        """
+        Return the corners of the rectangle, moving anti-clockwise from
+        (x0, y0).
+        """
+        return self.get_patch_transform().transform(
+            [(0, 0), (1, 0), (1, 1), (0, 1)])
+
+    def get_center(self):
+        """Return the centre of the rectangle."""
+        return self.get_patch_transform().transform((0.5, 0.5))
+
     def get_width(self):
         """Return the width of the rectangle."""
         return self._width
@@ -1656,6 +1668,16 @@ class Ellipse(Patch):
         return self._angle
 
     angle = property(get_angle, set_angle)
+
+    def get_corners(self):
+        """
+        Return the corners of the ellipse bounding box.
+
+        The bounding box orientation is moving anti-clockwise from the
+        lower left corner defined before rotation.
+        """
+        return self.get_patch_transform().transform(
+            [(-1, -1), (1, -1), (1, 1), (-1, 1)])
 
 
 class Annulus(Patch):

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -6,7 +6,7 @@ from numpy.testing import assert_almost_equal, assert_array_equal
 import pytest
 
 import matplotlib as mpl
-from matplotlib.patches import (Annulus, Patch, Polygon, Rectangle,
+from matplotlib.patches import (Annulus, Ellipse, Patch, Polygon, Rectangle,
                                 FancyArrowPatch)
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.transforms import Bbox
@@ -52,6 +52,54 @@ def test_Polygon_close():
     assert_array_equal(p.get_xy(), xyclosed)
     p.set_xy(xyclosed)
     assert_array_equal(p.get_xy(), xyclosed)
+
+
+def test_corner_center():
+    loc = [10, 20]
+    width = 1
+    height = 2
+
+    # Rectangle
+    # No rotation
+    corners = ((10, 20), (11, 20), (11, 22), (10, 22))
+    rect = Rectangle(loc, width, height)
+    assert_array_equal(rect.get_corners(), corners)
+    assert_array_equal(rect.get_center(), (10.5, 21))
+
+    # 90 deg rotation
+    corners_rot = ((10, 20), (10, 21), (8, 21), (8, 20))
+    rect.set_angle(90)
+    assert_array_equal(rect.get_corners(), corners_rot)
+    assert_array_equal(rect.get_center(), (9, 20.5))
+
+    # Rotation not a multiple of 90 deg
+    theta = 33
+    t = mtransforms.Affine2D().rotate_around(*loc, np.deg2rad(theta))
+    corners_rot = t.transform(corners)
+    rect.set_angle(theta)
+    assert_almost_equal(rect.get_corners(), corners_rot)
+
+    # Ellipse
+    loc = [loc[0] + width / 2,
+           loc[1] + height / 2]
+    ellipse = Ellipse(loc, width, height)
+
+    # No rotation
+    assert_array_equal(ellipse.get_corners(), corners)
+
+    # 90 deg rotation
+    corners_rot = ((11.5, 20.5), (11.5, 21.5), (9.5, 21.5), (9.5, 20.5))
+    ellipse.set_angle(90)
+    assert_array_equal(ellipse.get_corners(), corners_rot)
+    # Rotation shouldn't change ellipse center
+    assert_array_equal(ellipse.get_center(), loc)
+
+    # Rotation not a multiple of 90 deg
+    theta = 33
+    t = mtransforms.Affine2D().rotate_around(*loc, np.deg2rad(theta))
+    corners_rot = t.transform(corners)
+    ellipse.set_angle(theta)
+    assert_almost_equal(ellipse.get_corners(), corners_rot)
 
 
 def test_rotate_rect():


### PR DESCRIPTION
## PR Summary
This is pulled out of https://github.com/matplotlib/matplotlib/pull/21945 because it's a standalone feature, and I think it's worth the scrutiny of a separate PR.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
