### PR TITLE
Prepare for making create_dummy_axis not necessary.

### DIFF
--- a/doc/api/next_api_changes/deprecations/22554-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22554-AL.rst
@@ -1,0 +1,4 @@
+``_DummyAxis.dataLim`` and ``_DummyAxis.viewLim``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.  Use ``get_data_interval()``, ``set_data_interval()``,
+``get_view_interval()``, and ``set_view_interval()`` instead.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -154,25 +154,32 @@ __all__ = ('TickHelper', 'Formatter', 'FixedFormatter',
 class _DummyAxis:
     __name__ = "dummy"
 
+    # Once the deprecation elapses, replace dataLim and viewLim by plain
+    # _view_interval and _data_interval private tuples.
+    dataLim = _api.deprecate_privatize_attribute(
+        "3.6", alternative="get_data_interval() and set_data_interval()")
+    viewLim = _api.deprecate_privatize_attribute(
+        "3.6", alternative="get_view_interval() and set_view_interval()")
+
     def __init__(self, minpos=0):
-        self.dataLim = mtransforms.Bbox.unit()
-        self.viewLim = mtransforms.Bbox.unit()
+        self._dataLim = mtransforms.Bbox.unit()
+        self._viewLim = mtransforms.Bbox.unit()
         self._minpos = minpos
 
     def get_view_interval(self):
-        return self.viewLim.intervalx
+        return self._viewLim.intervalx
 
     def set_view_interval(self, vmin, vmax):
-        self.viewLim.intervalx = vmin, vmax
+        self._viewLim.intervalx = vmin, vmax
 
     def get_minpos(self):
         return self._minpos
 
     def get_data_interval(self):
-        return self.dataLim.intervalx
+        return self._dataLim.intervalx
 
     def set_data_interval(self, vmin, vmax):
-        self.dataLim.intervalx = vmin, vmax
+        self._dataLim.intervalx = vmin, vmax
 
     def get_tick_space(self):
         # Just use the long-standing default of nbins==9


### PR DESCRIPTION
create_dummy_axis() sets up some internal _DummyAxis, which should not
really have been leaked to end users; instead, we should just always
attach a _DummyAxis to locators and formatters at init to start with.

_DummyAxis should actually be quite cheap to create, but it does create
two Bbox.unit() (dataLim and viewLim) which are *slightly* expensive to
create, can be placed by plain tuples, and do not correspond to any APIs
on "standard" Axises (there's Axes.dataLim/viewLim, not
Axis.dataLim/viewLim).  While the offending attributes are on a private
class, they are publically accessible e.g. via
`locator.create_dummy_axis(); locator.axis` so go through a deprecation
to be extra safe.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
