### PR TITLE
Drop dependency on scipy in the docs.

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -29,7 +29,6 @@ dependencies:
   - numpydoc>=0.8
   - packaging
   - pydata-sphinx-theme
-  - scipy
   - sphinx>=1.8.1,!=2.0.0
   - sphinx-copybutton
   - sphinx-gallery>=0.10

--- a/examples/mplot3d/polys3d.py
+++ b/examples/mplot3d/polys3d.py
@@ -10,8 +10,8 @@ of 'jagged stained glass' effect.
 
 from matplotlib.collections import PolyCollection
 import matplotlib.pyplot as plt
+import math
 import numpy as np
-from scipy.stats import poisson
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
@@ -31,7 +31,9 @@ x = np.linspace(0., 10., 31)
 lambdas = range(1, 9)
 
 # verts[i] is a list of (x, y) pairs defining polygon i.
-verts = [polygon_under_graph(x, poisson.pmf(l, x)) for l in lambdas]
+gamma = np.vectorize(math.gamma)
+verts = [polygon_under_graph(x, l**x * np.exp(-l) / gamma(x + 1))
+         for l in lambdas]
 facecolors = plt.colormaps['viridis_r'](np.linspace(0, 1, len(verts)))
 
 poly = PolyCollection(verts, facecolors=facecolors, alpha=.7)

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -18,4 +18,3 @@ sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10
 sphinx-copybutton
 sphinx-panels
-scipy


### PR DESCRIPTION
## PR Summary

See discussion at https://github.com/matplotlib/matplotlib/pull/22043#discussion_r774668335.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
