### PR TITLE
Fix removed cross-references

### DIFF
--- a/doc/api/prev_api_changes/api_changes_0.91.0.rst
+++ b/doc/api/prev_api_changes/api_changes_0.91.0.rst
@@ -31,7 +31,7 @@ Changes for 0.91.0
   files. In the future the class might actually parse the font to
   allow e.g.,  subsetting.
 
-* :mod:`matplotlib.ft2font` now supports ``FT_Attach_File``. In
+* ``matplotlib.ft2font`` now supports ``FT_Attach_File``. In
   practice this can be used to read an afm file in addition to a
   pfa/pfb file, to get metrics and kerning information for a Type 1
   font.

--- a/doc/api/prev_api_changes/api_changes_0.98.x.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.x.rst
@@ -87,13 +87,13 @@ Changes for 0.98.x
   :class:`~matplotlib.collections.Collection` base class.
 
 * ``matplotlib.figure.Figure.figurePatch`` renamed
-  :attr:`matplotlib.figure.Figure.patch`;
+  ``matplotlib.figure.Figure.patch``;
   ``matplotlib.axes.Axes.axesPatch`` renamed
-  :attr:`matplotlib.axes.Axes.patch`;
+  ``matplotlib.axes.Axes.patch``;
   ``matplotlib.axes.Axes.axesFrame`` renamed
-  :attr:`matplotlib.axes.Axes.frame`.
+  ``matplotlib.axes.Axes.frame``.
   ``matplotlib.axes.Axes.get_frame``, which returns
-  :attr:`matplotlib.axes.Axes.patch`, is deprecated.
+  ``matplotlib.axes.Axes.patch``, is deprecated.
 
 * Changes in the :class:`matplotlib.contour.ContourLabeler` attributes
   (:func:`matplotlib.pyplot.clabel` function) so that they all have a

--- a/doc/api/prev_api_changes/api_changes_0.99.x.rst
+++ b/doc/api/prev_api_changes/api_changes_0.99.x.rst
@@ -21,8 +21,8 @@ Changes beyond 0.99.x
     on or off, and applies it.
 
   + :meth:`matplotlib.axes.Axes.margins` sets margins used to
-    autoscale the :attr:`matplotlib.axes.Axes.viewLim` based on
-    the :attr:`matplotlib.axes.Axes.dataLim`.
+    autoscale the ``matplotlib.axes.Axes.viewLim`` based on
+    the ``matplotlib.axes.Axes.dataLim``.
 
   + :meth:`matplotlib.axes.Axes.locator_params` allows one to
     adjust axes locator parameters such as *nbins*.

--- a/doc/api/prev_api_changes/api_changes_1.3.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.3.x.rst
@@ -33,7 +33,7 @@ Code removal
       functionality on `matplotlib.path.Path.contains_point` and
       friends instead.
 
-    - Instead of ``axes.Axes.get_frame``, use `.axes.Axes.patch`.
+    - Instead of ``axes.Axes.get_frame``, use ``axes.Axes.patch``.
 
     - The following keyword arguments to the `~.axes.Axes.legend` function have
       been renamed:
@@ -102,7 +102,7 @@ Code deprecation
   be used.  In previous Matplotlib versions this attribute was an undocumented
   tuple of ``(colorbar_instance, colorbar_axes)`` but is now just
   ``colorbar_instance``.  To get the colorbar axes it is possible to just use
-  the :attr:`~matplotlib.colorbar.ColorbarBase.ax` attribute on a colorbar
+  the ``matplotlib.colorbar.ColorbarBase.ax`` attribute on a colorbar
   instance.
 
 * The ``matplotlib.mpl`` module is now deprecated.  Those who relied on this

--- a/doc/api/prev_api_changes/api_changes_1.4.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.4.x.rst
@@ -82,7 +82,7 @@ original location:
 
 * The artist used to draw the outline of a `.Figure.colorbar` has been changed
   from a `matplotlib.lines.Line2D` to `matplotlib.patches.Polygon`, thus
-  `.colorbar.ColorbarBase.outline` is now a `matplotlib.patches.Polygon`
+  ``colorbar.ColorbarBase.outline`` is now a `matplotlib.patches.Polygon`
   object.
 
 * The legend handler interface has changed from a callable, to any object

