### PR TITLE
Let TransformedPatchPath inherit most functionality from TransformedPath.

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2815,37 +2815,25 @@ class TransformedPatchPath(TransformedPath):
     `~.patches.Patch`. This cached copy is automatically updated when the
     non-affine part of the transform or the patch changes.
     """
+
     def __init__(self, patch):
         """
         Parameters
         ----------
         patch : `~.patches.Patch`
         """
-        TransformNode.__init__(self)
-
-        transform = patch.get_transform()
+        # Defer to TransformedPath.__init__.
+        super().__init__(patch.get_path(), patch.get_transform())
         self._patch = patch
-        self._transform = transform
-        self.set_children(transform)
-        self._path = patch.get_path()
-        self._transformed_path = None
-        self._transformed_points = None
 
     def _revalidate(self):
         patch_path = self._patch.get_path()
-        # Only recompute if the invalidation includes the non_affine part of
-        # the transform, or the Patch's Path has changed.
-        if (self._transformed_path is None or self._path != patch_path or
-                (self._invalid & self.INVALID_NON_AFFINE ==
-                    self.INVALID_NON_AFFINE)):
+        # Force invalidation if the patch path changed; otherwise, let base
+        # class check invalidation.
+        if patch_path != self._path:
             self._path = patch_path
-            self._transformed_path = \
-                self._transform.transform_path_non_affine(patch_path)
-            self._transformed_points = \
-                Path._fast_from_codes_and_verts(
-                    self._transform.transform_non_affine(patch_path.vertices),
-                    None, patch_path)
-        self._invalid = 0
+            self._transformed_path = None
+        super()._revalidate()
 
 
 def nonsingular(vmin, vmax, expander=0.001, tiny=1e-15, increasing=True):


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
