### PR TITLE
Clarify handling of #rrggbb(aa) colors in matplotlibrc.

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -312,10 +312,11 @@ def validate_color(s):
     if isinstance(s, str):
         if s.lower() == 'none':
             return 'none'
-        if len(s) == 6 or len(s) == 8:
-            stmp = '#' + s
-            if is_color_like(stmp):
-                return stmp
+        # Support "rrggbb"/"rrggbbaa" without leading '#' as these would be
+        # interpreted as comments in matplotlibrc.  Note that "rgb" -> "#rgb"
+        # is explicitly not supported, because of the ambiguity e.g. in "C10".
+        if len(s) in [6, 8] and {*s.lower()} <= {*"0123456789abcdef"}:
+            return f'#{s}'
 
     if is_color_like(s):
         return s

--- a/tutorials/colors/colors.py
+++ b/tutorials/colors/colors.py
@@ -14,6 +14,12 @@ Matplotlib recognizes the following formats to specify a color.
 +--------------------------------------+--------------------------------------+
 | Case-insensitive hex RGB or RGBA     | - ``'#0f0f0f'``                      |
 | string.                              | - ``'#0f0f0f80'``                    |
+|                                      |                                      |
+| .. note::                            |                                      |
+|    In a matplotlibrc file, and only  |                                      |
+|    there, these strings must be      |                                      |
+|    given without the leading '#',    |                                      |
+|    e.g. as ``text.color: 0f0f0f``.   |                                      |
 +--------------------------------------+--------------------------------------+
 | Case-insensitive RGB or RGBA string  | - ``'#abc'`` as ``'#aabbcc'``        |
 | equivalent hex shorthand of          | - ``'#fb1'`` as ``'#ffbb11'``        |


### PR DESCRIPTION
The inconsistency is not that great, but let's at least document it.

See https://discourse.matplotlib.org/t/specifying-hex-colors-in-style-sheets/22624.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
