### PR TITLE
Unify toolbar init across backends.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2717,6 +2717,9 @@ class FigureManagerBase:
                 figure.canvas.manager.button_press_handler_id)
     """
 
+    _toolbar2_class = None
+    _toolmanager_toolbar_class = None
+
     def __init__(self, canvas, num):
         self.canvas = canvas
         canvas.manager = self  # store a pointer to parent
@@ -2734,7 +2737,19 @@ class FigureManagerBase:
         self.toolmanager = (ToolManager(canvas.figure)
                             if mpl.rcParams['toolbar'] == 'toolmanager'
                             else None)
-        self.toolbar = None
+        if (mpl.rcParams["toolbar"] == "toolbar2"
+                and self._toolbar2_class):
+            self.toolbar = self._toolbar2_class(self.canvas)
+        elif (mpl.rcParams["toolbar"] == "toolmanager"
+                and self._toolmanager_toolbar_class):
+            self.toolbar = self._toolmanager_toolbar_class(self.toolmanager)
+        else:
+            self.toolbar = None
+
+        if self.toolmanager:
+            tools.add_tools_to_manager(self.toolmanager)
+            if self.toolbar:
+                tools.add_tools_to_container(self.toolbar)
 
         @self.canvas.figure.add_axobserver
         def notify_axes_change(fig):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -410,13 +410,7 @@ class FigureManagerTk(FigureManagerBase):
         self.window.withdraw()
         # packing toolbar first, because if space is getting low, last packed
         # widget is getting shrunk first (-> the canvas)
-        self.toolbar = self._get_toolbar()
         self.canvas._tkcanvas.pack(side=tk.TOP, fill=tk.BOTH, expand=1)
-
-        if self.toolmanager:
-            backend_tools.add_tools_to_manager(self.toolmanager)
-            if self.toolbar:
-                backend_tools.add_tools_to_container(self.toolbar)
 
         # If the window has per-monitor DPI awareness, then setup a Tk variable
         # to store the DPI, which will be updated by the C code, and the trace
@@ -429,15 +423,6 @@ class FigureManagerTk(FigureManagerBase):
             window_dpi.trace_add('write', self._update_window_dpi)
 
         self._shown = False
-
-    def _get_toolbar(self):
-        if mpl.rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2Tk(self.canvas)
-        elif mpl.rcParams['toolbar'] == 'toolmanager':
-            toolbar = ToolbarTk(self.toolmanager)
-        else:
-            toolbar = None
-        return toolbar
 
     def _update_window_dpi(self, *args):
         newdpi = self._window_dpi.get()
@@ -898,6 +883,8 @@ class HelpTk(backend_tools.ToolHelpBase):
 
 
 Toolbar = ToolbarTk
+FigureManagerTk._toolbar2_class = NavigationToolbar2Tk
+FigureManagerTk._toolmanager_toolbar_class = ToolbarTk
 
 
 @_Backend.export

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -331,13 +331,6 @@ class FigureManagerGTK3(FigureManagerBase):
         # calculate size for window
         w, h = self.canvas.get_width_height()
 
-        self.toolbar = self._get_toolbar()
-
-        if self.toolmanager:
-            backend_tools.add_tools_to_manager(self.toolmanager)
-            if self.toolbar:
-                backend_tools.add_tools_to_container(self.toolbar)
-
         if self.toolbar is not None:
             self.toolbar.show()
             self.vbox.pack_end(self.toolbar, False, False, 0)
@@ -737,6 +730,8 @@ backend_tools._register_tool_class(
     FigureCanvasGTK3, _backend_gtk.ConfigureSubplotsGTK)
 backend_tools._register_tool_class(
     FigureCanvasGTK3, _backend_gtk.RubberbandGTK)
+FigureManagerGTK3._toolbar2_class = NavigationToolbar2GTK3
+FigureManagerGTK3._toolmanager_toolbar_class = ToolbarGTK3
 
 
 @_BackendGTK.export

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -279,13 +279,6 @@ class FigureManagerGTK4(FigureManagerBase):
         # calculate size for window
         w, h = self.canvas.get_width_height()
 
-        self.toolbar = self._get_toolbar()
-
-        if self.toolmanager:
-            backend_tools.add_tools_to_manager(self.toolmanager)
-            if self.toolbar:
-                backend_tools.add_tools_to_container(self.toolbar)
-
         if self.toolbar is not None:
             sw = Gtk.ScrolledWindow(vscrollbar_policy=Gtk.PolicyType.NEVER)
             sw.set_child(self.toolbar)
@@ -334,17 +327,6 @@ class FigureManagerGTK4(FigureManagerBase):
             self.window.fullscreen()
         else:
             self.window.unfullscreen()
-
-    def _get_toolbar(self):
-        # must be inited after the window, drawingArea and figure
-        # attrs are set
-        if mpl.rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2GTK4(self.canvas)
-        elif mpl.rcParams['toolbar'] == 'toolmanager':
-            toolbar = ToolbarGTK4(self.toolmanager)
-        else:
-            toolbar = None
-        return toolbar
 
     def get_window_title(self):
         return self.window.get_title()
@@ -673,6 +655,8 @@ backend_tools._register_tool_class(
 backend_tools._register_tool_class(
     FigureCanvasGTK4, _backend_gtk.RubberbandGTK)
 Toolbar = ToolbarGTK4
+FigureManagerGTK4._toolbar2_class = NavigationToolbar2GTK4
+FigureManagerGTK4._toolmanager_toolbar_class = ToolbarGTK4
 
 
 @_BackendGTK.export

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -62,30 +62,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         self.draw_idle()
 
 
-class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
-    """
-    Wrap everything up into a window for the pylab interface
-    """
-    def __init__(self, canvas, num):
-        _macosx.FigureManager.__init__(self, canvas)
-        icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
-        _macosx.FigureManager.set_icon(icon_path)
-        FigureManagerBase.__init__(self, canvas, num)
-        if mpl.rcParams['toolbar'] == 'toolbar2':
-            self.toolbar = NavigationToolbar2Mac(canvas)
-        else:
-            self.toolbar = None
-        if self.toolbar is not None:
-            self.toolbar.update()
-
-        if mpl.is_interactive():
-            self.show()
-            self.canvas.draw_idle()
-
-    def close(self):
-        Gcf.destroy(self)
-
-
 class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
 
     def __init__(self, canvas):
@@ -121,6 +97,24 @@ class NavigationToolbar2Mac(_macosx.NavigationToolbar2, NavigationToolbar2):
 
     def set_message(self, message):
         _macosx.NavigationToolbar2.set_message(self, message.encode('utf-8'))
+
+
+class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
+    _toolbar2_class = NavigationToolbar2Mac
+
+    def __init__(self, canvas, num):
+        _macosx.FigureManager.__init__(self, canvas)
+        icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
+        _macosx.FigureManager.set_icon(icon_path)
+        FigureManagerBase.__init__(self, canvas, num)
+        if self.toolbar is not None:
+            self.toolbar.update()
+        if mpl.is_interactive():
+            self.show()
+            self.canvas.draw_idle()
+
+    def close(self):
+        Gcf.destroy(self)
 
 
 @_Backend.export

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -72,7 +72,7 @@ class NavigationIPy(NavigationToolbar2WebAgg):
 
 
 class FigureManagerNbAgg(FigureManagerWebAgg):
-    ToolbarCls = NavigationIPy
+    _toolbar2_class = ToolbarCls = NavigationIPy
 
     def __init__(self, canvas, num):
         self._shown = False

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -529,13 +529,6 @@ class FigureManagerQT(FigureManagerBase):
 
         self.window._destroying = False
 
-        self.toolbar = self._get_toolbar(self.canvas, self.window)
-
-        if self.toolmanager:
-            backend_tools.add_tools_to_manager(self.toolmanager)
-            if self.toolbar:
-                backend_tools.add_tools_to_container(self.toolbar)
-
         if self.toolbar:
             self.window.addToolBar(self.toolbar)
             tbs_height = self.toolbar.sizeHint().height()
@@ -581,17 +574,6 @@ class FigureManagerQT(FigureManagerBase):
             # It seems that when the python session is killed,
             # Gcf can get destroyed before the Gcf.destroy
             # line is run, leading to a useless AttributeError.
-
-    def _get_toolbar(self, canvas, parent):
-        # must be inited after the window, drawingArea and figure
-        # attrs are set
-        if mpl.rcParams['toolbar'] == 'toolbar2':
-            toolbar = NavigationToolbar2QT(canvas)
-        elif mpl.rcParams['toolbar'] == 'toolmanager':
-            toolbar = ToolbarQt(self.toolmanager)
-        else:
-            toolbar = None
-        return toolbar
 
     def resize(self, width, height):
         # The Qt methods return sizes in 'virtual' pixels so we do need to
@@ -1019,6 +1001,10 @@ class ToolCopyToClipboardQT(backend_tools.ToolCopyToClipboardBase):
     def trigger(self, *args, **kwargs):
         pixmap = self.canvas.grab()
         qApp.clipboard().setPixmap(pixmap)
+
+
+FigureManagerQT._toolbar2_class = NavigationToolbar2QT
+FigureManagerQT._toolmanager_toolbar_class = ToolbarQt
 
 
 @_Backend.export

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -453,19 +453,14 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
 
 
 class FigureManagerWebAgg(backend_bases.FigureManagerBase):
-    ToolbarCls = NavigationToolbar2WebAgg
+    _toolbar2_class = ToolbarCls = NavigationToolbar2WebAgg
 
     def __init__(self, canvas, num):
         self.web_sockets = set()
         super().__init__(canvas, num)
-        self.toolbar = self._get_toolbar(canvas)
 
     def show(self):
         pass
-
-    def _get_toolbar(self, canvas):
-        toolbar = self.ToolbarCls(canvas)
-        return toolbar
 
     def resize(self, w, h, forward=True):
         self._send_event(

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -4,8 +4,6 @@ from matplotlib.testing import _check_for_pgf
 from matplotlib.backend_bases import (
     FigureCanvasBase, LocationEvent, MouseButton, MouseEvent,
     NavigationToolbar2, RendererBase)
-from matplotlib.backend_tools import (ToolZoom, ToolPan, RubberbandBase,
-                                      ToolViewsPositions, _views_positions)
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
 import matplotlib.transforms as transforms
@@ -250,14 +248,6 @@ def test_toolbar_zoompan():
         plt.rcParams['toolbar'] = 'toolmanager'
     ax = plt.gca()
     assert ax.get_navigate_mode() is None
-    ax.figure.canvas.manager.toolmanager.add_tool(name="zoom",
-                                                  tool=ToolZoom)
-    ax.figure.canvas.manager.toolmanager.add_tool(name="pan",
-                                                  tool=ToolPan)
-    ax.figure.canvas.manager.toolmanager.add_tool(name=_views_positions,
-                                                  tool=ToolViewsPositions)
-    ax.figure.canvas.manager.toolmanager.add_tool(name='rubberband',
-                                                  tool=RubberbandBase)
     ax.figure.canvas.manager.toolmanager.trigger_tool('zoom')
     assert ax.get_navigate_mode() == "ZOOM"
     ax.figure.canvas.manager.toolmanager.trigger_tool('pan')


### PR DESCRIPTION
... by instantiating classes specified by _toolbar2_class or
_toolmanager_toolbar_class.  (Third-parties can still manually
instantiate their toolbars the old-fashioned way.)

Note that this would read a bit nicer if the toolbar classes were
defined before the manager classes, as this would allow _toolbar2_class
and _toolmanager_toolbar_class to be set using normal class attributes,
but moving large chunks of code around did not seem worth it.  I only
did so for the macosx backend, where the moved code is very little.

This means that all toolbars default to having the standard tools added,
not just the interactive ones.  See e.g. changes in
test_toolbar_zoompan: it is no longer necessary to explicitly register
all the tools (this actually now emits a duplicate tool warning).

This also moves the canonical storage of the toolbar on wx from the
frame to the manager (keeping a proxy for backcompat), for consistency
with the other backends.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
