### PR TITLE
Fix units in quick start example

### DIFF
--- a/tutorials/introductory/quick_start.py
+++ b/tutorials/introductory/quick_start.py
@@ -468,16 +468,16 @@ ax.bar(categories, np.random.rand(len(categories)));
 # :doc:`/gallery/subplots_axes_and_figures/secondary_axis` for further
 # examples.
 
-fig, (ax1, ax3) = plt.subplots(1, 2, figsize=(8, 2.7), layout='constrained')
+fig, (ax1, ax3) = plt.subplots(1, 2, figsize=(7, 2.7), layout='constrained')
 l1, = ax1.plot(t, s)
 ax2 = ax1.twinx()
 l2, = ax2.plot(t, range(len(t)), 'C1')
 ax2.legend([l1, l2], ['Sine (left)', 'Straight (right)'])
 
 ax3.plot(t, s)
-ax3.set_xlabel('Angle [°]')
+ax3.set_xlabel('Angle [rad]')
 ax4 = ax3.secondary_xaxis('top', functions=(np.rad2deg, np.deg2rad))
-ax4.set_xlabel('Angle [rad]')
+ax4.set_xlabel('Angle [°]')
 
 ##############################################################################
 # Color mapped data


### PR DESCRIPTION
## PR Summary

cf. https://discourse.matplotlib.org/t/axis-labels-inverted-in-basic-usage-doc/22596

Also shrink figure slightly to not be larger than the HTML content width.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).