### PR TITLE
Give the Tk toolbar buttons a flat look

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -658,7 +658,10 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
 
     def _Button(self, text, image_file, toggle, command):
         if not toggle:
-            b = tk.Button(master=self, text=text, command=command)
+            b = tk.Button(
+                master=self, text=text, command=command,
+                relief="flat", overrelief="groove", borderwidth=1,
+            )
         else:
             # There is a bug in tkinter included in some python 3.6 versions
             # that without this variable, produces a "visual" toggling of
@@ -667,8 +670,10 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
             # https://bugs.python.org/issue25684
             var = tk.IntVar(master=self)
             b = tk.Checkbutton(
-                master=self, text=text, command=command,
-                indicatoron=False, variable=var)
+                master=self, text=text, command=command, indicatoron=False,
+                variable=var, offrelief="flat", overrelief="groove",
+                borderwidth=1
+            )
             b.var = var
         b._image_file = image_file
         if image_file is not None:


### PR DESCRIPTION
## PR Summary
This changes the parameters of the buttons in the Tk navigation toolbar to give them a flat look (with an outline showing when the mouse is over the button), similar to the Qt backend. For comparison:
Old:
![old](https://user-images.githubusercontent.com/6144189/148693449-0ddfb5d2-c076-4e38-8093-47bfe1e9fe99.png)
New:
![new](https://user-images.githubusercontent.com/6144189/148693451-9079aa73-7338-4a7d-838a-b9710aeaaa4b.png)

