### PR TITLE
DOC: Document default join style

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1292,6 +1292,8 @@ class Line2D(Artist):
         """
         How to join segments of the line if it `~Line2D.is_dashed`.
 
+        The default joinstyle is :rc:`lines.dash_joinstyle`.
+
         Parameters
         ----------
         s : `.JoinStyle` or %(JoinStyle)s
@@ -1305,6 +1307,8 @@ class Line2D(Artist):
     def set_solid_joinstyle(self, s):
         """
         How to join segments if the line is solid (not `~Line2D.is_dashed`).
+
+        The default joinstyle is :rc:`lines.solid_joinstyle`.
 
         Parameters
         ----------

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -494,6 +494,9 @@ class Patch(artist.Artist):
         """
         Set the `.JoinStyle`.
 
+        The default joinstyle is 'round' for `.FancyArrowPatch` and 'miter' for
+        all other patches.
+
         Parameters
         ----------
         s : `.JoinStyle` or %(JoinStyle)s


### PR DESCRIPTION
## PR Summary
Document default join style in the same way as the default cap styles (see #22053).

This just documents the current behavior, which may or may not be changed in the future, see #18597.



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
