### PR TITLE
Add Inset Zoom Axes with Automatic Plotting of Parent Axes Artists.

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -194,6 +194,7 @@ Text and annotations
    Axes.table
    Axes.arrow
    Axes.inset_axes
+   Axes.inset_zoom_axes
    Axes.indicate_inset
    Axes.indicate_inset_zoom
    Axes.secondary_xaxis

--- a/doc/users/next_whats_new/autoplot_inset_axes.rst
+++ b/doc/users/next_whats_new/autoplot_inset_axes.rst
@@ -15,7 +15,7 @@ compatible with the `~matplotlib.axes.Axes.inset_axes` method.
     np.random.seed(1)
     fig = plt.figure()
     ax = fig.gca()
-    ax.plot([i for i in range(10)], "r")
+    ax.plot([i for i in range(10)], "r-o")
     ax.text(3, 2.5, "Hello World!", ha="center")
     ax.imshow(np.random.rand(30, 30), origin="lower", cmap="Blues", alpha=0.5)
     axins = ax.inset_zoom_axes([0.5, 0.5, 0.48, 0.48])

--- a/doc/users/next_whats_new/autoplot_inset_axes.rst
+++ b/doc/users/next_whats_new/autoplot_inset_axes.rst
@@ -1,0 +1,25 @@
+Addition of an inset Axes with automatic zoom plotting
+------------------------------------------------------
+
+It is now possible to create an inset axes that is a zoom-in on a region in
+the parent axes without needing to replot all items a second time, using the
+`~matplotlib.axes.Axes.inset_zoom_axes` method of the
+`~matplotlib.axes.Axes` class. Arguments for this method are backwards
+compatible with the `~matplotlib.axes.Axes.inset_axes` method.
+
+.. plot::
+    :include-source: true
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    np.random.seed(1)
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.plot([i for i in range(10)], "r")
+    ax.text(3, 2.5, "Hello World!", ha="center")
+    ax.imshow(np.random.rand(30, 30), origin="lower", cmap="Blues", alpha=0.5)
+    axins = ax.inset_zoom_axes([0.5, 0.5, 0.48, 0.48])
+    axins.set_xlim(1, 5)
+    axins.set_ylim(1, 5)
+    ax.indicate_inset_zoom(axins, edgecolor="black")
+    plt.show()

--- a/examples/subplots_axes_and_figures/zoom_inset_axes.py
+++ b/examples/subplots_axes_and_figures/zoom_inset_axes.py
@@ -24,7 +24,7 @@ Z2 = np.zeros((150, 150))
 ny, nx = Z.shape
 Z2[30:30+ny, 30:30+nx] = Z
 
-ax.imshow(Z2, extent=extent, origin="lower")
+ax.imshow(Z2, extent=extent, interpolation='nearest', origin="lower")
 
 # inset axes....
 axins = ax.inset_zoom_axes([0.5, 0.5, 0.47, 0.47])

--- a/examples/subplots_axes_and_figures/zoom_inset_axes.py
+++ b/examples/subplots_axes_and_figures/zoom_inset_axes.py
@@ -27,8 +27,7 @@ Z2[30:30+ny, 30:30+nx] = Z
 ax.imshow(Z2, extent=extent, origin="lower")
 
 # inset axes....
-axins = ax.inset_axes([0.5, 0.5, 0.47, 0.47])
-axins.imshow(Z2, extent=extent, origin="lower")
+axins = ax.inset_zoom_axes([0.5, 0.5, 0.47, 0.47])
 # sub region of the original image
 x1, x2, y1, y2 = -1.5, -0.9, -2.5, -1.9
 axins.set_xlim(x1, x2)
@@ -47,6 +46,6 @@ plt.show()
 #    The use of the following functions, methods, classes and modules is shown
 #    in this example:
 #
-#    - `matplotlib.axes.Axes.inset_axes`
+#    - `matplotlib.axes.Axes.inset_zoom_axes`
 #    - `matplotlib.axes.Axes.indicate_inset_zoom`
 #    - `matplotlib.axes.Axes.imshow`

--- a/lib/matplotlib/axes/__init__.py
+++ b/lib/matplotlib/axes/__init__.py
@@ -1,2 +1,4 @@
 from ._subplots import *
 from ._axes import *
+from ._zoom_axes import *
+

