### PR TITLE
MNT: Fix types in C-code to reduce warnings

### DIFF
--- a/src/_path.h
+++ b/src/_path.h
@@ -840,7 +840,7 @@ inline bool segments_intersect(const double &x1,
 
     // If den == 0 we have two possibilities:
     if (isclose(den, 0.0)) {
-        float t_area = (x2*y3 - x3*y2) - x1*(y3 - y2) + y1*(x3 - x2);
+        double t_area = (x2*y3 - x3*y2) - x1*(y3 - y2) + y1*(x3 - x2);
         // 1 - If the area of the triangle made by the 3 first points (2 from the first segment
         // plus one from the second) is zero, they are collinear
         if (isclose(t_area, 0.0)) {
@@ -852,7 +852,6 @@ inline bool segments_intersect(const double &x1,
             else {
                 return (fmin(x1, x2) <= fmin(x3, x4) && fmin(x3, x4) <= fmax(x1, x2)) ||
                         (fmin(x3, x4) <= fmin(x1, x2) && fmin(x1, x2) <= fmax(x3, x4));
-                
             }
         }
         // 2 - If t_area is not zero, the segments are parallel, but not collinear
@@ -876,7 +875,6 @@ inline bool segments_intersect(const double &x1,
 template <class PathIterator1, class PathIterator2>
 bool path_intersects_path(PathIterator1 &p1, PathIterator2 &p2)
 {
-    
     typedef PathNanRemover<py::PathIterator> no_nans_t;
     typedef agg::conv_curve<no_nans_t> curve_t;
 
@@ -901,7 +899,6 @@ bool path_intersects_path(PathIterator1 &p1, PathIterator2 &p2)
         }
         c2.rewind(0);
         c2.vertex(&x21, &y21);
-        
 
         while (c2.vertex(&x22, &y22) != agg::path_cmd_stop) {
             // if the segment in path 2 is (almost) 0 length, skip to next vertex
@@ -1147,16 +1144,15 @@ bool __convert_to_string(PathIterator &path,
     double last_x = 0.0;
     double last_y = 0.0;
 
-    int size = 0;
     unsigned code;
 
     while ((code = path.vertex(&x[0], &y[0])) != agg::path_cmd_stop) {
         if (code == CLOSEPOLY) {
             buffer += codes[4];
         } else if (code < 5) {
-            size = NUM_VERTICES[code];
+            size_t size = NUM_VERTICES[code];
 
-            for (int i = 1; i < size; ++i) {
+            for (size_t i = 1; i < size; ++i) {
                 unsigned subcode = path.vertex(&x[i], &y[i]);
                 if (subcode != code) {
                     return false;
@@ -1176,7 +1172,7 @@ bool __convert_to_string(PathIterator &path,
                 buffer += ' ';
             }
 
-            for (int i = 0; i < size; ++i) {
+            for (size_t i = 0; i < size; ++i) {
                 __add_number(x[i], format_code, precision, buffer);
                 buffer += ' ';
                 __add_number(y[i], format_code, precision, buffer);

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -551,8 +551,8 @@ void FT2Font::get_bitmap_offset(long *x, long *y)
 
 void FT2Font::draw_glyphs_to_bitmap(bool antialiased)
 {
-    size_t width = (bbox.xMax - bbox.xMin) / 64 + 2;
-    size_t height = (bbox.yMax - bbox.yMin) / 64 + 2;
+    long width = (bbox.xMax - bbox.xMin) / 64 + 2;
+    long height = (bbox.yMax - bbox.yMin) / 64 + 2;
 
     image.resize(width, height);
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -291,7 +291,7 @@ exit:
             return 1;  // Non-zero signals error, when count == 0.
         }
     }
-    return n_read;
+    return PyLong_AsUnsignedLong(PyLong_FromSsize_t(n_read));
 }
 
 static void close_file_callback(FT_Stream stream)
@@ -589,7 +589,7 @@ const char *PyFT2Font_get_num_glyphs__doc__ =
 
 static PyObject *PyFT2Font_get_num_glyphs(PyFT2Font *self, PyObject *args)
 {
-    return PyLong_FromLong(self->x->get_num_glyphs());
+    return PyLong_FromSize_t(self->x->get_num_glyphs());
 }
 
 const char *PyFT2Font_load_char__doc__ =
@@ -1545,7 +1545,7 @@ PyMODINIT_FUNC PyInit_ft2font(void)
     FT_Int major, minor, patch;
     char version_string[64];
     FT_Library_Version(_ft2Library, &major, &minor, &patch);
-    sprintf(version_string, "%d.%d.%d", major, minor, patch);
+    snprintf(version_string, sizeof(version_string), "%d.%d.%d", major, minor, patch);
 
     PyObject *m = PyModule_Create(&moduledef);
     if (!m ||


### PR DESCRIPTION
## PR Summary

Minor fix getting rid of type cast warnings (on Windows).

```
   C:\Users\Oscar\matplotlib\src\_path.h(843): warning C4244: 'initializing': conversion from 'double' to 'float', possible loss of data
...
    C:\Users\Oscar\matplotlib\src\_path.h(1157): warning C4267: '=': conversion from 'size_t' to 'int', possible loss of data
```

(Editor removed some trailing spaces.)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
