### PR TITLE
DOC: Add replite console to the users docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,16 @@ commands:
             python -m pip install --upgrade --user wheel
             python -m pip install --upgrade --user 'setuptools!=60.6.0'
 
+  mamba-install:
+    description: Install micromamba so it can be used for building the emscripten-forge environment
+    steps:
+      - run:
+          name: Install micromamba
+          command: |
+            curl -Ls https://micro.mamba.pm/api/micromamba/linux-64/latest | tar -xvj bin/micromamba
+            pwd
+            ls
+
   doc-deps-install:
     parameters:
       numpy_version:
@@ -133,6 +143,8 @@ commands:
       - run:
           name: Build documentation
           command: |
+            export PATH="$(pwd)/../bin:$PATH"
+            echo $PATH
             # Set epoch to date of latest tag.
             export SOURCE_DATE_EPOCH="$(git log -1 --format=%at $(git describe --abbrev=0))"
             # Set release mode only when deploying to devdocs.
@@ -217,6 +229,7 @@ jobs:
       - apt-install
       - fonts-install
       - pip-install
+      - mamba-install
 
       - mpl-install
       - doc-deps-install

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -77,6 +77,7 @@ extensions = [
     'sphinxext.redirect_from',
     'sphinx_copybutton',
     'sphinx_design',
+    'jupyterlite_sphinx',
 ]
 
 exclude_patterns = [
@@ -614,6 +615,12 @@ texinfo_documents = [
      'Matplotlib', "Python plotting package", 'Programming',
      1),
 ]
