### PR TITLE
FIX: Return value instead of enum in get_capstyle/_joinstyle

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -322,10 +322,10 @@ class MarkerStyle:
         self._recache()
 
     def get_joinstyle(self):
-        return self._joinstyle
+        return self._joinstyle.name
 
     def get_capstyle(self):
-        return self._capstyle
+        return self._capstyle.name
 
     def get_marker(self):
         return self._marker

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -484,7 +484,7 @@ class Patch(artist.Artist):
 
     def get_capstyle(self):
         """Return the capstyle."""
-        return self._capstyle
+        return self._capstyle.name
 
     @docstring.interpd
     def set_joinstyle(self, s):
@@ -501,7 +501,7 @@ class Patch(artist.Artist):
 
     def get_joinstyle(self):
         """Return the joinstyle."""
-        return self._joinstyle
+        return self._joinstyle.name
 
     def set_hatch(self, hatch):
         r"""


### PR DESCRIPTION
## PR Summary
There's an API inconsistency in the return values of  `get_capstyle` / `get_joinstyle`: For `Line2D`, `Collections` and `GraphicsContextBase` they return a string whereas for `MarkerStyle` and `Patch` they return an enum object, see also https://github.com/matplotlib/matplotlib/issues/21979#issuecomment-996235405.

[`_enums`](https://matplotlib.org/devdocs/api/_enums_api.html) was introduced in #18544 in mpl 3.4.0 without being mentioned in the [release notes](https://matplotlib.org/devdocs/api/prev_api_changes/api_changes_3.4.0.html). Its [documentation](https://matplotlib.org/devdocs/api/_enums_api.html) states:
> The classes in this module are used internally and serve to document these concepts formally.

From this I conclude that the enum should not leak out to the user, i.e. `get_capstyle` / `get_joinstyle` should return as string for `MarkerStyle` and `Patch` too. As the change from string to enum as not mentioned in the release note I guess changing it back is not an API change but a bug fix and it doesn't need not be documented (see Checklist below).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
