### PR TITLE
FIX: make the show API on webagg consistent with others

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -306,7 +306,7 @@ class _BackendWebAgg(_Backend):
     FigureManager = FigureManagerWebAgg
 
     @staticmethod
-    def show():
+    def show(*, block=None):
         WebAggApplication.initialize()
 
         url = "http://{address}:{port}{prefix}".format(


### PR DESCRIPTION
## PR Summary

Adds a keyword-only block kwarg to the show method on webagg (like all other backends)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
