### PR TITLE
DOC: Include alternatives to deprecations in the documentation

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -326,9 +326,7 @@ Introducing
    All these helpers take a first parameter *since*, which should be set to
    the next point release, e.g. "3.x".
 
-   You can use standard rst cross references in the alternative. The string
-   will be processed to remove back ticks and only include the link caption
-   in the runtime warning.
+   You can use standard rst cross references in *alternative*.
 
 Expiring
 ~~~~~~~~

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -326,6 +326,10 @@ Introducing
    All these helpers take a first parameter *since*, which should be set to
    the next point release, e.g. "3.x".
 
+   You can use standard rst cross references in the alternative. The string
+   will be processed to remove back ticks and only include the link caption
+   in the runtime warning.
+
 Expiring
 ~~~~~~~~
 

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -14,6 +14,7 @@ import contextlib
 import functools
 import inspect
 import math
+import re
 import warnings
 
 
@@ -47,6 +48,10 @@ def _generate_deprecation_warning(
             + (" %(addendum)s" if addendum else ""))
     warning_cls = (PendingDeprecationWarning if pending
                    else MatplotlibDeprecationWarning)
+    # remove backticks, optional leading dot and replace reference by caption
+    if alternative:
+        alternative = re.sub(r"`([^`]*?) *<.*?>`|`\.?(.+?)`", r"\1\2",
+                             alternative)
     return warning_cls(message % dict(
         func=name, name=name, obj_type=obj_type, since=since, removal=removal,
         alternative=alternative, addendum=addendum))
@@ -207,10 +212,13 @@ def deprecated(since, *, message='', name='', alternative='', pending=False,
         old_doc = inspect.cleandoc(old_doc or '').strip('\n')
 
         notes_header = '\nNotes\n-----'
+        second_arg = ' '.join([t.strip() for t in
+                               (message, f"Use {alternative} instead."
+                                if alternative else "", addendum) if t])
         new_doc = (f"[*Deprecated*] {old_doc}\n"
                    f"{notes_header if notes_header not in old_doc else ''}\n"
                    f".. deprecated:: {since}\n"
-                   f"   {message.strip()}")
+                   f"   {second_arg}")
 
         if not old_doc:
             # This is to prevent a spurious 'unexpected unindent' warning from

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -14,7 +14,6 @@ import contextlib
 import functools
 import inspect
 import math
-import re
 import warnings
 
 
@@ -48,10 +47,6 @@ def _generate_deprecation_warning(
             + (" %(addendum)s" if addendum else ""))
     warning_cls = (PendingDeprecationWarning if pending
                    else MatplotlibDeprecationWarning)
-    # remove backticks, optional leading dot and replace reference by caption
-    if alternative:
-        alternative = re.sub(r"`([^`]*?) *<.*?>`|`\.?(.+?)`", r"\1\2",
-                             alternative)
     return warning_cls(message % dict(
         func=name, name=name, obj_type=obj_type, since=since, removal=removal,
         alternative=alternative, addendum=addendum))

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -211,7 +211,7 @@ class Tick(martist.Artist):
         self._tickdir = tickdir
         self._pad = self._base_pad + self.get_tick_padding()
 
-    @_api.deprecated("3.5", alternative="axis.set_tick_params")
+    @_api.deprecated("3.5", alternative="`.Axis.set_tick_params`")
     def apply_tickdir(self, tickdir):
         self._apply_tickdir(tickdir)
         self.stale = True
@@ -822,7 +822,7 @@ class Axis(martist.Artist):
         self.set_units(None)
         self.stale = True
 
-    @_api.deprecated("3.4", alternative="Axis.clear()")
+    @_api.deprecated("3.4", alternative="`.Axis.clear`")
     def cla(self):
         """Clear this axis."""
         return self.clear()

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2285,8 +2285,8 @@ class FigureCanvasBase:
         """
         return rcParams['savefig.format']
 
-    @_api.deprecated(
-        "3.4", alternative="manager.get_window_title or GUI-specific methods")
+    @_api.deprecated("3.4", alternative="`.FigureManagerBase.get_window_title`"
+                     " or GUI-specific methods")
     def get_window_title(self):
         """
         Return the title text of the window containing the figure, or None
@@ -2295,8 +2295,8 @@ class FigureCanvasBase:
         if self.manager is not None:
             return self.manager.get_window_title()
 
-    @_api.deprecated(
-        "3.4", alternative="manager.set_window_title or GUI-specific methods")
+    @_api.deprecated("3.4", alternative="`.FigureManagerBase.set_window_title`"
+                     " or GUI-specific methods")
     def set_window_title(self, title):
         """
         Set the title text of the window containing the figure.  Note that
@@ -3228,7 +3228,7 @@ class NavigationToolbar2:
         """Save the current figure."""
         raise NotImplementedError
 
-    @_api.deprecated("3.5", alternative="canvas.set_cursor")
+    @_api.deprecated("3.5", alternative="`.FigureCanvasBase.set_cursor`")
     def set_cursor(self, cursor):
         """
         Set the current cursor to one of the :class:`Cursors` enums values.

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -309,7 +309,7 @@ class SetCursorBase(ToolBase):
             self.canvas.set_cursor(self._default_cursor)
             self._last_cursor = self._default_cursor
 
