### PR TITLE
Fix clearing subfigures

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -913,6 +913,45 @@ default: %(va)s
         # Break link between any twinned axes
         _break_share_link(ax, ax._twinned_axes)
 
+    def clf(self, keep_observers=False):
+        """
+        Clear the figure.
+
+        Parameters
+        ----------
+        keep_observers: bool, default: False
+            Set *keep_observers* to True if, for example,
+            a gui widget is tracking the Axes in the figure.
+        """
+        self.suppressComposite = None
+        self.callbacks = cbook.CallbackRegistry()
+
+        # first clear the axes in any subfigures
+        for subfig in self.subfigs:
+            subfig.clf(keep_observers=keep_observers)
+        self.subfigs = []
+
+        for ax in tuple(self.axes):  # Iterate over the copy.
+            ax.cla()
+            self.delaxes(ax)  # Remove ax from self._axstack.
+
+        self.artists = []
+        self.lines = []
+        self.patches = []
+        self.texts = []
+        self.images = []
+        self.legends = []
+        if not keep_observers:
+            self._axobservers = cbook.CallbackRegistry()
+        self._suptitle = None
+        self._supxlabel = None
+        self._supylabel = None
+
+        self.stale = True
+
+    # synonym for `clf`."""
+    clear = clf
+
     # Note: in the docstring below, the newlines in the examples after the
     # calls to legend() allow replacing it with figlegend() to generate the
     # docstring of pyplot.figlegend.
@@ -2801,40 +2840,13 @@ class Figure(FigureBase):
         self.set_size_inches(self.get_figwidth(), val, forward=forward)
 
     def clf(self, keep_observers=False):
-        """
-        Clear the figure.
-
-        Set *keep_observers* to True if, for example,
-        a gui widget is tracking the Axes in the figure.
-        """
-        self.suppressComposite = None
-        self.callbacks = cbook.CallbackRegistry()
-
-        for ax in tuple(self.axes):  # Iterate over the copy.
-            ax.cla()
-            self.delaxes(ax)  # Remove ax from self._axstack.
-
+        # docstring inherited
+        super().clf(keep_observers=keep_observers)
+        # FigureBase.clf does not clear toolbars, as
+        # only Figure can have toolbars
         toolbar = self.canvas.toolbar
         if toolbar is not None:
             toolbar.update()
-        self._axstack = _AxesStack()
-        self.artists = []
-        self.lines = []
-        self.patches = []
-        self.texts = []
-        self.images = []
-        self.legends = []
-        if not keep_observers:
-            self._axobservers = cbook.CallbackRegistry()
-        self._suptitle = None
-        self._supxlabel = None
-        self._supylabel = None
-
-        self.stale = True
-
-    def clear(self, keep_observers=False):
-        """Clear the figure -- synonym for `clf`."""
-        self.clf(keep_observers=keep_observers)
 
     @_finalize_rasterization
     @allow_rasterization

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -709,6 +709,87 @@ def test_removed_axis():
     fig.canvas.draw()
 
 
