### PR TITLE
MNT: colorbar locators properties

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -490,14 +490,14 @@ class Colorbar:
     @property
     def locator(self):
         """
-        Major locator being used for colorbar
+        Major `~.Locator` being used for colorbar.
         """
         return self._long_axis().get_major_locator()
 
     @locator.setter
     def locator(self, loc):
         """
-        Set the major locator being used for colorbar
+        Set the major `~.Locator` being used for colorbar.
         """
         self._long_axis().set_major_locator(loc)
         self._locator = loc
@@ -505,14 +505,14 @@ class Colorbar:
     @property
     def minorlocator(self):
         """
-        Minor locator being used for colorbar
+        Minor `~.Locator` being used for colorbar.
         """
         return self._long_axis().get_minor_locator()
 
     @minorlocator.setter
     def minorlocator(self, loc):
         """
-        Set minor locator being used for colorbar
+        Set minor `~.Locator` being used for colorbar.
         """
         self._long_axis().set_minor_locator(loc)
         self._minorlocator = loc
@@ -520,14 +520,14 @@ class Colorbar:
     @property
     def formatter(self):
         """
-        Major formatter being used for colorbar
+        Major `~.Formatter` being used for colorbar.
         """
         return self._long_axis().get_major_formatter()
 
     @formatter.setter
     def formatter(self, fmt):
         """
-        Set major formatter being used for colorbar
+        Set major `~.Formatter` being used for colorbar.
         """
         self._long_axis().set_major_formatter(fmt)
         self._locator = fmt
@@ -535,14 +535,14 @@ class Colorbar:
     @property
     def minorformatter(self):
         """
-        Minor formatter being used for colorbar
+        Minor `~.Formatter` being used for colorbar
         """
         return self._long_axis().get_minor_formatter()
 
     @minorformatter.setter
     def minorformatter(self, fmt):
         """
-        Set minor formatter being used for colorbar
+        Set minor `~.Formatter` being used for colorbar
         """
         self._long_axis().set_minor_formatter(fmt)
         self._minorformatter = fmt

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -489,61 +489,41 @@ class Colorbar:
 
     @property
     def locator(self):
-        """
-        Major `~.Locator` being used for colorbar.
-        """
+        """Major tick `.Locator` for the colorbar."""
         return self._long_axis().get_major_locator()
 
     @locator.setter
     def locator(self, loc):
-        """
-        Set the major `~.Locator` being used for colorbar.
-        """
         self._long_axis().set_major_locator(loc)
         self._locator = loc
 
     @property
     def minorlocator(self):
-        """
-        Minor `~.Locator` being used for colorbar.
-        """
+        """Minor tick `.Locator` for the colorbar."""
         return self._long_axis().get_minor_locator()
 
     @minorlocator.setter
     def minorlocator(self, loc):
-        """
-        Set minor `~.Locator` being used for colorbar.
-        """
         self._long_axis().set_minor_locator(loc)
         self._minorlocator = loc
 
     @property
     def formatter(self):
-        """
-        Major `~.Formatter` being used for colorbar.
-        """
+        """Major tick label `.Formatter` for the colorbar."""
         return self._long_axis().get_major_formatter()
 
     @formatter.setter
     def formatter(self, fmt):
-        """
-        Set major `~.Formatter` being used for colorbar.
-        """
         self._long_axis().set_major_formatter(fmt)
         self._formatter = fmt
 
     @property
     def minorformatter(self):
-        """
-        Minor `~.Formatter` being used for colorbar
-        """
+        """Minor tick `.Formatter` for the colorbar."""
         return self._long_axis().get_minor_formatter()
 
     @minorformatter.setter
     def minorformatter(self, fmt):
-        """
-        Set minor `~.Formatter` being used for colorbar
-        """
         self._long_axis().set_minor_formatter(fmt)
         self._minorformatter = fmt
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -440,9 +440,10 @@ class Colorbar:
             linewidths=[0.5 * mpl.rcParams['axes.linewidth']])
         self.ax.add_collection(self.dividers)
 
-        self.locator = None
-        self.minorlocator = None
-        self.formatter = None
+        self._locator = None
+        self._minorlocator = None
+        self._formatter = None
+        self._minorformatter = None
         self.__scale = None  # linear, log10 for now.  Hopefully more?
 
         if ticklocation == 'auto':
