### PR TITLE
Fix 'misspelled' transform variable

### DIFF
--- a/examples/misc/demo_agg_filter.py
+++ b/examples/misc/demo_agg_filter.py
@@ -213,10 +213,9 @@ def drop_shadow_line(ax):
         shadow.update_from(l)
 
         # offset transform
-        ot = mtransforms.offset_copy(l.get_transform(), ax.figure,
-                                     x=4.0, y=-6.0, units='points')
-
-        shadow.set_transform(ot)
+        transform = mtransforms.offset_copy(l.get_transform(), ax.figure,
+                                            x=4.0, y=-6.0, units='points')
+        shadow.set_transform(transform)
 
         # adjust zorder of the shadow lines so that it is drawn below the
         # original lines

--- a/examples/misc/svg_filter_line.py
+++ b/examples/misc/svg_filter_line.py
@@ -41,10 +41,9 @@ for l in [l1, l2]:
     shadow.set_zorder(l.get_zorder() - 0.5)
 
     # offset transform
-    ot = mtransforms.offset_copy(l.get_transform(), fig1,
-                                 x=4.0, y=-6.0, units='points')
-
-    shadow.set_transform(ot)
+    transform = mtransforms.offset_copy(l.get_transform(), fig1,
+                                        x=4.0, y=-6.0, units='points')
+    shadow.set_transform(transform)
 
     # set the id for a later use
     shadow.set_gid(l.get_label() + "_shadow")

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -181,10 +181,9 @@ def test_agg_filter():
         shadow.update_from(line)
 
         # offset transform
-        ot = mtransforms.offset_copy(line.get_transform(), ax.figure,
-                                     x=4.0, y=-6.0, units='points')
-
-        shadow.set_transform(ot)
+        transform = mtransforms.offset_copy(line.get_transform(), ax.figure,
+                                            x=4.0, y=-6.0, units='points')
+        shadow.set_transform(transform)
 
         # adjust zorder of the shadow lines so that it is drawn below the
         # original lines


### PR DESCRIPTION
## PR Summary

The full word `transform` fits, so there's no need to abbreviate.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).