### PR TITLE
Deprecation removal/updates in axes3d

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1617,12 +1617,7 @@ class Axes3D(Axes):
         cmap = kwargs.get('cmap', None)
         shade = kwargs.pop('shade', cmap is None)
         if shade is None:
-            _api.warn_deprecated(
-                "3.1",
-                message="Passing shade=None to Axes3D.plot_surface() is "
-                        "deprecated since matplotlib 3.1 and will change its "
-                        "semantic or raise an error in matplotlib 3.3. "
-                        "Please use shade=False instead.")
+            raise ValueError("shade cannot be None.")
 
         colset = []  # the sampled facecolor
         if (rows - 1) % rstride == 0 and \

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -96,14 +96,14 @@ class Axes3D(Axes):
             does not produce the desired result. Note however, that a manual
             zorder will only be correct for a limited view angle. If the figure
             is rotated by the user, it will look wrong from certain angles.
-        auto_add_to_figure : bool, default: True
+        auto_add_to_figure : bool, default: False
             Prior to Matplotlib 3.4 Axes3D would add themselves
             to their host Figure on init.  Other Axes class do not
             do this.
 
-            This behavior is deprecated in 3.4, the default will
-            change to False in 3.5.  The keyword will be undocumented
-            and a non-False value will be an error in 3.6.
+            This behavior is deprecated in 3.4, the default is
+            changed to False in 3.6.  The keyword will be undocumented
+            and a non-False value will be an error in 3.7.
         focal_length : float, default: None
             For a projection type of 'persp', the focal length of the virtual
             camera. Must be > 0. If None, defaults to 1.
@@ -142,7 +142,7 @@ class Axes3D(Axes):
             self._shared_axes["z"].join(self, sharez)
             self._adjustable = 'datalim'
 
-        auto_add_to_figure = kwargs.pop('auto_add_to_figure', True)
+        auto_add_to_figure = kwargs.pop('auto_add_to_figure', False)
 
         super().__init__(
             fig, rect, frameon=True, box_aspect=box_aspect, *args, **kwargs
@@ -178,12 +178,12 @@ class Axes3D(Axes):
 
         if auto_add_to_figure:
             _api.warn_deprecated(
-                "3.4", removal="3.6", message="Axes3D(fig) adding itself "
+                "3.4", removal="3.7", message="Axes3D(fig) adding itself "
                 "to the figure is deprecated since %(since)s. "
                 "Pass the keyword argument auto_add_to_figure=False "
                 "and use fig.add_axes(ax) to suppress this warning. "
-                "The default value of auto_add_to_figure will change to "
-                "False in mpl3.5 and True values will "
+                "The default value of auto_add_to_figure is changed to "
+                "False in mpl3.6 and True values will "
                 "no longer work %(removal)s.  This is consistent with "
                 "other Axes classes.")
             fig.add_axes(self)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -6,7 +6,6 @@ import pytest
 from mpl_toolkits.mplot3d import Axes3D, axes3d, proj3d, art3d
 import matplotlib as mpl
 from matplotlib.backend_bases import MouseButton
-from matplotlib.cbook import MatplotlibDeprecationWarning
 from matplotlib import cm
 from matplotlib import colors as mcolors
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
@@ -1266,8 +1265,7 @@ def test_inverted_cla():
 
 def test_ax3d_tickcolour():
     fig = plt.figure()
-    with pytest.warns(MatplotlibDeprecationWarning):
-        ax = Axes3D(fig)
+    ax = Axes3D(fig)
 
     ax.tick_params(axis='x', colors='red')
     ax.tick_params(axis='y', colors='red')


### PR DESCRIPTION
## PR Summary

Removed deprecated support for `shade=None`, will add release note.

Updated documentation and removal version for `auto_add_to_figure`. Should there be a release note for this? If so, not obvious in which category. (I assume that this should not go into 3.5 now?)

There are also:
https://github.com/matplotlib/matplotlib/blob/6eba0af3a8cec1b576cbdee9d20d85df47d1df2b/lib/mpl_toolkits/mplot3d/axes3d.py#L236-L241

Should the pending be removed? If so, removal in two versions or later? Release note?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
