### PR TITLE
Stop sorting artists in Figure Options dialog

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -5,8 +5,6 @@
 
 """Module that provides a GUI-based editor for Matplotlib's figure options."""
 
-import re
-
 from matplotlib import cbook, cm, colors as mcolors, markers, image as mimage
 from matplotlib.backends.qt_compat import QtGui
 from matplotlib.backends.qt_editor import _formlayout
@@ -65,18 +63,6 @@ def figure_edit(axes, parent=None):
     xunits = axes.xaxis.get_units()
     yunits = axes.yaxis.get_units()
 
-    # Sorting for default labels (_lineXXX, _imageXXX).
-    def cmp_key(label):
-        """
-        Label should be a tuple consisting of the string label,
-        and the object being sorted by label.
-        """
-        match = re.match(r"(_line|_image)(\d+)", label[0])
-        if match:
-            return match.group(1), int(match.group(2))
-        else:
-            return label[0], 0
-
     # Get / Curves
     labeled_lines = []
     for line in axes.get_lines():
@@ -113,7 +99,7 @@ def figure_edit(axes, parent=None):
                 sorted(short2name.items(),
                        key=lambda short_and_name: short_and_name[1]))
 
-    for label, line in sorted(labeled_lines, key=cmp_key):
+    for label, line in labeled_lines:
         color = mcolors.to_hex(
             mcolors.to_rgba(line.get_color(), line.get_alpha()),
             keep_alpha=True)
@@ -150,7 +136,7 @@ def figure_edit(axes, parent=None):
         labeled_mappables.append((label, mappable))
     mappables = []
     cmaps = [(cmap, name) for name, cmap in sorted(cm._cmap_registry.items())]
-    for label, mappable in sorted(labeled_mappables, key=cmp_key):
+    for label, mappable in labeled_mappables:
         cmap = mappable.get_cmap()
         if cmap not in cm._cmap_registry.values():
             cmaps = [(cmap, cmap.name), *cmaps]


### PR DESCRIPTION
## PR Summary

With #18216, the order that artists are added to an Axes is their canonical order. The dialog should not be sorting them in some other manner.

Additionally, this fixes a bug in that `apply_callback` indexes back to the original list, which means that changes will be made to the *wrong* artist if sorting actually occurred. It also makes the legend almost entirely wrong as well.

See https://discourse.matplotlib.org/t/bug-on-re-generate-automatic-legend-of-matplotlib-figure-property/22511

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).