### PR TITLE
DOC: Add links to explicit vs implicit API everywhere "OO" is used

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -134,9 +134,9 @@ explicitly (e.g. when including them in GUI applications).
 Further reading:
 
 - `matplotlib.axes.Axes` and `matplotlib.figure.Figure` for an overview of
-   plotting functions.
+  plotting functions.
 - Most of the :ref:`examples <examples-index>` use the object-oriented approach
-   (except for the pyplot section)
+  (except for the pyplot section)
 
 
 The implicit API

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -114,10 +114,33 @@ Alphabetical list of modules:
 Usage patterns
 --------------
 
-Below we describe several common approaches to plotting with Matplotlib.
+Below we describe several common approaches to plotting with Matplotlib.  See
+:ref:`api_interfaces` for an explanation of the trade off of the supported user
+APIs.
 
-The pyplot API
-^^^^^^^^^^^^^^
+
+The Explicit API
+^^^^^^^^^^^^^^^^
+
+At its core, Matplotlib is an object-oriented library. We recommend directly
+working with the objects, if you need more control and customization of your
+plots.
+
+In many cases you will create a `.Figure` and one or more
+`~matplotlib.axes.Axes` using `.pyplot.subplots` and from then on only work
+on these objects. However, it's also possible to create `.Figure`\ s
+explicitly (e.g. when including them in GUI applications).
+
+Further reading:
+
+- `matplotlib.axes.Axes` and `matplotlib.figure.Figure` for an overview of
+   plotting functions.
+- Most of the :ref:`examples <examples-index>` use the object-oriented approach
+   (except for the pyplot section)
+
+
+The implicit API
+^^^^^^^^^^^^^^^^
 
 `matplotlib.pyplot` is a collection of functions that make
 Matplotlib work like MATLAB. Each pyplot function makes some change to a
@@ -134,24 +157,6 @@ Further reading:
 - :ref:`Pyplot examples <pyplots_examples>`
 
 .. _api-index:
-
-The object-oriented API
-^^^^^^^^^^^^^^^^^^^^^^^
-
-At its core, Matplotlib is object-oriented. We recommend directly working
-with the objects, if you need more control and customization of your plots.
-
-In many cases you will create a `.Figure` and one or more
-`~matplotlib.axes.Axes` using `.pyplot.subplots` and from then on only work
-on these objects. However, it's also possible to create `.Figure`\ s
-explicitly (e.g. when including them in GUI applications).
-
-Further reading:
-
-- `matplotlib.axes.Axes` and `matplotlib.figure.Figure` for an overview of
-   plotting functions.
-- Most of the :ref:`examples <examples-index>` use the object-oriented approach
-   (except for the pyplot section)
 
 The pylab API (discouraged)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -115,15 +115,15 @@ Usage patterns
 --------------
 
 Below we describe several common approaches to plotting with Matplotlib.  See
-:ref:`api_interfaces` for an explanation of the trade off of the supported user
+:ref:`api_interfaces` for an explanation of the trade-offs between the supported user
 APIs.
 
 
-The Explicit API
+The explicit API
 ^^^^^^^^^^^^^^^^
 
 At its core, Matplotlib is an object-oriented library. We recommend directly
-working with the objects, if you need more control and customization of your
+working with the objects if you need more control and customization of your
 plots.
 
 In many cases you will create a `.Figure` and one or more

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -30,6 +30,62 @@ methods on them to plot data, add axis labels and a figure title.
    fig.set_facecolor('lightsteelblue')
 
 
