### PR TITLE
Use standard toolbar in wx.

### DIFF
--- a/doc/api/next_api_changes/behavior/22013-AL.rst
+++ b/doc/api/next_api_changes/behavior/22013-AL.rst
@@ -1,0 +1,5 @@
+``FigureFrameWx.sizer``
+~~~~~~~~~~~~~~~~~~~~~~~
+... has been removed.  The frame layout is no longer based on a sizer, as the
+canvas is now the sole child widget; the toolbar is now a regular toolbar
+added using ``SetToolBar``.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -898,37 +898,25 @@ class FigureFrameWx(wx.Frame):
                 "required after the deprecation period starting in Matplotlib "
                 "%(since)s elapses.")
             self.canvas = self.get_canvas(fig)
-        w, h = map(math.ceil, fig.bbox.size)
-        self.canvas.SetInitialSize(wx.Size(w, h))
-        self.canvas.SetFocus()
-        self.sizer = wx.BoxSizer(wx.VERTICAL)
-        self.sizer.Add(self.canvas, 1, wx.TOP | wx.LEFT | wx.EXPAND)
-        # By adding toolbar in sizer, we are able to put it at the bottom
-        # of the frame - so appearance is closer to GTK version
 
         self.figmgr = FigureManagerWx(self.canvas, num, self)
 
         self.toolbar = self._get_toolbar()
-
         if self.figmgr.toolmanager:
             backend_tools.add_tools_to_manager(self.figmgr.toolmanager)
             if self.toolbar:
                 backend_tools.add_tools_to_container(self.toolbar)
-
         if self.toolbar is not None:
-            self.toolbar.Realize()
-            # On Windows platform, default window size is incorrect, so set
-            # toolbar width to figure width.
-            tw, th = self.toolbar.GetSize()
-            fw, fh = self.canvas.GetSize()
-            # By adding toolbar in sizer, we are able to put it at the bottom
-            # of the frame - so appearance is closer to GTK version.
-            self.toolbar.SetSize(wx.Size(fw, th))
-            self.sizer.Add(self.toolbar, 0, wx.LEFT | wx.EXPAND)
-        self.SetSizer(self.sizer)
-        self.Fit()
+            self.SetToolBar(self.toolbar)
 
+        # On Windows, canvas sizing must occur after toolbar addition;
+        # otherwise the toolbar further resizes the canvas.
+        w, h = map(math.ceil, fig.bbox.size)
+        self.canvas.SetInitialSize(wx.Size(w, h))
         self.canvas.SetMinSize((2, 2))
+        self.canvas.SetFocus()
+
+        self.Fit()
 
         self.Bind(wx.EVT_CLOSE, self._on_close)
 
@@ -965,10 +953,6 @@ class FigureFrameWx(wx.Frame):
         Gcf.destroy(self.figmgr)
         # Carry on with close event propagation, frame & children destruction
         event.Skip()
-
-    def GetToolBar(self):
-        """Override wxFrame::GetToolBar as we don't have managed toolbar"""
-        return self.toolbar
 
     def Destroy(self, *args, **kwargs):
         try:
@@ -1049,9 +1033,9 @@ class FigureManagerWx(FigureManagerBase):
 
     def resize(self, width, height):
         # docstring inherited
-        self.canvas.SetInitialSize(
-            wx.Size(math.ceil(width), math.ceil(height)))
-        self.window.GetSizer().Fit(self.window)
+        # Directly using SetClientSize doesn't handle the toolbar on Windows.
+        self.window.SetSize(self.window.ClientToWindowSize(wx.Size(
+            math.ceil(width), math.ceil(height))))
 
 
 def _load_bitmap(filename):
@@ -1073,8 +1057,8 @@ def _set_frame_icon(frame):
 
 
 class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
-    def __init__(self, canvas, coordinates=True):
-        wx.ToolBar.__init__(self, canvas.GetParent(), -1)
+    def __init__(self, canvas, coordinates=True, *, style=wx.TB_BOTTOM):
+        wx.ToolBar.__init__(self, canvas.GetParent(), -1, style=style)
 
         if 'wxMac' in wx.PlatformInfo:
             self.SetToolBitmapSize((24, 24))
@@ -1202,7 +1186,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 # tools for matplotlib.backend_managers.ToolManager:
 
 class ToolbarWx(ToolContainerBase, wx.ToolBar):
-    def __init__(self, toolmanager, parent, style=wx.TB_HORIZONTAL):
+    def __init__(self, toolmanager, parent, style=wx.TB_BOTTOM):
         ToolContainerBase.__init__(self, toolmanager)
         wx.ToolBar.__init__(self, parent, -1, style=style)
         self._space = self.AddStretchableSpace()


### PR DESCRIPTION
The previous approach manually positioned the toolbar to have it at the
bottom of the window, but this can in fact be achieved just with
style=wx.TB_BOTTOM.

Removing manual sizing of the toolbar also fixes a bug previously
present on Windows, whereby a `set_size_inches` reducing the size of the
canvas would *not* reduce the window width, likely because it was forced
to its max value by the toolbar's explicit size.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
