### PR TITLE
Bump minimum NumPy to 1.19

### DIFF
--- a/doc/api/next_api_changes/development/22205-ES.rst
+++ b/doc/api/next_api_changes/development/22205-ES.rst
@@ -1,0 +1,15 @@
+Increase to minimum supported versions of Python and dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For Maptlotlib 3.6, the :ref:`minimum supported versions <dependencies>` are
+being bumped:
+
++------------+-----------------+---------------+
+| Dependency |  min in mpl3.5  | min in mpl3.6 |
++============+=================+===============+
+|   NumPy    |       1.17      |      1.19     |
++------------+-----------------+---------------+
+
+This is consistent with our :ref:`min_deps_policy` and `NEP29
+<https://numpy.org/neps/nep-0029-deprecation_policy.html>`__
+

--- a/doc/api/next_api_changes/development/22205-ES.rst
+++ b/doc/api/next_api_changes/development/22205-ES.rst
@@ -1,7 +1,7 @@
 Increase to minimum supported versions of Python and dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For Maptlotlib 3.6, the :ref:`minimum supported versions <dependencies>` are
+For Matplotlib 3.6, the :ref:`minimum supported versions <dependencies>` are
 being bumped:
 
 +------------+-----------------+---------------+

--- a/doc/api/prev_api_changes/api_changes_3.2.0/development.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/development.rst
@@ -22,7 +22,7 @@ is desired.
 
 Packaging DLLs
 ~~~~~~~~~~~~~~
-Previously, it was possible to package Windows DLLs into the Maptlotlib
+Previously, it was possible to package Windows DLLs into the Matplotlib
 wheel (or sdist) by copying them into the source tree and setting the
 ``package_data.dlls`` entry in ``setup.cfg``.
 

--- a/doc/api/prev_api_changes/api_changes_3.4.0/development.rst
+++ b/doc/api/prev_api_changes/api_changes_3.4.0/development.rst
@@ -4,7 +4,7 @@ Development changes
 Increase to minimum supported versions of Python and dependencies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-For Maptlotlib 3.4, the :ref:`minimum supported versions <dependencies>` are
+For Matplotlib 3.4, the :ref:`minimum supported versions <dependencies>` are
 being bumped:
 
 +------------+-----------------+---------------+

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -15,7 +15,7 @@ mandatory dependencies are automatically installed. This list is mainly for
 reference.
 
 * `Python <https://www.python.org/downloads/>`_ (>= 3.7)
-* `NumPy <https://numpy.org>`_ (>= 1.17)
+* `NumPy <https://numpy.org>`_ (>= 1.19)
 * `setuptools <https://setuptools.readthedocs.io/en/latest/>`_
 * `cycler <https://matplotlib.org/cycler/>`_ (>= 0.10.0)
 * `dateutil <https://pypi.org/project/python-dateutil/>`_ (>= 2.7)

--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -61,7 +61,7 @@ We will support at least minor versions of the development
 dependencies released in the 12 months prior to our planned release.
 
 We will only bump these as needed or versions no longer support our
-minimum Python and numpy.
+minimum Python and NumPy.
 
 System and C-dependencies
 =========================
@@ -83,6 +83,7 @@ specification of the dependencies.
 ==========  ========  ======
 Matplotlib  Python    NumPy
 ==========  ========  ======
+`3.6`_      3.7       1.19.0
 `3.5`_      3.7       1.17.0
 `3.4`_      3.7       1.16.0
 `3.3`_      3.6       1.15.0
@@ -100,6 +101,7 @@ Matplotlib  Python    NumPy
 1.0         2.4       1.1
 ==========  ========  ======
 
+.. _`3.6`: https://matplotlib.org/3.6.0/devel/dependencies.html
 .. _`3.5`: https://matplotlib.org/3.5.0/devel/dependencies.html
 .. _`3.4`: https://matplotlib.org/3.4.0/devel/dependencies.html
 .. _`3.3`: https://matplotlib.org/3.3.0/users/installing.html#dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - cycler>=0.10.0
   - fonttools>=4.22.0
   - kiwisolver>=1.0.1
-  - numpy>=1.17
+  - numpy>=1.19
   - pillow>=6.2
   - pygobject
   - pyparsing

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -196,7 +196,7 @@ def _check_versions():
             ("cycler", "0.10"),
             ("dateutil", "2.7"),
             ("kiwisolver", "1.0.1"),
-            ("numpy", "1.17"),
+            ("numpy", "1.19"),
             ("pyparsing", "2.2.1"),
     ]:
         module = importlib.import_module(modname)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1025,19 +1025,13 @@ def test_fill_between_interpolate_nan():
     y1 = np.asarray([8, 18, np.nan, 18, 8, 18, 24, 18, 8, 18])
     y2 = np.asarray([18, 11, 8, 11, 18, 26, 32, 30, np.nan, np.nan])
 
-    # NumPy <1.19 issues warning 'invalid value encountered in greater_equal'
-    # for comparisons that include nan.
-    with np.errstate(invalid='ignore'):
-        greater2 = y2 >= y1
-        greater1 = y1 >= y2
-
     fig, ax = plt.subplots()
 
     ax.plot(x, y1, c='k')
     ax.plot(x, y2, c='b')
-    ax.fill_between(x, y1, y2, where=greater2, facecolor="green",
+    ax.fill_between(x, y1, y2, where=y2 >= y1, facecolor="green",
                     interpolate=True, alpha=0.5)
-    ax.fill_between(x, y1, y2, where=greater1, facecolor="red",
+    ax.fill_between(x, y1, y2, where=y1 >= y2, facecolor="red",
                     interpolate=True, alpha=0.5)
 
 

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -2,7 +2,7 @@
 
 cycler==0.10
 kiwisolver==1.0.1
-numpy==1.17.0
+numpy==1.19.0
 packaging==20.0
 pillow==6.2.0
 pyparsing==2.2.1

--- a/setup.py
+++ b/setup.py
@@ -308,7 +308,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
     python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
     setup_requires=[
         "certifi>=2020.06.20",
-        "numpy>=1.17",
+        "numpy>=1.19",
         "setuptools_scm>=4",
         "setuptools_scm_git_archive",
     ],
@@ -316,7 +316,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "cycler>=0.10",
         "fonttools>=4.22.0",
         "kiwisolver>=1.0.1",
-        "numpy>=1.17",
+        "numpy>=1.19",
         "packaging>=20.0",
         "pillow>=6.2.0",
         "pyparsing>=2.2.1,<3.0.0",


### PR DESCRIPTION
## PR Summary

By [NEP 29](https://numpy.org/neps/nep-0029-deprecation_policy.html), the rollover to 1.18 occurred on July 26, but we missed it due to delays in 3.5. The rollover to 1.19 occurred on Dec 22.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).