### PR TITLE
Re-enable cibuildwheel on push

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -20,6 +20,7 @@ on:
 jobs:
   build_wheels:
     if: |
+      github.event.action == 'push' ||
       (
         github.event.action == 'labeled' &&
         github.event.label.name == 'Run cibuildwheel'


### PR DESCRIPTION
## PR Summary

In the previous change #22235, the condition to enable wheels with a label left out pushes, so wheels have not been building on `main` like they should have been. (and also tags, but we haven't made any.)

I'm adding the label now to ensure that things haven't broken in the interim.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).