### PR TITLE
ENH: Use rcParams savefig.directory on macosx backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -1,3 +1,5 @@
+import os
+
 import matplotlib as mpl
 from matplotlib import cbook
 from matplotlib._pylab_helpers import Gcf
@@ -118,10 +120,15 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
         self.canvas.remove_rubberband()
 
     def save_figure(self, *args):
+        directory = os.path.expanduser(mpl.rcParams['savefig.directory'])
         filename = _macosx.choose_save_file('Save the figure',
+                                            directory,
                                             self.canvas.get_default_filename())
         if filename is None:  # Cancel
             return
+        # Save dir for next time, unless empty str (which means use cwd).
+        if mpl.rcParams['savefig.directory']:
+            mpl.rcParams['savefig.directory'] = os.path.dirname(filename)
         self.canvas.figure.savefig(filename)
 
     def prepare_configure_subplots(self):

--- a/lib/matplotlib/tests/test_backend_macosx.py
+++ b/lib/matplotlib/tests/test_backend_macosx.py
@@ -1,10 +1,13 @@
+import os
+
 import pytest
 
+import matplotlib as mpl
 import matplotlib.pyplot as plt
-
-
-pytest.importorskip("matplotlib.backends.backend_macosx",
-                    reason="These are mac only tests")
+try:
+    from matplotlib.backends import _macosx
+except ImportError:
+    pytest.skip("These are mac only tests", allow_module_level=True)
 
 
 @pytest.mark.backend('macosx')
@@ -18,3 +21,26 @@ def test_cached_renderer():
     fig = plt.figure(2)
     fig.draw_without_rendering()
     assert fig._cachedRenderer is not None
+
+
+@pytest.mark.backend('macosx')
+def test_savefig_rcparam(monkeypatch, tmp_path):
+
+    def new_choose_save_file(title, directory, filename):
+        # Replacement function instead of opening a GUI window
+        # Make a new directory for testing the update of the rcParams
+        assert directory == str(tmp_path)
+        os.makedirs(f"{directory}/test")
+        return f"{directory}/test/{filename}"
+
+    monkeypatch.setattr(_macosx, "choose_save_file", new_choose_save_file)
+    fig = plt.figure()
+    with mpl.rc_context({"savefig.directory": tmp_path}):
+        fig.canvas.toolbar.save_figure()
+        # Check the saved location got created
+        save_file = f"{tmp_path}/test/{fig.canvas.get_default_filename()}"
+        assert os.path.exists(save_file)
+
+        # Check the savefig.directory rcParam got updated because
+        # we added a subdirectory "test"
+        assert mpl.rcParams["savefig.directory"] == f"{tmp_path}/test"


### PR DESCRIPTION
## PR Summary

This adds the rcParams savefig.directory option into the macosx
backend for the savefig dialog window.

Additionally cleans up some of the UTF8 string allocations in this code block.

Closes #21710

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
