### PR TITLE
Fix incorrect deprecation warning

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -58,7 +58,7 @@ class StrCategoryConverter(units.ConversionInterface):
             is_numlike = all(units.ConversionInterface.is_numlike(v)
                              and not isinstance(v, (str, bytes))
                              for v in values)
-        if is_numlike:
+        if values.size and is_numlike:
             _api.warn_deprecated(
                 "3.5", message="Support for passing numbers through unit "
                 "converters is deprecated since %(since)s and support will be "
@@ -230,7 +230,7 @@ class UnitData:
                 convertible = self._str_is_convertible(val)
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
-        if convertible:
+        if data.size and convertible:
             _log.info('Using categorical units to plot a list of strings '
                       'that are all parsable as floats or dates. If these '
                       'strings should be plotted as numbers, cast to the '

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -307,6 +307,15 @@ def test_overriding_units_in_plot(fig_test, fig_ref):
         assert y_units is ax.yaxis.units
 
 
+def test_no_deprecation_on_empty_data():
+    """
+    Smoke test to check that no deprecation warning is emitted. See #22640.
+    """
+    f, ax = plt.subplots()
+    ax.xaxis.update_units(["a", "b"])
+    ax.plot([], [])
+
+
 def test_hist():
     fig, ax = plt.subplots()
     n, bins, patches = ax.hist(['a', 'b', 'a', 'c', 'ff'])


### PR DESCRIPTION
## PR Summary
Closes  #22640

Simple fix based on @anntzer's suggestion. Seems to get rid of the deprecation warning if nothing else. 

Makes sense to get it in for 3.5.2? (As it is caused by a change in 3.5 if I understand it correctly.)

Should I add a smoke test for it?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
