### PR TITLE
Specify font number for TTC font subsetting

### DIFF
--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -37,7 +37,11 @@ def get_glyphs_subset(fontfile, characters):
     options = subset.Options(glyph_names=True, recommended_glyphs=True)
 
     # prevent subsetting FontForge Timestamp and other tables
-    options.drop_tables += ['FFTM', 'PfEd']
+    options.drop_tables += ['FFTM', 'PfEd', 'BDF']
+
+    # if fontfile is a ttc, specify font number
+    if fontfile.endswith(".ttc"):
+        options.font_number = 0
 
     with subset.load_font(fontfile, options) as font:
         subsetter = subset.Subsetter(options=options)

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -12,6 +12,7 @@ import matplotlib as mpl
 from matplotlib import pyplot as plt, checkdep_usetex, rcParams
 from matplotlib.cbook import _get_data_path
 from matplotlib.ft2font import FT2Font
+from matplotlib.font_manager import findfont, FontProperties
 from matplotlib.backends._backend_pdf_ps import get_glyphs_subset
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.patches import Rectangle
@@ -43,12 +44,20 @@ and containing some French characters and the euro symbol:
     ax.axhline(0.5, linewidth=0.5)
 
 
-def test_type42():
-    rcParams['pdf.fonttype'] = 42
+@pytest.mark.parametrize('fontname, fontfile', [
+    ('DejaVu Sans', 'DejaVuSans.ttf'),
+    ('WenQuanYi Zen Hei', 'wqy-zenhei.ttc'),
+])
+@pytest.mark.parametrize('fonttype', [3, 42])
+def test_embed_fonts(fontname, fontfile, fonttype):
+    if Path(findfont(FontProperties(family=[fontname]))).name != fontfile:
+        pytest.skip(f'Font {fontname!r} may be missing')
 
+    rcParams['pdf.fonttype'] = fonttype
     fig, ax = plt.subplots()
     ax.plot([1, 2, 3])
-    fig.savefig(io.BytesIO())
+    ax.set_title('Axes Title', font=fontname)
+    fig.savefig(io.BytesIO(), format='pdf')
 
 
 def test_multipage_pagecount():


### PR DESCRIPTION
## PR Summary
Since https://github.com/matplotlib/matplotlib/pull/20804 isn't merged yet, the commit https://github.com/matplotlib/matplotlib/commit/1b53070f7c5ba8d9edbb855435960e30ae8cbd5a can go as a hotfix for https://github.com/matplotlib/matplotlib/issues/21893.

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).