### PR TITLE
Use repr in error messages

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -169,25 +169,25 @@ def _process_plot_format(fmt):
         if fmt[i:i+2] in mlines.lineStyles:  # First, the two-char styles.
             if linestyle is not None:
                 raise ValueError(
-                    'Illegal format string "%s"; two linestyle symbols' % fmt)
+                    f'Illegal format string {fmt!r}; two linestyle symbols')
             linestyle = fmt[i:i+2]
             i += 2
         elif c in mlines.lineStyles:
             if linestyle is not None:
                 raise ValueError(
-                    'Illegal format string "%s"; two linestyle symbols' % fmt)
+                    f'Illegal format string {fmt!r}; two linestyle symbols')
             linestyle = c
             i += 1
         elif c in mlines.lineMarkers:
             if marker is not None:
                 raise ValueError(
-                    'Illegal format string "%s"; two marker symbols' % fmt)
+                    f'Illegal format string {fmt!r}; two marker symbols')
             marker = c
             i += 1
         elif c in mcolors.get_named_colors_mapping():
             if color is not None:
                 raise ValueError(
-                    'Illegal format string "%s"; two color symbols' % fmt)
+                    f'Illegal format string {fmt!r}; two color symbols')
             color = c
             i += 1
         elif c == 'C' and i < len(fmt) - 1:
@@ -2084,8 +2084,8 @@ class _AxesBase(martist.Artist):
                     self.set_ylim([ylim[0], ylim[0] + edge_size],
                                   emit=emit, auto=False)
             else:
-                raise ValueError('Unrecognized string %s to axis; '
-                                 'try on or off' % s)
+                raise ValueError(f"Unrecognized string {s!r} to axis; "
+                                 "try 'on' or 'off'")
         else:
             if len(args) == 1:
                 limits = args[0]

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1764,7 +1764,7 @@ class EllipseCollection(Collection):
         elif self._units == 'dots':
             sc = 1.0
         else:
-            raise ValueError('unrecognized units: %s' % self._units)
+            raise ValueError(f'Unrecognized units: {self._units!r}')
 
         self._transforms = np.zeros((len(self._widths), 3, 3))
         widths = self._widths * sc

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1469,7 +1469,7 @@ class FancyArrow(Polygon):
                     coords = np.concatenate([left_half_arrow[:-1],
                                              right_half_arrow[-2::-1]])
                 else:
-                    raise ValueError("Got unknown shape: %s" % self.shape)
+                    raise ValueError(f"Got unknown shape: {self._shape!r}")
             if distance != 0:
                 cx = self._dx / distance
                 sx = self._dy / distance
@@ -2191,12 +2191,13 @@ class _Style:
         try:
             _cls = cls._style_list[_name]
         except KeyError as err:
-            raise ValueError(f"Unknown style: {stylename}") from err
+            raise ValueError(f"Unknown style: {stylename!r}") from err
         try:
             _args_pair = [cs.split("=") for cs in _list[1:]]
             _args = {k: float(v) for k, v in _args_pair}
         except ValueError as err:
-            raise ValueError(f"Incorrect style argument: {stylename}") from err
+            raise ValueError(
+                f"Incorrect style argument: {stylename!r}") from err
         return _cls(**{**_args, **kwargs})
 
     @classmethod

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -146,7 +146,7 @@ def validate_bool(b):
     elif b in ('f', 'n', 'no', 'off', 'false', '0', 0, False):
         return False
     else:
-        raise ValueError('Could not convert "%s" to bool' % b)
+        raise ValueError(f'Cannot convert {b!r} to bool')
 
 
 def validate_axisbelow(s):
@@ -156,8 +156,8 @@ def validate_axisbelow(s):
         if isinstance(s, str):
             if s == 'line':
                 return 'line'
-    raise ValueError('%s cannot be interpreted as'
-                     ' True, False, or "line"' % s)
+    raise ValueError(f'{s!r} cannot be interpreted as'
+                     ' True, False, or "line"')
 
 
 def validate_dpi(s):
@@ -739,14 +739,14 @@ def validate_cycler(s):
             _DunderChecker().visit(ast.parse(s))
             s = eval(s, {'cycler': cycler, '__builtins__': {}})
         except BaseException as e:
-            raise ValueError("'%s' is not a valid cycler construction: %s" %
-                             (s, e)) from e
+            raise ValueError(f"{s!r} is not a valid cycler construction: {e}"
+                             ) from e
     # Should make sure what comes from the above eval()
     # is a Cycler object.
     if isinstance(s, Cycler):
         cycler_inst = s
     else:
-        raise ValueError("object was not a string or Cycler instance: %s" % s)
+        raise ValueError(f"Object is not a string or Cycler instance: {s!r}")
 
     unknowns = cycler_inst.keys - (set(_prop_validators) | set(_prop_aliases))
     if unknowns:

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -183,7 +183,7 @@ def _option_boolean(arg):
     elif arg.strip().lower() in ('yes', '1', 'true'):
         return True
     else:
