### PR TITLE
Remove "Matplotlib version" from docs issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -30,10 +30,3 @@ body:
         * This line should be be changed to say [...]
         * Include a paragraph explaining [...]
         * Add a figure showing [...]
-  - type: input
-    id: matplotlib-version
-    attributes:
-      label: Matplotlib Version
-      description: "From Python prompt: `import matplotlib; print(matplotlib.__version__)`"
-    validations:
-      required: true


### PR DESCRIPTION
We don't need the code version installed by the user. If anything we need to
know the version of the docs the user is looking at.

Most of that is covered by the "Documentation Link" entry. It may point
to "stable" which could change contents in the future, but IMHO that's
not a practical problem.

Closes #22403.

