### PR TITLE
Backport PR #22732: FIX: maybe improve renderer dance

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3144,7 +3144,7 @@ class Figure(FigureBase):
         -------
         layoutgrid : private debugging object
         """
-        from matplotlib._tight_layout import get_renderer
+        from matplotlib.tight_layout import get_renderer
         from matplotlib._constrained_layout import do_constrained_layout
 
         _log.debug('Executing constrainedlayout')

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3144,7 +3144,7 @@ class Figure(FigureBase):
         -------
         layoutgrid : private debugging object
         """
-
+        from matplotlib._tight_layout import get_renderer
         from matplotlib._constrained_layout import do_constrained_layout
 
         _log.debug('Executing constrainedlayout')
@@ -3155,7 +3155,7 @@ class Figure(FigureBase):
         w_pad = w_pad / width
         h_pad = h_pad / height
         if renderer is None:
-            renderer = _get_renderer(fig)
+            renderer = get_renderer(fig)
         return do_constrained_layout(fig, renderer, h_pad, w_pad,
                                      hspace, wspace)
 
@@ -3186,13 +3186,13 @@ class Figure(FigureBase):
         """
         from contextlib import nullcontext
         from .tight_layout import (
-            get_subplotspec_list, get_tight_layout_figure)
+            get_subplotspec_list, get_tight_layout_figure, get_renderer)
         subplotspec_list = get_subplotspec_list(self.axes)
         if None in subplotspec_list:
             _api.warn_external("This figure includes Axes that are not "
                                "compatible with tight_layout, so results "
                                "might be incorrect.")
-        renderer = _get_renderer(self)
+        renderer = get_renderer(self)
         with getattr(renderer, "_draw_disabled", nullcontext)():
             kwargs = get_tight_layout_figure(
                 self, self.axes, subplotspec_list, renderer,


### PR DESCRIPTION
Merge pull request #22732 from jklymak/fix-renderer-dance

FIX: improve cached renderer dance
(cherry picked from commit 9e0eb54fd98bb804f51a74101db88164870a2458)

The changes had to be moved to figure.py due to a major refactoring that will
be released in 3.6 that is already on main.
