### PR TITLE
DOC: Add hatch API to reference

### DIFF
--- a/doc/api/hatch_api.rst
+++ b/doc/api/hatch_api.rst
@@ -1,0 +1,8 @@
+********************
+``matplotlib.hatch``
+********************
+
+.. automodule:: matplotlib.hatch
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -65,6 +65,7 @@ Alphabetical list of modules:
    font_manager_api.rst
    fontconfig_pattern_api.rst
    gridspec_api.rst
+   hatch_api.rst
    image_api.rst
    legend_api.rst
    legend_handler_api.rst

--- a/doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst
@@ -198,8 +198,8 @@ This affects `.ContourSet` itself and its subclasses, `.QuadContourSet`
 ``hatch.SmallFilledCircles`` inherits from ``hatch.Circles``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``hatch.SmallFilledCircles`` class now inherits from ``hatch.Circles``
-rather than from ``hatch.SmallCircles``.
+The `.hatch.SmallFilledCircles` class now inherits from `.hatch.Circles` rather
+than from `.hatch.SmallCircles`.
 
 hexbin with a log norm
 ~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## PR Summary

We don't have much there, but it may eventually be expanded.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).