### PR TITLE
FIX: Colorbars check for subplotspec attribute before using

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -263,12 +263,10 @@ class _ColorbarAxesLocator:
         # make tight_layout happy..
         ss = getattr(self._cbar.ax, 'get_subplotspec', None)
         if ss is None:
-            if self._orig_locator is None:
+            if not hasattr(self._orig_locator, "get_subplotspec"):
                 return None
-            ss = self._orig_locator.get_subplotspec()
-        else:
-            ss = ss()
-        return ss
+            ss = self._orig_locator.get_subplotspec
+        return ss()
 
 
 @docstring.Substitution(_colormap_kw_doc)

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -100,6 +100,18 @@ def test_axesgrid_colorbar_log_smoketest():
     grid.cbar_axes[0].colorbar(im)
 
 
+def test_inset_colorbar_tight_layout_smoketest():
+    fig, ax = plt.subplots(1, 1)
+    pts = ax.scatter([0, 1], [0, 1], c=[1, 5])
+
+    cax = inset_axes(ax, width="3%", height="70%")
+    plt.colorbar(pts, cax=cax)
+
+    with pytest.warns(UserWarning, match="This figure includes Axes"):
+        # Will warn, but not raise an error
+        plt.tight_layout()
+
+
 @image_comparison(['inset_locator.png'], style='default', remove_text=True)
 def test_inset_locator():
     fig, ax = plt.subplots(figsize=[5, 4])


### PR DESCRIPTION
## PR Summary

Update the colorbar `get_subplotspec()` to only access attributes
after a check for it having the attribute, else return None.

Fixes #22576

This will still warn about the Axes not being compatible, but I think that is expected as an AxesGrid `inset_axes()` without a colorbar also warns.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
