### PR TITLE
CI: skip test to work around gs bug

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -71,6 +71,13 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation):
 
         assert not s_buf.closed
         assert not b_buf.closed
+        if '\x80' in s_buf.getvalue():
+            pytest.skip(
+                "This appears to be the result of a bug in ghostscript or one "
+                "of its dependencies that fails to ascii85 encode the "
+                "compressed fonts which results in encoding the string as "
+                "ascii failing just below."
+            )
         s_val = s_buf.getvalue().encode('ascii')
         b_val = b_buf.getvalue()
 


### PR DESCRIPTION
We are seeing failures due to, what we believe, is an issue with ghostscript or
one of its dependencies failing to properly encode the compressed fonts in an
ascii compatible way.  This appears to be a transient issue has been fixed by
subsequent release, however we have not been able to identify exactly which
dependency is problematic.

For now skip the tests and remove this at some point in the future.

-----

Comparing what we installed from brew between the last working and first broken main branch builds on OSX on azure gives us

```
{'openexr': ('3.1.3', '3.1.4'),
 'glib': ('2.70.2', '2.70.3'),
 'harfbuzz': ('3.2.0', '3.3.1'),
 'little-cms2': ('2.12', '2.13'),
 'rubberband': ('2.0.1', '2.0.2'),
 'gnu-getopt': ('2.37.2', '2.37.3'),
 'imagemagick': ('7.1.0-20', '7.1.0-22')}
```

