### PR TITLE
Right-aligned status text in backends

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -554,7 +554,8 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
 
         self.message = tk.StringVar(master=self)
         self._message_label = tk.Label(master=self, font=self._label_font,
-                                       textvariable=self.message)
+                                       textvariable=self.message,
+                                       justify=tk.RIGHT)
         self._message_label.pack(side=tk.RIGHT)
 
         NavigationToolbar2.__init__(self, canvas)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -467,6 +467,7 @@ class NavigationToolbar2GTK3(_NavigationToolbar2GTK, Gtk.Toolbar):
         toolitem = Gtk.ToolItem()
         self.insert(toolitem, -1)
         self.message = Gtk.Label()
+        self.message.set_justify(Gtk.Justification.RIGHT)
         toolitem.add(self.message)
 
         self.show_all()
@@ -530,6 +531,7 @@ class ToolbarGTK3(ToolContainerBase, Gtk.Box):
         Gtk.Box.__init__(self)
         self.set_property('orientation', Gtk.Orientation.HORIZONTAL)
         self._message = Gtk.Label()
+        self._message.set_justify(Gtk.Justification.RIGHT)
         self.pack_end(self._message, False, False, 0)
         self.show_all()
         self._groups = {}

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -402,6 +402,7 @@ class NavigationToolbar2GTK4(_NavigationToolbar2GTK, Gtk.Box):
         self.append(label)
 
         self.message = Gtk.Label()
+        self.message.set_justify(Gtk.Justification.RIGHT)
         self.append(self.message)
 
         _NavigationToolbar2GTK.__init__(self, canvas)
@@ -494,6 +495,7 @@ class ToolbarGTK4(ToolContainerBase, Gtk.Box):
         self.append(label)
 
         self._message = Gtk.Label()
+        self._message.set_justify(Gtk.Justification.RIGHT)
         self.append(self._message)
 
     def add_toolitem(self, name, group, position, image_file, description,

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1098,7 +1098,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self._coordinates = coordinates
         if self._coordinates:
             self.AddStretchableSpace()
-            self._label_text = wx.StaticText(self)
+            self._label_text = wx.StaticText(self, style=wx.ALIGN_RIGHT)
             self.AddControl(self._label_text)
 
         self.Realize()
@@ -1206,7 +1206,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
         ToolContainerBase.__init__(self, toolmanager)
         wx.ToolBar.__init__(self, parent, -1, style=style)
         self._space = self.AddStretchableSpace()
-        self._label_text = wx.StaticText(self)
+        self._label_text = wx.StaticText(self, style=wx.ALIGN_RIGHT)
         self.AddControl(self._label_text)
         self._toolitems = {}
         self._groups = {}  # Mapping of groups to the separator after them.


### PR DESCRIPTION
## PR Summary
Closes #22012

Not clear how to add a test for it.

Also, should this be documented with a "what's new"? Seems quite marginal...

(I couldn't figure out how the macosx-version worked, and do not have a mac to test it...)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
