### PR TITLE
Fix TkAgg memory leaks and test for memory growth regressions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -47,6 +47,7 @@ dependencies:
   - nbformat!=5.0.0,!=5.0.1
   - pandas!=0.25.0
   - pikepdf
+  - psutil
   - pre-commit
   - pydocstyle>=5.1.0
   - pytest!=4.6.0,!=5.4.0

--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -65,7 +65,7 @@ class Gcf:
         if hasattr(manager, "_cidgcf"):
             manager.canvas.mpl_disconnect(manager._cidgcf)
         manager.destroy()
-        gc.collect(1)
+        gc.collect()
 
     @classmethod
     def destroy_fig(cls, fig):

--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -66,7 +66,10 @@ class Gcf:
             manager.canvas.mpl_disconnect(manager._cidgcf)
         manager.destroy()
         del manager, num
-        gc.collect()
+        # Full cyclic garbage collection may be too expensive to do on every
+        # figure destruction, so we collect only the youngest two generations.
+        # see: https://github.com/matplotlib/matplotlib/pull/3045
+        gc.collect(1)
 
     @classmethod
     def destroy_fig(cls, fig):

--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -65,6 +65,7 @@ class Gcf:
         if hasattr(manager, "_cidgcf"):
             manager.canvas.mpl_disconnect(manager._cidgcf)
         manager.destroy()
+        del manager, num
         gc.collect()
 
     @classmethod

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -424,7 +424,7 @@ class FigureManagerTk(FigureManagerBase):
         # will handle it on the Python side.
         window_frame = int(window.wm_frame(), 16)
         self._window_dpi = tk.IntVar(master=window, value=96,
-                               name=f'window_dpi{window_frame}')
+                                     name=f'window_dpi{window_frame}')
         self._window_dpi_cbname = ''
         if _tkagg.enable_dpi_awareness(window_frame, window.tk.interpaddr()):
             self._window_dpi_cbname = self._window_dpi.trace_add(

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -50,8 +50,9 @@ def _isolated_tk_test(success_count, func=None):
             )
         except subprocess.TimeoutExpired:
             pytest.fail("Subprocess timed out")
-        except subprocess.CalledProcessError:
-            pytest.fail("Subprocess failed to test intended behavior")
+        except subprocess.CalledProcessError as e:
+            pytest.fail("Subprocess failed to test intended behavior\n"
+                        + str(e.stderr))
         else:
             # macOS may actually emit irrelevant errors about Accelerated
             # OpenGL vs. software OpenGL, so suppress them.
@@ -146,6 +147,7 @@ def test_figuremanager_cleans_own_mainloop():
     thread.join()
 
 
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
 @pytest.mark.flaky(reruns=3)
 @_isolated_tk_test(success_count=0)
 def test_never_update():
@@ -159,14 +161,12 @@ def test_never_update():
 
     plt.draw()  # Test FigureCanvasTkAgg.
     fig.canvas.toolbar.configure_subplots()  # Test NavigationToolbar2Tk.
+    # Test FigureCanvasTk filter_destroy callback
+    fig.canvas.get_tk_widget().after(100, plt.close, fig)
 
     # Check for update() or update_idletasks() in the event queue, functionally
     # equivalent to tkinter.Misc.update.
-    # Must pause >= 1 ms to process tcl idle events plus extra time to avoid
-    # flaky tests on slow systems.
-    plt.pause(0.1)
-
-    plt.close(fig)  # Test FigureCanvasTk filter_destroy callback
+    plt.show(block=True)
 
     # Note that exceptions would be printed to stderr; _isolated_tk_test
     # checks them.

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -195,8 +195,7 @@ def _test_thread_impl():
     future = ThreadPoolExecutor().submit(fig.canvas.draw)
     plt.pause(0.5)  # flush_events fails here on at least Tkagg (bpo-41176)
     future.result()  # Joins the thread; rethrows any exception.
