### PR TITLE
Pass BytesIO to FT2Font instead of leaving files open

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1111,7 +1111,9 @@ class FontManager:
             prop = afmFontProperty(path, font)
             self.afmlist.append(prop)
         else:
-            font = ft2font.FT2Font(path)
+            with open(path, "rb") as fh:
+                bio = BytesIO(fh.read())
+            font = ft2font.FT2Font(bio)
             prop = ttfFontProperty(font)
             self.ttflist.append(prop)
         self._findfont_cached.cache_clear()
@@ -1429,8 +1431,10 @@ def is_opentype_cff_font(filename):
 
 @lru_cache(64)
 def _get_font(filename, hinting_factor, *, _kerning_factor, thread_id):
+    with open(filename, "rb") as fh:
+        bio = BytesIO(fh.read())
     return ft2font.FT2Font(
-        filename, hinting_factor, _kerning_factor=_kerning_factor)
+        bio, hinting_factor, _kerning_factor=_kerning_factor)
 
 
 # FT2Font objects cannot be used across fork()s because they reference the same

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -420,7 +420,7 @@ FontEntry = dataclasses.make_dataclass(
 )
 
 
-def ttfFontProperty(font):
+def ttfFontProperty(font, path=None):
     """
     Extract information from a TrueType font file.
 
@@ -428,6 +428,9 @@ def ttfFontProperty(font):
     ----------
     font : `.FT2Font`
         The TrueType font file from which information will be extracted.
+    path : str, default None
+        String specifying the file path of font file if file-like object
+        passed to FT2Font
 
     Returns
     -------
@@ -544,7 +547,7 @@ def ttfFontProperty(font):
         raise NotImplementedError("Non-scalable fonts are not supported")
     size = 'scalable'
 
-    return FontEntry(font.fname, name, style, variant, weight, stretch, size)
+    return FontEntry(path or font.fname, name, style, variant, weight, stretch, size)
 
 
 def afmFontProperty(fontpath, font):
@@ -1114,7 +1117,7 @@ class FontManager:
             with open(path, "rb") as fh:
                 bio = BytesIO(fh.read())
             font = ft2font.FT2Font(bio)
-            prop = ttfFontProperty(font)
+            prop = ttfFontProperty(font, path)
             self.ttflist.append(prop)
         self._findfont_cached.cache_clear()
 


### PR DESCRIPTION
## PR Summary

In https://github.com/pandas-dev/pandas/issues/44844, we're trying to debug a flaky ResourceWarning in our CI due to an unclosed file. We noticed some font files, e.g. `mpl-data/fonts/ttf/DejaVuSans.ttf`, are left open after tests are run.

This PR writes the file to `BytesIO` before passing to `FT2Font`

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
