### PR TITLE
Copy arrowprops argument to FancyAnnotationBbox.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1334,7 +1334,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
                                        xycoords=xycoords,
                                        annotation_clip=annotation_clip)
         self.offsetbox = offsetbox
-        self.arrowprops = arrowprops
+        self.arrowprops = arrowprops.copy() if arrowprops is not None else None
         self.set_fontsize(fontsize)
         self.xybox = xybox if xybox is not None else xy
         self.boxcoords = boxcoords if boxcoords is not None else xycoords

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -325,3 +325,13 @@ def test_annotationbbox_extents():
 
 def test_zorder():
     assert OffsetBox(zorder=42).zorder == 42
+
+
+def test_arrowprops_copied():
+    da = DrawingArea(20, 20, 0, 0, clip=True)
+    arrowprops = {"arrowstyle": "->", "relpos": (.3, .7)}
+    ab = AnnotationBbox(da, [.5, .5], xybox=(-0.2, 0.5), xycoords='data',
+                        boxcoords="axes fraction", box_alignment=(0., .5),
+                        arrowprops=arrowprops)
+    assert ab.arrowprops is not ab
+    assert arrowprops["relpos"] == (.3, .7)


### PR DESCRIPTION
... so that we don't mutate dicts passed in by the user (we in fact pop
a key from arrowprops a bit later), and so that later mutations to the
dict from the user side don't affect the artist.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
