### PR TITLE
Document ArtistList

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -607,3 +607,5 @@ Other
    Axes.get_transformed_clip_path_and_affine
    Axes.has_data
    Axes.set
+
+.. autoclass:: matplotlib.axes.Axes.ArtistList

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1317,8 +1317,12 @@ class _AxesBase(martist.Artist):
         """
         A sublist of Axes children based on their type.
 
-        This exists solely to warn on modification. In the future, the
-        type-specific children sublists will be immutable tuples.
+        The type-specific children sublists will become immutable in
+        Matplotlib 3.7. Then, these artist lists will likely be replaced by
+        tuples. Use as if this is a tuple already.
+
+        This class exists only for the transition period to warn on the
+        deprecated modifcation of artist lists.
         """
         def __init__(self, axes, prop_name, add_name,
                      valid_types=None, invalid_types=None):


### PR DESCRIPTION
## PR Summary

Closes #22094.

While `ArtistList` will vanish again in 3.7. Users can encounter it and thus should know what it is and how it is supposed to be used.