+
+.. _usage_patterns:
+
+Usage patterns
+--------------
+
+Below we describe several common approaches to plotting with Matplotlib.  See
+:ref:`api_interfaces` for an explanation of the trade-offs between the supported user
+APIs.
+
+
+The explicit API
+^^^^^^^^^^^^^^^^
+
+At its core, Matplotlib is an object-oriented library. We recommend directly
+working with the objects if you need more control and customization of your
+plots.
+
+In many cases you will create a `.Figure` and one or more
+`~matplotlib.axes.Axes` using `.pyplot.subplots` and from then on only work
+on these objects. However, it's also possible to create `.Figure`\ s
+explicitly (e.g. when including them in GUI applications).
+
+Further reading:
+
+- `matplotlib.axes.Axes` and `matplotlib.figure.Figure` for an overview of
+  plotting functions.
+- Most of the :ref:`examples <examples-index>` use the object-oriented approach
+  (except for the pyplot section)
+
+
+The implicit API
+^^^^^^^^^^^^^^^^
+
+`matplotlib.pyplot` is a collection of functions that make
+Matplotlib work like MATLAB. Each pyplot function makes some change to a
+figure: e.g., creates a figure, creates a plotting area in a figure, plots
+some lines in a plotting area, decorates the plot with labels, etc.
+
+`.pyplot` is mainly intended for interactive plots and simple cases of
+programmatic plot generation.
+
+Further reading:
+
+- The `matplotlib.pyplot` function reference
+- :doc:`/tutorials/introductory/pyplot`
+- :ref:`Pyplot examples <pyplots_examples>`
+
+.. _api-index:
+
+The pylab API (discouraged)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: pylab
+   :no-members:
+
 Modules
 -------
 
@@ -107,59 +163,3 @@ Alphabetical list of modules:
    toolkits/axes_grid1.rst
    toolkits/axisartist.rst
    toolkits/axes_grid.rst
-
-
-.. _usage_patterns:
-
-Usage patterns
---------------
-
-Below we describe several common approaches to plotting with Matplotlib.  See
-:ref:`api_interfaces` for an explanation of the trade-offs between the supported user
-APIs.
-
-
-The explicit API
-^^^^^^^^^^^^^^^^
-
-At its core, Matplotlib is an object-oriented library. We recommend directly
-working with the objects if you need more control and customization of your
-plots.
-
-In many cases you will create a `.Figure` and one or more
-`~matplotlib.axes.Axes` using `.pyplot.subplots` and from then on only work
-on these objects. However, it's also possible to create `.Figure`\ s
-explicitly (e.g. when including them in GUI applications).
-
-Further reading:
-
-- `matplotlib.axes.Axes` and `matplotlib.figure.Figure` for an overview of
-  plotting functions.
-- Most of the :ref:`examples <examples-index>` use the object-oriented approach
-  (except for the pyplot section)
-
-
-The implicit API
-^^^^^^^^^^^^^^^^
-
-`matplotlib.pyplot` is a collection of functions that make
-Matplotlib work like MATLAB. Each pyplot function makes some change to a
-figure: e.g., creates a figure, creates a plotting area in a figure, plots
-some lines in a plotting area, decorates the plot with labels, etc.
-
-`.pyplot` is mainly intended for interactive plots and simple cases of
-programmatic plot generation.
-
-Further reading:
-
-- The `matplotlib.pyplot` function reference
-- :doc:`/tutorials/introductory/pyplot`
-- :ref:`Pyplot examples <pyplots_examples>`
-
-.. _api-index:
-
-The pylab API (discouraged)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. automodule:: pylab
-   :no-members:

--- a/doc/users/project/history.rst
+++ b/doc/users/project/history.rst
@@ -11,7 +11,7 @@ History
 Matplotlib is a library for making 2D plots of arrays in `Python
 <https://www.python.org>`_.  Although it has its origins in emulating
 the MATLAB graphics commands, it is
-independent of MATLAB, and can be used in a Pythonic, object oriented
+independent of MATLAB, and can be used in a Pythonic, object-oriented
 way.  Although Matplotlib is written primarily in pure Python, it
 makes heavy use of `NumPy <https://numpy.org>`_ and other extension
 code to provide good performance even for large arrays.

--- a/examples/misc/pythonic_matplotlib.py
+++ b/examples/misc/pythonic_matplotlib.py
@@ -3,9 +3,9 @@
 Pythonic Matplotlib
 ===================
 
-Some people prefer to write more pythonic, object-oriented code
-rather than use the pyplot interface to matplotlib.  This example shows
-you how.
+Some people prefer to write more "Pythonic", explicitly object-oriented code
+rather than use the implicit pyplot interface to Matplotlib.  This example
+shows you how.
 
 Unless you are an application developer, I recommend using part of the
 pyplot interface, particularly the figure, close, subplot, axes, and
