### PR TITLE
De-duplicate mplot3D API docs

### DIFF
--- a/doc/api/next_api_changes/behavior/21026-DS.rst
+++ b/doc/api/next_api_changes/behavior/21026-DS.rst
@@ -1,5 +1,5 @@
 3D contourf polygons placed between levels
 ------------------------------------------
-The polygons used in a 3D `~mpl_toolkits.mplot3d.Axes3D.contourf` plot are
+The polygons used in a 3D `~.Axes3D.contourf` plot are
 now placed halfway between the contour levels, as each polygon represents the
 location of values that lie between two levels.

--- a/doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst
@@ -235,7 +235,7 @@ yet parsed, but this is a prerequisite for implementing subsetting.
 3D contourf polygons placed between levels
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The polygons used in a 3D `~mpl_toolkits.mplot3d.Axes3D.contourf` plot are now
+The polygons used in a 3D `~.Axes3D.contourf` plot are now
 placed halfway between the contour levels, as each polygon represents the
 location of values that lie between two levels.
 

--- a/doc/users/prev_whats_new/whats_new_1.4.rst
+++ b/doc/users/prev_whats_new/whats_new_1.4.rst
@@ -242,7 +242,7 @@ Simple quiver plot for mplot3d toolkit
 A team of students in an *Engineering Large Software Systems* course, taught
 by Prof. Anya Tafliovich at the University of Toronto, implemented a simple
 version of a quiver plot in 3D space for the mplot3d toolkit as one of their
-term project. This feature is documented in :func:`~mpl_toolkits.mplot3d.Axes3D.quiver`.
+term project. This feature is documented in `~.Axes3D.quiver`.
 The team members are: Ryan Steve D'Souza, Victor B, xbtsw, Yang Wang, David,
 Caradec Bisesar and Vlad Vassilovski.
 

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -340,7 +340,7 @@ Added a :mod:`.legend_handler` for :class:`~matplotlib.collections.PolyCollectio
 Support for alternate pivots in mplot3d quiver plot
 ```````````````````````````````````````````````````
 
-Added a :code:`pivot` kwarg to :func:`~mpl_toolkits.mplot3d.Axes3D.quiver`
+Added a :code:`pivot` kwarg to `~.Axes3D.quiver`
 that controls the pivot point around which the quiver line rotates. This also
 determines the placement of the arrow head along the quiver line.
 

--- a/tutorials/toolkits/mplot3d.py
+++ b/tutorials/toolkits/mplot3d.py
@@ -5,7 +5,8 @@ The mplot3d Toolkit
 
 Generating 3D plots using the mplot3d toolkit.
 
-.. currentmodule:: mpl_toolkits.mplot3d
+This tutorial showcases various 3D plots. Click on the figures to see each full
+gallery example with the code that generates the figures.
 
 .. contents::
    :backlinks: none
@@ -39,78 +40,71 @@ toolkit.
 
 Line plots
 ==========
+See `.Axes3D.plot` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_lines3d_001.png
    :target: ../../gallery/mplot3d/lines3d.html
    :align: center
 
-.. automethod:: Axes3D.plot
-
 .. _scatter3d:
 
 Scatter plots
 =============
+See `.Axes3D.scatter` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_scatter3d_001.png
    :target: ../../gallery/mplot3d/scatter3d.html
    :align: center
 
-.. automethod:: Axes3D.scatter
-
 .. _wireframe:
 
 Wireframe plots
 ===============
+See `.Axes3D.plot_wireframe` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_wire3d_001.png
    :target: ../../gallery/mplot3d/wire3d.html
    :align: center
 
-.. automethod:: Axes3D.plot_wireframe
-
 .. _surface:
 
 Surface plots
 =============
+See `.Axes3D.plot_surface` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_surface3d_001.png
    :target: ../../gallery/mplot3d/surface3d.html
    :align: center
 
-.. automethod:: Axes3D.plot_surface
-
 .. _trisurface:
 
 Tri-Surface plots
 =================
+See `.Axes3D.plot_trisurf` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_trisurf3d_001.png
    :target: ../../gallery/mplot3d/trisurf3d.html
    :align: center
 
-.. automethod:: Axes3D.plot_trisurf
-
 .. _contour3d:
 
 Contour plots
 =============
+See `.Axes3D.contour` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_contour3d_001.png
    :target: ../../gallery/mplot3d/contour3d.html
    :align: center
 
-.. automethod:: Axes3D.contour
-
 .. _contourf3d:
 
 Filled contour plots
 ====================
+See `.Axes3D.contourf` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_contourf3d_001.png
    :target: ../../gallery/mplot3d/contourf3d.html
    :align: center
-
-.. automethod:: Axes3D.contourf
 
 .. versionadded:: 1.1.0
    The feature demoed in the second contourf3d example was enabled as a
@@ -120,34 +114,31 @@ Filled contour plots
 
 Polygon plots
 =============
+See `.Axes3D.add_collection3d` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_polys3d_001.png
    :target: ../../gallery/mplot3d/polys3d.html
    :align: center
 
-.. automethod:: Axes3D.add_collection3d
-
 .. _bar3d:
 
 Bar plots
 =========
+See `.Axes3D.bar` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_bars3d_001.png
    :target: ../../gallery/mplot3d/bars3d.html
    :align: center
 
-.. automethod:: Axes3D.bar
-
 .. _quiver3d:
 
 Quiver
 ======
+See `.Axes3D.quiver` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_quiver3d_001.png
    :target: ../../gallery/mplot3d/quiver3d.html
    :align: center
-
-.. automethod:: Axes3D.quiver
 
 .. _2dcollections3d:
 
@@ -161,10 +152,9 @@ Quiver
 
 Text
 ====
+See `.Axes3D.text` for API documentation.
 
 .. figure:: ../../gallery/mplot3d/images/sphx_glr_text3d_001.png
    :target: ../../gallery/mplot3d/text3d.html
    :align: center
-
-.. automethod:: Axes3D.text
 """


### PR DESCRIPTION
## PR Summary
There are some API listings in the 3D tutorial that are duplicates of the actual API documentation. Remove these so it's possible to do e.g. \`.Axes3D.plot\` in sphinx RST without getting a duplicate entry warning.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
