### PR TITLE
Tweak Axes3D docstrings that refer to 2D plotting methods.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2705,11 +2705,11 @@ class _AxesBase(martist.Artist):
             only the y-axis.
 
         tight : bool or None, default: True
-            The *tight* parameter is passed to :meth:`autoscale_view`,
+            The *tight* parameter is passed to `autoscale_view`,
             which is executed after a margin is changed; the default
             here is *True*, on the assumption that when margins are
             specified, no additional padding to match tick marks is
-            usually desired.  Set *tight* to *None* will preserve
+            usually desired.  Setting *tight* to *None* preserves
             the previous setting.
 
         Returns

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -510,41 +510,11 @@ class Axes3D(Axes):
 
     def margins(self, *margins, x=None, y=None, z=None, tight=True):
         """
-        Convenience method to set or retrieve autoscaling margins.
+        Set or retrieve autoscaling margins.
 
-        Call signatures::
-
-            margins()
-
-        returns xmargin, ymargin, zmargin
-
-        ::
-
-            margins(margin)
-
-            margins(xmargin, ymargin, zmargin)
-
-            margins(x=xmargin, y=ymargin, z=zmargin)
-
-            margins(..., tight=False)
-
-        All forms above set the xmargin, ymargin and zmargin
-        parameters. All keyword parameters are optional.  A single
-        positional argument specifies xmargin, ymargin and zmargin.
-        Passing both positional and keyword arguments for xmargin,
-        ymargin, and/or zmargin is invalid.
-
-        The *tight* parameter
-        is passed to :meth:`autoscale_view`, which is executed after
-        a margin is changed; the default here is *True*, on the
-        assumption that when margins are specified, no additional
-        padding to match tick marks is usually desired.  Setting
-        *tight* to *None* will preserve the previous setting.
-
-        Specifying any margin changes only the autoscaling; for example,
-        if *xmargin* is not None, then *xmargin* times the X data
-        interval will be added to each end of that interval before
-        it is used in autoscaling.
+        See `.Axes.margins` for full documentation.  Because this function
+        applies to 3D Axes, it also takes a *z* argument, and returns
+        ``(xmargin, ymargin, zmargin)``.
         """
         if margins and x is not None and y is not None and z is not None:
             raise TypeError('Cannot pass both positional and keyword '
@@ -577,10 +547,10 @@ class Axes3D(Axes):
     def autoscale(self, enable=True, axis='both', tight=None):
         """
         Convenience method for simple axis view autoscaling.
-        See :meth:`matplotlib.axes.Axes.autoscale` for full explanation.
-        Note that this function behaves the same, but for all
-        three axes.  Therefore, 'z' can be passed for *axis*,
-        and 'both' applies to all three axes.
+
+        See `.Axes.autoscale` for full documentation.  Because this function
+        applies to 3D Axes, *axis* can also be set to 'z', and setting *axis*
+        to 'both' autoscales all three axes.
         """
         if enable is None:
             scalex = True
@@ -624,9 +594,9 @@ class Axes3D(Axes):
                        scalez=True):
         """
         Autoscale the view limits using the data limits.
-        See :meth:`matplotlib.axes.Axes.autoscale_view` for documentation.
-        Note that this function applies to the 3D axes, and as such
-        adds the *scalez* to the function arguments.
+
+        See `.Axes.autoscale_view` for full documentation.  Because this
+        function applies to 3D Axes, it also takes a *scalez* argument.
         """
         # This method looks at the rectangular volume (see above)
         # of data and decides how to scale the view portal to fit it.
@@ -694,7 +664,7 @@ class Axes3D(Axes):
         """
         Set 3D x limits.
 
-        See :meth:`matplotlib.axes.Axes.set_xlim` for full documentation.
+        See `.Axes.set_xlim` for full documentation.
         """
         if right is None and np.iterable(left):
             left, right = left
