### PR TITLE
Replace "an axes" with "an axis" throughout docs and tutorials

### DIFF
--- a/doc/api/prev_api_changes/api_changes_1.2.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.2.x.rst
@@ -102,7 +102,7 @@ API Changes in 1.2.x
   any artist's transform can be interrogated with
   ``artist_instance.get_transform().contains_branch(ax.transData)``
 
-* Lines added to an axes now take into account their transform when updating the
+* Lines added to an axis now take into account their transform when updating the
   data and view limits. This means transforms can now be used as a pre-transform.
   For instance::
 

--- a/doc/api/prev_api_changes/api_changes_1.4.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.4.x.rst
@@ -184,7 +184,7 @@ original location:
 
 * The use of the index 0 in `.pyplot.subplot` and related commands is
   deprecated.  Due to a lack of validation, calling ``plt.subplots(2, 2, 0)``
-  does not raise an exception, but puts an axes in the _last_
+  does not raise an exception, but puts an axis in the _last_
   position.  This is due to the indexing in subplot being 1-based (to
   mirror MATLAB) so before indexing into the `.GridSpec` object used to
   determine where the axes should go, 1 is subtracted off.  Passing in

--- a/doc/api/prev_api_changes/api_changes_2.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.1.0.rst
@@ -324,7 +324,7 @@ from ``mpl_toolkits.axes_grid`` based on ``Axis`` from
 ``Axes`` collision in ``Figure.add_axes``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Adding an axes instance to a figure by using the same arguments as for
+Adding an axis instance to a figure by using the same arguments as for
 a previous axes instance currently reuses the earlier instance.  This
 behavior has been deprecated in Matplotlib 2.1. In a future version, a
 *new* instance will always be created and returned.  Meanwhile, in such

--- a/doc/api/prev_api_changes/api_changes_3.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.0.0.rst
@@ -470,7 +470,7 @@ Hold machinery
 
 Setting or unsetting ``hold`` (:ref:`deprecated in version 2.0<v200_deprecate_hold>`) has now
 been completely removed. Matplotlib now always behaves as if ``hold=True``.
-To clear an axes you can manually use :meth:`~.axes.Axes.cla()`,
+To clear an axis you can manually use :meth:`~.axes.Axes.cla()`,
 or to clear an entire figure use :meth:`~.figure.Figure.clf()`.
 
 

--- a/doc/users/explain/event_handling.rst
+++ b/doc/users/explain/event_handling.rst
@@ -74,7 +74,7 @@ Event name             Class            Description
 'figure_enter_event'   `.LocationEvent` mouse enters a new figure
 'figure_leave_event'   `.LocationEvent` mouse leaves a figure
 'axes_enter_event'     `.LocationEvent` mouse enters a new axes
-'axes_leave_event'     `.LocationEvent` mouse leaves an axes
+'axes_leave_event'     `.LocationEvent` mouse leaves an axis
 ====================== ================ ======================================
 
 .. note::

--- a/doc/users/prev_whats_new/github_stats_3.1.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.1.0.rst
@@ -569,7 +569,7 @@ Pull Requests (918):
 * :ghpull:`13402`: Fix empty reshape2d
 * :ghpull:`11683`: Reuse axes_grid1's AxisDict in axisartist, instead of duplicating it.
 * :ghpull:`12141`: Let digits toggle axes nav only if they correspond to an existing axes.
-* :ghpull:`9845`: Add inaxes method to FigureCanvas to check whether point is in an axes.
+* :ghpull:`9845`: Add inaxes method to FigureCanvas to check whether point is in an axis.
 * :ghpull:`13396`: mpl_toolkits style fixes.
 * :ghpull:`11497`: Make CI fail if interactive toolkits can't be tested
 * :ghpull:`11595`: test doc rendering

