### PR TITLE
Expire colorbar-related deprecations.

### DIFF
--- a/doc/api/next_api_changes/removals/22081-AL.rst
+++ b/doc/api/next_api_changes/removals/22081-AL.rst
@@ -1,0 +1,11 @@
+colorbar defaults to stealing space from the mappable's axes rather than the current axes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pass ``ax=plt.gca()`` to restore the previous behavior.
+
+Removal of deprecated ``colorbar`` APIs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following deprecated :mod:`.colorbar` APIs have been removed:
+``ColorbarPatch`` and ``colorbar_factory`` (use `.Colorbar` instead);
+``colorbar_doc``, ``colorbar_kw_doc``, ``make_axes_kw_doc``.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -194,16 +194,6 @@ workaround is not used by default (see issue #1188).
        _colormap_kw_doc))
 
 
-@_api.caching_module_getattr  # module-level deprecations
-class __getattr__:
-    colorbar_doc = _api.deprecated("3.4", obj_type="")(property(
-        lambda self: docstring.interpd.params["colorbar_doc"]))
-    colorbar_kw_doc = _api.deprecated("3.4", obj_type="")(property(
-        lambda self: _colormap_kw_doc))
-    make_axes_kw_doc = _api.deprecated("3.4", obj_type="")(property(
-        lambda self: _make_axes_param_doc + _make_axes_other_param_doc))
-
-
 def _set_ticks_on_axis_warn(*args, **kwargs):
     # a top level function which gets put in at the axes'
     # set_xticks and set_yticks by Colorbar.__init__.
@@ -1587,36 +1577,3 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
         aspect=aspect0,
         pad=pad)
     return cax, kwargs
-
-
-@_api.deprecated("3.4", alternative="Colorbar")
-class ColorbarPatch(Colorbar):
-    pass
-
-
-@_api.deprecated("3.4", alternative="Colorbar")
-def colorbar_factory(cax, mappable, **kwargs):
-    """
-    Create a colorbar on the given axes for the given mappable.
-
-    .. note::
-        This is a low-level function to turn an existing axes into a colorbar
-        axes.  Typically, you'll want to use `~.Figure.colorbar` instead, which
-        automatically handles creation and placement of a suitable axes as
-        well.
-
-    Parameters
-    ----------
-    cax : `~matplotlib.axes.Axes`
-        The `~.axes.Axes` to turn into a colorbar.
-    mappable : `~matplotlib.cm.ScalarMappable`
-        The mappable to be described by the colorbar.
-    **kwargs
-        Keyword arguments are passed to the respective colorbar class.
-
-    Returns
-    -------
-    `.Colorbar`
-        The created colorbar instance.
-    """
-    return Colorbar(cax, mappable, **kwargs)

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1129,15 +1129,7 @@ default: %(va)s
             self, mappable, cax=None, ax=None, use_gridspec=True, **kwargs):
         """%(colorbar_doc)s"""
         if ax is None:
-            ax = self.gca()
-            if (hasattr(mappable, "axes") and ax is not mappable.axes
-                    and cax is None):
-                _api.warn_deprecated(
-                    "3.4", message="Starting from Matplotlib 3.6, colorbar() "
-                    "will steal space from the mappable's axes, rather than "
-                    "from the current axes, to place the colorbar.  To "
-                    "silence this warning, explicitly pass the 'ax' argument "
-                    "to colorbar().")
+            ax = getattr(mappable, "axes", self.gca())
 
         # Store the value of gca so that we can set it back later on.
         if cax is None:


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
