### PR TITLE
DEV: Add codespell to pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,3 +28,14 @@ repos:
       - id: flake8
         additional_dependencies: [pydocstyle>5.1.0, flake8-docstrings>1.4.0]
         args: ["--docstring-convention=all"]
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
+        files: ^.*\.(py|c|cpp|h|m|md|rst|yml)$
+        args: [
+          "--ignore-words",
+          "ci/codespell-ignore-words.txt",
+          "--skip",
+          "doc/users/project/credits.rst"
+          ]

--- a/ci/codespell-ignore-words.txt
+++ b/ci/codespell-ignore-words.txt
@@ -1,0 +1,17 @@
+ans
+axises
+ba
+cannotation
+coo
+curvelinear
+flate
+hist
+inout
+ment
+nd
+oly
+sur
+te
+thisy
+whis
+wit

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -420,7 +420,7 @@ def test_callbackregistry_blocking():
     ('# only comment "with quotes" xx', ''),
 ])
 def test_strip_comment(line, result):
-    """Strip everything from the first unqouted #."""
+    """Strip everything from the first unquoted #."""
     assert cbook._strip_comment(line) == result
 
 


### PR DESCRIPTION
## PR Summary

Resolves #22740

Add https://github.com/codespell-project/codespell as a pre-commit hook that checks for common misspellings of English words in files with the following extensions: `.py`, `.c`, `.cpp`, `.h`, `.m`, `.md`, `.rst`, `.yml`.

Ignore instances of:
* 'ans', 'axises', 'curvelinear', 'hist', 'nd', 'oly', 'thisy', 'wit'
* 'ba' for bound axis and bound args
* 'cannotation' for centered annotation
* 'coo' for COO (Coordinate list)
* 'flate' for Flate compression
* 'inout' for lib/matplotlib/rcsetup.py
* 'ment' for alignment with formatting
* 'whis' for whikser plot
* ~'ot' for offset transform~ (Resolved in PR #22784)
* 'sur' for Big Sur
* 'TE' for triangle elements

and skip checking [doc/users/project/credits.rst](https://github.com/matplotlib/matplotlib/blob/8b1881fd49b49bf85a7b91575f4653be41c26294/doc/users/project/credits.rst) as the list of names of contributors isn't worth adding in to the ignore file to avoid false positives.

The above is what is needed to get 

```console
$ pre-commit run codespell --all-files
codespell................................................................Passed
```

on the current `HEAD` of `main`.

Here only the `codespell` options `--ignore-words` and `--skip` are used, and the usual addition of `--write-changes` is ignored, as it seems from PR #21583 that automatic corrections were not desired.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