--- a/doc/users/prev_whats_new/whats_new_2.2.rst
+++ b/doc/users/prev_whats_new/whats_new_2.2.rst
@@ -207,7 +207,7 @@ errorbars.
 ---------------------------------
 
 The method `.Axes.set_title` now has a *pad* kwarg, that specifies the
-distance from the top of an axes to where the title is drawn.  The units
+distance from the top of an axis to where the title is drawn.  The units
 of *pad* is points, and the default is the value of the (already-existing)
 :rc:`axes.titlepad`.
 

--- a/doc/users/prev_whats_new/whats_new_3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.0.rst
@@ -135,7 +135,7 @@ The pgf backend now also supports multi-page PDF files.
 Pie charts are now circular by default
 --------------------------------------
 We acknowledge that the majority of people do not like egg-shaped pies.
-Therefore, an axes to which a pie chart is plotted will be set to have
+Therefore, an axis to which a pie chart is plotted will be set to have
 equal aspect ratio by default. This ensures that the pie appears circular
 independent on the axes size or units. To revert to the previous behaviour
 set the axes' aspect ratio to automatic by using ``ax.set_aspect("auto")`` or
@@ -145,7 +145,7 @@ Add ``ax.get_gridspec`` to `.SubplotBase`
 -----------------------------------------
 
 New method `.SubplotBase.get_gridspec` is added so that users can
-easily get the gridspec that went into making an axes:
+easily get the gridspec that went into making an axis:
 
   .. code::
 
@@ -166,7 +166,7 @@ easily get the gridspec that went into making an axes:
 Axes titles will no longer overlap xaxis
 ----------------------------------------
 
-Previously an axes title had to be moved manually if an xaxis overlapped
+Previously an axis title had to be moved manually if an xaxis overlapped
 (usually when the xaxis was put on the top of the axes).  Now, the title
 will be automatically moved above the xaxis and its decorators (including
 the xlabel) if they are at the top.

--- a/doc/users/prev_whats_new/whats_new_3.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.1.0.rst
@@ -142,7 +142,7 @@ Add ``inaxes`` method to `.FigureCanvasBase`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The `.FigureCanvasBase` class has now an `~.FigureCanvasBase.inaxes`
-method to check whether a point is in an axes and returns the topmost
+method to check whether a point is in an axis and returns the topmost
 axes, else None.
 
 cairo backend defaults to pycairo instead of cairocffi

--- a/doc/users/prev_whats_new/whats_new_3.3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.3.0.rst
@@ -136,7 +136,7 @@ From now on, the ``suptitle`` will be considered:
 Setting axes box aspect
 -----------------------
 
-It is now possible to set the aspect of an axes box directly via
+It is now possible to set the aspect of an axis box directly via
 `~.Axes.set_box_aspect`. The box aspect is the ratio between axes height and
 axes width in physical units, independent of the data limits. This is useful
 to, e.g., produce a square plot, independent of the data it contains, or to

--- a/tutorials/advanced/transforms_tutorial.py
+++ b/tutorials/advanced/transforms_tutorial.py
@@ -73,9 +73,9 @@ Note that specifying objects in *display* coordinates will change their
 location if the ``dpi`` of the figure changes.  This can cause confusion when
 printing or changing screen resolution, because the object can change location
 and size.  Therefore it is most common
-for artists placed in an axes or figure to have their transform set to
+for artists placed in an axis or figure to have their transform set to
 something *other* than the `~.transforms.IdentityTransform()`; the default when
-an artist is placed on an axes using `~.axes.Axes.add_artist` is for the
+an artist is placed on an axis using `~.axes.Axes.add_artist` is for the
 transform to be ``ax.transData``.
 
 .. _data-coords:

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -421,7 +421,7 @@ docomplicated()
 # Manually setting axes positions
 # ================================
 #
-# There can be good reasons to manually set an axes position.  A manual call
+# There can be good reasons to manually set an axis position.  A manual call
 # to `~.axes.Axes.set_position` will set the axes so constrained_layout has
 # no effect on it anymore. (Note that ``constrained_layout`` still leaves the
 # space for the axes that is moved).

