### PR TITLE
CI: Add GHA workflow to upload nightly wheels

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,0 +1,64 @@
+name: Upload nightly wheels to Anaconda Cloud
+
+on:
+  # Run daily at 1:23 UTC to upload nightly wheels to Anaconda Cloud
+  schedule:
+    - cron: '23 1 * * *'
+  # Run on demand with workflow dispatch
+  workflow_dispatch:
+
+jobs:
+  upload_nightly_wheels:
+    name: Upload nightly wheels to Anaconda Cloud
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'matplotlib'
+
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+
+      # c.f. https://github.com/actions/download-artifact/issues/3#issuecomment-1017141067
+      - name: Download wheel artifacts from last build on 'main'
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PROJECT_REPO="matplotlib/matplotlib"
+          BRANCH="main"
+          WORKFLOW_NAME="cibuildwheel.yml"
+          ARTIFACT_NAME="wheels"
+
+          gh run --repo "${PROJECT_REPO}" \
+             list --branch "${BRANCH}" \
+                  --workflow "${WORKFLOW_NAME}" \
+                  --json event,status,databaseId > runs.json
+          # Filter on 'push' events to main (merged PRs) that have completed
+          jq --compact-output \
+            '[ .[] | select(.event == "push") | select(.status == "completed") ]' \
+            runs.json > pushes.json
+          # Get id of latest build of wheels
+          RUN_ID=$(
+            jq --compact-output \
+              'sort_by(.databaseId) | reverse | .[0].databaseId' pushes.json
+          )
+          gh run --repo "${PROJECT_REPO}" \
+             download "${RUN_ID}" --name "${ARTIFACT_NAME}"
+
+          mkdir dist
+          mv *.whl dist/
+          ls -l dist/
+
+      - name: Install anaconda-client
+        run: |
+          python -m pip install --upgrade pip setuptools wheel
+          # c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/540
+          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+          python -m pip list
+
+      - name: Upload wheels to Anaconda Cloud as nightlies
+        run: |
+          anaconda --token ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }} upload \
+            --user scipy-wheels-nightly \
+            dist/matplotlib-*.whl

--- a/doc/users/installing/index.rst
+++ b/doc/users/installing/index.rst
@@ -80,6 +80,20 @@ you can install Matplotlib via your package manager, e.g.:
 
 .. _install_from_source:
 
+==========================
+Installing a nightly build
+==========================
+
+Matplotlib makes nightly development build wheels available on the
+`scipy-wheels-nightly Anaconda Cloud organization
+<https://anaconda.org/scipy-wheels-nightly>`_.
+These wheels can be installed with ``pip`` by specifying scipy-wheels-nightly
+as the package index to query:
+
+.. code-block:: sh
+
+  python -m pip install --upgrade --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
+
 ======================
 Installing from source
 ======================


### PR DESCRIPTION
## PR Summary

* Resolves #21635
* Resolves #9994
* Closes #21637 ([supersedes](https://github.com/matplotlib/matplotlib/pull/21637#issuecomment-1082582723))

