### PR TITLE
Replace "marker simplification" by "marker subsampling" in docs.

### DIFF
--- a/doc/users/explain/performance.rst
+++ b/doc/users/explain/performance.rst
@@ -55,7 +55,6 @@ simplification) and another style for publication quality plotting
 :doc:`/tutorials/introductory/customizing` for instructions on
 how to perform these actions.
 
-
 The simplification works by iteratively merging line segments
 into a single vector until the next line segment's perpendicular
 distance to the vector (measured in display-coordinate space)
@@ -67,18 +66,14 @@ is greater than the ``path.simplify_threshold`` parameter.
   parameters prior to 2.1, but rendering time for some kinds of
   data will be vastly improved in versions 2.1 and greater.
 
-Marker simplification
----------------------
+Marker subsampling
+------------------
 
-Markers can also be simplified, albeit less robustly than
-line segments. Marker simplification is only available
-to :class:`~matplotlib.lines.Line2D` objects (through the
-``markevery`` property). Wherever
-:class:`~matplotlib.lines.Line2D` construction parameters
-are passed through, such as
-:func:`matplotlib.pyplot.plot` and
-:meth:`matplotlib.axes.Axes.plot`, the ``markevery``
-parameter can be used::
+Markers can also be simplified, albeit less robustly than line
+segments. Marker subsampling is only available to `.Line2D` objects
+(through the ``markevery`` property). Wherever `.Line2D` construction
+parameters are passed through, such as `.pyplot.plot` and `.Axes.plot`,
+the ``markevery`` parameter can be used::
 
   plt.plot(x, y, markevery=10)
 


### PR DESCRIPTION
"Simplification" could be understood as "drawing a marker with a
simpler shape", whereas subsampling exactly describes the effect of
*markevery*.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