@@ -14,7 +14,7 @@ need to see in normal figure creation, like instantiating DPI
 instances, managing the bounding boxes of the figure elements,
 creating and realizing GUI windows and embedding figures in them.
 
-If you are an application developer and want to embed matplotlib in
+If you are an application developer and want to embed Matplotlib in
 your application, follow the lead of examples/embedding_in_wx.py,
 examples/embedding_in_gtk.py or examples/embedding_in_tk.py.  In this
 case you will want to control the creation of all your figures,
@@ -28,7 +28,7 @@ there is no reason why the pyplot interface won't work for web
 application developers, however.
 
 If you see an example in the examples dir written in pyplot interface,
-and you want to emulate that using the true python method calls, there
+and you want to emulate that using the true Python method calls, there
 is an easy mapping.  Many of those examples use 'set' to control
 figure properties.  Here's how to map those commands onto instance
 methods
@@ -52,6 +52,7 @@ So for your example, if a is your axes object, you can do::
     a.set_yticklabels([])
     a.set_xticks([])
     a.set_yticks([])
+
 """
 
 import matplotlib.pyplot as plt

--- a/examples/misc/pythonic_matplotlib.py
+++ b/examples/misc/pythonic_matplotlib.py
@@ -3,9 +3,9 @@
 Pythonic Matplotlib
 ===================
 
-Some people prefer to write more "Pythonic", explicitly object-oriented code
-rather than use the implicit pyplot interface to Matplotlib.  This example
-shows you how.
+Some people prefer to write more "Pythonic", explicit object-oriented code,
+rather than use the implicit pyplot interface to Matplotlib. This example
+shows you how to take advantage of the explicit Matplotlib interface.
 
 Unless you are an application developer, I recommend using part of the
 pyplot interface, particularly the figure, close, subplot, axes, and

--- a/examples/subplots_axes_and_figures/multiple_figs_demo.py
+++ b/examples/subplots_axes_and_figures/multiple_figs_demo.py
@@ -10,8 +10,8 @@ no figure with the number exists, a new one is created.
 
 .. note::
 
-    We discourage working with multiple figures through the implicit pyplot interface
-    because managing the *current figure* is cumbersome and
+    We discourage working with multiple figures through the implicit pyplot
+    interface because managing the *current figure* is cumbersome and
     error-prone. Instead, we recommend using the explicit approach and call
     methods on Figure and Axes instances. See :ref:`api_interfaces` for an
     explanation of the trade-offs between the implicit and explicit interfaces.

--- a/examples/subplots_axes_and_figures/multiple_figs_demo.py
+++ b/examples/subplots_axes_and_figures/multiple_figs_demo.py
@@ -10,11 +10,11 @@ no figure with the number exists, a new one is created.
 
 .. note::
 
-    We discourage working with multiple figures in implicit pyplot interface
+    We discourage working with multiple figures through the implicit pyplot interface
     because managing the *current figure* is cumbersome and
-    error-prone. Instead, we recommend to use the explicit approach and call
+    error-prone. Instead, we recommend using the explicit approach and call
     methods on Figure and Axes instances. See :ref:`api_interfaces` for an
-    explanation of the tradeoffs between the implicit and explicit interfaces.
+    explanation of the trade-offs between the implicit and explicit interfaces.
 
 """
 import matplotlib.pyplot as plt

--- a/examples/subplots_axes_and_figures/multiple_figs_demo.py
+++ b/examples/subplots_axes_and_figures/multiple_figs_demo.py
@@ -10,10 +10,11 @@ no figure with the number exists, a new one is created.
 
 .. note::
 
