### PR TITLE
Patchcollection keeps original patch

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1808,9 +1808,10 @@ class PatchCollection(Collection):
 
         *match_original*
             If True, use the colors and linewidths of the original
-            patches.  If False, new colors may be assigned by
-            providing the standard collection arguments, facecolor,
-            edgecolor, linewidths, norm or cmap.
+            patches. Also use the hatch of the first patch provided.
+            If False, new colors may be assigned by providing the
+            standard collection arguments, facecolor, edgecolor,
+            linewidths, norm or cmap.
 
         If any of *edgecolors*, *facecolors*, *linewidths*, *antialiaseds* are
         None, they default to their `.rcParams` patch setting, in sequence
@@ -1827,12 +1828,20 @@ class PatchCollection(Collection):
                 if patch.get_fill():
                     return patch.get_facecolor()
                 return [0, 0, 0, 0]
-
+            def is_default(c):
+                return mcolors.same_color([0, 0, 0, 0], c)
             kwargs['facecolors'] = [determine_facecolor(p) for p in patches]
-            kwargs['edgecolors'] = [p.get_edgecolor() for p in patches]
+            edgecolors = [p.get_edgecolor() for p in patches]
+            # Since the hatch color is updated when the edge color
+            # is updated, we will ignore the edge color if it is blank (the
+            # default of [0, 0, 0, 0]).
+            if not all(is_default(c) for c in edgecolors):
+                kwargs['edgecolors'] = edgecolors
             kwargs['linewidths'] = [p.get_linewidth() for p in patches]
             kwargs['linestyles'] = [p.get_linestyle() for p in patches]
             kwargs['antialiaseds'] = [p.get_antialiased() for p in patches]
+            if patches:
+                kwargs['hatch'] = patches[0].get_hatch()
 
         super().__init__(**kwargs)
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -10,6 +10,7 @@ import matplotlib.pyplot as plt
 from matplotlib.backend_bases import MouseEvent
 import matplotlib.collections as mcollections
 import matplotlib.colors as mcolors
+import matplotlib.patches as mpatches
 import matplotlib.transforms as mtransforms
 from matplotlib.collections import (Collection, LineCollection,
                                     EventCollection, PolyCollection)
@@ -1117,3 +1118,25 @@ def test_set_offset_units():
     off0 = sc.get_offsets()
     sc.set_offsets(list(zip(y, d)))
     np.testing.assert_allclose(off0, sc.get_offsets())
+
+
+@check_figures_equal(extensions=['png'])
+def test_patch_collection_keeps_hatch(fig_test, fig_ref):
+    # When creating a PatchCollection, the hatch of the original patches should
+    # be used if match_original == True.
+    ax = fig_test.subplots()
+    patches = [
+        mpatches.Rectangle((0, 0), 0.2, .2, hatch="/"),
+        mpatches.Rectangle((0.4, 0.4), 0.2, .2, hatch="/")
+    ]
+    collection = mcollections.PatchCollection(patches, match_original=True)
+    ax.add_collection(collection)
+
+    ax = fig_ref.subplots()
+    patches = [
+        mpatches.Rectangle((0, 0), 0.2, .2),
+        mpatches.Rectangle((0.4, 0.4), 0.2, .2)
+    ]
+    collection = mcollections.PatchCollection(patches, match_original=False,
+                                                hatch="/")
+    ax.add_collection(collection)


### PR DESCRIPTION
## PR Summary
Fixes [this issue](https://github.com/matplotlib/matplotlib/issues/22654). PatchCollection currently ignores the hatches of the provided patches, only allowing a hatch passed as a keyword into the constructor. If match_original is true, we now keep the hatch of the first patch provided in the collection, rather than using the hatch passed as a keyword into the constructor. Edited the doc strings to reflect this. Additionally, the hatchcolor is determined by the edge color, so we will only initialize the collection with the edgecolors of the patches if the edgecolor is not blank - its default color of [0, 0, 0, 0]. This ensures that the hatch will use its default of black in the case where no edgecolor of the patches is ever set. 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
