### PR TITLE
Expanded documentation of Axis.set_ticks as per discussion in issue #22262

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1841,9 +1841,6 @@ class Axis(martist.Artist):
         choice to prevent the surprise of a non-visible tick. If you need
         other limits, you should set the limits explicitly after setting the
         ticks.
-
-        Do not mix automatically and manually placed ticks with this method.
-        See :ghissue:`22262` for discussion.
         """
         result = self._set_tick_locations(ticks, minor=minor)
         if labels is not None:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1826,7 +1826,7 @@ class Axis(martist.Artist):
             List of tick locations.
         labels : list of str, optional
             List of tick labels. If not set, the labels show the data value.
-            
+
             .. warning::
                 Setting *labels=None* does not guarantee that labels for all
                 set ticks will be automatically generated - this depends
@@ -1853,20 +1853,20 @@ class Axis(martist.Artist):
         choice to prevent the surprise of a non-visible tick. If you need
         other limits, you should set the limits explicitly after setting the
         ticks.
-        
+
         This method implicitly calls :meth:`.set_major_locator` (or
         :meth:`.set_minor_locator` if *minor=True*) with a newly-constructed
         :class:`~matplotlib.ticker.FixedLocator` initialized to the provided
         tick locations.
-        
+
         Do not add ticks manually to an automatically ticked axis
         by e.g. doing::
-        
+
             special_ticks = [1.1, 2.5, 3.7]
             ticks = axes.get_yticks()
             ticks_ext = np.append(ticklist, special_ticks)
             axes.set_yticks(ticks_ext)
-            
+
         as this may give unpredictable results.
         See :ghissue:`22262` for discussion.
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1823,24 +1823,10 @@ class Axis(martist.Artist):
         Parameters
         ----------
         ticks : list of floats
-            List of tick locations.
+            List of tick locations.  The axis `.Locator` is replaced by a `.FixedLocator`.  Some  
+            default tick formatters will not label arbitrary ticks, so pass *label* if needed.  
         labels : list of str, optional
-            List of tick labels. If not set, the labels show the data value.
-
-            .. warning::
-                Setting *labels=None* does not guarantee that labels for all
-                set ticks will be automatically generated - this depends
-                on the :class:`~matplotlib.ticker.Formatter` of the axis.
-                Some tick label formatters, e.g.
-                :class:`~matplotlib.ticker.ScalarFormatter` (default for
-                plots made with :meth:`~.Axes.plot`) will make
-                labels for custom ticks, while
-                others like e.g.
-                :class:`~matplotlib.ticker.LogFormatterSciNotation`
-                (default for :meth:`~.Axes.semilogy` plots) may not.
-                Supply all tick labels in the *labels* parameter if you
-                want to be sure.
-
+            List of tick labels. If not set, the labels are generated with the axis tick `.Formatter`.
         minor : bool, default: False
             If ``False``, set the major ticks; if ``True``, the minor ticks.
         **kwargs

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1825,7 +1825,7 @@ class Axis(martist.Artist):
         ticks : list of floats
             List of tick locations.  The axis `.Locator` is replaced by a
             `.FixedLocator`.
-            
+
             Some tick formatters will not label arbitrary tick positions;
             e.g. log formatters only label decade ticks by default. In
             such a case you can set a formatter explicitly on the axis

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1842,8 +1842,8 @@ class Axis(martist.Artist):
         other limits, you should set the limits explicitly after setting the
         ticks.
 
-        Do not add ticks manually to an automatically ticked axis (as with
-        *labels=None*). See :ghissue:`22262` for discussion.
+        Do not mix automatically and manually placed ticks with this method.
+        See :ghissue:`22262` for discussion.
         """
         result = self._set_tick_locations(ticks, minor=minor)
         if labels is not None:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1824,7 +1824,7 @@ class Axis(martist.Artist):
         ----------
         ticks : list of floats
             List of tick locations.  The axis `.Locator` is replaced by a
-            `.FixedLocator`.
+            `~.ticker.FixedLocator`.
 
             Some tick formatters will not label arbitrary tick positions;
             e.g. log formatters only label decade ticks by default. In

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1826,6 +1826,21 @@ class Axis(martist.Artist):
             List of tick locations.
         labels : list of str, optional
             List of tick labels. If not set, the labels show the data value.
+            
+            .. warning::
+                Setting *labels=None* does not guarantee that labels for all
+                set ticks will be automatically generated - this depends
+                on the :class:`~matplotlib.ticker.Formatter` of the axis.
+                Some tick label formatters, e.g.
+                :class:`~matplotlib.ticker.ScalarFormatter` (default for
+                plots made with :meth:`~.Axes.plot`) will make
+                labels for custom ticks, while
+                others like e.g.
+                :class:`~matplotlib.ticker.LogFormatterSciNotation`
+                (default for :meth:`~.Axes.semilogy` plots) may not.
+                Supply all tick labels in the *labels* parameter if you
+                want to be sure.
+
         minor : bool, default: False
             If ``False``, set the major ticks; if ``True``, the minor ticks.
         **kwargs