-    We discourage working with multiple figures in pyplot because managing
-    the *current figure* is cumbersome and error-prone. Instead, we recommend
-    to use the object-oriented approach and call methods on Figure and Axes
-    instances.
+    We discourage working with multiple figures in implicit pyplot interface
+    because managing the *current figure* is cumbersome and
+    error-prone. Instead, we recommend to use the explicit approach and call
+    methods on Figure and Axes instances. See :ref:`api_interfaces` for an
+    explanation of the tradeoffs between the implicit and explicit interfaces.
 
 """
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -17,10 +17,12 @@ at your terminal, followed by::
 
 at the ipython shell prompt.
 
-For the most part, direct use of the object-oriented library is encouraged when
-programming; pyplot is primarily for working interactively.  The exceptions are
-the pyplot functions `.pyplot.figure`, `.pyplot.subplot`, `.pyplot.subplots`,
-and `.pyplot.savefig`, which can greatly simplify scripting.
+For the most part, direct use of the explicit object-oriented library is
+encouraged when programming; the implicit pyplot interface is primarily for
+working interactively.  The exceptions are the pyplot functions
+`.pyplot.figure`, `.pyplot.subplot`, `.pyplot.subplots`, and `.pyplot.savefig`,
+which can greatly simplify scripting.  See :ref:`api_interfaces` for an
+explanation of the tradeoffs between the implicit and explicit interfaces.
 
 Modules include:
 
@@ -79,6 +81,7 @@ developed and maintained by a host of others.
 
 Occasionally the internal documentation (python docstrings) will refer
 to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
+
 """
 
 import atexit

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -19,7 +19,7 @@ at the ipython shell prompt.
 
 For the most part, direct use of the explicit object-oriented library is
 encouraged when programming; the implicit pyplot interface is primarily for
-working interactively.  The exceptions are the pyplot functions
+working interactively. The exceptions to this suggestion are the pyplot functions
 `.pyplot.figure`, `.pyplot.subplot`, `.pyplot.subplots`, and `.pyplot.savefig`,
 which can greatly simplify scripting.  See :ref:`api_interfaces` for an
 explanation of the tradeoffs between the implicit and explicit interfaces.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -19,10 +19,11 @@ at the ipython shell prompt.
 
 For the most part, direct use of the explicit object-oriented library is
 encouraged when programming; the implicit pyplot interface is primarily for
-working interactively. The exceptions to this suggestion are the pyplot functions
-`.pyplot.figure`, `.pyplot.subplot`, `.pyplot.subplots`, and `.pyplot.savefig`,
-which can greatly simplify scripting.  See :ref:`api_interfaces` for an
-explanation of the tradeoffs between the implicit and explicit interfaces.
+working interactively. The exceptions to this suggestion are the pyplot
+functions `.pyplot.figure`, `.pyplot.subplot`, `.pyplot.subplots`, and
+`.pyplot.savefig`, which can greatly simplify scripting.  See
+:ref:`api_interfaces` for an explanation of the tradeoffs between the implicit
+and explicit interfaces.
 
 Modules include:
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -16,7 +16,7 @@ programmatic plot generation::
     y = np.sin(x)
     plt.plot(x, y)
 
-The explicit (object-oriented) API is recommended for complex plots, though
+The explicit object-oriented API is recommended for complex plots, though
 pyplot is still usually used to create the figure and often the axes in the
 figure. See `.pyplot.figure`, `.pyplot.subplots`, and
 `.pyplot.subplot_mosaic` to create figures, and
@@ -29,6 +29,10 @@ figure. See `.pyplot.figure`, `.pyplot.subplots`, and
     y = np.sin(x)
     fig, ax = plt.subplots()
     ax.plot(x, y)