@@ -751,7 +721,7 @@ class Axes3D(Axes):
         """
         Set 3D y limits.
 
-        See :meth:`matplotlib.axes.Axes.set_ylim` for full documentation.
+        See `.Axes.set_ylim` for full documentation.
         """
         if top is None and np.iterable(bottom):
             bottom, top = bottom
@@ -809,7 +779,7 @@ class Axes3D(Axes):
         """
         Set 3D z limits.
 
-        See :meth:`matplotlib.axes.Axes.set_ylim` for full documentation
+        See `.Axes.set_ylim` for full documentation
         """
         if top is None and np.iterable(bottom):
             bottom, top = bottom
@@ -1358,8 +1328,8 @@ class Axes3D(Axes):
         .. note::
 
             Currently, this function does not behave the same as
-            :meth:`matplotlib.axes.Axes.grid`, but it is intended to
-            eventually support that behavior.
+            `.axes.Axes.grid`, but it is intended to eventually support that
+            behavior.
         """
         # TODO: Operate on each axes separately
         if len(kwargs):
@@ -1372,13 +1342,9 @@ class Axes3D(Axes):
         Convenience method for changing the appearance of ticks and
         tick labels.
 
-        See :meth:`matplotlib.axes.Axes.tick_params` for more complete
-        documentation.
-
-        The only difference is that setting *axis* to 'both' will
-        mean that the settings are applied to all three axes. Also,
-        the *axis* parameter also accepts a value of 'z', which
-        would mean to apply to only the z-axis.
+        See `.Axes.tick_params` for full documentation.  Because this function
+        applies to 3D Axes, *axis* can also be set to 'z', and setting *axis*
+        to 'both' autoscales all three axes.
 
         Also, because of how Axes3D objects are drawn very differently
         from regular 2D axes, some of these settings may have
@@ -2104,8 +2070,7 @@ class Axes3D(Axes):
         Parameters
         ----------
         X, Y, Z : array-like,
-            Input data. See `~matplotlib.axes.Axes.contour` for acceptable
-            data shapes.
+            Input data. See `.Axes.contour` for supported data shapes.
         extend3d : bool, default: False
             Whether to extend contour in 3D.
         stride : int
@@ -2149,8 +2114,7 @@ class Axes3D(Axes):
         Parameters
         ----------
         X, Y, Z : array-like
-            Input data. See `~matplotlib.axes.Axes.tricontour` for acceptable
-            data shapes.
+            Input data. See `.Axes.tricontour` for supported data shapes.
         extend3d : bool, default: False
             Whether to extend contour in 3D.
         stride : int
@@ -2208,8 +2172,7 @@ class Axes3D(Axes):
         Parameters
         ----------
         X, Y, Z : array-like
-            Input data. See `~matplotlib.axes.Axes.contourf` for acceptable
-            data shapes.
+            Input data. See `.Axes.contourf` for supported data shapes.
         zdir : {'x', 'y', 'z'}, default: 'z'
             The direction to use.
         offset : float, optional
@@ -2247,8 +2210,7 @@ class Axes3D(Axes):
         Parameters
         ----------
         X, Y, Z : array-like
-            Input data. See `~matplotlib.axes.Axes.tricontourf` for acceptable
-            data shapes.
+            Input data. See `.Axes.tricontourf` for supported data shapes.
         zdir : {'x', 'y', 'z'}, default: 'z'
             The direction to use.
         offset : float, optional
@@ -3056,7 +3018,7 @@ pivot='tail', normalize=False, **kwargs)
             this. *lims*-arguments may be scalars, or array-likes of the same
             length as the errors. To use limits with inverted axes,
             `~.Axes.set_xlim` or `~.Axes.set_ylim` must be called before
-            :meth:`errorbar`. Note the tricky parameter names: setting e.g.
+            `errorbar`. Note the tricky parameter names: setting e.g.
             *ylolims* to True means that the y-value is a *lower* limit of the
             True value, so, only an *upward*-pointing arrow will be drawn!
 


### PR DESCRIPTION
... and minor edits to 2D Axes.margins docs as well.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
