### PR TITLE
Fix ambiguous link targets in docs.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3596,7 +3596,7 @@ class _AxesBase(martist.Artist):
 
         See Also
         --------
-        set_xlim
+        .Axes.set_xlim
         set_xbound, get_xbound
         invert_xaxis, xaxis_inverted
 
@@ -3604,7 +3604,6 @@ class _AxesBase(martist.Artist):
         -----
         The x-axis may be inverted, in which case the *left* value will
         be greater than the *right* value.
-
         """
         return tuple(self.viewLim.intervalx)
 
@@ -3885,7 +3884,7 @@ class _AxesBase(martist.Artist):
 
         See Also
         --------
-        set_ylim
+        .Axes.set_ylim
         set_ybound, get_ybound
         invert_yaxis, yaxis_inverted
 
@@ -3893,7 +3892,6 @@ class _AxesBase(martist.Artist):
         -----
         The y-axis may be inverted, in which case the *bottom* value
         will be greater than the *top* value.
-
         """
         return tuple(self.viewLim.intervaly)
 


### PR DESCRIPTION
## PR Summary

Trying to fix https://github.com/matplotlib/matplotlib/pull/21442#issuecomment-1033344534.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
