### PR TITLE
Tweak colorbar_placement example.

### DIFF
--- a/examples/subplots_axes_and_figures/colorbar_placement.py
+++ b/examples/subplots_axes_and_figures/colorbar_placement.py
@@ -23,7 +23,6 @@ for col in range(2):
         pcm = ax.pcolormesh(np.random.random((20, 20)) * (col + 1),
                             cmap=cmaps[col])
         fig.colorbar(pcm, ax=ax)
-plt.show()
 
 ######################################################################
 # The first column has the same type of data in both rows, so it may
@@ -38,7 +37,6 @@ for col in range(2):
         pcm = ax.pcolormesh(np.random.random((20, 20)) * (col + 1),
                             cmap=cmaps[col])
     fig.colorbar(pcm, ax=axs[:, col], shrink=0.6)
-plt.show()
 
 ######################################################################
 # Relatively complicated colorbar layouts are possible using this
@@ -53,7 +51,6 @@ fig.colorbar(pcm, ax=axs[0, :2], shrink=0.6, location='bottom')
 fig.colorbar(pcm, ax=[axs[0, 2]], location='bottom')
 fig.colorbar(pcm, ax=axs[1:, :], location='right', shrink=0.6)
 fig.colorbar(pcm, ax=[axs[2, 1]], location='left')
-plt.show()
 
 ######################################################################
 # Colorbars with fixed-aspect-ratio axes
@@ -75,7 +72,6 @@ for col in range(2):
             ax.set_aspect(1/2)
         if row == 1:
             fig.colorbar(pcm, ax=ax, shrink=0.6)
-plt.show()
 
 ######################################################################
 # One way around this issue is to use an `.Axes.inset_axes` to locate the
@@ -94,6 +90,7 @@ for col in range(2):
         else:
             ax.set_aspect(1/2)
         if row == 1:
-            cax = ax.inset_axes([1.04, 0.2, 0.05, 0.6], transform=ax.transAxes)
+            cax = ax.inset_axes([1.04, 0.2, 0.05, 0.6])
             fig.colorbar(pcm, ax=ax, cax=cax)
+
 plt.show()


### PR DESCRIPTION
- No need to plt.show() after every block; this makes running the
  example from the command line easier.
- inset_axes defaults to transAxes, no need to pass that explicitly.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
