### PR TITLE
Manual backport of pr 22635 on v3.5.x

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -449,6 +449,7 @@ class Colorbar:
         self.filled = filled
         self.extendfrac = extendfrac
         self.extendrect = extendrect
+        self._extend_patches = []
         self.solids = None
         self.solids_patches = []
         self.lines = []
@@ -509,6 +510,11 @@ class Colorbar:
             setattr(self.ax, x, getattr(self, x))
         # Set the cla function to the cbar's method to override it
         self.ax.cla = self._cbar_cla
+        # Callbacks for the extend calculations to handle inverting the axis
+        self._extend_cid1 = self.ax.callbacks.connect(
+            "xlim_changed", self._do_extends)
+        self._extend_cid2 = self.ax.callbacks.connect(
+            "ylim_changed", self._do_extends)
 
     def _cbar_cla(self):
         """Function to clear the interactive colorbar state."""
@@ -574,17 +580,20 @@ class Colorbar:
         # extensions:
         self.vmin, self.vmax = self._boundaries[self._inside][[0, -1]]
         # Compute the X/Y mesh.
-        X, Y, extendlen = self._mesh()
+        X, Y = self._mesh()
         # draw the extend triangles, and shrink the inner axes to accommodate.
         # also adds the outline path to self.outline spine:
-        self._do_extends(extendlen)
-
+        self._do_extends()
+        lower, upper = self.vmin, self.vmax
+        if self._long_axis().get_inverted():
+            # If the axis is inverted, we need to swap the vmin/vmax
+            lower, upper = upper, lower
         if self.orientation == 'vertical':
             self.ax.set_xlim(0, 1)
-            self.ax.set_ylim(self.vmin, self.vmax)
+            self.ax.set_ylim(lower, upper)
         else:
             self.ax.set_ylim(0, 1)
-            self.ax.set_xlim(self.vmin, self.vmax)
+            self.ax.set_xlim(lower, upper)
 
         # set up the tick locators and formatters.  A bit complicated because
         # boundary norms + uniform spacing requires a manual locator.
@@ -637,12 +646,19 @@ class Colorbar:
             patches.append(patch)
         self.solids_patches = patches
 
-    def _do_extends(self, extendlen):
+    def _do_extends(self, ax=None):
         """
         Add the extend tri/rectangles on the outside of the axes.
+
+        ax is unused, but required due to the callbacks on xlim/ylim changed
         """
+        # Clean up any previous extend patches
+        for patch in self._extend_patches:
+            patch.remove()
+        self._extend_patches = []
         # extend lengths are fraction of the *inner* part of colorbar,
         # not the total colorbar:
+        _, extendlen = self._proportional_y()
         bot = 0 - (extendlen[0] if self._extend_lower() else 0)
         top = 1 + (extendlen[1] if self._extend_upper() else 0)
 
@@ -684,12 +700,17 @@ class Colorbar:
             if self.orientation == 'horizontal':
                 xy = xy[:, ::-1]
             # add the patch
-            color = self.cmap(self.norm(self._values[0]))
+            val = -1 if self._long_axis().get_inverted() else 0
+            color = self.cmap(self.norm(self._values[val]))
             patch = mpatches.PathPatch(
                 mpath.Path(xy), facecolor=color, linewidth=0,
                 antialiased=False, transform=self.ax.transAxes,
-                hatch=hatches[0], clip_on=False)
+                hatch=hatches[0], clip_on=False,
+                # Place it right behind the standard patches, which is
+                # needed if we updated the extends
+                zorder=np.nextafter(self.ax.patch.zorder, -np.inf))
             self.ax.add_patch(patch)
+            self._extend_patches.append(patch)
         if self._extend_upper():
             if not self.extendrect:
                 # triangle
@@ -700,12 +721,17 @@ class Colorbar:
             if self.orientation == 'horizontal':
                 xy = xy[:, ::-1]
             # add the patch
-            color = self.cmap(self.norm(self._values[-1]))
+            val = 0 if self._long_axis().get_inverted() else -1
+            color = self.cmap(self.norm(self._values[val]))
             patch = mpatches.PathPatch(
                 mpath.Path(xy), facecolor=color,
                 linewidth=0, antialiased=False,
-                transform=self.ax.transAxes, hatch=hatches[-1], clip_on=False)
+                transform=self.ax.transAxes, hatch=hatches[-1], clip_on=False,
+                # Place it right behind the standard patches, which is
+                # needed if we updated the extends
+                zorder=np.nextafter(self.ax.patch.zorder, -np.inf))
             self.ax.add_patch(patch)
