### PR TITLE
Added color keyword argument to math_to_image

### DIFF
--- a/doc/users/next_whats_new/color_support_for_math_to_image.rst
+++ b/doc/users/next_whats_new/color_support_for_math_to_image.rst
@@ -1,9 +1,9 @@
 ``math_to_image`` now has a *color* keyword argument
 --------------------------------------------------------
 
-To easily support external libraries that rely on the rendering of Matplotlib
-to generate figures, a *color* keyword argument was added to
-``math_to_image``.
+To easily support external libraries that rely on the MathText rendering of
+Matplotlib to generate equation images, a *color* keyword argument was added
+to`~matplotlib.mathtext.math_to_image`.
 
 .. code-block:: python
 

--- a/doc/users/next_whats_new/color_support_for_math_to_image.rst
+++ b/doc/users/next_whats_new/color_support_for_math_to_image.rst
@@ -3,7 +3,7 @@
 
 To easily support external libraries that rely on the MathText rendering of
 Matplotlib to generate equation images, a *color* keyword argument was added
-to`~matplotlib.mathtext.math_to_image`.
+to `~matplotlib.mathtext.math_to_image`.
 
 .. code-block:: python
 

--- a/doc/users/next_whats_new/color_support_for_math_to_image.rst
+++ b/doc/users/next_whats_new/color_support_for_math_to_image.rst
@@ -1,0 +1,11 @@
+``math_to_image`` now has a ``color`` keyword argument
+--------------------------------------------------------
+
+To easily support external libraries that rely on the rendering of Matplotlib
+to generate figures, a ``color`` keyword argument was added to
+``math_to_image``.
+
+.. code-block:: python
+
+    from matplotlib import mathtext
+    mathtext.math_to_image('$x**2$', 'filename.png', color='Maroon')

--- a/doc/users/next_whats_new/color_support_for_math_to_image.rst
+++ b/doc/users/next_whats_new/color_support_for_math_to_image.rst
@@ -1,11 +1,11 @@
-``math_to_image`` now has a ``color`` keyword argument
+``math_to_image`` now has a *color* keyword argument
 --------------------------------------------------------
 
 To easily support external libraries that rely on the rendering of Matplotlib
-to generate figures, a ``color`` keyword argument was added to
+to generate figures, a *color* keyword argument was added to
 ``math_to_image``.
 
 .. code-block:: python
 
     from matplotlib import mathtext
-    mathtext.math_to_image('$x**2$', 'filename.png', color='Maroon')
+    mathtext.math_to_image('$x^2$', 'filename.png', color='Maroon')

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -584,7 +584,7 @@ def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None,
         The output format, e.g., 'svg', 'pdf', 'ps' or 'png'.  If not set, the
         format is determined as for `.Figure.savefig`.
     color : str, optional
-        Foreground color, if not set the color is determined by rc params.
+        Foreground color, defaults to :rc:`text.color`.
     """
     from matplotlib import figure
 

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -563,7 +563,8 @@ class MathTextParser:
         return depth
 
 
-def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
+def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None,
+                  color=None):
     """
     Given a math expression, renders it in a closely-clipped bounding
     box to an image file.
@@ -582,6 +583,8 @@ def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
     format : str, optional
         The output format, e.g., 'svg', 'pdf', 'ps' or 'png'.  If not set, the
         format is determined as for `.Figure.savefig`.
+    color : str, optional
+        Foreground color, if not set the color is determined by rc params.
     """
     from matplotlib import figure
 
@@ -589,7 +592,7 @@ def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None):
     width, height, depth, _, _ = parser.parse(s, dpi=72, prop=prop)
 
     fig = figure.Figure(figsize=(width / 72.0, height / 72.0))
-    fig.text(0, depth/height, s, fontproperties=prop)
+    fig.text(0, depth/height, s, fontproperties=prop, color=color)
     fig.savefig(filename_or_obj, dpi=dpi, format=format)
 
     return depth

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -564,7 +564,7 @@ class MathTextParser:
 
 
 def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None,
-                  color=None):
+                  *, color=None):
     """
     Given a math expression, renders it in a closely-clipped bounding
     box to an image file.

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -373,6 +373,7 @@ def test_mathtext_fallback(fallback, fontlist):
 def test_math_to_image(tmpdir):
     mathtext.math_to_image('$x^2$', str(tmpdir.join('example.png')))
     mathtext.math_to_image('$x^2$', io.BytesIO())
+    mathtext.math_to_image('$x^2$', io.BytesIO(), color='Maroon')
 
 
 def test_mathtext_to_png(tmpdir):


### PR DESCRIPTION
## PR Summary

A `color` optional keyword argument was added to `math_to_image`. 

As `to_png` etc are deprecated and e.g. IPython relies on the Matplotlib rendering if no LaTeX compiler exists, it seems like a convenient feature to provide a `color` argument instead of modifying the rc parameters.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
