### PR TITLE
Simplify impl. of polar limits setting API.

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1175,7 +1175,14 @@ class PolarAxes(Axes):
     @_api.make_keyword_only("3.6", "emit")
     def set_rlim(self, bottom=None, top=None, emit=True, auto=False, **kwargs):
         """
-        See `~.polar.PolarAxes.set_ylim`.
+        Set the radial axis view limits.
+
+        This function behaves like `.Axes.set_ylim`, but additionally supports
+        *rmin* and *rmax* as aliases for *bottom* and *top*.
+
+        See Also
+        --------
+        .Axes.set_ylim
         """
         if 'rmin' in kwargs:
             if bottom is None:
@@ -1191,46 +1198,6 @@ class PolarAxes(Axes):
                                  'argument and kwarg "rmax"')
         return self.set_ylim(bottom=bottom, top=top, emit=emit, auto=auto,
                              **kwargs)
-
-    @_api.make_keyword_only("3.6", "emit")
-    def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
-                 *, ymin=None, ymax=None):
-        """
-        Set the view limits for the radial axis.
-
-        Parameters
-        ----------
-        bottom : float, optional
-            The bottom limit (default: None, which leaves the bottom
-            limit unchanged).
-            The bottom and top ylims may be passed as the tuple
-            (*bottom*, *top*) as the first positional argument (or as
-            the *bottom* keyword argument).
-
-        top : float, optional
-            The top limit (default: None, which leaves the top limit
-            unchanged).
-
-        emit : bool, default: True
-            Whether to notify observers of limit change.
-
-        auto : bool or None, default: False
-            Whether to turn on autoscaling of the y-axis. True turns on,
-            False turns off, None leaves unchanged.
-
-        ymin, ymax : float, optional
-            These arguments are deprecated and will be removed in a future
-            version.  They are equivalent to *bottom* and *top* respectively,
-            and it is an error to pass both *ymin* and *bottom* or
-            *ymax* and *top*.
-
-        Returns
-        -------
-        bottom, top : (float, float)
-            The new y-axis limits in data coordinates.
-        """
-        return super().set_ylim(
-            bottom, top, emit=emit, auto=auto, ymin=ymin, ymax=ymax)
 
     def get_rlabel_position(self):
         """


### PR DESCRIPTION
AFAICT we can just inherit set_ylim.  Also slightly improve the docs of
set_rlim.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
