### PR TITLE
FIX: make safe to add / remove artists during ArtistList iteration

### DIFF
--- a/doc/api/next_api_changes/behavior/22229-TAC.rst
+++ b/doc/api/next_api_changes/behavior/22229-TAC.rst
@@ -1,0 +1,18 @@
+AritistList proxies copy contents on iteration
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When iterating over the contents of the the dynamically generated proxy lists
+for the Artist-type accessors (see :ref:`Behavioural API Changes 3.5 - Axes
+children combined`), a copy of the contents is made.  This ensure that artists
+can safely be added or removed from the Axes while iterating over their children.
+
+This is a departure from the expected behavior of mutable iterable data types
+in Python -- iterating over list while mutating it has surprising consequences
+and dictionaries will error if they change size during iteration.  In this case
+because all of the accessors are filtered views of the same underlying list, it
+is possible for seemingly unrelated changes, such as removing a Line, to affect
+the to affect the iteration over any of the other accessors, we have opted to
+make a copy of the relevant children before yielding them to the user.
+
+This change is also consistent with our plan to make these accessors immutable
+in Matplotlib 3.7.

--- a/doc/api/next_api_changes/behavior/22229-TAC.rst
+++ b/doc/api/next_api_changes/behavior/22229-TAC.rst
@@ -8,10 +8,10 @@ can safely be added or removed from the Axes while iterating over their children
 
 This is a departure from the expected behavior of mutable iterable data types
 in Python -- iterating over list while mutating it has surprising consequences
-and dictionaries will error if they change size during iteration.  In this case
-because all of the accessors are filtered views of the same underlying list, it
+and dictionaries will error if they change size during iteration.
+Because all of the accessors are filtered views of the same underlying list, it
 is possible for seemingly unrelated changes, such as removing a Line, to affect
-the to affect the iteration over any of the other accessors, we have opted to
+the iteration over any of the other accessors. In this case, we have opted to
 make a copy of the relevant children before yielding them to the user.
 
 This change is also consistent with our plan to make these accessors immutable

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1366,7 +1366,7 @@ class _AxesBase(martist.Artist):
                        for artist in self._axes._children)
 
         def __iter__(self):
-            for artist in self._axes._children:
+            for artist in list(self._axes._children):
                 if self._type_check(artist):
                     yield artist
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7360,6 +7360,10 @@ def test_artist_sublists():
     assert ax.lines + [1, 2, 3] == [*lines, 1, 2, 3]
     assert [1, 2, 3] + ax.lines == [1, 2, 3, *lines]
 
+    for ln in ax.lines:
+        ln.remove()
+    assert len(ax.lines) == 0
+
 
 def test_empty_line_plots():
     # Incompatible nr columns, plot "nothing"


### PR DESCRIPTION

## PR Summary

If you remove artists during iteration some of the artists will be skipped due
to the underlying list being mutated.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

