### PR TITLE
Revert "CI: skip test to work around gs bug"

### DIFF
--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -71,13 +71,6 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation):
 
         assert not s_buf.closed
         assert not b_buf.closed
-        if '\x80' in s_buf.getvalue():
-            pytest.skip(
-                "This appears to be the result of a bug in ghostscript or one "
-                "of its dependencies that fails to ascii85 encode the "
-                "compressed fonts which results in encoding the string as "
-                "ascii failing just below."
-            )
         s_val = s_buf.getvalue().encode('ascii')
         b_val = b_buf.getvalue()
 


### PR DESCRIPTION
Reverts matplotlib/matplotlib#22442

Eventually we expect that the environment on the OSX machines will update which ever dependency is the problem and we can remove this work-around.

Hopefully what ever the problem was we will jump over it on the other CI systems.