### PR TITLE
Fix new leak in ft2font introduced in #22604

### DIFF
--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -291,7 +291,7 @@ exit:
             return 1;  // Non-zero signals error, when count == 0.
         }
     }
-    return PyLong_AsUnsignedLong(PyLong_FromSsize_t(n_read));
+    return (unsigned long)n_read;
 }
 
 static void close_file_callback(FT_Stream stream)


### PR DESCRIPTION
## PR Summary

As noted at https://github.com/matplotlib/matplotlib/pull/22604#discussion_r821118057

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).