### PR TITLE
BLD: do not put an upper bound on pyparsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -312,7 +312,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "numpy>=1.19",
         "packaging>=20.0",
         "pillow>=6.2.0",
-        "pyparsing>=2.2.1,<3.0.0",
+        "pyparsing>=2.2.1",
         "python-dateutil>=2.7",
     ] + (
         # Installing from a git checkout that is not producing a wheel.


### PR DESCRIPTION
We missed relaxing the requirement in
https://github.com/matplotlib/matplotlib/pull/21501

The 3.5.x branch is already un-pinned.