### PR TITLE
Remove Axes sublists from docs

### DIFF
--- a/examples/mplot3d/wire3d_animation_sgskip.py
+++ b/examples/mplot3d/wire3d_animation_sgskip.py
@@ -39,7 +39,7 @@ tstart = time.time()
 for phi in np.linspace(0, 180. / np.pi, 100):
     # If a line collection is already remove it before drawing.
     if wframe:
-        ax.collections.remove(wframe)
+        wframe.remove()
 
     # Plot the new wireframe and pause briefly before continuing.
     Z = generate(X, Y, phi)

--- a/examples/pie_and_polar_charts/bar_of_pie.py
+++ b/examples/pie_and_polar_charts/bar_of_pie.py
@@ -19,40 +19,36 @@ fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(9, 5))
 fig.subplots_adjust(wspace=0)
 
 # pie chart parameters
-ratios = [.27, .56, .17]
+overall_ratios = [.27, .56, .17]
 labels = ['Approve', 'Disapprove', 'Undecided']
 explode = [0.1, 0, 0]
 # rotate so that first wedge is split by the x-axis
-angle = -180 * ratios[0]
-ax1.pie(ratios, autopct='%1.1f%%', startangle=angle,
-        labels=labels, explode=explode)
+angle = -180 * overall_ratios[0]
+wedges, *_ = ax1.pie(overall_ratios, autopct='%1.1f%%', startangle=angle,
+                     labels=labels, explode=explode)
 
 # bar chart parameters
-
-xpos = 0
-bottom = 0
-ratios = [.33, .54, .07, .06]
+age_ratios = [.33, .54, .07, .06]
+age_labels = ['Under 35', '35-49', '50-65', 'Over 65']
+bottom = 1
 width = .2
-colors = [[.1, .3, .5], [.1, .3, .3], [.1, .3, .7], [.1, .3, .9]]
 
-for j in range(len(ratios)):
-    height = ratios[j]
-    ax2.bar(xpos, height, width, bottom=bottom, color=colors[j])
-    ypos = bottom + ax2.patches[j].get_height() / 2
-    bottom += height
-    ax2.text(xpos, ypos, "%d%%" % (ax2.patches[j].get_height() * 100),
-             ha='center')
+# Adding from the top matches the legend.
+for j, (height, label) in enumerate(reversed([*zip(age_ratios, age_labels)])):
+    bottom -= height
+    bc = ax2.bar(0, height, width, bottom=bottom, color='C0', label=label,
+                 alpha=0.1 + 0.25 * j)
+    ax2.bar_label(bc, labels=[f"{height:.0%}"], label_type='center')
 
 ax2.set_title('Age of approvers')
-ax2.legend(('50-65', 'Over 65', '35-49', 'Under 35'))
+ax2.legend()
 ax2.axis('off')
 ax2.set_xlim(- 2.5 * width, 2.5 * width)
 
 # use ConnectionPatch to draw lines between the two plots
-# get the wedge data
-theta1, theta2 = ax1.patches[0].theta1, ax1.patches[0].theta2
-center, r = ax1.patches[0].center, ax1.patches[0].r
-bar_height = sum([item.get_height() for item in ax2.patches])
+theta1, theta2 = wedges[0].theta1, wedges[0].theta2
+center, r = wedges[0].center, wedges[0].r
+bar_height = sum(age_ratios)
 
 # draw top connecting line
 x = r * np.cos(np.pi / 180 * theta2) + center[0]

--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -79,13 +79,11 @@ Continuing with our example::
     line, = ax.plot(t, s, color='blue', lw=2)
 
 In this example, ``ax`` is the ``Axes`` instance created by the
