### PR TITLE
Tweak _ConverterError reporting.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -92,7 +92,7 @@ class _Converter:
         while True:
             c = self._proc.stdout.read(1)
             if not c:
-                raise _ConverterError
+                raise _ConverterError(os.fsdecode(bytes(buf)))
             buf.extend(c)
             if buf.endswith(terminator):
                 return bytes(buf)
@@ -109,7 +109,8 @@ class _GSConverter(_Converter):
             try:
                 self._read_until(b"\nGS")
             except _ConverterError as err:
-                raise OSError("Failed to start Ghostscript") from err
+                raise OSError(
+                    "Failed to start Ghostscript:\n\n" + err.args[0]) from None
 
         def encode_and_escape(name):
             return (os.fsencode(name)
@@ -172,8 +173,9 @@ class _SVGConverter(_Converter):
             try:
                 self._read_until(terminator)
             except _ConverterError as err:
-                raise OSError("Failed to start Inkscape in interactive "
-                              "mode") from err
+                raise OSError(
+                    "Failed to start Inkscape in interactive mode:\n\n"
+                    + err.args[0]) from err
 
         # Inkscape's shell mode does not support escaping metacharacters in the
         # filename ("\n", and ":;" for inkscape>=1).  Avoid any problems by


### PR DESCRIPTION
Chaining an empty _ConverterError doesn't add useful info; instead,
print out the output stream.

e.g. modify _GSConverter to use the invalid `-sDEVICE=1234`; previously
`_GSConverter()("foo", "bar")` would give:
```
Traceback (most recent call last):
  File ".../matplotlib/testing/compare.py", line 110, in __call__
    self._read_until(b"\nGS")
  File ".../matplotlib/testing/compare.py", line 95, in _read_until
    raise _ConverterError
matplotlib.testing.compare._ConverterError

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/antony/src/extern/matplotlib/lib/matplotlib/testing/compare.py", line 112, in __call__
    raise OSError("Failed to start Ghostscript") from err
OSError: Failed to start Ghostscript
```
or, if just passing buf as parameter when constructing the
_ConverterError:
```
Traceback (most recent call last):
  File ".../matplotlib/testing/compare.py", line 110, in __call__
    self._read_until(b"\nGS")
  File ".../matplotlib/testing/compare.py", line 95, in _read_until
    raise _ConverterError(buf)
matplotlib.testing.compare._ConverterError: bytearray(b'GPL Ghostscript 9.55.0 (2021-09-27)\nCopyright (C) 2021 Artifex Software, Inc.  All rights reserved.\nThis software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:\nsee the file COPYING for details.\nUnknown device: 1234\n')

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../matplotlib/testing/compare.py", line 112, in __call__
    raise OSError("Failed to start Ghostscript") from err
OSError: Failed to start Ghostscript
```
and now it gives:
```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File ".../matplotlib/testing/compare.py", line 112, in __call__
    raise OSError("Failed to start Ghostscript:\n\n" + err.args[0]) from None
OSError: Failed to start Ghostscript:

GPL Ghostscript 9.55.0 (2021-09-27)
Copyright (C) 2021 Artifex Software, Inc.  All rights reserved.
This software is supplied under the GNU AGPLv3 and comes with NO WARRANTY:
see the file COPYING for details.
Unknown device: 1234
```

Inspired by #22768; should probably wait for that one to go in first to prevent a rebase, unless @tacaswell is OK with doing the rebase in the other direction.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
