### PR TITLE
Fix ps export of colored hatches with no linewidth

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -778,6 +778,7 @@ grestore
             self.set_linejoin(gc.get_joinstyle())
             self.set_linecap(gc.get_capstyle())
             self.set_linedash(*gc.get_dashes())
+        if mightstroke or hatch:
             self.set_color(*gc.get_rgb()[:3])
         write('gsave\n')
 

--- a/lib/matplotlib/tests/baseline_images/test_backend_ps/coloredhatcheszerolw.eps
+++ b/lib/matplotlib/tests/baseline_images/test_backend_ps/coloredhatcheszerolw.eps
@@ -1,0 +1,216 @@
+%!PS-Adobe-3.0 EPSF-3.0
+%%Title: coloredhatcheszerolw.eps
+%%Creator: Matplotlib v3.6.0.dev1993+g86a08ee.d20220407, https://matplotlib.org/
+%%CreationDate: Thu Apr  7 11:52:41 2022
+%%Orientation: portrait
+%%BoundingBox: 18 180 594 612
+%%HiResBoundingBox: 18.000000 180.000000 594.000000 612.000000
+%%EndComments
+%%BeginProlog
+/mpldict 10 dict def
+mpldict begin
+/_d { bind def } bind def
+/m { moveto } _d
+/l { lineto } _d
+/r { rlineto } _d
+/c { curveto } _d
+/cl { closepath } _d
+/ce { closepath eofill } _d
+/box {
+      m
+      1 index 0 r
+      0 exch r
+      neg 0 r
+      cl
+    } _d
+/clipbox {
+      box
+      clip
+      newpath
+    } _d
+/sc { setcachedevice } _d
+end
+%%EndProlog
+mpldict begin
+18 180 translate
+576 432 0 0 clipbox
+gsave
+0 0 m
+576 0 l
+576 432 l
+0 432 l
+cl
+1.000 setgray
+fill
+grestore
+1.000 0.000 0.000 setrgbcolor
+gsave
+446.4 345.6 72 43.2 clipbox
+72 -129.6 m
+131.193332 -129.6 187.970227 -111.392702 229.826234 -78.988052 c
+271.68224 -46.583402 295.2 -2.627096 295.2 43.2 c
+295.2 89.027096 271.68224 132.983402 229.826234 165.388052 c
+187.970227 197.792702 131.193332 216 72 216 c
+12.806668 216 -43.970227 197.792702 -85.826234 165.388052 c
+-127.68224 132.983402 -151.2 89.027096 -151.2 43.2 c
+-151.2 -2.627096 -127.68224 -46.583402 -85.826234 -78.988052 c
+-43.970227 -111.392702 12.806668 -129.6 72 -129.6 c
+cl
+  << /PatternType 1
+     /PaintType 2
+     /TilingType 2
+     /BBox[0 0 72 72]
+     /XStep 72
+     /YStep 72
+
+     /PaintProc {
+        pop
+        1 setlinewidth
+-36 36 m
+36 108 l
+-24 24 m
+48 96 l
+-12 12 m
+60 84 l
+0 0 m
+72 72 l
+12 -12 m
+84 60 l
+24 -24 m
+96 48 l
+36 -36 m
+108 36 l
+
+        gsave
+        fill
+        grestore
+        stroke
+     } bind
+   >>
+   matrix
+   0 432 translate
+   makepattern
+   /H0 exch def
+gsave
+1.000000 0.000000 0.000000 H0 setpattern fill grestore
+grestore
+0.200 setlinewidth
+0 setlinejoin
+0 setlinecap
+[] 0 setdash
+0.000 0.500 0.000 setrgbcolor
+gsave
+446.4 345.6 72 43.2 clipbox
+295.2 129.6 m
+324.796666 129.6 353.185114 138.703649 374.113117 154.905974 c
+395.04112 171.108299 406.8 193.086452 406.8 216 c
+406.8 238.913548 395.04112 260.891701 374.113117 277.094026 c
+353.185114 293.296351 324.796666 302.4 295.2 302.4 c
+265.603334 302.4 237.214886 293.296351 216.286883 277.094026 c
+195.35888 260.891701 183.6 238.913548 183.6 216 c
+183.6 193.086452 195.35888 171.108299 216.286883 154.905974 c
+237.214886 138.703649 265.603334 129.6 295.2 129.6 c
+cl
+  << /PatternType 1
+     /PaintType 2
+     /TilingType 2
+     /BBox[0 0 72 72]
+     /XStep 72
+     /YStep 72
+
+     /PaintProc {
+        pop
+        1 setlinewidth
+0 6 m
+72 6 l
+0 18 m
+72 18 l
+0 30 m
+72 30 l
+0 42 m
+72 42 l
+0 54 m
+72 54 l
+0 66 m
+72 66 l
+6 0 m
+6 72 l
+18 0 m
+18 72 l
+30 0 m
+30 72 l
+42 0 m
+42 72 l
+54 0 m
+54 72 l
+66 0 m
+66 72 l
+
+        gsave
+        fill
+        grestore
+        stroke
+     } bind
+   >>
+   matrix
+   0 432 translate
+   makepattern
+   /H1 exch def
+gsave
+0.000000 0.500000 0.000000 H1 setpattern fill grestore
+stroke
+grestore
+0.000 0.000 1.000 setrgbcolor
+gsave
+446.4 345.6 72 43.2 clipbox
+518.4 250.56 m
+536.158 250.56 553.191068 265.125838 565.74787 291.049559 c
+578.304672 316.973279 585.36 352.138323 585.36 388.8 c
+585.36 425.461677 578.304672 460.626721 565.74787 486.550441 c
+553.191068 512.474162 536.158 527.04 518.4 527.04 c
+500.642 527.04 483.608932 512.474162 471.05213 486.550441 c
+458.495328 460.626721 451.44 425.461677 451.44 388.8 c
+451.44 352.138323 458.495328 316.973279 471.05213 291.049559 c
+483.608932 265.125838 500.642 250.56 518.4 250.56 c
+cl
+  << /PatternType 1
+     /PaintType 2
+     /TilingType 2
+     /BBox[0 0 72 72]
+     /XStep 72
+     /YStep 72
+
+     /PaintProc {
+        pop
+        1 setlinewidth
+-36 36 m
+36 -36 l
+-24 48 m
+48 -24 l
+-12 60 m
+60 -12 l
+0 72 m
+72 0 l
+12 84 m
+84 12 l
+24 96 m
+96 24 l
+36 108 m
+108 36 l
+
+        gsave
+        fill
+        grestore
+        stroke
+     } bind
+   >>
+   matrix
+   0 432 translate
+   makepattern
+   /H2 exch def
+gsave
+0.000000 0.000000 1.000000 H2 setpattern fill grestore
+grestore
+
+end
+showpage

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -9,6 +9,7 @@ import pytest
 from matplotlib import cbook, patheffects
 from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.figure import Figure
+from matplotlib.patches import Ellipse
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -190,6 +191,18 @@ def test_useafm():
 @image_comparison(["type3.eps"])
 def test_type3_font():
     plt.figtext(.5, .5, "I/J")
+
+
+@image_comparison(["coloredhatcheszerolw.eps"])
+def test_colored_hatch_zero_linewidth():
+    ax = plt.gca()
+    ax.add_patch(Ellipse((0, 0), 1, 1, hatch='/', facecolor='none',
+                         edgecolor='r', linewidth=0))
+    ax.add_patch(Ellipse((0.5, 0.5), 0.5, 0.5, hatch='+', facecolor='none',
+                         edgecolor='g', linewidth=0.2))
+    ax.add_patch(Ellipse((1, 1), 0.3, 0.8, hatch='\\', facecolor='none',
+                         edgecolor='b', linewidth=0))
+    ax.set_axis_off()
 
 
 @check_figures_equal(extensions=["eps"])


### PR DESCRIPTION
## PR Summary
Closes #22792

Color was not set when linewidth = 0. This adds a condition that either linewidth is non-zero or there are hatches.

~I'm having problem adding a test for this as the generated eps-files differ in size when converted to png.~ Edit: the test code was more clever than me...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
