### PR TITLE
Fix BoundaryNorm cursor data output

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1307,12 +1307,10 @@ class Artist:
                 if isinstance(self.norm, BoundaryNorm):
                     # not an invertible normalization mapping
                     cur_idx = np.argmin(np.abs(self.norm.boundaries - data))
-                    neigh_idx1 = max(0, cur_idx - 1)
-                    neigh_idx2 = min(
-                        len(self.norm.boundaries) - 1, cur_idx + 1)
+                    neigh_idx = max(0, cur_idx - 1)
                     # use max diff to prevent delta == 0
                     delta = np.diff(
-                        self.norm.boundaries[[neigh_idx1, cur_idx, neigh_idx2]]
+                        self.norm.boundaries[neigh_idx:cur_idx + 2]
                     ).max()
 
                 else:

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -12,6 +12,7 @@ import numpy as np
 
 import matplotlib as mpl
 from . import _api, cbook
+from .colors import BoundaryNorm
 from .cm import ScalarMappable
 from .path import Path
 from .transforms import (Bbox, IdentityTransform, Transform, TransformedBbox,
@@ -1303,10 +1304,22 @@ class Artist:
                 return "[]"
             normed = self.norm(data)
             if np.isfinite(normed):
-                # Midpoints of neighboring color intervals.
-                neighbors = self.norm.inverse(
-                    (int(self.norm(data) * n) + np.array([0, 1])) / n)
-                delta = abs(neighbors - data).max()
+                if isinstance(self.norm, BoundaryNorm):
+                    # not an invertible normalization mapping
+                    cur_idx = np.argmin(np.abs(self.norm.boundaries - data))
+                    neigh_idx1 = max(0, cur_idx - 1)
+                    neigh_idx2 = min(
+                        len(self.norm.boundaries) - 1, cur_idx + 1)
+                    # use max diff to prevent delta == 0
+                    delta = np.diff(
+                        self.norm.boundaries[[neigh_idx1, cur_idx, neigh_idx2]]
+                    ).max()
+
+                else:
+                    # Midpoints of neighboring color intervals.
+                    neighbors = self.norm.inverse(
+                        (int(normed * n) + np.array([0, 1])) / n)
+                    delta = abs(neighbors - data).max()
                 g_sig_digits = cbook._g_sig_digits(data, delta)
             else:
                 g_sig_digits = 3  # Consistent with default below.

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -5,6 +5,8 @@ import numpy as np
 
 import pytest
 
+from matplotlib import cbook, cm
+import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.lines as mlines
@@ -372,3 +374,117 @@ def test_set_is_overwritten():
         pass
 
     assert MyArtist4.set is MyArtist3.set
+
+
+def test_format_cursor_data_BoundaryNorm():
+    """Test if cursor data is correct when using BoundaryNorm."""
+    X = np.empty((3, 3))
+    X[0, 0] = 0.9
+    X[0, 1] = 0.99
+    X[0, 2] = 0.999
+    X[1, 0] = -1
+    X[1, 1] = 0
+    X[1, 2] = 1
+    X[2, 0] = 0.09
+    X[2, 1] = 0.009
+    X[2, 2] = 0.0009
+
+    # map range -1..1 to 0..256 in 0.1 steps
+    fig, ax = plt.subplots()
+    fig.suptitle("-1..1 to 0..256 in 0.1")
+    norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 20), 256)
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.1))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    # map range -1..1 to 0..256 in 0.01 steps
+    fig, ax = plt.subplots()
+    fig.suptitle("-1..1 to 0..256 in 0.01")
+    cmap = cm.get_cmap('RdBu_r', 200)
+    norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 200), 200)
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.01))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    # map range -1..1 to 0..256 in 0.01 steps
+    fig, ax = plt.subplots()
+    fig.suptitle("-1..1 to 0..256 in 0.001")
+    cmap = cm.get_cmap('RdBu_r', 2000)
+    norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 2000), 2000)
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.001))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    # out of bounds values for 0..1
+    Y = np.empty((7, 1))
+    Y[0] = -1.0
+    Y[1] = 0.0
+    Y[2] = 0.1
+    Y[3] = 0.5
+    Y[4] = 0.9
+    Y[5] = 1.0
+    Y[6] = 2.0
+
+    fig, ax = plt.subplots()
+    fig.suptitle("noclip, neither")
+    norm = mcolors.BoundaryNorm(
+        np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='neither')
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    fig, ax = plt.subplots()
+    fig.suptitle("noclip, min")
+    norm = mcolors.BoundaryNorm(
+        np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='min')
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    fig, ax = plt.subplots()
+    fig.suptitle("noclip, max")
+    norm = mcolors.BoundaryNorm(
+        np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='max')
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    fig, ax = plt.subplots()
+    fig.suptitle("noclip, both")
+    norm = mcolors.BoundaryNorm(
+        np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='both')
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()
+
+    fig, ax = plt.subplots()
+    fig.suptitle("clip, neither")
+    norm = mcolors.BoundaryNorm(
+        np.linspace(0, 1, 4, endpoint=True), 256, clip=True, extend='neither')
+    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    for v in X.flat:
+        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+        assert img.format_cursor_data(v) == label
+
+    plt.close()

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -405,7 +405,7 @@ def test_format_cursor_data_BoundaryNorm():
     fig.suptitle("-1..1 to 0..256 in 0.01")
     cmap = cm.get_cmap('RdBu_r', 200)
     norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 200), 200)