--- a/lib/matplotlib/axes/__init__.py
+++ b/lib/matplotlib/axes/__init__.py
@@ -1,4 +1,2 @@
 from ._subplots import *
 from ._axes import *
-from ._zoom_axes import *
-

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -30,7 +30,6 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
 import matplotlib.units as munits
-import matplotlib.image as mimage
 from matplotlib import _api, _preprocess_data, rcParams
 from matplotlib.axes._base import (
     _AxesBase, _TransformedBoundsLocator, _process_plot_format)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -406,7 +406,7 @@ class Axes(_AxesBase):
 
         Examples
         --------
-        See `~.axes.Axes.inset_zoom` method for examples.
+        See `Axes.inset_axes` method for examples.
         """
         from ._zoom_axes import ZoomViewAxes
         return ZoomViewAxes(self, mtransforms.Bbox.from_bounds(*bounds),

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -30,6 +30,7 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 import matplotlib.tri as mtri
 import matplotlib.units as munits
+import matplotlib.image as mimage
 from matplotlib import _api, _preprocess_data, rcParams
 from matplotlib.axes._base import (
     _AxesBase, _TransformedBoundsLocator, _process_plot_format)
@@ -367,8 +368,9 @@ class Axes(_AxesBase):
 
         return inset_ax
 
-    def inset_zoom_axes(self, bounds, *, transform=None, zorder=5, **kwargs):
-        """
+    def inset_zoom_axes(self, bounds, *, transform=None, zorder=5,
+                        image_interpolation="nearest", **kwargs):
+        f"""
         Add a child inset Axes to this existing Axes, which automatically plots
         artists contained within the parent Axes.
 
@@ -386,6 +388,11 @@ class Axes(_AxesBase):
             to change whether it is above or below data plotted on the
             parent Axes.
 
+        image_interpolation: string
+            Supported options are: {set(mimage._interpd_)}
+            The default value is 'nearest'. This determines the interpolation
+            used when attempting to render a zoomed version of an image.
+
         **kwargs
             Other keyword arguments are passed on to the child `.Axes`.
 
@@ -400,7 +407,7 @@ class Axes(_AxesBase):
         """
         from ._zoom_axes import ZoomViewAxes
         return ZoomViewAxes(self, mtransforms.Bbox.from_bounds(*bounds),
-                            transform, zorder, **kwargs)
+                            transform, zorder, image_interpolation, **kwargs)
 
     @docstring.dedent_interpd
     def indicate_inset(self, bounds, inset_ax=None, *, transform=None,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -367,6 +367,40 @@ class Axes(_AxesBase):
 
         return inset_ax
 
+    def inset_zoom_axes(self, bounds, *, transform=None, zorder=5, **kwargs):
+        """
+        Add a child inset Axes to this existing Axes, which automatically plots artists contained within the parent
+        Axes.
+
+        Parameters
+        ----------
+        bounds : [x0, y0, width, height]
+            Lower-left corner of inset Axes, and its width and height.
+
+        transform : `.Transform`
+            Defaults to `ax.transAxes`, i.e. the units of *rect* are in
+            Axes-relative coordinates.
+
+        zorder : number
+            Defaults to 5 (same as `.Axes.legend`).  Adjust higher or lower
+            to change whether it is above or below data plotted on the
+            parent Axes.
+
+        **kwargs
+            Other keyword arguments are passed on to the child `.Axes`.
+
+        Returns
+        -------
+        ax
+            The created `~.axes.Axes` instance.
+
+        Examples
+        --------
+        See `~.axes.Axes.inset_zoom` method for examples.
+        """
+        from ._zoom_axes import ZoomViewAxes
+        return ZoomViewAxes(self, mtransforms.Bbox.from_bounds(*bounds), transform, zorder, **kwargs)
+
     @docstring.dedent_interpd
     def indicate_inset(self, bounds, inset_ax=None, *, transform=None,
                        facecolor='none', edgecolor='0.5', alpha=0.5,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -370,7 +370,7 @@ class Axes(_AxesBase):
 
     def inset_zoom_axes(self, bounds, *, transform=None, zorder=5,
                         image_interpolation="nearest", **kwargs):
-        f"""
+        """
         Add a child inset Axes to this existing Axes, which automatically plots
         artists contained within the parent Axes.
 
@@ -389,9 +389,12 @@ class Axes(_AxesBase):
             parent Axes.
 
         image_interpolation: string
-            Supported options are: {set(mimage._interpd_)}
-            The default value is 'nearest'. This determines the interpolation
-            used when attempting to render a zoomed version of an image.
+            Supported options are 'antialiased', 'nearest', 'bilinear',
+            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
+            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell',
+            'sinc', 'lanczos', or 'none'. The default value is 'nearest'. This
+            determines the interpolation used when attempting to render a
+            zoomed version of an image.
 
         **kwargs
             Other keyword arguments are passed on to the child `.Axes`.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -369,8 +369,8 @@ class Axes(_AxesBase):
 
     def inset_zoom_axes(self, bounds, *, transform=None, zorder=5, **kwargs):
         """
-        Add a child inset Axes to this existing Axes, which automatically plots artists contained within the parent
-        Axes.
+        Add a child inset Axes to this existing Axes, which automatically plots
+        artists contained within the parent Axes.
 
         Parameters
         ----------
@@ -399,7 +399,8 @@ class Axes(_AxesBase):
         See `~.axes.Axes.inset_zoom` method for examples.
         """
         from ._zoom_axes import ZoomViewAxes
-        return ZoomViewAxes(self, mtransforms.Bbox.from_bounds(*bounds), transform, zorder, **kwargs)
+        return ZoomViewAxes(self, mtransforms.Bbox.from_bounds(*bounds),
+                            transform, zorder, **kwargs)
 
     @docstring.dedent_interpd
     def indicate_inset(self, bounds, inset_ax=None, *, transform=None,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -407,9 +407,18 @@ class Axes(_AxesBase):
         --------
         See `Axes.inset_axes` method for examples.
         """
-        from ._zoom_axes import ZoomViewAxes
-        return ZoomViewAxes(self, mtransforms.Bbox.from_bounds(*bounds),
-                            transform, zorder, image_interpolation, **kwargs)
+        if(transform is None):
+            transform = self.transAxes
+
+        inset_loc = _TransformedBoundsLocator(bounds, transform)
+        bb = inset_loc(self, None)
+
+        from ._zoom_axes import ViewAxes
+        axin = ViewAxes(self, bb.bounds, zorder, image_interpolation, **kwargs)
+        axin.set_axes_locator(inset_loc)
+        self.add_child_axes(axin)
+
+        return axin
 
     @docstring.dedent_interpd
     def indicate_inset(self, bounds, inset_ax=None, *, transform=None,

--- a/lib/matplotlib/axes/_zoom_axes.py
+++ b/lib/matplotlib/axes/_zoom_axes.py
@@ -10,6 +10,7 @@ import matplotlib.docstring as docstring
 import numpy as np
 from matplotlib.image import _interpd_
 
+
 class _TransformRenderer(RendererBase):
     """
     A matplotlib renderer which performs transforms to change the final
@@ -49,7 +50,7 @@ class _TransformRenderer(RendererBase):
         bounding_axes: `~matplotlib.axes.Axes`
             The axes to plot everything within. Everything outside of this
             axes will be clipped.
-            
+
         image_interpolation: string
             Supported options are 'antialiased', 'nearest', 'bilinear',
             'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
@@ -283,11 +284,11 @@ class ZoomViewAxes(Axes):
             An integer, the z-order of the axes. Defaults to 5.
 
         image_interpolation: string
-            Supported options are 'antialiased', 'nearest', 'bilinear', 
-            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite', 
-            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell', 
-            'sinc', 'lanczos', or 'none'. The default value is 'nearest'. This 
-            determines the interpolation used when attempting to render a 
+            Supported options are 'antialiased', 'nearest', 'bilinear',
+            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
+            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell',
+            'sinc', 'lanczos', or 'none'. The default value is 'nearest'. This
+            determines the interpolation used when attempting to render a
             zoomed version of an image.
 
         **kwargs

--- a/lib/matplotlib/axes/_zoom_axes.py
+++ b/lib/matplotlib/axes/_zoom_axes.py
@@ -25,7 +25,7 @@ class _TransformRenderer(RendererBase):
         bounding_axes: Axes,
         image_interpolation: str = "nearest"
     ):
-        f"""
+        """
         Constructs a new TransformRender.
 
         Parameters
@@ -51,9 +51,12 @@ class _TransformRenderer(RendererBase):
             axes will be clipped.
             
         image_interpolation: string
-            Supported options are: {set(_interpd_)}
-            The default value is 'nearest'. This determines the interpolation
-            used when attempting to render a zoomed version of an image.
+            Supported options are 'antialiased', 'nearest', 'bilinear',
+            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
+            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell',
+            'sinc', 'lanczos', or 'none'. The default value is 'nearest'. This
+            determines the interpolation used when attempting to render a
+            zoomed version of an image.
 
         Returns
         -------
@@ -261,7 +264,7 @@ class ZoomViewAxes(Axes):
         image_interpolation: str = "nearest",
         **kwargs
     ):
-        f"""
+        """
         Construct a new zoomed inset axes.
 
         Parameters
@@ -280,9 +283,12 @@ class ZoomViewAxes(Axes):
             An integer, the z-order of the axes. Defaults to 5.
 
         image_interpolation: string
-            Supported options are: {set(_interpd_)}
-            The default value is 'nearest'. This determines the interpolation
-            used when attempting to render a zoomed version of an image.
+            Supported options are 'antialiased', 'nearest', 'bilinear', 
+            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite', 
+            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell', 
+            'sinc', 'lanczos', or 'none'. The default value is 'nearest'. This 
+            determines the interpolation used when attempting to render a 
+            zoomed version of an image.
 
         **kwargs
             Other optional keyword arguments:

--- a/lib/matplotlib/axes/_zoom_axes.py
+++ b/lib/matplotlib/axes/_zoom_axes.py
@@ -354,7 +354,7 @@ class ViewAxes(Axes):
             *self.__view_axes.child_axes
         ]
 
