### PR TITLE
Fix reference to Matplotlib FAQ in doc/index.rst

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -56,7 +56,7 @@ Learning resources
     How-tos
     ^^^^^^^
     - :doc:`Example gallery <gallery/index>`
-    - :doc:`Matplotlib FAQ <faq/index>`
+    - :doc:`Matplotlib FAQ <users/faq/index>`
 
     ---
 


### PR DESCRIPTION
## PR Summary
The documentation's main page at https://matplotlib.org/stable/index.html (also https://matplotlib.org/devdocs/index.html) contains a link to the Matplotlib FAQ:

![screenshot of doc main page](https://user-images.githubusercontent.com/17914410/147886362-ced77a4e-f801-4e91-a934-be49f1927e54.png)

but the link points to the Python FAQ at https://docs.python.org/3/faq/index.html. I could reproduce this with a local build from `main`.

The raw `.rst` looks like this:
```rst
    How-tos
    ^^^^^^^
    - :doc:`Example gallery <gallery/index>`
    - :doc:`Matplotlib FAQ <faq/index>`
```
It seems that the `<faq/index>` is incorrect, it should be `<users/faq/index>`, and there happen to be two intersphinx items by that path in Python:
```py
[
    'faq-index std:label -1 faq/index.html#$ Python Frequently Asked Questions',
    'faq/index std:doc -1 faq/index.html Python Frequently Asked Questions',
]
```
(I just decompressed the python.org intersphinx inventory and picked out the rows that contain `faq/index`).

Changing the path to `<users/faq/index>` seems to fix the link in a local build.

There are some other instances of `faq/index` without the `users/` endpoint, and I wonder if any of them should also be amended:
```sh
$ cd doc
$ git grep -n 'faq/'
index.rst:59:    - :doc:`Matplotlib FAQ <users/faq/index>`
users/faq/environment_variables_faq.rst:3:.. redirect-from:: /faq/environment_variables_faq
users/faq/howto_faq.rst:3:.. redirect-from:: /faq/howto_faq
users/faq/index.rst:3:.. redirect-from:: /faq/index
users/faq/troubleshooting_faq.rst:3:.. redirect-from:: /faq/troubleshooting_faq
users/index.rst:19:   faq/index.rst
users/installing/index.rst:163:.. redirect-from:: /faq/installing_faq
users/installing/index.rst:164:.. redirect-from:: /users/faq/installing_faq
```

## PR Checklist

**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).