### PR TITLE
Skip tests on the -doc branches

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,8 @@ on:
       - auto-backport-of-pr-[0-9]+
       - v[0-9]+.[0-9]+.[0-9x]+-doc
   pull_request:
+    branches-ignore:
+      - v[0-9]+.[0-9]+.[0-9x]+-doc
 
 env:
   NO_AT_BRIDGE: 1  # Necessary for GTK3 interactive test.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,6 +3,15 @@
 # Add steps that analyze code, save the dist with the build record, publish to a PyPI-compatible index, and more:
 # https://docs.microsoft.com/en-us/azure/devops/pipelines/ecosystems/python?view=azure-devops
 
+trigger:
+  branches:
+    exclude:
+      - v[0-9]+.[0-9]+.[0-9x]+-doc
+pr:
+  branches:
+    exclude:
+      - v[0-9]+.[0-9]+.[0-9x]+-doc
+
 stages:
 
 - stage: Check


### PR DESCRIPTION
## PR Summary

GitHub Actions tests are already disabled for direct pushes, but not for the PRs directed at -doc branches. Azure is not disabled in any case. I'm not sure if I have that config right though.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
