### PR TITLE
Fix LaTeX formatting in examples

### DIFF
--- a/examples/mplot3d/projections.py
+++ b/examples/mplot3d/projections.py
@@ -16,15 +16,15 @@ zoom effect.
 
 You can calculate focal length from a FOV via the equation:
 
-.. mathmpl::
+.. math::
 
-    1 / \tan (FOV / 2)
+    1 / \\tan (\\mathrm{FOV} / 2)
 
 Or vice versa:
 
-.. mathmpl::
+.. math::
 
-    FOV = 2 * \atan (1 / focal length)
+    \\mathrm{FOV} = 2 \\arctan (1 / \\mathrm{focal length})
 
 """
 

--- a/examples/scales/asinh_demo.py
+++ b/examples/scales/asinh_demo.py
@@ -15,13 +15,13 @@ the "linear width" :math:`a_0`), this leaves values essentially unchanged:
 
 .. math::
 
-    a \\rightarrow a + {\\cal O}(a^3)
+    a \\rightarrow a + \\mathcal{O}(a^3)
 
 but for larger values (i.e. :math:`|a| \\gg a_0`, this is asymptotically
 
 .. math::
 
-    a \\rightarrow a_0 \\, {\\rm sgn}(a) \\ln |a| + {\\cal O}(1)
+    a \\rightarrow a_0 \\, \\mathrm{sgn}(a) \\ln |a| + \\mathcal{O}(1)
 
 As with the `symlog <.scale.SymmetricalLogScale>` scaling,
 this allows one to plot quantities

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -505,9 +505,9 @@ class AsinhScale(ScaleBase):
     :math:`a \\rightarrow a_0 \\sinh^{-1} (a / a_0)` where :math:`a_0`
     is the effective width of the linear region of the transformation.
     In that region, the transformation is
-    :math:`a \\rightarrow a + {\\cal O}(a^3)`.
+    :math:`a \\rightarrow a + \\mathcal{O}(a^3)`.
     For large values of :math:`a` the transformation behaves as
-    :math:`a \\rightarrow a_0 \\, {\\rm sgn}(a) \\ln |a| + {\\cal O}(1)`.
+    :math:`a \\rightarrow a_0 \\, \\mathrm{sgn}(a) \\ln |a| + \\mathcal{O}(1)`.
 
     .. note::
 


### PR DESCRIPTION
## PR Summary

These are not displayed in the documentation. Not sure if that is caused by the formatting or not, but at least the projection example had incorrect formatting. (The others just "old".)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
