### PR TITLE
Increase coverage

### DIFF
--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -31,6 +31,7 @@ def test_Polygon_close():
 
     # start with open path and close it:
     p = Polygon(xy, closed=True)
+    assert p.get_closed()
     assert_array_equal(p.get_xy(), xyclosed)
     p.set_xy(xy)
     assert_array_equal(p.get_xy(), xyclosed)
@@ -43,6 +44,7 @@ def test_Polygon_close():
 
     # start with open path and leave it open:
     p = Polygon(xy, closed=False)
+    assert not p.get_closed()
     assert_array_equal(p.get_xy(), xy)
     p.set_xy(xy)
     assert_array_equal(p.get_xy(), xy)
@@ -719,6 +721,31 @@ def test_annulus_setters():
 
     ell.center = (0.5, 0.5)
     ell.radii = (0.5, 0.3)
+    ell.width = 0.1
+    ell.angle = 45
+
+
+@image_comparison(baseline_images=['annulus'], extensions=['png'])
+def test_annulus_setters2():
+
+    fig, ax = plt.subplots()
+    cir = Annulus((0., 0.), 0.2, 0.01, fc='g')   # circular annulus
+    ell = Annulus((0., 0.), (1, 2), 0.1, 0,      # elliptical
+                  fc='m', ec='b', alpha=0.5, hatch='xxx')
+    ax.add_patch(cir)
+    ax.add_patch(ell)
+    ax.set_aspect('equal')
+
+    cir.center = (0.5, 0.5)
+    cir.set_semimajor(0.2)
+    cir.set_semiminor(0.2)
+    assert cir.radii == (0.2, 0.2)
+    cir.width = 0.05
+
+    ell.center = (0.5, 0.5)
+    ell.set_semimajor(0.5)
+    ell.set_semiminor(0.3)
+    assert ell.radii == (0.5, 0.3)
     ell.width = 0.1
     ell.angle = 45
 

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -43,11 +43,16 @@ def test_font_styles():
         style="normal",
         variant="normal",
         size=14)
-    ax.annotate(
+    a = ax.annotate(
         "Normal Font",
         (0.1, 0.1),
         xycoords='axes fraction',
         fontproperties=normal_font)
+    assert a.get_fontname() == 'DejaVu Sans'
+    assert a.get_fontstyle() == 'normal'
+    assert a.get_fontvariant() == 'normal'
+    assert a.get_weight() == 'normal'
+    assert a.get_stretch() == 'normal'
 
     bold_font = find_matplotlib_font(
         family="Foo",


### PR DESCRIPTION
## PR Summary

Some minor coverage improvements.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