-        # Sort all rendered item by their z-order so the render in layers
+        # Sort all rendered items by their z-order so they render in layers
         # correctly...
         axes_children.sort(key=lambda obj: obj.get_zorder())
 
@@ -394,7 +394,7 @@ class ViewAxes(Axes):
             a.set_clip_box(box)
 
         # We need to redraw the splines if enabled, as we have finally drawn
-        # everything... This avoids other objects being drawn over the splines
+        # everything... This avoids other objects being drawn over the splines.
         if(self.axison and self._frameon):
             for spine in self.spines.values():
                 spine.draw(renderer)

--- a/lib/matplotlib/axes/_zoom_axes.py
+++ b/lib/matplotlib/axes/_zoom_axes.py
@@ -1,0 +1,261 @@
+from matplotlib.path import Path
+from matplotlib.axes import Axes
+from matplotlib.axes._axes import _TransformedBoundsLocator
+from matplotlib.transforms import Bbox, Transform, IdentityTransform, Affine2D
+from matplotlib.backend_bases import RendererBase
+import matplotlib._image as _image
+import numpy as np
+
+
+class _TransformRenderer(RendererBase):
+    """
+    A matplotlib renderer which performs transforms to change the final location of plotted
+    elements, and then defers drawing work to the original renderer. Used to produce zooming effects...
+    """
+    def __init__(self, base_renderer: RendererBase, mock_transform: Transform, transform: Transform,
+                 bounding_axes: Axes):
+        """
+        Constructs a new TransformRender.
+
+        :param base_renderer: The renderer to use for finally drawing objects.
+        :param mock_transform: The transform or coordinate space which all passed paths/triangles/images will be
+                               converted to before being placed back into display coordinates by the main transform.
+                               For example if the parent axes transData is passed, all objects will be converted to
+                               the parent axes data coordinate space before being transformed via the main transform
+                               back into coordinate space.
+        :param transform: The main transform to be used for plotting all objects once converted into the mock_transform
+                          coordinate space. Typically this is the child axes data coordinate space (transData).
+        :param bounding_axes: The axes to plot everything within. Everything outside of this axes will be clipped.
+        """
+        super().__init__()
+        self.__renderer = base_renderer
+        self.__mock_trans = mock_transform
+        self.__core_trans = transform
+        self.__bounding_axes = bounding_axes
+
+    def _get_axes_display_box(self) -> Bbox:
+        """
+        Private method, get the bounding box of the child axes in display coordinates.
+        """
+        return self.__bounding_axes.patch.get_bbox().transformed(self.__bounding_axes.transAxes)
+
+    def _get_transfer_transform(self, orig_transform):
+        """
+        Private method, returns the transform which translates and scales coordinates as if they were originally
+        plotted on the child axes instead of the parent axes.
+
+        :param orig_transform: The transform that was going to be originally used by the object/path/text/image.
+
+        :return: A matplotlib transform which goes from original point data -> display coordinates if the data was
+                 originally plotted on the child axes instead of the parent axes.
+        """
+        # We apply the original transform to go to display coordinates, then apply the parent data transform inverted
+        # to go to the parent axes coordinate space (data space), then apply the child axes data transform to
+        # go back into display space, but as if we originally plotted the artist on the child axes....
+        return orig_transform + self.__mock_trans.inverted() + self.__core_trans
+
+    # We copy all of the properties of the renderer we are mocking, so that artists plot themselves as if they were
+    # placed on the original renderer.
+    @property
+    def height(self):
+        return self.__renderer.get_canvas_width_height()[1]
+
+    @property
+    def width(self):
+        return self.__renderer.get_canvas_width_height()[0]
+
+    def get_text_width_height_descent(self, s, prop, ismath):
+        return self.__renderer.get_text_width_height_descent(s, prop, ismath)
+
+    def get_canvas_width_height(self):
+        return self.__renderer.get_canvas_width_height()
+
+    def get_texmanager(self):
+        return self.__renderer.get_texmanager()
+
+    def get_image_magnification(self):
+        return self.__renderer.get_image_magnification()
+
+    def _get_text_path_transform(self, x, y, s, prop, angle, ismath):
+        return self.__renderer._get_text_path_transform(x, y, s, prop, angle, ismath)
+
+    def option_scale_image(self):
+        return False
+
+    def points_to_pixels(self, points):
+        return self.__renderer.points_to_pixels(points)
+
+    def flipy(self):
+        return self.__renderer.flipy()
+
+    # Actual drawing methods below:
+
+    def draw_path(self, gc, path: Path, transform: Transform, rgbFace=None):
+        # Convert the path to display coordinates, but if it was originally drawn on the child axes.
+        path = path.deepcopy()
+        path.vertices = self._get_transfer_transform(transform).transform(path.vertices)
+        bbox = self._get_axes_display_box()
+
+        # We check if the path intersects the axes box at all, if not don't waste time drawing it.
+        if(not path.intersects_bbox(bbox, True)):
+            return
+
+        # Change the clip to the sub-axes box
+        gc.set_clip_rectangle(bbox)
+
+        self.__renderer.draw_path(gc, path, IdentityTransform(), rgbFace)
+
+    def _draw_text_as_path(self, gc, x, y, s: str, prop, angle, ismath):
+        # If the text field is empty, don't even try rendering it...
+        if((s is None) or (s.strip() == "")):
+            return
+        # Call the super class instance, which works for all cases except one checked above... (Above case causes error)
+        super()._draw_text_as_path(gc, x, y, s, prop, angle, ismath)
+
+    def draw_gouraud_triangle(self, gc, points, colors, transform):
+        # Pretty much identical to draw_path, transform the points and adjust clip to the child axes bounding box.
+        points = self._get_transfer_transform(transform).transform(points)
+        path = Path(points, closed=True)
+        bbox = self._get_axes_display_box()
+
+        if(not path.intersects_bbox(bbox, True)):
+            return
+
+        gc.set_clip_rectangle(bbox)
+
+        self.__renderer.draw_gouraud_triangle(gc, path.vertices, colors, IdentityTransform())
+
+    # Images prove to be especially messy to deal with...
+    def draw_image(self, gc, x, y, im, transform=None):
+        mag = self.get_image_magnification()
+        shift_data_transform = self._get_transfer_transform(IdentityTransform())
+        axes_bbox = self._get_axes_display_box()
+        # Compute the image bounding box in display coordinates.... Image arrives pre-magnified.
+        img_bbox_disp = Bbox.from_bounds(x, y, im.shape[1], im.shape[0])
+        # Now compute the output location, clipping it with the final axes patch.
+        out_box = img_bbox_disp.transformed(shift_data_transform)
+        clipped_out_box = Bbox.intersection(out_box, axes_bbox)
+
+        if(clipped_out_box is None):
+            return
+
+        # We compute what the dimensions of the final output image within the sub-axes are going to be.
+        x, y, out_w, out_h = clipped_out_box.bounds
+        out_w, out_h = int(np.ceil(out_w * mag)), int(np.ceil(out_h * mag))
+
+        if((out_w <= 0) or (out_h <= 0)):
+            return
+
+        # We can now construct the transform which converts between the original image (a 2D numpy array which starts
+        # at the origin) to the final zoomed image (also a 2D numpy array which starts at the origin).
+        img_trans = (
+            Affine2D().scale(1/mag, 1/mag).translate(img_bbox_disp.x0, img_bbox_disp.y0)
+            + shift_data_transform
+            + Affine2D().translate(-clipped_out_box.x0, -clipped_out_box.y0).scale(mag, mag)
+        )
+
+        # We resize and zoom the original image onto the out_arr.
+        out_arr = np.zeros((out_h, out_w, im.shape[2]), dtype=im.dtype)
+        trans_msk = np.zeros((out_h, out_w), dtype=im.dtype)
+
+        _image.resample(im, out_arr, img_trans, _image.NEAREST, alpha=1)
+        _image.resample(im[:, :, 3], trans_msk, img_trans, _image.NEAREST, alpha=1)
+        out_arr[:, :, 3] = trans_msk
+
+        gc.set_clip_rectangle(clipped_out_box)
+
+        x, y = clipped_out_box.x0, clipped_out_box.y0
+
+        if(self.option_scale_image()):
+            self.__renderer.draw_image(gc, x, y, out_arr, None)
+        else:
+            self.__renderer.draw_image(gc, x, y, out_arr)
+
+
+class ZoomViewAxes(Axes):
+    """
+    A zoom axes which automatically displays all of the elements it is currently zoomed in on. Does not require
+    Artists to be plotted twice.
+    """
+    MAX_RENDER_DEPTH = 1  # The number of allowed recursions in the draw method.
+    # Allows for zoom axes to zoom in on zoom axes
+
+    def __init__(self, axes_of_zoom: Axes, rect: Bbox, transform = None, zorder = 5, **kwargs):
+        """
+        Construct a new zoom axes.
+
+        :param axes_of_zoom: The axes to zoom in on, which this axes will be nested inside.
+        :param rect: The bounding box to place this axes in, within the parent axes.
+        :param transform: The transform to use when placing this axes in the parent axes. Defaults to
+                          'axes_of_zoom.transData'.
+        :param zorder: An integer, the z-order of the axes. Defaults to 5.
+        :param kwargs: Any other keyword arguments which the Axes class accepts.
+        """
+        if(transform is None):
+            transform = axes_of_zoom.transData
+
+        inset_loc = _TransformedBoundsLocator(rect.bounds, transform)
+        bb = inset_loc(axes_of_zoom, None)
+
+        super().__init__(axes_of_zoom.figure, bb.bounds, zorder=zorder, **kwargs)
+
+        self.__zoom_axes = axes_of_zoom
+        self.set_axes_locator(inset_loc)
+
+        self._render_depth = 0
+
+        axes_of_zoom.add_child_axes(self)
+
+    def draw(self, renderer=None):
+        if(self._render_depth >= self.MAX_RENDER_DEPTH):
+            return
+        self._render_depth += 1
+
+        super().draw(renderer)
+
+        if(not self.get_visible()):
+            return
+
+        axes_children = [
+            *self.__zoom_axes.collections,
+            *self.__zoom_axes.patches,
+            *self.__zoom_axes.lines,
+            *self.__zoom_axes.texts,
+            *self.__zoom_axes.artists,
+            *self.__zoom_axes.images,
+            *self.__zoom_axes.child_axes
+        ]
+
+        img_boxes = []
+        # We need to temporarily disable the clip boxes of all of the images, in order to allow us to continue
+        # rendering them it even if it is outside of the parent axes (they might still be visible in this zoom axes).
+        for img in self.__zoom_axes.images:
+            img_boxes.append(img.get_clip_box())
+            img.set_clip_box(img.get_window_extent(renderer))
+
+        # Sort all rendered item by their z-order so the render in layers correctly...
+        axes_children.sort(key=lambda obj: obj.get_zorder())
+
+        # Construct mock renderer and draw all artists to it.
+        mock_renderer = _TransformRenderer(renderer, self.__zoom_axes.transData, self.transData, self)
+        x1, x2 = self.get_xlim()
+        y1, y2 = self.get_ylim()
+        axes_box = Bbox.from_extents(x1, y1, x2, y2).transformed(self.__zoom_axes.transData)
+
+        for artist in axes_children:
+            # If the artist is this or it does not land in the area we are drawing artists from, do not draw it,
+            # otherwise go ahead.
+            if((artist is not self) and (Bbox.intersection(artist.get_window_extent(renderer), axes_box) is not None)):
+                artist.draw(mock_renderer)
+
+        # Reset all of the image clip boxes...
+        for img, box in zip(self.__zoom_axes.images, img_boxes):
+            img.set_clip_box(box)
+
+        # We need to redraw the splines if enabled, as we have finally drawn everything... This avoids other objects
+        # being drawn over the splines
+        if(self.axison and self._frameon):
+            for spine in self.spines.values():
+                spine.draw(renderer)
+
+        self._render_depth -= 1

