### PR TITLE
MNT: Deprecate cbook.maxdict

### DIFF
--- a/doc/api/next_api_changes/deprecations/22299-GL.rst
+++ b/doc/api/next_api_changes/deprecations/22299-GL.rst
@@ -1,0 +1,4 @@
+``matplotlib.cbook.maxdict`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This class has been deprecated in favor of the standard library
+``functools.lru_cache``.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -540,6 +540,7 @@ def flatten(seq, scalarp=is_scalar_or_string):
             yield from flatten(item, scalarp)
 
 
+@_api.deprecated("3.6", alternative="functools.lru_cache")
 class maxdict(dict):
     """
     A dictionary with a maximum size.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -2,6 +2,7 @@
 Classes for including text in a figure.
 """
 
+import functools
 import logging
 import math
 import numbers
@@ -108,7 +109,6 @@ class Text(Artist):
     """Handle storing and drawing of text in window or data coordinates."""
 
     zorder = 3
-    _cached = cbook.maxdict(50)
 
     def __repr__(self):
         return "Text(%s, %s, %s)" % (self._x, self._y, repr(self._text))
@@ -294,9 +294,13 @@ class Text(Artist):
         of a rotated text when necessary.
         """
         key = self._get_layout_cache_key(renderer=renderer)
-        if key in self._cached:
-            return self._cached[key]
+        return self._get_layout_cache(key, renderer)
 
+    @functools.lru_cache(maxsize=50)
+    def _get_layout_cache(self, key, renderer):
+        """
+        Return the layout using a lru_cache decorator
+        """
         thisx, thisy = 0.0, 0.0
         lines = self.get_text().split("\n")  # Ensures lines is not empty.
 
@@ -440,7 +444,6 @@ class Text(Artist):
         xys = M.transform(offset_layout) - (offsetx, offsety)
 
         ret = bbox, list(zip(lines, zip(ws, hs), *xys.T)), descent
-        self._cached[key] = ret
         return ret
 
     def set_bbox(self, rectprops):


### PR DESCRIPTION
## PR Summary

It was used in one place in the library and there is now a standard library lru_cache that we can take advantage of instead. This adds a new private method that is called after the key is created.

Closes #22278

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
