### PR TITLE
Update deprecated vmImage 'vs2017-win2016' in azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -57,13 +57,13 @@ stages:
             vmImage: 'macOS-latest'
             python.version: '3.10'
           Windows_py38:
-            vmImage: 'windows-latest'
+            vmImage: 'windows-2019'  # keep one job pinned to the oldest image
             python.version: '3.8'
           Windows_py39:
             vmImage: 'windows-latest'
             python.version: '3.9'
           Windows_py310:
-            vmImage: 'vs2017-win2016'
+            vmImage: 'windows-latest'
             python.version: '3.10'
         maxParallel: 4
       pool:


### PR DESCRIPTION
## PR Summary

https://devblogs.microsoft.com/devops/hosted-pipelines-image-deprecation/#windows says that 'vs2017-win2016' will likely work with 'windows-2019' as well.

This changes from VisualStudio 2017 to VisualStudio 2019. Not sure if that's a problem. Lets's see.

N.b. 'windows-2019' is the same as 'windows-latest', and the py38 and py39 builds use the latter. Is there a reason that we pin the version here?

