### PR TITLE
Remove invalid `</input>` tag in `animation.HTMLWriter`

### DIFF
--- a/lib/matplotlib/_animation_data.py
+++ b/lib/matplotlib/_animation_data.py
@@ -196,7 +196,7 @@ DISPLAY_TEMPLATE = """
   <div class="anim-controls">
     <input id="_anim_slider{id}" type="range" class="anim-slider"
            name="points" min="0" max="1" step="1" value="0"
-           oninput="anim{id}.set_frame(parseInt(this.value));"></input>
+           oninput="anim{id}.set_frame(parseInt(this.value));">
     <div class="anim-buttons">
       <button title="Decrease speed" aria-label="Decrease speed" onclick="anim{id}.slower()">
           <i class="fa fa-minus"></i></button>


### PR DESCRIPTION
The template for HTML export of an animation included an `</input>` tag, which is not valid HTML. This causes some HTML parsers to fail (specifically the one in [MathJax for Node](https://github.com/mathjax/MathJax-demos-node)).

## PR Summary

Removed the `</input>` tag from the HTML template for the `animation.HTMLWriter.finish()` function.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] ~~Has pytest style unit tests (and `pytest` passes).~~
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] ~~New features are documented, with examples if plot related.~~
- [N/A] ~~New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).~~
- [N/A] ~~API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).~~
- [N/A] ~~Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).~~

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