--- a/doc/api/prev_api_changes/api_changes_1.5.0.rst
+++ b/doc/api/prev_api_changes/api_changes_1.5.0.rst
@@ -41,7 +41,7 @@ fully delegate to `.Quiver`).  Previously any input matching 'mid.*' would be
 interpreted as 'middle', 'tip.*' as 'tip' and any string not matching one of
 those patterns as 'tail'.
 
-The value of `.Quiver.pivot` is normalized to be in the set {'tip', 'tail',
+The value of ``Quiver.pivot`` is normalized to be in the set {'tip', 'tail',
 'middle'} in `.Quiver`.
 
 Reordered ``Axes.get_children``
@@ -116,10 +116,10 @@ In either case to update the data in the `.Line2D` object you must update
 both the ``x`` and ``y`` data.
 
 
-Removed *args* and *kwargs* from `.MicrosecondLocator.__call__`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Removed *args* and *kwargs* from ``MicrosecondLocator.__call__``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The call signature of :meth:`~matplotlib.dates.MicrosecondLocator.__call__`
+The call signature of ``matplotlib.dates.MicrosecondLocator.__call__``
 has changed from ``__call__(self, *args, **kwargs)`` to ``__call__(self)``.
 This is consistent with the superclass :class:`~matplotlib.ticker.Locator`
 and also all the other Locators derived from this superclass.

--- a/doc/api/prev_api_changes/api_changes_2.2.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.2.0.rst
@@ -74,7 +74,7 @@ rcParam.
 Deprecated ``Axis.unit_data``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use `.Axis.units` (which has long existed) instead.
+Use ``Axis.units`` (which has long existed) instead.
 
 
 Removals
@@ -198,11 +198,11 @@ Changes to Qt backend class MRO
 
 To support both Agg and cairo rendering for Qt backends all of the non-Agg
 specific code previously in ``backend_qt5agg.FigureCanvasQTAggBase`` has been
-moved to :class:`.backend_qt5.FigureCanvasQT` so it can be shared with the
+moved to ``backend_qt5.FigureCanvasQT`` so it can be shared with the
 cairo implementation.  The ``FigureCanvasQTAggBase.paintEvent``,
 ``FigureCanvasQTAggBase.blit``, and ``FigureCanvasQTAggBase.print_figure``
-methods have moved to :meth:`.FigureCanvasQTAgg.paintEvent`,
-:meth:`.FigureCanvasQTAgg.blit`, and :meth:`.FigureCanvasQTAgg.print_figure`.
+methods have moved to ``FigureCanvasQTAgg.paintEvent``,
+``FigureCanvasQTAgg.blit``, and ``FigureCanvasQTAgg.print_figure``.
 The first two methods assume that the instance is also a ``QWidget`` so to use
 ``FigureCanvasQTAggBase`` it was required to multiple inherit from a
 ``QWidget`` sub-class.
@@ -210,9 +210,9 @@ The first two methods assume that the instance is also a ``QWidget`` so to use
 Having moved all of its methods either up or down the class hierarchy
 ``FigureCanvasQTAggBase`` has been deprecated.  To do this without warning and
 to preserve as much API as possible, ``.backend_qt5agg.FigureCanvasQTAggBase``
-now inherits from :class:`.backend_qt5.FigureCanvasQTAgg`.
+now inherits from ``backend_qt5.FigureCanvasQTAgg``.
 
-The MRO for :class:`.FigureCanvasQTAgg` and ``FigureCanvasQTAggBase`` used to
+The MRO for ``FigureCanvasQTAgg`` and ``FigureCanvasQTAggBase`` used to
 be ::
 
 

--- a/doc/api/prev_api_changes/api_changes_3.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.0.0.rst
@@ -297,7 +297,7 @@ Blacklisted rcparams no longer updated by `~matplotlib.rcdefaults`, `~matplotlib
 
 The rc modifier functions `~matplotlib.rcdefaults`,
 `~matplotlib.rc_file_defaults` and `~matplotlib.rc_file`
-now ignore rcParams in the `matplotlib.style.core.STYLE_BLACKLIST` set.  In
+now ignore rcParams in the ``matplotlib.style.core.STYLE_BLACKLIST`` set.  In
 particular, this prevents the ``backend`` and ``interactive`` rcParams from
 being incorrectly modified by these functions.
 
@@ -324,12 +324,12 @@ instead of ``\usepackage{ucs}\usepackage[utf8x]{inputenc}``.
 Return type of ArtistInspector.get_aliases changed
 --------------------------------------------------
 
-`ArtistInspector.get_aliases` previously returned the set of aliases as
+``ArtistInspector.get_aliases`` previously returned the set of aliases as
 ``{fullname: {alias1: None, alias2: None, ...}}``.  The dict-to-None mapping
 was used to simulate a set in earlier versions of Python.  It has now been
 replaced by a set, i.e. ``{fullname: {alias1, alias2, ...}}``.
 
-This value is also stored in `.ArtistInspector.aliasd`, which has likewise
+This value is also stored in ``ArtistInspector.aliasd``, which has likewise
 changed.
 
 

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -293,9 +293,9 @@ where the `.cm.ScalarMappable` passed to `matplotlib.colorbar.Colorbar`
 (`~.Figure.colorbar`) had a ``set_norm`` method, as did the colorbar.
 The colorbar is now purely a follower to the `.ScalarMappable` norm and
 colormap, and the old inherited methods
-`~matplotlib.colorbar.ColorbarBase.set_norm`,
-`~matplotlib.colorbar.ColorbarBase.set_cmap`,
-`~matplotlib.colorbar.ColorbarBase.set_clim` are deprecated, as are
+``matplotlib.colorbar.ColorbarBase.set_norm``,
+``matplotlib.colorbar.ColorbarBase.set_cmap``,
+``matplotlib.colorbar.ColorbarBase.set_clim`` are deprecated, as are
 the getter versions of those calls.  To set the norm associated with a
 colorbar do ``colorbar.mappable.set_norm()`` etc.
 
@@ -394,11 +394,11 @@ returned.
 `matplotlib.font_manager.win32InstalledFonts` returns an empty list instead
 of None if no fonts are found.
 
-`.Axes.fmt_xdata` and `.Axes.fmt_ydata` error handling
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``Axes.fmt_xdata`` and ``Axes.fmt_ydata`` error handling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, if the user provided a `.Axes.fmt_xdata` or
-`.Axes.fmt_ydata` function that raised a `TypeError` (or set them to a
+Previously, if the user provided a ``Axes.fmt_xdata`` or
+``Axes.fmt_ydata`` function that raised a `TypeError` (or set them to a
 non-callable), the exception would be silently ignored and the default
 formatter be used instead.  This is no longer the case; the exception
 is now propagated out.
@@ -476,7 +476,7 @@ Exception changes
 - `.Axes.streamplot` does not support irregularly gridded ``x`` and ``y`` values.
   So far, it used to silently plot an incorrect result.  This has been changed to
   raise a `ValueError` instead.
-- The `.streamplot.Grid` class, which is internally used by streamplot
+- The ``streamplot.Grid`` class, which is internally used by streamplot
   code, also throws a `ValueError` when irregularly gridded values are
   passed in.
 
@@ -566,7 +566,7 @@ in Matplotlib 2.2 has been removed. See below for a list:
 - ``mlab.safe_isnan`` (use `numpy.isnan` instead)
 - ``mlab.cohere_pairs`` (use `scipy.signal.coherence` instead)
 - ``mlab.entropy`` (use `scipy.stats.entropy` instead)
-- ``mlab.normpdf`` (use `scipy.stats.norm.pdf` instead)
+- ``mlab.normpdf`` (use ``scipy.stats.norm.pdf`` instead)
 - ``mlab.find`` (use ``np.nonzero(np.ravel(condition))`` instead)
 - ``mlab.longest_contiguous_ones``
 - ``mlab.longest_ones``
@@ -652,7 +652,7 @@ no longer available in the `pylab` module:
 - ``longest_ones``
 - ``movavg``
 - ``norm_flat`` (use ``numpy.linalg.norm(a.flat, ord=2)`` instead)
-- ``normpdf`` (use `scipy.stats.norm.pdf` instead)
+- ``normpdf`` (use ``scipy.stats.norm.pdf`` instead)
 - ``path_length``
 - ``poly_below``
 - ``poly_between``
@@ -705,7 +705,7 @@ now a no-op).
 
 The image comparison test decorators now skip (rather than xfail) the test for
 uncomparable formats. The affected decorators are `~.image_comparison` and
-`~.check_figures_equal`. The deprecated `~.ImageComparisonTest` class is
+`~.check_figures_equal`. The deprecated ``ImageComparisonTest`` class is
 likewise changed.
 
 Dependency changes
@@ -825,7 +825,7 @@ This has not been used in the codebase since its addition in 2009.
 
   This has never been used internally, there is no equivalent method exists on
   the 2D Axis classes, and despite the similar name, it has a completely
-  different behavior from the 2D Axis' `axis.Axis.get_ticks_position` method.
+  different behavior from the 2D Axis' ``axis.Axis.get_ticks_position`` method.
 - ``.backend_pgf.LatexManagerFactory``
 
 - ``mpl_toolkits.axisartist.axislines.SimpleChainedObjects``
@@ -936,8 +936,8 @@ Axes3D
 - `.axes3d.Axes3D.w_yaxis`
 - `.axes3d.Axes3D.w_zaxis`
 
-Use `.axes3d.Axes3D.xaxis`, `.axes3d.Axes3D.yaxis` and `.axes3d.Axes3D.zaxis`
-instead.
+Use ``axes3d.Axes3D.xaxis``, ``axes3d.Axes3D.yaxis`` and
+``axes3d.Axes3D.zaxis`` instead.
 
 Testing
 ~~~~~~~
@@ -945,7 +945,7 @@ Testing
 - ``matplotlib.testing.decorators.switch_backend`` decorator
 
 Test functions should use ``pytest.mark.backend``, and the mark will be
-picked up by the `matplotlib.testing.conftest.mpl_test_settings` fixture.
+picked up by the ``matplotlib.testing.conftest.mpl_test_settings`` fixture.
 
 Quiver
 ~~~~~~
@@ -1069,7 +1069,7 @@ Axis
 
 - ``Axis.iter_ticks``
 
-This only served as a helper to the private `.Axis._update_ticks`
+This only served as a helper to the private ``Axis._update_ticks``
 
 
 Undeprecations
@@ -1123,10 +1123,10 @@ The `.Formatter` class gained a new `~.Formatter.format_ticks` method, which
 takes the list of all tick locations as a single argument and returns the list
 of all formatted values.  It is called by the axis tick handling code and, by
 default, first calls `~.Formatter.set_locs` with all locations, then repeatedly
-calls `~.Formatter.__call__` for each location.
+calls ``Formatter.__call__`` for each location.
 
 Tick-handling code in the codebase that previously performed this sequence
-(`~.Formatter.set_locs` followed by repeated `~.Formatter.__call__`) have been
+(`~.Formatter.set_locs` followed by repeated ``Formatter.__call__``) have been
 updated to use `~.Formatter.format_ticks`.
 
 `~.Formatter.format_ticks` is intended to be overridden by `.Formatter`

--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -88,13 +88,13 @@ enough to be accommodated by the default data limit margins.
 While the new behavior is algorithmically simpler, it is conditional on
 properties of the `.Collection` object:
 
-  1. ``offsets = None``, ``transform`` is a child of `.Axes.transData`: use the paths
+  1. ``offsets = None``, ``transform`` is a child of ``Axes.transData``: use the paths
      for the automatic limits (i.e. for `.LineCollection` in `.Axes.streamplot`).
-  2.  ``offsets != None``, and ``offset_transform`` is child of `.Axes.transData`:
+  2.  ``offsets != None``, and ``offset_transform`` is child of ``Axes.transData``:
 
-    a) ``transform`` is child of `.Axes.transData`: use the ``path + offset`` for
+    a) ``transform`` is child of ``Axes.transData``: use the ``path + offset`` for
         limits (i.e., for `.Axes.bar`).
-    b) ``transform`` is not a child of `.Axes.transData`: just use the offsets
+    b) ``transform`` is not a child of ``Axes.transData``: just use the offsets
         for the limits (i.e. for scatter)
 
   3. otherwise return a null `.Bbox`.
@@ -294,7 +294,7 @@ Exception changes
 ~~~~~~~~~~~~~~~~~
 Various APIs that raised a `ValueError` for incorrectly typed inputs now raise
 `TypeError` instead: `.backend_bases.GraphicsContextBase.set_clip_path`,
-`.blocking_input.BlockingInput.__call__`, `.cm.register_cmap`, `.dviread.DviFont`,
+``blocking_input.BlockingInput.__call__``, `.cm.register_cmap`, `.dviread.DviFont`,
 `.rcsetup.validate_hatch`, ``.rcsetup.validate_animation_writer_path``, `.spines.Spine`,
 many classes in the :mod:`matplotlib.transforms` module and :mod:`matplotlib.tri`
 package, and Axes methods that take a ``norm`` parameter.

--- a/doc/users/explain/interactive_guide.rst
+++ b/doc/users/explain/interactive_guide.rst
@@ -424,7 +424,7 @@ based prompt to a ``prompt_toolkit`` based prompt.  ``prompt_toolkit``
 has the same conceptual input hook, which is fed into ``prompt_toolkit`` via the
 :meth:`IPython.terminal.interactiveshell.TerminalInteractiveShell.inputhook`
 method.  The source for the ``prompt_toolkit`` input hooks lives at
-:mod:`IPython.terminal.pt_inputhooks`.
+``IPython.terminal.pt_inputhooks``.
 
 
 

--- a/doc/users/prev_whats_new/whats_new_3.5.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.5.0.rst
@@ -126,7 +126,7 @@ Setting collection offset transform after initialization
 The added `.collections.Collection.set_offset_transform` may be used to set the
 offset transform after initialization. This can be helpful when creating a
 `.collections.Collection` outside an Axes object, and later adding it with
-`.Axes.add_collection()` and setting the offset transform to `.Axes.transData`.
+`.Axes.add_collection()` and setting the offset transform to ``Axes.transData``.
 
 Colors and colormaps
 ====================

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -986,7 +986,7 @@ def rcdefaults():
     Restore the `.rcParams` from Matplotlib's internal default style.
 
     Style-blacklisted `.rcParams` (defined in
-    `matplotlib.style.core.STYLE_BLACKLIST`) are not updated.
+    ``matplotlib.style.core.STYLE_BLACKLIST``) are not updated.
 
     See Also
     --------
@@ -1011,7 +1011,7 @@ def rc_file_defaults():
     Restore the `.rcParams` from the original rc file loaded by Matplotlib.
 
     Style-blacklisted `.rcParams` (defined in
-    `matplotlib.style.core.STYLE_BLACKLIST`) are not updated.
+    ``matplotlib.style.core.STYLE_BLACKLIST``) are not updated.
     """
     # Deprecation warnings were already handled when creating rcParamsOrig, no
     # need to reemit them here.
@@ -1026,7 +1026,7 @@ def rc_file(fname, *, use_default_template=True):
     Update `.rcParams` from file.
 
     Style-blacklisted `.rcParams` (defined in
-    `matplotlib.style.core.STYLE_BLACKLIST`) are not updated.
+    ``matplotlib.style.core.STYLE_BLACKLIST``) are not updated.
 
     Parameters
     ----------

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1522,7 +1522,8 @@ class Axes(_AxesBase):
         ----------------
         scalex, scaley : bool, default: True
             These parameters determine if the view limits are adapted to the
-            data limits. The values are passed on to `autoscale_view`.
+            data limits. The values are passed on to
+            `~.axes.Axes.autoscale_view`.
 
         **kwargs : `.Line2D` properties, optional
             *kwargs* are used to specify properties like a line label (for

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2691,7 +2691,7 @@ class _AxesBase(martist.Artist):
             only the y-axis.
 
         tight : bool or None, default: True
-            The *tight* parameter is passed to `autoscale_view`,
+            The *tight* parameter is passed to `~.axes.Axes.autoscale_view`,
             which is executed after a margin is changed; the default
             here is *True*, on the assumption that when margins are
             specified, no additional padding to match tick marks is
@@ -2777,8 +2777,8 @@ class _AxesBase(martist.Artist):
             to 'z', and 'both' refers to all three axes.)
         tight : bool or None, default: None
             If True, first set the margins to zero.  Then, this argument is
-            forwarded to `autoscale_view` (regardless of its value); see the
-            description of its behavior there.
+            forwarded to `~.axes.Axes.autoscale_view` (regardless of
+            its value); see the description of its behavior there.
         """
         if enable is None:
             scalex = True


### PR DESCRIPTION
## PR Summary

Primarily in the old release notes, stuff that was removed over time.

Also some fixes that should lead to working cross-references in pyplot documentation.

I will continue along these lines as time allows and at some time regenerate the whole missing references-file.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