@@ -453,19 +454,19 @@ class Colorbar:
         self._reset_locator_formatter_scale()
 
         if np.iterable(ticks):
-            self.locator = ticker.FixedLocator(ticks, nbins=len(ticks))
+            self._locator = ticker.FixedLocator(ticks, nbins=len(ticks))
         else:
-            self.locator = ticks  # Handle default in _ticker()
+            self._locator = ticks  # Handle default in _ticker()
 
         if isinstance(format, str):
             # Check format between FormatStrFormatter and StrMethodFormatter
             try:
-                self.formatter = ticker.FormatStrFormatter(format)
-                _ = self.formatter(0)
+                self._formatter = ticker.FormatStrFormatter(format)
+                _ = self._formatter(0)
             except TypeError:
-                self.formatter = ticker.StrMethodFormatter(format)
+                self._formatter = ticker.StrMethodFormatter(format)
         else:
-            self.formatter = format  # Assume it is a Formatter or None
+            self._formatter = format  # Assume it is a Formatter or None
         self._draw_all()
 
         if isinstance(mappable, contour.ContourSet) and not mappable.filled:
@@ -485,6 +486,66 @@ class Colorbar:
             setattr(self.ax, x, getattr(self, x))
         # Set the cla function to the cbar's method to override it
         self.ax.cla = self._cbar_cla
+
+    @property
+    def locator(self):
+        """
+        Major locator being used for colorbar
+        """
+        return self._long_axis().get_major_locator()
+
+    @locator.setter
+    def locator(self, loc):
+        """
+        Set the major locator being used for colorbar
+        """
+        self._long_axis().set_major_locator(loc)
+        self._locator = loc
+
+    @property
+    def minorlocator(self):
+        """
+        Minor locator being used for colorbar
+        """
+        return self._long_axis().get_minor_locator()
+
+    @minorlocator.setter
+    def minorlocator(self, loc):
+        """
+        Set minor locator being used for colorbar
+        """
+        self._long_axis().set_minor_locator(loc)
+        self._minorlocator = loc
+
+    @property
+    def formatter(self):
+        """
+        Major formatter being used for colorbar
+        """
+        return self._long_axis().get_major_formatter()
+
+    @formatter.setter
+    def formatter(self, fmt):
+        """
+        Set major formatter being used for colorbar
+        """
+        self._long_axis().set_major_formatter(fmt)
+        self._locator = fmt
+
+    @property
+    def minorformatter(self):
+        """
+        Minor formatter being used for colorbar
+        """
+        return self._long_axis().get_minor_formatter()
+
+    @minorformatter.setter
+    def minorformatter(self, fmt):
+        """
+        Set minor formatter being used for colorbar
+        """
+        self._long_axis().set_minor_locator(fmt)
+        self._minorformatter = fmt
 
     def _cbar_cla(self):
         """Function to clear the interactive colorbar state."""
@@ -778,11 +839,11 @@ class Colorbar:
         """
         Setup the ticks and ticklabels. This should not be needed by users.
         """
-        # Get the locator and formatter; defaults to self.locator if not None.
+        # Get the locator and formatter; defaults to self._locator if not None.
         self._get_ticker_locator_formatter()
-        self._long_axis().set_major_locator(self.locator)
-        self._long_axis().set_minor_locator(self.minorlocator)
-        self._long_axis().set_major_formatter(self.formatter)
+        self._long_axis().set_major_locator(self._locator)
+        self._long_axis().set_minor_locator(self._minorlocator)
+        self._long_axis().set_major_formatter(self._formatter)
 
     def _get_ticker_locator_formatter(self):
         """
@@ -794,13 +855,15 @@ class Colorbar:
 
         Called by update_ticks...
         """
-        locator = self.locator
-        formatter = self.formatter
-        minorlocator = self.minorlocator
+        locator = self._locator
+        formatter = self._formatter
+        minorlocator = self._minorlocator
         if isinstance(self.norm, colors.BoundaryNorm):
             b = self.norm.boundaries
             if locator is None:
                 locator = ticker.FixedLocator(b, nbins=10)
