### PR TITLE
Deprecated is_decade and is_close_to_int

### DIFF
--- a/doc/api/next_api_changes/deprecations/22268-OG.rst
+++ b/doc/api/next_api_changes/deprecations/22268-OG.rst
@@ -1,0 +1,10 @@
+``ticker`` functions deprecated
+-------------------------------
+
+The functions ``matplotlib.ticker.is_decade`` and
+``matplotlib.ticker.is_close_to_int`` are considered internal and public access
+is deprecated.
+
+For ``is_close_to_int`` use ``math.isclose(x, round(x))`` instead.
+For ``is_decade`` use
+``y = numpy.log(x)/numpy.log(base); numpy.isclose(y, numpy.round(y))``


### PR DESCRIPTION
## PR Summary

Deprecating two functions that should be internal. Original issue (as discussed on gitter):

---

Digging into ticker.py and found the following concern: is_close_to_int uses a keyword argument atol (absolute tolerance?) comparing using absolute tolerance. However, it is also called from isdecade where the keyword argument rtol (relative tolerance?) is passed as absolut tolerance.
1) It seems like relative tolerance makes more sense for is_close_to_int
2) It seems inconsistent to pass rtol as atol (if now the keyword naming actually says something)

If I would change this, I guess the safest way is to provide an additional keyword argument to is_close_to_int, rtol=None, check if that is set and if so use that instead? For isdecade it is not so obvious as making it consistent will break the behavior.

(I originally just wanted to use isdecade in a few places...)

---

Outcome:
* Deprecating `is_decade` and introducing `_is_decade` that use `rtol` as relative tolerance, not as absolute tolerance.
* Deprecating `is_close_to_int` which is not replaced (rely on `math.isclose` and `np.isclose`).

The behavior is slightly changed, although it is hard to say that if it will actually be an issue. The tolerances seems quite arbitrarily set and considering that these are mainly used for exponents of bases, so typically rather small integers. But there may indeed be cases which will behave differently now.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