-    plt.close()
-    fig.canvas.flush_events()  # pause doesn't process events after close
+    plt.close()  # backend is responsible for flushing any events here
 
 
 _thread_safe_backends = _get_testable_interactive_backends()

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -508,6 +508,7 @@ def test_blitting_events(env):
 # The source of this function gets extracted and run in another process, so it
 # must be fully self-contained.
 def _test_figure_leak():
+    import gc
     import sys
 
     import psutil
@@ -523,12 +524,14 @@ def _test_figure_leak():
             plt.pause(t)
         plt.close(fig)
     mem = p.memory_info().rss
+    gc.collect()
 
     for _ in range(5):
         fig = plt.figure()
         if t:
             plt.pause(t)
         plt.close(fig)
+        gc.collect()
     growth = p.memory_info().rss - mem
 
     print(growth)

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -518,16 +518,20 @@ def _test_figure_leak():
     # Warmup cycle, this reasonably allocates a lot
     for _ in range(2):
         fig = plt.figure()
-        if flush: fig.canvas.flush_events()
+        if flush:
+            fig.canvas.flush_events()
         plt.close(fig)
-        if flush: fig.canvas.flush_events()
+        if flush:
+            fig.canvas.flush_events()
     mem = p.memory_info().rss
 
     for _ in range(5):
         fig = plt.figure()
-        if flush: fig.canvas.flush_events()
+        if flush:
+            fig.canvas.flush_events()
         plt.close(fig)
-        if flush: fig.canvas.flush_events()
+        if flush:
+            fig.canvas.flush_events()
     growth = p.memory_info().rss - mem
 
     print(growth)
@@ -542,7 +546,9 @@ def test_figure_leak_20490(env, flush):
     # so test with a memory growth threshold
     acceptable_memory_leakage = 3_000_000
 
-    result = _run_helper(_test_figure_leak, flush, timeout=_test_timeout, **env)
+    result = _run_helper(
+        _test_figure_leak, flush, timeout=_test_timeout, **env
+    )
 
     growth = int(result.stdout)
     assert growth <= acceptable_memory_leakage

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -534,16 +534,19 @@ def _test_figure_leak():
     print(growth)
 
 
+# TODO: "0.1" memory threshold could be reduced 10x by fixing tkagg
 @pytest.mark.parametrize("env", _get_testable_interactive_backends())
-@pytest.mark.parametrize("time", ["0.0", "0.1"])
-def test_figure_leak_20490(env, time):
+@pytest.mark.parametrize("time_mem", [(0.0, 2_000_000), (0.1, 30_000_000)])
+def test_figure_leak_20490(env, time_mem):
     pytest.importorskip("psutil", reason="psutil needed to run this test")
 
     # We can't yet directly identify the leak
     # so test with a memory growth threshold
-    acceptable_memory_leakage = 2_000_000
+    pause_time, acceptable_memory_leakage = time_mem
 
-    result = _run_helper(_test_figure_leak, time, timeout=_test_timeout, **env)
+    result = _run_helper(
+        _test_figure_leak, str(pause_time), timeout=_test_timeout, **env
+    )
 
     growth = int(result.stdout)
     assert growth <= acceptable_memory_leakage

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -196,6 +196,7 @@ def _test_thread_impl():
     plt.pause(0.5)  # flush_events fails here on at least Tkagg (bpo-41176)
     future.result()  # Joins the thread; rethrows any exception.
     plt.close()  # backend is responsible for flushing any events here
+    fig.canvas.flush_events()  # TODO: debug why WX needs this only on py3.8
 
 
 _thread_safe_backends = _get_testable_interactive_backends()

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -511,38 +511,38 @@ def _test_figure_leak():
 
     import psutil
     from matplotlib import pyplot as plt
-    # Second argument is pause length, but if zero we should skip pausing
-    t = float(sys.argv[1])
+
+    flush = sys.argv[1] == "yes"
     p = psutil.Process()
 
     # Warmup cycle, this reasonably allocates a lot
     for _ in range(2):
         fig = plt.figure()
-        if t:
-            plt.pause(t)
+        if flush: fig.canvas.flush_events()
         plt.close(fig)
