### PR TITLE
Fix inkscape tests

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -161,7 +161,7 @@ class _SVGConverter(_Converter):
                 # just be reported as a regular exception below).
                 "DISPLAY": "",
                 # Do not load any user options.
-                "INKSCAPE_PROFILE_DIR": os.devnull,
+                "INKSCAPE_PROFILE_DIR": self._tmpdir.name,
             }
             # Old versions of Inkscape (e.g. 0.48.3.1) seem to sometimes
             # deadlock when stderr is redirected to a pipe, so we redirect it

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -147,6 +147,11 @@ class _SVGConverter(_Converter):
             weakref.finalize(self._tmpdir, self.__del__)
         if (not self._proc  # First run.
                 or self._proc.poll() is not None):  # Inkscape terminated.
+            if self._proc is not None and self._proc.poll() is not None:
+                for stream in filter(None, [self._proc.stdin,
+                                            self._proc.stdout,
+                                            self._proc.stderr]):
+                    stream.close()
             env = {
                 **os.environ,
                 # If one passes e.g. a png file to Inkscape, it will try to


### PR DESCRIPTION
## PR Summary

This lead me down a several hour rabbit hole, but on Inkscape 1.1.2 (0a00cf5339, 2022-02-04, custom) I need these patches for the test to run locally.    I am not convinced that the version of inkscape this is actually the problem though.  I updated on March 3 and I only started having trouble with the tests in the last few days.  I'm happy to share my pacman logs if someone wants to chase this down.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

