### PR TITLE
Remove some unnecessary extra boundaries for colorbars with extensions.

### DIFF
--- a/examples/specialty_plots/leftventricle_bulleye.py
+++ b/examples/specialty_plots/leftventricle_bulleye.py
@@ -171,8 +171,6 @@ bounds = [2, 3, 7, 9, 15]
 norm3 = mpl.colors.BoundaryNorm(bounds, cmap3.N)
 fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap3, norm=norm3),
              cax=axl3,
-             # to use 'extend', you must specify two extra boundaries:
-             boundaries=[0] + bounds + [18],
              extend='both',
              ticks=bounds,  # optional
              spacing='proportional',

--- a/tutorials/colors/colorbar_only.py
+++ b/tutorials/colors/colorbar_only.py
@@ -77,8 +77,7 @@ fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
 # `~.Figure.colorbar`. For the out-of-range values to display on the colorbar
 # without using the *extend* keyword with
 # `.colors.BoundaryNorm`, we have to use the *extend* keyword argument directly
-# in the colorbar call, and supply an additional boundary on each end of the
-# range.  Here we also
+# in the colorbar call.  Here we also
 # use the spacing argument to make
 # the length of each colorbar segment proportional to its corresponding
 # interval.
@@ -94,7 +93,6 @@ norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
 fig.colorbar(
     mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
     cax=ax,
-    boundaries=[0] + bounds + [13],  # Adding values for extensions.
     extend='both',
     ticks=bounds,
     spacing='proportional',
@@ -121,7 +119,6 @@ norm = mpl.colors.BoundaryNorm(bounds, cmap.N)
 fig.colorbar(
     mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
     cax=ax,
-    boundaries=[-10] + bounds + [10],
     extend='both',
     extendfrac='auto',
     ticks=bounds,


### PR DESCRIPTION
AFAICT these do not affect the resulting colorbar at all (run the code
before and after to compare).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
