### PR TITLE
Fix Tk error when updating toolbar checkbutton images

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -669,9 +669,13 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
             button._ntimage_alt = image_alt
 
         if _is_dark("background"):
-            button.configure(image=image_alt)
+            # For Checkbuttons, we need to set `image` and `selectimage` at
+            # the same time. Otherwise, when updating the `image` option
+            # (such as when changing DPI), if the old `selectimage` has
+            # just been overwritten, Tk will throw an error.
+            image_kwargs = {"image": image_alt}
         else:
-            button.configure(image=image)
+            image_kwargs = {"image": image}
         # Checkbuttons may switch the background to `selectcolor` in the
         # checked state, so check separately which image it needs to use in
         # that state to still ensure enough contrast with the background.
@@ -689,11 +693,11 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
                 r2, g2, b2 = _get_color("activebackground")
                 selectcolor = ((r1+r2)/2, (g1+g2)/2, (b1+b2)/2)
             if _is_dark(selectcolor):
-                button.configure(selectimage=image_alt)
+                image_kwargs["selectimage"] = image_alt
             else:
-                button.configure(selectimage=image)
+                image_kwargs["selectimage"] = image
 
-        button.configure(height='18p', width='18p')
+        button.configure(**image_kwargs, height='18p', width='18p')
 
     def _Button(self, text, image_file, toggle, command):
         if not toggle:


### PR DESCRIPTION
## PR Summary
Fixes #22836 introduced in #22163
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