-        raise ValueError('"%s" unknown boolean' % arg)
+        raise ValueError(f'{arg!r} unknown boolean')
 
 
 def _option_context(arg):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5095,7 +5095,8 @@ def test_shared_aspect_error():
                            r"axis\(\) takes 0 or 1 positional arguments but 2"
                            " were given"),
                           (ValueError, ('foo', ), {},
-                           "Unrecognized string foo to axis; try on or off"),
+                           "Unrecognized string 'foo' to axis; try 'on' or "
+                           "'off'"),
                           (TypeError, ([1, 2], ), {},
                            "the first argument to axis*"),
                           (TypeError, tuple(), {'foo': None},
@@ -7572,6 +7573,19 @@ def test_empty_line_plots():
     _, ax = plt.subplots()
     line = ax.plot([], [])
     assert len(line) == 1
+
+
+@pytest.mark.parametrize('fmt, match', (
+    ("foo", "Unrecognized character f in format string 'foo'"),
+    ("o+", "Illegal format string 'o\\+'; two marker symbols"),
+    (":-", "Illegal format string ':-'; two linestyle symbols"),
+    ("rk", "Illegal format string 'rk'; two color symbols"),
+    (":o-r", "Illegal format string ':o-r'; two linestyle symbols"),
+))
+def test_plot_format_errors(fmt, match):
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match=match):
+        ax.plot((0, 0), fmt)
 
 
 def test_clim():

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -7,7 +7,7 @@ import pytest
 
 import matplotlib as mpl
 from matplotlib.patches import (Annulus, Ellipse, Patch, Polygon, Rectangle,
-                                FancyArrowPatch)
+                                FancyArrowPatch, FancyArrow, BoxStyle)
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.transforms import Bbox
 import matplotlib.pyplot as plt
@@ -690,6 +690,20 @@ def test_rotated_arcs():
         ax.axvline(0, color="k")
         ax.set_axis_off()
         ax.set_aspect("equal")
+
+
+def test_fancyarrow_shape_error():
+    with pytest.raises(ValueError, match="Got unknown shape: 'foo'"):
+        FancyArrow(0, 0, 0.2, 0.2, shape='foo')
+
+
+@pytest.mark.parametrize('fmt, match', (
+    ("foo", "Unknown style: 'foo'"),
+    ("Round,foo", "Incorrect style argument: 'Round,foo'"),
+))
+def test_boxstyle_errors(fmt, match):
+    with pytest.raises(ValueError, match=match):
+        BoxStyle(fmt)
 
 
 @image_comparison(baseline_images=['annulus'], extensions=['png'])

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -251,6 +251,21 @@ def test_annotation_contains():
     assert ann.contains(event) == (False, {})
 
 
+@pytest.mark.parametrize('err, xycoords, match', (
+    (RuntimeError, print, "Unknown return type"),
+    (RuntimeError, [0, 0], r"Unknown coordinate type: \[0, 0\]"),
+    (ValueError, "foo", "'foo' is not a recognized coordinate"),
+    (ValueError, "foo bar", "'foo bar' is not a recognized coordinate"),
+    (ValueError, "offset foo", "xycoords cannot be an offset coordinate"),
+    (ValueError, "axes foo", "'foo' is not a recognized unit"),
+))
+def test_annotate_errors(err, xycoords, match):
+    fig, ax = plt.subplots()
+    with pytest.raises(err, match=match):
+        ax.annotate('xy', (0, 0), xytext=(0.5, 0.5), xycoords=xycoords)
+        fig.canvas.draw()
+
+
 @image_comparison(['titles'])
 def test_titles():
     # left and right side titles

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1466,7 +1466,7 @@ class _AnnotationBase:
 
         s_ = s.split()
         if len(s_) != 2:
-            raise ValueError("%s is not a recognized coordinate" % s)
+            raise ValueError(f"{s!r} is not a recognized coordinate")
 
         bbox0, xy0 = None, None
 
@@ -1506,12 +1506,12 @@ class _AnnotationBase:
                 w, h = bbox0.size
                 tr = Affine2D().scale(w, h)
             else:
-                raise ValueError("%s is not a recognized coordinate" % s)
+                raise ValueError(f"{unit!r} is not a recognized unit")
 
             return tr.translate(ref_x, ref_y)
 
         else:
-            raise ValueError("%s is not a recognized coordinate" % s)
+            raise ValueError(f"{s!r} is not a recognized coordinate")
 
     def _get_ref_xy(self, renderer):
         """


### PR DESCRIPTION
## PR Summary

Related to  #21959

Added tests for some of the errors.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
