### PR TITLE
Cleanup unused imports and variables in backends

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -29,11 +29,9 @@ from contextlib import nullcontext
 from math import radians, cos, sin
 
 import numpy as np
-from PIL import Image
 
 import matplotlib as mpl
 from matplotlib import _api, cbook
-from matplotlib import colors as mcolors
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
 from matplotlib.font_manager import findfont, get_font
@@ -152,7 +150,7 @@ class RendererAgg(RendererBase):
                 p.simplify_threshold = path.simplify_threshold
                 try:
                     self._renderer.draw_path(gc, p, transform, rgbFace)
-                except OverflowError as err:
+                except OverflowError:
                     msg = (
                         "Exceeded cell block limit in Agg.\n\n"
                         "Please reduce the value of "
@@ -167,7 +165,7 @@ class RendererAgg(RendererBase):
         else:
             try:
                 self._renderer.draw_path(gc, path, transform, rgbFace)
-            except OverflowError as err:
+            except OverflowError:
                 cant_chunk = ''
                 if rgbFace is not None:
                     cant_chunk += "- can not split filled path\n"

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -8,7 +8,6 @@ import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
 from matplotlib.backend_bases import FigureCanvasBase, ToolContainerBase
 from matplotlib.backend_tools import Cursors
-from matplotlib.figure import Figure
 
 try:
     import gi
@@ -27,9 +26,10 @@ except ValueError as e:
 from gi.repository import Gio, GLib, GObject, Gtk, Gdk
 from . import _backend_gtk
 from ._backend_gtk import (
-    backend_version, _BackendGTK, _FigureManagerGTK, _NavigationToolbar2GTK,
+    _BackendGTK, _FigureManagerGTK, _NavigationToolbar2GTK,
     TimerGTK as TimerGTK3,
 )
+from ._backend_gtk import backend_version  # noqa: F401 # pylint: disable=W0611
 
 
 _log = logging.getLogger(__name__)
@@ -50,7 +50,7 @@ class __getattr__:
                 Cursors.SELECT_REGION: new_cursor("crosshair"),
                 Cursors.WAIT:          new_cursor("wait"),
             }
