### PR TITLE
MAINT: Move docstring of `LogLocator` to class

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2255,35 +2255,37 @@ def _is_close_to_int(x):
 
 class LogLocator(Locator):
     """
-    Determine the tick locations for log axes
+
+    Determine the tick locations for log axes.
+
+    Place ticks on the locations : ``subs[j] * base**i``
+
+    Parameters
+    ----------
+    base : float, default: 10.0
+        The base of the log used, so major ticks are placed at
+        ``base**n``, where ``n`` is an integer.
+    subs : None or {'auto', 'all'} or sequence of float, default: (1.0,)
+        Gives the multiples of integer powers of the base at which
+        to place ticks.  The default of ``(1.0, )`` places ticks only at
+        integer powers of the base.
+        Permitted string values are ``'auto'`` and ``'all'``.
+        Both of these use an algorithm based on the axis view
+        limits to determine whether and how to put ticks between
+        integer powers of the base.  With ``'auto'``, ticks are
+        placed only between integer powers; with ``'all'``, the
+        integer powers are included.  A value of None is
+        equivalent to ``'auto'``.
+    numticks : None or int, default: None
+        The maximum number of ticks to allow on a given axis. The default
+        of ``None`` will try to choose intelligently as long as this
+        Locator has already been assigned to an axis using
+        `~.axis.Axis.get_tick_space`, but otherwise falls back to 9.
+
     """
 
     def __init__(self, base=10.0, subs=(1.0,), numdecs=4, numticks=None):
-        """
-        Place ticks at values ``subs[j] * base**n``.
-
-        Parameters
-        ----------
-        base : float, default: 10.0
-            The base of the log used, so major ticks are placed at
-            ``base**n``, where ``n`` is an integer.
-        subs : None or {'auto', 'all'} or sequence of float, default: (1.0,)
-            Gives the multiples of integer powers of the base at which
-            to place ticks.  The default of ``(1.0, )`` places ticks only at
-            integer powers of the base.
-            Permitted string values are ``'auto'`` and ``'all'``.
-            Both of these use an algorithm based on the axis view
-            limits to determine whether and how to put ticks between
-            integer powers of the base.  With ``'auto'``, ticks are
-            placed only between integer powers; with ``'all'``, the
-            integer powers are included.  A value of None is
-            equivalent to ``'auto'``.
-        numticks : None or int, default: None
-            The maximum number of ticks to allow on a given axis. The default
-            of ``None`` will try to choose intelligently as long as this
-            Locator has already been assigned to an axis using
-            `~.axis.Axis.get_tick_space`, but otherwise falls back to 9.
-        """
+        """Place ticks on the locations : subs[j] * base**i."""
         if numticks is None:
             if mpl.rcParams['_internal.classic_mode']:
                 numticks = 15


### PR DESCRIPTION
Doc string is not accessible as it is placed in `__init__` instead of class.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