+            if minorlocator is None:
+                minorlocator = ticker.FixedLocator(b)
         elif isinstance(self.norm, colors.NoNorm):
             if locator is None:
                 # put ticks on integers between the boundaries of NoNorm
@@ -825,9 +888,9 @@ class Colorbar:
         if formatter is None:
             formatter = self._long_axis().get_major_formatter()
 
-        self.locator = locator
-        self.formatter = formatter
-        self.minorlocator = minorlocator
+        self._locator = locator
+        self._formatter = formatter
+        self._minorlocator = minorlocator
         _log.debug('locator: %r', locator)
 
     @_api.delete_parameter("3.5", "update_ticks")
@@ -851,10 +914,10 @@ class Colorbar:
         if np.iterable(ticks):
             self._long_axis().set_ticks(ticks, labels=labels, minor=minor,
                                         **kwargs)
-            self.locator = self._long_axis().get_major_locator()
+            self._locator = self._long_axis().get_major_locator()
         else:
-            self.locator = ticks
-            self._long_axis().set_major_locator(self.locator)
+            self._locator = ticks
+            self._long_axis().set_major_locator(self._locator)
         self.stale = True
 
     def get_ticks(self, minor=False):
@@ -912,14 +975,14 @@ class Colorbar:
         """
         Turn on colorbar minor ticks.
         """
+        print(self._minorlocator)
         self.ax.minorticks_on()
-        self.minorlocator = self._long_axis().get_minor_locator()
         self._short_axis().set_minor_locator(ticker.NullLocator())
 
     def minorticks_off(self):
         """Turn the minor ticks of the colorbar off."""
-        self.minorlocator = ticker.NullLocator()
-        self._long_axis().set_minor_locator(self.minorlocator)
+        self._minorlocator = ticker.NullLocator()
+        self._long_axis().set_minor_locator(self._minorlocator)
 
     def set_label(self, label, *, loc=None, **kwargs):
         """
@@ -1157,9 +1220,9 @@ class Colorbar:
         the mappable normal gets changed: Colorbar.update_normal)
         """
         self._process_values()
