### PR TITLE
Fix deprecation of backend_tools.ToolBase.destroy

### DIFF
--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -206,9 +206,11 @@ class ToolManager:
         """
 
         tool = self.get_tool(name)
-        _api.deprecate_method_override(
+        destroy = _api.deprecate_method_override(
             backend_tools.ToolBase.destroy, tool, since="3.6",
-            alternative="tool_removed_event")()
+            alternative="tool_removed_event")
+        if destroy is not None:
+            destroy()
 
         # If it's a toggle tool and toggled, untoggle
         if getattr(tool, 'toggled', False):


### PR DESCRIPTION
## PR Summary

If not overridden, this will crash since it attempts to call `None()`.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).