### PR TITLE
Tweak mathtext/tex docs.

### DIFF
--- a/tutorials/text/mathtext.py
+++ b/tutorials/text/mathtext.py
@@ -9,16 +9,16 @@ Note that you do not need to have TeX installed, since Matplotlib ships
 its own TeX expression parser, layout engine, and fonts.  The layout engine
 is a fairly direct adaptation of the layout algorithms in Donald Knuth's
 TeX, so the quality is quite good (Matplotlib also provides a ``usetex``
-option for those who do want to call out to TeX to generate their text (see
+option for those who do want to call out to TeX to generate their text; see
 :doc:`/tutorials/text/usetex`).
 
 Any text element can use math text.  You should use raw strings (precede the
 quotes with an ``'r'``), and surround the math text with dollar signs ($), as
 in TeX. Regular text and mathtext can be interleaved within the same string.
 Mathtext can use DejaVu Sans (default), DejaVu Serif, the Computer Modern fonts
-(from (La)TeX), `STIX <http://www.stixfonts.org/>`_ fonts (with are designed
+(from (La)TeX), `STIX <http://www.stixfonts.org/>`_ fonts (which are designed
 to blend well with Times), or a Unicode font that you provide.  The mathtext
-font can be selected with the customization variable ``mathtext.fontset`` (see
+font can be selected via :rc:`mathtext.fontset` (see
 :doc:`/tutorials/introductory/customizing`)
 
 Here is a simple example::

--- a/tutorials/text/pgf.py
+++ b/tutorials/text/pgf.py
@@ -1,7 +1,7 @@
 r"""
-*********************************************************
-Typesetting with XeLaTeX/LuaLaTeX via the ``pgf`` backend
-*********************************************************
+************************************************************
+Text rendering with XeLaTeX/LuaLaTeX via the ``pgf`` backend
+************************************************************
 
 Using the ``pgf`` backend, Matplotlib can export figures as pgf drawing
 commands that can be processed with pdflatex, xelatex or lualatex. XeLaTeX and

--- a/tutorials/text/usetex.py
+++ b/tutorials/text/usetex.py
@@ -19,59 +19,54 @@ post-processing steps, but note that it is not used to parse the TeX string
 itself (only LaTeX is supported).  The executables for these external
 dependencies must all be located on your :envvar:`PATH`.
 
-There are a couple of options to mention, which can be changed using
-:doc:`rc settings </tutorials/introductory/customizing>`. Here is an example
-matplotlibrc file::
+Only a small number of font families (defined by the PSNFSS_ scheme) are
+supported.  They are listed here, with the corresponding LaTeX font selection
+commands and LaTeX packages, which are automatically used.
 
-  font.family        : serif
-  font.serif         : Times, Palatino, New Century Schoolbook, Bookman, Computer Modern Roman
-  font.sans-serif    : Helvetica, Avant Garde, Computer Modern Sans Serif
-  font.cursive       : Zapf Chancery
-  font.monospace     : Courier, Computer Modern Typewriter
+=========================== =================================================
+generic family              fonts
+=========================== =================================================
+serif (``\rmfamily``)       Computer Modern Roman, Palatino (``mathpazo``),
+                            Times (``mathptmx``),  Bookman (``bookman``),
+                            New Century Schoolbook (``newcent``),
+                            Charter (``charter``)
 
-  text.usetex        : true
+sans-serif (``\sffamily``)  Computer Modern Serif, Helvetica (``helvet``),
+                            Avant Garde (``avant``)
 
-The first valid font in each family is the one that will be loaded. If the
-fonts are not specified, the Computer Modern fonts are used by default. All of
-the other fonts are Adobe fonts. Times and Palatino each have their own
-accompanying math fonts, while the other Adobe serif fonts make use of the
-Computer Modern math fonts. See the PSNFSS_ documentation for more details.
+cursive (``\rmfamily``)     Zapf Chancery (``chancery``)
 
-To use LaTeX and select Helvetica as the default font, without editing
-matplotlibrc use::
+monospace (``\ttfamily``)   Computer Modern Typewriter, Courier (``courier``)
+=========================== =================================================
 
-  import matplotlib.pyplot as plt
-  plt.rcParams.update({
-      "text.usetex": True,
-      "font.family": "sans-serif",
-      "font.sans-serif": ["Helvetica"]})
-  # for Palatino and other serif fonts use:
-  plt.rcParams.update({
-      "text.usetex": True,
-      "font.family": "serif",
-      "font.serif": ["Palatino"],
-  })
-  # It's also possible to use the reduced notation by directly setting font.family:
-  plt.rcParams.update({
-    "text.usetex": True,
-    "font.family": "Helvetica"
-  })
+The default font family (which does not require loading any LaTeX package) is
+Computer Modern.  All other families are Adobe fonts.  Times and Palatino each
+have their own accompanying math fonts, while the other Adobe serif fonts make
+use of the Computer Modern math fonts.
 
-Currently, the supported fonts are:
+To enable LaTeX and select a font, use e.g.::
 
-================= ============================================================
-family            fonts
-================= ============================================================
-``'serif'``         ``'New Century Schoolbook'``, ``'Bookman'``, ``'Times'``,
-                    ``'Palatino'``, ``'Charter'``, ``'Computer Modern Roman'``
+    plt.rcParams.update({
+        "text.usetex": True,
+        "font.family": "Helvetica"
+    })
 
-``'sans-serif'``  ``'Helvetica'``, ``'Avant Garde'``, ``'Computer Modern
-                  Serif'``
+or equivalently, set your :doc:`matplotlibrc
+</tutorials/introductory/customizing>` to::
 
-``'cursive'``     ``'Zapf Chancery'``
+    text.usetex : true
+    font.family : Helvetica
 
-``'monospace'``   ``'Courier'``, ``'Computer Modern Typewriter'``
-================= ============================================================
+It is also possible to instead set ``font.family`` to one of the generic family
+names and then configure the corresponding generic family; e.g.::
+
+    plt.rcParams.update({
+        "text.usetex": True,
+        "font.family": "sans-serif",
+        "font.sans-serif": "Helvetica",
+    })
+
+(this was the required approach until Matplotlib 3.5).
 
 Here is the standard example,
 :doc:`/gallery/text_labels_and_annotations/tex_demo`:
@@ -87,12 +82,22 @@ Non-ASCII characters (e.g. the degree sign in the y-label above) are supported
 to the extent that they are supported by inputenc_.
 
 .. note::
+   For consistency with the non-usetex case, Matplotlib special-cases newlines,
+   so that single-newlines yield linebreaks (rather than being interpreted as
+   whitespace in standard LaTeX).
+
+   Matplotlib uses the underscore_ package so that underscores (``_``) are
+   printed "as-is" in text mode (rather than causing an error as in standard
+   LaTeX).  Underscores still introduce subscripts in math mode.
+
+.. note::
    Certain characters require special escaping in TeX, such as::
 
-     # $ % & ~ _ ^ \ { } \( \) \[ \]
+     # $ % & ~ ^ \ { } \( \) \[ \]
 
    Therefore, these characters will behave differently depending on
-   :rc:`text.usetex`.
+   :rc:`text.usetex`.  As noted above, underscores (``_``) do not require
+   escaping outside of math mode.
 
 PostScript options
 ==================
@@ -164,5 +169,6 @@ Troubleshooting
 .. _Poppler: https://poppler.freedesktop.org/
 .. _PSNFSS: http://www.ctan.org/tex-archive/macros/latex/required/psnfss/psnfss2e.pdf
 .. _PSfrag: https://ctan.org/pkg/psfrag
+.. _underscore: https://ctan.org/pkg/underscore
 .. _Xpdf: http://www.xpdfreader.com/
 """


### PR DESCRIPTION
- Fix typos/mismatched parentheses/markup in mathtext.py.
- Make the title of pgf.py consistent with the title of usetex.py.
- Prefer "modern" approach for setting fonts in usetex.py, but keep the
  old approach around (as the new API is only on Matplotlib 3.5).
- Clarify non-standard tex settings.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
