### PR TITLE
Added clim support to tripcolor

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -266,6 +266,16 @@ def test_tripcolor_color():
     ax.tripcolor(x, y, facecolors=[1, 2])  # faces
 
 
+def test_tripcolor_clim():
+    np.random.seed(19680801)
+    a, b, c = np.random.rand(10), np.random.rand(10), np.random.rand(10)
+
+    ax = plt.figure().add_subplot()
+    clim = (0.25, 0.75)
+    norm = ax.tripcolor(a, b, c, clim=clim).norm
+    assert((norm.vmin, norm.vmax) == clim)
+
+
 def test_tripcolor_warnings():
     x = [-1, 0, 1, 0]
     y = [0, -1, 0, 1]

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -115,13 +115,14 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
     if 'antialiaseds' not in kwargs and ec.lower() == "none":
         kwargs['antialiaseds'] = False
 
+    _api.check_isinstance((Normalize, None), norm=norm)
     if shading == 'gouraud':
         if facecolors is not None:
             raise ValueError(
                 "shading='gouraud' can only be used when the colors "
                 "are specified at the points, not at the faces.")
-        collection = TriMesh(tri, **kwargs)
-        colors = point_colors
+        collection = TriMesh(tri, alpha=alpha, array=point_colors,
+                             cmap=cmap, norm=norm, **kwargs)
     else:
         # Vertices of triangles.
         maskedTris = tri.get_masked_triangles()
@@ -136,14 +137,9 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
             colors = facecolors[~tri.mask]
         else:
             colors = facecolors
+        collection = PolyCollection(verts, alpha=alpha, array=colors,
+                                    cmap=cmap, norm=norm, **kwargs)
 
-        collection = PolyCollection(verts, **kwargs)
-
-    collection.set_alpha(alpha)
-    collection.set_array(colors)
-    _api.check_isinstance((Normalize, None), norm=norm)
-    collection.set_cmap(cmap)
-    collection.set_norm(norm)
     collection._scale_norm(norm, vmin, vmax)
     ax.grid(False)
 


### PR DESCRIPTION
## PR Summary
tripcolor was ignoring ```clim``` input.

Added parameters to collection instantiations in tripcolor to ensure that all parameters are being handled properly (including ```kwargs```).

Closes #22726

Example code:
```
from pylab import *

x, y, z = np.random.rand(100), np.random.rand(100), np.random.rand(100)

tripcolor(x, y, z, clim=(0.25, 0.75))
colorbar()
show()
```

## Incorrect output
![image](https://user-images.githubusercontent.com/28690153/160921410-1fea947b-4dd8-44b1-bd8c-e14d3602e0d9.png)

## Correct output
![image](https://user-images.githubusercontent.com/28690153/160921445-828ca48a-a2cb-4540-a02c-7efea996bb49.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
