### PR TITLE
ENH: add colorbar.set_aspect

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1015,6 +1015,26 @@ class Colorbar:
         else:
             self.__scale = scale
 
+    def set_aspect(self, aspect):
+        """
+        Set ratio of the long axis to short axis.  Note this only works for axes
+        created by `~.FigureBase.colorbar`, `~.colorbar.make_axes`, or
+        `~.colorbar.make_axes_grdispec`.  User-created axes should be changed by
+        the user.
+
+        Parameters:
+        -----------
+        aspect : float
+        """
+        if not hasattr(self.ax, '_colorbar_info'):
+            raise RuntimeError('Colorbar cannot change the aspect ratio of '
+                               'user-defined axes.')
+        self.ax._colorbar_info['aspect'] = aspect
+        if self.orientation == 'horizontal':
+            aspect = 1 / aspect
+        self.ax.set_box_aspect(aspect)
+        self.ax.set_aspect('auto')
+
     def remove(self):
         """
         Remove this colorbar from the figure.


### PR DESCRIPTION
## PR Summary

Replaces #20588

Closes #22087 (?)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
