### PR TITLE
Share FigureManager class between gtk3 and gtk4.

### DIFF
--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -3,15 +3,18 @@ Common code for GTK3 and GTK4 backends.
 """
 
 import logging
+import sys
 
 import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
-from matplotlib.backend_bases import _Backend, NavigationToolbar2, TimerBase
+from matplotlib._pylab_helpers import Gcf
+from matplotlib.backend_bases import (
+    _Backend, FigureManagerBase, NavigationToolbar2, TimerBase)
 from matplotlib.backend_tools import Cursors
 
 # The GTK3/GTK4 backends will have already called `gi.require_version` to set
 # the desired GTK.
-from gi.repository import Gio, GLib, Gtk
+from gi.repository import Gdk, Gio, GLib, Gtk
 
 
 _log = logging.getLogger(__name__)
@@ -107,6 +110,134 @@ class TimerGTK(TimerBase):
         else:
             self._timer = None
             return False
+
+
+class _FigureManagerGTK(FigureManagerBase):
+    """
+    Attributes
+    ----------
+    canvas : `FigureCanvas`
+        The FigureCanvas instance
+    num : int or str
+        The Figure number
+    toolbar : Gtk.Toolbar or Gtk.Box
+        The toolbar
+    vbox : Gtk.VBox
+        The Gtk.VBox containing the canvas and toolbar
+    window : Gtk.Window
+        The Gtk.Window
+    """
+
+    def __init__(self, canvas, num):
+        self._gtk_ver = gtk_ver = Gtk.get_major_version()
+
+        app = _create_application()
+        self.window = Gtk.Window()
+        app.add_window(self.window)
+        super().__init__(canvas, num)
+
+        if gtk_ver == 3:
+            self.window.set_wmclass("matplotlib", "Matplotlib")
+            icon_ext = "png" if sys.platform == "win32" else "svg"
+            self.window.set_icon_from_file(
+                str(cbook._get_data_path(f"images/matplotlib.{icon_ext}")))
+
+        self.vbox = Gtk.Box()
+        self.vbox.set_property("orientation", Gtk.Orientation.VERTICAL)
+
+        if gtk_ver == 3:
+            self.window.add(self.vbox)
+            self.vbox.show()
+            self.canvas.show()
+            self.vbox.pack_start(self.canvas, True, True, 0)
+        elif gtk_ver == 4:
+            self.window.set_child(self.vbox)
+            self.vbox.prepend(self.canvas)
+
+        # calculate size for window
+        w, h = self.canvas.get_width_height()
+
+        if self.toolbar is not None:
+            if gtk_ver == 3:
+                self.toolbar.show()
+                self.vbox.pack_end(self.toolbar, False, False, 0)
+            elif gtk_ver == 4:
+                sw = Gtk.ScrolledWindow(vscrollbar_policy=Gtk.PolicyType.NEVER)
+                sw.set_child(self.toolbar)
+                self.vbox.append(sw)
+            min_size, nat_size = self.toolbar.get_preferred_size()
+            h += nat_size.height
+
+        self.window.set_default_size(w, h)
+
+        self._destroying = False
+        self.window.connect("destroy", lambda *args: Gcf.destroy(self))
+        self.window.connect({3: "delete_event", 4: "close-request"}[gtk_ver],
+                            lambda *args: Gcf.destroy(self))
+        if mpl.is_interactive():
+            self.window.show()
+            self.canvas.draw_idle()
+
+        self.canvas.grab_focus()
+
+    def destroy(self, *args):
+        if self._destroying:
+            # Otherwise, this can be called twice when the user presses 'q',
+            # which calls Gcf.destroy(self), then this destroy(), then triggers
+            # Gcf.destroy(self) once again via
+            # `connect("destroy", lambda *args: Gcf.destroy(self))`.
+            return
+        self._destroying = True
+        self.window.destroy()
+        self.canvas.destroy()
+
+    def show(self):
+        # show the figure window
+        self.window.show()
+        self.canvas.draw()
+        if mpl.rcParams["figure.raise_window"]:
+            meth_name = {3: "get_window", 4: "get_surface"}[self._gtk_ver]
+            if getattr(self.window, meth_name)():
+                self.window.present()
+            else:
+                # If this is called by a callback early during init,
+                # self.window (a GtkWindow) may not have an associated
+                # low-level GdkWindow (on GTK3) or GdkSurface (on GTK4) yet,
+                # and present() would crash.
+                _api.warn_external("Cannot raise window yet to be setup")
+
+    def full_screen_toggle(self):
+        is_fullscreen = {
+            3: lambda w: (w.get_window().get_state()
+                          & Gdk.WindowState.FULLSCREEN),
+            4: lambda w: w.is_fullscreen(),
+        }[self._gtk_ver]
+        if is_fullscreen(self.window):
+            self.window.unfullscreen()
+        else:
+            self.window.fullscreen()
+
+    def get_window_title(self):
+        return self.window.get_title()
+
+    def set_window_title(self, title):
+        self.window.set_title(title)
+
+    def resize(self, width, height):
+        width = int(width / self.canvas.device_pixel_ratio)
+        height = int(height / self.canvas.device_pixel_ratio)
+        if self.toolbar:
+            toolbar_size = self.toolbar.size_request()
+            height += toolbar_size.height
+        canvas_size = self.canvas.get_allocation()
+        if self._gtk_ver >= 4 or canvas_size.width == canvas_size.height == 1:
+            # A canvas size of (1, 1) cannot exist in most cases, because
+            # window decorations would prevent such a small window. This call
+            # must be before the window has been mapped and widgets have been
+            # sized, so just change the window's starting size.
+            self.window.set_default_size(width, height)
+        else:
+            self.window.resize(width, height)
 
 
 class _NavigationToolbar2GTK(NavigationToolbar2):


### PR DESCRIPTION
The gtk version checks are not the nicest, but sharing most of the setup
code between gtk3 and gtk4 still seems worthwhile?

(Note that on gtk3, it is explicitly OK to not bother to destroy the
vbox and toolbar, as gtk3 always destroys child widgets upon parent
destruction.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
