### PR TITLE
Add explanatory comments to "broken" horizontal bar plot example

### DIFF
--- a/examples/lines_bars_and_markers/broken_barh.py
+++ b/examples/lines_bars_and_markers/broken_barh.py
@@ -15,8 +15,8 @@ ax.broken_barh([(10, 50), (100, 20), (130, 10)], (20, 9),
 ax.set_ylim(5, 35)
 ax.set_xlim(0, 200)
 ax.set_xlabel('seconds since start')
-ax.set_yticks([15, 25], labels=['Bill', 'Jim']) # Modify y-axis tick labels
-ax.grid(True) # Make grid lines visible
+ax.set_yticks([15, 25], labels=['Bill', 'Jim'])     # Modify y-axis tick labels
+ax.grid(True)                                       # Make grid lines visible
 ax.annotate('race interrupted', (61, 25),
             xytext=(0.8, 0.9), textcoords='axes fraction',
             arrowprops=dict(facecolor='black', shrink=0.05),

--- a/examples/lines_bars_and_markers/broken_barh.py
+++ b/examples/lines_bars_and_markers/broken_barh.py
@@ -7,6 +7,7 @@ Make a "broken" horizontal bar plot, i.e., one with gaps
 """
 import matplotlib.pyplot as plt
 
+# Horizontal bar plot with gaps
 fig, ax = plt.subplots()
 ax.broken_barh([(110, 30), (150, 10)], (10, 9), facecolors='tab:blue')
 ax.broken_barh([(10, 50), (100, 20), (130, 10)], (20, 9),
@@ -14,8 +15,8 @@ ax.broken_barh([(10, 50), (100, 20), (130, 10)], (20, 9),
 ax.set_ylim(5, 35)
 ax.set_xlim(0, 200)
 ax.set_xlabel('seconds since start')
-ax.set_yticks([15, 25], labels=['Bill', 'Jim'])
-ax.grid(True)
+ax.set_yticks([15, 25], labels=['Bill', 'Jim']) # Modify y-axis tick labels
+ax.grid(True) # Make grid lines visible
 ax.annotate('race interrupted', (61, 25),
             xytext=(0.8, 0.9), textcoords='axes fraction',
             arrowprops=dict(facecolor='black', shrink=0.05),


### PR DESCRIPTION
## PR Summary

This pull request adds explanatory comments to the "broken" horizontal bar plot example. PR related to issue [#11654](https://github.com/matplotlib/matplotlib/issues/11654). 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
