### PR TITLE
turn off the grid after creating colorbar axes

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1143,6 +1143,7 @@ default: %(va)s
                 cax, kwargs = cbar.make_axes_gridspec(ax, **kwargs)
             else:
                 cax, kwargs = cbar.make_axes(ax, **kwargs)
+            cax.grid(visible=False, which='both', axis='both')
         else:
             userax = True
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -938,3 +938,15 @@ def test_boundaries():
     fig, ax = plt.subplots(figsize=(2, 2))
     pc = ax.pcolormesh(np.random.randn(10, 10), cmap='RdBu_r')
     cb = fig.colorbar(pc, ax=ax, boundaries=np.linspace(-3, 3, 7))
+
+
+def test_colorbar_no_warning_rcparams_grid_true():
+    # github issue #21723 - If mpl style has 'axes.grid' = True,
+    # fig.colorbar raises a warning about Auto-removal of grids
+    # by pcolor() and pcolormesh(). This is fixed by PR #22216.
+    plt.rcParams['axes.grid'] = True
+    fig, ax = plt.subplots()
+    ax.grid(False)
+    im = ax.pcolormesh([0, 1], [0, 1], [[1]])
+    # make sure that no warning is raised by fig.colorbar
+    fig.colorbar(im)


### PR DESCRIPTION
## PR Summary
This PR turns the grid off for the colorbar axes created automatically (when user doesn't explicitly specify `cax`) by `fig.colorbar` or 'plt.colorbar'. This is needed since Auto-removal of grids by pcolor() and pcolormesh is deprecated.
```python
import matplotlib.pyplot as plt
# turn the grid on as a part of the style-sheet
plt.rcParams['axes.grid'] = True  
fig, ax = plt.subplots()
# turn the grid off since "Auto-removal of grids by pcolor() and pcolormesh() is deprecated since 3.5"
ax.grid(False) 
im = ax.pcolormesh([0, 1], [0, 1], [[1]])
# on the main branch (as well as v3.5) this still results in a warning about grid not being turned off
# (since mpl automatically creates cax using the default rcParams and doesn't turn off the grid before
#  plotting the colorbar)
fig.colorbar(im) 
```
possibly closes #21723?
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
