### PR TITLE
Fix loading user-defined icons for Qt plot window

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -682,8 +682,14 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
         Construct a `.QIcon` from an image file *name*, including the extension
         and relative to Matplotlib's "images" data directory.
         """
-        name = name.replace('.png', '_large.png')
-        pm = QtGui.QPixmap(str(cbook._get_data_path('images', name)))
+        # use a high-resolution icon with suffix '_large' if available
+        # note: user-provided icons may not have '_large' versions
+        path_regular = cbook._get_data_path('images', name)
+        path_large = path_regular.with_name(
+            path_regular.name.replace('.png', '_large.png'))
+        filename = str(path_large if path_large.exists() else path_regular)
+
+        pm = QtGui.QPixmap(filename)
         _setDevicePixelRatio(pm, _devicePixelRatioF(self))
         if self.palette().color(self.backgroundRole()).value() < 128:
             icon_color = self.palette().color(self.foregroundRole())


### PR DESCRIPTION
## PR Summary

Closes #22131.

I'll refrain from writing a test for this because that would be quite cumbersome. One can manually test the correctness be deleting one of the `_large` icons. Then the plot window falls back to the low-res version of that icon.
It's also unlike to break again, because the comment should make future authors aware that we have to have the fall back for user icons.