### PR TITLE
Fix check 1d

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1306,9 +1306,6 @@ def _check_1d(x):
     if not hasattr(x, 'shape') or len(x.shape) < 1:
         return np.atleast_1d(x)
     else:
-        ndim = x[:, None].ndim
-        if ndim < 2:
-            return np.atleast_1d(x)
         return x
 
 

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -1339,7 +1339,8 @@ def _check_1d(x):
         # AssertionError for some Series objects, but should be
         # IndexError as described in
         # https://github.com/pandas-dev/pandas/issues/35527
-        except (AssertionError, IndexError, TypeError):
+        # ValueError: https://github.com/matplotlib/matplotlib/issues/22125
+        except (AssertionError, IndexError, TypeError, ValueError):
             return np.atleast_1d(x)
 
 
@@ -1649,7 +1650,7 @@ def index_of(y):
        The x and y values to plot.
     """
     try:
-        return y.index.values, y.values
+        return y.index.to_numpy(), y.to_numpy()
     except AttributeError:
         pass
     try:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1749,11 +1749,12 @@ def test_bar_hatches(fig_test, fig_ref):
 
 def test_pandas_minimal_plot(pd):
     # smoke test that series and index objcets do not warn
-    x = pd.Series([1, 2], dtype="float64")
-    plt.plot(x, x)
-    plt.plot(x.index, x)
-    plt.plot(x)
-    plt.plot(x.index)
+    for x in [pd.Series([1, 2], dtype="float64"),
+              pd.Series([1, 2], dtype="Float32")]:
+        plt.plot(x, x)
+        plt.plot(x.index, x)
+        plt.plot(x)
+        plt.plot(x.index)
 
 
 @image_comparison(['hist_log'], remove_text=True)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1750,11 +1750,14 @@ def test_bar_hatches(fig_test, fig_ref):
 def test_pandas_minimal_plot(pd):
     # smoke test that series and index objcets do not warn
     for x in [pd.Series([1, 2], dtype="float64"),
-              pd.Series([1, 2], dtype="Float32")]:
+              pd.Series([1, 2], dtype="Float64")]:
         plt.plot(x, x)
         plt.plot(x.index, x)
         plt.plot(x)
         plt.plot(x.index)
+    df = pd.DataFrame({'col': [1, 2, 3]})
+    plt.plot(df)
+    plt.plot(df, df)
 
 
 @image_comparison(['hist_log'], remove_text=True)


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/22125 and #22330

This was an issue with handling 

```
x = pd.Series(x, dtype="Float32")  
```

in the logic of our plot argument parsing.

`x.values` returns a `FloatingArray`.  But it doesn't behave like a numpy array, in that `x.values[:, None]` returns a `ValueError: values must be a 1D array`.  I actually think this is a Pandas bug, but I'll leave that to someone with more pandas knowledge to inform them.  However, we can get around it by using `x.to_numpy()` which seems to work fine.  



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