+
+
+See :ref:`api_interfaces` for an explanation of the tradeoffs between the
+implicit and explicit interfaces.
 """
 
 import functools

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -37,15 +37,15 @@ However, for other backends, such as Qt, that open a separate window,
 cells below those that create the plot will change the plot - it is a
 live object in memory.
 
-This tutorial will use Matplotlib's imperative-style plotting
-interface, pyplot.  This interface maintains global state, and is very
-useful for quickly and easily experimenting with various plot
-settings.  The alternative is the object-oriented interface, which is also
-very powerful, and generally more suitable for large application
-development.  If you'd like to learn about the object-oriented
-interface, a great place to start is our :doc:`Quick start guide
-</tutorials/introductory/quick_start>`.  For now, let's get on
-with the imperative-style approach:
+This tutorial will use Matplotlib's implicit plotting interface, pyplot.  This
+interface maintains global state, and is very useful for quickly and easily
+experimenting with various plot settings.  The alternative is the explicit,
+which is more suitable for large application development.  For an explanation
+of the tradeoffs between the implicit and explicit interfaces See
+:ref:`api_interfaces` and the :doc:`Quick start guide
+</tutorials/introductory/quick_start>` to start using the explicit interface.
+For now, let's get on with the implicit approach:
+
 """
 
 import matplotlib.pyplot as plt

--- a/tutorials/introductory/lifecycle.py
+++ b/tutorials/introductory/lifecycle.py
@@ -20,7 +20,7 @@ to highlight some neat features and best-practices using Matplotlib.
 A note on the explicit vs. implicit interfaces
 ==============================================
 
-Matplotlib has two interfaces. For an explanation of the tradeoffs between the
+Matplotlib has two interfaces. For an explanation of the trade-offs between the
 implicit and explicit interfaces see :ref:`api_interfaces`.
 
 The first is an explicit object-oriented (OO) interface. In this case, we

--- a/tutorials/introductory/lifecycle.py
+++ b/tutorials/introductory/lifecycle.py
@@ -21,15 +21,15 @@ A note on the explicit vs. implicit interfaces
 ==============================================
 
 Matplotlib has two interfaces. For an explanation of the trade-offs between the
-implicit and explicit interfaces see :ref:`api_interfaces`.
+explicit and implicit interfaces see :ref:`api_interfaces`.
 
-The first is an explicit object-oriented (OO) interface. In this case, we
-utilize an instance of :class:`axes.Axes` in order to render visualizations on
-an instance of :class:`figure.Figure`.  The second is based on MATLAB and uses
-an implicit global state-based interface.  This is encapsulated in the
-:mod:`.pyplot` module. See the :doc:`pyplot tutorials
-</tutorials/introductory/pyplot>` for a more in-depth look at the pyplot
-interface.
+In the explicit object-oriented (OO) interface we directly utilize instances of
+:class:`axes.Axes` to build up the visualization in an instance of
+:class:`figure.Figure`.  In the implicit interface, inspired by and modeled on
+MATLAB, uses an global state-based interface which is is encapsulated in the
+:mod:`.pyplot` module to plot to the "current Axes".  See the :doc:`pyplot
+tutorials </tutorials/introductory/pyplot>` for a more in-depth look at the
+pyplot interface.
 
 Most of the terms are straightforward but the main thing to remember
 is that:
@@ -43,8 +43,8 @@ us much more flexibility and power in customizing our plot.
 
 .. note::
 
-   In general, try to use the explicit interface over the implicit pyplot
-   interface for plotting.
+   In general prefer the explicit interface over the implicit pyplot interface
+   for plotting.
 
 Our data
 ========

--- a/tutorials/introductory/lifecycle.py
+++ b/tutorials/introductory/lifecycle.py
@@ -17,15 +17,17 @@ to highlight some neat features and best-practices using Matplotlib.
     <https://pbpython.com/effective-matplotlib.html>`_
     by Chris Moffitt. It was transformed into this tutorial by Chris Holdgraf.
 
-A note on the Object-Oriented API vs. Pyplot
-============================================
+A note on the explicit vs. implicit interfaces
+==============================================
 
-Matplotlib has two interfaces. The first is an object-oriented (OO)
-interface. In this case, we utilize an instance of :class:`axes.Axes`
-in order to render visualizations on an instance of :class:`figure.Figure`.
+Matplotlib has two interfaces. For an explanation of the tradeoffs between the
+implicit and explicit interfaces see :ref:`api_interfaces`.
 
