### PR TITLE
FIX: account for constant deprecations in Pillow 9.1

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,6 +138,9 @@ stages:
       - script: env
         displayName: 'print env'
 
+      - script: pip list
+        displayName: 'print pip'
+
       - bash: |
           PYTHONFAULTHANDLER=1 python -m pytest --junitxml=junit/test-results.xml -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n 2 ||
             [[ "$PYTHON_VERSION" = 'Pre' ]]

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -17,6 +17,7 @@
 #   * Can blit be enabled for movies?
 # * Need to consider event sources to allow clicking through multiple figures
 
+
 import abc
 import base64
 import contextlib
@@ -473,8 +474,11 @@ class FileMovieWriter(MovieWriter):
             super().finish()
         finally:
             if self._tmpdir:
-                _log.debug('MovieWriter: clearing temporary path=%s', self._tmpdir)
+                _log.debug(
+                    'MovieWriter: clearing temporary path=%s', self._tmpdir
+                )
                 self._tmpdir.cleanup()
+
 
 @writers.register('pillow')
 class PillowWriter(AbstractMovieWriter):

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -468,15 +468,13 @@ class FileMovieWriter(MovieWriter):
     def finish(self):
         # Call run here now that all frame grabbing is done. All temp files
         # are available to be assembled.
-        self._run()
-        super().finish()  # Will call clean-up
-
-    def _cleanup(self):  # Inline to finish() once cleanup() is removed.
-        super()._cleanup()
-        if self._tmpdir:
-            _log.debug('MovieWriter: clearing temporary path=%s', self._tmpdir)
-            self._tmpdir.cleanup()
-
+        try:
+            self._run()
+            super().finish()
+        finally:
+            if self._tmpdir:
+                _log.debug('MovieWriter: clearing temporary path=%s', self._tmpdir)
+                self._tmpdir.cleanup()
 
 @writers.register('pillow')
 class PillowWriter(AbstractMovieWriter):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1700,8 +1700,19 @@ end"""
                 # Convert to indexed color if there are 256 colors or fewer
                 # This can significantly reduce the file size
                 num_colors = len(img_colors)
-                img = img.convert(mode='P', dither=Image.NONE,
-                                  palette=Image.ADAPTIVE, colors=num_colors)
+                # These constants were converted to IntEnums and deprecated in
+                # Pillow 9.2
+                dither = (
+                    Image.Dither.NONE if hasattr(Image, 'Dither')
+                    else Image.NONE
+                )
+                pmode = (
+                    Image.Palette.ADAPTIVE if hasattr(Image, 'Palette')
+                    else Image.ADAPTIVE
+                )
+                img = img.convert(
+                    mode='P', dither=dither, palette=pmode, colors=num_colors
+                )
                 png_data, bit_depth, palette = self._writePng(img)
                 if bit_depth is None or palette is None:
                     raise RuntimeError("invalid PNG header")

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1702,14 +1702,8 @@ end"""
                 num_colors = len(img_colors)
                 # These constants were converted to IntEnums and deprecated in
                 # Pillow 9.2
-                dither = (
-                    Image.Dither.NONE if hasattr(Image, 'Dither')
-                    else Image.NONE
-                )
-                pmode = (
-                    Image.Palette.ADAPTIVE if hasattr(Image, 'Palette')
-                    else Image.ADAPTIVE
-                )
+                dither = getattr(Image, 'Dither', Image).NONE
+                pmode = getattr(Image, 'Palette', Image).ADAPTIVE
                 img = img.convert(
                     mode='P', dither=dither, palette=pmode, colors=num_colors
                 )


### PR DESCRIPTION
https://pillow.readthedocs.io/en/stable/deprecations.html#constants

Image.None -> Image.Dither.None
Image.ADAPTIVE -> Image.Palette.ADAPTIVE

## PR Summary

un-break CI by not triggering warnings from Pilllow

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