@@ -1838,6 +1853,22 @@ class Axis(martist.Artist):
         choice to prevent the surprise of a non-visible tick. If you need
         other limits, you should set the limits explicitly after setting the
         ticks.
+        
+        This method implicitly calls :meth:`.set_major_locator` (or
+        :meth:`.set_minor_locator` if *minor=True*) with a newly-constructed
+        :class:`~matplotlib.ticker.FixedLocator` initialized to the provided
+        tick locations.
+        
+        Do not add ticks manually to an automatically ticked axis
+        by e.g. doing::
+        
+            special_ticks = [1.1, 2.5, 3.7]
+            ticks = axes.get_yticks()
+            ticks_ext = np.append(ticklist, special_ticks)
+            axes.set_yticks(ticks_ext)
+            
+        as this may give unpredictable results.
+        See :ghissue:`22262` for discussion.
         """
         result = self._set_tick_locations(ticks, minor=minor)
         if labels is not None:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1860,14 +1860,26 @@ class Axis(martist.Artist):
         tick locations.
 
         Do not add ticks manually to an automatically ticked axis
-        by e.g. doing::
+        by e.g. doing (for the *y* axis, in this example)::
 
-            special_ticks = [1.1, 2.5, 3.7]
+            special_ticks = [1.1, 2.5, 3.7] # arbitrary tick locations
             ticks = axes.get_yticks()
             ticks_ext = np.append(ticklist, special_ticks)
             axes.set_yticks(ticks_ext)
 
-        as this may give unpredictable results.
+        as this may give unpredictable results. Instead, create a secondary
+        axis with :meth:`.Axes.secondary_yaxis` and set its ticks and tick
+        labels manually::
+
+            special_ticks = [1.1, 2.5, 3.7] # arbitrary tick locations
+            special_labels = [f"{tick:g}" for tick in special_ticks]
+            secaxis = axes.secondary_yaxis("left") # or "right", according to\
+preference
+            # Manually setting the labels, as outlined in the warning.
+            secaxis.set_yticks(special_ticks, labels=special_labels)
+
+        Note that there is no limit to the number of secondary axes and it
+        is possible to overlay a secondary axis on another axis.
         See :ghissue:`22262` for discussion.
         """
         result = self._set_tick_locations(ticks, minor=minor)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1823,10 +1823,12 @@ class Axis(martist.Artist):
         Parameters
         ----------
         ticks : list of floats
-            List of tick locations.  The axis `.Locator` is replaced by a `.FixedLocator`.  Some  
-            default tick formatters will not label arbitrary ticks, so pass *label* if needed.  
+            List of tick locations.  The axis `.Locator` is replaced by a
+            `.FixedLocator`.  Some default tick formatters will not label
+            arbitrary ticks, so pass *label* to ensure labels are visible.
         labels : list of str, optional
-            List of tick labels. If not set, the labels are generated with the axis tick `.Formatter`.
+            List of tick labels. If not set, the labels are generated with
+            the axis tick `.Formatter`.
         minor : bool, default: False
             If ``False``, set the major ticks; if ``True``, the minor ticks.
         **kwargs
@@ -1840,33 +1842,8 @@ class Axis(martist.Artist):
         other limits, you should set the limits explicitly after setting the
         ticks.
 
-        This method implicitly calls :meth:`.set_major_locator` (or
-        :meth:`.set_minor_locator` if *minor=True*) with a newly-constructed
-        :class:`~matplotlib.ticker.FixedLocator` initialized to the provided
-        tick locations.
-
-        Do not add ticks manually to an automatically ticked axis
-        by e.g. doing (for the *y* axis, in this example)::
-
-            special_ticks = [1.1, 2.5, 3.7] # arbitrary tick locations
-            ticks = axes.get_yticks()
-            ticks_ext = np.append(ticklist, special_ticks)
-            axes.set_yticks(ticks_ext)
-
-        as this may give unpredictable results. Instead, create a secondary
-        axis with :meth:`.Axes.secondary_yaxis` and set its ticks and tick
-        labels manually::
-
-            special_ticks = [1.1, 2.5, 3.7] # arbitrary tick locations
-            special_labels = [f"{tick:g}" for tick in special_ticks]
-            secaxis = axes.secondary_yaxis("left") # or "right", according to\
-preference
-            # Manually setting the labels, as outlined in the warning.
-            secaxis.set_yticks(special_ticks, labels=special_labels)
-
-        Note that there is no limit to the number of secondary axes and it
-        is possible to overlay a secondary axis on another axis.
-        See :ghissue:`22262` for discussion.
+        Do not add ticks manually to an automatically ticked axis (as with
+        *labels=None*). See :ghissue:`22262` for discussion.
         """
         result = self._set_tick_locations(ticks, minor=minor)
         if labels is not None:


### PR DESCRIPTION
## PR Summary
Expanded documentation of `Axis.set_ticks` as per discussion in #22262 to help protect future users from pitfalls when trying to add special/custom ticks.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error). (*I can't build the docs without installing from source, and there appears to be no way to finish the installation without VC++ which I cannot fit onto my old PC*)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
