### PR TITLE
Slightly refactor TeX source generation.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -206,23 +206,27 @@ class TexManager:
         """
         basefile = self.get_basefile(tex, fontsize)
         texfile = '%s.tex' % basefile
-        fontcmd = {'sans-serif': r'{\sffamily %s}',
-                   'monospace': r'{\ttfamily %s}'}.get(self._font_family,
-                                                       r'{\rmfamily %s}')
-
-        Path(texfile).write_text(
-            r"""
-%s
+        fontcmd = (r'\sffamily' if self._font_family == 'sans-serif' else
+                   r'\ttfamily' if self._font_family == 'monospace' else
+                   r'\rmfamily')
+        tex_template = r"""
+%(preamble)s
 \pagestyle{empty}
 \begin{document}
 %% The empty hbox ensures that a page is printed even for empty inputs, except
 %% when using psfrag which gets confused by it.
-\fontsize{%f}{%f}%%
+\fontsize{%(fontsize)f}{%(baselineskip)f}%%
 \ifdefined\psfrag\else\hbox{}\fi%%
-%s
+{%(fontcmd)s %(tex)s}
 \end{document}
-""" % (self._get_preamble(), fontsize, fontsize * 1.25, fontcmd % tex),
-            encoding='utf-8')
+"""
+        Path(texfile).write_text(tex_template % {
+            "preamble": self._get_preamble(),
+            "fontsize": fontsize,
+            "baselineskip": fontsize * 1.25,
+            "fontcmd": fontcmd,
+            "tex": tex,
+        }, encoding="utf-8")
 
         return texfile
 


### PR DESCRIPTION
- Don't use a nested format string (`fontcmd % tex`); simply pass
  `fontcmd` and `tex` separately.
- Use named formats to make things easier to track.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
