### PR TITLE
Auto font selection corresponding system locale

### DIFF
--- a/examples/pyplots/locale_font.py
+++ b/examples/pyplots/locale_font.py
@@ -1,0 +1,18 @@
+"""
+========================================
+Auto font management for various locales
+========================================
+
+This program use matplotlib.use_locale_font to put Chinese (Simplified)
+characters onto a plot.
+"""
+
+
+import matplotlib.pyplot as plt
+
+plt.use_locale_font()
+plt.plot([1, 2, 3], [1, 4, 9])
+plt.xlabel("$x$")
+plt.ylabel("$x^2$")
+plt.title("平方关系")
+plt.show()

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1449,3 +1449,5 @@ _log.debug('platform is %s', sys.platform)
 # workaround: we must defer colormaps import to after loading rcParams, because
 # colormap creation depends on rcParams
 from matplotlib.cm import _colormaps as colormaps
+
+from locale_font import use_locale_font

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1450,4 +1450,4 @@ _log.debug('platform is %s', sys.platform)
 # colormap creation depends on rcParams
 from matplotlib.cm import _colormaps as colormaps
 
-from locale_font import use_locale_font
+from matplotlib.locale_font import use_locale_font

--- a/lib/matplotlib/locale_font.py
+++ b/lib/matplotlib/locale_font.py
@@ -1,0 +1,35 @@
+from locale import getdefaultlocale
+from os.path import sep
+from sys import stderr
+
+from matplotlib import rcParams
+from matplotlib.font_manager import fontManager
+
+
+locale_font = {
+    "zh_CN": ["SimSun", "SimHei", "Songti SC"]
+}
+
+
+def use_locale_font():
+    lc = getdefaultlocale()[0]
+    available_font_names = [f.name for f in fontManager.ttflist]
+
+    if lc in locale_font.keys():
+        expected_fonts = locale_font[lc]
+        for f in expected_fonts:
+            if f in available_font_names:
+                rcParams["font.family"] = f
+                break
+        else:
+            stderr.write(f"No fonts for {lc} was found. ")
+    else:
+        stderr.write(f"Locale {lc} is not configured\n")
+
+
+if __name__ == "__main__":
+    import matplotlib.pyplot as plt
+    use_locale_font()
+    plt.plot([1, 2, 3])
+    plt.title("测试")
+    plt.show()

--- a/lib/matplotlib/locale_font.py
+++ b/lib/matplotlib/locale_font.py
@@ -1,35 +1,115 @@
+"""
+This module provides auto font selection for variable locales
+to avoid display mistaken.
+See "examples/pyplots/locale_font.py" for usage example.
+"""
+
 from locale import getdefaultlocale
-from os.path import sep
+from os.path import sep, join
+from os import listdir
 from sys import stderr
 
-from matplotlib import rcParams
+from matplotlib import rcParams, get_data_path
 from matplotlib.font_manager import fontManager
+from matplotlib.style import available
 
+"""
+Fonts corresponds to each locales.
 
+{ <locale>: [[font_names...], [font_filenames...]] }
+"""
 locale_font = {
-    "zh_CN": ["SimSun", "SimHei", "Songti SC"]
+    "zh_CN": [["SimSun", "SimHei", "Songti SC"], ["simsun.ttf", "simhei.ttf", "songti.ttf"]]
 }
 
 
-def use_locale_font():
-    lc = getdefaultlocale()[0]
+def _match_font_name(lc):
+    """
+    Find the first font in locale_font[lc][0] that appears in
+    matplotlib.font_manager.fontManager.ttflist
+
+    Parameters
+    ----------
+    lc : str
+        locale
+
+    Returns
+    -------
+    (int, str)
+        returns the index and the font name of the font.
+        If no fonts were found, return (None, None)
+    """
     available_font_names = [f.name for f in fontManager.ttflist]
+    expected_fonts = locale_font[lc][0]
+    for i, f in enumerate(expected_fonts):
+        if f in available_font_names:
+            return i, f
+    else:
+        return None, None
+
+
+def _match_font_filename(lc):
+    """
+    Find the first font file in locale_font[lc][1] that appears in
+    <data_path>/fonts/ttf
+
+    Parameters
+    ----------
+    lc : str
+        locale
+
+    Returns
+    -------
+    (int, str)
+        returns the index and the font name of the font.
+        If no fonts were found, return (None, None)
+    """
+    ttf_dir = join(get_data_path(), "fonts", "ttf")
+    available_files = listdir(ttf_dir)
+    expected_files = locale_font[lc][1]
+    for i, file in enumerate(expected_files):
+        if file in available_files:
+            fontManager.addfont(join(ttf_dir, file))
+            f = locale_font[lc][0][i]
+            return i, f
+    else:
+        return None, None
+
+
+def use_locale_font():
+    """
+    Set rc parameter "font.family" as the best font,
+    where "best" means it has the minimum index among those 
+    available on this computer.
+
+    Returns
+    -------
+    str
+        the name of the best font. If no best font, return None
+    """
+    lc = getdefaultlocale()[0]
 
     if lc in locale_font.keys():
-        expected_fonts = locale_font[lc]
-        for f in expected_fonts:
-            if f in available_font_names:
-                rcParams["font.family"] = f
-                break
+        i1, f1 = _match_font_name(lc)
+        i2, f2 = _match_font_filename(lc)
+        if i1 is not None and i2 is not None:
+            if i1 <= i2:
+                rcParams["font.family"] = f1
+                return f1
+            else:
+                rcParams["font.family"] = f2
+                return f2
+        elif i1 is not None:
+            rcParams["font.family"] = f1
+            return f1
+        elif i2 is not None:
+            rcParams["font.family"] = f2
+            return f2
         else:
-            stderr.write(f"No fonts for {lc} was found. ")
+            stderr.write(f"No supported font for locale {lc}\n. "
+                         f"Supported ones are {locale_font[lc][1]}, "
+                         f"which you can download and place into "
+                         f"{join(get_data_path(), 'fonts', 'ttf')}")
     else:
         stderr.write(f"Locale {lc} is not configured\n")
 
-
-if __name__ == "__main__":
-    import matplotlib.pyplot as plt
-    use_locale_font()
-    plt.plot([1, 2, 3])
-    plt.title("测试")
-    plt.show()

--- a/lib/matplotlib/locale_font.py
+++ b/lib/matplotlib/locale_font.py
@@ -5,13 +5,12 @@ See "examples/pyplots/locale_font.py" for usage example.
 """
 
 from locale import getdefaultlocale
-from os.path import sep, join
+from os.path import join
 from os import listdir
 from sys import stderr
 
 from matplotlib import rcParams, get_data_path
-from matplotlib.font_manager import fontManager
-from matplotlib.style import available
+from matplotlib.font_manager import fontManager\
 
 """
 Fonts corresponds to each locales.
@@ -112,4 +111,3 @@ def use_locale_font():
                          f"{join(get_data_path(), 'fonts', 'ttf')}")
     else:
         stderr.write(f"Locale {lc} is not configured\n")
-

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3085,3 +3085,5 @@ def nipy_spectral(): set_cmap('nipy_spectral')
 
 
 _setup_pyplot_info_docstrings()
+
+from matplotlib import use_locale_font


### PR DESCRIPTION
## PR Summary
Switch to the font that supports system language automatically just by calling use_locale_font(), which can avoid display mistaken for non-ascii characters.
Now Chinese (Simplified) is provided experimentally. More languages can be added by adding items to the dict "locale_font".
An example is given in ./examples/pyplots/locale_font.py