--- a/lib/matplotlib/axes/_zoom_axes.py
+++ b/lib/matplotlib/axes/_zoom_axes.py
@@ -1,7 +1,7 @@
 from matplotlib.path import Path
 from matplotlib.axes import Axes
-from matplotlib.transforms import Bbox, Transform, IdentityTransform, Affine2D
-from matplotlib.backend_bases import RendererBase, GraphicsContextBase
+from matplotlib.transforms import Bbox, IdentityTransform, Affine2D
+from matplotlib.backend_bases import RendererBase
 import matplotlib._image as _image
 import matplotlib.docstring as docstring
 import numpy as np
@@ -17,12 +17,12 @@ class _TransformRenderer(RendererBase):
 
     def __init__(
         self,
-        base_renderer: RendererBase,
-        mock_transform: Transform,
-        transform: Transform,
-        bounding_axes: Axes,
-        image_interpolation: str = "nearest",
-        scale_linewidths: bool = True
+        base_renderer,
+        mock_transform,
+        transform,
+        bounding_axes,
+        image_interpolation="nearest",
+        scale_linewidths=True
     ):
         """
         Constructs a new TransformRender.
@@ -80,10 +80,7 @@ class _TransformRenderer(RendererBase):
                 f"Invalid Interpolation Mode: {image_interpolation}"
             )
 
-    def _scale_gc(
-        self,
-        gc: GraphicsContextBase
-    ) -> GraphicsContextBase:
+    def _scale_gc(self, gc):
         transfer_transform = self._get_transfer_transform(IdentityTransform())
         new_gc = self.__renderer.new_gc()
         new_gc.copy_properties(gc)
@@ -97,7 +94,7 @@ class _TransformRenderer(RendererBase):
 
         return new_gc
 
-    def _get_axes_display_box(self) -> Bbox:
+    def _get_axes_display_box(self):
         """
         Private method, get the bounding box of the child axes in display
         coordinates.
