### PR TITLE
Expire axes_grid1/axisartist deprecations.

### DIFF
--- a/doc/api/next_api_changes/deprecations/22098-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22098-AL.rst
@@ -1,0 +1,13 @@
+``axes_grid`` and ``axisartist`` removals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following deprecated APIs have been removed:
+
+- ``SubplotDivider.figbox``, ``SubplotDivider.update_params``,
+- ``SubplotDivider.get_geometry`` (use ``get_subplotspec`` instead),
+- ``change_geometry`` (use ``set_subplotspec`` instead),
+- ``ParasiteAxesBase.update_viewlim`` (use ``apply_aspect`` instead),
+- ``ParasiteAxesAuxTransBase`` (use ``ParasiteAxesBase`` instead),
+- ``parasite_axes_auxtrans_class_factory`` (use ``parasite_axes_class_factory``
+  instead),
+-  ``ParasiteAxesAuxTrans`` (use ``ParasiteAxes`` instead),

--- a/lib/mpl_toolkits/axes_grid/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid/parasite_axes.py
@@ -1,12 +1,9 @@
-from matplotlib import _api
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
-    parasite_axes_auxtrans_class_factory, subplot_class_factory)
+    subplot_class_factory)
 from mpl_toolkits.axisartist.axislines import Axes
 
 
 ParasiteAxes = parasite_axes_class_factory(Axes)
 HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
-with _api.suppress_matplotlib_deprecation_warning():
-    ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -7,7 +7,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib import _api
 from matplotlib.axes import SubplotBase
-from matplotlib.gridspec import SubplotSpec, GridSpec
+from matplotlib.gridspec import SubplotSpec
 import matplotlib.transforms as mtransforms
 from . import axes_size as Size
 
@@ -367,30 +367,6 @@ class SubplotDivider(Divider):
     def get_position(self):
         """Return the bounds of the subplot box."""
         return self.get_subplotspec().get_position(self.figure).bounds
-
-    @_api.deprecated("3.4")
-    @property
-    def figbox(self):
-        return self.get_subplotspec().get_position(self.figure)
-
-    @_api.deprecated("3.4")
-    def update_params(self):
-        pass
-
-    @_api.deprecated(
-        "3.4", alternative="get_subplotspec",
-        addendum="(get_subplotspec returns a SubplotSpec instance.)")
-    def get_geometry(self):
-        """Get the subplot geometry, e.g., (2, 2, 3)."""
-        rows, cols, num1, num2 = self.get_subplotspec().get_geometry()
-        return rows, cols, num1 + 1  # for compatibility
-
-    @_api.deprecated("3.4", alternative="set_subplotspec")
-    def change_geometry(self, numrows, numcols, num):
-        """Change subplot geometry, e.g., from (1, 1, 1) to (2, 2, 3)."""
-        self._subplotspec = GridSpec(numrows, numcols)[num-1]
-        self.update_params()
-        self.set_position(self.figbox)
 
     def get_subplotspec(self):
         """Get the SubplotSpec instance."""

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -1,5 +1,3 @@
-import functools
-
 from matplotlib import _api, cbook
 import matplotlib.artist as martist
 import matplotlib.image as mimage
@@ -71,10 +69,6 @@ class ParasiteAxesBase:
     def get_viewlim_mode(self):
         return self._viewlim_mode
 
-    @_api.deprecated("3.4", alternative="apply_aspect")
-    def update_viewlim(self):
-        return self._update_viewlim
-
     def _update_viewlim(self):  # Inline after deprecation elapses.
         viewlim = self._parent_axes.viewLim.frozen()
         mode = self.get_viewlim_mode()
@@ -98,68 +92,6 @@ class ParasiteAxesBase:
 parasite_axes_class_factory = cbook._make_class_factory(
     ParasiteAxesBase, "{}Parasite")
 ParasiteAxes = parasite_axes_class_factory(Axes)
-
-
-@_api.deprecated("3.4", alternative="ParasiteAxesBase")
-class ParasiteAxesAuxTransBase:
-    def __init__(self, parent_axes, aux_transform, viewlim_mode=None,
-                 **kwargs):
-        # Explicit wrapper for deprecation to work.
-        super().__init__(parent_axes, aux_transform,
-                         viewlim_mode=viewlim_mode, **kwargs)
-
-    def _set_lim_and_transforms(self):
-        self.transAxes = self._parent_axes.transAxes
-        self.transData = self.transAux + self._parent_axes.transData
-        self._xaxis_transform = mtransforms.blended_transform_factory(
-            self.transData, self.transAxes)
-        self._yaxis_transform = mtransforms.blended_transform_factory(
-            self.transAxes, self.transData)
-
-    def set_viewlim_mode(self, mode):
-        _api.check_in_list([None, "equal", "transform"], mode=mode)
-        self._viewlim_mode = mode
-
-    def get_viewlim_mode(self):
-        return self._viewlim_mode
-
-    @_api.deprecated("3.4", alternative="apply_aspect")
-    def update_viewlim(self):
-        return self._update_viewlim()
-
-    def _update_viewlim(self):  # Inline after deprecation elapses.
-        viewlim = self._parent_axes.viewLim.frozen()
-        mode = self.get_viewlim_mode()
-        if mode is None:
-            pass
-        elif mode == "equal":
-            self.axes.viewLim.set(viewlim)
-        elif mode == "transform":
-            self.axes.viewLim.set(
-                viewlim.transformed(self.transAux.inverted()))
-        else:
-            _api.check_in_list([None, "equal", "transform"], mode=mode)
-
-    def apply_aspect(self, position=None):
-        self._update_viewlim()
-        super().apply_aspect()
-
-
-@_api.deprecated("3.4", alternative="parasite_axes_class_factory")
-@functools.lru_cache(None)
-def parasite_axes_auxtrans_class_factory(axes_class):
-    if not issubclass(axes_class, ParasiteAxesBase):
-        parasite_axes_class = parasite_axes_class_factory(axes_class)
-    else:
-        parasite_axes_class = axes_class
-    return type("%sParasiteAuxTrans" % parasite_axes_class.__name__,
-                (ParasiteAxesAuxTransBase, parasite_axes_class),
-                {'name': 'parasite_axes'})
-
-
-# Also deprecated.
-with _api.suppress_matplotlib_deprecation_warning():
-    ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)
 
 
 class HostAxesBase:

