### PR TITLE
Remove _point_size_reduction.

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -222,9 +222,6 @@ class MarkerStyle:
     fillstyles = ('full', 'left', 'right', 'bottom', 'top', 'none')
     _half_fillstyles = ('left', 'right', 'bottom', 'top')
 
-    # TODO: Is this ever used as a non-constant?
-    _point_size_reduction = 0.5
-
     _unset = object()  # For deprecation of MarkerStyle(<noargs>).
 
     def __init__(self, marker=_unset, fillstyle=None,
@@ -553,8 +550,8 @@ class MarkerStyle:
     def _half_fill(self):
         return self.get_fillstyle() in self._half_fillstyles
 
-    def _set_circle(self, reduction=1.0):
-        self._transform = Affine2D().scale(0.5 * reduction)
+    def _set_circle(self, size=1.0):
+        self._transform = Affine2D().scale(0.5 * size)
         self._snap_threshold = np.inf
         if not self._half_fill():
             self._path = Path.unit_circle()
@@ -564,6 +561,9 @@ class MarkerStyle:
             self._transform.rotate_deg(
                 {'right': 0, 'top': 90, 'left': 180, 'bottom': 270}[fs])
             self._alt_transform = self._transform.frozen().rotate_deg(180.)
+
+    def _set_point(self):
+        self._set_circle(size=0.5)
 
     def _set_pixel(self):
         self._path = Path.unit_rectangle()
@@ -578,9 +578,6 @@ class MarkerStyle:
         # beyond just its path data.
         self._transform = Affine2D().translate(-0.49999, -0.49999)
         self._snap_threshold = None
-
-    def _set_point(self):
-        self._set_circle(reduction=self._point_size_reduction)
 
     _triangle_path = Path([[0, 1], [-1, -1], [1, -1], [0, 1]], closed=True)
     # Going down halfway looks to small.  Golden ratio is too far.


### PR DESCRIPTION
As implied by the comment, it may not be worth having this as a separate
variable.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
