### PR TITLE
Clarify error message for bad keyword arguments.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -166,7 +166,7 @@ class Axes(_AxesBase):
         title.update(default)
         if fontdict is not None:
             title.update(fontdict)
-        title.update(kwargs)
+        title._internal_update(kwargs)
         return title
 
     def get_legend_handles_labels(self, legend_handler_map=None):
@@ -1064,7 +1064,7 @@ class Axes(_AxesBase):
         lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
         self.add_collection(lines, autolim=False)
-        lines.update(kwargs)
+        lines._internal_update(kwargs)
 
         if len(y) > 0:
             minx = min(xmin.min(), xmax.min())
@@ -1143,7 +1143,7 @@ class Axes(_AxesBase):
         lines = mcoll.LineCollection(masked_verts, colors=colors,
                                      linestyles=linestyles, label=label)
         self.add_collection(lines, autolim=False)
-        lines.update(kwargs)
+        lines._internal_update(kwargs)
 
         if len(x) > 0:
             minx = x.min()
@@ -1363,7 +1363,7 @@ class Axes(_AxesBase):
                                          color=color,
                                          linestyle=linestyle)
             self.add_collection(coll, autolim=False)
-            coll.update(kwargs)
+            coll._internal_update(kwargs)
             colls.append(coll)
 
         if len(positions) > 0:
@@ -2410,7 +2410,7 @@ class Axes(_AxesBase):
                 label='_nolegend_',
                 hatch=htch,
                 )
-            r.update(kwargs)
+            r._internal_update(kwargs)
             r.get_path()._interpolation_steps = 100
             if orientation == 'vertical':
                 r.sticky_edges.y.append(b)
@@ -4502,7 +4502,7 @@ default: :rc:`scatter.edgecolors`
             collection.set_cmap(cmap)
             collection.set_norm(norm)
             collection._scale_norm(norm, vmin, vmax)
-        collection.update(kwargs)
+        collection._internal_update(kwargs)
 
         # Classic mode only:
         # ensure there are margins to allow for the
@@ -4830,7 +4830,7 @@ default: :rc:`scatter.edgecolors`
         collection.set_cmap(cmap)
         collection.set_norm(norm)
         collection.set_alpha(alpha)
-        collection.update(kwargs)
+        collection._internal_update(kwargs)
         collection._scale_norm(norm, vmin, vmax)
 
         corners = ((xmin, ymin), (xmax, ymax))
@@ -4882,7 +4882,7 @@ default: :rc:`scatter.edgecolors`
             bar.set_cmap(cmap)
             bar.set_norm(norm)
             bar.set_alpha(alpha)
-            bar.update(kwargs)
+            bar._internal_update(kwargs)
             bars.append(self.add_collection(bar, autolim=False))
 
         collection.hbar, collection.vbar = bars
@@ -6763,11 +6763,11 @@ such objects
         for patch, lbl in itertools.zip_longest(patches, labels):
             if patch:
                 p = patch[0]
-                p.update(kwargs)
+                p._internal_update(kwargs)
                 if lbl is not None:
                     p.set_label(lbl)
                 for p in patch[1:]:
-                    p.update(kwargs)
+                    p._internal_update(kwargs)
                     p.set_label('_nolegend_')
 
         if nx == 1:

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -642,7 +642,7 @@ class _AxesBase(martist.Artist):
         if yscale:
             self.set_yscale(yscale)
 
