### PR TITLE
Make emit and auto args of set_{x,y,z}lim keyword only.

### DIFF
--- a/doc/api/next_api_changes/deprecations/22415-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22415-AL.rst
@@ -1,0 +1,4 @@
+*emit* and *auto* parameters of ``set_xlim``, ``set_ylim``, ``set_zlim``, ``set_rlim``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing these parameters positionally is deprecated; they will become
+keyword-only in a future release.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3625,6 +3625,7 @@ class _AxesBase(martist.Artist):
                 raise ValueError("Axis limits cannot be NaN or Inf")
             return converted_limit
 
+    @_api.make_keyword_only("3.6", "emit")
     def set_xlim(self, left=None, right=None, emit=True, auto=False,
                  *, xmin=None, xmax=None):
         """
@@ -3897,6 +3898,7 @@ class _AxesBase(martist.Artist):
         """
         return tuple(self.viewLim.intervaly)
 
+    @_api.make_keyword_only("3.6", "emit")
     def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
                  *, ymin=None, ymax=None):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1172,6 +1172,7 @@ class PolarAxes(Axes):
     def get_rsign(self):
         return np.sign(self._originViewLim.y1 - self._originViewLim.y0)
 
+    @_api.make_keyword_only("3.6", "emit")
     def set_rlim(self, bottom=None, top=None, emit=True, auto=False, **kwargs):
         """
         See `~.polar.PolarAxes.set_ylim`.
@@ -1191,6 +1192,7 @@ class PolarAxes(Axes):
         return self.set_ylim(bottom=bottom, top=top, emit=emit, auto=auto,
                              **kwargs)
 
+    @_api.make_keyword_only("3.6", "emit")
     def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
                  *, ymin=None, ymax=None):
         """
@@ -1227,7 +1229,8 @@ class PolarAxes(Axes):
         bottom, top : (float, float)
             The new y-axis limits in data coordinates.
         """
-        return super().set_ylim(bottom, top, emit, auto, ymin=ymin, ymax=ymax)
+        return super().set_ylim(
+            bottom, top, emit=emit, auto=auto, ymin=ymin, ymax=ymax)
 
     def get_rlabel_position(self):
         """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -660,6 +660,7 @@ class Axes3D(Axes):
         return minx, maxx, miny, maxy, minz, maxz
 
     # set_xlim, set_ylim are directly inherited from base Axes.
+    @_api.make_keyword_only("3.6", "emit")
     def set_zlim(self, bottom=None, top=None, emit=True, auto=False,
                  *, zmin=None, zmax=None):
         """


### PR DESCRIPTION
## PR Summary

This should help with later improving argument checking in the setters,
e.g. to make `set_xlim(3)` error out (requiring `set_xlim(left=3)`), as
that is likely a logic error.

Goes on top of #21442 to avoid a rebase.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
