### PR TITLE
allow setting collection offsets to empty

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -549,11 +549,15 @@ class Collection(artist.Artist, cm.ScalarMappable):
         offsets : (N, 2) or (2,) array-like
         """
         offsets = np.asanyarray(offsets)
-        if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
+        if offsets.shape == (2,):
             offsets = offsets[None, :]
-        self._offsets = np.column_stack(
-            (np.asarray(self.convert_xunits(offsets[:, 0]), 'float'),
-             np.asarray(self.convert_yunits(offsets[:, 1]), 'float')))
+
+        if offsets.shape == (2, 0):
+            self._offsets = offsets.astype('float').T
+        else:
+            self._offsets = np.column_stack(
+                (np.asarray(self.convert_xunits(offsets[:, 0]), 'float'),
+                 np.asarray(self.convert_yunits(offsets[:, 1]), 'float')))
         self.stale = True
 
     def get_offsets(self):

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1101,3 +1101,13 @@ def test_set_offset_units():
     off0 = sc.get_offsets()
     sc.set_offsets(list(zip(y, d)))
     np.testing.assert_allclose(off0, sc.get_offsets())
+
+
+def test_set_offset_empty():
+    expected = mcollections.Collection(offsets=np.column_stack([[], []]))
+
+    modified = mcollections.Collection(
+        offsets=np.column_stack([[0, 1], [0, 1]])
+    )
+    modified.set_offsets([[], []])
+    np.testing.assert_allclose(expected.get_offsets(), modified.get_offsets())


### PR DESCRIPTION
## PR Summary
Fixes: https://github.com/matplotlib/matplotlib/issues/22401

Importantly allows this:

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()

scat = ax.scatter([0,.5], [0, .5])
scat.set_offsets([[],[]])
plt.show()
```
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [NA] New features are documented, with examples if plot related.
- [NA] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [NA] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [NA] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
