### PR TITLE
Revert "Backport PR #22179 on branch v3.5.x (FIX: macosx check case-insensitive app name)"

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1376,8 +1376,8 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
     CFMachPortRef port;
     CFRunLoopSourceRef source;
     NSDictionary* dictionary = [notification userInfo];
-    if (![[dictionary valueForKey:@"NSApplicationName"]
-            localizedCaseInsensitiveContainsString:@"python"])
+    if (! [[dictionary valueForKey:@"NSApplicationName"]
+           isEqualToString:@"Python"])
         return;
     NSNumber* psnLow = [dictionary valueForKey: @"NSApplicationProcessSerialNumberLow"];
     NSNumber* psnHigh = [dictionary valueForKey: @"NSApplicationProcessSerialNumberHigh"];


### PR DESCRIPTION
Reverts matplotlib/matplotlib#22195, as it breaks the wheel build, and we probably don't want to bump the minimum supported MacOSX (currently 10.9) in a bugfix release to fix this.