-    @_api.deprecated("3.5", alternative="figure.canvas.set_cursor")
+    @_api.deprecated("3.5", alternative="`.FigureCanvasBase.set_cursor`")
     def set_cursor(self, cursor):
         """
         Set the cursor.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2076,7 +2076,8 @@ class QuadMesh(Collection):
         return self._coordinates
 
     @staticmethod
-    @_api.deprecated("3.5", alternative="QuadMesh(coordinates).get_paths()")
+    @_api.deprecated("3.5", alternative="`QuadMesh(coordinates).get_paths()"
+                     "<.QuadMesh.get_paths>`")
     def convert_mesh_to_paths(meshWidth, meshHeight, coordinates):
         return QuadMesh._convert_mesh_to_paths(coordinates)
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1685,12 +1685,12 @@ class MicrosecondLocator(DateLocator):
         self._wrapped_locator.set_axis(axis)
         return super().set_axis(axis)
 
-    @_api.deprecated("3.5", alternative=".axis.set_view_interval")
+    @_api.deprecated("3.5", alternative="`.Axis.set_view_interval`")
     def set_view_interval(self, vmin, vmax):
         self._wrapped_locator.set_view_interval(vmin, vmax)
         return super().set_view_interval(vmin, vmax)
 
-    @_api.deprecated("3.5", alternative=".axis.set_data_interval")
+    @_api.deprecated("3.5", alternative="`.Axis.set_data_interval`")
     def set_data_interval(self, vmin, vmax):
         self._wrapped_locator.set_data_interval(vmin, vmax)
         return super().set_data_interval(vmin, vmax)
@@ -1726,8 +1726,9 @@ class MicrosecondLocator(DateLocator):
         return self._interval
 
 
-@_api.deprecated("3.5",
-                 alternative="mdates.date2num(datetime.utcfromtimestamp(e))")
+@_api.deprecated(
+    "3.5",
+    alternative="`date2num(datetime.utcfromtimestamp(e))<.date2num>`")
 def epoch2num(e):
     """
     Convert UNIX time to days since Matplotlib epoch.
@@ -1749,7 +1750,7 @@ def epoch2num(e):
     return (dt + np.asarray(e)) / SEC_PER_DAY
 
 
-@_api.deprecated("3.5", alternative="mdates.num2date(e).timestamp()")
+@_api.deprecated("3.5", alternative="`num2date(e).timestamp()<.num2date>`")
 def num2epoch(d):
     """
     Convert days since Matplotlib epoch to UNIX time.

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -179,7 +179,7 @@ class MathtextBackendAgg(MathtextBackend):
         return backend_agg.get_hinting_flag()
 
 
-@_api.deprecated("3.4", alternative="mathtext.math_to_image")
+@_api.deprecated("3.4", alternative="`.mathtext.math_to_image`")
 class MathtextBackendBitmap(MathtextBackendAgg):
     def get_results(self, box, used_characters):
         ox, oy, width, height, depth, image, characters = \
@@ -187,7 +187,7 @@ class MathtextBackendBitmap(MathtextBackendAgg):
         return image, depth
 
 
-@_api.deprecated("3.4", alternative="MathtextBackendPath")
+@_api.deprecated("3.4", alternative="`.MathtextBackendPath`")
 class MathtextBackendPs(MathtextBackend):
     """
     Store information to write a mathtext rendering to the PostScript backend.
@@ -231,7 +231,7 @@ class MathtextBackendPs(MathtextBackend):
                               used_characters)
 
 
-@_api.deprecated("3.4", alternative="MathtextBackendPath")
+@_api.deprecated("3.4", alternative="`.MathtextBackendPath`")
 class MathtextBackendPdf(MathtextBackend):
     """Store information to write a mathtext rendering to the PDF backend."""
 
@@ -263,7 +263,7 @@ class MathtextBackendPdf(MathtextBackend):
                                used_characters)
 
 
-@_api.deprecated("3.4", alternative="MathtextBackendPath")
+@_api.deprecated("3.4", alternative="`.MathtextBackendPath`")
 class MathtextBackendSvg(MathtextBackend):
     """
     Store information to write a mathtext rendering to the SVG
@@ -324,7 +324,7 @@ class MathtextBackendPath(MathtextBackend):
                             self.rects)
 
 
-@_api.deprecated("3.4", alternative="MathtextBackendPath")
+@_api.deprecated("3.4", alternative="`.MathtextBackendPath`")
 class MathtextBackendCairo(MathtextBackend):
     """
     Store information to write a mathtext rendering to the Cairo
@@ -457,7 +457,7 @@ class MathTextParser:
         font_output.set_canvas_size(box.width, box.height, box.depth)
         return font_output.get_results(box)
 