+        if flush: fig.canvas.flush_events()
     mem = p.memory_info().rss
 
     for _ in range(5):
         fig = plt.figure()
-        if t:
-            plt.pause(t)
+        if flush: fig.canvas.flush_events()
         plt.close(fig)
+        if flush: fig.canvas.flush_events()
     growth = p.memory_info().rss - mem
 
     print(growth)
 
 
 @pytest.mark.parametrize("env", _get_testable_interactive_backends())
-@pytest.mark.parametrize("time", ["0.0", "0.1"])
-def test_figure_leak_20490(env, time):
+@pytest.mark.parametrize("flush", ["no", "yes"])
+def test_figure_leak_20490(env, flush):
     pytest.importorskip("psutil", reason="psutil needed to run this test")
 
     # We can't yet directly identify the leak
     # so test with a memory growth threshold
-    acceptable_memory_leakage = 2_000_000
+    acceptable_memory_leakage = 3_000_000
 
-    result = _run_helper(_test_figure_leak, time, timeout=_test_timeout, **env)
+    result = _run_helper(_test_figure_leak, flush, timeout=_test_timeout, **env)
 
     growth = int(result.stdout)
     assert growth <= acceptable_memory_leakage

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -545,9 +545,11 @@ def _test_figure_leak():
 def test_figure_leak_20490(env, time_mem):
     pytest.importorskip("psutil", reason="psutil needed to run this test")
 
-    # We can't yet directly identify the leak
-    # so test with a memory growth threshold
+    # We haven't yet directly identified the leaks so test with a memory growth
+    # threshold.
     pause_time, acceptable_memory_leakage = time_mem
+    if env["MPLBACKEND"] == "macosx":
+        acceptable_memory_leakage += 10_000_000
 
     result = _run_helper(
         _test_figure_leak, str(pause_time), timeout=_test_timeout, **env

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -196,7 +196,9 @@ def _test_thread_impl():
     plt.pause(0.5)  # flush_events fails here on at least Tkagg (bpo-41176)
     future.result()  # Joins the thread; rethrows any exception.
     plt.close()  # backend is responsible for flushing any events here
-    fig.canvas.flush_events()  # TODO: debug why WX needs this only on py3.8
+    if plt.rcParams["backend"].startswith("WX"):
+        # TODO: debug why WX needs this only on py3.8
+        fig.canvas.flush_events()
 
 
 _thread_safe_backends = _get_testable_interactive_backends()

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -513,21 +513,22 @@ def _test_figure_leak():
     from matplotlib import pyplot as plt
     # Second argument is pause length, but if zero we should skip pausing
     t = float(sys.argv[1])
+    p = psutil.Process()
 
     # Warmup cycle, this reasonably allocates a lot
-    p = psutil.Process()
-    fig = plt.figure()
-    if t:
-        plt.pause(t)
-    plt.close(fig)
-    mem = p.memory_full_info().uss
+    for _ in range(2):
+        fig = plt.figure()
+        if t:
+            plt.pause(t)
+        plt.close(fig)
+    mem = p.memory_info().rss
 
     for _ in range(5):
         fig = plt.figure()
         if t:
             plt.pause(t)
         plt.close(fig)
-    growth = p.memory_full_info().uss - mem
+    growth = p.memory_info().rss - mem
 
     print(growth)
 

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -2,6 +2,7 @@
 
 certifi
 coverage<6.3
+psutil
 pytest!=4.6.0,!=5.4.0
 pytest-cov
 pytest-rerunfailures


### PR DESCRIPTION
## PR Summary
This PR is an attempt to fix #20490. Basically it allows a normally-forbidden `self.window.update()` if we detect that the `tkinter` mainloop is not running. The new test currently still fails though because of some additional leak related to the HiDPI stuff in #19167.

I took the liberty of introducing a new dependency in the test suite. Let me know if I should insert it into any other files or if you would rather find a different way to observe the leak.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests
- [ ]  (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] ~~New features are documented, with examples if plot related.~~
- [ ] ~~New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).~~
- [ ] ~~API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).~~
- [ ] ~~Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
