### PR TITLE
DOC: fix version switcher 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,7 +325,8 @@ html_theme_options = {
     "show_prev_next": False,
     "switcher": {
         "json_url": "https://matplotlib.org/devdocs/_static/switcher.json",
-        "url_template": "https://matplotlib.org/{version}/"
+        "url_template": "https://matplotlib.org/{version}/",
+        "version_match": version,
     },
     "navbar_end": ["version-switcher", "mpl_icon_links"]
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -324,7 +324,7 @@ html_theme_options = {
     "collapse_navigation": not is_release_build,
     "show_prev_next": False,
     "switcher": {
-        "json_url": "https://matplotlib.org/en/devdocs/_static/switcher.json",
+        "json_url": "https://matplotlib.org/devdocs/_static/switcher.json",
         "url_template": "https://matplotlib.org/{version}/"
     },
     "navbar_end": ["version-switcher", "mpl_icon_links"]


### PR DESCRIPTION
## PR Summary

Fix version switcher now that json file is in place.

Note that changes to the json file itself will have to be merged, but the switcher is still not quite working, so lets make sure we understand that first.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
