### PR TITLE
Let TeX handle multiline strings itself.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -291,40 +291,11 @@ class Dvi:
         Read one page from the file. Return True if successful,
         False if there were no more pages.
         """
-        # Pages appear to start with the sequence
-        #   bop (begin of page)
-        #   xxx comment
-        #   <push, ..., pop>  # if using chemformula
-        #   down
-        #   push
-        #     down
-        #     <push, push, xxx, right, xxx, pop, pop>  # if using xcolor
-        #     down
-        #     push
-        #       down (possibly multiple)
-        #       push  <=  here, v is the baseline position.
-        #         etc.
-        # (dviasm is useful to explore this structure.)
-        # Thus, we use the vertical position at the first time the stack depth
-        # reaches 3, while at least three "downs" have been executed (excluding
-        # those popped out (corresponding to the chemformula preamble)), as the
-        # baseline (the "down" count is necessary to handle xcolor).
-        down_stack = [0]
         self._baseline_v = None
         while True:
             byte = self.file.read(1)[0]
             self._dtable[byte](self, byte)
             name = self._dtable[byte].__name__
-            if name == "_push":
-                down_stack.append(down_stack[-1])
-            elif name == "_pop":
-                down_stack.pop()
-            elif name == "_down":
-                down_stack[-1] += 1
-            if (self._baseline_v is None
-                    and len(getattr(self, "stack", [])) == 3
-                    and down_stack[-1] >= 4):
-                self._baseline_v = self.v
             if byte == 140:                         # end of page
                 return True
             if self.state is _dvistate.post_post:   # end of file
@@ -457,6 +428,8 @@ class Dvi:
     @_dispatch(min=239, max=242, args=('ulen1',))
     def _xxx(self, datalen):
         special = self.file.read(datalen)
+        if special == b'matplotlibbaselinemarker':
+            self._baseline_v = self.v
         _log.debug(
             'Dvi._xxx: encountered special: %s',
             ''.join([chr(ch) if 32 <= ch < 127 else '<%02x>' % ch

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -776,26 +776,11 @@ def test_metrics_cache():
 
     fig = plt.figure()
     fig.text(.3, .5, "foo\nbar")
+    fig.text(.5, .5, "foo\nbar")
     fig.text(.3, .5, "foo\nbar", usetex=True)
     fig.text(.5, .5, "foo\nbar", usetex=True)
     fig.canvas.draw()
-    renderer = fig._cachedRenderer
-    ys = {}  # mapping of strings to where they were drawn in y with draw_tex.
-
-    def call(*args, **kwargs):
-        renderer, x, y, s, *_ = args
-        ys.setdefault(s, set()).add(y)
-
-    renderer.draw_tex = call
-    fig.canvas.draw()
-    assert [*ys] == ["foo", "bar"]
-    # Check that both TeX strings were drawn with the same y-position for both
-    # single-line substrings.  Previously, there used to be an incorrect cache
-    # collision with the non-TeX string (drawn first here) whose metrics would
-    # get incorrectly reused by the first TeX string.
-    assert len(ys["foo"]) == len(ys["bar"]) == 1
 
     info = mpl.text._get_text_metrics_with_cache_impl.cache_info()
-    # Every string gets a miss for the first layouting (extents), then a hit
-    # when drawing, but "foo\nbar" gets two hits as it's drawn twice.
-    assert info.hits > info.misses
+    # Each string gets drawn twice, so the second draw results in a hit.
+    assert info.hits == info.misses

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -217,7 +217,7 @@ class TexManager:
 %% when using psfrag which gets confused by it.
 \fontsize{%(fontsize)f}{%(baselineskip)f}%%
 \ifdefined\psfrag\else\hbox{}\fi%%
-{%(fontcmd)s %(tex)s}
+{%(fontcmd)s %(tex)s}\special{matplotlibbaselinemarker}
 \end{document}
 """
         Path(texfile).write_text(tex_template % {

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -217,7 +217,7 @@ class TexManager:
 %% when using psfrag which gets confused by it.
 \fontsize{%(fontsize)f}{%(baselineskip)f}%%
 \ifdefined\psfrag\else\hbox{}\fi%%
-{%(fontcmd)s %(tex)s}\special{matplotlibbaselinemarker}
+{\obeylines%(fontcmd)s %(tex)s}\special{matplotlibbaselinemarker}
 \end{document}
 """
         Path(texfile).write_text(tex_template % {

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -184,31 +184,34 @@ class TexManager:
                    r'\rmfamily')
         return "\n".join([
             r"\documentclass{article}",
-            # Pass-through \mathdefault, which is used in non-usetex mode to
-            # use the default text font but was historically suppressed in
-            # usetex mode.
+            r"% Pass-through \mathdefault, which is used in non-usetex mode",
+            r"% to use the default text font but was historically suppressed",
+            r"% in usetex mode.",
             r"\newcommand{\mathdefault}[1]{#1}",
             self._font_preamble,
             r"\usepackage[utf8]{inputenc}",
             r"\DeclareUnicodeCharacter{2212}{\ensuremath{-}}",
-            # geometry is loaded before the custom preamble as convert_psfrags
-            # relies on a custom preamble to change the geometry.
+            r"% geometry is loaded before the custom preamble as ",
+            r"% convert_psfrags relies on a custom preamble to change the ",
+            r"% geometry.",
             r"\usepackage[papersize=72in, margin=1in]{geometry}",
             self.get_custom_preamble(),
-            # Use `underscore` package to take care of underscores in text
-            # The [strings] option allows to use underscores in file names
+            r"% Use `underscore` package to take care of underscores in text.",
+            r"% The [strings] option allows to use underscores in file names.",
             _usepackage_if_not_loaded("underscore", option="strings"),
-            # Custom packages (e.g. newtxtext) may already have loaded textcomp
-            # with different options.
+            r"% Custom packages (e.g. newtxtext) may already have loaded ",
+            r"% textcomp with different options.",
             _usepackage_if_not_loaded("textcomp"),
             r"\pagestyle{empty}",
             r"\begin{document}",
-            r"% The empty hbox ensures that a page is printed even for empty ",
+            r"% The empty hbox ensures that a page is printed even for empty",
             r"% inputs, except when using psfrag which gets confused by it.",
-            r"\fontsize{%f}{%f}%%" % (fontsize, baselineskip),
+            r"% matplotlibbaselinemarker is used by dviread to detect the",
+            r"% last line's baseline.",
+            rf"\fontsize{{{fontsize}}}{{{baselineskip}}}%",
             r"\ifdefined\psfrag\else\hbox{}\fi%",
-            r"{\obeylines%s %s}\special{matplotlibbaselinemarker}"
-            % (fontcmd, tex),
+            rf"{{\obeylines{fontcmd} {tex}}}%",
+            r"\special{matplotlibbaselinemarker}%",
             r"\end{document}",
         ])
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -295,7 +295,8 @@ class Text(Artist):
         of a rotated text when necessary.
         """
         thisx, thisy = 0.0, 0.0
-        lines = self.get_text().split("\n")  # Ensures lines is not empty.
+        text = self.get_text()
+        lines = [text] if self.get_usetex() else text.split("\n")  # Not empty.
 
         ws = []
         hs = []


### PR DESCRIPTION
## PR Summary

Previously, multiline strings were split at `\n` and passed one at a time to TeX -- likely, this is a remnant of how multiline strings are handled for the non-TeX case, as Matplotlib also renders one line at a time.  This series of commits switches things to instead pass entire multiline strings all at once to TeX, which is useful e.g. if a tex font command must apply to arbitrary strings that may contain newlines.  Goes on top of #22359.

1st commit: Switch TeX baseline detection to use a dvi special.

Insert a `\special` at the end of the TeX output and record the baseline
position there.  This should be more robust than trying to guess the
format of the dvi preamble, and more importantly this will also allow
detecting the last baseline of *multiline* TeX output, which will then
allow letting TeX handle multiline strings itself (while keeping the
correct alignment).

2nd commit: Let TeX handle newlines itself.

Note that it may be worth passing the baselineskip
(`Text.get_linespacing()`) as argument to texmanager, but that'll wait
for a bigger refactor... for now, let's stick to the old default of
1.25.

test_metrics_cache changes as the cache hit pattern changed for usetex
strings.

-----

Edit: I suspect that the tests are failing on some builds because the tex cache needs to be invalidated (the minver test run is also the only one that clears the cache first).  Will do something about that...

3rd commit: Pick TeX cache name based on entire TeX source.

This allows invalidating the cache when the source generation algorithm
changes.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
