### PR TITLE
Fix configure_subplots with tool manager

### DIFF
--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -295,8 +295,7 @@ class RubberbandGTK(backend_tools.RubberbandBase):
 
 class ConfigureSubplotsGTK(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
-        _NavigationToolbar2GTK.configure_subplots(
-            self._make_classic_style_pseudo_toolbar(), None)
+        _NavigationToolbar2GTK.configure_subplots(self, None)
 
 
 class _BackendGTK(_Backend):

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -934,8 +934,7 @@ class SaveFigureTk(backend_tools.SaveFigureBase):
 @backend_tools._register_tool_class(FigureCanvasTk)
 class ConfigureSubplotsTk(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
-        NavigationToolbar2Tk.configure_subplots(
-            self._make_classic_style_pseudo_toolbar())
+        NavigationToolbar2Tk.configure_subplots(self)
 
 
 @backend_tools._register_tool_class(FigureCanvasTk)

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -985,9 +985,12 @@ class ToolbarQt(ToolContainerBase, QtWidgets.QToolBar):
 
 @backend_tools._register_tool_class(FigureCanvasQT)
 class ConfigureSubplotsQt(backend_tools.ConfigureSubplotsBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._subplot_dialog = None
+
     def trigger(self, *args):
-        NavigationToolbar2QT.configure_subplots(
-            self._make_classic_style_pseudo_toolbar())
+        NavigationToolbar2QT.configure_subplots(self)
 
 
 @backend_tools._register_tool_class(FigureCanvasQT)

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1242,8 +1242,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
 @backend_tools._register_tool_class(_FigureCanvasWxBase)
 class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
-        NavigationToolbar2Wx.configure_subplots(
-            self._make_classic_style_pseudo_toolbar())
+        NavigationToolbar2Wx.configure_subplots(self)
 
 
 @backend_tools._register_tool_class(_FigureCanvasWxBase)


### PR DESCRIPTION
## PR Summary

`configure_subplots` requires a) an object from which it can get the
`canvas` property, and b) somewhere it can store its handle for re-use.

The pseudo-toolbar that is used for most `Tool` classes is temporary and
does not provide the latter. However, tools inherit from `ToolBase`
which contains a `canvas` property and they exist for the lifetime of
the toolbar, so can be used instead.

Fixes #22088

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
