### PR TITLE
Removed unused code and variables

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -573,7 +573,6 @@ def reposition_axes(layoutgrids, fig, renderer, *,
         # coordinates...
         ss = ax.get_subplotspec()
         gs = ss.get_gridspec()
-        nrows, ncols = gs.get_geometry()
         if gs not in layoutgrids:
             return
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1528,7 +1528,6 @@ def _get_renderer(figure, print_method=None):
     def _draw(renderer): raise Done(renderer)
 
     with cbook._setattr_cm(figure, draw=_draw), ExitStack() as stack:
-        orig_canvas = figure.canvas
         if print_method is None:
             fmt = figure.canvas.get_default_filetype()
             # Even for a canvas' default output type, a canvas switch may be

--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -172,7 +172,6 @@ def find_bezier_t_intersecting_with_closedpath(
         if start_inside ^ middle_inside:
             t1 = middle_t
             end = middle
-            end_inside = middle_inside
         else:
             t0 = middle_t
             start = middle

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -8,7 +8,6 @@ import hashlib
 import logging
 import os
 from pathlib import Path
-import re
 import shutil
 import subprocess
 import sys
@@ -62,15 +61,6 @@ def get_file_hash(path, block_size=2 ** 20):
                    .encode('utf-8'))
 
     return md5.hexdigest()
-
-
-# Modified from https://bugs.python.org/issue25567.
-_find_unsafe_bytes = re.compile(br'[^a-zA-Z0-9_@%+=:,./-]').search
-
-
-def _shlex_quote_bytes(b):
-    return (b if _find_unsafe_bytes(b) is None
-            else b"'" + b.replace(b"'", b"'\"'\"'") + b"'")
 
 
 class _ConverterError(Exception):

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -40,9 +40,7 @@ class Axes(maxes.Axes):
         def __call__(self, *v, **kwargs):
             return maxes.Axes.axis(self.axes, *v, **kwargs)
 
-    def _init_axis_artists(self, axes=None):
-        if axes is None:
-            axes = self
+    def _init_axis_artists(self):
         self._axislines = self.AxisDict(self)
         self._axislines.update(
             bottom=SimpleAxisArtist(self.xaxis, 1, self.spines["bottom"]),

--- a/tools/make_icons.py
+++ b/tools/make_icons.py
@@ -46,8 +46,8 @@ def save_icon(fig, dest_dir, name):
 def make_icon(font_path, ccode):
     fig = plt.figure(figsize=(1, 1))
     fig.patch.set_alpha(0.0)
-    text = fig.text(0.5, 0.48, chr(ccode), ha='center', va='center',
-                    font=font_path, fontsize=68)
+    fig.text(0.5, 0.48, chr(ccode), ha='center', va='center',
+             font=font_path, fontsize=68)
     return fig
 
 


### PR DESCRIPTION
## PR Summary

Removed some unused code and unused variables.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
