### PR TITLE
Make RendererCairo auto-infer surface size.

### DIFF
--- a/doc/api/next_api_changes/deprecations/21981-AL.rst
+++ b/doc/api/next_api_changes/deprecations/21981-AL.rst
@@ -1,4 +1,8 @@
 ``RendererGTK3Cairo`` and ``RendererGTK4Cairo``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-... have been deprecated.  Use ``RendererCairo`` instead, which has gained the
-``set_context`` method.
+... have been deprecated.  Use ``RendererCairo`` instead, which has gained
+the ``set_context`` method, which also auto-infers the size of the underlying
+surface.
+
+``RendererCairo.set_ctx_from_surface`` and ``RendererCairo.set_width_height``
+have likewise been deprecated, in favor of ``set_context``.

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -26,8 +26,6 @@ class FigureCanvasGTK3Cairo(backend_gtk3.FigureCanvasGTK3,
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
                 allocation.width, allocation.height)
-            self._renderer.set_width_height(
-                allocation.width * scale, allocation.height * scale)
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 

--- a/lib/matplotlib/backends/backend_gtk4cairo.py
+++ b/lib/matplotlib/backends/backend_gtk4cairo.py
@@ -27,8 +27,6 @@ class FigureCanvasGTK4Cairo(backend_gtk4.FigureCanvasGTK4,
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
                 allocation.width, allocation.height)
-            self._renderer.set_width_height(
-                allocation.width * scale, allocation.height * scale)
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 

--- a/lib/matplotlib/backends/backend_qtcairo.py
+++ b/lib/matplotlib/backends/backend_qtcairo.py
@@ -21,8 +21,7 @@ class FigureCanvasQTCairo(FigureCanvasQT, FigureCanvasCairo):
         height = int(self.device_pixel_ratio * self.height())
         if (width, height) != self._renderer.get_canvas_width_height():
             surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
-            self._renderer.set_ctx_from_surface(surface)
-            self._renderer.set_width_height(width, height)
+            self._renderer.set_context(cairo.Context(surface))
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
         buf = self._renderer.gc.ctx.get_target().get_data()

--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -12,8 +12,7 @@ class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
         width = int(self.figure.bbox.width)
         height = int(self.figure.bbox.height)
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
-        self._renderer.set_ctx_from_surface(surface)
-        self._renderer.set_width_height(width, height)
+        self._renderer.set_context(cairo.Context(surface))
         self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)
         buf = np.reshape(surface.get_data(), (height, width, 4))

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -24,8 +24,7 @@ class FigureCanvasWxCairo(_FigureCanvasWxBase, FigureCanvasCairo):
     def draw(self, drawDC=None):
         size = self.figure.bbox.size.astype(int)
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, *size)
-        self._renderer.set_ctx_from_surface(surface)
-        self._renderer.set_width_height(*size)
+        self._renderer.set_context(cairo.Context(surface))
         self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)
         self.bitmap = wxcairo.BitmapFromImageSurface(surface)


### PR DESCRIPTION
This avoids a redundant set_width_height on the caller side, and
prevents the width/height from getting out of sync from the actual
surface size.

Followup to #21981, which conveniently introduces a new API whose
semantics we can still modify :)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
