### PR TITLE
Deprecate selector `visible` attribute

### DIFF
--- a/doc/api/next_api_changes/deprecations/22167-EP.rst
+++ b/doc/api/next_api_changes/deprecations/22167-EP.rst
@@ -1,0 +1,4 @@
+Selector widget state internals
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The *visible* attribute has been deprecated, use *set_visible* or
+*get_visible* instead.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -104,6 +104,19 @@ def test_rectangle_minspan(ax, spancoords, minspanx, x1, minspany, y1):
     assert ax._erelease.ydata == y1
 
 
+def test_deprecation_selector_visible_attribute():
+    ax = get_ax()
+    tool = widgets.RectangleSelector(ax, lambda *args: None)
+
+    assert tool.get_visible()
+
+    with pytest.warns(
+        MatplotlibDeprecationWarning,
+            match="was deprecated in Matplotlib 3.6"):
+        tool.visible = False
+    assert not tool.get_visible()
+
+
 @pytest.mark.parametrize('drag_from_anywhere, new_center',
                          [[True, (60, 75)],
                           [False, (30, 20)]])
@@ -789,18 +802,18 @@ def test_selector_clear_method(ax, selector):
         tool = widgets.RectangleSelector(ax, onselect=noop, interactive=True)
     click_and_drag(tool, start=(10, 10), end=(100, 120))
     assert tool._selection_completed
-    assert tool.visible
+    assert tool.get_visible()
     if selector == 'span':
         assert tool.extents == (10, 100)
 
     tool.clear()
     assert not tool._selection_completed
-    assert not tool.visible
+    assert not tool.get_visible()
 
     # Do another cycle of events to make sure we can
     click_and_drag(tool, start=(10, 10), end=(50, 120))
     assert tool._selection_completed
-    assert tool.visible
+    assert tool.get_visible()
     if selector == 'span':
         assert tool.extents == (10, 50)
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1804,7 +1804,7 @@ class _SelectorWidget(AxesWidget):
                  state_modifier_keys=None, use_data_coordinates=False):
         super().__init__(ax)
 
-        self.visible = True
+        self._visible = True
         self.onselect = onselect
         self.useblit = useblit and self.canvas.supports_blit
         self.connect_default_events()
@@ -2052,10 +2052,23 @@ class _SelectorWidget(AxesWidget):
         """Key release event handler."""
 
     def set_visible(self, visible):
-        """Set the visibility of our artists."""
-        self.visible = visible
+        """Set the visibility of the selector artists."""
+        self._visible = visible
         for artist in self.artists:
             artist.set_visible(visible)
+
+    def get_visible(self):
+        """Get the visibility of the selector artists."""
+        return self._visible
+
+    @property
+    def visible(self):
+        return self.get_visible()
+
+    @visible.setter
+    def visible(self, visible):
+        _api.warn_deprecated("3.6", alternative="set_visible")
+        self.set_visible(visible)
 
     def clear(self):
         """Clear the selection and set the selector ready to make a new one."""
@@ -2266,8 +2279,6 @@ class SpanSelector(_SelectorWidget):
         props['animated'] = self.useblit
 
         self.direction = direction
-
-        self.visible = True
         self._extents_on_press = None
         self.snap_values = snap_values
 
@@ -2405,11 +2416,11 @@ class SpanSelector(_SelectorWidget):
             # when the press event outside the span, we initially set the
             # visibility to False and extents to (v, v)
             # update will be called when setting the extents
-            self.visible = False
+            self._visible = False
             self.extents = v, v
             # We need to set the visibility back, so the span selector will be
             # drawn when necessary (span width > 0)
-            self.visible = True
+            self._visible = True
         else:
             self.set_visible(True)
 
@@ -2598,7 +2609,7 @@ class SpanSelector(_SelectorWidget):
         if self._interactive:
             # Update displayed handles
             self._edge_handles.set_data(self.extents)
-        self.set_visible(self.visible)
+        self.set_visible(self._visible)
         self.update()
 
 
@@ -2912,7 +2923,6 @@ class RectangleSelector(_SelectorWidget):
                          state_modifier_keys=state_modifier_keys,
                          use_data_coordinates=use_data_coordinates)
 
-        self.visible = True
         self._interactive = interactive
         self.drag_from_anywhere = drag_from_anywhere
         self.ignore_event_outside = ignore_event_outside
@@ -2931,14 +2941,14 @@ class RectangleSelector(_SelectorWidget):
                                "%(removal)s."
                                "Use props=dict(visible=False) instead.")
             drawtype = 'line'
-            self.visible = False
+            self._visible = False
 
         if drawtype == 'box':
             if props is None:
                 props = dict(facecolor='red', edgecolor='black',
                              alpha=0.2, fill=True)
             props['animated'] = self.useblit
-            self.visible = props.pop('visible', self.visible)
+            self._visible = props.pop('visible', self._visible)
             self._props = props
             to_draw = self._init_shape(**self._props)
             self.ax.add_patch(to_draw)
@@ -3035,9 +3045,9 @@ class RectangleSelector(_SelectorWidget):
                 self._allow_creation):
             x = event.xdata
             y = event.ydata
-            self.visible = False
+            self._visible = False
             self.extents = x, x, y, y
-            self.visible = True
+            self._visible = True
         else:
             self.set_visible(True)
 
@@ -3331,7 +3341,7 @@ class RectangleSelector(_SelectorWidget):
             self._corner_handles.set_data(*self.corners)
             self._edge_handles.set_data(*self.edge_centers)
             self._center_handle.set_data(*self.center)
-        self.set_visible(self.visible)
+        self.set_visible(self._visible)
         self.update()
 
     @property

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2072,9 +2072,12 @@ class _SelectorWidget(AxesWidget):
 
     def clear(self):
         """Clear the selection and set the selector ready to make a new one."""
+        self._clear_without_update()
+        self.update()
+
+    def _clear_without_update(self):
         self._selection_completed = False
         self.set_visible(False)
-        self.update()
 
     @property
     def artists(self):
@@ -3092,12 +3095,10 @@ class RectangleSelector(_SelectorWidget):
         # either x or y-direction
         minspanxy = (spanx <= self.minspanx or spany <= self.minspany)
         if (self._drawtype != 'none' and minspanxy):
-            for artist in self.artists:
-                artist.set_visible(False)
             if self._selection_completed:
                 # Call onselect, only when the selection is already existing
                 self.onselect(self._eventpress, self._eventrelease)
-            self._selection_completed = False
+            self._clear_without_update()
         else:
             self.onselect(self._eventpress, self._eventrelease)
             self._selection_completed = True


### PR DESCRIPTION
## PR Summary

As noticed in #22146, the use of the selector `visible` attribute is ambiguous. This PR deprecate the `visible` attribute in favour of using `set_visible`/`get_visible` to be consistent with other matplotlib objects.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
