### PR TITLE
ENH: MacOSX backend to use sRGB instead of GenericRGB colorspace

### DIFF
--- a/doc/api/next_api_changes/behavior/22639-RA.rst
+++ b/doc/api/next_api_changes/behavior/22639-RA.rst
@@ -1,0 +1,5 @@
+MacOSX backend to use sRGB instead of GenericRGB colorspace
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+MacOSX backend now display sRGB tagged image instead of GenericRGB which is
+an older (now deprecated) Apple colorspace. This is the source colorspace
+used by ColorSync to convert to the current display profile.

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1205,7 +1205,7 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     const size_t bitsPerPixel = bitsPerComponent * nComponents;
     const size_t bytesPerRow = nComponents * bytesPerComponent * ncols;
 
-    CGColorSpaceRef colorspace = CGColorSpaceCreateWithName(kCGColorSpaceGenericRGB);
+    CGColorSpaceRef colorspace = CGColorSpaceCreateWithName(kCGColorSpaceSRGB);
     if (!colorspace) {
         _buffer_release(buffer, NULL, 0);
         return 1;


### PR DESCRIPTION
## PR Summary

Closes #22638.