-The second is based on MATLAB and uses a state-based interface. This is
-encapsulated in the :mod:`.pyplot` module. See the :doc:`pyplot tutorials
+The first is an explicit object-oriented (OO) interface. In this case, we
+utilize an instance of :class:`axes.Axes` in order to render visualizations on
+an instance of :class:`figure.Figure`.  The second is based on MATLAB and uses
+an implicit global state-based interface.  This is encapsulated in the
+:mod:`.pyplot` module. See the :doc:`pyplot tutorials
 </tutorials/introductory/pyplot>` for a more in-depth look at the pyplot
 interface.
 
@@ -41,14 +43,15 @@ us much more flexibility and power in customizing our plot.
 
 .. note::
 
-   In general, try to use the object-oriented interface over the pyplot
-   interface.
+   In general, try to use the explicit interface over the implicit pyplot
+   interface for plotting.
 
 Our data
 ========
 
 We'll use the data from the post from which this tutorial was derived.
 It contains sales information for a number of companies.
+
 """
 
 # sphinx_gallery_thumbnail_number = 10

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -4,19 +4,20 @@ Pyplot tutorial
 ===============
 
 An introduction to the pyplot interface.  Please also see
-:doc:`/tutorials/introductory/quick_start` for an overview of how Matplotlib works.
+:doc:`/tutorials/introductory/quick_start` for an overview of how Matplotlib
+works and :ref:`api_interfaces` for an explanation of the trade off of the
+supported user APIs.
+
 """
 
 ###############################################################################
 # Intro to pyplot
 # ===============
 #
-# :mod:`matplotlib.pyplot` is a collection of functions
-# that make matplotlib work like MATLAB.
-# Each ``pyplot`` function makes
-# some change to a figure: e.g., creates a figure, creates a plotting area
-# in a figure, plots some lines in a plotting area, decorates the plot
-# with labels, etc.
+# :mod:`matplotlib.pyplot` is a collection of functions that make matplotlib
+# work like MATLAB.  Each ``pyplot`` function makes some change to a figure:
+# e.g., creates a figure, creates a plotting area in a figure, plots some lines
+# in a plotting area, decorates the plot with labels, etc.
 #
 # In :mod:`matplotlib.pyplot` various states are preserved
 # across function calls, so that it keeps track of things like
@@ -28,10 +29,11 @@ An introduction to the pyplot interface.  Please also see
 #
 # .. note::
 #
-#    the pyplot API is generally less-flexible than the object-oriented API.
-#    Most of the function calls you see here can also be called as methods
-#    from an ``Axes`` object. We recommend browsing the tutorials and
-#    examples to see how this works.
+#    the implicit pyplot API is generally terser but less-flexible than the
+#    explicit API.  Most of the function calls you see here can also be called
+#    as methods from an ``Axes`` object. We recommend browsing the tutorials
+#    and examples to see how this works. See :ref:`api_interfaces` for an
+#    explanation of the trade off of the supported user APIs.
 #
 # Generating visualizations with pyplot is very quick:
 
@@ -301,7 +303,7 @@ plt.show()
 # and the current axes with `~.pyplot.cla`.  If you find
 # it annoying that states (specifically the current image, figure and axes)
 # are being maintained for you behind the scenes, don't despair: this is just a thin
-# stateful wrapper around an object oriented API, which you can use
+# stateful wrapper around an object-oriented API, which you can use
 # instead (see :doc:`/tutorials/intermediate/artists`)
 #
 # If you are making lots of figures, you need to be aware of one

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -29,7 +29,7 @@ supported user APIs.
 #
 # .. note::
 #
-#    the implicit pyplot API is generally terser but less-flexible than the
+#    the implicit pyplot API is generally less verbose but also not as flexible as the
 #    explicit API.  Most of the function calls you see here can also be called
 #    as methods from an ``Axes`` object. We recommend browsing the tutorials
 #    and examples to see how this works. See :ref:`api_interfaces` for an

--- a/tutorials/introductory/pyplot.py
+++ b/tutorials/introductory/pyplot.py
@@ -5,7 +5,7 @@ Pyplot tutorial
 
 An introduction to the pyplot interface.  Please also see
 :doc:`/tutorials/introductory/quick_start` for an overview of how Matplotlib
-works and :ref:`api_interfaces` for an explanation of the trade off of the
+works and :ref:`api_interfaces` for an explanation of the trade-offs between the
 supported user APIs.
 
 """

--- a/tutorials/introductory/quick_start.py
+++ b/tutorials/introductory/quick_start.py
@@ -134,15 +134,18 @@ ax.set_ylabel('entry b');
 # Coding styles
 # =============
 #
-# The object-oriented and the pyplot interfaces
-# ---------------------------------------------
+# The explicit and the implicit interfaces
+# ----------------------------------------
 #
 # As noted above, there are essentially two ways to use Matplotlib:
 #
 # - Explicitly create Figures and Axes, and call methods on them (the
 #   "object-oriented (OO) style").
-# - Rely on pyplot to automatically create and manage the Figures and Axes, and
+# - Rely on pyplot to implicitly create and manage the Figures and Axes, and
 #   use pyplot functions for plotting.
+#
+# See :ref:`api_interfaces` for an explanation of the tradeoffs between the
+# implicit and explicit interfaces.
 #
 # So one can use the OO-style
 

--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -31,11 +31,11 @@ math symbols and commands, supporting :doc:`mathematical expressions
 Basic text commands
 ===================
 
