### PR TITLE
Remove deprecated `MovieWriter.cleanup`

### DIFF
--- a/doc/api/next_api_changes/removals/22365-OG.rst
+++ b/doc/api/next_api_changes/removals/22365-OG.rst
@@ -1,0 +1,5 @@
+Removal of deprecated ``MovieWriter.cleanup``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The cleanup logic is instead fully implemented in `.MovieWriter.finish` and
+``cleanup`` is no longer called.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -334,29 +334,6 @@ class MovieWriter(AbstractMovieWriter):
 
     def finish(self):
         """Finish any processing for writing the movie."""
-        overridden_cleanup = _api.deprecate_method_override(
-            __class__.cleanup, self, since="3.4", alternative="finish()")
-        if overridden_cleanup is not None:
-            overridden_cleanup()
-        else:
-            self._cleanup()  # Inline _cleanup() once cleanup() is removed.
-
-    def grab_frame(self, **savefig_kwargs):
-        # docstring inherited
-        _log.debug('MovieWriter.grab_frame: Grabbing frame.')
-        # Readjust the figure size in case it has been changed by the user.
-        # All frames must have the same size to save the movie correctly.
-        self.fig.set_size_inches(self._w, self._h)
-        # Save the figure data to the sink, using the frame format and dpi.
-        self.fig.savefig(self._proc.stdin, format=self.frame_format,
-                         dpi=self.dpi, **savefig_kwargs)
-
-    def _args(self):
-        """Assemble list of encoder-specific command-line arguments."""
-        return NotImplementedError("args needs to be implemented by subclass.")
-
-    def _cleanup(self):  # Inline to finish() once cleanup() is removed.
-        """Clean-up and collect the process used to write the movie file."""
         out, err = self._proc.communicate()
         # Use the encoding/errors that universal_newlines would use.
         out = TextIOWrapper(BytesIO(out)).read()
@@ -373,9 +350,19 @@ class MovieWriter(AbstractMovieWriter):
             raise subprocess.CalledProcessError(
                 self._proc.returncode, self._proc.args, out, err)
 
-    @_api.deprecated("3.4")
-    def cleanup(self):
-        self._cleanup()
+    def grab_frame(self, **savefig_kwargs):
+        # docstring inherited
+        _log.debug('MovieWriter.grab_frame: Grabbing frame.')
+        # Readjust the figure size in case it has been changed by the user.
+        # All frames must have the same size to save the movie correctly.
+        self.fig.set_size_inches(self._w, self._h)
+        # Save the figure data to the sink, using the frame format and dpi.
+        self.fig.savefig(self._proc.stdin, format=self.frame_format,
+                         dpi=self.dpi, **savefig_kwargs)
+
+    def _args(self):
+        """Assemble list of encoder-specific command-line arguments."""
+        return NotImplementedError("args needs to be implemented by subclass.")
 
     @classmethod
     def bin_path(cls):


### PR DESCRIPTION
## PR Summary

Removed deprecated `MovieWriter.cleanup`.

(Diff looks a bit weird...)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
