### PR TITLE
Deprecate in testing.decorators 

### DIFF
--- a/doc/api/next_api_changes/deprecations/22697-OG.rst
+++ b/doc/api/next_api_changes/deprecations/22697-OG.rst
@@ -1,0 +1,9 @@
+Deprecations in ``testing.decorators``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The unused class ``CleanupTestCase`` and decorator ``cleanup`` are deprecated
+and will be removed. Vendor the code, including the private function
+``_cleanup_cm``.
+
+The function ``check_freetype_version`` is considered internal and deprecated.
+Vendor the code of the private function ``_check_freetype_version``.

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -14,7 +14,8 @@ from packaging.version import parse as parse_version
 import matplotlib.style
 import matplotlib.units
 import matplotlib.testing
-from matplotlib import cbook, ft2font, pyplot as plt, ticker, _pylab_helpers
+from matplotlib import (_api, _pylab_helpers, cbook, ft2font, pyplot as plt,
+                        ticker)
 from .compare import comparable_formats, compare_images, make_test_filename
 from .exceptions import ImageComparisonFailure
 
@@ -31,6 +32,8 @@ def _cleanup_cm():
         plt.close("all")
 
 
+@_api.deprecated("3.6", alternative="Vendor the existing code, "
+                 "including the private function _cleanup_cm.")
 class CleanupTestCase(unittest.TestCase):
     """A wrapper for unittest.TestCase that includes cleanup operations."""
     @classmethod
@@ -42,6 +45,8 @@ class CleanupTestCase(unittest.TestCase):
         cls._cm.__exit__(None, None, None)
 
 
+@_api.deprecated("3.6", alternative="Vendor the existing code, "
+                 "including the private function _cleanup_cm.")
 def cleanup(style=None):
     """
     A decorator to ensure that any global state is reset before
@@ -83,7 +88,13 @@ def cleanup(style=None):
         return make_cleanup
 
 
+@_api.deprecated("3.6", alternative="Vendor the existing code "
+                 "of _check_freetype_version.")
 def check_freetype_version(ver):
+    return _check_freetype_version(ver)
+
+
+def _check_freetype_version(ver):
     if ver is None:
         return True
 
@@ -98,7 +109,7 @@ def check_freetype_version(ver):
 def _checked_on_freetype_version(required_freetype_version):
     import pytest
     return pytest.mark.xfail(
-        not check_freetype_version(required_freetype_version),
+        not _check_freetype_version(required_freetype_version),
         reason=f"Mismatched version of freetype. "
                f"Test requires '{required_freetype_version}', "
                f"you have '{ft2font.__freetype_version__}'",


### PR DESCRIPTION
## PR Summary

`CleanupUnitTest` and the `cleanup` decorator are not used. 

`check_freetype_version` is only used inside the file so makes sense to make private.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
