### PR TITLE
See if pinning numpy to < 1.22 fixes tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -157,7 +157,7 @@ jobs:
 
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \
-            cycler fonttools kiwisolver numpy packaging pillow pyparsing \
+            cycler fonttools kiwisolver "numpy<1.22" packaging pillow pyparsing \
             python-dateutil setuptools-scm \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
     python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
     setup_requires=[
         "certifi>=2020.06.20",
-        "numpy>=1.17",
+        "numpy>=1.17,<1.22",
         "setuptools_scm>=4",
         "setuptools_scm_git_archive",
     ],
@@ -316,7 +316,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "cycler>=0.10",
         "fonttools>=4.22.0",
         "kiwisolver>=1.0.1",
-        "numpy>=1.17",
+        "numpy>=1.17,<1.22",
         "packaging>=20.0",
         "pillow>=6.2.0",
         "pyparsing>=2.2.1,<3.0.0",


### PR DESCRIPTION
## PR Summary
In the last couple of days a few of the tests have been failing on some builds. The test fails are:
```
FAILED lib/matplotlib/tests/test_axes.py::test_errorbar[png] - matplotlib.tes...
FAILED lib/matplotlib/tests/test_axes.py::test_errorbar[svg] - matplotlib.tes...
FAILED lib/matplotlib/tests/test_axes.py::test_errorbar[pdf] - matplotlib.tes...
FAILED lib/matplotlib/tests/test_streamplot.py::test_direction[png] - matplot...
FAILED lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py::test_axis_direction[png]
FAILED lib/mpl_toolkits/tests/test_mplot3d.py::test_trisurf3d[png] - matplotl...
FAILED lib/mpl_toolkits/tests/test_mplot3d.py::test_stem3d[png] - matplotlib....
```

Running a diff between installed packages on a succesful and failed run shows that the only packages that have changed are numpy-1.22.0, pikepdf-4.3.1, and pygments-2.11.1. I don't think it's a MPL commit causing the new test failures, so try pinning numpy to see if that's the cause.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
