### PR TITLE
Fix cl subgridspec

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -203,9 +203,9 @@ def make_layoutgrids_gs(layoutgrids, gs):
         if parentgs not in layoutgrids:
             layoutgrids = make_layoutgrids_gs(layoutgrids, parentgs)
         subspeclb = layoutgrids[parentgs]
-        # get a unique representation:
-        rep = object.__repr__(gs) + 'top'
         # gridspecfromsubplotspec need an outer container:
+        # get a unique representation:
+        rep = (gs, 'top')
         if rep not in layoutgrids:
             layoutgrids[rep] = mlayoutgrid.LayoutGrid(
                 parent=subspeclb,

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -203,15 +203,17 @@ def make_layoutgrids_gs(layoutgrids, gs):
         if parentgs not in layoutgrids:
             layoutgrids = make_layoutgrids_gs(layoutgrids, parentgs)
         subspeclb = layoutgrids[parentgs]
+        # get a unique representation:
+        rep = object.__repr__(gs) + 'top'
         # gridspecfromsubplotspec need an outer container:
-        if f'{gs}top' not in layoutgrids:
-            layoutgrids[f'{gs}top'] = mlayoutgrid.LayoutGrid(
+        if rep not in layoutgrids:
+            layoutgrids[rep] = mlayoutgrid.LayoutGrid(
                 parent=subspeclb,
                 name='top',
                 nrows=1, ncols=1,
                 parent_pos=(subplot_spec.rowspan, subplot_spec.colspan))
         layoutgrids[gs] = mlayoutgrid.LayoutGrid(
-                parent=layoutgrids[f'{gs}top'],
+                parent=layoutgrids[rep],
                 name='gridspec',
                 nrows=gs._nrows, ncols=gs._ncols,
                 width_ratios=gs.get_width_ratios(),

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -115,6 +115,26 @@ def test_constrained_layout6():
                  ticks=ticker.MaxNLocator(nbins=5))
 
 
+def test_identical_subgridspec():
+
+    fig = plt.figure(constrained_layout=True)
+
+    GS = fig.add_gridspec(2, 1)
+
+    GSA = GS[0].subgridspec(1, 3)
+    GSB = GS[1].subgridspec(1, 3)
+
+    axa = []
+    axb = []
+    for i in range(3):
+        axa += [fig.add_subplot(GSA[i])]
+        axb += [fig.add_subplot(GSB[i])]
+
+    fig.draw_without_rendering()
+    # chech first row above second
+    assert axa[0].get_position().y0 > axb[0].get_position().y1
+
+
 def test_constrained_layout7():
     """Test for proper warning if fig not set in GridSpec"""
     with pytest.warns(


### PR DESCRIPTION
## PR Summary
Closes #22143

If subgridspecs were identical, then their strings were identical, and the dictionary we had for the layoutgrids was being addressed with the same key twice.  Changed the key to a unique repr for the subgridspec.   

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
