### PR TITLE
Small cleanup to font handling in agg.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -222,18 +222,12 @@ class RendererAgg(RendererBase):
 
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         # docstring inherited
-
         if ismath:
             return self.draw_mathtext(gc, x, y, s, prop, angle)
-
-        flags = get_hinting_flag()
-        font = self._get_agg_font(prop)
-
-        if font is None:
-            return None
+        font = self._prepare_font(prop)
         # We pass '0' for angle here, since it will be rotated (in raster
         # space) in the following call to draw_text_image).
-        font.set_text(s, 0, flags=flags)
+        font.set_text(s, 0, flags=get_hinting_flag())
         font.draw_glyphs_to_bitmap(
             antialiased=mpl.rcParams['text.antialiased'])
         d = font.get_descent() / 64.0
@@ -264,9 +258,8 @@ class RendererAgg(RendererBase):
                 self.mathtext_parser.parse(s, self.dpi, prop)
             return width, height, descent
 
-        flags = get_hinting_flag()
-        font = self._get_agg_font(prop)
-        font.set_text(s, 0.0, flags=flags)
+        font = self._prepare_font(prop)
+        font.set_text(s, 0.0, flags=get_hinting_flag())
         w, h = font.get_width_height()  # width and height of unrotated string
         d = font.get_descent()
         w /= 64.0  # convert from subpixels
@@ -295,17 +288,14 @@ class RendererAgg(RendererBase):
         # docstring inherited
         return self.width, self.height
 
-    def _get_agg_font(self, prop):
+    def _prepare_font(self, font_prop):
         """
-        Get the font for text instance t, caching for efficiency
+        Get the `.FT2Font` for *font_prop*, clear its buffer, and set its size.
         """
-        fname = findfont(prop)
-        font = get_font(fname)
-
+        font = get_font(findfont(font_prop))
         font.clear()
-        size = prop.get_size_in_points()
+        size = font_prop.get_size_in_points()
         font.set_size(size, self.dpi)
-
         return font
 
     def points_to_pixels(self, points):


### PR DESCRIPTION
Rename _get_agg_font to _prepare_font, as it doesn't really do
anything agg-specific.  Fix its docstring.  Rename the *prop* arg to
*font_prop*, which makes its type clear in the context (and avoids
having to mention it in the docstring, thus keeping the docstring
single-line).

_get_agg_font/_prepare_font never returns None (e.g. we always call
`clear` on the font instance) so skip a None check in draw_text.

Skip a few temporary variables, which don't add much to legibility.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