-        except TypeError as exc:
+        except TypeError:
             return {}
 
     icon_filename = _api.deprecated("3.6", obj_type="")(property(

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -1,7 +1,6 @@
 import functools
 import io
 import os
-from pathlib import Path
 
 import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
@@ -24,9 +23,10 @@ except ValueError as e:
 from gi.repository import Gio, GLib, GObject, Gtk, Gdk, GdkPixbuf
 from . import _backend_gtk
 from ._backend_gtk import (
-    backend_version, _BackendGTK, _FigureManagerGTK, _NavigationToolbar2GTK,
+    _BackendGTK, _FigureManagerGTK, _NavigationToolbar2GTK,
     TimerGTK as TimerGTK4,
 )
+from .backend_gtk import backend_version  # noqa: F401 # pylint: disable=W0611
 
 
 class FigureCanvasGTK4(Gtk.DrawingArea, FigureCanvasBase):

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -1,8 +1,8 @@
 import matplotlib as mpl
 from matplotlib import cbook
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backends import _macosx
-from matplotlib.backends.backend_agg import FigureCanvasAgg
+from . import _macosx
+from .backend_agg import FigureCanvasAgg
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
     TimerBase)

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from matplotlib import cbook
-from matplotlib.backends.backend_agg import RendererAgg
+from .backend_agg import RendererAgg
 from matplotlib._tight_bbox import process_figure_for_rasterizing
 
 

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -20,10 +20,10 @@ except ImportError:
 from matplotlib import is_interactive
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_bases import _Backend, NavigationToolbar2
-from matplotlib.backends.backend_webagg_core import (
-    FigureCanvasWebAggCore, FigureManagerWebAgg, NavigationToolbar2WebAgg,
-    TimerTornado, TimerAsyncio
-)
+from .backend_webagg_core import (
+    FigureCanvasWebAggCore, FigureManagerWebAgg, NavigationToolbar2WebAgg)
+from .backend_webagg_core import (  # noqa: F401 # pylint: disable=W0611
+    TimerTornado, TimerAsyncio)
 
 
 def connection_info():

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -18,8 +18,7 @@ from PIL import Image
 import matplotlib as mpl
 from matplotlib import _api, cbook, font_manager as fm
 from matplotlib.backend_bases import (
-    _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase,
-    RendererBase
+    _Backend, FigureCanvasBase, FigureManagerBase, RendererBase
 )
 from matplotlib.backends.backend_mixed import MixedModeRenderer
 from matplotlib.backends.backend_pdf import (

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -405,8 +405,7 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
             raise RuntimeError("Event loop already running")
         self._event_loop = event_loop = QtCore.QEventLoop()
         if timeout > 0:
-            timer = QtCore.QTimer.singleShot(int(timeout * 1000),
-                                             event_loop.quit)
+            _ = QtCore.QTimer.singleShot(int(timeout * 1000), event_loop.quit)
 
         with _maybe_allow_interrupt(event_loop):
             qt_compat._exec(event_loop)

--- a/lib/matplotlib/backends/backend_qt5agg.py
+++ b/lib/matplotlib/backends/backend_qt5agg.py
@@ -2,8 +2,9 @@
 Render to qt from agg
 """
 
-from .backend_qtagg import (
-    _BackendQTAgg, FigureCanvasQTAgg, FigureManagerQT, NavigationToolbar2QT,
+from .backend_qtagg import _BackendQTAgg
+from .backend_qtagg import (  # noqa: F401 # pylint: disable=W0611
+    FigureCanvasQTAgg, FigureManagerQT, NavigationToolbar2QT,
     backend_version,  FigureCanvasAgg,  FigureCanvasQT
 )
 

--- a/lib/matplotlib/backends/backend_qt5cairo.py
+++ b/lib/matplotlib/backends/backend_qt5cairo.py
@@ -1,5 +1,6 @@
-from .backend_qtcairo import (
-    _BackendQTCairo, FigureCanvasQTCairo, FigureCanvasCairo, FigureCanvasQT)
+from .backend_qtcairo import _BackendQTCairo
+from .backend_qtcairo import (  # noqa: F401 # pylint: disable=W0611
+    FigureCanvasQTCairo, FigureCanvasCairo, FigureCanvasQT)
 
 
 @_BackendQTCairo.export

--- a/lib/matplotlib/backends/backend_qtagg.py
+++ b/lib/matplotlib/backends/backend_qtagg.py
@@ -9,9 +9,9 @@ from matplotlib.transforms import Bbox
 from .qt_compat import QT_API, _enum, _setDevicePixelRatio
 from .. import cbook
 from .backend_agg import FigureCanvasAgg
-from .backend_qt import (
-    QtCore, QtGui, QtWidgets, _BackendQT, FigureCanvasQT, FigureManagerQT,
-    NavigationToolbar2QT, backend_version)
+from .backend_qt import QtCore, QtGui, _BackendQT, FigureCanvasQT
+from .backend_qt import (  # noqa: F401 # pylint: disable=W0611
+    FigureManagerQT, NavigationToolbar2QT, backend_version)
 
 
 class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -1,7 +1,8 @@
 from . import _backend_tk
 from .backend_agg import FigureCanvasAgg
-from ._backend_tk import (
-    _BackendTk, FigureCanvasTk, FigureManagerTk, NavigationToolbar2Tk)
+from ._backend_tk import _BackendTk, FigureCanvasTk
+from ._backend_tk import (  # noqa: F401 # pylint: disable=W0611
+                          FigureManagerTk, NavigationToolbar2Tk)
 
 
 class FigureCanvasTkAgg(FigureCanvasAgg, FigureCanvasTk):

--- a/lib/matplotlib/backends/backend_tkagg.py
+++ b/lib/matplotlib/backends/backend_tkagg.py
@@ -2,7 +2,7 @@ from . import _backend_tk
 from .backend_agg import FigureCanvasAgg
 from ._backend_tk import _BackendTk, FigureCanvasTk
 from ._backend_tk import (  # noqa: F401 # pylint: disable=W0611
-                          FigureManagerTk, NavigationToolbar2Tk)
+    FigureManagerTk, NavigationToolbar2Tk)
 
 
 class FigureCanvasTkAgg(FigureCanvasAgg, FigureCanvasTk):

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -36,7 +36,8 @@ import matplotlib as mpl
 from matplotlib.backend_bases import _Backend
 from matplotlib._pylab_helpers import Gcf
 from . import backend_webagg_core as core
-from .backend_webagg_core import TimerAsyncio, TimerTornado
+from .backend_webagg_core import (  # noqa: F401 # pylint: disable=W0611
+    TimerAsyncio, TimerTornado)
 
 
 class ServerThread(threading.Thread):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -25,11 +25,8 @@ from matplotlib.backend_bases import (
 
 from matplotlib import _api, cbook, backend_tools
 from matplotlib._pylab_helpers import Gcf
-from matplotlib.backend_managers import ToolManager
-from matplotlib.figure import Figure
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
-from matplotlib.widgets import SubplotTool
 
 import wx
 

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -2,8 +2,8 @@ import wx
 
 from .. import _api
 from .backend_agg import FigureCanvasAgg
-from .backend_wx import (
-    _BackendWx, _FigureCanvasWxBase, FigureFrameWx,
+from .backend_wx import _BackendWx, _FigureCanvasWxBase, FigureFrameWx
+from .backend_wx import (  # noqa: F401 # pylint: disable=W0611
     NavigationToolbar2Wx as NavigationToolbar2WxAgg)
 
 

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -2,8 +2,8 @@ import wx.lib.wxcairo as wxcairo
 
 from .. import _api
 from .backend_cairo import cairo, FigureCanvasCairo
-from .backend_wx import (
-    _BackendWx, _FigureCanvasWxBase, FigureFrameWx,
+from .backend_wx import _BackendWx, _FigureCanvasWxBase, FigureFrameWx
+from .backend_wx import (  # noqa: F401 # pylint: disable=W0611
     NavigationToolbar2Wx as NavigationToolbar2WxCairo)
 
 

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -69,7 +69,7 @@ elif QT_API_ENV is None:
 else:
     try:
         QT_API = _ETS[QT_API_ENV]
-    except KeyError as err:
+    except KeyError:
         raise RuntimeError(
             "The environment variable QT_API has the unrecognized value "
             f"{QT_API_ENV!r}; "


### PR DESCRIPTION
## PR Summary

Remove unused imports and local variables.

I split some import lines into two: one with the used and one with the unused. In this way, tools will warn if any previously used import becomes unused.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