This PR adds a `nightlies.yml` GitHub Action workflow that uses the `gh` CLI API to download the 'wheels' artifact from the latest completed build of the `cibuildwheel` workflow from the 'main' branch (idea taken from https://github.com/actions/download-artifact/issues/3#issuecomment-1017141067).

<details>
<summary>gh run example:</summary>

```console
$ gh run --repo matplotlib/matplotlib list --branch main --workflow cibuildwheel.yml
STATUS  NAME                                                                  WORKFLOW         BRANCH  EVENT         ID          ELAPSED   AGE
✓       Merge pull request #22719 from oscargus/incorrectdeprecationwarning   Build CI wheels  main    push          2067808346  1h11m7s   5h
✓       Merge pull request #22138 from stanleyjs/subfigure-clear              Build CI wheels  main    push          2067068506  1h11m8s   7h
✓       Merge pull request #22698 from oscargus/fixdoclinks                   Build CI wheels  main    push          2063032633  1h24m7s   21h
✓       Merge pull request #22711 from andrew-fennell/RangeSlider-bugfix      Build CI wheels  main    push          2062983684  1h25m25s  21h
✓       Merge pull request #22263 from jklymak/doc-version-switcher-condense  Build CI wheels  main    push          2061330182  1h14m20s  1d
✓       Merge pull request #22361 from anntzer/datetex                        Build CI wheels  main    push          2061179011  1h18m39s  1d
✓       Merge pull request #22721 from anntzer/style                          Build CI wheels  main    push          2059315555  1h3m24s   1d
X       PendingDeprecationWarning:                                            Build CI wheels  main    pull_request  2059201532  0s        1d
X       change test_aspect_equal_error() into test_aspect_equal()             Build CI wheels  main    pull_request  2057642015  0s        1d
✓       Merge pull request #22356 from timhoffm/triplot                       Build CI wheels  main    push          2057490803  1h2m25s   1d
✓       Merge pull request #22360 from anntzer/multilinetex                   Build CI wheels  main    push          2057057079  1h3m4s    1d
✓       Merge pull request #22418 from anntzer/ov                             Build CI wheels  main    push          2057027071  1h0m11s   1d
✓       Merge pull request #22722 from anntzer/cmf                            Build CI wheels  main    push          2056818352  1h8m22s   1d
✓       Merge pull request #22697 from oscargus/removecleanuptestcase         Build CI wheels  main    push          2056286785  1h3m30s   1d
✓       Merge pull request #22716 from jklymak/doc-set-canonical              Build CI wheels  main    push          2056271472  1h1m49s   1d
✓       Merge pull request #22556 from oscargus/parse_math_rcparams           Build CI wheels  main    push          2056265621  1h15m47s  2d
-       Locale font                                                           Build CI wheels  main    pull_request  2051994021  4s        2d
-       Locale font                                                           Build CI wheels  main    pull_request  2051993409  3s        2d
✓       Merge pull request #22163 from daniilS/tk_toolbar_colours             Build CI wheels  main    push          2044974231  1h13m49s  4d
-       Provide axis('equal') for Axes3D                                      Build CI wheels  main    pull_request  2040650565  3s        5d

For details on a run, try: gh run view <run-id>
```

</details>

This is done by getting the fields `event`, `status`, and `databaseId` from the output of `gh run list` as JSON and then using `jq` to filter for 'push' events (which correspond to merged PRs to the 'main' branch) that have completed runs. This is then sorted by the `databaseId`s in descending order to get the latest completed build run number.

<details>
<summary>filter and download example:</summary>

```console
$ gh run --repo matplotlib/matplotlib list --branch main --workflow cibuildwheel.yml --json event,status,databaseId
[
  {
    "databaseId": 2067808346,
    "event": "push",
    "status": "completed"
  },
  {
    "databaseId": 2067068506,
    "event": "push",
    "status": "completed"
  },
  ...,
  {
    "databaseId": 2044974231,
    "event": "push",
    "status": "completed"
  },
  {
    "databaseId": 2040650565,
    "event": "pull_request",
    "status": "completed"
  }
]
$ cat runs.json | jq -c '[ .[] | select(.event == "push") | select(.status == "completed") ] | sort_by(.databaseId) | reverse'
[{"databaseId":2067808346,"event":"push","status":"completed"},{"databaseId":2067068506,"event":"push","status":"completed"},{"databaseId":2063032633,"event":"push","status":"completed"},{"databaseId":2062983684,"event":"push","status":"completed"},{"databaseId":2061330182,"event":"push","status":"completed"},{"databaseId":2061179011,"event":"push","status":"completed"},{"databaseId":2059315555,"event":"push","status":"completed"},{"databaseId":2057490803,"event":"push","status":"completed"},{"databaseId":2057057079,"event":"push","status":"completed"},{"databaseId":2057027071,"event":"push","status":"completed"},{"databaseId":2056818352,"event":"push","status":"completed"},{"databaseId":2056286785,"event":"push","status":"completed"},{"databaseId":2056271472,"event":"push","status":"completed"},{"databaseId":2056265621,"event":"push","status":"completed"},{"databaseId":2044974231,"event":"push","status":"completed"}]
$ cat runs.json | jq -c '[ .[] | select(.event == "push") | select(.status == "completed") ] | sort_by(.databaseId) | reverse | .[0].databaseId'
2067808346
$ gh run --repo matplotlib/matplotlib download 2067808346 --name wheels
$ ls *.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-macosx_10_12_universal2.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-macosx_10_12_x86_64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-macosx_11_0_arm64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-manylinux_2_17_i686.manylinux2014_i686.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-win32.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp310-cp310-win_amd64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-macosx_10_12_universal2.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-macosx_10_12_x86_64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-macosx_11_0_arm64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-win32.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp38-cp38-win_amd64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-macosx_10_12_universal2.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-macosx_10_12_x86_64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-macosx_11_0_arm64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-win32.whl
matplotlib-3.6.0.dev1935+gda9533d507-cp39-cp39-win_amd64.whl
```

</details>

The ~~subset of all the~~ downloaded wheels ~~that are `x86_64.manylinux*`~~ are then uploaded to the `scipy-wheels-nightly` organization using the `anaconda-client` CLI API.

N.B.: `anaconda-client` must currently be installed from GitHub as there have been no uploads to PyPI since 2016. c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/540

The workflow runs nightly as a CRON job ('schedule' in GHA parlance) at 01:23 UTC (the time has no meaning (it is just 0123) beyond making sure it misses the wall of CRON jobs that slams CI providers at 00:00 and 00:01) and on demand through workflow dispatch.

The status of the build on my fork is currently summarized in https://github.com/matplotlib/matplotlib/issues/21635#issuecomment-1082777172.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

(No Python code was changed, so checking these off as `main` is passing)

**Documentation**
- [x] New features are documented, with examples if plot related. (N/A as no new features)
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there). (N/A as no new features)
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there). (N/A as no API changes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
