### PR TITLE
Issue Fix #21959

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -813,8 +813,8 @@ class Axes(_AxesBase):
         # Helper method to check that vals are not unitized
         for val, name in zip(vals, names):
             if not munits._is_natively_supported(val):
-                raise ValueError(f"{name} must be a single scalar value, "
-                                 f"but got {val}")
+                raise ValueError(f"{name!r} must be a single scalar value, "
+                                 f"but got {val!r}")
 
     @docstring.dedent_interpd
     def axline(self, xy1, xy2=None, *, slope=None, **kwargs):
@@ -3075,7 +3075,7 @@ class Axes(_AxesBase):
 
         _api.check_isinstance(Number, radius=radius, startangle=startangle)
         if radius <= 0:
-            raise ValueError(f'radius must be a positive number, not {radius}')
+            raise ValueError(f'radius must be a positive number, not {radius!r}')
 
         # Starting theta1 is the start fraction of the circle
         theta1 = startangle / 360
@@ -6600,7 +6600,7 @@ such objects
             if len(color) != nx:
                 raise ValueError(f"The 'color' keyword argument must have one "
                                  f"color per dataset, but {nx} datasets and "
-                                 f"{len(color)} colors were provided")
+                                 f"{len(color!r)} colors were provided")
 
         hist_kwargs = dict()
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6600,7 +6600,7 @@ such objects
             if len(color) != nx:
                 raise ValueError(f"The 'color' keyword argument must have one "
                                  f"color per dataset, but {nx} datasets and "
-                                 f"{len(color!r)} colors were provided")
+                                 f"{len(color)} colors were provided")
 
         hist_kwargs = dict()
 


### PR DESCRIPTION
In case of ValueError caused by user given input, raw string will be displayed in Error Message.
Example:
```
raise ValueError(
                        f"'c' argument must be a color, a sequence of colors, "
                        f"or a sequence of numbers, not {c!r}")
```

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [N/A ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ N/A] New features are documented, with examples if plot related.
- [N/A ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
