### PR TITLE
MNT: make Axes.cla an alias for Axes.clear in all cases

### DIFF
--- a/doc/api/next_api_changes/removals/22738-JL.rst
+++ b/doc/api/next_api_changes/removals/22738-JL.rst
@@ -1,0 +1,10 @@
+Removal of deprecated methods in `matplotlib.projections.polar`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``cla`` method in both ``ThetaAxis`` and ``RadialAxis`` has been removed
+after being deprecated in 3.4. Use ``clear`` instead.
+
+Removal of deprecated methods in `matplotlib.spines`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``cla`` method in ``Spine`` is removed after being deprecated in 3.4.
+Use ``clear`` instead.

--- a/examples/misc/custom_projection.py
+++ b/examples/misc/custom_projection.py
@@ -52,8 +52,9 @@ class GeoAxes(Axes):
         # self.spines['geo'].register_axis(self.yaxis)
         self._update_transScale()
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        # docstring inherited
+        super().clear()
 
         self.set_longitude_grid(30)
         self.set_latitude_grid(15)
@@ -424,7 +425,7 @@ class HammerAxes(GeoAxes):
         self._longitude_cap = np.pi / 2.0
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
-        self.cla()
+        self.clear()
 
     def _get_core_transform(self, resolution):
         return self.HammerTransform(resolution)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -641,7 +641,7 @@ class _AxesBase(martist.Artist):
         self.set_axisbelow(mpl.rcParams['axes.axisbelow'])
 
         self._rasterization_zorder = None
-        self.cla()
+        self.clear()
 
         # funcs used to format x and y - fall back on major formatters
         self.fmt_xdata = None
@@ -1193,7 +1193,7 @@ class _AxesBase(martist.Artist):
         self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
         self.yaxis._scale = other.yaxis._scale
 
-    def cla(self):
+    def clear(self):
         """Clear the Axes."""
         # Note: this is called by Axes.__init__()
 
@@ -1487,9 +1487,9 @@ class _AxesBase(martist.Artist):
         return self.ArtistList(self, 'texts', 'add_artist',
                                valid_types=mtext.Text)
 
-    def clear(self):
+    def cla(self):
         """Clear the Axes."""
-        self.cla()
+        self.clear()
 
     def get_facecolor(self):
         """Get the facecolor of the Axes."""

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -932,7 +932,7 @@ default: %(va)s
         self.subfigs = []
 
         for ax in tuple(self.axes):  # Iterate over the copy.
-            ax.cla()
+            ax.clear()
             self.delaxes(ax)  # Remove ax from self._axstack.
 
         self.artists = []

--- a/lib/matplotlib/projections/geo.py
+++ b/lib/matplotlib/projections/geo.py
@@ -36,8 +36,9 @@ class GeoAxes(Axes):
         # self.spines['geo'].register_axis(self.yaxis)
         self._update_transScale()
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        # docstring inherited
+        super().clear()
 
         self.set_longitude_grid(30)
         self.set_latitude_grid(15)
@@ -284,7 +285,7 @@ class AitoffAxes(GeoAxes):
         self._longitude_cap = np.pi / 2.0
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
-        self.cla()
+        self.clear()
 
     def _get_core_transform(self, resolution):
         return self.AitoffTransform(resolution)
@@ -329,7 +330,7 @@ class HammerAxes(GeoAxes):
         self._longitude_cap = np.pi / 2.0
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
-        self.cla()
+        self.clear()
 
     def _get_core_transform(self, resolution):
         return self.HammerTransform(resolution)
@@ -399,7 +400,7 @@ class MollweideAxes(GeoAxes):
         self._longitude_cap = np.pi / 2.0
         super().__init__(*args, **kwargs)
         self.set_aspect(0.5, adjustable='box', anchor='C')
-        self.cla()
+        self.clear()
 
     def _get_core_transform(self, resolution):
         return self.MollweideTransform(resolution)
@@ -484,10 +485,11 @@ class LambertAxes(GeoAxes):
         self._center_latitude = center_latitude
         super().__init__(*args, **kwargs)
         self.set_aspect('equal', adjustable='box', anchor='C')
-        self.cla()
+        self.clear()
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        # docstring inherited
+        super().clear()
         self.yaxis.set_major_formatter(NullFormatter())
 
     def _get_core_transform(self, resolution):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -373,13 +373,10 @@ class ThetaAxis(maxis.XAxis):
         self.isDefault_majfmt = True
 
     def clear(self):
+        # docstring inherited
         super().clear()
         self.set_ticks_position('none')
         self._wrap_locator_formatter()
-
-    @_api.deprecated("3.4", alternative="ThetaAxis.clear()")
-    def cla(self):
-        self.clear()
 
     def _set_scale(self, value, **kwargs):
         if value != 'linear':
