### PR TITLE
Support passing rgbaFace as an array to agg's draw_path.

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -7,7 +7,8 @@ import pytest
 
 
 from matplotlib import (
-    collections, path, pyplot as plt, transforms as mtransforms, rcParams)
+    collections, path, patheffects, pyplot as plt, transforms as mtransforms,
+    rcParams)
 from matplotlib.backends.backend_agg import RendererAgg
 from matplotlib.figure import Figure
 from matplotlib.image import imread
@@ -349,3 +350,11 @@ def test_chunksize_toobig_chunks(chunk_limit_setup):
     rcParams['agg.path.chunksize'] = 90_000
     with pytest.raises(OverflowError, match='Please reduce'):
         ra.draw_path(gc, p, idt)
+
+
+def test_non_tuple_rgbaface():
+    # This passes rgbaFace as a ndarray to draw_path.
+    fig = plt.figure()
+    fig.add_subplot(projection="3d").scatter(
+        [0, 1, 2], [0, 1, 2], path_effects=[patheffects.Stroke(linewidth=4)])
+    fig.canvas.draw()

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -191,21 +191,28 @@ int convert_rect(PyObject *rectobj, void *rectp)
 int convert_rgba(PyObject *rgbaobj, void *rgbap)
 {
     agg::rgba *rgba = (agg::rgba *)rgbap;
-
+    PyObject *rgbatuple = NULL;
+    int success = 1;
     if (rgbaobj == NULL || rgbaobj == Py_None) {
         rgba->r = 0.0;
         rgba->g = 0.0;
         rgba->b = 0.0;
         rgba->a = 0.0;
     } else {
+        if (!(rgbatuple = PySequence_Tuple(rgbaobj))) {
+            success = 0;
+            goto exit;
+        }
         rgba->a = 1.0;
         if (!PyArg_ParseTuple(
-                 rgbaobj, "ddd|d:rgba", &(rgba->r), &(rgba->g), &(rgba->b), &(rgba->a))) {
-            return 0;
+                 rgbatuple, "ddd|d:rgba", &(rgba->r), &(rgba->g), &(rgba->b), &(rgba->a))) {
+            success = 0;
+            goto exit;
         }
     }
-
-    return 1;
+exit:
+    Py_XDECREF(rgbatuple);
+    return success;
 }
 
 int convert_dashes(PyObject *dashobj, void *dashesp)


### PR DESCRIPTION
This occurs (rarely) when combining patheffects and mplot3d.

Closes #8650.  Closes #19563.  Closes #20991.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
