### PR TITLE
Change string representation of AxesImage

### DIFF
--- a/doc/api/next_api_changes/behavior/22485-TH.rst
+++ b/doc/api/next_api_changes/behavior/22485-TH.rst
@@ -1,0 +1,5 @@
+``AxesImage`` string representation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The string representation of `.AxesImage` changes from
+stating the position in the figure ``"AxesImage(80,52.8;496x369.6)"`` to
+giving the number of pixels ``"AxesImage(size=(300, 200))"``.

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -275,6 +275,13 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
         self._internal_update(kwargs)
 
+    def __str__(self):
+        try:
+            size = self.get_size()
+            return f"{type(self).__name__}(size={size!r})"
+        except RuntimeError:
+            return type(self).__name__
+
     def __getstate__(self):
         # Save some space on the pickle by not saving the cache.
         return {**super().__getstate__(), "_imcache": None}
@@ -896,8 +903,6 @@ class AxesImage(_ImageBase):
         the output image is larger than the input image.
     **kwargs : `.Artist` properties
     """
-    def __str__(self):
-        return "AxesImage(%g,%g;%gx%g)" % tuple(self.axes.bbox.bounds)
 
     def __init__(self, ax,
                  cmap=None,


### PR DESCRIPTION
- The current implementation was unhelpful / incorrect: It returned
  the axes bounding box: Fixes #20294.
- The string should contain helpful information. I argue that the
  figure coordinates of the image are not helpful most of the time.
  Instead, giving the number of pixels seems more useful. Note that
  __str__ does not need to be unique.
- Also move the definition to the base class and make it
  type-agnostic so that it works correctly for all derived classes.

