### PR TITLE
Run wheel builds on PRs when requested by a label

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,15 +1,30 @@
 name: Build CI wheels
 
 on:
+  # Save CI by only running this on release branches or tags.
   push:
     branches:
       - main
       - v[0-9]+.[0-9]+.x
     tags:
       - v*
+  # Also allow running this action on PRs if requested by applying the
+  # "Run cibuildwheel" label.
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
 
 jobs:
   build_wheels:
+    if: |
+      (
+        github.event.action == 'labeled' &&
+        github.event.label.name == 'Run cibuildwheel'
+      ) ||
+      contains(github.event.pull_request.labels.*.name, 'Run cibuildwheel')
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -123,6 +123,8 @@ Labels
 
 * If you have the rights to set labels, tag the PR with descriptive labels.
   See the `list of labels <https://github.com/matplotlib/matplotlib/labels>`__.
+* If the PR makes changes to the wheel building Action, add the
+  "Run cibuildwheel" label to enable testing wheels.
 
 .. _pr-milestones:
 


### PR DESCRIPTION
## PR Summary

When I need to change the wheel building process, I need to push a copy to my fork's `main`, and then force push that away. But we can enable this on PRs by checking for a special label, reducing this extra work.

I used the "Run cibuildwheel" label, but if there's consensus for a better label name, we can use it. Then I'll actually create the label.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).