--- a/tutorials/intermediate/tight_layout_guide.py
+++ b/tutorials/intermediate/tight_layout_guide.py
@@ -276,7 +276,7 @@ plt.tight_layout()
 
 ###############################################################################
 # Another option is to use the AxesGrid1 toolkit to
-# explicitly create an axes for the colorbar.
+# explicitly create an axis for the colorbar.
 
 from mpl_toolkits.axes_grid1 import make_axes_locatable
 

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -260,7 +260,7 @@ plt.show()
 
 ###############################################################################
 # The `~.pyplot.figure` call here is optional because a figure will be created
-# if none exists, just as an axes will be created (equivalent to an explicit
+# if none exists, just as an axis will be created (equivalent to an explicit
 # ``subplot()`` call) if none exists.
 # The `~.pyplot.subplot` call specifies ``numrows,
 # numcols, plot_number`` where ``plot_number`` ranges from 1 to
@@ -269,7 +269,7 @@ plt.show()
 # to ``subplot(2, 1, 1)``.
 #
 # You can create an arbitrary number of subplots
-# and axes.  If you want to place an axes manually, i.e., not on a
+# and axes.  If you want to place an axis manually, i.e., not on a
 # rectangular grid, use `~.pyplot.axes`,
 # which allows you to specify the location as ``axes([left, bottom,
 # width, height])`` where all values are in fractional (0 to 1)

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -160,7 +160,7 @@ from matplotlib import pyplot as plt
 # Annotating with Arrow
 # ~~~~~~~~~~~~~~~~~~~~~
 #
-# `~.Axes.annotate` draws an arrow connecting two points in an axes::
+# `~.Axes.annotate` draws an arrow connecting two points in an axis::
 #
 #     ax.annotate("Annotation",
 #                 xy=(x1, y1), xycoords='data',

--- a/tutorials/toolkits/axes_grid.py
+++ b/tutorials/toolkits/axes_grid.py
@@ -68,7 +68,7 @@ location of the axes at drawing time.
 Users typically do not need to directly instantiate dividers
 by calling `~.axes_grid1.axes_divider.AxesDivider`; instead,
 `~.axes_grid1.axes_divider.make_axes_locatable` can be used to create a divider
-for an axes::
+for an axis::
 
   ax = subplot(1, 1, 1)
   divider = make_axes_locatable(ax)
@@ -119,7 +119,7 @@ x-axis or y-axis is shared accordingly.
 ParasiteAxes
 ------------
 
-The ParasiteAxes is an axes whose location is identical to its host
+The ParasiteAxes is an axis whose location is identical to its host
 axes. The location is adjusted in the drawing time, thus it works even
 if the host change its location (e.g., images).
 

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -45,7 +45,7 @@ dictionary that contains artists (note that ax.axis is still a
 callable method and it behaves as an original Axes.axis method in
 Matplotlib).
 
-To create an axes, ::
+To create an axis, ::
 
   import mpl_toolkits.axisartist as AA
   fig = plt.figure()
@@ -83,8 +83,8 @@ Or a fixed axis with some offset ::
 axisartist with ParasiteAxes
 ----------------------------
 
-Most commands in the axes_grid1 toolkit can take an axes_class keyword
-argument, and the commands create an axes of the given class. For example,
+Most commands in the axes_grid1 toolkit can take an axis_class keyword
+argument, and the commands create an axis of the given class. For example,
 to create a host subplot with axisartist.Axes, ::
 
   import mpl_toolkits.axisartist as AA


### PR DESCRIPTION
## PR Summary

There is inconsistent use of "an axis" or "an axes" throughout the docs. The grammatically correct version is the singular "an axis". This is the result of a `sed -i` operation so does not convert examples such as "a new axes" which is also incorrect.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
