### PR TITLE
Replace quiver dpi callback with reinit-on-dpi-changed.

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -15,7 +15,6 @@ the Quiver code.
 """
 
 import math
-import weakref
 
 import numpy as np
 from numpy import ma
@@ -299,21 +298,6 @@ class QuiverKey(martist.Artist):
         self.color = color
         self.label = label
         self._labelsep_inches = labelsep
-        self.labelsep = (self._labelsep_inches * Q.axes.figure.dpi)
-
-        # try to prevent closure over the real self
-        weak_self = weakref.ref(self)
-
-        def on_dpi_change(fig):
-            self_weakref = weak_self()
-            if self_weakref is not None:
-                self_weakref.labelsep = self_weakref._labelsep_inches * fig.dpi
-                # simple brute force update works because _init is called at
-                # the start of draw.
-                self_weakref._initialized = False
-
-        self._cid = Q.axes.figure.callbacks.connect(
-            'dpi_changed', on_dpi_change)
 
         self.labelpos = labelpos
         self.labelcolor = labelcolor
@@ -329,18 +313,16 @@ class QuiverKey(martist.Artist):
 
         if self.labelcolor is not None:
             self.text.set_color(self.labelcolor)
-        self._initialized = False
+        self._dpi_at_last_init = None
         self.zorder = Q.zorder + 0.1
 
-    def remove(self):
-        # docstring inherited
-        self.Q.axes.figure.callbacks.disconnect(self._cid)
-        self._cid = None
-        super().remove()  # pass the remove call up the stack
+    @property
+    def labelsep(self):
+        return self._labelsep_inches * self.Q.axes.figure.dpi
 
     def _init(self):
-        if True:  # not self._initialized:
-            if not self.Q._initialized:
+        if True:  # self._dpi_at_last_init != self.axes.figure.dpi
+            if self.Q._dpi_at_last_init != self.Q.axes.figure.dpi:
                 self.Q._init()
             self._set_transform()
             with cbook._setattr_cm(self.Q, pivot=self.pivot[self.labelpos],
@@ -363,7 +345,7 @@ class QuiverKey(martist.Artist):
                 self.vector.set_color(self.color)
             self.vector.set_transform(self.Q.get_transform())
             self.vector.set_figure(self.get_figure())
-            self._initialized = True
+            self._dpi_at_last_init = self.Q.axes.figure.dpi
 
     def _text_x(self, x):
         if self.labelpos == 'E':
@@ -534,26 +516,7 @@ class Quiver(mcollections.PolyCollection):
                          closed=False, **kwargs)
         self.polykw = kwargs
         self.set_UVC(U, V, C)
-        self._initialized = False
-
-        weak_self = weakref.ref(self)  # Prevent closure over the real self.
-
-        def on_dpi_change(fig):
-            self_weakref = weak_self()
-            if self_weakref is not None:
-                # vertices depend on width, span which in turn depend on dpi
-                self_weakref._new_UV = True
-                # simple brute force update works because _init is called at
-                # the start of draw.
-                self_weakref._initialized = False
-
-        self._cid = ax.figure.callbacks.connect('dpi_changed', on_dpi_change)
-
-    def remove(self):
-        # docstring inherited
-        self.axes.figure.callbacks.disconnect(self._cid)
-        self._cid = None
-        super().remove()  # pass the remove call up the stack
+        self._dpi_at_last_init = None
 
     def _init(self):
         """
@@ -562,7 +525,7 @@ class Quiver(mcollections.PolyCollection):
         """
         # It seems that there are not enough event notifications
         # available to have this work on an as-needed basis at present.
-        if True:  # not self._initialized:
+        if True:  # self._dpi_at_last_init != self.axes.figure.dpi
             trans = self._set_transform()
             self.span = trans.inverted().transform_bbox(self.axes.bbox).width
             if self.width is None:
@@ -570,10 +533,11 @@ class Quiver(mcollections.PolyCollection):
                 self.width = 0.06 * self.span / sn
 
             # _make_verts sets self.scale if not already specified
-            if not self._initialized and self.scale is None:
+            if (self._dpi_at_last_init != self.axes.figure.dpi
+                    and self.scale is None):
                 self._make_verts(self.U, self.V, self.angles)
 
-            self._initialized = True
+            self._dpi_at_last_init = self.axes.figure.dpi
 
     def get_datalim(self, transData):
         trans = self.get_transform()
@@ -589,7 +553,6 @@ class Quiver(mcollections.PolyCollection):
         self._init()
         verts = self._make_verts(self.U, self.V, self.angles)
         self.set_verts(verts, closed=False)
-        self._new_UV = False
         super().draw(renderer)
         self.stale = False
 
@@ -618,7 +581,6 @@ class Quiver(mcollections.PolyCollection):
         self.Umask = mask
         if C is not None:
             self.set_array(C)
-        self._new_UV = True
         self.stale = True
 
     def _dots_per_unit(self, units):


### PR DESCRIPTION
Instead of registering a callback to update itself whenever the dpi
changes, do the same thing as every other artist which depends on dpi
(e.g. FancyArrowPatch), i.e. update oneself as needed.  We can still
save duplicate calculations by only doing the init if the figure dpi
changed compared to last time.

Also drop _new_UV, which is never read.

Closes #22804.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
