### PR TITLE
Proof of concept for adding kwdoc content to properties using a decorator

### DIFF
--- a/lib/matplotlib/_docstring.py
+++ b/lib/matplotlib/_docstring.py
@@ -3,6 +3,34 @@ import inspect
 from . import _api
 
 
+def kwarg_doc(text):
+    """
+    Decorator for defining the kwdoc documentation of artist properties.
+
+    This decorator can be applied to artist property setter methods.
+    The given text is stored in a privat attribute ``_kwarg_doc`` on
+    the method.  It is used to overwrite auto-generated documentation
+    in the *kwdoc list* for artists. The kwdoc list is used to document
+    ``**kwargs`` when they are properties of an artist. See e.g. the
+    ``**kwargs`` section in `.Axes.text`.
+
+    The text should contain the supported types as well as the default value
+    if applicable, e.g.:
+
+        @_docstring.kwarg_doc("bool, default: :rc:`text.usetex`")
+        def set_usetex(self, usetex):
+
+    See Also
+    --------
+    matplotlib.artist.kwdoc
+
+    """
+    def decorator(func):
+        func._kwarg_doc = text
+        return func
+    return decorator
+
+
 class Substitution:
     """
     A decorator that performs %-substitution on an object's docstring.

--- a/lib/matplotlib/_docstring.pyi
+++ b/lib/matplotlib/_docstring.pyi
@@ -4,6 +4,9 @@ from typing import Any, Callable, TypeVar, overload
 _T = TypeVar('_T')
 
 
+def kwarg_doc(text: str) -> Callable[[_T], _T]: ...
+
+
 class Substitution:
     @overload
     def __init__(self, *args: str): ...

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1482,6 +1482,9 @@ class ArtistInspector:
             raise AttributeError(f'{self.o} has no function {name}')
         func = getattr(self.o, name)
 
+        if hasattr(func, '_kwarg_doc'):
+            return func._kwarg_doc
+
         docstring = inspect.getdoc(func)
         if docstring is None:
             return 'unknown'

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1314,6 +1314,7 @@ class Text(Artist):
         self._fontproperties = FontProperties._from_any(fp).copy()
         self.stale = True
 
+    @_docstring.kwarg_doc("bool, default: :rc:`text.usetex`")
     def set_usetex(self, usetex):
         """
         Parameters


### PR DESCRIPTION
## PR Summary

As discussed in today's dev call. The effect is visible in the `Axes.text` docstring:

![grafik](https://user-images.githubusercontent.com/2836374/160026258-d8edc69c-b3fb-421b-84e9-216c3eb99996.png)


### Performance prognosis

I slightly underestimated the number of artist properties we have. Instead of a few hundred, we have 4119 artist properties. :astonished:. Anyway, using a string given via the decorator should be significantly faster than scraping the docstring for such info. I'm 99.9% certain we won't have longer import times due to the decorator mechanism.

### Feedback is welcome before I start to roll this out massively.

