### PR TITLE
Improve inheritance diagrams

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -99,3 +99,13 @@ table.property-table td {
     display: inline-block;
     margin: 0 0.5em;
 }
+
+/* Make inheritance images have a scroll bar if necessary. */
+div.graphviz {
+    border: 1px solid lightgrey;
+    max-height: 50em;
+    overflow: auto;
+}
+img.graphviz.inheritance {
+    max-width: none;
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -619,7 +619,12 @@ texinfo_documents = [
 
 numpydoc_show_class_members = False
 
-inheritance_node_attrs = dict(fontsize=16)
+# We want to prevent any size limit, as we'll add scroll bars with CSS.
+inheritance_graph_attrs = dict(dpi=100, size='1000.0', splines='polyline')
+# Also remove minimum node dimensions, and increase line size a bit.
+inheritance_node_attrs = dict(height=0.02, margin=0.055, penwidth=1,
+                              width=0.01)
+inheritance_edge_attrs = dict(penwidth=1)
 
 graphviz_dot = shutil.which('dot')
 # Still use PNG until SVG linking is fixed


### PR DESCRIPTION
## PR Summary

When Graphviz is given a page size (which Sphinx does by default), it will layout the whole graph, and then scale the _entire_ thing down to fit. This means that text and lines on large diagrams are inconsistent with ones that fit.

Additionally, the default size is larger than the content width which means the browser will also scale the image down a bit. But the URL map is _not_ scaled down, so the links will appear in the wrong spot.

To fix this, set the page size in Graphviz very large, and make the diagram scrollable with CSS.

Plus a few minor tweaks to font and line sizes now that images are a consistent scale.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).