### PR TITLE
Move tracking of autoscale status to Axis.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -686,6 +686,7 @@ class Axis(martist.Artist):
 
         self.clear()
         self._set_scale('linear')
+        self._autoscale_on = True
 
     @property
     def isDefault_majloc(self):
@@ -777,6 +778,21 @@ class Axis(martist.Artist):
 
     def limit_range_for_scale(self, vmin, vmax):
         return self._scale.limit_range_for_scale(vmin, vmax, self.get_minpos())
+
+    def _get_autoscale_on(self):
+        """Return whether this Axis is autoscaled."""
+        return self._autoscale_on
+
+    def _set_autoscale_on(self, b):
+        """
+        Set whether this Axis is autoscaled when drawing or by
+        `.Axes.autoscale_view`.
+
+        Parameters
+        ----------
+        b : bool
+        """
+        self._autoscale_on = b
 
     def get_children(self):
         return [self.label, self.offsetText,
@@ -1088,7 +1104,7 @@ class Axis(martist.Artist):
         for ax in self.axes._shared_axes[name].get_siblings(self.axes):
             ax._stale_viewlims[name] = False
         if auto is not None:
-            setattr(self.axes, f"_autoscale{name.upper()}on", bool(auto))
+            self._set_autoscale_on(bool(auto))
 
         if emit:
             self.axes.callbacks.process(f"{name}lim_changed", self.axes)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -976,9 +976,9 @@ class AxesImage(_ImageBase):
         self.axes.update_datalim(corners)
         self.sticky_edges.x[:] = [xmin, xmax]
         self.sticky_edges.y[:] = [ymin, ymax]
-        if self.axes._autoscaleXon:
+        if self.axes.get_autoscalex_on():
             self.axes.set_xlim((xmin, xmax), auto=None)
-        if self.axes._autoscaleYon:
+        if self.axes.get_autoscaley_on():
             self.axes.set_ylim((ymin, ymax), auto=None)
         self.stale = True
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -462,29 +462,8 @@ class Axes3D(Axes):
     def update_datalim(self, xys, **kwargs):
         pass
 
-    def get_autoscale_on(self):
-        # docstring inherited
-        return super().get_autoscale_on() and self.get_autoscalez_on()
-
-    def get_autoscalez_on(self):
-        """Return whether the z-axis is autoscaled."""
-        return self._autoscaleZon
-
-    def set_autoscale_on(self, b):
-        # docstring inherited
-        super().set_autoscale_on(b)
-        self.set_autoscalez_on(b)
-
-    def set_autoscalez_on(self, b):
-        """
-        Set whether the z-axis is autoscaled on the next draw or call to
-        `.Axes.autoscale_view`.
-
-        Parameters
-        ----------
-        b : bool
-        """
-        self._autoscaleZon = b
+    get_autoscalez_on = _axis_method_wrapper("zaxis", "_get_autoscale_on")
+    set_autoscalez_on = _axis_method_wrapper("zaxis", "_set_autoscale_on")
 
     def set_zmargin(self, m):
         """
@@ -558,15 +537,18 @@ class Axes3D(Axes):
             scalez = True
         else:
             if axis in ['x', 'both']:
-                self._autoscaleXon = scalex = bool(enable)
+                self.set_autoscalex_on(bool(enable))
+                scalex = self.get_autoscalex_on()
             else:
                 scalex = False
             if axis in ['y', 'both']:
-                self._autoscaleYon = scaley = bool(enable)
+                self.set_autoscaley_on(bool(enable))
+                scaley = self.get_autoscaley_on()
             else:
                 scaley = False
             if axis in ['z', 'both']:
-                self._autoscaleZon = scalez = bool(enable)
+                self.set_autoscalez_on(bool(enable))
+                scalez = self.get_autoscalez_on()
             else:
                 scalez = False
         if scalex:
@@ -613,7 +595,7 @@ class Axes3D(Axes):
         else:
             _tight = self._tight = bool(tight)
 
-        if scalex and self._autoscaleXon:
+        if scalex and self.get_autoscalex_on():
             self._shared_axes["x"].clean()
             x0, x1 = self.xy_dataLim.intervalx
             xlocator = self.xaxis.get_major_locator()
@@ -626,7 +608,7 @@ class Axes3D(Axes):
                 x0, x1 = xlocator.view_limits(x0, x1)
             self.set_xbound(x0, x1)
 
-        if scaley and self._autoscaleYon:
+        if scaley and self.get_autoscaley_on():
             self._shared_axes["y"].clean()
             y0, y1 = self.xy_dataLim.intervaly
             ylocator = self.yaxis.get_major_locator()
@@ -639,7 +621,7 @@ class Axes3D(Axes):
                 y0, y1 = ylocator.view_limits(y0, y1)
             self.set_ybound(y0, y1)
 
-        if scalez and self._autoscaleZon:
+        if scalez and self.get_autoscalez_on():
             self._shared_axes["z"].clean()
             z0, z1 = self.zz_dataLim.intervalx
             zlocator = self.zaxis.get_major_locator()
@@ -976,7 +958,7 @@ class Axes3D(Axes):
             except TypeError:
                 pass
 
-        self._autoscaleZon = True
+        self.set_autoscalez_on(True)
         if self._focal_length == np.inf:
             self._zmargin = rcParams['axes.zmargin']
         else:


### PR DESCRIPTION
As always, this can makes it easier to write generic code looping over
all axises.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
