### PR TITLE
MNT: Don't require renderer for window_extent and tightbbox

### DIFF
--- a/doc/api/next_api_changes/behavior/22745-JMK.rst
+++ b/doc/api/next_api_changes/behavior/22745-JMK.rst
@@ -1,0 +1,9 @@
+No need to specify renderer for get_tightbbox and get_window_extent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``get_tightbbox`` and `~.Artist.get_window_extent` methods
+no longer require the *renderer* kwarg, saving users from having to
+querry it from ``fig.canvas.get_renderer``.  If the *renderer*
+kwarg is not supplied these methods first check if there is a cached renderer
+from a previous draw and use that.  If there is no cahched renderer, then
+the methods will use ``fig.canvas.get_renderer()`` as a fallback.

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -52,7 +52,6 @@ import logging
 import numpy as np
 
 from matplotlib import _api, artist as martist
-from matplotlib._tight_layout import get_renderer
 import matplotlib.transforms as mtransforms
 import matplotlib._layoutgrid as mlayoutgrid
 
@@ -94,7 +93,7 @@ def do_constrained_layout(fig, h_pad, w_pad,
     layoutgrid : private debugging structure
     """
 
-    renderer = get_renderer(fig)
+    renderer = fig._get_renderer()
     # make layoutgrid tree...
     layoutgrids = make_layoutgrids(fig, None, rect=rect)
     if not layoutgrids['hasgrids']:

--- a/lib/matplotlib/_tight_layout.py
+++ b/lib/matplotlib/_tight_layout.py
@@ -198,18 +198,6 @@ def auto_adjust_subplotpars(
         ax_bbox_list, pad, h_pad, w_pad, rect)
 
 
-def get_renderer(fig):
-    if fig._cachedRenderer:
-        return fig._cachedRenderer
-    else:
-        canvas = fig.canvas
-        if canvas and hasattr(canvas, "get_renderer"):
-            return canvas.get_renderer()
-        else:
-            from . import backend_bases
-            return backend_bases._get_renderer(fig)
-
-
 def get_subplotspec_list(axes_list, grid_spec=None):
     """
     Return a list of subplotspec from the given list of axes.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -298,7 +298,7 @@ class Artist:
         if val and self.stale_callback is not None:
             self.stale_callback(self, val)
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         """
         Get the artist's bounding box in display space.
 
@@ -318,7 +318,7 @@ class Artist:
         """
         return Bbox([[0, 0], [0, 0]])
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer=None):
         """
         Like `.Artist.get_window_extent`, but includes any clipping.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4441,7 +4441,7 @@ class _AxesBase(martist.Artist):
         return [a for a in artists if a.get_visible() and a.get_in_layout()
                 and (isinstance(a, noclip) or not a._fully_clipped_to_axes())]
 
-    def get_tightbbox(self, renderer, call_axes_locator=True,
+    def get_tightbbox(self, renderer=None, call_axes_locator=True,
                       bbox_extra_artists=None, *, for_layout_only=False):
         """
         Return the tight bounding box of the Axes, including axis and their
@@ -4485,6 +4485,8 @@ class _AxesBase(martist.Artist):
         """
 
         bb = []
+        if renderer is None:
+            renderer = self.figure._get_renderer()
 
         if not self.get_visible():
             return None

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1198,14 +1198,16 @@ class Axis(martist.Artist):
 
         return ticks_to_draw
 
-    def _get_ticklabel_bboxes(self, ticks, renderer):
+    def _get_ticklabel_bboxes(self, ticks, renderer=None):
         """Return lists of bboxes for ticks' label1's and label2's."""
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         return ([tick.label1.get_window_extent(renderer)
                  for tick in ticks if tick.label1.get_visible()],
                 [tick.label2.get_window_extent(renderer)
                  for tick in ticks if tick.label2.get_visible()])
 