--- a/lib/mpl_toolkits/axisartist/__init__.py
+++ b/lib/mpl_toolkits/axisartist/__init__.py
@@ -1,4 +1,3 @@
-from matplotlib import _api
 from .axislines import (
     Axes, AxesZero, AxisArtistHelper, AxisArtistHelperRectlinear,
     GridHelperBase, GridHelperRectlinear, Subplot, SubplotZero)
@@ -7,11 +6,9 @@ from .grid_helper_curvelinear import GridHelperCurveLinear
 from .floating_axes import FloatingAxes, FloatingSubplot
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
-    parasite_axes_auxtrans_class_factory, subplot_class_factory)
+    subplot_class_factory)
 
 
 ParasiteAxes = parasite_axes_class_factory(Axes)
 HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
-with _api.suppress_matplotlib_deprecation_warning():
-    ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -624,11 +624,6 @@ class AxisArtist(martist.Artist):
 
     zorder = 2.5
 
-    @_api.deprecated("3.4")
-    @_api.classproperty
-    def ZORDER(cls):
-        return cls.zorder
-
     @property
     def LABELPAD(self):
         return self.label.get_pad()

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -315,28 +315,18 @@ class AxisArtistHelperRectlinear:
 class GridHelperBase:
 
     def __init__(self):
-        self._force_update = True  # Remove together with invalidate()/valid().
         self._old_limits = None
         super().__init__()
 
     def update_lim(self, axes):
         x1, x2 = axes.get_xlim()
         y1, y2 = axes.get_ylim()
-        if self._force_update or self._old_limits != (x1, x2, y1, y2):
+        if self._old_limits != (x1, x2, y1, y2):
             self._update_grid(x1, y1, x2, y2)
-            self._force_update = False
             self._old_limits = (x1, x2, y1, y2)
 
     def _update_grid(self, x1, y1, x2, y2):
         """Cache relevant computations when the axes limits have changed."""
-
-    @_api.deprecated("3.4")
-    def invalidate(self):
-        self._force_update = True
-
-    @_api.deprecated("3.4")
-    def valid(self):
-        return not self._force_update
 
     def get_gridlines(self, which, axis):
         """
@@ -554,10 +544,6 @@ class Axes(maxes.Axes):
             children = []
         children.extend(super().get_children())
         return children
-
-    @_api.deprecated("3.4")
-    def invalidate_grid_helper(self):
-        self._grid_helper.invalidate()
 
     def new_fixed_axis(self, loc, offset=None):
         gh = self.get_grid_helper()

--- a/lib/mpl_toolkits/axisartist/parasite_axes.py
+++ b/lib/mpl_toolkits/axisartist/parasite_axes.py
@@ -1,12 +1,9 @@
-from matplotlib import _api
 from mpl_toolkits.axes_grid1.parasite_axes import (
     host_axes_class_factory, parasite_axes_class_factory,
-    parasite_axes_auxtrans_class_factory, subplot_class_factory)
+    subplot_class_factory)
 from .axislines import Axes
 
 
 ParasiteAxes = parasite_axes_class_factory(Axes)
 HostAxes = host_axes_class_factory(Axes)
 SubplotHost = subplot_class_factory(HostAxes)
-with _api.suppress_matplotlib_deprecation_warning():
-    ParasiteAxesAuxTrans = parasite_axes_auxtrans_class_factory(ParasiteAxes)

--- a/lib/mpl_toolkits/tests/test_axisartist_axislines.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axislines.py
@@ -1,14 +1,10 @@
 import numpy as np
-from matplotlib import _api
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 from matplotlib.transforms import IdentityTransform
 
 from mpl_toolkits.axisartist.axislines import SubplotZero, Subplot
-from mpl_toolkits.axisartist import (
-    Axes, SubplotHost, ParasiteAxes, ParasiteAxesAuxTrans)
-
-import pytest
+from mpl_toolkits.axisartist import Axes, SubplotHost, ParasiteAxes
 
 
 @image_comparison(['SubplotZero.png'], style='default')
@@ -61,10 +57,9 @@ def test_Axes():
     fig.canvas.draw()
 
 
-@pytest.mark.parametrize('parasite_cls', [ParasiteAxes, ParasiteAxesAuxTrans])
 @image_comparison(['ParasiteAxesAuxTrans_meshplot.png'],
                   remove_text=True, style='default', tol=0.075)
-def test_ParasiteAxesAuxTrans(parasite_cls):
+def test_ParasiteAxesAuxTrans():
     # Remove this line when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False
 
@@ -86,8 +81,7 @@ def test_ParasiteAxesAuxTrans(parasite_cls):
         ax1 = SubplotHost(fig, 1, 3, i+1)
         fig.add_subplot(ax1)
 
-        with _api.suppress_matplotlib_deprecation_warning():
-            ax2 = parasite_cls(ax1, IdentityTransform())
+        ax2 = ParasiteAxes(ax1, IdentityTransform())
         ax1.parasites.append(ax2)
         if name.startswith('pcolor'):
             getattr(ax2, name)(xx, yy, data[:-1, :-1])


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
