### PR TITLE
Micro-optimize rotation transform.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2002,9 +2002,16 @@ class Affine2D(Affine2DBase):
         """
         a = math.cos(theta)
         b = math.sin(theta)
-        rotate_mtx = np.array([[a, -b, 0.0], [b, a, 0.0], [0.0, 0.0, 1.0]],
-                              float)
-        self._mtx = np.dot(rotate_mtx, self._mtx)
+        mtx = self._mtx
+        # Operating and assigning one scalar at a time is much faster.
+        (xx, xy, x0), (yx, yy, y0), _ = mtx.tolist()
+        # mtx = [[a -b 0], [b a 0], [0 0 1]] * mtx
+        mtx[0, 0] = a * xx - b * yx
+        mtx[0, 1] = a * xy - b * yy
+        mtx[0, 2] = a * x0 - b * y0
+        mtx[1, 0] = b * xx + a * yx
+        mtx[1, 1] = b * xy + a * yy
+        mtx[1, 2] = b * x0 + a * y0
         self.invalidate()
         return self
 


### PR DESCRIPTION
The following test script shows a ~3x speedup.

```python
import math, numpy as np

mtx = np.array([[.1, .2, .3], [.4, .5, .6], [0, 0, 1]])
theta = np.pi / 4

def rotate(mtx, theta):
    a = math.cos(theta)
    b = math.sin(theta)
    rotate_mtx = np.array([[a, -b, 0.0], [b, a, 0.0], [0.0, 0.0, 1.0]],
                          float)
    return np.dot(rotate_mtx, mtx)

def rfast(mtx, theta):
    a = math.cos(theta)
    b = math.sin(theta)
    (xx, xy, x0), (yx, yy, y0), _ = mtx.tolist()
    # mtx = [[a -b 0], [b a 0], [0 0 1]] * mtx
    mtx[0, 0] = a * xx - b * yx
    mtx[0, 1] = a * xy - b * yy
    mtx[0, 2] = a * x0 - b * y0
    mtx[1, 0] = b * xx + a * yx
    mtx[1, 1] = b * xy + a * yy
    mtx[1, 2] = b * x0 + a * y0
    return mtx

%timeit rotate(mtx, theta)
%timeit rfast(mtx, theta)
```

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
