### PR TITLE
Improved coverage of mathtext and removed unused code

### DIFF
--- a/lib/matplotlib/_mathtext_data.py
+++ b/lib/matplotlib/_mathtext_data.py
@@ -1116,6 +1116,7 @@ tex2uni = {
     'cwopencirclearrow'        : 8635,
     'geqq'                     : 8807,
     'rightleftarrows'          : 8644,
+    'aa'                       : 229,
     'ac'                       : 8766,
     'ae'                       : 230,
     'int'                      : 8747,

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -257,6 +257,11 @@ def test_fontinfo():
         (r'$\dfrac{}{}$', r'Expected \dfrac{num}{den}'),
         (r'$\overset$', r'Expected \overset{body}{annotation}'),
         (r'$\underset$', r'Expected \underset{body}{annotation}'),
+        (r'$\foo$', r'Unknown symbol: \foo'),
+        (r'$a^2^2$', r'Double superscript'),
+        (r'$a_2_2$', r'Double subscript'),
+        (r'$a^2_a^2$', r'Subscript/superscript sequence is too long.'\
+            r' Use braces { } to remove ambiguity.'),
     ],
     ids=[
         'hspace without value',
@@ -279,6 +284,10 @@ def test_fontinfo():
         'dfrac with empty parameters',
         'overset without parameters',
         'underset without parameters',
+        'unknown symbol',
+        'double superscript',
+        'double subscript',
+        'super on sub without braces'
     ]
 )
 def test_mathtext_exceptions(math, msg):
@@ -286,6 +295,11 @@ def test_mathtext_exceptions(math, msg):
     match = re.escape(msg) if isinstance(msg, str) else msg
     with pytest.raises(ValueError, match=match):
         parser.parse(math)
+
+
+def test_get_unicode_index_exception():
+    with pytest.raises(ValueError):
+        _mathtext.get_unicode_index(r'\foo')
 
 
 def test_single_minus_sign():


### PR DESCRIPTION
## PR Summary

I set out to improve the test coverage of `mathtext` and related modules.

The method `c_over_c` only had support `\AA`. However, that is not used in any of the practical cases as the Unicode mapping is used instead. Hence, I removed `c_over_c`. There is of course a risk that there will be fonts used that do not have a Unicode mapping for it, but since `\AA` has a quite low code point (197), it seems unlikely that it will render any sensible maths anyway.

I also added support for `\aa` (the lower case version of `\AA`) which earlier gave an error.

Not sure if and where this should go in the documentation of the next version. Maybe not worth mention that `\aa` is now supported?

For tests, it primarily ended up in triggering exceptions.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
