### PR TITLE
Replace sole use of maxdict by lru_cache.

### DIFF
--- a/doc/api/next_api_changes/deprecations/22323-GL.rst
+++ b/doc/api/next_api_changes/deprecations/22323-GL.rst
@@ -1,0 +1,4 @@
+``matplotlib.cbook.maxdict`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This class has been deprecated in favor of the standard library
+``functools.lru_cache``.

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -540,6 +540,7 @@ def flatten(seq, scalarp=is_scalar_or_string):
             yield from flatten(item, scalarp)
 
 
+@_api.deprecated("3.6", alternative="functools.lru_cache")
 class maxdict(dict):
     """
     A dictionary with a maximum size.

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -768,6 +768,8 @@ def test_pdf_chars_beyond_bmp():
 
 @needs_usetex
 def test_metrics_cache():
+    mpl.text._get_text_metrics_with_cache_impl.cache_clear()
+
     fig = plt.figure()
     fig.text(.3, .5, "foo\nbar")
     fig.text(.3, .5, "foo\nbar", usetex=True)
@@ -788,3 +790,8 @@ def test_metrics_cache():
     # collision with the non-TeX string (drawn first here) whose metrics would
     # get incorrectly reused by the first TeX string.
     assert len(ys["foo"]) == len(ys["bar"]) == 1
+
+    info = mpl.text._get_text_metrics_with_cache_impl.cache_info()
+    # Every string gets a miss for the first layouting (extents), then a hit
+    # when drawing, but "foo\nbar" gets two hits as it's drawn twice.
+    assert info.hits > info.misses


### PR DESCRIPTION
... and expand the cache size, while we're at it.

Actual deprecation of maxdict can be done in https://github.com/matplotlib/matplotlib/pull/22299.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
