### PR TITLE
Add some tests for minspan{x,y} in RectangleSelector

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -59,6 +59,47 @@ def test_rectangle_selector():
     check_rectangle(props=dict(fill=True))
 
 
+@pytest.mark.parametrize('spancoords', ['data', 'pixels'])
+@pytest.mark.parametrize('minspanx, x1', [[0, 10], [1, 10.5], [1, 11]])
+@pytest.mark.parametrize('minspany, y1', [[0, 10], [1, 10.5], [1, 11]])
+def test_rectangle_minspan(spancoords, minspanx, x1, minspany, y1):
+    ax = get_ax()
+    # attribute to track number of onselect calls
+    ax._n_onselect = 0
+
+    def onselect(epress, erelease):
+        ax._n_onselect += 1
+        ax._epress = epress
+        ax._erelease = erelease
+
+    x0, y0 = (10, 10)
+    if spancoords == 'pixels':
+        minspanx, minspany = (ax.transData.transform((x1, y1)) -
+                              ax.transData.transform((x0, y0)))
+
+    tool = widgets.RectangleSelector(ax, onselect, interactive=True,
+                                     spancoords=spancoords,
+                                     minspanx=minspanx, minspany=minspany)
+    # Too small to create a selector
+    click_and_drag(tool, start=(x0, x1), end=(y0, y1))
+    assert not tool._selection_completed
+    assert ax._n_onselect == 0
+
+    click_and_drag(tool, start=(20, 20), end=(30, 30))
+    assert tool._selection_completed
+    assert ax._n_onselect == 1
+
+    # Too small to create a selector. Should clear exising selector, and
+    # trigger onselect because there was a pre-exisiting selector
+    click_and_drag(tool, start=(x0, y0), end=(x1, y1))
+    assert not tool._selection_completed
+    assert ax._n_onselect == 2
+    assert ax._epress.xdata == x0
+    assert ax._epress.ydata == y0
+    assert ax._erelease.xdata == x1
+    assert ax._erelease.ydata == y1
+
+
 @pytest.mark.parametrize('drag_from_anywhere, new_center',
                          [[True, (60, 75)],
                           [False, (30, 20)]])


### PR DESCRIPTION
## PR Summary
There aren't currently any tests for the `minspan{x,y}` arguments, so add some. There isn't any public API for checking if a given selector is currently 'active', so I had to use the private `tool._selection_completed` flag for that.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
