### PR TITLE
Clarify secondary_axis documentation

### DIFF
--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -276,7 +276,8 @@ functions : 2-tuple of func, or Transform with an inverse
     If a 2-tuple of functions, the user specifies the transform
     function and its inverse.  i.e.
     ``functions=(lambda x: 2 / x, lambda x: 2 / x)`` would be an
-    reciprocal transform with a factor of 2.
+    reciprocal transform with a factor of 2. Both functions must accept
+    numpy arrays as input.
 
     The user can also directly supply a subclass of
     `.transforms.Transform` so long as it has an inverse.


### PR DESCRIPTION
The documentation dos not specify that the functions used to set the secondary axis must be able to accept numpy arrays as inputs. The relevant docstring has been edited for better clarity.

Resolves #22473

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