-    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    img = ax.imshow(X, cmap=cmap, norm=norm)
     for v in X.flat:
         label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.01))
         assert img.format_cursor_data(v) == label
@@ -417,7 +417,7 @@ def test_format_cursor_data_BoundaryNorm():
     fig.suptitle("-1..1 to 0..256 in 0.001")
     cmap = cm.get_cmap('RdBu_r', 2000)
     norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 2000), 2000)
-    img = ax.imshow(X, cmap='RdBu_r', norm=norm)
+    img = ax.imshow(X, cmap=cmap, norm=norm)
     for v in X.flat:
         label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.001))
         assert img.format_cursor_data(v) == label

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -5,7 +5,7 @@ import numpy as np
 
 import pytest
 
-from matplotlib import cbook, cm
+from matplotlib import cm
 import matplotlib.colors as mcolors
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
@@ -394,8 +394,20 @@ def test_format_cursor_data_BoundaryNorm():
     fig.suptitle("-1..1 to 0..256 in 0.1")
     norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 20), 256)
     img = ax.imshow(X, cmap='RdBu_r', norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.1))
+
+    labels_list = [
+        "[0.9]",
+        "[1.]",
+        "[1.]",
+        "[-1.0]",
+        "[0.0]",
+        "[1.0]",
+        "[0.09]",
+        "[0.009]",
+        "[0.0009]",
+    ]
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.1))
         assert img.format_cursor_data(v) == label
 
     plt.close()
@@ -406,8 +418,20 @@ def test_format_cursor_data_BoundaryNorm():
     cmap = cm.get_cmap('RdBu_r', 200)
     norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 200), 200)
     img = ax.imshow(X, cmap=cmap, norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.01))
+
+    labels_list = [
+        "[0.90]",
+        "[0.99]",
+        "[1.0]",
+        "[-1.00]",
+        "[0.00]",
+        "[1.00]",
+        "[0.09]",
+        "[0.009]",
+        "[0.0009]",
+    ]
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.01))
         assert img.format_cursor_data(v) == label
 
     plt.close()
@@ -418,29 +442,52 @@ def test_format_cursor_data_BoundaryNorm():
     cmap = cm.get_cmap('RdBu_r', 2000)
     norm = mcolors.BoundaryNorm(np.linspace(-1, 1, 2000), 2000)
     img = ax.imshow(X, cmap=cmap, norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.001))
