### PR TITLE
Disable QuadMesh cursor data by default

### DIFF
--- a/doc/api/next_api_changes/behavior/22254-DS.rst
+++ b/doc/api/next_api_changes/behavior/22254-DS.rst
@@ -1,0 +1,5 @@
+QuadMesh cursor data disabled by default
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Showing the cursor data of a `.QuadMesh` is now disabled by default, as it has
+significant performance issues with large meshes. To manually enable this
+use :meth:`.QuadMesh.set_show_cursor_data`.

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2000,6 +2000,7 @@ class QuadMesh(Collection):
         self._shading = shading
         self._bbox = transforms.Bbox.unit()
         self._bbox.update_from_data_xy(self._coordinates.reshape(-1, 2))
+        self._show_cursor_data = False
         # super init delayed after own init because array kwarg requires
         # self._coordinates and self._shading
         super().__init__(**kwargs)
@@ -2197,7 +2198,23 @@ class QuadMesh(Collection):
         renderer.close_group(self.__class__.__name__)
         self.stale = False
 
+    def set_show_cursor_data(self, show_cursor_data):
+        """
+        Set whether cursor data should be shown.
+
+        Notes
+        -----
+        This is set to `False` by default for new quad meshes. Showing cursor
+        data can have significant performance impacts for large meshes.
+        """
+        self._show_cursor_data = show_cursor_data
+
+    def get_show_cursor_data(self):
+        return self._show_cursor_data
+
     def get_cursor_data(self, event):
+        if not self._show_cursor_data:
+            return
         contained, info = self.contains(event)
         if len(info["ind"]) == 1:
             ind, = info["ind"]

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1027,13 +1027,20 @@ def test_quadmesh_cursor_data():
     fig, ax = plt.subplots()
     *_, qm = ax.hist2d(
         np.arange(11)**2, 100 + np.arange(11)**2)  # width-10 bins
+
     x, y = ax.transData.transform([1, 101])
     event = MouseEvent('motion_notify_event', fig.canvas, x, y)
+
+    assert qm.get_show_cursor_data() is False
+    assert qm.get_cursor_data(event) is None
+
+    qm.set_show_cursor_data(True)
     assert qm.get_cursor_data(event) == 4  # (0**2, 1**2, 2**2, 3**2)
-    for out_xydata in []:
-        x, y = ax.transData.transform([-1, 101])
-        event = MouseEvent('motion_notify_event', fig.canvas, x, y)
-        assert qm.get_cursor_data(event) is None
+
+    # Outside the quadmesh bounds
+    x, y = ax.transData.transform([-1, 101])
+    event = MouseEvent('motion_notify_event', fig.canvas, x, y)
+    assert qm.get_cursor_data(event) is None
 
 
 def test_get_segments():


### PR DESCRIPTION
## PR Summary
For moderately sized QuadMeshes getting the cursor data is very slow - see https://github.com/matplotlib/matplotlib/issues/21917#issuecomment-1002201750. As such, disable by default for now, but allow users to manually enable it.

Fixes https://github.com/matplotlib/matplotlib/issues/22253
Fixes https://github.com/matplotlib/matplotlib/issues/21917


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
