### PR TITLE
DOC: Clarify y parameter in Axes.set_title

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -119,8 +119,8 @@ class Axes(_AxesBase):
 
         y : float, default: :rc:`axes.titley`
             Vertical Axes loation for the title (1.0 is the top).  If
-            None (the default), y is determined automatically to avoid
-            decorators on the Axes.
+            None (the default) and :rc:`axes.titley` is also None, y is
+            determined automatically to avoid decorators on the Axes.
 
         pad : float, default: :rc:`axes.titlepad`
             The offset of the title from the top of the Axes, in points.


### PR DESCRIPTION
## PR Summary
Autopositioning only works if `rcParams["axes.titley"]` is `None` in addition
to `y` being `None` in the function call. If `rcParams["axes.titley"]` is set
to a float, there's no way to enforce autopositioning by function call
parameters (passing `y=None` has no effect in this case).

Link to current doc: https://matplotlib.org/devdocs/api/_as_gen/matplotlib.axes.Axes.set_title.html

Example:
```python
import matplotlib.pyplot as plt

plt.rcParams["axes.titley"] = 1.0
fig, ax = plt.subplots()
ax.xaxis.tick_top()
ax.set_title('Title', y=None)  # trying to override rcParams["axes.titley"] here
```
![grafik](https://user-images.githubusercontent.com/19879328/147661178-85654018-51fd-436b-b69a-0d8a736918cd.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
