### PR TITLE
MNT: Simplify imports

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -9,9 +9,8 @@ import logging
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _api
+from matplotlib import _api, cbook
 import matplotlib.artist as martist
-import matplotlib.cbook as cbook
 import matplotlib.colors as mcolors
 import matplotlib.lines as mlines
 import matplotlib.scale as mscale

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -1,5 +1,5 @@
+from matplotlib import cbook
 from matplotlib.artist import Artist
-import matplotlib.cbook as cbook
 
 
 class Container(tuple):

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -13,17 +13,15 @@ import numpy as np
 import PIL.PngImagePlugin
 
 import matplotlib as mpl
-from matplotlib import _api
+from matplotlib import _api, cbook, cm
+# For clarity, names from _image are given explicitly in this module
+from matplotlib import _image
+# For user convenience, the names from _image are also imported into
+# the image namespace
+from matplotlib._image import *
 import matplotlib.artist as martist
 from matplotlib.backend_bases import FigureCanvasBase
 import matplotlib.colors as mcolors
-import matplotlib.cm as cm
-import matplotlib.cbook as cbook
-# For clarity, names from _image are given explicitly in this module:
-import matplotlib._image as _image
-# For user convenience, the names from _image are also imported into
-# the image namespace:
-from matplotlib._image import *
 from matplotlib.transforms import (
     Affine2D, BboxBase, Bbox, BboxTransform, BboxTransformTo,
     IdentityTransform, TransformedBbox)

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -6,11 +6,10 @@ Streamline plotting for 2D vector fields.
 import numpy as np
 
 import matplotlib
-from matplotlib import _api, cm
+from matplotlib import _api, cm, patches
 import matplotlib.colors as mcolors
 import matplotlib.collections as mcollections
 import matplotlib.lines as mlines
-import matplotlib.patches as patches
 
 
 __all__ = ['streamplot']

--- a/lib/matplotlib/testing/jpl_units/EpochConverter.py
+++ b/lib/matplotlib/testing/jpl_units/EpochConverter.py
@@ -1,7 +1,6 @@
 """EpochConverter module containing class EpochConverter."""
 
-from matplotlib import cbook
-import matplotlib.units as units
+from matplotlib import cbook, units
 import matplotlib.dates as date_ticker
 
 __all__ = ['EpochConverter']

--- a/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
+++ b/lib/matplotlib/testing/jpl_units/UnitDblConverter.py
@@ -2,8 +2,7 @@
 
 import numpy as np
 
-from matplotlib import cbook
-import matplotlib.units as units
+from matplotlib import cbook, units
 import matplotlib.projections.polar as polar
 
 __all__ = ['UnitDblConverter']

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,13 +1,12 @@
 import re
 
+from matplotlib import path, transforms
 from matplotlib.testing import _check_for_pgf
 from matplotlib.backend_bases import (
     FigureCanvasBase, LocationEvent, MouseButton, MouseEvent,
     NavigationToolbar2, RendererBase)
 from matplotlib.figure import Figure
 import matplotlib.pyplot as plt
-import matplotlib.transforms as transforms
-import matplotlib.path as path
 
 import numpy as np
 import pytest

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -11,8 +11,7 @@ from numpy.testing import (assert_array_equal, assert_approx_equal,
                            assert_array_almost_equal)
 import pytest
 
-from matplotlib import _api
-import matplotlib.cbook as cbook
+from matplotlib import _api, cbook
 import matplotlib.colors as mcolors
 from matplotlib.cbook import delete_masked_points
 

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -3,9 +3,8 @@ import pytest
 
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.pyplot as plt
-import matplotlib.gridspec as gridspec
 import matplotlib.transforms as mtransforms
-from matplotlib import ticker, rcParams
+from matplotlib import gridspec, ticker, rcParams
 
 
 def example_plot(ax, fontsize=12, nodec=False):

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -6,12 +6,11 @@ import functools
 import numpy as np
 import pytest
 
-from matplotlib import rc_context, style
+from matplotlib import _api, rc_context, style
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 import matplotlib.ticker as mticker
-import matplotlib._api as _api
 
 
 def test_date_numpyx():

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -12,7 +12,7 @@ import pytest
 from PIL import Image
 
 import matplotlib as mpl
-from matplotlib import rcParams
+from matplotlib import gridspec, rcParams
 from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
@@ -22,7 +22,6 @@ from matplotlib.layout_engine import (ConstrainedLayoutEngine,
 from matplotlib.ticker import AutoMinorLocator, FixedFormatter, ScalarFormatter
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
-import matplotlib.gridspec as gridspec
 
 
 @image_comparison(['figure_align_labels'], extensions=['png', 'svg'],

--- a/lib/matplotlib/tests/test_png.py
+++ b/lib/matplotlib/tests/test_png.py
@@ -4,8 +4,7 @@ from pathlib import Path
 import pytest
 
 from matplotlib.testing.decorators import image_comparison
-from matplotlib import pyplot as plt
-import matplotlib.cm as cm
+from matplotlib import cm, pyplot as plt
 
 
 @image_comparison(['pngsuite.png'], tol=0.03)


### PR DESCRIPTION
## PR Summary
```
import matplotlib.foo as foo
```
is typically better (shorter) written as
```
from matplotlib import foo
```

Note that some of the existing ones are changed in #22148 so these should be (most) of the remaining ones.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
