### PR TITLE
FIX: Handle inverted colorbar axes with extensions

### DIFF
--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -124,6 +124,30 @@ def test_colorbar_extension_length():
     _colorbar_extension_length('proportional')
 
 
+@pytest.mark.parametrize("orientation", ["horizontal", "vertical"])
+@pytest.mark.parametrize("extend,expected", [("min", (0, 0, 0, 1)),
+                                             ("max", (1, 1, 1, 1)),
+                                             ("both", (1, 1, 1, 1))])
+def test_colorbar_extension_inverted_axis(orientation, extend, expected):
+    """Test extension color with an inverted axis"""
+    data = np.arange(12).reshape(3, 4)
+    fig, ax = plt.subplots()
+    cmap = plt.get_cmap("viridis").with_extremes(under=(0, 0, 0, 1),
+                                                 over=(1, 1, 1, 1))
+    im = ax.imshow(data, cmap=cmap)
+    cbar = fig.colorbar(im, orientation=orientation, extend=extend)
+    if orientation == "horizontal":
+        cbar.ax.invert_xaxis()
+    else:
+        cbar.ax.invert_yaxis()
+    assert cbar._extend_patches[0].get_facecolor() == expected
+    if extend == "both":
+        assert len(cbar._extend_patches) == 2
+        assert cbar._extend_patches[1].get_facecolor() == (0, 0, 0, 1)
+    else:
+        assert len(cbar._extend_patches) == 1
+
+
 @pytest.mark.parametrize('use_gridspec', [True, False])
 @image_comparison(['cbar_with_orientation',
                    'cbar_locationing',


### PR DESCRIPTION
## PR Summary
This fixes the colorbar extensions to use the proper color when the long axis is inverted. One of the issues is that the extensions are created immediately upon colorbar creation, but not updated with new draws. This adds a callback listener on xlim/ylim changes for the colorbar axes to redraw the extensions, so it is a bit unfortunate in that sense, but not too bad.

Closes #22052

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
