### PR TITLE
Expire deprecations in cbook.deprecation

### DIFF
--- a/doc/api/next_api_changes/removals/22514-OG.rst
+++ b/doc/api/next_api_changes/removals/22514-OG.rst
@@ -1,0 +1,7 @@
+Removal of deprecations in ``cbook``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The module ``cbook.deprecation`` is removed from the public API as it is
+considered internal. This also holds for deprecation-related re-imports in
+``cbook``: ``deprecated``, ``MatplotlibDeprecationWarning``,
+``mplDeprecation``, and ``warn_deprecated``.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -107,8 +107,8 @@ from packaging.version import parse as parse_version
 # cbook must import matplotlib only within function
 # definitions, so it is safe to import from it here.
 from . import _api, _version, cbook, docstring, rcsetup
-from matplotlib.cbook import MatplotlibDeprecationWarning, sanitize_sequence
-from matplotlib.cbook import mplDeprecation  # deprecated
+from matplotlib.cbook import sanitize_sequence
+from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.rcsetup import validate_backend, cycler
 
 

--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -21,11 +21,6 @@ class MatplotlibDeprecationWarning(DeprecationWarning):
     """A class for issuing deprecation warnings for Matplotlib users."""
 
 
-# mplDeprecation is deprecated. Use MatplotlibDeprecationWarning instead.
-# remove when removing the re-import from cbook
-mplDeprecation = MatplotlibDeprecationWarning
-
-
 def _generate_deprecation_warning(
         since, message='', name='', alternative='', pending=False, obj_type='',
         addendum='', *, removal=''):

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -29,18 +29,6 @@ import numpy as np
 
 import matplotlib
 from matplotlib import _api, _c_internal_utils
-from matplotlib._api.deprecation import (
-    MatplotlibDeprecationWarning, mplDeprecation)
-
-
-@_api.deprecated("3.4")
-def deprecated(*args, **kwargs):
-    return _api.deprecated(*args, **kwargs)
-
-
-@_api.deprecated("3.4")
-def warn_deprecated(*args, **kwargs):
-    _api.warn_deprecated(*args, **kwargs)
 
 
 def _get_running_interactive_framework():
@@ -365,7 +353,8 @@ class silent_list(list):
 
 
 def _local_over_kwdict(
-        local_var, kwargs, *keys, warning_cls=MatplotlibDeprecationWarning):
+        local_var, kwargs, *keys,
+        warning_cls=_api.MatplotlibDeprecationWarning):
     out = local_var
     for key in keys:
         kwarg_val = kwargs.pop(key, None)

--- a/lib/matplotlib/cbook/deprecation.py
+++ b/lib/matplotlib/cbook/deprecation.py
@@ -1,8 +1,0 @@
-# imports are for backward compatibility
-from matplotlib._api.deprecation import (
-    MatplotlibDeprecationWarning, mplDeprecation, warn_deprecated, deprecated)
-
-warn_deprecated("3.4",
-                message="The module matplotlib.cbook.deprecation is "
-                "considered internal and it will be made private in the "
-                "future.")

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1420,7 +1420,7 @@ class LineCollection(Collection):
         if args:
             argkw = {name: val for name, val in zip(argnames, args)}
             kwargs.update(argkw)
