### PR TITLE
Fix colorbar aspect when colorbar created, not its axes...

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -260,10 +260,9 @@ class _ColorbarAxesLocator:
         offset = extendlen[0] / len
         # we need to reset the aspect ratio of the axes to account
         # of the extends...
-        if hasattr(ax, '_colorbar_info'):
-            aspect = ax._colorbar_info['aspect']
-        else:
-            aspect = False
+
+        aspect = ax.get_box_aspect()
+        ax._colorbar_info['aspect'] = aspect
         # now shrink and/or offset to take into account the
         # extend tri/rectangles.
         if self._cbar.orientation == 'vertical':
@@ -1467,7 +1466,6 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         anchor=anchor,
         panchor=panchor,
         fraction=fraction,
-        aspect=aspect0,
         pad=pad)
     # and we need to set the aspect ratio by hand...
     cax.set_anchor(anchor)

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -261,7 +261,6 @@ class _ColorbarAxesLocator:
         # we need to reset the aspect ratio of the axes to account
         # of the extends...
 
-        aspect = ax.get_box_aspect()
         ax._colorbar_info['aspect'] = aspect
         # now shrink and/or offset to take into account the
         # extend tri/rectangles.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1465,6 +1465,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
         anchor=anchor,
         panchor=panchor,
         fraction=fraction,
+        aspect=aspect0,
         pad=pad)
     # and we need to set the aspect ratio by hand...
     cax.set_anchor(anchor)

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -260,7 +260,7 @@ class _ColorbarAxesLocator:
         offset = extendlen[0] / len
         # we need to reset the aspect ratio of the axes to account
         # of the extends...
-
+        aspect = self._cbar.ax.get_box_aspect()
         ax._colorbar_info['aspect'] = aspect
         # now shrink and/or offset to take into account the
         # extend tri/rectangles.


### PR DESCRIPTION
## PR Summary

Closes #22087 (?)

Creating a colorbar axes and then subsequently setting its aspect ratio after creation, but before creating the colorbar, failed after #20501.  That is because the new colorbar logic consults `cax._colorbar_info` for the aspect ratio of the colorbar, and we were setting that when the colorbar axes was created.  Here we change the logic so the aspect ratio is not set until the colorbar is put into the axes.  

#22087 is still broken in that users used to be able to set the aspect ratio via `cax.set_aspect`, whereas now we are using `cax.set_box_aspect`.  That could maybe be fixed.  

We probably should also allow a way for colorbars to reset their aspect ratio (#20588).  



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
