### PR TITLE
Add minimum macosx version

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
+      MACOSX_DEPLOYMENT_TARGET: "10.12"
     strategy:
       matrix:
         os: [ubuntu-18.04, windows-latest, macos-10.15]

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -47,6 +47,7 @@ and the capabilities they provide.
 * pycairo_ (>= 1.11.0) or cairocffi_ (>= 0.8): for the GTK and/or cairo-based
   backends.
 * Tornado_ (>=5): for the WebAgg backend.
+* macOS (>=10.12): for the macosx backend.
 
 .. _Tk: https://docs.python.org/3/library/tk.html
 .. _PyQt5: https://pypi.org/project/PyQt5/

--- a/doc/users/next_whats_new/min_macos_version.rst
+++ b/doc/users/next_whats_new/min_macos_version.rst
@@ -1,0 +1,3 @@
+New minimum macOS version
+-------------------------
+The macosx backend now requires macOS >= 10.12.

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -11,40 +11,9 @@
 
 /* Proper way to check for the OS X version we are compiling for, from
  * https://developer.apple.com/library/archive/documentation/DeveloperTools/Conceptual/cross_development/Using/using.html
- */
-#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 1070
-#define COMPILING_FOR_10_7
-#endif
 
-/* Renamed symbols cause deprecation warnings, so define macros for the new
+ * Renamed symbols cause deprecation warnings, so define macros for the new
  * names if we are compiling on an older SDK */
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101000
-#define NSModalResponseOK                    NSOKButton
-#endif
-#if __MAC_OS_X_VERSION_MIN_REQUIRED < 101200
-#define NSEventMaskAny                       NSAnyEventMask
-#define NSEventTypeApplicationDefined        NSApplicationDefined
-#define NSEventModifierFlagCommand           NSCommandKeyMask
-#define NSEventModifierFlagControl           NSControlKeyMask
-#define NSEventModifierFlagOption            NSAlternateKeyMask
-#define NSEventModifierFlagShift             NSShiftKeyMask
-#define NSEventTypeKeyUp                     NSKeyUp
-#define NSEventTypeKeyDown                   NSKeyDown
-#define NSEventTypeMouseMoved                NSMouseMoved
-#define NSEventTypeLeftMouseDown             NSLeftMouseDown
-#define NSEventTypeRightMouseDown            NSRightMouseDown
-#define NSEventTypeOtherMouseDown            NSOtherMouseDown
-#define NSEventTypeLeftMouseDragged          NSLeftMouseDragged
-#define NSEventTypeRightMouseDragged         NSRightMouseDragged
-#define NSEventTypeOtherMouseDragged         NSOtherMouseDragged
-#define NSEventTypeLeftMouseUp               NSLeftMouseUp
-#define NSEventTypeRightMouseUp              NSRightMouseUp
-#define NSEventTypeOtherMouseUp              NSOtherMouseUp
-#define NSWindowStyleMaskClosable            NSClosableWindowMask
-#define NSWindowStyleMaskMiniaturizable      NSMiniaturizableWindowMask
-#define NSWindowStyleMaskResizable           NSResizableWindowMask
-#define NSWindowStyleMaskTitled              NSTitledWindowMask
-#endif
 #if __MAC_OS_X_VERSION_MIN_REQUIRED < 101400
 #define NSButtonTypeMomentaryLight           NSMomentaryLightButton
 #define NSButtonTypePushOnPushOff            NSPushOnPushOffButton
@@ -895,9 +864,7 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     NSSize scale;
 
     rect = NSMakeRect(0, 0, imagesize, imagesize);
-#ifdef COMPILING_FOR_10_7
     rect = [window convertRectToBacking: rect];
-#endif
     size = rect.size;
     scale = NSMakeSize(imagesize / size.width, imagesize / size.height);
 
@@ -934,10 +901,8 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     rect.size.height = 0;
     rect.origin.x += height;
     NSTextView* messagebox = [[NSTextView alloc] initWithFrame: rect];
-    if (@available(macOS 10.11, *)) {
-        messagebox.textContainer.maximumNumberOfLines = 2;
-        messagebox.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
-    }
+    messagebox.textContainer.maximumNumberOfLines = 2;
+    messagebox.textContainer.lineBreakMode = NSLineBreakByTruncatingTail;
     [messagebox setFont: font];
     [messagebox setDrawsBackground: NO];
     [messagebox setSelectable: NO];


### PR DESCRIPTION
This is a draft to see if we can specify the macosx minimum version to be higher to fix wheel building. See https://github.com/matplotlib/matplotlib/pull/22179#issuecomment-1013696274 for details on why the wheels are currently failing.

As per https://github.com/matplotlib/matplotlib/pull/18128#issuecomment-667354695 and other discussion on that issue I've set the minimum version to 10.12.

Fixes https://github.com/matplotlib/matplotlib/issues/18066