### PR TITLE
DOC: Fix upstream URL for merge in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ commands:
           name: Merge with upstream
           command: |
             if ! git remote -v | grep upstream; then
-              git remote add upstream git://github.com/matplotlib/matplotlib.git
+              git remote add upstream https://github.com/matplotlib/matplotlib.git
             fi
             git fetch upstream
             if [[ "$CIRCLE_BRANCH" != "main" ]] && \


### PR DESCRIPTION
## PR Summary

The git:// URL is not supported and causing the following error:

>   The unauthenticated git protocol on port 9418 is no longer supported.
> Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).