-    @_api.deprecated("3.4", alternative="mathtext.math_to_image")
+    @_api.deprecated("3.4", alternative="`.mathtext.math_to_image`")
     def to_mask(self, texstr, dpi=120, fontsize=14):
         r"""
         Convert a mathtext string to a grayscale array and depth.
@@ -483,7 +483,7 @@ class MathTextParser:
         ftimage, depth = self.parse(texstr, dpi=dpi, prop=prop)
         return np.asarray(ftimage), depth
 
-    @_api.deprecated("3.4", alternative="mathtext.math_to_image")
+    @_api.deprecated("3.4", alternative="`.mathtext.math_to_image`")
     def to_rgba(self, texstr, color='black', dpi=120, fontsize=14):
         r"""
         Convert a mathtext string to an RGBA array and depth.
@@ -512,7 +512,7 @@ class MathTextParser:
         rgba[:, :, 3] = alpha
         return rgba, depth
 
-    @_api.deprecated("3.4", alternative="mathtext.math_to_image")
+    @_api.deprecated("3.4", alternative="`.mathtext.math_to_image`")
     def to_png(self, filename, texstr, color='black', dpi=120, fontsize=14):
         r"""
         Render a tex expression to a PNG file.
@@ -540,7 +540,7 @@ class MathTextParser:
         Image.fromarray(rgba).save(filename, format="png")
         return depth
 
-    @_api.deprecated("3.4", alternative="mathtext.math_to_image")
+    @_api.deprecated("3.4", alternative="`.mathtext.math_to_image`")
     def get_depth(self, texstr, dpi=120, fontsize=14):
         r"""
         Get the depth of a mathtext string.

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -222,7 +222,7 @@ class Spine(mpatches.Patch):
         if self.axis is not None:
             self.axis.clear()
 
-    @_api.deprecated("3.4", alternative="Spine.clear()")
+    @_api.deprecated("3.4", alternative="`.Spine.clear`")
     def cla(self):
         self.clear()
 

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -85,3 +85,14 @@ def test_make_keyword_only():
         func(1, 2)
     with pytest.warns(_api.MatplotlibDeprecationWarning):
         func(1, 2, 3)
+
+
+def test_deprecation_alternative():
+    alternative = "`.f1`, `f2`, `f3(x) <.f3>` or `f4(x)<f4>`"
+    @_api.deprecated("1", alternative=alternative)
+    def f():
+        pass
+    assert alternative in f.__doc__
+    with pytest.warns(_api.MatplotlibDeprecationWarning,
+                      match=r".* f1, f2, f3\(x\) or f4\(x\)"):
+        f()

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -93,6 +93,3 @@ def test_deprecation_alternative():
     def f():
         pass
     assert alternative in f.__doc__
-    with pytest.warns(_api.MatplotlibDeprecationWarning,
-                      match=r".* f1, f2, f3\(x\) or f4\(x\)"):
-        f()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -187,17 +187,17 @@ class TickHelper:
         if self.axis is None:
             self.axis = _DummyAxis(**kwargs)
 
-    @_api.deprecated("3.5", alternative=".axis.set_view_interval")
+    @_api.deprecated("3.5", alternative="`.Axis.set_view_interval`")
     def set_view_interval(self, vmin, vmax):
         self.axis.set_view_interval(vmin, vmax)
 
-    @_api.deprecated("3.5", alternative=".axis.set_data_interval")
+    @_api.deprecated("3.5", alternative="`.Axis.set_data_interval`")
     def set_data_interval(self, vmin, vmax):
         self.axis.set_data_interval(vmin, vmax)
 
     @_api.deprecated(
         "3.5",
-        alternative=".axis.set_view_interval and .axis.set_data_interval")
+        alternative="`.Axis.set_view_interval` and `.Axis.set_data_interval`")
     def set_bounds(self, vmin, vmax):
         self.set_view_interval(vmin, vmax)
         self.set_data_interval(vmin, vmax)


### PR DESCRIPTION
## PR Summary

There are 90 deprecations currently, for 38 of which alternatives are given in the deprecation warning. These alternatives are not included, however, in the documentation.  
The first commit enables inclusion of alternatives along with links in the documentation and the second commit adds links to the documentation for the existing alternatives if they refer to another function or class.

### Current:
Documentation: ![grafik](https://user-images.githubusercontent.com/19879328/147122069-17decf72-a5d6-470f-a62c-a214f129d6ac.png)

### New: 
Documentation: ![grafik](https://user-images.githubusercontent.com/19879328/147122274-1321e178-6b03-41fd-b1a2-fed0b43bfeee.png)


    Include alternatives to deprecations in the documentation

    - add `alternative` and `addendum` to the documentation by including
      them in the second argument of the `.. deprecated::` directive
    - allow for backticks and optional reference to create links to the
      mentioned alternatives in the documentation
    - remove these additional links and backticks in the deprecation
      warning message that is emitted when using a deprecated item

    Example:
    @_api.deprecated("3.5", alternative="`num2date(e).timestamp() <.num2date>`"
    will create the directive

    .. deprecated:: 3.5
       Use `num2date(e).timestamp() <.num2date>` instead.

    which creates a link to matplotlib.dates.num2date with the caption
    num2date(e).timestamp(). The deprecation warning message will read
    "... Use num2date(e).timestamp() instead."

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
