### PR TITLE
Add box when setting `PolygonSelector.verts`

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1332,17 +1332,20 @@ def test_polygon_selector_redraw(ax, draw_bounding_box):
     assert tool.verts == verts[0:2]
 
 
-@check_figures_equal()
-def test_polygon_selector_verts_setter(fig_test, fig_ref):
+@pytest.mark.parametrize('draw_bounding_box', [False, True])
+@check_figures_equal(extensions=['png'])
+def test_polygon_selector_verts_setter(fig_test, fig_ref, draw_bounding_box):
     verts = [(0.1, 0.4), (0.5, 0.9), (0.3, 0.2)]
     ax_test = fig_test.add_subplot()
 
-    tool_test = widgets.PolygonSelector(ax_test, onselect=noop)
+    tool_test = widgets.PolygonSelector(
+        ax_test, onselect=noop, draw_bounding_box=draw_bounding_box)
     tool_test.verts = verts
     assert tool_test.verts == verts
 
     ax_ref = fig_ref.add_subplot()
-    tool_ref = widgets.PolygonSelector(ax_ref, onselect=noop)
+    tool_ref = widgets.PolygonSelector(
+        ax_ref, onselect=noop, draw_bounding_box=draw_bounding_box)
     event_sequence = (polygon_place_vertex(*verts[0]) +
                       polygon_place_vertex(*verts[1]) +
                       polygon_place_vertex(*verts[2]) +

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -3928,6 +3928,8 @@ class PolygonSelector(_SelectorWidget):
         self._ys.append(self._ys[0])
         self._selection_completed = True
         self.set_visible(True)
+        if self._draw_box and self._box is None:
+            self._add_box()
         self._draw_polygon()
 
 


### PR DESCRIPTION
## PR Summary
Previously when using `.verts` manually as a setter the box wasn't drawn.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
