### PR TITLE
FIX: squash memory leak in colorbar

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1414,8 +1414,8 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     # use .flatten or .ravel as these copy the references rather than
     # reuse them, leading to a memory leak
     if isinstance(parents, np.ndarray):
-        parents = [parent for parent in parents.flat]
-    if not isinstance(parents, list):
+        parents = list(parents.flat)
+    elif not isinstance(parents, list):
         parents = [parents]
     fig = parents[0].get_figure()
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1410,10 +1410,13 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     anchor = kwargs.pop('anchor', loc_settings['anchor'])
     panchor = kwargs.pop('panchor', loc_settings['panchor'])
     aspect0 = aspect
-    # turn parents into a list if it is not already. We do this w/ np
-    # because `plt.subplots` can return an ndarray and is natural to
-    # pass to `colorbar`.
-    parents = np.atleast_1d(parents).ravel()
+    # turn parents into a list if it is not already.  Note we cannot
+    # use .flatten or .ravel as these copy the references rather than
+    # reuse them, leading to a memory leak
+    if isinstance(parents, np.ndarray):
+        parents = [parent for parent in parents.flat]
+    if not isinstance(parents, list):
+        parents = [parents]
     fig = parents[0].get_figure()
 
     pad0 = 0.05 if fig.get_constrained_layout() else loc_settings['pad']
@@ -1461,8 +1464,8 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         # tell the parent it has a colorbar
         a._colorbars += [cax]
     cax._colorbar_info = dict(
-        location=location,
         parents=parents,
+        location=location,
         shrink=shrink,
         anchor=anchor,
         panchor=panchor,
@@ -1586,6 +1589,7 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
         fraction=fraction,
         aspect=aspect0,
         pad=pad)
+
     return cax, kwargs
 
 


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/22085

I guess I'm not 100% sure why the old code breaks, but this new code does not leak memory.

Tested via 

```python
import matplotlib.pyplot as plt
from matplotlib import colorbar
import psutil
import gc
import numpy as np

p = psutil.Process()
for i in range(20):
    fig, ax = plt.subplots(1, 1)
    ax.imshow(np.random.normal(size=(10,10)))
    cax, _ = colorbar.make_axes(ax)
    # plt.savefig("test.png")
    plt.pause(0.1)
    plt.close(fig)
    del fig
    del cax
    del ax
    gc.collect()
    print(p.memory_full_info().uss/1e6)
```

### Before:

```

66.297856
60.760064
...
86.355968
87.8592
```


### Now:

(OK, there actually appears to be a slow memory leak somewhere else, but it is _far_ slower than this memory leak...)

```
55.66464
51.818496
...
57.421824
57.63072
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
