### PR TITLE
BLD: require packaging in setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -304,6 +304,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "numpy>=1.19",
         "setuptools_scm>=4",
         "setuptools_scm_git_archive",
+        "packaging>=20.0",
     ],
     install_requires=[
         "cycler>=0.10",

--- a/setupext.py
+++ b/setupext.py
@@ -14,8 +14,8 @@ import sysconfig
 import tarfile
 import textwrap
 import urllib.request
-from packaging import version
 
+from packaging import version
 from setuptools import Distribution, Extension
 
 _log = logging.getLogger(__name__)


### PR DESCRIPTION
Closes #22648

## PR Summary

#22429 added a setup-time dependency on packaging that we missed on CI due to packaging also being a run-time dependency which is otherwise installed.

This should be combined with https://github.com/matplotlib/matplotlib/pull/22647 when backported.