### PR TITLE
Backport PR #22138: Fix clearing subfigures

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.0.0.rst
@@ -471,7 +471,7 @@ Hold machinery
 Setting or unsetting ``hold`` (:ref:`deprecated in version 2.0<v200_deprecate_hold>`) has now
 been completely removed. Matplotlib now always behaves as if ``hold=True``.
 To clear an axes you can manually use :meth:`~.axes.Axes.cla()`,
-or to clear an entire figure use :meth:`~.figure.Figure.clf()`.
+or to clear an entire figure use :meth:`~.figure.Figure.clear()`.
 
 
 Removal of deprecated backends

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -3139,7 +3139,7 @@ the `API changes <../../api/api_changes.html>`_.
     Fixed a bug in backend_qt4, reported on mpl-dev - DSD
 
 2007-03-26
-    Removed colorbar_classic from figure.py; fixed bug in Figure.clf() in which
+    Removed colorbar_classic from figure.py; fixed bug in Figure.clear() in which
     _axobservers was not getting cleared.  Modernization and cleanups. - EF
 
 2007-03-26

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -935,6 +935,45 @@ default: %(va)s
         # Break link between any twinned axes
         _break_share_link(ax, ax._twinned_axes)
 
+    def clf(self, keep_observers=False):
+        """
+        Clear the figure.
+
+        Parameters
+        ----------
+        keep_observers: bool, default: False
+            Set *keep_observers* to True if, for example,
+            a gui widget is tracking the Axes in the figure.
+        """
+        self.suppressComposite = None
+        self.callbacks = cbook.CallbackRegistry()
+
+        # first clear the axes in any subfigures
+        for subfig in self.subfigs:
+            subfig.clf(keep_observers=keep_observers)
+        self.subfigs = []
+
+        for ax in tuple(self.axes):  # Iterate over the copy.
+            ax.cla()
+            self.delaxes(ax)  # Remove ax from self._axstack.
+
+        self.artists = []
+        self.lines = []
+        self.patches = []
+        self.texts = []
+        self.images = []
+        self.legends = []
+        if not keep_observers:
+            self._axobservers = cbook.CallbackRegistry()
+        self._suptitle = None
+        self._supxlabel = None
+        self._supylabel = None
+
+        self.stale = True
+
+    # synonym for `clf`."""
+    clear = clf
+
     # Note: in the docstring below, the newlines in the examples after the
     # calls to legend() allow replacing it with figlegend() to generate the
     # docstring of pyplot.figlegend.
@@ -2748,40 +2787,13 @@ class Figure(FigureBase):
         self.set_size_inches(self.get_figwidth(), val, forward=forward)
 
     def clf(self, keep_observers=False):
-        """
-        Clear the figure.
-
-        Set *keep_observers* to True if, for example,
-        a gui widget is tracking the Axes in the figure.
-        """
-        self.suppressComposite = None
-        self.callbacks = cbook.CallbackRegistry()
-
-        for ax in tuple(self.axes):  # Iterate over the copy.
-            ax.cla()
-            self.delaxes(ax)         # removes ax from self._axstack
-
+        # docstring inherited
+        super().clf(keep_observers=keep_observers)
+        # FigureBase.clf does not clear toolbars, as
+        # only Figure can have toolbars
         toolbar = getattr(self.canvas, 'toolbar', None)
         if toolbar is not None:
             toolbar.update()
-        self._axstack.clear()
-        self.artists = []
-        self.lines = []
-        self.patches = []
-        self.texts = []
-        self.images = []
-        self.legends = []
-        if not keep_observers:
-            self._axobservers = cbook.CallbackRegistry()
-        self._suptitle = None
-        self._supxlabel = None
-        self._supylabel = None
-
-        self.stale = True
-
-    def clear(self, keep_observers=False):
-        """Clear the figure -- synonym for `clf`."""
-        self.clf(keep_observers=keep_observers)
 
     @_finalize_rasterization
     @allow_rasterization

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -935,7 +935,7 @@ default: %(va)s
         # Break link between any twinned axes
         _break_share_link(ax, ax._twinned_axes)
 
-    def clf(self, keep_observers=False):
+    def clear(self, keep_observers=False):
         """
         Clear the figure.
 
@@ -950,7 +950,7 @@ default: %(va)s
 
         # first clear the axes in any subfigures
         for subfig in self.subfigs:
-            subfig.clf(keep_observers=keep_observers)
+            subfig.clear(keep_observers=keep_observers)
         self.subfigs = []
 
         for ax in tuple(self.axes):  # Iterate over the copy.
@@ -971,8 +971,22 @@ default: %(va)s
 
         self.stale = True
 
-    # synonym for `clf`."""
-    clear = clf
+    # synonym for `clear`.
+    def clf(self, keep_observers=False):
+        """
+        Alias for the `clear()` method.
+
+        .. admonition:: Discouraged
+
+            The use of ``clf()`` is discouraged. Use ``clear()`` instead.
+
+        Parameters
+        ----------
+        keep_observers: bool, default: False
+            Set *keep_observers* to True if, for example,
+            a gui widget is tracking the Axes in the figure.
+        """
+        return self.clear(keep_observers=keep_observers)
 
     # Note: in the docstring below, the newlines in the examples after the
     # calls to legend() allow replacing it with figlegend() to generate the
