### PR TITLE
FIX: Remove trailing zeros from offset significand

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -500,6 +500,13 @@ class TestScalarFormatter:
         [12.3, "12.300"],
     ]
 
+    format_data = [
+        (.1, "1e-1"),
+        (.11, "1.1e-1"),
+        (1e8, "1e8"),
+        (1.1e8, "1.1e8"),
+    ]
+
     @pytest.mark.parametrize('unicode_minus, result',
                              [(True, "\N{MINUS SIGN}1"), (False, "-1")])
     def test_unicode_minus(self, unicode_minus, result):
@@ -560,6 +567,12 @@ class TestScalarFormatter:
 
         tmp_form.set_locs(ax.yaxis.get_majorticklocs())
         assert orderOfMag == tmp_form.orderOfMagnitude
+
+    @pytest.mark.parametrize('value, expected', format_data)
+    def test_format_data(self, value, expected):
+        mpl.rcParams['axes.unicode_minus'] = False
+        sf = mticker.ScalarFormatter()
+        assert sf.format_data(value) == expected
 
     @pytest.mark.parametrize('data, expected', cursor_data)
     def test_cursor_precision(self, data, expected):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -664,7 +664,7 @@ class ScalarFormatter(Formatter):
         s = round(value / 10**e, 10)
         exponent = self._format_maybe_minus_and_locale("%d", e)
         significand = self._format_maybe_minus_and_locale(
-            "%d" if s % 1 == 0 else "%1.10f", s)
+            "%d" if s % 1 == 0 else "%1.10g", s)
         if e == 0:
             return significand
         elif self._useMathText or self._usetex:


### PR DESCRIPTION
## PR Summary
Fix regression in 3.4.0 introduced by b5fb685a61f0 (#18506).  

Closes #22065.

### **CURRENT:**
 ![grafik](https://user-images.githubusercontent.com/19879328/147680188-5564397e-8dcc-453c-8245-cf6bd6091045.png)  


### **NEW (same as before 3.4.0):**
 ![grafik](https://user-images.githubusercontent.com/19879328/147681122-667fe715-7f65-41ce-8995-38133a8aa4ab.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