As of the weekend (2022-02-05) I could reproduce this issue locally (https://gitter.im/matplotlib/matplotlib?at=61fec01c3e52f56a26ecbbee) but no longer can.   Under the fold is data extracted from my system updates (Arch)  I beleive (but did not keep good enough notes to be sure) that something in the 2022-02-04 updates broke it and something in the the 2022-02-07 updates fixed it, but 


<details>

```
                             |                2022-02-04                 |                2022-02-07                
            acl              |           (2.3.1-1 -> 2.3.1-2)            |                     -                    
      akonadi-contacts       |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
     alsa-card-profiles      |        (1:0.3.44-1 -> 1:0.3.45-1)         |                     -                    
            attr             |           (2.5.1-1 -> 2.5.1-2)            |                     -                    
           audit             |           (3.0.6-5 -> 3.0.7-1)            |                     -                    
       baloo-widgets         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
           brltty            |             (6.4-8 -> 6.4-9)              |                     -                    
        btrfs-progs          |                     -                     |           (5.16-1 -> 5.16.1-1)           
          buildah            |          (1.24.0-1 -> 1.24.1-1)           |                     -                    
  ca-certificates-mozilla    |                     -                     |            (3.74-1 -> 3.75-1)            
       cabal-install         |        (3.4.0.0-90 -> 3.4.0.0-93)         |        (3.4.0.0-93 -> 3.4.0.0-95)        
            ccid             |           (1.4.36-1 -> 1.5.0-1)           |                     -                    
          chromium           |    (97.0.4692.99-2 -> 98.0.4758.80-1)     |                     -                    
          clojure            |     (1.10.3.1069-1 -> 1.10.3.1075-1)      |                     -                    
     containers-common       |          (0.47.1-1 -> 0.47.2-1)           |           (0.47.2-1 -> 1.0.1-1)          
         cryptsetup          |           (2.4.3-1 -> 2.4.3-2)            |                     -                    
            cuda             |          (11.5.1-1 -> 11.6.0-1)           |                     -                    
          digikam            |           (7.5.0-1 -> 7.5.0-3)            |                     -                    
          dolphin            |         (21.12.1-1 -> 21.12.2-1)          |        (21.12.2-1 -> 21.12.2.1-1)        
         dosfstools          |             (4.2-1 -> 4.2-2)              |                     -                    
         e2fsprogs           |          (1.46.5-1 -> 1.46.5-2)           |                     -                    
          elfutils           |                     -                     |           (0.186-3 -> 0.186-4)           
            fftw             |                     -                     |          (3.3.10-1 -> 3.3.10-2)          
         filezilla           |          (3.57.0-1 -> 3.57.0-2)           |                     -                    
         findutils           |                     -                     |           (4.8.0-1 -> 4.9.0-1)           
         fontconfig          |                     -                     |       (2:2.13.94-2 -> 2:2.13.96-1)       
       frei0r-plugins        |                     -                     |           (1.7.0-1 -> 1.7.0-2)           
       fuse-overlayfs        |           (1.8.1-1 -> 1.8.2-1)            |                     -                    
           fwupd             |                     -                     |           (1.7.4-1 -> 1.7.5-1)           
            gdal             |           (3.4.0-2 -> 3.4.0-3)            |                     -                    
        ghostscript          |                     -                     |          (9.55.0-3 -> 9.55.0-4)          
    gimagereader-common      |           (3.4.0-1 -> 3.4.0-2)            |                     -                    
      gimagereader-qt        |           (3.4.0-1 -> 3.4.0-2)            |                     -                    
         github-cli          |           (2.4.0-1 -> 2.5.0-1)            |                     -                    
       grantleetheme         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
   gtk-update-icon-cache     |         (1:4.6.0-2 -> 1:4.6.0-3)          |                     -                    
            gtk4             |         (1:4.6.0-2 -> 1:4.6.0-3)          |                     -                    
          gwenview           |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
          harfbuzz           |           (3.2.0-1 -> 3.3.1-1)            |           (3.3.1-1 -> 3.3.2-1)           
        harfbuzz-icu         |           (3.2.0-1 -> 3.3.1-1)            |           (3.3.1-1 -> 3.3.2-1)           
       hopenpgp-tools        |        (0.23.6-203 -> 0.23.6-207)         |        (0.23.6-207 -> 0.23.6-210)        
           hugin             |                     -                     |        (2021.0.0-1 -> 2021.0.0-2)        
        imagemagick          |                     -                     |        (7.1.0.22-1 -> 7.1.0.23-1)        
           imlib2            |                     -                     |           (1.7.5-1 -> 1.8.0-1)           
          inkscape           |           (1.1.1-7 -> 1.1.1-8)            |           (1.1.1-8 -> 1.1.2-1)           
           jack2             |          (1.9.20-3 -> 1.9.20-4)           |                     -                    
           json-c            |            (0.15-2 -> 0.15-3)             |                     -                    
           jxrlib            |                     -                     |           (0.2.1-3 -> 0.2.4-1)           
            k3b              |       (1:21.12.1-1 -> 1:21.12.2-1)        |                     -                    
   kaccounts-integration     |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
           kamera            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
           kamoso            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
       kcolorchooser         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
          kdialog            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
      kimageannotator        |           (0.5.3-1 -> 0.5.3-2)            |                     -                    
         kio-extras          |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
        kipi-plugins         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
           kitty             |          (0.24.1-1 -> 0.24.2-1)           |                     -                    
  kitty-shell-integration    |          (0.24.1-1 -> 0.24.2-1)           |                     -                    
       kitty-terminfo        |          (0.24.1-1 -> 0.24.2-1)           |                     -                    
           kmime             |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
            kmod             |              (29-1 -> 29-2)               |                     -                    
        kolourpaint          |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
          konsole            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
        konversation         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
        kpimtextedit         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
           kruler            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
       kuserfeedback         |           (1.0.0-1 -> 1.0.0-3)            |           (1.0.0-3 -> 1.2.0-1)           
           lcms2             |           (2.13-1 -> 2.13.1-1)            |                     -                    
         libakonadi          |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
         libarchive          |           (3.5.2-2 -> 3.5.2-3)            |                     -                    
           libcap            |                     -                     |            (2.63-1 -> 2.63-2)            
         libcap-ng           |                     -                     |           (0.8.2-6 -> 0.8.2-7)           
           libelf            |                     -                     |           (0.186-3 -> 0.186-4)           
        libfilezilla         |          (0.35.0-1 -> 0.36.0-1)           |                     -                    
         libfreexl           |                     -                     |           (1.0.6-1 -> 1.0.6-2)           
          libical            |                     -                     |          (3.0.13-1 -> 3.0.14-1)          
          libixion           |          (0.16.1-9 -> 0.17.0-1)           |                     -                    
          libkcddb           |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
         libkdcraw           |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
         libkexiv2           |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
          libkipi            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
          libkleo            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
          libksane           |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
           libnsl            |                     -                     |           (2.0.0-1 -> 2.0.0-2)           
          liborcus           |          (0.16.1-10 -> 0.17.2-1)          |                     -                    
          libpcap            |                     -                     |          (1.10.1-1 -> 1.10.1-2)          
         libplacebo          |         (4.192.0-1 -> 4.192.1-1)          |                     -                    
     libreoffice-fresh       |           (7.2.5-4 -> 7.3.0-2)            |           (7.3.0-2 -> 7.3.0-4)           
         libspeechd          |                     -                     |          (0.11.1-1 -> 0.11.1-2)          
           libusb            |                     -                     |          (1.0.24-2 -> 1.0.25-2)          
         libxcrypt           |          (4.4.27-1 -> 4.4.28-1)           |                     -                    
        libxkbcommon         |                     -                     |           (1.3.1-1 -> 1.4.0-1)           
      libxkbcommon-x11       |                     -                     |           (1.3.1-1 -> 1.4.0-1)           
         libxnvctrl          |         (495.46-2 -> 510.47.03-1)         |                     -                    
         lua53-lgi           |           (0.9.2-4 -> 0.9.2-7)            |                     -                    
           luajit            | (2.0.5-3 -> 2.1.0.beta3.r384.g1d7b5029-1) |                     -                    
           man-db            |                     -                     |           (2.9.4-2 -> 2.10.0-1)          
       marble-common         |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
         mercurial           |           (6.0.1-1 -> 6.0.2-1)            |                     -                    
         mesa-demos          |                     -                     |           (8.4.0-6 -> 8.4.0-7)           
          ncurses            |                     -                     |             (6.3-1 -> 6.3-2)             
            npm              |           (8.4.0-1 -> 8.4.1-1)            |                     -                    
            nss              |                     -                     |            (3.74-1 -> 3.75-1)            
          numactl            |          (2.0.14-1 -> 2.0.14-2)           |                     -                    
           nvidia            |        (495.46-12 -> 510.47.03-2)         |       (510.47.03-2 -> 510.47.03-3)       
      nvidia-settings        |         (495.46-2 -> 510.47.03-1)         |                     -                    
        nvidia-utils         |         (495.46-2 -> 510.47.03-3)         |                     -                    
           okular            |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
       opencl-nvidia         |         (495.46-2 -> 510.47.03-3)         |                     -                    
           pandoc            |         (2.14.2-23 -> 2.14.2-27)          |         (2.14.2-27 -> 2.14.2-30)         
          pipewire           |        (1:0.3.44-1 -> 1:0.3.45-1)         |                     -                    
          poppler            |         (22.01.0-1 -> 22.02.0-2)          |                     -                    
        poppler-glib         |         (22.01.0-1 -> 22.02.0-2)          |                     -                    
            popt             |            (1.18-2 -> 1.18-3)             |                     -                    
          pybind11           |                     -                     |           (2.9.0-1 -> 2.9.1-1)           
        python-black         |                     -                     |          (22.1.0-1 -> 22.1.0-2)          
     python-entrypoints      |             (0.3-8 -> 0.4-1)              |                     -                    
      python-fonttools       |          (4.29.0-1 -> 4.29.1-1)           |                     -                    
        python-numpy         |                     -                     |          (1.21.5-2 -> 1.22.2-1)          
       python-pillow         |           (9.0.0-1 -> 9.0.1-1)            |                     -                    
   python-prompt_toolkit     |                     -                     |          (3.0.26-1 -> 3.0.27-1)          
        python-pyqt6         |           (6.2.2-4 -> 6.2.3-1)            |                     -                    
      python-pyqt6-sip       |          (13.2.0-4 -> 13.2.1-1)           |                     -                    
      python-pywlroots       |          (0.15.3-1 -> 0.15.7-2)           |                     -                    
  python-websocket-client    |           (0.59.0-3 -> 1.2.3-2)           |                     -                    
    python2-pycryptodome     |                     -                     |          (3.14.0-1 -> 3.14.1-1)          
         qt6-tools           |                     -                     |           (6.2.3-2 -> 6.2.3-3)           
          qtspell            |           (0.9.0-1 -> 1.0.1-1)            |                     -                    
            re2              |      (1:20211101-1 -> 1:20220201-1)       |                     -                    
          readline           |         (8.1.001-1 -> 8.1.002-1)          |                     -                    
          rkcommon           |                     -                     |           (1.8.0-2 -> 1.8.0-3)           
           shadow            |           (4.8.1-4 -> 4.11.1-1)           |                     -                    
         shellcheck          |          (0.8.0-15 -> 0.8.0-19)           |          (0.8.0-19 -> 0.8.0-22)          
  signon-kwallet-extension   |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
         spectacle           |         (21.12.1-1 -> 21.12.2-1)          |                     -                    
     speech-dispatcher       |                     -                     |          (0.11.1-1 -> 0.11.1-2)          
           stack             |         (2.7.3-130 -> 2.7.3-134)          |         (2.7.3-134 -> 2.7.3-139)         
            sudo             |          (1.9.8.p2-3 -> 1.9.9-2)          |                     -                    
         tesseract           |           (5.0.1-2 -> 5.0.1-3)            |                     -                    
     tesseract-data-eng      |         (2:4.1.0-2 -> 2:4.1.0-3)          |                     -                    
           upower            |                     -                     |         (0.99.13-1 -> 0.99.14-1)         
            vde2             |          (2.3.2-18 -> 2.3.2-19)           |                     -                    
virtualbox-host-modules-arch |          (6.1.32-4 -> 6.1.32-5)           |          (6.1.32-5 -> 6.1.32-6)          
           weston            |           (9.0.0-1 -> 10.0.0-1)           |                     -                    
          wlroots            |                     -                     |          (0.15.0-4 -> 0.15.1-2)          
```

restricting this table to just the ones that got updated both days gets:

```
                            |                2022-02-04                 |                2022-02-07                
       cabal-install         |        (3.4.0.0-90 -> 3.4.0.0-93)         |        (3.4.0.0-93 -> 3.4.0.0-95)        
     containers-common       |          (0.47.1-1 -> 0.47.2-1)           |           (0.47.2-1 -> 1.0.1-1)          
          dolphin            |         (21.12.1-1 -> 21.12.2-1)          |        (21.12.2-1 -> 21.12.2.1-1)        
          harfbuzz           |           (3.2.0-1 -> 3.3.1-1)            |           (3.3.1-1 -> 3.3.2-1)           
        harfbuzz-icu         |           (3.2.0-1 -> 3.3.1-1)            |           (3.3.1-1 -> 3.3.2-1)           
       hopenpgp-tools        |        (0.23.6-203 -> 0.23.6-207)         |        (0.23.6-207 -> 0.23.6-210)        
          inkscape           |           (1.1.1-7 -> 1.1.1-8)            |           (1.1.1-8 -> 1.1.2-1)           
       kuserfeedback         |           (1.0.0-1 -> 1.0.0-3)            |           (1.0.0-3 -> 1.2.0-1)           
       lib32-harfbuzz        |           (3.2.0-1 -> 3.3.1-1)            |           (3.3.1-1 -> 3.3.2-1)           
     libreoffice-fresh       |           (7.2.5-4 -> 7.3.0-2)            |           (7.3.0-2 -> 7.3.0-4)           
           nvidia            |        (495.46-12 -> 510.47.03-2)         |       (510.47.03-2 -> 510.47.03-3)       
           pandoc            |         (2.14.2-23 -> 2.14.2-27)          |         (2.14.2-27 -> 2.14.2-30)         
         shellcheck          |          (0.8.0-15 -> 0.8.0-19)           |          (0.8.0-19 -> 0.8.0-22)          
           stack             |         (2.7.3-130 -> 2.7.3-134)          |         (2.7.3-134 -> 2.7.3-139)         
virtualbox-host-modules-arch |          (6.1.32-4 -> 6.1.32-5)           |          (6.1.32-5 -> 6.1.32-6)   
```

</details>

However attempts to downgrade things to reproduce the issue have utterly failed...