### PR TITLE
Improve usability of dviread.Text by third parties.

### DIFF
--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -131,7 +131,7 @@ def test_missing_psfont(fmt, monkeypatch):
     monkeypatch.setattr(
         dviread.PsfontsMap, '__getitem__',
         lambda self, k: dviread.PsFont(
-            texname='texfont', psname='Some Font',
+            texname=b'texfont', psname=b'Some Font',
             effects=None, encoding=None, filename=None))
     mpl.rcParams['text.usetex'] = True
     fig, ax = plt.subplots()

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-import functools
 import logging
 import urllib.parse
 
@@ -243,25 +242,29 @@ class TextToPath:
 
         # Gather font information and do some setup for combining
         # characters into strings.
-        for x1, y1, dvifont, glyph, width in page.text:
-            font, enc = self._get_ps_font_and_encoding(dvifont.texname)
-            char_id = self._get_char_id(font, glyph)
-
+        for text in page.text:
+            font = get_font(text.font_path)
+            char_id = self._get_char_id(font, text.glyph)
             if char_id not in glyph_map:
                 font.clear()
                 font.set_size(self.FONT_SCALE, self.DPI)
-                # See comments in _get_ps_font_and_encoding.
-                if enc is not None:
-                    index = font.get_name_index(enc[glyph])
+                glyph_name_or_index = text.glyph_name_or_index
+                if isinstance(glyph_name_or_index, str):
+                    index = font.get_name_index(glyph_name_or_index)
                     font.load_glyph(index, flags=LOAD_TARGET_LIGHT)
-                else:
-                    font.load_char(glyph, flags=LOAD_TARGET_LIGHT)
+                elif isinstance(glyph_name_or_index, int):
+                    self._select_native_charmap(font)
+                    font.load_char(
+                        glyph_name_or_index, flags=LOAD_TARGET_LIGHT)
+                else:  # Should not occur.
+                    raise TypeError(f"Glyph spec of unexpected type: "
+                                    f"{glyph_name_or_index!r}")
                 glyph_map_new[char_id] = font.get_path()
 
             glyph_ids.append(char_id)
-            xpositions.append(x1)
-            ypositions.append(y1)
-            sizes.append(dvifont.size / self.FONT_SCALE)
+            xpositions.append(text.x)
+            ypositions.append(text.y)
+            sizes.append(text.font_size / self.FONT_SCALE)
 
         myrects = []
 
@@ -277,48 +280,21 @@ class TextToPath:
                 glyph_map_new, myrects)
 
     @staticmethod
-    @functools.lru_cache(50)
-    def _get_ps_font_and_encoding(texname):
-        tex_font_map = dviread.PsfontsMap(dviread._find_tex_file('pdftex.map'))
-        psfont = tex_font_map[texname]
-        if psfont.filename is None:
-            raise ValueError(
-                f"No usable font file found for {psfont.psname} ({texname}). "
-                f"The font may lack a Type-1 version.")
-
-        font = get_font(psfont.filename)
-
-        if psfont.encoding:
-            # If psfonts.map specifies an encoding, use it: it gives us a
-            # mapping of glyph indices to Adobe glyph names; use it to convert
-            # dvi indices to glyph names and use the FreeType-synthesized
-            # Unicode charmap to convert glyph names to glyph indices (with
-            # FT_Get_Name_Index/get_name_index), and load the glyph using
-            # FT_Load_Glyph/load_glyph.  (That charmap has a coverage at least
-            # as good as, and possibly better than, the native charmaps.)
-            enc = dviread._parse_enc(psfont.encoding)
-        else:
-            # If psfonts.map specifies no encoding, the indices directly
-            # map to the font's "native" charmap; so don't use the
-            # FreeType-synthesized charmap but the native ones (we can't
-            # directly identify it but it's typically an Adobe charmap), and
-            # directly load the dvi glyph indices using FT_Load_Char/load_char.
-            for charmap_code in [
-                    1094992451,  # ADOBE_CUSTOM.
-                    1094995778,  # ADOBE_STANDARD.
-            ]:
-                try:
-                    font.select_charmap(charmap_code)
-                except (ValueError, RuntimeError):
-                    pass
-                else:
-                    break
+    def _select_native_charmap(font):
+        # Select the native charmap. (we can't directly identify it but it's
+        # typically an Adobe charmap).
+        for charmap_code in [
+                1094992451,  # ADOBE_CUSTOM.
+                1094995778,  # ADOBE_STANDARD.
+        ]:
+            try:
+                font.select_charmap(charmap_code)
+            except (ValueError, RuntimeError):
+                pass
             else:
-                _log.warning("No supported encoding in font (%s).",
-                             psfont.filename)
-            enc = None
-
-        return font, enc
+                break
+        else:
+            _log.warning("No supported encoding in font (%s).", font.fname)
 
 
 text_to_path = TextToPath()


### PR DESCRIPTION
dviread.Text specifies individual glyphs in parsed dvi files; this is
used by the pdf and svg backends (via textpath, for svg) to parse the
result of usetex-compiled strings and embed the right glyphs at the
right places in the output file (as a reminder, agg currenly uses dvipng
to rasterize the dvi file, and the ps backend relies on pstricks).
Unfortunately, if third-party backends (e.g. mplcairo) want to do use
the same strategy as pdf/svg, then they need to jump through a few hoops
(e.g. understand PsfontsMap and find_tex_font) and use some private APIs
(_parse_enc), as explained below.  Try to improve the situation, by
adding some methods on the Text class (which may later allow deprecating
PsfontsMap and find_tex_font as public API).

First, the actual font to be used is speficied via the `.font`
attribute, which itself has a `.texname` which itself must be used as
a key into `PsfontsMap(find_tex_font("pdftex.map"))` to get the actual
font path (and some other info).  Instead, just provide a `.font_path`
property. pdftex.map can also require that the font be "slanted" or
"extended" (that's some of the "other info), lift that as well to
`.font_effects`.  The `.font` attribute has a `.size`; also we can lift
up to `.font_size`.  Altogether, this will allow making `.font` private
(later) -- except for the fact that Text is a namedtuple so deprecating
fields is rather annoying.

The trickiest part is actually specifying what glyph to select from the
font.  dvi just gives us an integer, whose interpretation depends again
on pdftex.map.  If pdftex.map specifies "no encoding" for the font, then
the integer is the "native glyph index" of the font, and should be
passed as-is to FreeType's FT_Load_Char (after selecting the native
charmap).  If pdftex.map does specify an encoding, then that's a file
that needs to be separately loaded, parsed (with _parse_enc), and
ultimately converts the index into a glyph name (which can be passed to
FreeType's FT_Load_Glyph).  Altogether, from the PoV of the end user,
the "glyph specification" is thus either an int (a native charmap index)
or a str (a glyph name); thus, provide `.glyph_spec` which is that API.

As an example of using that API, see the changes to textpath.py.

-----

I probably won't have too much time to hash out the best API here (well, I'm OK with the one I wrote, but perhaps better choices are possible) in the coming days, but just posting this out in response to #22127, as this is, I think, the way towards tightening the dviread public API while consolidating the useful functionality for third parties.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
