### PR TITLE
Simplify wxframe deletion.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -937,23 +937,12 @@ class FigureFrameWx(wx.Frame):
         self.figmgr.frame = None
         # remove figure manager from Gcf.figs
         Gcf.destroy(self.figmgr)
+        try:  # See issue 2941338.
+            self.canvas.mpl_disconnect(self.canvas.toolbar._id_drag)
+        except AttributeError:  # If there's no toolbar.
+            pass
         # Carry on with close event propagation, frame & children destruction
         event.Skip()
-
-    def Destroy(self, *args, **kwargs):
-        try:
-            self.canvas.mpl_disconnect(self.canvas.manager.toolbar._id_drag)
-            # Rationale for line above: see issue 2941338.
-        except AttributeError:
-            pass  # classic toolbar lacks the attribute
-        # The "if self" check avoids a "wrapped C/C++ object has been deleted"
-        # RuntimeError at exit with e.g.
-        # MPLBACKEND=wxagg python -c 'from pylab import *; plot()'.
-        if self and not self.IsBeingDeleted():
-            super().Destroy(*args, **kwargs)
-            # toolbar.Destroy() should not be necessary if the close event is
-            # allowed to propagate.
-        return True
 
 
 class FigureManagerWx(FigureManagerBase):


### PR DESCRIPTION
Instead of reimplementing Destroy and fiddling around with supercalls
and IsBeingDeleted, move the toolbar disconnection to the _on_close
handler (which anyways already unregisters the figure from Gcf, so it's
definitely going to destroy the figure) and inherit Destroy from the
base class.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
