### PR TITLE
Add missing space before : for parameters

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -172,7 +172,7 @@ class ColormapRegistry(Mapping):
         name : str, optional
             The name for the colormap. If not given, ``cmap.name`` is used.
 
-        force: bool, default: False
+        force : bool, default: False
             If False, a ValueError is raised if trying to overwrite an already
             registered name. True supports overwriting registered colormaps
             other than the builtin colormaps.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -400,7 +400,7 @@ def to_hex(c, keep_alpha=False):
     ----------
     c : :doc:`color </tutorials/colors/colors>` or `numpy.ma.masked`
 
-    keep_alpha: bool, default: False
+    keep_alpha : bool, default: False
       If False, use the ``#rrggbb`` format, otherwise use ``#rrggbbaa``.
 
     Returns

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2330,11 +2330,11 @@ class Figure(FigureBase):
 
         Parameters
         ----------
-        layout: {'constrained', 'tight'} or `~.LayoutEngine`
+        layout : {'constrained', 'tight'} or `~.LayoutEngine`
             'constrained' will use `~.ConstrainedLayoutEngine`, 'tight' will
             use `~.TightLayoutEngine`.  Users and libraries can define their
             own layout engines as well.
-        kwargs: dict
+        kwargs : dict
             The keyword arguments are passed to the layout engine to set things
             like padding and margin sizes.  Only used if *layout* is a string.
         """

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1394,13 +1394,13 @@ class FancyArrow(Polygon):
         dx, dy : float or None, default: None
             The length of the arrow along x and y direction.
 
-        width: float or None, default: None
+        width : float or None, default: None
             Width of full arrow tail.
 
-        head_width: float or None, default: None
+        head_width : float or None, default: None
             Total width of the full arrow head.
 
-        head_length: float or None, default: None
+        head_length : float or None, default: None
             Length of arrow head.
         """
         if x is not None:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1691,7 +1691,7 @@ class MultiCursor(Widget):
     horizOn : bool, default: False
         Whether to draw the horizontal line.
 
-    vertOn: bool, default: True
+    vertOn : bool, default: True
         Whether to draw the vertical line.
 
     Other Parameters


### PR DESCRIPTION
## PR Summary

A number of parameters were missing a space before the :, which affects the rendering.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