-    def get_tightbbox(self, renderer, *, for_layout_only=False):
+    def get_tightbbox(self, renderer=None, *, for_layout_only=False):
         """
         Return a bounding box that encloses the axis. It only accounts
         tick labels, axis label, and offsetText.
@@ -1217,7 +1219,8 @@ class Axis(martist.Artist):
         """
         if not self.get_visible():
             return
-
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         ticks_to_draw = self._update_ticks()
 
         self._update_label_position(renderer)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -303,7 +303,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 return bbox
         return transforms.Bbox.null()
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # TODO: check to ensure that this does not fail for
         # cases other than scatter plot legend
         return self.get_datalim(transforms.IdentityTransform())

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -251,13 +251,14 @@ class ContourLabeler:
     def _get_nth_label_width(self, nth):
         """Return the width of the *nth* label, in pixels."""
         fig = self.axes.figure
+        renderer = fig._get_renderer()
         return (
             text.Text(0, 0,
                       self.get_text(self.labelLevelList[nth], self.labelFmt),
                       figure=fig,
                       size=self.labelFontSizeList[nth],
                       fontproperties=self.labelFontProps)
-            .get_window_extent(mpl._tight_layout.get_renderer(fig)).width)
+            .get_window_extent(renderer).width)
 
     @_api.deprecated("3.5")
     def get_label_width(self, lev, fmt, fsize):
@@ -265,9 +266,10 @@ class ContourLabeler:
         if not isinstance(lev, str):
             lev = self.get_text(lev, fmt)
         fig = self.axes.figure
+        renderer = fig._get_renderer()
         width = (text.Text(0, 0, lev, figure=fig,
                            size=fsize, fontproperties=self.labelFontProps)
-                 .get_window_extent(mpl._tight_layout.get_renderer(fig)).width)
+                 .get_window_extent(renderer).width)
         width *= 72 / fig.dpi
         return width
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -474,7 +474,7 @@ class GridSpec(GridSpecBase):
                                "might be incorrect.")
 
         if renderer is None:
