### PR TITLE
DOC: git:// is deprecated.

### DIFF
--- a/doc/devel/gitwash/development_workflow.rst
+++ b/doc/devel/gitwash/development_workflow.rst
@@ -211,7 +211,7 @@ Now all those people can do::
     git clone https://github.com/your-user-name/matplotlib.git
 
 Remember that links starting with ``https`` or ``git@`` are read-write, and that
-``git@`` uses the ssh protocol; links starting with ``git://`` are read-only.
+``git@`` uses the ssh protocol.
 
 Your collaborators can then commit directly into that repo with the
 usual::

--- a/doc/devel/gitwash/following_latest.rst
+++ b/doc/devel/gitwash/following_latest.rst
@@ -20,7 +20,7 @@ Get the local copy of the code
 
 From the command line::
 
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone https://github.com/matplotlib/matplotlib.git
 
 You now have a copy of the code tree in the new ``matplotlib`` directory.
 

--- a/doc/devel/gitwash/maintainer_workflow.rst
+++ b/doc/devel/gitwash/maintainer_workflow.rst
@@ -31,7 +31,7 @@ Let's say you have some changes that need to go into trunk
 The changes are in some branch that you are currently on.  For example, you are
 looking at someone's changes like this::
 
-    git remote add someone git://github.com/someone/matplotlib.git
+    git remote add someone https://github.com/someone/matplotlib.git
     git fetch someone
     git branch cool-feature --track someone/cool-feature
     git checkout cool-feature

--- a/doc/devel/gitwash/patching.rst
+++ b/doc/devel/gitwash/patching.rst
@@ -31,7 +31,7 @@ Overview
    git config --global user.email you@yourdomain.example.com
    git config --global user.name "Your Name Comes Here"
    # get the repository if you don't have it
-   git clone git://github.com/matplotlib/matplotlib.git
+   git clone https://github.com/matplotlib/matplotlib.git
    # make a branch for your patching
    cd matplotlib
    git branch the-fix-im-thinking-of
@@ -61,7 +61,7 @@ In detail
 #. If you don't already have one, clone a copy of the
    `Matplotlib`_ repository::
 
-      git clone git://github.com/matplotlib/matplotlib.git
+      git clone https://github.com/matplotlib/matplotlib.git
       cd matplotlib
 
 #. Make a 'feature branch'.  This will be where you work on

--- a/doc/devel/gitwash/set_up_fork.rst
+++ b/doc/devel/gitwash/set_up_fork.rst
@@ -15,7 +15,7 @@ Overview
 
    git clone https://github.com/your-user-name/matplotlib.git
    cd matplotlib
-   git remote add upstream git://github.com/matplotlib/matplotlib.git
+   git remote add upstream https://github.com/matplotlib/matplotlib.git
 
 In detail
 =========
@@ -50,23 +50,18 @@ Linking your repository to the upstream repo
 ::
 
    cd matplotlib
-   git remote add upstream git://github.com/matplotlib/matplotlib.git
+   git remote add upstream https://github.com/matplotlib/matplotlib.git
 
 ``upstream`` here is just the arbitrary name we're using to refer to the
 main `Matplotlib`_ repository at `Matplotlib github`_.
-
-Note that we've used ``git://`` for the URL rather than ``https://`` or ``git@``.  The
-``git://`` URL is read only.  This means that we can't accidentally
-(or deliberately) write to the upstream repo, and we are only going to
-use it to merge into our own code.
 
 Just for your own satisfaction, show yourself that you now have a new
 'remote', with ``git remote -v show``, giving you something like:
 
 .. code-block:: none
 
-   upstream	git://github.com/matplotlib/matplotlib.git (fetch)
-   upstream	git://github.com/matplotlib/matplotlib.git (push)
+   upstream	https://github.com/matplotlib/matplotlib.git (fetch)
+   upstream	https://github.com/matplotlib/matplotlib.git (push)
    origin	https://github.com/your-user-name/matplotlib.git (fetch)
    origin	https://github.com/your-user-name/matplotlib.git (push)
 


### PR DESCRIPTION
See https://github.blog/2021-09-01-improving-git-protocol-security-github/

Today is a brownout day.

I removed the sentence that git:// is RO and https:// is RW as you soon
won't be able to use git://

Personally I use https:// as RO and ssh:// as RW, but I understand it
might not be convenient on windows.


