### PR TITLE
Fix colorbar exponents

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2977,7 +2977,7 @@ class _AxesBase(martist.Artist):
                 if bb is None:
                     if 'outline' in ax.spines:
                         # Special case for colorbars:
-                        bb = self.axes.spines['outline'].get_window_extent()
+                        bb = ax.spines['outline'].get_window_extent()
                     else:
                         bb = ax.get_window_extent(renderer)
                 top = max(top, bb.ymax)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2975,7 +2975,11 @@ class _AxesBase(martist.Artist):
                         or ax.xaxis.get_label_position() == 'top'):
                     bb = ax.xaxis.get_tightbbox(renderer)
                 if bb is None:
-                    bb = ax.get_window_extent(renderer)
+                    if 'outline' in ax.spines:
+                        # Special case for colorbars:
+                        bb = self.axes.spines['outline'].get_window_extent()
+                    else:
+                        bb = ax.get_window_extent(renderer)
                 top = max(top, bb.ymax)
                 if title.get_text():
                     ax.yaxis.get_tightbbox(renderer)  # update offsetText

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2474,8 +2474,13 @@ class YAxis(Axis):
         Update the offset_text position based on the sequence of bounding
         boxes of all the ticklabels
         """
-        x, y = self.offsetText.get_position()
-        top = self.axes.bbox.ymax
+        x, _ = self.offsetText.get_position()
+        if 'outline' in self.axes.spines:
+            # Special case for colorbars:
+            bbox = self.axes.spines['outline'].get_window_extent()
+        else:
+            bbox = self.axes.bbox
+        top = bbox.ymax
         self.offsetText.set_position(
             (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
         )

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -979,3 +979,30 @@ def test_colorbar_set_formatter_locator():
     fmt = LogFormatter()
     cb.minorformatter = fmt
     assert cb.ax.yaxis.get_minor_formatter() is fmt
+
+
+def test_offset_text_loc():
+    plt.style.use('mpl20')
+    fig, ax = plt.subplots()
+    np.random.seed(seed=19680808)
+    pc = ax.pcolormesh(np.random.randn(10, 10)*1e6)
+    cb = fig.colorbar(pc, location='right', extend='max')
+    fig.draw_without_rendering()
+    # check that the offsetText is in the proper place above the
+    # colorbar axes.  In this case the colorbar axes is the same
+    # height as the parent, so use the parents bbox.
+    assert cb.ax.yaxis.offsetText.get_position()[1] > ax.bbox.y1
+
+
+def test_title_text_loc():
+    plt.style.use('mpl20')
+    fig, ax = plt.subplots()
+    np.random.seed(seed=19680808)
+    pc = ax.pcolormesh(np.random.randn(10, 10))
+    cb = fig.colorbar(pc, location='right', extend='max')
+    cb.ax.set_title('Aardvark')
+    fig.draw_without_rendering()
+    # check that the title is in the proper place above the
+    # colorbar axes, including its extend triangles....
+    assert (cb.ax.title.get_window_extent(fig.canvas.get_renderer()).ymax >
+            cb.ax.spines['outline'].get_window_extent().ymax)

--- a/tutorials/introductory/quick_start.py
+++ b/tutorials/introductory/quick_start.py
@@ -505,7 +505,7 @@ axs[1, 0].set_title('imshow() with LogNorm()')
 
 pc = axs[1, 1].scatter(data1, data2, c=data3, cmap='RdBu_r')
 fig.colorbar(pc, ax=axs[1, 1], extend='both')
-axs[1, 1].set_title('scatter()');
+axs[1, 1].set_title('scatter()')
 
 ##############################################################################
 # Colormaps


### PR DESCRIPTION
## PR Summary

Fix offsetText for colorbars with extends so they are above the extends...  Closes #22312


### Before
![CbarOffsetPosBroke](https://user-images.githubusercontent.com/1562854/150974710-f3cde5e8-1e87-459b-812a-bd4c901a8e9a.png)

### After

![CbarOffsetPosFixed](https://user-images.githubusercontent.com/1562854/150974732-2405a7e3-dd8f-41dc-8e7c-87e4ee58c307.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