+
+# jupyterlite config
+jupyterlite_config = "jupyter_lite_config.json"
+jupyterlite_dir = "."
+jupyterlite_content = ["gallery/**/*.ipynb"]
+jupyterlite_bind_ipynb_suffix = False
 
 # numpydoc config
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -619,7 +619,7 @@ texinfo_documents = [
 # jupyterlite config
 jupyterlite_config = "jupyter_lite_config.json"
 jupyterlite_dir = "."
-jupyterlite_content = ["gallery/**/*.ipynb"]
+jupyterlite_contents = ["gallery"]
 jupyterlite_bind_ipynb_suffix = False
 
 # numpydoc config

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -619,7 +619,7 @@ texinfo_documents = [
 # jupyterlite config
 jupyterlite_config = "jupyter_lite_config.json"
 jupyterlite_dir = "."
-jupyterlite_contents = ["gallery"]
+jupyterlite_contents = ["gallery/**"]
 jupyterlite_bind_ipynb_suffix = False
 
 # numpydoc config

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,7 +36,6 @@ Installation
 
 Further details are available in the :doc:`Installation Guide <users/installing/index>`.
 
-
 ******************
 Learning resources
 ******************
@@ -88,6 +87,28 @@ Learning resources
 
           - Figures (`.pyplot.figure`)
           - Subplots (`.pyplot.subplots`, `.pyplot.subplot_mosaic`)
+
+
+************
+Live example
+************
+
+Try Matplotlib directly in this documentation!
+
+.. replite::
+   :kernel: python
+   :height: 600px
+   :prompt: Try Matplotlib!
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    x = np.linspace(0, 2 * np.pi, 200)
+    y = np.sin(x)
+
+    fig, ax = plt.subplots()
+    ax.plot(x, y)
+    plt.show()
 
 
 ********************

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -95,20 +95,10 @@ Live example
 
 Try Matplotlib directly in this documentation (Press ``shift+Enter`` to execute code)! Alternatively, you can try the gallery examples in `our JupyterLite deployment <./lite/lab>`__.
 
-.. replite::
+.. retrolite:: matplotlib.ipynb
    :kernel: xeus-python
    :height: 600px
    :prompt: Try Matplotlib!
-
-   %matplotlib inline
-
-   import matplotlib.pyplot as plt
-   import numpy as np
-
-   fig = plt.figure()
-   plt.plot(np.sin(np.linspace(0, 20, 100)))
-   plt.show();
-
 
 ********************
 Third-party packages

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -93,22 +93,21 @@ Learning resources
 Live example
 ************
 
-Try Matplotlib directly in this documentation!
+Try Matplotlib directly in this documentation (Press ``shift+Enter`` to execute code)! Alternatively, you can try the gallery examples in `our JupyterLite deployment <./lite/lab>`__.
 
 .. replite::
-   :kernel: python
+   :kernel: xeus-python
    :height: 600px
    :prompt: Try Matplotlib!
 
-    import matplotlib.pyplot as plt
-    import numpy as np
+   %matplotlib inline
 
-    x = np.linspace(0, 2 * np.pi, 200)
-    y = np.sin(x)
+   import matplotlib.pyplot as plt
+   import numpy as np
 
-    fig, ax = plt.subplots()
-    ax.plot(x, y)
-    plt.show()
+   fig = plt.figure()
+   plt.plot(np.sin(np.linspace(0, 20, 100)))
+   plt.show();
 
 
 ********************

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -96,7 +96,6 @@ Live example
 Try Matplotlib directly in this documentation (Press ``shift+Enter`` to execute code)! Alternatively, you can try the gallery examples in `our JupyterLite deployment <./lite/lab>`__.
 
 .. retrolite:: matplotlib.ipynb
-   :kernel: xeus-python
    :height: 600px
    :prompt: Try Matplotlib!
 

--- a/doc/jupyter-lite.json
+++ b/doc/jupyter-lite.json
@@ -1,0 +1,9 @@
+{
+    "jupyter-lite-schema-version": 0,
+    "jupyter-config-data": {
+        "disabledExtensions": [
+          "@jupyterlite/javascript-kernel-extension",
+          "@jupyterlite/pyolite-kernel-extension"
+        ]
+    }
+}

--- a/doc/jupyter_lite_config.json
+++ b/doc/jupyter_lite_config.json
@@ -1,5 +1,8 @@
 {
     "XeusPythonEnv": {
         "packages": ["numpy", "matplotlib", "ipympl"]
+    },
+    "LiteBuildConfig": {
+        "ignore_contents": ["\\.(rst|zip|pickle|py|md5|png|gif)"]
     }
 }

--- a/doc/jupyter_lite_config.json
+++ b/doc/jupyter_lite_config.json
@@ -1,0 +1,5 @@
+{
+    "XeusPythonEnv": {
+        "packages": ["numpy", "matplotlib", "ipympl"]
+    }
+}

--- a/doc/matplotlib.ipynb
+++ b/doc/matplotlib.ipynb
@@ -1,0 +1,44 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "55c65d1e-870c-4358-b125-0595e497103b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib widget\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "\n",
+    "fig = plt.figure()\n",
+    "n = 250\n",
+    "x = np.linspace(0, 200, n)\n",
+    "y = np.random.randint(200, size=n)\n",
+    "plt.plot(x, y);"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+    "display_name": "Python (XPython)",
+    "language": "python",
+    "name": "xeus-python"
+  },
+  "language_info": {
+    "codemirror_mode": {
+      "name": "ipython",
+      "version": 3
+    },
+    "file_extension": ".py",
+    "mimetype": "text/x-python",
+    "name": "python",
+    "nbconvert_exporter": "python",
+    "pygments_lexer": "ipython3",
+    "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/environment.yml
+++ b/environment.yml
@@ -42,7 +42,7 @@ dependencies:
       - mpl-sphinx-theme
       - sphinxcontrib-svg2pdfconverter
       - pikepdf
-      - jupyterlite-sphinx>=0.7.0
+      - jupyterlite-sphinx>=0.7.1
       - jupyterlite-xeus-python>=0.5.3
   # testing
   - coverage

--- a/environment.yml
+++ b/environment.yml
@@ -42,6 +42,8 @@ dependencies:
       - mpl-sphinx-theme
       - sphinxcontrib-svg2pdfconverter
       - pikepdf
+      - jupyterlite-sphinx>=0.7.0
+      - jupyterlite-xeus-python>=0.5.0
   # testing
   - coverage
   - flake8>=3.8

--- a/environment.yml
+++ b/environment.yml
@@ -43,7 +43,7 @@ dependencies:
       - sphinxcontrib-svg2pdfconverter
       - pikepdf
       - jupyterlite-sphinx>=0.7.0
-      - jupyterlite-xeus-python>=0.5.0
+      - jupyterlite-xeus-python>=0.5.3
   # testing
   - coverage
   - flake8>=3.8

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -19,3 +19,5 @@ sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10
 sphinx-copybutton
 sphinx-design
+jupyterlite-sphinx>=0.7.0
+jupyterlite-xeus-python>=0.5.0

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -19,5 +19,5 @@ sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10
 sphinx-copybutton
 sphinx-design
-jupyterlite-sphinx>=0.7.0
+jupyterlite-sphinx>=0.7.1
 jupyterlite-xeus-python>=0.5.3

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -20,4 +20,4 @@ sphinx-gallery>=0.10
 sphinx-copybutton
 sphinx-design
 jupyterlite-sphinx>=0.7.0
-jupyterlite-xeus-python>=0.5.0
+jupyterlite-xeus-python>=0.5.3


### PR DESCRIPTION
## PR Summary

cc. @ianhi 

Add a JupyterLite console to the docs, allowing users to try and play with Matplotlib directly in the documentation 

![replite](https://user-images.githubusercontent.com/21197331/157636759-1fdbc20b-11e5-46b0-8a59-701dfd3f6d89.png)

I have not been able to build the docs locally due to some latex issue I'm having. But the CI should allow us to test this :)