### PR TITLE
Improve readability of mathtext internal structures.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1236,11 +1236,11 @@ class List(Box):
         self.glue_order   = 0    # The order of infinity (0 - 3) for the glue
 
     def __repr__(self):
-        return '[%s <%.02f %.02f %.02f %.02f> %s]' % (
+        return '%s<w=%.02f h=%.02f d=%.02f s=%.02f>[%s]' % (
             super().__repr__(),
             self.width, self.height,
             self.depth, self.shift_amount,
-            ' '.join([repr(x) for x in self.children]))
+            ', '.join([repr(x) for x in self.children]))
 
     @staticmethod
     def _determine_order(totals):


### PR DESCRIPTION
This changes the repr of mathtext lists from e.g.
```
[Hlist <70.39 41.78 0.00 0.00> [Hlist <0.00 0.00 0.00 0.00> ] [Hlist <37.62 40.09 0.00 0.00> `V` k1.11] [Hlist <32.76 41.78 0.00 0.00> ` ` `l` k10.34]]
```
to
```
Hlist<w=70.39 h=41.78 d=0.00 s=0.00>[Hlist<w=0.00 h=0.00 d=0.00 s=0.00>[], Hlist<w=37.62 h=40.09 d=0.00 s=0.00>[`V`, k1.11], Hlist<w=32.76 h=41.78 d=0.00 s=0.00>[` `, `l`, k10.34]]
```
These are internal structures that should only ever be seen when
debugging mathtext layout and can be quite deeply nested, so a somewhat
concise notation should is good (e.g., backticks for Chars, k for
Kerns), but still...
- indicate what each of the four numbers correspond to
  (width/height/descent shift),
- move the brackets *after* the class name and metrics, which makes it
  clearer what is info about the list instance itself and what are the
  contents of the instance (in particular, the empty hlist at the
  beginning is now clearer),
- separate list items with commas.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
