### PR TITLE
DOC: Document default cap styles

### DIFF
--- a/lib/matplotlib/_enums.py
+++ b/lib/matplotlib/_enums.py
@@ -128,6 +128,9 @@ class CapStyle(str, _AutoStringNameEnum):
     For a visual impression of each *CapStyle*, `view these docs online
     <CapStyle>` or run `CapStyle.demo`.
 
+    By default, `~.backend_bases.GraphicsContextBase` draws a stroked line as
+    squared off at its endpoints.
+
     **Supported values:**
 
     .. rst-class:: value-list
@@ -168,7 +171,6 @@ class CapStyle(str, _AutoStringNameEnum):
             ax.plot(xx, yy, lw=12, color='tab:blue', solid_capstyle=style)
             ax.plot(xx, yy, lw=1, color='black')
             ax.plot(xx, yy, 'o', color='tab:red', markersize=3)
-        ax.text(2.25, 0.55, '(default)', ha='center')
 
         ax.set_ylim(-.5, 1.5)
         ax.set_axis_off()

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1336,6 +1336,8 @@ class Line2D(Artist):
         """
         How to draw the end caps if the line is `~Line2D.is_dashed`.
 
+        The default capstyle is :rc:`lines.dash_capstyle`.
+
         Parameters
         ----------
         s : `.CapStyle` or %(CapStyle)s
@@ -1349,6 +1351,8 @@ class Line2D(Artist):
     def set_solid_capstyle(self, s):
         """
         How to draw the end caps if the line is solid (not `~Line2D.is_dashed`)
+
+        The default capstyle is :rc:`lines.solid_capstyle`.
 
         Parameters
         ----------

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -474,6 +474,9 @@ class Patch(artist.Artist):
         """
         Set the `.CapStyle`.
 
+        The default capstyle is 'round' for `.FancyArrowPatch` and 'butt' for
+        all other patches.
+
         Parameters
         ----------
         s : `.CapStyle` or %(CapStyle)s


### PR DESCRIPTION
## PR Summary
- remove '(default)' from cap style demo as this is only true for Line2D
  and the default rcParameters
- document default cap styles for Line2D and Patch in their cap style
  setters
- document default cap style for GraphicsContextBase in the same way as
  it's already done for joinstyle

Closes #21979. If this goes in I can do the same for join styles, see #18597 (just documenting the current state).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
