### PR TITLE
Require sphinx>=3 & numpydoc>=1.0 for building docs.

### DIFF
--- a/doc/api/next_api_changes/development/22550-AL.rst
+++ b/doc/api/next_api_changes/development/22550-AL.rst
@@ -1,0 +1,2 @@
+sphinx>=3.0 and numpydoc>=1.0 are now required for building the docs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,6 @@ import sys
 import warnings
 
 import matplotlib
-import sphinx
 
 from datetime import datetime
 import time
@@ -48,10 +47,6 @@ sys.path.append('.')
 # docs build to fail. This is especially useful for getting rid of deprecated
 # usage in the gallery.
 warnings.filterwarnings('error', append=True)
-
-# Strip backslashes in function's signature
-# To be removed when numpydoc > 0.9.x
-strip_signature_backslash = True
 
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -144,9 +139,7 @@ autodoc_default_options = {'members': None, 'undoc-members': None}
 warnings.filterwarnings('ignore', category=DeprecationWarning,
                         module='sphinx.util.inspect')
 
-# missing-references names matches sphinx>=3 behavior, so we can't be nitpicky
-# for older sphinxes.
-nitpicky = sphinx.version_info >= (3,)
+nitpicky = True
 # change this to True to update the allowed failures
 missing_references_write_json = False
 missing_references_warn_unused_ignores = False
@@ -429,7 +422,7 @@ latex_elements['fontenc'] = r'''
 # Sphinx 2.0 adopts GNU FreeFont by default, but it does not have all
 # the Unicode codepoints needed for the section about Mathtext
 # "Writing mathematical expressions"
-fontpkg = r"""
+latex_elements['fontpkg'] = r"""
 \IfFontExistsTF{XITS}{
  \setmainfont{XITS}
 }{
@@ -469,12 +462,7 @@ fontpkg = r"""
   Extension      = .otf,
 ]}
 """
-latex_elements['fontpkg'] = fontpkg
 
-# Sphinx <1.8.0 or >=2.0.0 does this by default, but the 1.8.x series
-# did not for latex_engine = 'xelatex' (as it used Latin Modern font).
-# We need this for code-blocks as FreeMono has wide glyphs.
-latex_elements['fvset'] = r'\fvset{fontsize=\small}'
 # Fix fancyhdr complaining about \headheight being too small
 latex_elements['passoptionstopackages'] = r"""
     \PassOptionsToPackage{headheight=14pt}{geometry}

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,11 +7,11 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=1.8.1,!=2.0.0
+sphinx>=3.0.0
 colorspacious
 ipython
 ipywidgets
-numpydoc>=0.8
+numpydoc>=1.0
 packaging>=20
 pydata-sphinx-theme>=0.8.0
 mpl-sphinx-theme


### PR DESCRIPTION
both are nearly two years old now (so OK wrt NEP29); the version bump
allows dropping some backcompat code.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