-            cbook.warn_deprecated(
+            _api.warn_deprecated(
                 "3.4", message="Since %(since)s, passing LineCollection "
                 "arguments other than the first, 'segments', as positional "
                 "arguments is deprecated, and they will become keyword-only "

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -17,8 +17,8 @@ import pytest
 
 import matplotlib
 import matplotlib as mpl
-from matplotlib.testing.decorators import (
-    image_comparison, check_figures_equal, remove_ticks_and_titles)
+from matplotlib import rc_context
+from matplotlib._api import MatplotlibDeprecationWarning
 import matplotlib.colors as mcolors
 import matplotlib.dates as mdates
 from matplotlib.figure import Figure
@@ -32,8 +32,8 @@ import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
 from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
-from matplotlib import rc_context
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib.testing.decorators import (
+    image_comparison, check_figures_equal, remove_ticks_and_titles)
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -7,7 +7,7 @@ import tempfile
 import pytest
 
 from matplotlib import cbook, patheffects
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.figure import Figure
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib as mpl

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -10,12 +10,10 @@ import base64
 
 from numpy.testing import assert_array_equal, assert_array_almost_equal
 
-from matplotlib import cycler
+from matplotlib import _api, cbook, cm, cycler
 import matplotlib
 import matplotlib.colors as mcolors
-import matplotlib.cm as cm
 import matplotlib.colorbar as mcolorbar
-import matplotlib.cbook as cbook
 import matplotlib.pyplot as plt
 import matplotlib.scale as mscale
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
@@ -109,7 +107,7 @@ def test_colormap_global_set_warn():
     new_cm = plt.get_cmap('viridis')
     # Store the old value so we don't override the state later on.
     orig_cmap = copy.copy(new_cm)
-    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+    with pytest.warns(_api.MatplotlibDeprecationWarning,
                       match="You are modifying the state of a globally"):
         # This should warn now because we've modified the global state
         new_cm.set_under('k')
@@ -120,7 +118,7 @@ def test_colormap_global_set_warn():
     # Test that registering and then modifying warns
     plt.register_cmap(name='test_cm', cmap=copy.copy(orig_cmap))
     new_cm = plt.get_cmap('test_cm')
-    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+    with pytest.warns(_api.MatplotlibDeprecationWarning,
                       match="You are modifying the state of a globally"):
         # This should warn now because we've modified the global state
         new_cm.set_under('k')
@@ -132,11 +130,11 @@ def test_colormap_global_set_warn():
 
 def test_colormap_dict_deprecate():
     # Make sure we warn on get and set access into cmap_d
-    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+    with pytest.warns(_api.MatplotlibDeprecationWarning,
                       match="The global colormaps dictionary is no longer"):
         cmap = plt.cm.cmap_d['viridis']
 
-    with pytest.warns(cbook.MatplotlibDeprecationWarning,
+    with pytest.warns(_api.MatplotlibDeprecationWarning,
                       match="The global colormaps dictionary is no longer"):
         plt.cm.cmap_d['test'] = cmap
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -8,7 +8,7 @@ import pytest
 
 import matplotlib as mpl
 from matplotlib import pyplot as plt
-from matplotlib.cbook import MatplotlibDeprecationWarning
+from matplotlib._api import MatplotlibDeprecationWarning
 
 
 def test_pyplot_up_to_date(tmpdir):


### PR DESCRIPTION
## PR Summary

Expire deprecations in cbook.deprecation. Will add a release note, but was a bit confused which things actually are deprecated.

cbook.MatplotlibDeprecationWarning and cbook.mplDeprecation are deprecated based on the earlier release note:

> The module matplotlib.cbook.deprecation is considered internal and will be removed from the public API. This also holds for deprecation-related re-imports in matplotlib.cbook, i.e. matplotlib.cbook.deprecated(), matplotlib.cbook.warn_deprecated(), matplotlib.cbook.MatplotlibDeprecationWarning and matplotlib.cbook.mplDeprecation.
If needed, external users may import MatplotlibDeprecationWarning directly from the matplotlib namespace. mplDeprecation is only an alias of MatplotlibDeprecationWarning and should not be used anymore.


However, it is possible to import cbook.MatplotlibDeprecationWarning and cbook.mplDeprecation and use them without any deprecation warnings. Is it still OK to removed them?

Btw, the current code gave a dual deprecation warning: :-)
```

In [4]: from matplotlib.collections import LineCollection

In [5]: LineCollection(1, 2)
C:\Users\Oscar\AppData\Local\Temp\ipykernel_21208\127307086.py:1: MatplotlibDeprecationWarning: 
The warn_deprecated function was deprecated in Matplotlib 3.4 and will be removed two minor releases later.
  LineCollection(1, 2)
C:\Users\Oscar\AppData\Local\Temp\ipykernel_21208\127307086.py:1: MatplotlibDeprecationWarning: Since 3.4, passing LineCollection arguments other than the first, 'segments', as positional arguments is deprecated, and they will become keyword-only arguments two minor releases later.
  LineCollection(1, 2)
```
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
