### PR TITLE
Fix rubberbanding on wx+py3.10.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -618,7 +618,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
                else self.bitmap)
         drawDC.DrawBitmap(bmp, 0, 0)
         if self._rubberband_rect is not None:
-            x0, y0, x1, y1 = self._rubberband_rect
+            # Some versions of wx+python don't support numpy.float64 here.
+            x0, y0, x1, y1 = map(int, self._rubberband_rect)
             drawDC.DrawLineList(
                 [(x0, y0, x1, y0), (x1, y0, x1, y1),
                  (x0, y0, x0, y1), (x0, y1, x1, y1)],

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -128,6 +128,8 @@ def _test_interactive_impl():
         "matplotlib.backends.backend_{}".format(backend))
 
     ax.plot([0, 1], [2, 3])
+    if fig.canvas.toolbar:  # i.e toolbar2.
+        fig.canvas.toolbar.draw_rubberband(None, 1., 1, 2., 2)
 
     timer = fig.canvas.new_timer(1.)  # Test floats casting to int as needed.
     timer.add_callback(FigureCanvasBase.key_press_event, fig.canvas, "q")


### PR DESCRIPTION
Locally (Arch standard packages), it otherwise fails with

  File "/usr/lib/python3.10/site-packages/wx/core.py", line 1098, in _DC_DrawLineList
    return self._DrawLineList(lines, pens, [])
TypeError: 'numpy.float64' object cannot be interpreted as an integer

Likely the same root cause as https://github.com/matplotlib/matplotlib/pull/19395.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
