### PR TITLE
CI: cache pip dependencies

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -56,6 +56,7 @@ jobs:
         name: Install Python
         with:
           python-version: '3.8'
+          cache: pip
 
       - name: Install cibuildwheel
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+
       - name: Install OS dependencies
         run: |
           case "${{ runner.os }}" in
@@ -114,22 +115,6 @@ jobs:
             ;;
           esac
 
-      - name: Cache pip
-        uses: actions/cache@v2
-        if: startsWith(runner.os, 'Linux')
-        with:
-          path: ~/.cache/pip
-          key: ${{ matrix.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements/*/*.txt') }}
-          restore-keys: |
-            ${{ matrix.os }}-py${{ matrix.python-version }}-pip-
-      - name: Cache pip
-        uses: actions/cache@v2
-        if: startsWith(runner.os, 'macOS')
-        with:
-          path: ~/Library/Caches/pip
-          key: ${{ matrix.os }}-py${{ matrix.python-version }}-pip-${{ hashFiles('requirements/*/*.txt') }}
-          restore-keys: |
-            ${{ matrix.os }}-py${{ matrix.python-version }}-pip-
       - name: Cache ccache
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
This appears to be a new feature now that we are on v3 of the action.

Follow on to #22573 .


https://github.com/actions/setup-python#caching-packages-dependencies