@@ -106,7 +103,7 @@ class _TransformRenderer(RendererBase):
             self.__bounding_axes.transAxes
         )
 
-    def _get_transfer_transform(self, orig_transform: Transform) -> Transform:
+    def _get_transfer_transform(self, orig_transform):
         """
         Private method, returns the transform which translates and scales
         coordinates as if they were originally plotted on the child axes
@@ -173,7 +170,7 @@ class _TransformRenderer(RendererBase):
         return self.__renderer.new_gc()
 
     # Actual drawing methods below:
-    def draw_path(self, gc, path: Path, transform: Transform, rgbFace=None):
+    def draw_path(self, gc, path, transform, rgbFace=None):
         # Convert the path to display coordinates, but if it was originally
         # drawn on the child axes.
         path = path.deepcopy()
@@ -195,7 +192,7 @@ class _TransformRenderer(RendererBase):
 
         self.__renderer.draw_path(gc, path, IdentityTransform(), rgbFace)
 
-    def _draw_text_as_path(self, gc, x, y, s: str, prop, angle, ismath):
+    def _draw_text_as_path(self, gc, x, y, s, prop, angle, ismath):
         # If the text field is empty, don't even try rendering it...
         if((s is None) or (s.strip() == "")):
             return
@@ -404,7 +401,7 @@ class ViewAxes(Axes):
 
         self._render_depth -= 1
 
-    def get_linescaling(self) -> bool:
+    def get_linescaling(self):
         """
         Get if line width scaling is enabled.
 
