### PR TITLE
FIX: Update macosx animation handling

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1199,9 +1199,16 @@ class Animation:
         # axes
         self._blit_cache = dict()
         self._drawn_artists = []
+        # _post_draw needs to be called first to initialize the renderer
+        self._post_draw(None, self._blit)
+        # Then we need to clear the Frame for the initial draw
+        # This is typically handled in _on_resize because QT and Tk
+        # emit a resize event on launch, but the macosx backend does not,
+        # thus we force it here for everyone for consistency
+        self._init_draw()
+        # Connect to future resize events
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
                                                        self._on_resize)
-        self._post_draw(None, self._blit)
 
     def _on_resize(self, event):
         # On resize, we need to disable the resize event handling so we don't

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1329,6 +1329,8 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
         goto exit;
     }
     if (PyObject_IsTrue(change)) {
+        // Notify that there was a resize_event that took place
+        gil_call_method(canvas, "resize_event");
         [self setNeedsDisplay: YES];
     }
 


### PR DESCRIPTION
## PR Summary
- Emit a resize_event signal when the pixel ratio is updated. This
  enables an animation to move between hidpi and standard dpi screens
  without ruining the blitting.

- Init the draw in the animation. This is only necessary for macosx
  because an initial resize isn't emitted upon figure manager creation,
  versus the other backends where it is. This would cause the first frame
  to be stale on the macosx animations when used with blitting.

Closes #18451

This is the example I was testing with that kept the first frame previously, but now updates as expected like the other backends.
https://matplotlib.org/stable/gallery/animation/simple_anim.html

I'm not sure if there is a simple test for these updates as they are interactive-based primarily. Happy to add one if someone has a good idea for how to verify this without seeing it.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
