### PR TITLE
Replace MathtextBackend mechanism.

### DIFF
--- a/doc/api/next_api_changes/deprecations/22506-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22506-AL.rst
@@ -1,0 +1,3 @@
+``MathtextBackend``, ``MathtextBackendAgg``, ``MathtextBackendPath``, ``MathTextWarning``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated with no replacement.

--- a/lib/matplotlib/mathtext.py
+++ b/lib/matplotlib/mathtext.py
@@ -24,14 +24,16 @@ import numpy as np
 from matplotlib import _api, rcParams, _mathtext
 from matplotlib.ft2font import FT2Image, LOAD_NO_HINTING
 from matplotlib.font_manager import FontProperties
+from ._mathtext import (  # noqa: reexported API
+    RasterParse, VectorParse, get_unicode_index)
 
 _log = logging.getLogger(__name__)
 
 
-get_unicode_index = _mathtext.get_unicode_index
 get_unicode_index.__module__ = __name__
 
 
+@_api.deprecated("3.6")
 class MathtextBackend:
     """
     The base class for the mathtext backend-specific code.  `MathtextBackend`
@@ -87,6 +89,7 @@ class MathtextBackend:
         return LOAD_NO_HINTING
 
 
+@_api.deprecated("3.6")
 class MathtextBackendAgg(MathtextBackend):
     """
     Render glyphs and rectangles to an FTImage buffer, which is later
@@ -135,32 +138,16 @@ class MathtextBackendAgg(MathtextBackend):
             self.image.draw_rect_filled(int(x1), y, np.ceil(x2), y + height)
 
     def get_results(self, box):
-        self.mode = 'bbox'
-        orig_height = box.height
-        orig_depth  = box.depth
-        _mathtext.ship(0, 0, box)
-        bbox = self.bbox
-        bbox = [bbox[0] - 1, bbox[1] - 1, bbox[2] + 1, bbox[3] + 1]
-        self.mode = 'render'
-        self.set_canvas_size(
-            bbox[2] - bbox[0],
-            (bbox[3] - bbox[1]) - orig_depth,
-            (bbox[3] - bbox[1]) - orig_height)
-        _mathtext.ship(-bbox[0], -bbox[1], box)
-        result = (self.ox,
-                  self.oy,
-                  self.width,
-                  self.height + self.depth,
-                  self.depth,
-                  self.image)
         self.image = None
-        return result
+        self.mode = 'render'
+        return _mathtext.ship(box).to_raster()
 
     def get_hinting_type(self):
         from matplotlib.backends import backend_agg
         return backend_agg.get_hinting_flag()
 
 
+@_api.deprecated("3.6")
 class MathtextBackendPath(MathtextBackend):
     """
     Store information to write a mathtext rendering to the text path
@@ -182,14 +169,10 @@ class MathtextBackendPath(MathtextBackend):
         self.rects.append((x1, self.height - y2, x2 - x1, y2 - y1))
 
     def get_results(self, box):
-        _mathtext.ship(0, 0, box)
-        return self._Result(self.width,
-                            self.height + self.depth,
-                            self.depth,
-                            self.glyphs,
-                            self.rects)
+        return _mathtext.ship(box).to_vector()
 
 
+@_api.deprecated("3.6")
 class MathTextWarning(Warning):
     pass
 
@@ -200,12 +183,6 @@ class MathTextWarning(Warning):
 
 class MathTextParser:
     _parser = None
-
-    _backend_mapping = {
-        'agg':    MathtextBackendAgg,
-        'path':   MathtextBackendPath,
-        'macosx': MathtextBackendAgg,
-    }
     _font_type_mapping = {
         'cm':          _mathtext.BakomaFonts,
         'dejavuserif': _mathtext.DejaVuSerifFonts,
@@ -216,8 +193,18 @@ class MathTextParser:
     }
 
     def __init__(self, output):
-        """Create a MathTextParser for the given backend *output*."""
-        self._output = output.lower()
+        """
+        Create a MathTextParser for the given backend *output*.
+
+        Parameters
+        ----------
+        output : {"path", "agg"}
+            Whether to return a `VectorParse` ("path") or a
+            `RasterParse` ("agg", or its synonym "macosx").
+        """
+        self._output_type = _api.check_getitem(
+            {"path": "vector", "agg": "raster", "macosx": "raster"},
+            output=output.lower())
 
     def parse(self, s, dpi=72, prop=None):
         """
