### PR TITLE
FIX: ensure that used sub-packages are actually imported

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -441,8 +441,9 @@ class ScalarFormatter(Formatter):
             useMathText = mpl.rcParams['axes.formatter.use_mathtext']
             if useMathText is False:
                 try:
-                    ufont = mpl.font_manager.findfont(
-                        mpl.font_manager.FontProperties(
+                    from matplotlib import font_manager
+                    ufont = font_manager.findfont(
+                        font_manager.FontProperties(
                             mpl.rcParams["font.family"]
                         ),
                         fallback_to_default=False,


### PR DESCRIPTION

## PR Summary

closes #22305

We were relying on an implicit import of a sub-module. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

We could test this by adding a sub-process test, but I am not sure that it is worth it.  That said, if someone wants a test on this I will add it.