### PR TITLE
Deprecate accepting arbitrary parameters in some get_window_extent() methods

### DIFF
--- a/doc/api/next_api_changes/deprecations/22123-TH.rst
+++ b/doc/api/next_api_changes/deprecations/22123-TH.rst
@@ -1,0 +1,4 @@
+``Axes.get_window_extent`` and ``Figure.get_window_extent`` won't accept parameters other than *renderer* anymore
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This aligns the API with the general `.Artist.get_window_extent` API.
+All parameters were ignored anyway.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -719,7 +719,9 @@ class _AxesBase(martist.Artist):
             fields += [f"ylabel={self.get_ylabel()!r}"]
         return f"<{self.__class__.__name__}:" + ", ".join(fields) + ">"
 
-    def get_window_extent(self, *args, **kwargs):
+    @_api.delete_parameter("3.6", "args")
+    @_api.delete_parameter("3.6", "kwargs")
+    def get_window_extent(self, renderer=None, *args, **kwargs):
         """
         Return the Axes bounding box in display space; *args* and *kwargs*
         are empty.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -316,7 +316,9 @@ class FigureBase(Artist):
         inside = self.bbox.contains(mouseevent.x, mouseevent.y)
         return inside, {}
 
-    def get_window_extent(self, *args, **kwargs):
+    @_api.delete_parameter("3.6", "args")
+    @_api.delete_parameter("3.6", "kwargs")
+    def get_window_extent(self, renderer=None, *args, **kwargs):
         # docstring inherited
         return self.bbox
 


### PR DESCRIPTION
## PR Summary

This will align the API with the general `.Artist.get_window_extent` API.
All parameters were ignored anyway.

After the deprecation, we'll use `get_window_extent(renderer=None)`.