-The following commands are used to create text in the pyplot
-interface and the object-oriented API:
+The following commands are used to create text in the implicit and explicit
+interfaces (see :ref:`api_interfaces` for an explanation of the tradeoffs):
 
 =================== =================== ======================================
-`.pyplot` API       OO API              description
+implicit API        explicit API        description
 =================== =================== ======================================
 `~.pyplot.text`     `~.Axes.text`       Add text at an arbitrary location of
                                         the `~matplotlib.axes.Axes`.
@@ -63,6 +63,7 @@ All of these functions create and return a `.Text` instance, which can be
 configured with a variety of font and other properties.  The example below
 shows all of these commands in action, and more detail is provided in the
 sections that follow.
+
 """
 
 import matplotlib


### PR DESCRIPTION

## PR Summary

Closes #18249

I search for every use of "object-oriented" in the code base and make sure they all had some reference to the https://matplotlib.org/devdocs/users/explain/api_interfaces.html 

```
$ ack 'object[- ]oriented'
doc/api/index.rst
125:At its core, Matplotlib is an object-oriented library. We recommend directly
138:- Most of the :ref:`examples <examples-index>` use the object-oriented approach

doc/users/explain/api_interfaces.rst
11:  been called an "object-oriented" interface.

doc/users/prev_whats_new/changelog.rst
1264:    object-oriented and pylab interfaces. It is now strictly object-oriented -

doc/users/prev_whats_new/github_stats_3.1.1.rst
177:* :ghissue:`1219`: Show fails on figures created with the object-oriented system

doc/users/prev_whats_new/github_stats_3.5.0.rst
418:* :ghpull:`21132`: Backport PR #21093 on branch v3.5.x (DOC: clarify what we mean by object oriented in pyplot api)
422:* :ghpull:`21093`: DOC: clarify what we mean by object oriented in pyplot api
627:* :ghpull:`20792`: Change legend guide to object oriented approach

doc/users/project/history.rst
14:independent of MATLAB, and can be used in a Pythonic, object-oriented

examples/misc/pythonic_matplotlib.py
6:Some people prefer to write more "Pythonic", explicitly object-oriented code

examples/text_labels_and_annotations/fonts_demo.py
3:Fonts demo (object-oriented style)

lib/matplotlib/__init__.py
2:An object-oriented plotting library.
20:For the most part, direct use of the explicit object-oriented library is

lib/matplotlib/pyplot.py
19:The explicit object-oriented API is recommended for complex plots, though

tutorials/introductory/lifecycle.py
26:The first is an explicit object-oriented (OO) interface. In this case, we
81:# group. To do this with the object-oriented approach, we first generate

tutorials/introductory/pyplot.py
306:# stateful wrapper around an object-oriented API, which you can use

tutorials/introductory/quick_start.py
143:#   "object-oriented (OO) style").

```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [/] New features are documented, with examples if plot related.
- [/] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [/] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
