### PR TITLE
Partial fix for grid alpha

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -12,6 +12,7 @@ import matplotlib as mpl
 from matplotlib import _api
 import matplotlib.artist as martist
 import matplotlib.cbook as cbook
+import matplotlib.colors as mcolors
 import matplotlib.lines as mlines
 import matplotlib.scale as mscale
 import matplotlib.text as mtext
@@ -143,7 +144,12 @@ class Tick(martist.Artist):
             grid_linestyle = mpl.rcParams["grid.linestyle"]
         if grid_linewidth is None:
             grid_linewidth = mpl.rcParams["grid.linewidth"]
-        if grid_alpha is None:
+        if grid_alpha is None and not mcolors._has_alpha_channel(grid_color):
+            # alpha precedence: kwarg > color alpha > rcParams['grid.alpha']
+            # Note: only resolve to rcParams if the color does not have alpha
+            # otherwise `grid(color=(1, 1, 1, 0.5))` would work like
+            #   grid(color=(1, 1, 1, 0.5), alpha=rcParams['grid.alpha'])
+            # so the that the rcParams default would override color alpha.
             grid_alpha = mpl.rcParams["grid.alpha"]
         grid_kw = {k[5:]: v for k, v in kwargs.items()}
 
@@ -1413,7 +1419,7 @@ class Axis(martist.Artist):
                 visible = True
         which = which.lower()
         _api.check_in_list(['major', 'minor', 'both'], which=which)
-        gridkw = {'grid_' + item[0]: item[1] for item in kwargs.items()}
+        gridkw = {f'grid_{name}': value for name, value in kwargs.items()}
         if which in ['minor', 'both']:
             gridkw['gridOn'] = (not self._minor_tick_kw['gridOn']
                                 if visible is None else visible)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -121,6 +121,12 @@ def is_color_like(c):
         return True
 
 
+def _has_alpha_channel(c):
+    """Return whether *c* is a color with an alpha channel."""
+    # 4-element sequences are interpreted as r, g, b, a
+    return not isinstance(c, str) and len(c) == 4
+
+
 def _check_color_like(**kwargs):
     """
     For each *key, value* pair in *kwargs*, check that *value* is color-like.

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1166,6 +1166,15 @@ def test_colormap_reversing(name):
     assert_array_almost_equal(cmap(np.nan), cmap_r(np.nan))
 
 
+def test_has_alpha_channel():
+    assert mcolors._has_alpha_channel((0, 0, 0, 0))
+    assert mcolors._has_alpha_channel([1, 1, 1, 1])
+    assert not mcolors._has_alpha_channel('blue')  # 4-char string!
+    assert not mcolors._has_alpha_channel('0.25')
+    assert not mcolors._has_alpha_channel('r')
+    assert not mcolors._has_alpha_channel((1, 0, 0))
+
+
 def test_cn():
     matplotlib.rcParams['axes.prop_cycle'] = cycler('color',
                                                     ['blue', 'r'])


### PR DESCRIPTION
## PR Summary

Partial fix for #22231.

This is clearly a logic error fix, see comment in code. Unfortunately, there is a much larger underlying problem, which is why this PR alone won't fix the problem and I cannot add tests.

The underlying problem lies in the arcane tick mechanism; roughly: via the `_LazyTickList`s we generate `majorTicks[0]`, which gets not parameters and thus resolves `rcParams['grid.alpha']` to a float. OTOH new ticks are created by copying properties from existing ticks. Even though this PR fixes the tick gridline initialization to respect a color alpha, `_copy_tick_props()` overwrites the gridline alpha afterwards.

I've spent a couple of hours digging this out and trying to find a proper fix. My time budget on this issue is exhausted. You may merge this PR as a partial fix if you think it's reasonable; or you may take it as a basis for digging into the complete fix.




