### PR TITLE
Really fix wheel building on CI

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -20,12 +20,14 @@ on:
 jobs:
   build_wheels:
     if: |
-      github.event.action == 'push' ||
-      (
-        github.event.action == 'labeled' &&
-        github.event.label.name == 'Run cibuildwheel'
-      ) ||
-      contains(github.event.pull_request.labels.*.name, 'Run cibuildwheel')
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && (
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'Run cibuildwheel'
+        ) ||
+        contains(github.event.pull_request.labels.*.name, 'Run cibuildwheel')
+      )
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:


### PR DESCRIPTION
## PR Summary

I had the wrong condition in #22375, so that they were still not triggered on push.

This time I've done a full check of the PR cycle on my fork, including labelling, re-opening, and merging.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).