### PR TITLE
`dates` classes and functions support `tz` both as string and `tzinfo`

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -395,7 +395,9 @@ def datestr2num(d, default=None):
         return date2num(dt)
     else:
         if default is not None:
-            d = [dateutil.parser.parse(s, default=default) for s in d]
+            d = [date2num(dateutil.parser.parse(s, default=default))
+                 for s in d]
+            return np.asarray(d)
         d = np.asarray(d)
         if not d.size:
             return d

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1594,7 +1594,7 @@ class Locator(TickHelper):
 
         .. note::
             To get tick locations with the vmin and vmax values defined
-            automatically for the associated :attr:`axis` simply call
+            automatically for the associated ``axis`` simply call
             the Locator instance::
 
                 >>> print(type(loc))


### PR DESCRIPTION
## PR Summary

Edit:
There were inconsistent use/documentation of the `tz` parameters in `dates`, where the documentation stated string in some cases, although only `tzinfo` was working. Now, both approaches do work (and there is even an error if the `rcParams`-provided string is not a valid time zone). See below for discussion.

Original purpose: Added a bunch of tests for `dates.py` to increase coverage.

In addition: Found an issue with `datestr2num` where passing a list and a default `datetime` object gives an error in current `main`.

``` python
import datetime
import matplotlib.dates as mdates

dt = datetime.date(year=2022, month=1, day=10)
mdates.datestr2num(['2022-01', '2022-02'], default=dt)
```
results in
```
Traceback (most recent call last):

  File "/tmp/ipykernel_117358/3002628473.py", line 1, in <module>
    mdates.datestr2num(['2022-01', '2022-02'], default=dt)

  File "/home/oscar/dev/matplotlib/lib/matplotlib/dates.py", line 402, in datestr2num
    return date2num(_dateutil_parser_parse_np_vectorized(d))

  File "/usr/lib/python3.10/site-packages/numpy/lib/function_base.py", line 2163, in __call__
    return self._vectorize_call(func=func, args=vargs)

  File "/usr/lib/python3.10/site-packages/numpy/lib/function_base.py", line 2241, in _vectorize_call
    ufunc, otypes = self._get_ufunc_and_otypes(func=func, args=args)

  File "/usr/lib/python3.10/site-packages/numpy/lib/function_base.py", line 2201, in _get_ufunc_and_otypes
    outputs = func(*inputs)

  File "/usr/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 1368, in parse
    return DEFAULTPARSER.parse(timestr, **kwargs)

  File "/usr/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 640, in parse
    res, skipped_tokens = self._parse(timestr, **kwargs)

  File "/usr/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 719, in _parse
    l = _timelex.split(timestr)         # Splits the timestr into tokens

  File "/usr/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 201, in split
    return list(cls(s))

  File "/usr/lib/python3.10/site-packages/dateutil/parser/_parser.py", line 69, in __init__
    raise TypeError('Parser must be a string or character stream, not '

TypeError: Parser must be a string or character stream, not date
```
Do you use release notes for this type of minor bug fixes?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
