### PR TITLE
Use latex as the program name for kpsewhich

### DIFF
--- a/lib/matplotlib/mpl-data/kpsewhich.lua
+++ b/lib/matplotlib/mpl-data/kpsewhich.lua
@@ -1,3 +1,3 @@
 -- see dviread._LuatexKpsewhich
-kpse.set_program_name("tex")
+kpse.set_program_name("latex")
 while true do print(kpse.lookup(io.read():gsub("\r", ""))); io.flush(); end


### PR DESCRIPTION
## PR Summary

If `tex` is not installed, then setting the program name to it will fail to find the 'program' in the current directory, and then be unable to find any TeX files.

Setting it to `latex` should be okay, since that's what we're running to create the `.dvi` in the first place.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).