### PR TITLE
Remove unnecessary `.figure` qualifier in docs.

### DIFF
--- a/doc/users/explain/interactive.rst
+++ b/doc/users/explain/interactive.rst
@@ -28,15 +28,15 @@ that include interactive tools, a toolbar, a tool-tip, and
 :ref:`key bindings <key-event-handling>`:
 
 `.pyplot.figure`
-    Creates a new empty `.figure.Figure` or selects an existing figure
+    Creates a new empty `.Figure` or selects an existing figure
 
 `.pyplot.subplots`
-    Creates a new `.figure.Figure` and fills it with a grid of `.axes.Axes`
+    Creates a new `.Figure` and fills it with a grid of `~.axes.Axes`
 
 `.pyplot` has a notion of "The Current Figure" which can be accessed
 through `.pyplot.gcf` and a notion of "The Current Axes" accessed
 through `.pyplot.gca`.  Almost all of the functions in `.pyplot` pass
-through the current `.Figure` / `.axes.Axes` (or create one) as
+through the current `.Figure` / `~.axes.Axes` (or create one) as
 appropriate.
 
 Matplotlib keeps a reference to all of the open figures
@@ -184,7 +184,7 @@ the GUI main loop in some other way.
 
 .. warning::
 
-   Using `.figure.Figure.show` it is possible to display a figure on
+   Using `.Figure.show` it is possible to display a figure on
    the screen without starting the event loop and without being in
    interactive mode.  This may work (depending on the GUI toolkit) but
    will likely result in a non-responsive figure.

--- a/doc/users/explain/interactive_guide.rst
+++ b/doc/users/explain/interactive_guide.rst
@@ -213,7 +213,7 @@ Blocking functions
 ------------------
 
 If you only need to collect points in an Axes you can use
-`.figure.Figure.ginput` or more generally the tools from
+`.Figure.ginput` or more generally the tools from
 `.blocking_input` the tools will take care of starting and stopping
 the event loop for you.  However if you have written some custom event
 handling or are using `.widgets` you will need to manually run the GUI
@@ -315,7 +315,7 @@ Artists (as of Matplotlib 1.5) have a **stale** attribute which is
 `True` if the internal state of the artist has changed since the last
 time it was rendered. By default the stale state is propagated up to
 the Artists parents in the draw tree, e.g., if the color of a `.Line2D`
-instance is changed, the `.axes.Axes` and `.figure.Figure` that
+instance is changed, the `~.axes.Axes` and `.Figure` that
 contain it will also be marked as "stale".  Thus, ``fig.stale`` will
 report if any artist in the figure has been modified and is out of sync
 with what is displayed on the screen.  This is intended to be used to
@@ -332,11 +332,11 @@ which by default is set to a function that forwards the stale state to
 the artist's parent.   If you wish to suppress a given artist from propagating
 set this attribute to None.
 
-`.figure.Figure` instances do not have a containing artist and their
+`.Figure` instances do not have a containing artist and their
 default callback is `None`.  If you call `.pyplot.ion` and are not in
 ``IPython`` we will install a callback to invoke
 `~.backend_bases.FigureCanvasBase.draw_idle` whenever the
-`.figure.Figure` becomes stale.  In ``IPython`` we use the
+`.Figure` becomes stale.  In ``IPython`` we use the
 ``'post_execute'`` hook to invoke
 `~.backend_bases.FigureCanvasBase.draw_idle` on any stale figures
 after having executed the user's input, but before returning the prompt

--- a/examples/color/colorbar_basics.py
+++ b/examples/color/colorbar_basics.py
@@ -3,8 +3,8 @@
 Colorbar
 ========
 
-Use `~.figure.Figure.colorbar` by specifying the mappable object (here
-the `~.matplotlib.image.AxesImage` returned by `~.axes.Axes.imshow`)
+Use `~.Figure.colorbar` by specifying the mappable object (here
+the `.AxesImage` returned by `~.axes.Axes.imshow`)
 and the axes to attach the colorbar to.
 """
 

--- a/examples/subplots_axes_and_figures/demo_tight_layout.py
+++ b/examples/subplots_axes_and_figures/demo_tight_layout.py
@@ -3,9 +3,8 @@
 Resizing axes with tight layout
 ===============================
 
-`~.figure.Figure.tight_layout` attempts to resize subplots in
-a figure so that there are no overlaps between axes objects and labels
-on the axes.
+`~.Figure.tight_layout` attempts to resize subplots in a figure so that there
+are no overlaps between axes objects and labels on the axes.
 
 See :doc:`/tutorials/intermediate/tight_layout_guide` for more details and
 :doc:`/tutorials/intermediate/constrainedlayout_guide` for an alternative.

--- a/examples/subplots_axes_and_figures/gridspec_nested.py
+++ b/examples/subplots_axes_and_figures/gridspec_nested.py
@@ -7,7 +7,7 @@ GridSpecs can be nested, so that a subplot from a parent GridSpec can
 set the position for a nested grid of subplots.
 
 Note that the same functionality can be achieved more directly with
-`~.figure.FigureBase.subfigures`; see
+`~.FigureBase.subfigures`; see
 :doc:`/gallery/subplots_axes_and_figures/subfigures`.
 
 """

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -180,8 +180,8 @@ class SubplotParams:
 
 class FigureBase(Artist):
     """
-    Base class for `.figure.Figure` and `.figure.SubFigure` containing the
-    methods that add artists to the figure or subfigure, create Axes, etc.
+    Base class for `.Figure` and `.SubFigure` containing the methods that add
+    artists to the figure or subfigure, create Axes, etc.
     """
     def __init__(self, **kwargs):
         super().__init__()
