### PR TITLE
FIX: Include (0, 0) offsets in scatter autoscaling

### DIFF
--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -711,6 +711,22 @@ def test_singleton_autolim():
     np.testing.assert_allclose(ax.get_xlim(), [-0.06, 0.06])
 
 
+@pytest.mark.parametrize("transform, expected", [
+    ("transData", (-0.5, 3.5)),
+    ("transAxes", (2.8, 3.2)),
+])
+def test_autolim_with_zeros(transform, expected):
+    # 1) Test that a scatter at (0, 0) data coordinates contributes to
+    # autoscaling even though any(offsets) would be False in that situation.
+    # 2) Test that specifying transAxes for the transform does not contribute
+    # to the autoscaling.
+    fig, ax = plt.subplots()
+    ax.scatter(0, 0, transform=getattr(ax, transform))
+    ax.scatter(3, 3)
+    np.testing.assert_allclose(ax.get_ylim(), expected)
+    np.testing.assert_allclose(ax.get_xlim(), expected)
+
+
 @pytest.mark.parametrize('flat_ref, kwargs', [
     (True, {}),
     (False, {}),


### PR DESCRIPTION
## PR Summary

A scatter point at (0, 0) has offsets with 0s and `any(offsets)`
then gets evaluated to False. We still want to include this point
in the autoscaling if it is there.

Closes #22470

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
