### PR TITLE
MNT: deprecate arrow

### DIFF
--- a/doc/api/next_api_changes/deprecations/22382-JK.rst
+++ b/doc/api/next_api_changes/deprecations/22382-JK.rst
@@ -1,0 +1,8 @@
+``arrow`` method is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The `~.axes.Axes.arrow` method is deprecated, and is scheduled to be
+removed in Matplotlib 3.9.  It only produces properly shaped
+arrow heads if the aspect ratio of the axes is 1, and the parameters to
+control the size of the arrow heads is in data space, and hence
+unintuitive.  Users should use `~.axes.Axes.annotate` to create arrows.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4892,6 +4892,7 @@ default: :rc:`scatter.edgecolors`
 
         return collection
 
+    @_api.deprecated("3.6", alternative='annotate', removal='3.9')
     @docstring.dedent_interpd
     def arrow(self, x, y, dx, dy, **kwargs):
         """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -31,7 +31,7 @@ import matplotlib.transforms as mtransforms
 from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
 from matplotlib import rc_context
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib._api import MatplotlibDeprecationWarning
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
@@ -591,24 +591,27 @@ def test_arrow_simple():
         (length_includes_head, shape, head_starts_at_zero) = kwarg
         theta = 2 * np.pi * i / 12
         # Draw arrow
-        ax.arrow(0, 0, np.sin(theta), np.cos(theta),
-                 width=theta/100,
-                 length_includes_head=length_includes_head,
-                 shape=shape,
-                 head_starts_at_zero=head_starts_at_zero,
-                 head_width=theta / 10,
-                 head_length=theta / 10)
+        with pytest.warns(MatplotlibDeprecationWarning):
+            ax.arrow(0, 0, np.sin(theta), np.cos(theta),
+                     width=theta/100,
+                     length_includes_head=length_includes_head,
+                     shape=shape,
+                     head_starts_at_zero=head_starts_at_zero,
+                     head_width=theta / 10,
+                     head_length=theta / 10)
 
 
 def test_arrow_empty():
     _, ax = plt.subplots()
     # Create an empty FancyArrow
-    ax.arrow(0, 0, 0, 0, head_length=0)
+    with pytest.warns(MatplotlibDeprecationWarning):
+        ax.arrow(0, 0, 0, 0, head_length=0)
 
 
 def test_arrow_in_view():
     _, ax = plt.subplots()
-    ax.arrow(1, 1, 1, 1)
+    with pytest.warns(MatplotlibDeprecationWarning):
+        ax.arrow(1, 1, 1, 1)
     assert ax.get_xlim() == (0.8, 2.2)
     assert ax.get_ylim() == (0.8, 2.2)
 

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -14,6 +14,7 @@ import matplotlib.pyplot as plt
 from matplotlib import (
     collections as mcollections, colors as mcolors, patches as mpatches,
     path as mpath, transforms as mtransforms, rcParams)
+from matplotlib._api import MatplotlibDeprecationWarning
 
 import sys
 on_win = (sys.platform == 'win32')
@@ -604,7 +605,8 @@ def test_fancyarrow_units():
 
 def test_fancyarrow_setdata():
     fig, ax = plt.subplots()
-    arrow = ax.arrow(0, 0, 10, 10, head_length=5, head_width=1, width=.5)
+    with pytest.warns(MatplotlibDeprecationWarning):
+        arrow = ax.arrow(0, 0, 10, 10, head_length=5, head_width=1, width=.5)
     expected1 = np.array(
       [[13.54, 13.54],
        [10.35,  9.65],


### PR DESCRIPTION
## PR Summary

Closes #20387

`ax.arrow` is fundamentally broken, and only works for certain types of axes; users should use `annotate` instead.  Not deprecating `FancyArrow`, but maybe that should happen too.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
