### PR TITLE
DOC: remove space in directive.

### DIFF
--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -36,7 +36,7 @@ that the draw command is deferred and only called once.
 The upshot of this is that for interactive backends (including
 ``%matplotlib notebook``) in interactive mode (with ``plt.ion()``)
 
-.. code-block :: python
+.. code-block:: python
 
    import matplotlib.pyplot as plt
    fig, ax = plt.subplots()

--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -34,7 +34,7 @@ class LayoutEngine:
     layout engine ``execute`` function is called at draw time by
     `~.figure.Figure.draw`, providing a special draw-time hook.
 
-    .. note ::
+    .. note::
 
        However, note that layout engines affect the creation of colorbars, so
        `~.figure.Figure.set_layout_engine` should be called before any


### PR DESCRIPTION
While sphinx/docutils seem to accept it, it is technically not in the
spec and many parsers get that as a comment

--- 

You can actually see that in github highlighting of the diff, where the `.. code-block :: python` remove is in gray, while `.. code-block:: python` is blue + purple.
