### PR TITLE
Fix keyboard event routing in Tk backend (fixes #13484, #14081, and #22028)

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -279,6 +279,9 @@ class FigureCanvasTk(FigureCanvasBase):
             guiEvent=event, xy=self._event_mpl_coords(event))
 
     def button_press_event(self, event, dblclick=False):
+        # set focus to the canvas so that it can receive keyboard events
+        self._tkcanvas.focus_set()
+
         num = getattr(event, 'num', None)
         if sys.platform == 'darwin':  # 2 and 3 are reversed.
             num = {2: 3, 3: 2}.get(num, num)
@@ -467,6 +470,7 @@ class FigureManagerTk(FigureManagerBase):
                     Gcf.destroy(self)
                 self.window.protocol("WM_DELETE_WINDOW", destroy)
                 self.window.deiconify()
+                self.canvas._tkcanvas.focus_set()
             else:
                 self.canvas.draw_idle()
             if mpl.rcParams['figure.raise_window']:

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -186,3 +186,33 @@ def test_missing_back_button():  # pragma: no cover
     print("success")
     Toolbar(fig.canvas, fig.canvas.manager.window)  # This should not raise.
     print("success")
+
+
+@pytest.mark.backend('TkAgg', skip_on_importerror=True)
+@_isolated_tk_test(success_count=1)
+def test_canvas_focus():  # pragma: no cover
+    import tkinter as tk
+    import matplotlib.pyplot as plt
+    success = []
+
+    def check_focus():
+        tkcanvas = fig.canvas.get_tk_widget()
+        # Give the plot window time to appear
+        if not tkcanvas.winfo_viewable():
+            tkcanvas.wait_visibility()
+        # Make sure the canvas has the focus, so that it's able to receive
+        # keyboard events.
+        if tkcanvas.focus_lastfor() == tkcanvas:
+            success.append(True)
+        plt.close()
+        root.destroy()
+
+    root = tk.Tk()
+    fig = plt.figure()
+    plt.plot([1, 2, 3])
+    root.after(0, plt.show)
+    root.after(100, check_focus)
+    root.mainloop()
+
+    if success:
+        print("success")


### PR DESCRIPTION
## PR Summary
Currently, when using the Tk backend, Matplotlib sets the focus to the figure canvas upon its creation, as this is required to process keyboard events. As reported in #14081, this takes away the focus from other widgets when embedding a plot in a tkinter GUI, which creating a widget should never do (though the issue of other widgets being unable to take back the focus [was fixed in Tk 8.6.11](https://github.com/tcltk/tk/commit/b36fe5790a29cf78c58ab273cce93ab0604076ba)). Since a recent Python/Tk update, the focus doesn't get set to the canvas at all (#22028), though I cannot reproduce this outside of Matplotlib so can't tell what exactly caused this regression. Finally, the canvas has no visual indicator of having the focus, which makes it hard to get it to accept keyboard events again after tabbing out (#13484).

In this PR, the focus instead gets set to the canvas during the first call to `plt.show()`. It also gets set when the canvas receives a mouse click event, as is standard for widgets responding to keyboard events (e.g. entry widgets). 
- For pyplot windows, this fixes the regression from #22028, and shouldn't behave any different apart from that
- For embedded plots, this no longer steals the focus from other tkinter widgets, and the focus can instead be set by clicking the plot (or via `canvas.get_tk_widget().focus_set()`), as with any other widget
- In both cases, it allows restoring the focus by clicking the canvas after tabbing out, or when dealing with multiple embedded plots.

I've also added a unit test, and updated the "embedding in tk" example to reflect this behaviour.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