-            renderer = _tight_layout.get_renderer(figure)
+            renderer = figure._get_renderer()
 
         kwargs = _tight_layout.get_tight_layout_figure(
             figure, figure.axes, subplotspec_list, renderer,

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1425,7 +1425,7 @@ class BboxImage(_ImageBase):
 
     def get_window_extent(self, renderer=None):
         if renderer is None:
-            renderer = self.get_figure()._cachedRenderer
+            renderer = self.get_figure()._get_renderer()
 
         if isinstance(self.bbox, BboxBase):
             return self.bbox

--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -22,8 +22,6 @@ import matplotlib._api as _api
 from matplotlib._constrained_layout import do_constrained_layout
 from matplotlib._tight_layout import (get_subplotspec_list,
                                       get_tight_layout_figure)
-# from matplotlib.backend_bases import _get_renderer
-from matplotlib._tight_layout import get_renderer
 
 
 class LayoutEngine:
@@ -154,7 +152,7 @@ class TightLayoutEngine(LayoutEngine):
             _api.warn_external("This figure includes Axes that are not "
                                "compatible with tight_layout, so results "
                                "might be incorrect.")
-        renderer = get_renderer(fig)
+        renderer = fig._get_renderer()
         with getattr(renderer, "_draw_disabled", nullcontext)():
             kwargs = get_tight_layout_figure(
                 fig, fig.axes, subplotspec_list, renderer,

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -883,10 +883,10 @@ class Legend(Artist):
     def get_window_extent(self, renderer=None):
         # docstring inherited
         if renderer is None:
-            renderer = self.figure._cachedRenderer
+            renderer = self.figure._get_renderer()
         return self._legend_box.get_window_extent(renderer=renderer)
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer=None):
         # docstring inherited
         return self._legend_box.get_window_extent(renderer)
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -616,7 +616,7 @@ class Line2D(Artist):
         bbox.update_from_data_xy(self.get_xydata())
         return bbox
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         bbox = Bbox([[0, 0], [0, 0]])
         trans_data_to_xy = self.get_transform().transform
         bbox.update_from_data_xy(trans_data_to_xy(self.get_xydata()),

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -345,8 +345,10 @@ class OffsetBox(martist.Artist):
         w, h, xd, yd, offsets = self.get_extent_offsets(renderer)
         return w, h, xd, yd
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         w, h, xd, yd, offsets = self.get_extent_offsets(renderer)
         px, py = self.get_offset(w, h, xd, yd, renderer)
         return mtransforms.Bbox.from_bounds(px - xd, py - yd, w, h)
@@ -631,8 +633,10 @@ class DrawingArea(OffsetBox):
         """Return offset of the container."""
         return self._offset
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         w, h, xd, yd = self.get_extent(renderer)
         ox, oy = self.get_offset()  # w, h, xd, yd)
 
@@ -765,8 +769,10 @@ class TextArea(OffsetBox):
         """Return offset of the container."""
         return self._offset
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         w, h, xd, yd = self.get_extent(renderer)
         ox, oy = self.get_offset()
         return mtransforms.Bbox.from_bounds(ox - xd, oy - yd, w, h)
@@ -866,8 +872,10 @@ class AuxTransformBox(OffsetBox):
         """Return offset of the container."""
         return self._offset
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         w, h, xd, yd = self.get_extent(renderer)
         ox, oy = self.get_offset()  # w, h, xd, yd)
         return mtransforms.Bbox.from_bounds(ox - xd, oy - yd, w, h)
@@ -1048,8 +1056,11 @@ class AnchoredOffsetbox(OffsetBox):
         self._bbox_to_anchor_transform = transform
         self.stale = True
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
+
         self._update_offset_func(renderer)
         w, h, xd, yd = self.get_extent(renderer)
         ox, oy = self.get_offset(w, h, xd, yd, renderer)
@@ -1211,8 +1222,10 @@ class OffsetImage(OffsetBox):
     def get_children(self):
         return [self.image]
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         w, h, xd, yd = self.get_extent(renderer)
         ox, oy = self.get_offset()
         return mtransforms.Bbox.from_bounds(ox - xd, oy - yd, w, h)
@@ -1390,12 +1403,14 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         """Return the fontsize in points."""
         return self.prop.get_size_in_points()
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         return Bbox.union([child.get_window_extent(renderer)
                            for child in self.get_children()])
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer=None):
         # docstring inherited
         return Bbox.union([child.get_tightbbox(renderer)
                            for child in self.get_children()])
@@ -1511,7 +1526,8 @@ class DraggableBase:
             self.update_offset(dx, dy)
             if self._use_blit:
                 self.canvas.restore_region(self.background)
-                self.ref_artist.draw(self.ref_artist.figure._cachedRenderer)
+                self.ref_artist.draw(
+                    self.ref_artist.figure._get_renderer())
                 self.canvas.blit()
             else:
                 self.canvas.draw()
@@ -1526,7 +1542,8 @@ class DraggableBase:
                 self.canvas.draw()
                 self.background = \
                     self.canvas.copy_from_bbox(self.ref_artist.figure.bbox)
-                self.ref_artist.draw(self.ref_artist.figure._cachedRenderer)
+                self.ref_artist.draw(
+                    self.ref_artist.figure._get_renderer())
                 self.canvas.blit()
             self._c1 = self.canvas.callbacks._connect_picklable(
                 "motion_notify_event", self.on_motion)
@@ -1576,7 +1593,7 @@ class DraggableOffsetBox(DraggableBase):
 
     def save_offset(self):
         offsetbox = self.offsetbox
-        renderer = offsetbox.figure._cachedRenderer
+        renderer = offsetbox.figure._get_renderer()
         w, h, xd, yd = offsetbox.get_extent(renderer)
         offset = offsetbox.get_offset(w, h, xd, yd, renderer)
         self.offsetbox_x, self.offsetbox_y = offset
@@ -1588,7 +1605,7 @@ class DraggableOffsetBox(DraggableBase):
 
     def get_loc_in_canvas(self):
         offsetbox = self.offsetbox
-        renderer = offsetbox.figure._cachedRenderer
+        renderer = offsetbox.figure._get_renderer()
         w, h, xd, yd = offsetbox.get_extent(renderer)
         ox, oy = offsetbox._offset
         loc_in_canvas = (ox - xd, oy - yd)

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -398,7 +398,7 @@ class Table(Artist):
         # Need a renderer to do hit tests on mouseevent; assume the last one
         # will do
         if renderer is None:
-            renderer = self.figure._cachedRenderer
+            renderer = self.figure._get_renderer()
         if renderer is None:
             raise RuntimeError('No renderer defined')
 
@@ -432,7 +432,7 @@ class Table(Artist):
             return inside, info
         # TODO: Return index of the cell containing the cursor so that the user
         # doesn't have to bind to each one individually.
-        renderer = self.figure._cachedRenderer
+        renderer = self.figure._get_renderer()
         if renderer is not None:
             boxes = [cell.get_window_extent(renderer)
                      for (row, col), cell in self._cells.items()
@@ -446,8 +446,10 @@ class Table(Artist):
         """Return the Artists contained by the table."""
         return list(self._cells.values())
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         self._update_positions(renderer)
         boxes = [cell.get_window_extent(renderer)
                  for cell in self._cells.values()]

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -905,7 +905,7 @@ class Text(Artist):
         if renderer is not None:
             self._renderer = renderer
         if self._renderer is None:
-            self._renderer = self.figure._cachedRenderer
+            self._renderer = self.figure._get_renderer()
         if self._renderer is None:
             raise RuntimeError(
                 "Cannot get window extent of text w/o renderer. You likely "
@@ -1567,8 +1567,10 @@ class _AnnotationBase:
         x, y = self.xy
         return self._get_xy(renderer, x, y, self.xycoords)
 
-    def _check_xy(self, renderer):
+    def _check_xy(self, renderer=None):
         """Check whether the annotation at *xy_pixel* should be drawn."""
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         b = self.get_annotation_clip()
         if b or (b is None and self.xycoords == "data"):
             # check if self.xy is inside the axes.
@@ -1999,7 +2001,7 @@ class Annotation(Text, _AnnotationBase):
         if renderer is not None:
             self._renderer = renderer
         if self._renderer is None:
-            self._renderer = self.figure._cachedRenderer
+            self._renderer = self.figure._get_renderer()
         if self._renderer is None:
             raise RuntimeError('Cannot get window extent w/o renderer')
 
@@ -2013,7 +2015,7 @@ class Annotation(Text, _AnnotationBase):
 
         return Bbox.union(bboxes)
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer=None):
         # docstring inherited
         if not self._check_xy(renderer):
             return Bbox.null()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1201,7 +1201,7 @@ class TextBox(AxesWidget):
         # This causes a single extra draw if the figure has never been rendered
         # yet, which should be fine as we're going to repeatedly re-render the
         # figure later anyways.
-        if self.ax.figure._cachedRenderer is None:
+        if self.ax.figure._get_renderer() is None:
             self.ax.figure.canvas.draw()
 
         text = self.text_disp.get_text()  # Save value before overwriting it.
@@ -1917,7 +1917,8 @@ class _SelectorWidget(AxesWidget):
 
     def update(self):
         """Draw using blit() or draw_idle(), depending on ``self.useblit``."""
-        if not self.ax.get_visible() or self.ax.figure._cachedRenderer is None:
+        if (not self.ax.get_visible() or
+                self.ax.figure._get_renderer() is None):
             return False
         if self.useblit:
             if self.background is not None:

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -215,7 +215,7 @@ class HostAxesBase:
         self.axis[tuple(restore)].set_visible(True)
         self.axis[tuple(restore)].toggle(ticklabels=False, label=False)
 
-    def get_tightbbox(self, renderer, call_axes_locator=True,
+    def get_tightbbox(self, renderer=None, call_axes_locator=True,
                       bbox_extra_artists=None):
         bbs = [
             *[ax.get_tightbbox(renderer, call_axes_locator=call_axes_locator)

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -250,7 +250,10 @@ class LabelBase(mtext.Text):
         self.set_transform(tr)
         self.set_rotation(angle_orig)
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
+        if renderer is None:
+            renderer = self.figure._get_renderer()
+
         # save original and adjust some properties
         tr = self.get_transform()
         angle_orig = self.get_rotation()
@@ -361,7 +364,9 @@ class AxisLabel(AttributeCopier, LabelBase):
 
         super().draw(renderer)
 
-    def get_window_extent(self, renderer):
+    def get_window_extent(self, renderer=None):
+        if renderer is None:
+            renderer = self.figure._get_renderer()
         if not self.get_visible():
             return
 
@@ -513,7 +518,9 @@ class TickLabels(AxisLabel):  # mtext.Text
     def set_locs_angles_labels(self, locs_angles_labels):
         self._locs_angles_labels = locs_angles_labels
 
-    def get_window_extents(self, renderer):
+    def get_window_extents(self, renderer=None):
+        if renderer is None:
+            renderer = self.figure._get_renderer()
 
         if not self.get_visible():
             self._axislabel_pad = self._external_pad
@@ -846,9 +853,12 @@ class AxisArtist(martist.Artist):
 
         return ticks_loc_angle, ticklabels_loc_angle_label
 
-    def _update_ticks(self, renderer):
+    def _update_ticks(self, renderer=None):
         # set extra pad for major and minor ticklabels: use ticksize of
         # majorticks even for minor ticks. not clear what is best.
+
+        if renderer is None:
+            renderer = self.figure._get_renderer()
 
         dpi_cor = renderer.points_to_pixels(1.)
         if self.major_ticks.get_visible() and self.major_ticks.get_tick_out():
@@ -963,7 +973,7 @@ class AxisArtist(martist.Artist):
     def set_label(self, s):
         self.label.set_text(s)
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer=None):
         if not self.get_visible():
             return
         self._axis_artist_helper.update_lim(self.axes)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -144,7 +144,7 @@ class Text3D(mtext.Text):
             mtext.Text.draw(self, renderer)
         self.stale = False
 
-    def get_tightbbox(self, renderer):
+    def get_tightbbox(self, renderer=None):
         # Overwriting the 2d Text behavior which is not valid for 3d.
         # For now, just return None to exclude from layout calculation.
         return None

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3096,7 +3096,7 @@ pivot='tail', normalize=False, **kwargs)
 
         return errlines, caplines, limmarks
 
-    def get_tightbbox(self, renderer, call_axes_locator=True,
+    def get_tightbbox(self, renderer=None, call_axes_locator=True,
                       bbox_extra_artists=None, *, for_layout_only=False):
         ret = super().get_tightbbox(renderer,
                                     call_axes_locator=call_axes_locator,

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -483,7 +483,7 @@ class Axis(maxis.XAxis):
 
     # TODO: Get this to work (more) properly when mplot3d supports the
     #       transforms framework.
-    def get_tightbbox(self, renderer, *, for_layout_only=False):
+    def get_tightbbox(self, renderer=None, *, for_layout_only=False):
         # docstring inherited
         if not self.get_visible():
             return


### PR DESCRIPTION
## PR Summary

This PR is a proof of concept of making renderers globally optional.  We don't need to use this in `tight_layout` because it has a funky `_draw_disabled` context.  However, constrained_layout can have all the renderer tracking pulled out and still works in the tests and interactively so far as I can tell.  

See #22744 for more discussion, but I think deciding on the renderer at the Figure level is the right thing to do, and stop trying to sort it out at a higher level.  

See also:
- https://github.com/matplotlib/matplotlib/pull/21319
- https://github.com/matplotlib/matplotlib/pull/21758


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