-        self.update(kwargs)
+        self._internal_update(kwargs)
 
         for name, axis in self._get_axis_map().items():
             axis.callbacks._pickled_cids.add(

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1818,10 +1818,10 @@ class Axis(martist.Artist):
             tick_label = formatter(loc, pos)
             # deal with label1
             tick.label1.set_text(tick_label)
-            tick.label1.update(kwargs)
+            tick.label1._internal_update(kwargs)
             # deal with label2
             tick.label2.set_text(tick_label)
-            tick.label2.update(kwargs)
+            tick.label2._internal_update(kwargs)
             # only return visible tick labels
             if tick.label1.get_visible():
                 ret.append(tick.label1)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -206,7 +206,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         self._offset_transform = offset_transform
 
         self._path_effects = None
-        self.update(kwargs)
+        self._internal_update(kwargs)
         self._paths = None
 
     def get_paths(self):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -273,7 +273,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
         self._imcache = None
 
-        self.update(kwargs)
+        self._internal_update(kwargs)
 
     def __getstate__(self):
         # Save some space on the pickle by not saving the cache.
@@ -1215,7 +1215,7 @@ class PcolorImage(AxesImage):
         **kwargs : `.Artist` properties
         """
         super().__init__(ax, norm=norm, cmap=cmap)
-        self.update(kwargs)
+        self._internal_update(kwargs)
         if A is not None:
             self.set_data(x, y, A)
 
@@ -1356,7 +1356,7 @@ class FigureImage(_ImageBase):
         self.figure = fig
         self.ox = offsetx
         self.oy = offsety
-        self.update(kwargs)
+        self._internal_update(kwargs)
         self.magnification = 1.0
 
     def get_extent(self):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -391,7 +391,7 @@ class Line2D(Artist):
 
         # update kwargs before updating data to give the caller a
         # chance to init axes (and hence unit support)
-        self.update(kwargs)
+        self._internal_update(kwargs)
         self.pickradius = pickradius
         self.ind_offset = 0
         if (isinstance(self._picker, Number) and

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -193,7 +193,7 @@ class OffsetBox(martist.Artist):
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args)
-        self.update(kwargs)
+        self._internal_update(kwargs)
         # Clipping has not been implemented in the OffsetBox family, so
         # disable the clip flag for consistency. It can always be turned back
         # on to zero effect.
@@ -1359,7 +1359,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         if bboxprops:
             self.patch.set(**bboxprops)
 
-        self.update(kwargs)
+        self._internal_update(kwargs)
 
     @property
     def xyann(self):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -111,7 +111,7 @@ class Patch(artist.Artist):
         self.set_joinstyle(joinstyle)
 
         if len(kwargs):
-            self.update(kwargs)
+            self._internal_update(kwargs)
 
     def get_verts(self):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1307,7 +1307,7 @@ class PolarAxes(Axes):
         elif fmt is not None:
             self.xaxis.set_major_formatter(mticker.FormatStrFormatter(fmt))
         for t in self.xaxis.get_ticklabels():
-            t.update(kwargs)
+            t._internal_update(kwargs)
         return self.xaxis.get_ticklines(), self.xaxis.get_ticklabels()
 
     def set_rgrids(self, radii, labels=None, angle=None, fmt=None, **kwargs):
@@ -1362,7 +1362,7 @@ class PolarAxes(Axes):
             angle = self.get_rlabel_position()
         self.set_rlabel_position(angle)
         for t in self.yaxis.get_ticklabels():
-            t.update(kwargs)
+            t._internal_update(kwargs)
         return self.yaxis.get_gridlines(), self.yaxis.get_ticklabels()
 
     def format_coord(self, theta, r):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1789,7 +1789,7 @@ def xticks(ticks=None, labels=None, **kwargs):
     if labels is None:
         labels = ax.get_xticklabels()
         for l in labels:
-            l.update(kwargs)
+            l._internal_update(kwargs)
     else:
         labels = ax.set_xticklabels(labels, **kwargs)
 
@@ -1849,7 +1849,7 @@ def yticks(ticks=None, labels=None, **kwargs):
     if labels is None:
         labels = ax.get_yticklabels()
         for l in labels:
-            l.update(kwargs)
+            l._internal_update(kwargs)
     else:
         labels = ax.set_yticklabels(labels, **kwargs)
 

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -184,7 +184,7 @@ class Cell(Rectangle):
 
         %(Text:kwdoc)s
         """
-        self._text.update(kwargs)
+        self._text._internal_update(kwargs)
         self.stale = True
 
     @property
@@ -315,7 +315,7 @@ class Table(Artist):
         self._edges = None
         self._autoColumns = []
         self._autoFontsize = True
-        self.update(kwargs)
+        self._internal_update(kwargs)
 
         self.set_clip_on(False)
 


### PR DESCRIPTION
`plot([], [], foo=42)` previously emitted
```
'Line2D' object has no property 'foo'
```
which refers to the Matplotlib-specific concept of "properties".  It now
instead emits
```
Line2D.set() got an unexpected keyword argument 'foo'
```
which is modeled after the standard error message for unknown keyword
arguments.

(To maximize backcompat, the implementation goes through a new
_internal_update, which does *not* error when the same prop is passed
under different aliases.  This could be changed later, but is not the
goal of this PR.)

(This was triggered by https://discourse.matplotlib.org/t/line2d-object-has-no-property-line-error/22585)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
