### PR TITLE
Remove some trivial private getters/setters in axisartist

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -231,12 +231,6 @@ class LabelBase(mtext.Text):
     def _get_offset_ref_angle(self):
         return self._get_ref_angle()
 
-    def _set_offset_radius(self, offset_radius):
-        self._offset_radius = offset_radius
-
-    def _get_offset_radius(self):
-        return self._offset_radius
-
     _get_opposite_direction = {"left": "right",
                                "right": "left",
                                "top": "bottom",
@@ -252,7 +246,7 @@ class LabelBase(mtext.Text):
         text_ref_angle = self._get_text_ref_angle()
         offset_ref_angle = self._get_offset_ref_angle()
         theta = np.deg2rad(offset_ref_angle)
-        dd = self._get_offset_radius()
+        dd = self._offset_radius
         dx, dy = dd * np.cos(theta), dd * np.sin(theta)
 
         self.set_transform(tr + Affine2D().translate(dx, dy))
@@ -269,7 +263,7 @@ class LabelBase(mtext.Text):
         text_ref_angle = self._get_text_ref_angle()
         offset_ref_angle = self._get_offset_ref_angle()
         theta = np.deg2rad(offset_ref_angle)
-        dd = self._get_offset_radius()
+        dd = self._offset_radius
         dx, dy = dd * np.cos(theta), dd * np.sin(theta)
 
         self.set_transform(tr + Affine2D().translate(dx, dy))
@@ -380,7 +374,7 @@ class AxisLabel(AttributeCopier, LabelBase):
 
         pad = renderer.points_to_pixels(self.get_pad())
         r = self._get_external_pad() + pad
-        self._set_offset_radius(r)
+        self._offset_radius = r
 
         super().draw(renderer)
 
@@ -390,7 +384,7 @@ class AxisLabel(AttributeCopier, LabelBase):
 
         pad = renderer.points_to_pixels(self.get_pad())
         r = self._get_external_pad() + pad
-        self._set_offset_radius(r)
+        self._offset_radius = r
 
         bb = super().get_window_extent(renderer)
 
@@ -521,7 +515,7 @@ class TickLabels(AxisLabel):  # mtext.Text
 
         pad = (self._get_external_pad()
                + renderer.points_to_pixels(self.get_pad()))
-        self._set_offset_radius(r+pad)
+        self._offset_radius = r + pad
 
         for (x, y), a, l in self._locs_angles_labels:
             if not l.strip():
@@ -551,7 +545,7 @@ class TickLabels(AxisLabel):  # mtext.Text
 
         pad = self._get_external_pad() + \
             renderer.points_to_pixels(self.get_pad())
-        self._set_offset_radius(r+pad)
+        self._offset_radius = r + pad
 
         for (x, y), a, l in self._locs_angles_labels:
             self._set_ref_angle(a)  # + add_angle

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -216,20 +216,14 @@ class LabelBase(mtext.Text):
         self.set_rotation_mode("anchor")
         self._text_follow_ref_angle = True
 
-    def _set_ref_angle(self, a):
-        self._ref_angle = a
-
-    def _get_ref_angle(self):
-        return self._ref_angle
-
     def _get_text_ref_angle(self):
         if self._text_follow_ref_angle:
-            return self._get_ref_angle()+90
+            return self._ref_angle + 90
         else:
-            return 0  # self.get_ref_angle()
+            return 0
 
     def _get_offset_ref_angle(self):
-        return self._get_ref_angle()
+        return self._ref_angle
 
     _get_opposite_direction = {"left": "right",
                                "right": "left",
@@ -520,7 +514,7 @@ class TickLabels(AxisLabel):  # mtext.Text
         for (x, y), a, l in self._locs_angles_labels:
             if not l.strip():
                 continue
-            self._set_ref_angle(a)  # + add_angle
+            self._ref_angle = a
             self.set_x(x)
             self.set_y(y)
             self.set_text(l)
@@ -548,7 +542,7 @@ class TickLabels(AxisLabel):  # mtext.Text
         self._offset_radius = r + pad
 
         for (x, y), a, l in self._locs_angles_labels:
-            self._set_ref_angle(a)  # + add_angle
+            self._ref_angle = a
             self.set_x(x)
             self.set_y(y)
             self.set_text(l)
@@ -974,7 +968,7 @@ class AxisArtist(martist.Artist):
         angle_label = angle_tangent - 90
 
         x, y = xy
-        self.label._set_ref_angle(angle_label+self._axislabel_add_angle)
+        self.label._ref_angle = angle_label + self._axislabel_add_angle
         self.label.set(x=x, y=y)
 
     def _draw_label(self, renderer):

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -216,13 +216,15 @@ class LabelBase(mtext.Text):
         self.set_rotation_mode("anchor")
         self._text_follow_ref_angle = True
 
-    def _get_text_ref_angle(self):
+    @property
+    def _text_ref_angle(self):
         if self._text_follow_ref_angle:
             return self._ref_angle + 90
         else:
             return 0
 
-    def _get_offset_ref_angle(self):
+    @property
+    def _offset_ref_angle(self):
         return self._ref_angle
 
     _get_opposite_direction = {"left": "right",
@@ -237,14 +239,12 @@ class LabelBase(mtext.Text):
         # save original and adjust some properties
         tr = self.get_transform()
         angle_orig = self.get_rotation()
-        text_ref_angle = self._get_text_ref_angle()
-        offset_ref_angle = self._get_offset_ref_angle()
-        theta = np.deg2rad(offset_ref_angle)
+        theta = np.deg2rad(self._offset_ref_angle)
         dd = self._offset_radius
         dx, dy = dd * np.cos(theta), dd * np.sin(theta)
 
         self.set_transform(tr + Affine2D().translate(dx, dy))
-        self.set_rotation(text_ref_angle+angle_orig)
+        self.set_rotation(self.text_ref_angle + angle_orig)
         super().draw(renderer)
         # restore original properties
         self.set_transform(tr)
@@ -254,14 +254,12 @@ class LabelBase(mtext.Text):
         # save original and adjust some properties
         tr = self.get_transform()
         angle_orig = self.get_rotation()
-        text_ref_angle = self._get_text_ref_angle()
-        offset_ref_angle = self._get_offset_ref_angle()
-        theta = np.deg2rad(offset_ref_angle)
+        theta = np.deg2rad(self._offset_ref_angle)
         dd = self._offset_radius
         dx, dy = dd * np.cos(theta), dd * np.sin(theta)
 
         self.set_transform(tr + Affine2D().translate(dx, dy))
-        self.set_rotation(text_ref_angle+angle_orig)
+        self.set_rotation(self.text_ref_angle + angle_orig)
         bbox = super().get_window_extent(renderer).frozen()
         # restore original properties
         self.set_transform(tr)
@@ -282,7 +280,7 @@ class AxisLabel(AttributeCopier, LabelBase):
     def __init__(self, *args, axis_direction="bottom", axis=None, **kwargs):
         self._axis = axis
         self._pad = 5
-        self._extra_pad = 0
+        self._extra_pad = 0  # in pixels
         LabelBase.__init__(self, *args, **kwargs)
         self.set_axis_direction(axis_direction)
 

--- a/lib/mpl_toolkits/tests/test_axisartist_axis_artist.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axis_artist.py
@@ -35,7 +35,7 @@ def test_labelbase():
 
     label = LabelBase(0.5, 0.5, "Test")
     label._set_ref_angle(-90)
-    label._set_offset_radius(offset_radius=50)
+    label._offset_radius = 50
     label.set_rotation(-90)
     label.set(ha="center", va="top")
     ax.add_artist(label)
@@ -67,7 +67,7 @@ def test_ticklabels():
 
     ax.plot([0.5], [0.5], "s")
     axislabel = AxisLabel(0.5, 0.5, "Test")
-    axislabel._set_offset_radius(20)
+    axislabel._offset_radius = 20
     axislabel._set_ref_angle(0)
     axislabel.set_axis_direction("bottom")
     ax.add_artist(axislabel)

--- a/lib/mpl_toolkits/tests/test_axisartist_axis_artist.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axis_artist.py
@@ -34,7 +34,7 @@ def test_labelbase():
     ax.plot([0.5], [0.5], "o")
 
     label = LabelBase(0.5, 0.5, "Test")
-    label._set_ref_angle(-90)
+    label._ref_angle = -90
     label._offset_radius = 50
     label.set_rotation(-90)
     label.set(ha="center", va="top")
@@ -68,7 +68,7 @@ def test_ticklabels():
     ax.plot([0.5], [0.5], "s")
     axislabel = AxisLabel(0.5, 0.5, "Test")
     axislabel._offset_radius = 20
-    axislabel._set_ref_angle(0)
+    axislabel._ref_angle = 0
     axislabel.set_axis_direction("bottom")
     ax.add_artist(axislabel)
 


### PR DESCRIPTION
## PR Summary

- Remove trivial private `_get_offset_radius` / `_set_offset_radius`
- Remove trivial private `_get_ref_angle` / `_set_ref_angle`
- Remove trivial private `_get_external_pad` / `_set_external_pad`
- Turn `_get_text_ref_angle` and `_get_offset_ref_angle` into properties
