### PR TITLE
Fix backend in matplotlibrc if unset in mplsetup.cfg

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -201,7 +201,7 @@ def update_matplotlibrc(path):
     template_lines[backend_line_idx] = (
         "#backend: {}\n".format(setupext.options["backend"])
         if setupext.options["backend"]
-        else "##backend: Agg")
+        else "##backend: Agg\n")
     path.write_text("".join(template_lines))
 
 


### PR DESCRIPTION
## PR Summary

As reported in https://github.com/matplotlib/matplotlib/issues/21660#issuecomment-1057440502

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).