-``fig.add_subplot`` call above (remember ``Subplot`` is just a
-subclass of ``Axes``) and when you call ``ax.plot``, it creates a
-``Line2D`` instance and adds it to the :attr:`Axes.lines
-<matplotlib.axes.Axes.lines>` list.  In the interactive `IPython
-<https://ipython.org/>`_ session below, you can see that the
-``Axes.lines`` list is length one and contains the same line that was
-returned by the ``line, = ax.plot...`` call:
+``fig.add_subplot`` call above (remember ``Subplot`` is just a subclass of
+``Axes``) and when you call ``ax.plot``, it creates a ``Line2D`` instance and
+adds it to the ``Axes``.  In the interactive `IPython <https://ipython.org/>`_
+session below, you can see that the ``Axes.lines`` list is length one and
+contains the same line that was returned by the ``line, = ax.plot...`` call:
 
 .. sourcecode:: ipython
 
@@ -97,11 +95,10 @@ returned by the ``line, = ax.plot...`` call:
 
 If you make subsequent calls to ``ax.plot`` (and the hold state is "on"
 which is the default) then additional lines will be added to the list.
-You can remove lines later simply by calling the list methods; either
-of these will work::
+You can remove a line later by calling its ``remove`` method::
 
-    del ax.lines[0]
-    ax.lines.remove(line)  # one or the other, not both!
+    line = ax.lines[0]
+    line.remove()
 
 The Axes also has helper methods to configure and decorate the x-axis
 and y-axis tick, tick labels and axis labels::
@@ -386,11 +383,10 @@ plt.show()
 #     rect.set_facecolor('green')
 #
 # When you call a plotting method, e.g., the canonical
-# :meth:`~matplotlib.axes.Axes.plot` and pass in arrays or lists of
-# values, the method will create a :meth:`matplotlib.lines.Line2D`
-# instance, update the line with all the ``Line2D`` properties passed as
-# keyword arguments, add the line to the :attr:`Axes.lines
-# <matplotlib.axes.Axes.lines>` container, and returns it to you:
+# `~matplotlib.axes.Axes.plot` and pass in arrays or lists of values, the
+# method will create a `matplotlib.lines.Line2D` instance, update the line with
+# all the ``Line2D`` properties passed as keyword arguments, add the line to
+# the ``Axes``, and return it to you:
 #
 # .. sourcecode:: ipython
 #
@@ -423,19 +419,20 @@ plt.show()
 #     In [235]: print(len(ax.patches))
 #     Out[235]: 50
 #
-# You should not add objects directly to the ``Axes.lines`` or
-# ``Axes.patches`` lists unless you know exactly what you are doing,
-# because the ``Axes`` needs to do a few things when it creates and adds
-# an object.  It sets the figure and axes property of the ``Artist``, as
-# well as the default ``Axes`` transformation (unless a transformation
-# is set).  It also inspects the data contained in the ``Artist`` to
-# update the data structures controlling auto-scaling, so that the view
-# limits can be adjusted to contain the plotted data.  You can,
-# nonetheless, create objects yourself and add them directly to the
-# ``Axes`` using helper methods like
-# :meth:`~matplotlib.axes.Axes.add_line` and
-# :meth:`~matplotlib.axes.Axes.add_patch`.  Here is an annotated
-# interactive session illustrating what is going on:
+# You should not add objects directly to the ``Axes.lines`` or ``Axes.patches``
+# lists, because the ``Axes`` needs to do a few things when it creates and adds
+# an object:
+#
+# - It sets the ``figure`` and ``axes`` property of the ``Artist``;
+# - It sets the default ``Axes`` transformation (unless one is already set);
+# - It inspects the data contained in the ``Artist`` to update the data
+#   structures controlling auto-scaling, so that the view limits can be
+#   adjusted to contain the plotted data.
+#
+# You can, nonetheless, create objects yourself and add them directly to the
+# ``Axes`` using helper methods like `~matplotlib.axes.Axes.add_line` and
+# `~matplotlib.axes.Axes.add_patch`.  Here is an annotated interactive session
+# illustrating what is going on:
 #
 # .. sourcecode:: ipython
 #


### PR DESCRIPTION
## PR Summary

There are some bits of the tutorials that should have been changed to remove reference to modifying the Axes sublists.

Also remove the use of the sublists in the 'bar of pie' example, and improve its colours.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).