@@ -227,6 +214,9 @@ class MathTextParser:
 
         The results are cached, so multiple calls to `parse`
         with the same expression should be fast.
+
+        Depending on the *output* type, this returns either a `VectorParse` or
+        a `RasterParse`.
         """
         # lru_cache can't decorate parse() directly because prop
         # is mutable; key the cache using an internal copy (see
@@ -236,24 +226,29 @@ class MathTextParser:
 
     @functools.lru_cache(50)
     def _parse_cached(self, s, dpi, prop):
+        from matplotlib.backends import backend_agg
+
         if prop is None:
             prop = FontProperties()
-
         fontset_class = _api.check_getitem(
-                self._font_type_mapping, fontset=prop.get_math_fontfamily())
-        backend = self._backend_mapping[self._output]()
-        font_output = fontset_class(prop, backend)
+            self._font_type_mapping, fontset=prop.get_math_fontfamily())
+        load_glyph_flags = {
+            "vector": LOAD_NO_HINTING,
+            "raster": backend_agg.get_hinting_flag(),
+        }[self._output_type]
+        fontset = fontset_class(prop, load_glyph_flags)
 
         fontsize = prop.get_size_in_points()
 
-        # This is a class variable so we don't rebuild the parser
-        # with each request.
-        if self._parser is None:
+        if self._parser is None:  # Cache the parser globally.
             self.__class__._parser = _mathtext.Parser()
 
-        box = self._parser.parse(s, font_output, fontsize, dpi)
-        backend.set_canvas_size(*np.ceil([box.width, box.height, box.depth]))
-        return backend.get_results(box)
+        box = self._parser.parse(s, fontset, fontsize, dpi)
+        output = _mathtext.ship(box)
+        if self._output_type == "vector":
+            return output.to_vector()
+        elif self._output_type == "raster":
+            return output.to_raster()
 
 
 def math_to_image(s, filename_or_obj, prop=None, dpi=None, format=None,


### PR DESCRIPTION
The MathtextBackend ("MB") mechanism was previously used to let actual
backends customize how they received mathtext results -- either as lists
of glyphs and rectangles (for vector backends: MathtextBackendPath),
or a bitmap (for raster backends: MathtextBackendAgg); in both cases,
metrics are also provided.  MBs also controlled font hinting.  Note that
the MB mechanism was not publically user-extendable (this would require
touching the private MathTextParser._backend_mapping dict), so third
parties could not meaningfully provide their own backends.

MBs were attached to _mathtext.Fonts objects, which were central to
the "shipping" stage of the parse (ship(), which converts the nested
parse tree created by pyparsing into flat calls to render_glyph and
render_rect_filled).  This led to a slightly curious API, where
the old MathtextBackendAgg.get_results() (for example) calls
`_mathtext.ship(0, 0, box)` and this somehow magically mutates self --
this is because self is indirectly attached to sub-elements of box.

This PR changes the implementation to instead detach output logic
from Fonts (which become restricted to providing glyph metrics and
related info), and makes ship() instead return a simple Output object
(lists of glyphs and rects) which is itself able either to convert to
a VectorParse or a RasterParse -- namedtuples that are backcompatible
with the tuples previously returned by MathTextParser.parse().  (While
technically these are "new" classes in the API, they are simply there to
(slightly) better document the return value of MathtextBackend.parse().)

In summary, this patch
- removes the non-extensible MB system,
- detaches output logic from Fonts objects, thus avoiding "action at
  distance" where `ship(0, 0, box)` would mutate the calling MB,
- (weakly) documents the return value of MathtextBackend.parse().

Unrelatedly, also deprecate the unused MathTextWarning.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