+def test_figure_clear():
+    # we test the following figure clearing scenarios:
+    fig = plt.figure()
+
+    # a) an empty figure
+    fig.clear()
+    assert fig.axes == []
+
+    # b) a figure with a single unnested axes
+    ax = fig.add_subplot(111)
+    fig.clear()
+    assert fig.axes == []
+
+    # c) a figure multiple unnested axes
+    axes = [fig.add_subplot(2, 1, i+1) for i in range(2)]
+    fig.clear()
+    assert fig.axes == []
+
+    # d) a figure with a subfigure
+    gs = fig.add_gridspec(ncols=2, nrows=1)
+    subfig = fig.add_subfigure(gs[0])
+    subaxes = subfig.add_subplot(111)
+    fig.clear()
+    assert subfig not in fig.subfigs
+    assert fig.axes == []
+
+    # e) a figure with a subfigure and a subplot
+    subfig = fig.add_subfigure(gs[0])
+    subaxes = subfig.add_subplot(111)
+    mainaxes = fig.add_subplot(gs[1])
+
+    # e.1) removing just the axes leaves the subplot
+    mainaxes.remove()
+    assert fig.axes == [subaxes]
+
+    # e.2) removing just the subaxes leaves the subplot
+    # and subfigure
+    mainaxes = fig.add_subplot(gs[1])
+    subaxes.remove()
+    assert fig.axes == [mainaxes]
+    assert subfig in fig.subfigs
+
+    # e.3) clearing the subfigure leaves the subplot
+    subaxes = subfig.add_subplot(111)
+    assert mainaxes in fig.axes
+    assert subaxes in fig.axes
+    subfig.clear()
+    assert subfig in fig.subfigs
+    assert subaxes not in subfig.axes
+    assert subaxes not in fig.axes
+    assert mainaxes in fig.axes
+
+    # e.4) clearing the whole thing
+    subaxes = subfig.add_subplot(111)
+    fig.clear()
+    assert fig.axes == []
+    assert fig.subfigs == []
+
+    # f) multiple subfigures
+    subfigs = [fig.add_subfigure(gs[i]) for i in [0, 1]]
+    subaxes = [sfig.add_subplot(111) for sfig in subfigs]
+    assert all(ax in fig.axes for ax in subaxes)
+    assert all(sfig in fig.subfigs for sfig in subfigs)
+
+    # f.1) clearing only one subfigure
+    subfigs[0].clear()
+    assert subaxes[0] not in fig.axes
+    assert subaxes[1] in fig.axes
+    assert subfigs[1] in fig.subfigs
+
+    # f.2) clearing the whole thing
+    subfigs[1].clear()
+    subfigs = [fig.add_subfigure(gs[i]) for i in [0, 1]]
+    subaxes = [sfig.add_subplot(111) for sfig in subfigs]
+    assert all(ax in fig.axes for ax in subaxes)
+    assert all(sfig in fig.subfigs for sfig in subfigs)
+    fig.clear()
+    assert fig.subfigs == []
+    assert fig.axes == []
+
+
 @mpl.style.context('mpl20')
 def test_picking_does_not_stale():
     fig, ax = plt.subplots()


### PR DESCRIPTION
## PR Summary

Closes #22137 

``Figure.clf()`` and ``Figure.clear()`` were broken 
when ``Figure`` contained axes not stored in `Figure._localaxes`. #  Moved the
``clear`` and ``clf`` methods to ``FigureBase``, so ``Subfigure``s can now be
independently cleared. Added a routine to clear ``Figure.subfigs`` when 
``Figure.clear()`` is called. This effects the API as it removes active 
subfigure references when clearing a figure.     

This scenario occurred when ``Figure`` was instantiated with ``Subfigure``s.
The bug was thrown in a call to ``_localaxes.remove`` in ``FigureBase.delaxes``.
The children ``Subfigure``s do not register their axes in ``_localaxes``,
which meant that the ``_localaxes`` are empty during clear, leading to the bug.
This was fixed first by moving the ``.clear`` and ``.clf``
methods into ``FigureBase``, so that ``Subfigure`` would inherit these methods.
This allowed for ``Subfigure`` to clear its own axes, but because each child 
``Subfigure`` shares its ``_axstack`` with its parent ``Figure``, the ``clf``
function had to be modified: an extra call to ``_axstack.clear`` was removed.
This call had no effect on normal operation, as the stack is previously cleared
in ``clf`` by iterating over the ``_localaxes`` returned by ``FigureBase.axes``;
however, in the case of ``Subfigure.clear``, ``_axstack.clear`` cleared
the entire ``_axstack`` of the parent, thus wiping all axes independent of their
parent subfigure/figure. With these two changes (``clf/clear`` inheritance and 
removing the call to ``_axstack``), subfigures can now be cleared.  
However, the initial bug remained. To fix the bug in the clearing of the parent figure,
an additional loop was added to the beginning of ``clf``. This loop recurses through
child ``Subfigures``,clearing all children before returning to the original function.
As the child axes, which live in ``_axstack`` but not ``_localaxes``, are no longer in 
``Figure.axes``, the remainder of ``clf`` functions as before, clearing out
``Figure.axes`` without risk of calling ``delaxes`` on an axis that is not contained in
``_localaxes``. Finally, to make ``FigureBase.clf`` an exhaustive function that truely removes
all references to child objects, a line was added to clear ``Figure.subfigs`` of any
unlinked, cleared subfigures.

## PR Checklist

**Tests and Styling**
- [ x] Has pytest style unit tests (and `pytest` passes).
- [x ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ x] New features are documented, with examples if plot related.
- [ x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