@@ -415,7 +412,7 @@ class ViewAxes(Axes):
         """
         return self.__scale_lines
 
-    def set_linescaling(self, value: bool):
+    def set_linescaling(self, value):
         """
         Set whether line widths should be scaled when rendering a view of an
         axes.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6429,6 +6429,7 @@ def test_auto_zoom_inset(fig_test, fig_ref):
     ax_test.imshow(im_data, origin="lower", cmap="Blues", alpha=0.5,
                    interpolation="nearest")
     axins_test = ax_test.inset_zoom_axes([0.5, 0.5, 0.48, 0.48])
+    axins_test.set_linescaling(False)
     axins_test.set_xlim(1, 5)
     axins_test.set_ylim(1, 5)
     ax_test.indicate_inset_zoom(axins_test, edgecolor="black")

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6415,6 +6415,40 @@ def test_zoom_inset():
         axin1.get_position().get_points(), xx, rtol=1e-4)
 
 
+# Tolerance needed because the way the auto-zoom axes handles images is
+# entirely different, leading to a slightly different result.
+@check_figures_equal(tol=3)
+def test_auto_zoom_inset(fig_test, fig_ref):
+    np.random.seed(1)
+    im_data = np.random.rand(30, 30)
+
+    # Test Case...
+    ax_test = fig_test.gca()
+    ax_test.plot([i for i in range(10)], "r")
+    ax_test.add_patch(plt.Circle((3, 3), 1, ec="black", fc="blue"))
+    ax_test.imshow(im_data, origin="lower", cmap="Blues", alpha=0.5,
+                   interpolation="nearest")
+    axins_test = ax_test.inset_zoom_axes([0.5, 0.5, 0.48, 0.48])
+    axins_test.set_xlim(1, 5)
+    axins_test.set_ylim(1, 5)
+    ax_test.indicate_inset_zoom(axins_test, edgecolor="black")
+
+    # Reference
+    ax_ref = fig_ref.gca()
+    ax_ref.plot([i for i in range(10)], "r")
+    ax_ref.add_patch(plt.Circle((3, 3), 1, ec="black", fc="blue"))
+    ax_ref.imshow(im_data, origin="lower", cmap="Blues", alpha=0.5,
+                  interpolation="nearest")
+    axins_ref = ax_ref.inset_axes([0.5, 0.5, 0.48, 0.48])
+    axins_ref.set_xlim(1, 5)
+    axins_ref.set_ylim(1, 5)
+    axins_ref.plot([i for i in range(10)], "r")
+    axins_ref.add_patch(plt.Circle((3, 3), 1, ec="black", fc="blue"))
+    axins_ref.imshow(im_data, origin="lower", cmap="Blues", alpha=0.5,
+                     interpolation="nearest")
+    ax_ref.indicate_inset_zoom(axins_ref, edgecolor="black")
+
+
 @pytest.mark.parametrize('x_inverted', [False, True])
 @pytest.mark.parametrize('y_inverted', [False, True])
 def test_indicate_inset_inverted(x_inverted, y_inverted):


