### PR TITLE
FIX: maybe improve renderer dance

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -18,7 +18,7 @@ import logging
 import numpy as np
 
 from matplotlib import _api, artist as martist
-from matplotlib.backend_bases import _get_renderer
+from matplotlib._tight_layout import get_renderer
 import matplotlib.transforms as mtransforms
 import matplotlib._layoutgrid as mlayoutgrid
 
@@ -92,7 +92,7 @@ def do_constrained_layout(fig, h_pad, w_pad,
     layoutgrid : private debugging structure
     """
 
-    renderer = _get_renderer(fig)
+    renderer = get_renderer(fig)
     # make layoutgrid tree...
     layoutgrids = make_layoutgrids(fig, None)
     if not layoutgrids['hasgrids']:

--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -22,7 +22,8 @@ import matplotlib._api as _api
 from matplotlib._constrained_layout import do_constrained_layout
 from matplotlib._tight_layout import (get_subplotspec_list,
                                       get_tight_layout_figure)
-from matplotlib.backend_bases import _get_renderer
+# from matplotlib.backend_bases import _get_renderer
+from matplotlib._tight_layout import get_renderer
 
 
 class LayoutEngine:
@@ -153,7 +154,7 @@ class TightLayoutEngine(LayoutEngine):
             _api.warn_external("This figure includes Axes that are not "
                                "compatible with tight_layout, so results "
                                "might be incorrect.")
-        renderer = _get_renderer(fig)
+        renderer = get_renderer(fig)
         with getattr(renderer, "_draw_disabled", nullcontext)():
             kwargs = get_tight_layout_figure(
                 fig, fig.axes, subplotspec_list, renderer,


### PR DESCRIPTION
## PR Summary

Closes #22673

`tight_layout` and `constrained_layout` were both calling `backend_bases._get_renderer`.  However, that was probably too low-level, and seems to cause canvas-dpi related flakiness as in #22673, in particular some users were seeing changed dpi because `savefig.format` was set to a vector backend. 

This uses the more robust algorithm in `_tight_layout.get_renderer`.  In particular if `fig.canvas` already exists and has a renderer, use that because it means the user has already (perhaps interactively) created a canvas.  This stops prematurely falling back to a default canvas indicated by `savefig.format`.  This probably _mostly_ worked for folks because the default `format` is `png` which is enough like on-screen display that things didn't break.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
