### PR TITLE
Update Scipy intersphinx inventory link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -160,7 +160,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'pytest': ('https://pytest.org/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
-    'scipy': ('https://docs.scipy.org/doc/scipy/reference/', None),
+    'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'tornado': ('https://www.tornadoweb.org/en/stable/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None),
 }
@@ -191,7 +191,7 @@ sphinx_gallery_conf = {
     'reference_url': {
         'matplotlib': None,
         'numpy': 'https://numpy.org/doc/stable/',
-        'scipy': 'https://docs.scipy.org/doc/scipy/reference/',
+        'scipy': 'https://docs.scipy.org/doc/scipy/',
     },
     'backreferences_dir': Path('api') / Path('_as_gen'),
     'subsection_order': gallery_order.sectionorder,

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -190,8 +190,6 @@ sphinx_gallery_conf = {
     'doc_module': ('matplotlib', 'mpl_toolkits'),
     'reference_url': {
         'matplotlib': None,
-        'numpy': 'https://numpy.org/doc/stable/',
-        'scipy': 'https://docs.scipy.org/doc/scipy/',
     },
     'backreferences_dir': Path('api') / Path('_as_gen'),
     'subsection_order': gallery_order.sectionorder,

--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -307,7 +307,7 @@ commands::
 
   python -m sphinx.ext.intersphinx 'https://docs.python.org/3/objects.inv'
   python -m sphinx.ext.intersphinx 'https://numpy.org/doc/stable/objects.inv'
-  python -m sphinx.ext.intersphinx 'https://docs.scipy.org/doc/scipy/reference/objects.inv'
+  python -m sphinx.ext.intersphinx 'https://docs.scipy.org/doc/scipy/objects.inv'
   python -m sphinx.ext.intersphinx 'https://pandas.pydata.org/pandas-docs/stable/objects.inv'
 
 .. _rst-figures-and-includes:


### PR DESCRIPTION
## PR Summary

As noted in https://github.com/scipy/scipy/issues/15545 the object inventory has moved. Though there's a redirect, it has paths like `reference/..` which doubles the `reference` in the URL.

Additionally, we don't need explicit entries in `reference_url` because sphinx-gallery will get them from the intersphinx config.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).