+            self._extend_patches.append(patch)
         return
 
     def add_lines(self, *args, **kwargs):
@@ -1024,6 +1050,9 @@ class Colorbar:
         self.mappable.callbacks.disconnect(self.mappable.colorbar_cid)
         self.mappable.colorbar = None
         self.mappable.colorbar_cid = None
+        # Remove the extension callbacks
+        self.ax.callbacks.disconnect(self._extend_cid1)
+        self.ax.callbacks.disconnect(self._extend_cid2)
 
         try:
             ax = self.mappable.axes
@@ -1133,19 +1162,23 @@ class Colorbar:
         norm = copy.deepcopy(self.norm)
         norm.vmin = self.vmin
         norm.vmax = self.vmax
-        y, extendlen = self._proportional_y()
-        # invert:
-        if (isinstance(norm, (colors.BoundaryNorm, colors.NoNorm)) or
-                self.boundaries is not None):
-            y = y * (self.vmax - self.vmin) + self.vmin  # not using a norm.
+        y, _ = self._proportional_y()
+        # Use the vmin and vmax of the colorbar, which may not be the same
+        # as the norm. There are situations where the colormap has a
+        # narrower range than the colorbar and we want to accommodate the
+        # extra contours.
+        if (isinstance(norm, (colors.BoundaryNorm, colors.NoNorm))
+                or self.boundaries is not None):
+            # not using a norm.
+            y = y * (self.vmax - self.vmin) + self.vmin
         else:
             y = norm.inverse(y)
         self._y = y
         X, Y = np.meshgrid([0., 1.], y)
         if self.orientation == 'vertical':
-            return (X, Y, extendlen)
+            return (X, Y)
         else:
-            return (Y, X, extendlen)
+            return (Y, X)
 
     def _forward_boundaries(self, x):
         # map boundaries equally between 0 and 1...
@@ -1292,11 +1325,13 @@ class Colorbar:
 
     def _extend_lower(self):
         """Return whether the lower limit is open ended."""
-        return self.extend in ('both', 'min')
+        minmax = "max" if self._long_axis().get_inverted() else "min"
+        return self.extend in ('both', minmax)
 
     def _extend_upper(self):
         """Return whether the upper limit is open ended."""
-        return self.extend in ('both', 'max')
+        minmax = "min" if self._long_axis().get_inverted() else "max"
+        return self.extend in ('both', minmax)
 
     def _long_axis(self):
         """Return the long axis"""

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -124,6 +124,30 @@ def test_colorbar_extension_length():
     _colorbar_extension_length('proportional')
 
 
+@pytest.mark.parametrize("orientation", ["horizontal", "vertical"])
+@pytest.mark.parametrize("extend,expected", [("min", (0, 0, 0, 1)),
+                                             ("max", (1, 1, 1, 1)),
+                                             ("both", (1, 1, 1, 1))])
+def test_colorbar_extension_inverted_axis(orientation, extend, expected):
+    """Test extension color with an inverted axis"""
+    data = np.arange(12).reshape(3, 4)
+    fig, ax = plt.subplots()
+    cmap = plt.get_cmap("viridis").with_extremes(under=(0, 0, 0, 1),
+                                                 over=(1, 1, 1, 1))
+    im = ax.imshow(data, cmap=cmap)
+    cbar = fig.colorbar(im, orientation=orientation, extend=extend)
+    if orientation == "horizontal":
+        cbar.ax.invert_xaxis()
+    else:
+        cbar.ax.invert_yaxis()
+    assert cbar._extend_patches[0].get_facecolor() == expected
+    if extend == "both":
+        assert len(cbar._extend_patches) == 2
+        assert cbar._extend_patches[1].get_facecolor() == (0, 0, 0, 1)
+    else:
+        assert len(cbar._extend_patches) == 1
+
+
 @pytest.mark.parametrize('use_gridspec', [True, False])
 @image_comparison(['cbar_with_orientation',
                    'cbar_locationing',


### PR DESCRIPTION
## PR Summary

Manual backport of PR #22635

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
