### PR TITLE
Use system distutils instead of the setuptools copy

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,7 +130,8 @@ stages:
         displayName: 'Install dependencies with pip'
 
       - bash: |
-          python -m pip install -ve . ||
+          # Due to https://github.com/pypa/setuptools/pull/2896
+          SETUPTOOLS_USE_DISTUTILS=stdlib python -m pip install -ve . ||
             [[ "$PYTHON_VERSION" = 'Pre' ]]
         displayName: "Install self"
 


### PR DESCRIPTION
## PR Summary

setuptools 60 re-enabled their local copy of `distutils`: https://github.com/pypa/setuptools/pull/2896

This apparently fails to set up paths that can find `msbuild`, so switch back the standard library `distutils`.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).