### PR TITLE
Backport PR #22743: Fix configure_subplots with tool manager

### DIFF
--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -156,8 +156,7 @@ class ConfigureSubplotsGTK(backend_tools.ConfigureSubplotsBase, Gtk.Window):
         return self.canvas.__class__(fig)
 
     def trigger(self, *args):
-        _NavigationToolbar2GTK.configure_subplots(
-            self._make_classic_style_pseudo_toolbar(), None)
+        _NavigationToolbar2GTK.configure_subplots(self, None)
 
 
 class _BackendGTK(_Backend):

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -995,9 +995,12 @@ class ToolbarQt(ToolContainerBase, QtWidgets.QToolBar):
 
 
 class ConfigureSubplotsQt(backend_tools.ConfigureSubplotsBase):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._subplot_dialog = None
+
     def trigger(self, *args):
-        NavigationToolbar2QT.configure_subplots(
-            self._make_classic_style_pseudo_toolbar())
+        NavigationToolbar2QT.configure_subplots(self)
 
 
 class SaveFigureQt(backend_tools.SaveFigureBase):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1294,8 +1294,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
 
 class ConfigureSubplotsWx(backend_tools.ConfigureSubplotsBase):
     def trigger(self, *args):
-        NavigationToolbar2Wx.configure_subplots(
-            self._make_classic_style_pseudo_toolbar())
+        NavigationToolbar2Wx.configure_subplots(self)
 
 
 class SaveFigureWx(backend_tools.SaveFigureBase):


### PR DESCRIPTION
## PR Summary

Note, the Tk backend in 3.5 uses an old subplot tool that was manually generated, so that part of #22743 has been dropped.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).