### PR TITLE
Deprecate unused AddList.

### DIFF
--- a/doc/api/next_api_changes/removals/22465-AL.rst
+++ b/doc/api/next_api_changes/removals/22465-AL.rst
@@ -1,0 +1,4 @@
+``mpl_toolkits.axes_grid1.axes_size.AddList``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated due to being unused.  Use ``sum(sizes, start=Fixed(0))`` (for
+example) to sum multiple size objects.

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -16,7 +16,6 @@ from matplotlib.axes import Axes
 
 
 class _Base:
-
     def __rmul__(self, other):
         return Fraction(other, self)
 
@@ -38,6 +37,8 @@ class Add(_Base):
         return a_rel_size + b_rel_size, a_abs_size + b_abs_size
 
 
+@_api.deprecated(
+    "3.6", alternative="sum(sizes, start=Fixed(0))")
 class AddList(_Base):
     def __init__(self, add_list):
         self._list = add_list


### PR DESCRIPTION
It's actually still used in get_vsize_hsize, but that is also currently
deprecated.  Also, there's a reasonable replacement.  The replacement
may be very slightly less efficient because it constructs deeply nested
Add objects, but given the low level of maintenance for axes_grid1,
decreasing the public API still seems a good idea.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
