### PR TITLE
MNT: Skip existing wheels during nightly wheel upload

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -61,4 +61,5 @@ jobs:
         run: |
           anaconda --token ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }} upload \
             --user scipy-wheels-nightly \
+            --skip-existing \
             dist/matplotlib-*.whl

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -54,7 +54,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           # c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/540
-          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client
+          python -m pip install git+https://github.com/Anaconda-Server/anaconda-client@be1e14936a8e947da94d026c990715f0596d7043
           python -m pip list
 
       - name: Upload wheels to Anaconda Cloud as nightlies


### PR DESCRIPTION
## PR Summary

Resolves #22757 

Amends PR #22733

Add the `--skip-existing` option for `anaconda upload` to

> Skip errors on package batch upload if it already exists

This will keep the [`nightlies.yml` workflow](https://github.com/matplotlib/matplotlib/blob/162e30645dd38cb265e315f3650a7d8dee8c4a5c/.github/workflows/nightlies.yml) from erroring out if no new wheels were generated, or if a workflow is manually rerun.

As `anaconda-client` does not have any stable releases on PyPI that support the API desired for uploads (c.f. https://github.com/Anaconda-Platform/anaconda-client/issues/540), pin it to the last commit on https://github.com/Anaconda-Platform/anaconda-client known to install and work (which is the merge commit of https://github.com/Anaconda-Platform/anaconda-client/pull/589). This is done for API stability.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
