### PR TITLE
Small cleanup to quiver.

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -55,7 +55,7 @@ triangle, make *headaxislength* the same as *headlength*. To make the
 arrow more pointed, reduce *headwidth* or increase *headlength* and
 *headaxislength*. To make the head smaller relative to the shaft,
 scale down all the head parameters. You will probably do best to leave
-minshaft alone.
+*minshaft* alone.
 
 **Arrow outline**
 
@@ -595,32 +595,18 @@ class Quiver(mcollections.PolyCollection):
         self.stale = True
 
     def _dots_per_unit(self, units):
-        """
-        Return a scale factor for converting from units to pixels
-        """
-        if units in ('x', 'y', 'xy'):
-            if units == 'x':
-                dx0 = self.axes.viewLim.width
-                dx1 = self.axes.bbox.width
-            elif units == 'y':
-                dx0 = self.axes.viewLim.height
-                dx1 = self.axes.bbox.height
-            else:  # 'xy', i.e. hypot(x, y)
-                dx0 = np.hypot(*self.axes.viewLim.size)
-                dx1 = np.hypot(*self.axes.bbox.size)
-            dx = dx1 / dx0
-        else:
-            if units == 'width':
-                dx = self.axes.bbox.width
-            elif units == 'height':
-                dx = self.axes.bbox.height
-            elif units == 'dots':
-                dx = 1.0
-            elif units == 'inches':
-                dx = self.axes.figure.dpi
-            else:
-                raise ValueError('unrecognized units')
-        return dx
+        """Return a scale factor for converting from units to pixels."""
+        bb = self.axes.bbox
+        vl = self.axes.viewLim
+        return _api.check_getitem({
+            'x': bb.width / vl.width,
+            'y': bb.height / vl.height,
+            'xy': np.hypot(*bb.size) / np.hypot(*vl.size),
+            'width': bb.width,
+            'height': bb.height,
+            'dots': 1.,
+            'inches': self.axes.figure.dpi,
+        }, units=units)
 
     def _set_transform(self):
         """


### PR DESCRIPTION
## PR Summary

(I was trying to improve the docs re: u,v in x,y units as discussed during the call, but can't figure out what `scale_units=None` (the default) is supposed to mean.  Perhaps @efiring knows? :-))

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