@@ -671,13 +668,10 @@ class RadialAxis(maxis.YAxis):
         self.isDefault_majloc = True
 
     def clear(self):
+        # docstring inherited
         super().clear()
         self.set_ticks_position('none')
         self._wrap_locator_formatter()
-
-    @_api.deprecated("3.4", alternative="RadialAxis.clear()")
-    def cla(self):
-        self.clear()
 
     def _set_scale(self, value, **kwargs):
         super()._set_scale(value, **kwargs)
@@ -776,10 +770,11 @@ class PolarAxes(Axes):
         super().__init__(*args, **kwargs)
         self.use_sticky_edges = True
         self.set_aspect('equal', adjustable='box', anchor='C')
-        self.cla()
+        self.clear()
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        # docstring inherited
+        super().clear()
 
         self.title.set_y(1.05)
 

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -222,10 +222,6 @@ class Spine(mpatches.Patch):
         if self.axis is not None:
             self.axis.clear()
 
-    @_api.deprecated("3.4", alternative="`.Spine.clear`")
-    def cla(self):
-        self.clear()
-
     def _adjust_location(self):
         """Automatically set spine bounds to the view interval."""
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -22,6 +22,7 @@ from matplotlib._api import MatplotlibDeprecationWarning
 import matplotlib.colors as mcolors
 import matplotlib.dates as mdates
 from matplotlib.figure import Figure
+from matplotlib.axes import Axes
 import matplotlib.font_manager as mfont_manager
 import matplotlib.markers as mmarkers
 import matplotlib.patches as mpatches
@@ -466,6 +467,12 @@ def test_inverted_cla():
 
     # clean up
     plt.close(fig)
+
+
+def test_cla_not_redefined():
+    for klass in Axes.__subclasses__():
+        # check that cla does not get redefined in our Axes subclasses
+        assert 'cla' not in klass.__dict__
 
 
 @check_figures_equal(extensions=["png"])

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -52,8 +52,9 @@ class Axes(maxes.Axes):
     def axis(self):
         return self._axislines
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        # docstring inherited
+        super().clear()
         self._init_axis_artists()
 
 

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -17,8 +17,8 @@ class ParasiteAxesBase:
         kwargs["frameon"] = False
         super().__init__(parent_axes.figure, parent_axes._position, **kwargs)
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        super().clear()
         martist.setp(self.get_children(), visible=False)
         self._get_lines = self._parent_axes._get_lines
 
@@ -138,10 +138,10 @@ class HostAxesBase:
         super().draw(renderer)
         self._children = self._children[:orig_children_len]
 
-    def cla(self):
+    def clear(self):
         for ax in self.parasites:
-            ax.cla()
-        super().cla()
+            ax.clear()
+        super().clear()
 
     def pick(self, mouseevent):
         super().pick(mouseevent)

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -499,12 +499,13 @@ class Axes(maxes.Axes):
         # It is done inside the cla.
         self.gridlines = self.new_gridlines(grid_helper)
 
-    def cla(self):
-        # gridlines need to b created before cla() since cla calls grid()
+    def clear(self):
+        # docstring inherited
+        # gridlines need to be created before clear() since clear calls grid()
         self._init_gridlines()
-        super().cla()
+        super().clear()
 
-        # the clip_path should be set after Axes.cla() since that's
+        # the clip_path should be set after Axes.clear() since that's
         # when a patch is created.
         self.gridlines.set_clip_path(self.axes.patch)
 

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -329,8 +329,8 @@ class FloatingAxesBase:
         patch.get_path()._interpolation_steps = 100
         return patch
 
-    def cla(self):
-        super().cla()
+    def clear(self):
+        super().clear()
         self.patch.set_transform(
             self.get_grid_helper().grid_finder.get_transform()
             + self.transData)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -932,10 +932,9 @@ class Axes3D(Axes):
         """
         return False
 
-    def cla(self):
+    def clear(self):
         # docstring inherited.
-
-        super().cla()
+        super().clear()
         self.zaxis.clear()
 
         if self._sharez is not None:


### PR DESCRIPTION
## PR Summary
We (myself and @neil-gurnani) consolidated all implementations of cla/clear under a clear method (the clear functionality is implemented in clear, and cla calls clear for the sake of minimizing code duplication and improving maintainability). We added 2 tests ensuring subclasses do not override cla. Existing tests for cla were left as-is; since cla calls clear, coverage is not compromised.

Every subclass has both cla and clear, since it was mentioned in #22738 that cla is still too widely used to be fully deprecated as of now. We added appropriate docstrings/comments for all cla/clear methods.

We left all original '_api.deprecated' decorators as-is but did not add any new decorators (please let us know if this is needed).

Finally, please let us know if there's any issue with this PR we should address. This was our first PR and we really enjoyed working on it. 

Thanks

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
