### PR TITLE
TST: fix doc build

### DIFF
--- a/doc/api/next_api_changes/deprecations/22345-JK.rst
+++ b/doc/api/next_api_changes/deprecations/22345-JK.rst
@@ -1,14 +1,14 @@
 Pending deprecation of layout methods
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-The methods `~Figure.set_tight_layout`, `~Figure.set_constrained_layout`,
+The methods `~.Figure.set_tight_layout`, `~.Figure.set_constrained_layout`,
 are discouraged, and now emit a ``PendingDeprecationWarning`` in favor of
 explicitly referencing the layout engine via
-`figure.set_layout_engine('tight')` and
-`figure.set_layout_engine('constrained')`.  End users should not see the
+``figure.set_layout_engine('tight')`` and
+``figure.set_layout_engine('constrained')``.  End users should not see the
 warning, but library authors should adjust.
 
-The methods `~Figure.set_constrained_layout_pads` and
-`~Figure.get_constrained_layout_pads` are will be deprecated in favor of
+The methods `~.Figure.set_constrained_layout_pads` and
+`~.Figure.get_constrained_layout_pads` are will be deprecated in favor of
 ``figure.get_layout_engine().set()`` and
 ``figure.get_layout_engine().get()``, and currently emit a
 ``PendingDeprecationWarning``.


### PR DESCRIPTION
## PR Summary
#22345 was merged while our circle CI was failing, so bad formatting in the api change was missed.  Sorry about that!

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