-        self.locator = None
-        self.minorlocator = None
-        self.formatter = None
+        self._locator = None
+        self._minorlocator = None
+        self._formatter = None
         if (self.boundaries is not None or
                 isinstance(self.norm, colors.BoundaryNorm)):
             if self.spacing == 'uniform':

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -530,7 +530,7 @@ class Colorbar:
         Set major `~.Formatter` being used for colorbar.
         """
         self._long_axis().set_major_formatter(fmt)
-        self._locator = fmt
+        self._formatter = fmt
 
     @property
     def minorformatter(self):
@@ -975,7 +975,6 @@ class Colorbar:
         """
         Turn on colorbar minor ticks.
         """
-        print(self._minorlocator)
         self.ax.minorticks_on()
         self._short_axis().set_minor_locator(ticker.NullLocator())
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1202,6 +1202,7 @@ class Colorbar:
         self._locator = None
         self._minorlocator = None
         self._formatter = None
+        self._minorformatter = None
         if (self.boundaries is not None or
                 isinstance(self.norm, colors.BoundaryNorm)):
             if self.spacing == 'uniform':

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -544,7 +544,7 @@ class Colorbar:
         """
         Set minor formatter being used for colorbar
         """
-        self._long_axis().set_minor_locator(fmt)
+        self._long_axis().set_minor_formatter(fmt)
         self._minorformatter = fmt
 
     def _cbar_cla(self):

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -11,7 +11,7 @@ from matplotlib.colors import (
     BoundaryNorm, LogNorm, PowerNorm, Normalize, NoNorm
 )
 from matplotlib.colorbar import Colorbar
-from matplotlib.ticker import FixedLocator
+from matplotlib.ticker import FixedLocator, LogFormatter
 from matplotlib.testing.decorators import check_figures_equal
 
 
@@ -950,3 +950,32 @@ def test_colorbar_no_warning_rcparams_grid_true():
     im = ax.pcolormesh([0, 1], [0, 1], [[1]])
     # make sure that no warning is raised by fig.colorbar
     fig.colorbar(im)
+
+
+def test_colorbar_set_formatter_locator():
+    # check that the locator properties echo what is on the axis:
+    fig, ax = plt.subplots()
+    pc = ax.pcolormesh(np.random.randn(10, 10))
+    cb = fig.colorbar(pc)
+    cb.ax.yaxis.set_major_locator(FixedLocator(np.arange(10)))
+    cb.ax.yaxis.set_minor_locator(FixedLocator(np.arange(0, 10, 0.2)))
+    assert cb.locator == cb.ax.yaxis.get_major_locator()
+    assert cb.minorlocator == cb.ax.yaxis.get_minor_locator()
+    cb.ax.yaxis.set_major_formatter(LogFormatter())
+    cb.ax.yaxis.set_minor_formatter(LogFormatter())
+    assert cb.formatter == cb.ax.yaxis.get_major_formatter()
+    assert cb.minorformatter == cb.ax.yaxis.get_minor_formatter()
+
+    # check that the setter works as expected:
+    loc = FixedLocator(np.arange(7))
+    cb.locator = loc
+    assert cb.ax.yaxis.get_major_locator() == loc
+    loc = FixedLocator(np.arange(0, 7, 0.1))
+    cb.minorlocator = loc
+    assert cb.ax.yaxis.get_minor_locator() == loc
+    fmt = LogFormatter()
+    cb.formatter = fmt
+    assert cb.ax.yaxis.get_major_formatter() == fmt
+    fmt = LogFormatter()
+    cb.minorformatter = fmt
+    assert cb.ax.yaxis.get_minor_formatter() == fmt

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -959,23 +959,23 @@ def test_colorbar_set_formatter_locator():
     cb = fig.colorbar(pc)
     cb.ax.yaxis.set_major_locator(FixedLocator(np.arange(10)))
     cb.ax.yaxis.set_minor_locator(FixedLocator(np.arange(0, 10, 0.2)))
-    assert cb.locator == cb.ax.yaxis.get_major_locator()
-    assert cb.minorlocator == cb.ax.yaxis.get_minor_locator()
+    assert cb.locator is cb.ax.yaxis.get_major_locator()
+    assert cb.minorlocator is cb.ax.yaxis.get_minor_locator()
     cb.ax.yaxis.set_major_formatter(LogFormatter())
     cb.ax.yaxis.set_minor_formatter(LogFormatter())
-    assert cb.formatter == cb.ax.yaxis.get_major_formatter()
-    assert cb.minorformatter == cb.ax.yaxis.get_minor_formatter()
+    assert cb.formatter is cb.ax.yaxis.get_major_formatter()
+    assert cb.minorformatter is cb.ax.yaxis.get_minor_formatter()
 
     # check that the setter works as expected:
     loc = FixedLocator(np.arange(7))
     cb.locator = loc
-    assert cb.ax.yaxis.get_major_locator() == loc
+    assert cb.ax.yaxis.get_major_locator() is loc
     loc = FixedLocator(np.arange(0, 7, 0.1))
     cb.minorlocator = loc
-    assert cb.ax.yaxis.get_minor_locator() == loc
+    assert cb.ax.yaxis.get_minor_locator() is loc
     fmt = LogFormatter()
     cb.formatter = fmt
-    assert cb.ax.yaxis.get_major_formatter() == fmt
+    assert cb.ax.yaxis.get_major_formatter() is fmt
     fmt = LogFormatter()
     cb.minorformatter = fmt
-    assert cb.ax.yaxis.get_minor_formatter() == fmt
+    assert cb.ax.yaxis.get_minor_formatter() is fmt


### PR DESCRIPTION
## PR Summary

This is to prepare to address #22233

Currently the user can set the colorbar locator and formatter by direct access to the properties `cb.formatter`, `cb.locator`, and `cb.minorlocator`.  However, they can also set `cb.ax.yaxis.set_major_locator` etc.  

This moves the attributes to properties with setters and getters.  The advantage of this is keeping the attributes in sync, but also we can track if the user set the locators via the properties.  If not, then we assume we can replace the locators and formatters with defaults. 

This does _not_ catch if the user set the locator and formatter using `cb.ax.yaxis.*`, so we may still have some things to figure out there.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