@@ -2349,7 +2363,7 @@ class Figure(FigureBase):
         self.set_tight_layout(tight_layout)
 
         self._axstack = _AxesStack()  # track all figure axes and current axes
-        self.clf()
+        self.clear()
         self._cachedRenderer = None
 
         self.set_constrained_layout(constrained_layout)
@@ -2786,10 +2800,10 @@ class Figure(FigureBase):
         """
         self.set_size_inches(self.get_figwidth(), val, forward=forward)
 
-    def clf(self, keep_observers=False):
+    def clear(self, keep_observers=False):
         # docstring inherited
-        super().clf(keep_observers=keep_observers)
-        # FigureBase.clf does not clear toolbars, as
+        super().clear(keep_observers=keep_observers)
+        # FigureBase.clear does not clear toolbars, as
         # only Figure can have toolbars
         toolbar = getattr(self.canvas, 'toolbar', None)
         if toolbar is not None:

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -955,7 +955,7 @@ def close(fig=None):
 
 def clf():
     """Clear the current figure."""
-    gcf().clf()
+    gcf().clear()
 
 
 def draw():

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -15,7 +15,7 @@ from matplotlib import cbook, rcParams
 from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
-from matplotlib.figure import Figure
+from matplotlib.figure import Figure, FigureBase
 from matplotlib.ticker import AutoMinorLocator, FixedFormatter, ScalarFormatter
 import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
@@ -689,7 +689,8 @@ def test_removed_axis():
     fig.canvas.draw()
 
 
-def test_figure_clear():
+@pytest.mark.parametrize('clear_meth', ['clear', 'clf'])
+def test_figure_clear(clear_meth):
     # we test the following figure clearing scenarios:
     fig = plt.figure()
 
@@ -699,19 +700,19 @@ def test_figure_clear():
 
     # b) a figure with a single unnested axes
     ax = fig.add_subplot(111)
-    fig.clear()
+    getattr(fig, clear_meth)()
     assert fig.axes == []
 
     # c) a figure multiple unnested axes
     axes = [fig.add_subplot(2, 1, i+1) for i in range(2)]
-    fig.clear()
+    getattr(fig, clear_meth)()
     assert fig.axes == []
 
     # d) a figure with a subfigure
     gs = fig.add_gridspec(ncols=2, nrows=1)
     subfig = fig.add_subfigure(gs[0])
     subaxes = subfig.add_subplot(111)
-    fig.clear()
+    getattr(fig, clear_meth)()
     assert subfig not in fig.subfigs
     assert fig.axes == []
 
@@ -735,7 +736,7 @@ def test_figure_clear():
     subaxes = subfig.add_subplot(111)
     assert mainaxes in fig.axes
     assert subaxes in fig.axes
-    subfig.clear()
+    getattr(subfig, clear_meth)()
     assert subfig in fig.subfigs
     assert subaxes not in subfig.axes
     assert subaxes not in fig.axes
@@ -743,7 +744,7 @@ def test_figure_clear():
 
     # e.4) clearing the whole thing
     subaxes = subfig.add_subplot(111)
-    fig.clear()
+    getattr(fig, clear_meth)()
     assert fig.axes == []
     assert fig.subfigs == []
 
@@ -754,20 +755,26 @@ def test_figure_clear():
     assert all(sfig in fig.subfigs for sfig in subfigs)
 
     # f.1) clearing only one subfigure
-    subfigs[0].clear()
+    getattr(subfigs[0], clear_meth)()
     assert subaxes[0] not in fig.axes
     assert subaxes[1] in fig.axes
     assert subfigs[1] in fig.subfigs
 
     # f.2) clearing the whole thing
-    subfigs[1].clear()
+    getattr(subfigs[1], clear_meth)()
     subfigs = [fig.add_subfigure(gs[i]) for i in [0, 1]]
     subaxes = [sfig.add_subplot(111) for sfig in subfigs]
     assert all(ax in fig.axes for ax in subaxes)
     assert all(sfig in fig.subfigs for sfig in subfigs)
-    fig.clear()
+    getattr(fig, clear_meth)()
     assert fig.subfigs == []
     assert fig.axes == []
+
+
+def test_clf_not_refedined():
+    for klass in FigureBase.__subclasses__():
+        # check that subclasses do not get redefined in our Figure subclasses
+        assert 'clf' not in klass.__dict__
 
 
 @mpl.style.context('mpl20')

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -71,7 +71,7 @@ def test_minus_no_descent(fontsize):
     heights = {}
     fig = plt.figure()
     for vals in [(1,), (-1,), (-1, 1)]:
-        fig.clf()
+        fig.clear()
         for x in vals:
             fig.text(.5, .5, f"${x}$", usetex=True)
         fig.canvas.draw()


### PR DESCRIPTION
Merge pull request #22138 from stanleyjs/subfigure-clear

Fix clearing subfigures

(cherry picked from commit a395083238625500dd3fa879e4976617d5353342)


I think that we should backport #22735 at the same time.
