### PR TITLE
Simplify FreeType version check to avoid packaging

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -14,7 +14,6 @@ import sysconfig
 import tarfile
 import textwrap
 import urllib.request
-from packaging import version
 
 from setuptools import Distribution, Extension
 
@@ -699,8 +698,7 @@ class FreeType(SetupPackage):
             # Freetype 2.10.0+ support static builds.
             msbuild_config = (
                 "Release Static"
-                if version.parse(LOCAL_FREETYPE_VERSION) >=
-                   version.parse("2.10.0")
+                if [*map(int, LOCAL_FREETYPE_VERSION.split("."))] >= [2, 10]
                 else "Release"
             )
 


### PR DESCRIPTION
## PR Summary

Closes #22648

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).