### PR TITLE
Slightly tighten the _get_layout_cache_key API.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -272,15 +272,14 @@ class Text(Artist):
         self._linespacing = other._linespacing
         self.stale = True
 
-    def _get_layout_cache_key(self, renderer=None):
+    def _get_layout_cache_key(self, renderer):
         """
         Return a hashable tuple of properties that lets `_get_layout` know
         whether a previously computed layout can be reused.
         """
-        x, y = self.get_unitless_position()
-        renderer = renderer or self._renderer
         return (
-            x, y, self.get_text(), hash(self._fontproperties),
+            self.get_unitless_position(), self.get_text(),
+            hash(self._fontproperties),
             self._verticalalignment, self._horizontalalignment,
             self._linespacing,
             self._rotation, self._rotation_mode, self._transform_rotates_text,


### PR DESCRIPTION
_get_layout_cache_key is only ever called from _get_layout, which always
passes a renderer arg which is never None (_get_layout calls
`renderer.get_text_width_height_descent` immediately after).  So we can
make the `renderer` arg required and not check for None.

Also, get_unitless_position() can be directly used instead of unpacking
it.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