@@ -1453,8 +1453,7 @@ default: %(va)s
 
     def add_subfigure(self, subplotspec, **kwargs):
         """
-        Add a `~.figure.SubFigure` to the figure as part of a subplot
-        arrangement.
+        Add a `.SubFigure` to the figure as part of a subplot arrangement.
 
         Parameters
         ----------
@@ -1464,12 +1463,12 @@ default: %(va)s
 
         Returns
         -------
-        `.figure.SubFigure`
+        `.SubFigure`
 
         Other Parameters
         ----------------
         **kwargs
-            Are passed to the `~.figure.SubFigure` object.
+            Are passed to the `.SubFigure` object.
 
         See Also
         --------
@@ -1964,7 +1963,7 @@ class SubFigure(FigureBase):
         """
         Parameters
         ----------
-        parent : `.figure.Figure` or `.figure.SubFigure`
+        parent : `.Figure` or `.SubFigure`
             Figure or subfigure that contains the SubFigure.  SubFigures
             can be nested.
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -344,7 +344,7 @@ class GridSpec(GridSpecBase):
         nrows, ncols : int
             The number of rows and columns of the grid.
 
-        figure : `~.figure.Figure`, optional
+        figure : `.Figure`, optional
             Only used for constrained layout to create a proper layoutgrid.
 
         left, right, top, bottom : float, optional

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1748,7 +1748,7 @@ def thumbnail(infile, thumbfile, scale=0.1, interpolation='bilinear',
 
     Returns
     -------
-    `~.figure.Figure`
+    `.Figure`
         The figure instance containing the thumbnail.
     """
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1363,13 +1363,12 @@ def subplots(nrows=1, ncols=1, *, sharex=False, sharey=False, squeeze=True,
 
     Returns
     -------
-    fig : `~.figure.Figure`
+    fig : `.Figure`
 
-    ax : `.axes.Axes` or array of Axes
-        *ax* can be either a single `~matplotlib.axes.Axes` object or an
-        array of Axes objects if more than one subplot was created.  The
-        dimensions of the resulting array can be controlled with the squeeze
-        keyword, see above.
+    ax : `~.axes.Axes` or array of Axes
+        *ax* can be either a single `~.axes.Axes` object, or an array of Axes
+        objects if more than one subplot was created.  The dimensions of the
+        resulting array can be controlled with the squeeze keyword, see above.
 
         Typical idioms for handling the return value are::
 
@@ -1516,7 +1515,7 @@ def subplot_mosaic(mosaic, *, sharex=False, sharey=False,
 
     Returns
     -------
-    fig : `~.figure.Figure`
+    fig : `.Figure`
        The new figure
 
     dict[label, Axes]

--- a/tutorials/intermediate/arranging_axes.py
+++ b/tutorials/intermediate/arranging_axes.py
@@ -1,7 +1,7 @@
 """
-=====================================
+===================================
 Arranging multiple Axes in a Figure
-=====================================
+===================================
 
 Often more than one Axes is wanted on a figure at a time, usually
 organized into a regular grid.  Matplotlib has a variety of tools for
@@ -37,7 +37,7 @@ or
     `.Figure.subplot_mosaic` and :doc:`/tutorials/provisional/mosaic`.
 
 Sometimes it is natural to have more than one distinct group of Axes grids,
-in which case Matplotlib has the concept of `~.figure.SubFigure`:
+in which case Matplotlib has the concept of `.SubFigure`:
 
 `~matplotlib.figure.SubFigure`
     A virtual figure within a figure.

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -142,7 +142,7 @@ fig.colorbar(im, ax=axs[:, -1], shrink=0.6)
 # Suptitle
 # =========
 #
-# ``constrained_layout`` can also make room for `~.figure.Figure.suptitle`.
+# ``constrained_layout`` can also make room for `~.Figure.suptitle`.
 
 fig, axs = plt.subplots(2, 2, figsize=(4, 4), constrained_layout=True)
 for ax in axs.flat:
@@ -228,7 +228,7 @@ fig.savefig('../../doc/_static/constrained_layout_2b.png',
 #
 # Padding between axes is controlled in the horizontal by *w_pad* and
 # *wspace*, and vertical by *h_pad* and *hspace*.  These can be edited
-# via `~.figure.Figure.set_constrained_layout_pads`.  *w/h_pad* are
+# via `~.Figure.set_constrained_layout_pads`.  *w/h_pad* are
 # the minimum space around the axes in units of inches:
 
 fig, axs = plt.subplots(2, 2, constrained_layout=True)

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -17,7 +17,7 @@ import numpy as np
 # A simple example
 # ================
 #
-# Matplotlib graphs your data on `~.figure.Figure`\s (e.g., windows, Jupyter
+# Matplotlib graphs your data on `.Figure`\s (e.g., windows, Jupyter
 # widgets, etc.), each of which can contain one or more `~.axes.Axes`, an
 # area where points can be specified in terms of x-y coordinates (or theta-r
 # in a polar plot, x-y-z in a 3D plot, etc).  The simplest way of


### PR DESCRIPTION
`figure.Figure` actually looks not so nice in rendered docs and `Figure`
is just as clear; one can suppress the leading `figure` with a tilde but
it can also just be removed.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
