### PR TITLE
Colorbar: round corners

### DIFF
--- a/doc/users/next_whats_new/colorbar_round_corners.rst
+++ b/doc/users/next_whats_new/colorbar_round_corners.rst
@@ -1,0 +1,21 @@
+Round corners in colorbars
+--------------------------
+
+Colorbars can now have round corners using the keyword
+round, while the radius of the corners can be controlled with
+the keyword rounding_size (min=0, max=0.5).
+
+.. plot::
+    :include-source: true
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    N = 37
+    x, y = np.mgrid[:N, :N]
+    Z = (np.cos(x*0.2) + np.sin(y*0.3))
+    cmap = plt.get_cmap("plasma")
+    fig, ax1 = plt.subplots(figsize=(5, 4))
+    pos = ax1.imshow(Z, cmap=cmap, interpolation='bicubic')
+    fig.colorbar(pos, ax=ax1, round='both', rounding_size=0.4, aspect=15)
+    plt.show()
+

--- a/examples/color/colorbar_round_corners.py
+++ b/examples/color/colorbar_round_corners.py
@@ -1,0 +1,71 @@
+"""
+===========================
+Colorbar with round corners
+===========================
+
+This example demonstrates how to create colorbars with round corners.
+"""
+import numpy as np
+import matplotlib.pyplot as plt
+
+# setup some generic data
+N = 37
+x, y = np.mgrid[:N, :N]
+Z = (np.cos(x*0.2) + np.sin(y*0.3))
+
+cmap = plt.get_cmap("plasma")
+
+fig, (ax1, ax2) = plt.subplots(figsize=(10, 4), ncols=2)
+
+pos = ax1.imshow(Z, cmap=cmap, interpolation='bicubic')
+
+# with the *round* keyword we specify which edges
+# should have round corners
+fig.colorbar(pos, ax=ax1, round='both', aspect=15)
+
+ax1.set_title('round="both"')
+
+pos = ax2.imshow(Z, cmap=cmap, interpolation='bicubic')
+
+# the *rounding_size* keyword controls the radius of the corners
+fig.colorbar(pos, ax=ax2, round='max', rounding_size=0.5, aspect=15)
+ax2.set_title('round="max", rounding_size=0.5')
+plt.show()
+
+############################################################################
+# Extended colorbar with round corners
+# ------------------------------------
+#
+# The extensions of a colorbar can also be round
+# or even mixed (one extension triangular and the other round).
+
+# specify color for extensions
+cmap = plt.cm.gray.with_extremes(over='b', under='g')
+
+fig, (ax1, ax2) = plt.subplots(figsize=(10, 4), ncols=2)
+
+pos = ax1.imshow(Z, cmap=cmap, vmin=-1.5, vmax=1.5, interpolation='bicubic')
+
+fig.colorbar(pos, ax=ax1, extend='both', location='bottom', round='both')
+
+ax1.set_title('extend="both", round="both"')
+
+pos = ax2.imshow(Z, cmap=cmap, vmin=-1.5, vmax=1.5, interpolation='bicubic')
+
+# the *extendfrac* keyword can affect the length of the
+# round patch as well
+fig.colorbar(pos, ax=ax2, location='bottom',
+             extend='both', extendfrac=(0.1, 0.05),
+             round='min', rounding_size=0.5)
+
+ax2.set_title('extend="both", round="min"')
+plt.show()
+
+#############################################################################
+#
+# .. admonition:: References
+#
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.figure.Figure.colorbar` / `matplotlib.pyplot.colorbar`


### PR DESCRIPTION
## PR Summary
Hello everyone! This is my first attempt at a PR: rounded corners in colorbars.

![cbar](https://user-images.githubusercontent.com/58076098/162613517-38cf5f1d-a55f-405a-84d4-c3bc45fd1db9.png)

The implementation combines the round corners functionality from `FancyBboxPatch` and the `extend` functionality of colorbars. 

The user can choose to round both edges of the colorbar or only one. It can also be used as an `extend` patch or
together with other `extend` patches, see below:

![extend](https://user-images.githubusercontent.com/58076098/162613764-3e7f1714-db5e-4dc3-a826-abc6c5b84cf4.png)

For the outline of the colorbar, I use a `mpath.Path` with one set of codes consisting of `Path.CURVE3` code types, and depending on the location of the control points; this will make it either rectangular or triangular, or round. A strange bug that comes with this implementation is that  in the case of a fully rectangular outline, the outline seems to be drawn one pixel to the left and one pixel upwards of where it should be drawn, as can be seen below:

![bug](https://user-images.githubusercontent.com/58076098/162614014-2bfb99bb-09f9-41be-b127-a37a684e559e.png)
To get around this bug I just convert all `CURVE3` types to `LINETO` types in the case of a rectangular outline and everything seems to work fine (it passes all the tests). If you have an explanation on why this happens or a better way to approach this problem let me know! (you can comment out lines`796-800` and run the colorbar tests and see the bug in action).

I am happy to hear your thoughts and make any necessary changes.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
