### PR TITLE
Also use _TransformedBoundsLocator to position twin subplots.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4523,9 +4523,11 @@ class _AxesBase(martist.Artist):
 
     def _make_twin_axes(self, *args, **kwargs):
         """Make a twinx Axes of self. This is used for twinx and twiny."""
-        # Typically, SubplotBase._make_twin_axes is called instead of this.
         if 'sharex' in kwargs and 'sharey' in kwargs:
-            raise ValueError("Twinned Axes may share only one axis")
+            # The following line is added in v2.2 to avoid breaking Seaborn,
+            # which currently uses this internal API.
+            if kwargs["sharex"] is not self and kwargs["sharey"] is not self:
+                raise ValueError("Twinned Axes may share only one axis")
         ax2 = self.figure.add_axes(
             self.get_position(True), *args, **kwargs,
             axes_locator=_TransformedBoundsLocator(

--- a/lib/matplotlib/axes/_subplots.py
+++ b/lib/matplotlib/axes/_subplots.py
@@ -151,19 +151,6 @@ class SubplotBase:
             if self.yaxis.offsetText.get_position()[0] == 1:
                 self.yaxis.offsetText.set_visible(False)
 
-    def _make_twin_axes(self, *args, **kwargs):
-        """Make a twinx axes of self. This is used for twinx and twiny."""
-        if 'sharex' in kwargs and 'sharey' in kwargs:
-            # The following line is added in v2.2 to avoid breaking Seaborn,
-            # which currently uses this internal API.
-            if kwargs["sharex"] is not self and kwargs["sharey"] is not self:
-                raise ValueError("Twinned Axes may share only one axis")
-        twin = self.figure.add_subplot(self.get_subplotspec(), *args, **kwargs)
-        self.set_adjustable('datalim')
-        twin.set_adjustable('datalim')
-        self._twinned_axes.join(self, twin)
-        return twin
-
 
 subplot_class_factory = cbook._make_class_factory(
     SubplotBase, "{}Subplot", "_axes_class")

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -1,3 +1,4 @@
+from functools import partial
 from itertools import product
 import platform
 
@@ -536,3 +537,20 @@ def test_auto_adjustable():
     assert tbb.x1 == pytest.approx(fig.bbox.width - pad * fig.dpi)
     assert tbb.y0 == pytest.approx(pad * fig.dpi)
     assert tbb.y1 == pytest.approx(fig.bbox.height - pad * fig.dpi)
+
+
+def test_axes_locatable_and_twin():
+    positions = []
+
+    def record_position_on_draw(orig_draw, renderer):
+        orig_draw(renderer)
+        positions.append(orig_draw.__self__.get_position().get_points())
+
+    fig, ax = plt.subplots()
+    tw = ax.twiny()
+    cb_axis = make_axes_locatable(ax).append_axes("right", size="2%", pad=0.1)
+    ax.draw = partial(record_position_on_draw, ax.draw)
+    tw.draw = partial(record_position_on_draw, tw.draw)
+    fig.canvas.draw()
+    ax_pos, tw_pos = positions
+    np.testing.assert_almost_equal(ax_pos, tw_pos)


### PR DESCRIPTION
i.e. position the twin "at the same position as the parent" instead of
trying to locate it as a subplot (which breaks if the parent is then
modified using make_axes_locatable).

Closes #5904 (despite https://github.com/matplotlib/matplotlib/issues/5904#issuecomment-1081994385).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
