### PR TITLE
ENH: by-pass creating a local class if backend has a Backend class

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3523,6 +3523,9 @@ class _Backend:
             def mainloop(self):
                 return cls.mainloop()
 
+        if not hasattr(sys.modules[cls.__module__], "Backend"):
+            setattr(sys.modules[cls.__module__], "Backend", cls)
+
         setattr(sys.modules[cls.__module__], "Show", Show)
         return cls
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -269,8 +269,16 @@ def switch_backend(newbackend):
 
     backend_name = cbook._backend_module_name(newbackend)
 
-    class backend_mod(matplotlib.backend_bases._Backend):
-        locals().update(vars(importlib.import_module(backend_name)))
+    backend_mod = importlib.import_module(backend_name)
+    if hasattr(backend_mod, "Backend"):
+        backend_mod = backend_mod.Backend
+    else:
+        class backend_mod(matplotlib.backend_bases._Backend):
+            locals().update(vars(backend_mod))
+
+            @classmethod
+            def mainloop(cls):
+                return backend_mod.Show().mainloop()
 
     required_framework = _get_required_interactive_framework(backend_mod)
     if required_framework is not None:


### PR DESCRIPTION
## PR Summary

Simplify using a backend that has a backend class.  I think this is the next step down the path @anntzer started us on.

There is analogous code in mpl-gui at https://github.com/tacaswell/mpl-gui/blob/bc0cdc7bd58095039f124516cd6ca88611509513/mpl_gui/_manage_backend.py#L87-L109  .

It may be worth holding this PR until we sort out if there is anything else we want to hoist upstream from mpl_gui.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

This is implicitly tested, but might be worth pushing in some explicit tests of when the local backend does or does not get created.

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

