### PR TITLE
Support quoted strings in matplotlibrc

### DIFF
--- a/doc/users/next_whats_new/double_quotes_matplolibrc.rst
+++ b/doc/users/next_whats_new/double_quotes_matplolibrc.rst
@@ -1,0 +1,10 @@
+Double-quoted strings in matplotlibrc
+-------------------------------------
+
+You can now use double-quotes around strings. This allows using the '#'
+character in strings. Without quotes, '#' is interpreted as start of a comment.
+In particular, you can now define hex-colors:
+
+.. code-block:: none
+
+   grid.color: "#b0b0b0"

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -780,7 +780,7 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
         try:
             for line_no, line in enumerate(fd, 1):
                 line = transform(line)
-                strippedline = line.split('#', 1)[0].strip()
+                strippedline = cbook._strip_comment(line)
                 if not strippedline:
                     continue
                 tup = strippedline.split(':', 1)
@@ -791,6 +791,8 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
                 key, val = tup
                 key = key.strip()
                 val = val.strip()
+                if val.startswith('"') and val.endswith('"'):
+                    val = val[1:-1]  # strip double quotes
                 if key in rc_temp:
                     _log.warning('Duplicate key in file %r, line %d (%r)',
                                  fname, line_no, line.rstrip('\n'))

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -400,6 +400,21 @@ def strip_math(s):
     return s
 
 
+def _strip_comment(s):
+    """Strip everything from the first unquoted #."""
+    pos = 0
+    while True:
+        quote_pos = s.find('"', pos)
+        hash_pos = s.find('#', pos)
+        if quote_pos < 0:
+            without_comment = s if hash_pos < 0 else s[:hash_pos]
+            return without_comment.strip()
+        elif 0 <= hash_pos < quote_pos:
+            return s[:hash_pos].strip()
+        else:
+            pos = s.find('"', quote_pos + 1) + 1  # behind closing quote
+
+
 def is_writable_file_like(obj):
     """Return whether *obj* looks like a file object with a *write* method."""
     return callable(getattr(obj, 'write', None))

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -33,9 +33,14 @@
 ## Colors: for the color values below, you can either use
 ##     - a Matplotlib color string, such as r, k, or b
 ##     - an RGB tuple, such as (1.0, 0.5, 0.0)
-##     - a hex string, such as ff00ff
+##     - a double-quoted hex string, such as "#ff00ff".
+##       The unquoted string ff00ff is also supported for backward
+##       compatibility, but is discouraged.
 ##     - a scalar grayscale intensity such as 0.75
 ##     - a legal html color name, e.g., red, blue, darkslategray
+##
+## String values may optionally be enclosed in double quotes, which allows
+## using the comment character # in the string.
 ##
 ## Matplotlib configuration are currently divided into following parts:
 ##     - BACKENDS
@@ -506,10 +511,10 @@
 ## ***************************************************************************
 ## * GRIDS                                                                   *
 ## ***************************************************************************
-#grid.color:     b0b0b0  # grid color
-#grid.linestyle: -       # solid
-#grid.linewidth: 0.8     # in points
-#grid.alpha:     1.0     # transparency, between 0.0 and 1.0
+#grid.color:     "#b0b0b0"  # grid color
+#grid.linestyle: -          # solid
+#grid.linewidth: 0.8        # in points
+#grid.alpha:     1.0        # transparency, between 0.0 and 1.0
 
 
 ## ***************************************************************************

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -408,6 +408,22 @@ def test_callbackregistry_blocking():
         cb.process("test2")
 
 
+@pytest.mark.parametrize('line, result', [
+    ('a : no_comment', 'a : no_comment'),
+    ('a : "quoted str"', 'a : "quoted str"'),
+    ('a : "quoted str" # comment', 'a : "quoted str"'),
+    ('a : "#000000"', 'a : "#000000"'),
+    ('a : "#000000" # comment', 'a : "#000000"'),
+    ('a : ["#000000", "#FFFFFF"]', 'a : ["#000000", "#FFFFFF"]'),
+    ('a : ["#000000", "#FFFFFF"] # comment', 'a : ["#000000", "#FFFFFF"]'),
+    ('a : val  # a comment "with quotes"', 'a : val'),
+    ('# only comment "with quotes" xx', ''),
+])
+def test_strip_comment(line, result):
+    """Strip everything from the first unqouted #."""
+    assert cbook._strip_comment(line) == result
+
+
 def test_sanitize_sequence():
     d = {'a': 1, 'b': 2, 'c': 3}
     k = ['a', 'b', 'c']


### PR DESCRIPTION
This enables using the comment character # within strings. Also it lets you write hex colors more consistently as "#FFFFFF" rather than FFFFFF (i.e. omitting the hash). We discourage the latter but keep it for backward compatibility.

Closes #19288.
Superseeds #22565.
