### PR TITLE
Fixed `repr` for `SecondaryAxis`

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -710,10 +710,8 @@ class _AxesBase(martist.Artist):
         for k in ["left", "center", "right"]:
             if hasattr(self, 'get_title'):
                 title = self.get_title(loc=k)
-            else:
-                title = ""
-            if title:
-                titles.append(f"{k!r}:{title!r}")
+                if title:
+                    titles.append(f"{k!r}:{title!r}")
         if titles:
             fields += ["title={" + ",".join(titles) + "}"]
         if self.get_xlabel():

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -708,7 +708,10 @@ class _AxesBase(martist.Artist):
             fields += [f"label={self.get_label()!r}"]
         titles = []
         for k in ["left", "center", "right"]:
-            title = self.get_title(loc=k)
+            if hasattr(self, 'get_title'):
+                title = self.get_title(loc=k)
+            else:
+                title = ""
             if title:
                 titles.append(f"{k!r}:{title!r}")
         if titles:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -490,18 +490,18 @@ def test_autoscale_tight():
     assert_allclose(ax.get_ylim(), (1.0, 4.0))
 
     # Check that autoscale is on
-    assert ax.get_autoscalex_on() is True
-    assert ax.get_autoscaley_on() is True
-    assert ax.get_autoscale_on() is True
+    assert ax.get_autoscalex_on()
+    assert ax.get_autoscaley_on()
+    assert ax.get_autoscale_on()
     # Set enable to None
     ax.autoscale(enable=None)
     # Same limits
     assert_allclose(ax.get_xlim(), (-0.15, 3.15))
     assert_allclose(ax.get_ylim(), (1.0, 4.0))
     # autoscale still on
-    assert ax.get_autoscalex_on() is True
-    assert ax.get_autoscaley_on() is True
-    assert ax.get_autoscale_on() is True
+    assert ax.get_autoscalex_on()
+    assert ax.get_autoscaley_on()
+    assert ax.get_autoscale_on()
 
 
 @mpl.style.context('default')


### PR DESCRIPTION
and increase coverage for axes/_base.py

## PR Summary

Main purpuse was to increase test coverage, but when I played around, I found the following:

```
>>> ax.secondary_xaxis('bottom')
Traceback (most recent call last):

  File ~\miniconda3\lib\site-packages\IPython\core\formatters.py:707 in __call__
    printer.pretty(obj)

  File ~\miniconda3\lib\site-packages\IPython\lib\pretty.py:410 in pretty
    return _repr_pprint(obj, self, cycle)

  File ~\miniconda3\lib\site-packages\IPython\lib\pretty.py:778 in _repr_pprint
    output = repr(obj)

  File ~\matplotlib\lib\matplotlib\axes\_base.py:711 in __repr__
    title = self.get_title(loc=k)

AttributeError: 'SecondaryAxis' object has no attribute 'get_title'
```

so I fixed that as well.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