### PR DESCRIPTION
## PR Summary

Extends the inset axes API adding a new method `Axes.inset_zoom_axes`. Has the same signature and behavior as `inset_axes`, except it returns a subclass of `Axes` capable of automatically rendering the contents of the parent axes. This means plot elements don't need to be plotted again on the inset axes to be visible.
```python
import matplotlib.pyplot as plt
import numpy as np
np.random.seed(1)
fig = plt.figure()
ax = fig.gca()

# A line, some text, and an image...
ax.plot([i for i in range(10)], "r")
ax.text(3, 2.5, "Hello World!", ha="center")
ax.imshow(np.random.rand(30, 30), origin="lower", cmap="Blues", alpha=0.5)

# Setup the zoom axes, no additional plotting needed...
axins = ax.inset_zoom_axes([0.5, 0.5, 0.48, 0.48])
axins.set_xlim(1, 5)
axins.set_ylim(1, 5)
ax.indicate_inset_zoom(axins, edgecolor="black")

plt.show()
```
![Resulting Plot with Inset Zoom View](https://user-images.githubusercontent.com/47544550/147632865-5dd8dbcd-79db-40fe-8c26-5082e8a185d7.png)

Supports all artists types (some of them shown in the above example), and any new ones that may eventually be added. It achieves this using a custom `Renderer` which transforms the data before deferring it the the actual underlying `Renderer` which does the actual drawing. It should work on all backends, I've personally tested the svg, png, pdf, and qt backends. I initially implemented this for a personal project and thought it might be nice to have directly in matplotlib.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
