### PR TITLE
Added tests for ContourSet.legend_elements

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -7,7 +7,7 @@ from numpy.testing import assert_array_almost_equal
 import matplotlib as mpl
 from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt, rc_context
-from matplotlib.colors import LogNorm
+from matplotlib.colors import LogNorm, same_color
 import pytest
 
 
@@ -478,3 +478,43 @@ def test_contour_autolabel_beyond_powerlimits():
     ax.clabel(cs)
     # Currently, the exponent is missing, but that may be fixed in the future.
     assert {text.get_text() for text in ax.texts} == {"0.25", "1.00", "4.00"}
+
+
+def test_contourf_legend_elements():
+    from matplotlib.patches import Rectangle
+    x = np.arange(1, 10)
+    y = x.reshape(-1, 1)
+    h = x * y
+
+    cs = plt.contourf(h, levels=[10, 30, 50],
+                      colors=['#FFFF00', '#FF00FF', '#00FFFF'],
+                      extend='both')
+    cs.cmap.set_over('red')
+    cs.cmap.set_under('blue')
+    cs.changed()
+    artists, labels = cs.legend_elements()
+    assert labels == ['$x \\leq -1e+250s$',
+                      '$10.0 < x \\leq 30.0$',
+                      '$30.0 < x \\leq 50.0$',
+                      '$x > 1e+250s$']
+    expected_colors = ('blue', '#FFFF00', '#FF00FF', 'red')
+    assert all(isinstance(a, Rectangle) for a in artists)
+    assert all(same_color(a.get_facecolor(), c)
+               for a, c in zip(artists, expected_colors))
+
+
+def test_contour_legend_elements():
+    from matplotlib.collections import LineCollection
+    x = np.arange(1, 10)
+    y = x.reshape(-1, 1)
+    h = x * y
+
+    colors = ['blue', '#00FF00', 'red']
+    cs = plt.contour(h, levels=[10, 30, 50],
+                     colors=colors,
+                     extend='both')
+    artists, labels = cs.legend_elements()
+    assert labels == ['$x = 10.0$', '$x = 30.0$', '$x = 50.0$']
+    assert all(isinstance(a, LineCollection) for a in artists)
+    assert all(same_color(a.get_color(), c)
+               for a, c in zip(artists, colors))


### PR DESCRIPTION
## PR Summary
Added tests of a previously untested method.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