+
+    labels_list = [
+        "[0.900]",
+        "[0.990]",
+        "[0.999]",
+        "[-1.000]",
+        "[0.000]",
+        "[1.000]",
+        "[0.090]",
+        "[0.009]",
+        "[0.0009]",
+    ]
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.001))
         assert img.format_cursor_data(v) == label
 
     plt.close()
 
-    # out of bounds values for 0..1
-    Y = np.empty((7, 1))
-    Y[0] = -1.0
-    Y[1] = 0.0
-    Y[2] = 0.1
-    Y[3] = 0.5
-    Y[4] = 0.9
-    Y[5] = 1.0
-    Y[6] = 2.0
+    # different testing data set with
+    # out of bounds values for 0..1 range
+    X = np.empty((7, 1))
+    X[0] = -1.0
+    X[1] = 0.0
+    X[2] = 0.1
+    X[3] = 0.5
+    X[4] = 0.9
+    X[5] = 1.0
+    X[6] = 2.0
+
+    labels_list = [
+        "[-1.0]",
+        "[0.0]",
+        "[0.1]",
+        "[0.5]",
+        "[0.9]",
+        "[1.0]",
+        "[2.0]",
+    ]
 
     fig, ax = plt.subplots()
     fig.suptitle("noclip, neither")
     norm = mcolors.BoundaryNorm(
         np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='neither')
     img = ax.imshow(X, cmap='RdBu_r', norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
         assert img.format_cursor_data(v) == label
 
     plt.close()
@@ -450,8 +497,8 @@ def test_format_cursor_data_BoundaryNorm():
     norm = mcolors.BoundaryNorm(
         np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='min')
     img = ax.imshow(X, cmap='RdBu_r', norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
         assert img.format_cursor_data(v) == label
 
     plt.close()
@@ -461,8 +508,8 @@ def test_format_cursor_data_BoundaryNorm():
     norm = mcolors.BoundaryNorm(
         np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='max')
     img = ax.imshow(X, cmap='RdBu_r', norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
         assert img.format_cursor_data(v) == label
 
     plt.close()
@@ -472,8 +519,8 @@ def test_format_cursor_data_BoundaryNorm():
     norm = mcolors.BoundaryNorm(
         np.linspace(0, 1, 4, endpoint=True), 256, clip=False, extend='both')
     img = ax.imshow(X, cmap='RdBu_r', norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
         assert img.format_cursor_data(v) == label
 
     plt.close()
@@ -483,8 +530,8 @@ def test_format_cursor_data_BoundaryNorm():
     norm = mcolors.BoundaryNorm(
         np.linspace(0, 1, 4, endpoint=True), 256, clip=True, extend='neither')
     img = ax.imshow(X, cmap='RdBu_r', norm=norm)
-    for v in X.flat:
-        label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
+    for v, label in zip(X.flat, labels_list):
+        # label = "[{:-#.{}g}]".format(v, cbook._g_sig_digits(v, 0.33))
         assert img.format_cursor_data(v) == label
 
     plt.close()


### PR DESCRIPTION
## PR Summary

This should fix #21915 with an `isinstance(norm, BoundaryNorm)` check and special logic to figure out the `delta` for calculating the value for the significant digits to show as cursor data output.
I opted to use the boundaries of the `BoundaryNorm` directly, instead of calculating the midpoints of neighboring regions (midpoint is done in the non-`BoundaryNorm` cases).  
I also added tests in `lib/matplotlib/tests/test_artist.py::test_format_cursor_data_BoundaryNorm`. For the tests I compare the cursor data output to identically formatted strings with fixed `delta` taken as the stepping of `np.linspace` that is used to create the boundaries for `BoundarNorm`. The fixed `delta` values are not identical to what this PR computed, but should give identical output for the strings.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ N/A] New features are documented, with examples if plot related.
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
