### PR TITLE
Fix the error- TypeError: 'float' object is not iterable

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1825,8 +1825,10 @@ class Axis(martist.Artist):
             For each tick, includes ``tick.label1`` if it is visible, then
             ``tick.label2`` if it is visible, in that order.
         """
-        ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
-                      for t in ticklabels]
+        ticklabels = []
+            for t in ticklabels:
+                if hasattr(t, 'get_text'):
+                    ticklabels.append(t.get_text())
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1825,13 +1825,10 @@ class Axis(martist.Artist):
             For each tick, includes ``tick.label1`` if it is visible, then
             ``tick.label2`` if it is visible, in that order.
         """
-        ticklabels = []
         try:
-            ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
-                            for t in ticklabels]
+            ticklabels = [t.get_text() if hasattr(t, 'get_text') else t for t in ticklabels]
         except TypeError:
             raise TypeError(f"{ticklabels:=} must be a sequence") from None
-    
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1827,7 +1827,7 @@ class Axis(martist.Artist):
         """
         try:
             ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
-                         for t in ticklabels]
+                          for t in ticklabels]
         except TypeError:
             raise TypeError(f"{ticklabels:=} must be a sequence") from None
         locator = (self.get_minor_locator() if minor

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1825,10 +1825,16 @@ class Axis(martist.Artist):
             For each tick, includes ``tick.label1`` if it is visible, then
             ``tick.label2`` if it is visible, in that order.
         """
+
+        
         ticklabels = []
-        for t in ticklabels:
-            if hasattr(t, 'get_text'):
-                ticklabels.append(t.get_text())
+        try:
+              ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
+                            for t in ticklabels]
+        except:
+              raise TypeError(f"{ticklabels:=} must be a sequence") from None
+    
+    
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1825,15 +1825,12 @@ class Axis(martist.Artist):
             For each tick, includes ``tick.label1`` if it is visible, then
             ``tick.label2`` if it is visible, in that order.
         """
-
-        
         ticklabels = []
         try:
-              ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
+            ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
                             for t in ticklabels]
-        except:
-              raise TypeError(f"{ticklabels:=} must be a sequence") from None
-    
+        except TypeError:
+            raise TypeError(f"{ticklabels:=} must be a sequence") from None
     
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1826,7 +1826,8 @@ class Axis(martist.Artist):
             ``tick.label2`` if it is visible, in that order.
         """
         try:
-            ticklabels = [t.get_text() if hasattr(t, 'get_text') else t for t in ticklabels]
+            ticklabels = [t.get_text() if hasattr(t, 'get_text') else t
+                         for t in ticklabels]
         except TypeError:
             raise TypeError(f"{ticklabels:=} must be a sequence") from None
         locator = (self.get_minor_locator() if minor

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1826,9 +1826,9 @@ class Axis(martist.Artist):
             ``tick.label2`` if it is visible, in that order.
         """
         ticklabels = []
-            for t in ticklabels:
-                if hasattr(t, 'get_text'):
-                    ticklabels.append(t.get_text())
+        for t in ticklabels:
+            if hasattr(t, 'get_text'):
+                ticklabels.append(t.get_text())
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if isinstance(locator, mticker.FixedLocator):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -442,6 +442,8 @@ def test_inverted_cla():
     assert not ax.xaxis_inverted()
     assert ax.yaxis_inverted()
 
+    for ax in fig.axes:
+        ax.remove()
     # 5. two shared axes. Inverting the leader axis should invert the shared
     # axes; clearing the leader axis should bring axes in shared
     # axes back to normal.
@@ -5386,6 +5388,12 @@ def test_set_ticks_with_labels(fig_test, fig_ref):
     ax.set_xticks([1, 2, 4, 6], ['a', 'b', 'c', 'd'], fontweight='bold')
     ax.set_yticks([1, 3, 5])
     ax.set_yticks([2, 4], ['A', 'B'], minor=True)
+
+
+def test_iterable_ticklabels():
+    with pytest.raises(TypeError):
+        fig, ax = plt.subplots(2)
+        ax[1].set_xticks([2, 9], 3.1)
 
 
 def test_subsampled_ticklabels():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5389,7 +5389,9 @@ def test_set_ticks_with_labels(fig_test, fig_ref):
 
 
 def test_set_noniterable_ticklabels():
-    # Ensure a useful TypeError message is raised when given a non-iterable ticklabels argument. Pull request #22710
+    # Ensure a useful TypeError message is raised
+    # when given a non-iterable ticklabels argument
+    # Pull request #22710
     with pytest.raises(TypeError, match='must be a sequence'):
         fig, ax = plt.subplots(2)
         ax[1].set_xticks([2, 9], 3.1)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -442,8 +442,6 @@ def test_inverted_cla():
     assert not ax.xaxis_inverted()
     assert ax.yaxis_inverted()
 
-    for ax in fig.axes:
-        ax.remove()
     # 5. two shared axes. Inverting the leader axis should invert the shared
     # axes; clearing the leader axis should bring axes in shared
     # axes back to normal.
@@ -5390,8 +5388,9 @@ def test_set_ticks_with_labels(fig_test, fig_ref):
     ax.set_yticks([2, 4], ['A', 'B'], minor=True)
 
 
-def test_iterable_ticklabels():
-    with pytest.raises(TypeError):
+def test_set_noniterable_ticklabels():
+    # Ensure a useful TypeError message is raised when given a non-iterable ticklabels argument. Pull request #22710
+    with pytest.raises(TypeError, match='must be a sequence'):
         fig, ax = plt.subplots(2)
         ax[1].set_xticks([2, 9], 3.1)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7614,3 +7614,4 @@ def test_bezier_autoscale():
     # Bottom ylim should be at the edge of the curve (-0.5), and not include
     # the control point (at -1)
     assert ax.get_ylim()[0] == -0.5
+    


### PR DESCRIPTION
## PR Summary

This commit fixes the issue "TypeError: 'float' object is not iterable" that I faced while training a machine learning model. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
