### PR TITLE
Corrected a mistake in comments (Issue #22369)

### DIFF
--- a/examples/subplots_axes_and_figures/ganged_plots.py
+++ b/examples/subplots_axes_and_figures/ganged_plots.py
@@ -21,7 +21,7 @@ s2 = np.exp(-t)
 s3 = s1 * s2
 
 fig, axs = plt.subplots(3, 1, sharex=True)
-# Remove horizontal space between axes
+# Remove vertical space between axes
 fig.subplots_adjust(hspace=0)
 
 # Plot each graph, and manually set the y tick values


### PR DESCRIPTION
## PR Summary

Issue #22369
Corrected a mistake in comments
Changed horizontal to vertical since hspace is used to denote the vertical space between the axis and not the horizontal space

## PR Checklist

**Documentation**
-  Fixed a Typo