### PR TITLE
FIX: stop supporting strange pandas

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -15,7 +15,7 @@ import matplotlib as mpl
 from matplotlib import _api, cbook, docstring, offsetbox
 import matplotlib.artist as martist
 import matplotlib.axis as maxis
-from matplotlib.cbook import _OrderedSet, _check_1d, index_of
+from matplotlib.cbook import _OrderedSet, index_of
 import matplotlib.collections as mcoll
 import matplotlib.colors as mcolors
 import matplotlib.font_manager as font_manager
@@ -484,8 +484,8 @@ class _process_plot_var_args:
                 kw[prop_name] = val
 
         if len(xy) == 2:
-            x = _check_1d(xy[0])
-            y = _check_1d(xy[1])
+            x = np.atleast_1d(xy[0])
+            y = np.atleast_1d(xy[1])
         else:
             x, y = index_of(xy[-1])
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1300,47 +1300,7 @@ def _to_unmasked_float_array(x):
 
 def _check_1d(x):
     """Convert scalars to 1D arrays; pass-through arrays as is."""
-    if not hasattr(x, 'shape') or len(x.shape) < 1:
-        return np.atleast_1d(x)
-    else:
-        try:
-            # work around
-            # https://github.com/pandas-dev/pandas/issues/27775 which
-            # means the shape of multi-dimensional slicing is not as
-            # expected.  That this ever worked was an unintentional
-            # quirk of pandas and will raise an exception in the
-            # future.  This slicing warns in pandas >= 1.0rc0 via
-            # https://github.com/pandas-dev/pandas/pull/30588
-            #
-            # < 1.0rc0 : x[:, None].ndim == 1, no warning, custom type
-            # >= 1.0rc1 : x[:, None].ndim == 2, warns, numpy array
-            # future : x[:, None] -> raises
-            #
-            # This code should correctly identify and coerce to a
-            # numpy array all pandas versions.
-            with warnings.catch_warnings(record=True) as w:
-                warnings.filterwarnings(
-                    "always",
-                    category=Warning,
-                    message='Support for multi-dimensional indexing')
-
-                ndim = x[:, None].ndim
-                # we have definitely hit a pandas index or series object
-                # cast to a numpy array.
-                if len(w) > 0:
-                    return np.asanyarray(x)
-            # We have likely hit a pandas object, or at least
-            # something where 2D slicing does not result in a 2D
-            # object.
-            if ndim < 2:
-                return np.atleast_1d(x)
-            return x
-        # In pandas 1.1.0, multidimensional indexing leads to an
-        # AssertionError for some Series objects, but should be
-        # IndexError as described in
-        # https://github.com/pandas-dev/pandas/issues/35527
-        except (AssertionError, IndexError, TypeError):
-            return np.atleast_1d(x)
+    return np.atleast_1d(x)
 
 
 def _reshape_2D(X, name):
@@ -1653,7 +1613,7 @@ def index_of(y):
     except AttributeError:
         pass
     try:
-        y = _check_1d(y)
+        y = np.atleast_1d(y)
     except (np.VisibleDeprecationWarning, ValueError):
         # NumPy 1.19 will warn on ragged input, and we can't actually use it.
         pass


### PR DESCRIPTION
## PR Summary

Mostly reverts #16347.  Probably missing some edge cases...




## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
