### PR TITLE
Refactor handling of tick and ticklabel visiblity in Axis.clear()

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -781,14 +781,36 @@ class Axis(martist.Artist):
         return [self.label, self.offsetText,
                 *self.get_major_ticks(), *self.get_minor_ticks()]
 
-    def _reset_major_tick_kw(self):
+    def _reset_major_tick_kw(self, keep_tick_and_label_visibility=False):
+        """
+        Reset major tick params to defaults.
+
+        Shared subplots pre-configure tick and label visibility. To keep this
+        beyond an Axis.clear() operation, we may
+        *keep_tick_and_label_visibility*.
+        """
+        backup = {name: value for name, value in self._major_tick_kw.items()
+                  if name in ['tick1On', 'tick2On', 'label1On', 'label2On']}
         self._major_tick_kw.clear()
+        if keep_tick_and_label_visibility:
+            self._major_tick_kw.update(backup)
         self._major_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'major'))
 
-    def _reset_minor_tick_kw(self):
+    def _reset_minor_tick_kw(self, keep_tick_and_label_visibility=False):
+        """
+        Reset minor tick params to defaults.
+
+        Shared subplots pre-configure tick and label visibility. To keep this
+        beyond an Axis.clear() operation, we may
+        *keep_tick_and_label_visibility*.
+        """
+        backup = {name: value for name, value in self._minor_tick_kw.items()
+                  if name in ['tick1On', 'tick2On', 'label1On', 'label2On']}
         self._minor_tick_kw.clear()
+        if keep_tick_and_label_visibility:
+            self._minor_tick_kw.update(backup)
         self._minor_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
@@ -805,6 +827,8 @@ class Axis(martist.Artist):
         - major and minor grid
         - units
         - registered callbacks
+
+        This does not reset tick and tick label visibility.
         """
 
         self.label.set_text('')  # self.set_label_text would change isDefault_
@@ -816,12 +840,8 @@ class Axis(martist.Artist):
             signals=["units", "units finalize"])
 
         # whether the grids are on
-        self._major_tick_kw['gridOn'] = (
-                mpl.rcParams['axes.grid'] and
-                mpl.rcParams['axes.grid.which'] in ('both', 'major'))
-        self._minor_tick_kw['gridOn'] = (
-                mpl.rcParams['axes.grid'] and
-                mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
+        self._reset_major_tick_kw(keep_tick_and_label_visibility=True)
+        self._reset_minor_tick_kw(keep_tick_and_label_visibility=True)
         self.reset_ticks()
 
         self.converter = None


### PR DESCRIPTION
This is a follow-up to #20826, which makes the exceptions from clearing more explicit.

While being a bit more verbose, this makes it more clear what is going on. Also I think having proper `_reset_*_tick_kw` methods will make patching the 3D default tick direction for https://github.com/matplotlib/matplotlib/pull/22517#issuecomment-1050349508 easy. Something along the lines (to be tested):

```
# in axis3d.py
class Axis(...):

    def reset_major_tick_kw(keep_tick_and_label_visibility=False)
        super().reset_major_tick_kw(keep_tick_and_label_visibility)
        self._major_tick_kw['tickdir'] = 'inout'
```

The test introduced in #20826 should verify that this solution is equivalent and does not break something.