### PR TITLE
FIX: Autoposition title when yaxis has offset

### DIFF
--- a/doc/api/next_api_changes/behavior/22063-SR.rst
+++ b/doc/api/next_api_changes/behavior/22063-SR.rst
@@ -1,0 +1,7 @@
+Move Axes title to not overlap with y axis offset
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, Axes titles could overlap the y-axis offset text, which is often
+in the upper left corner of the axes.  Now titles are moved above the offset
+text if overlapping, and autopositioning is in effect (i.e. if *y* in
+`.Axes.set_title` is *None* and :rc:`axes.titley` is also *None*).

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2990,6 +2990,12 @@ class _AxesBase(martist.Artist):
                 if bb is None:
                     bb = ax.get_window_extent(renderer)
                 top = max(top, bb.ymax)
+                if title.get_text():
+                    ax.yaxis.get_tightbbox(renderer)  # update offsetText
+                    if ax.yaxis.offsetText.get_text():
+                        bb = ax.yaxis.offsetText.get_tightbbox(renderer)
+                        if bb.intersection(title.get_tightbbox(renderer), bb):
+                            top = bb.ymax
             if top < 0:
                 # the top of Axes is not even on the figure, so don't try and
                 # automatically place it.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6121,6 +6121,36 @@ def test_title_xticks_top_both():
     assert ax.title.get_position()[1] > 1.04
 
 
+@pytest.mark.parametrize(
+    'left, center', [
+        ('left', ''),
+        ('', 'center'),
+        ('left', 'center')
+    ], ids=[
+        'left title moved',
+        'center title kept',
+        'both titles aligned'
+    ]
+)
+def test_title_above_offset(left, center):
+    # Test that title moves if overlaps with yaxis offset text.
+    mpl.rcParams['axes.titley'] = None
+    fig, ax = plt.subplots()
+    ax.set_ylim(1e11)
+    ax.set_title(left, loc='left')
+    ax.set_title(center)
+    fig.draw_without_rendering()
+    if left and not center:
+        assert ax._left_title.get_position()[1] > 1.0
+    elif not left and center:
+        assert ax.title.get_position()[1] == 1.0
+    else:
+        yleft = ax._left_title.get_position()[1]
+        ycenter = ax.title.get_position()[1]
+        assert yleft > 1.0
+        assert ycenter == yleft
+
+
 def test_title_no_move_off_page():
     # If an axes is off the figure (ie. if it is cropped during a save)
     # make sure that the automatic title repositioning does not get done.


### PR DESCRIPTION
## PR Summary
Move the title above the offset text if present.  

**OLD:**  
![old](https://user-images.githubusercontent.com/19879328/147657214-f312cb80-a06b-44ab-8678-0125209a1203.png)
**NEW:** 
![new](https://user-images.githubusercontent.com/19879328/147659776-e88c5d73-3447-4103-8991-c9c5bacbdde3.png)

Closes #22062.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
