### PR TITLE
Backport PR #22313 on branch v3.5.x (Fix colorbar exponents)

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2990,7 +2990,11 @@ class _AxesBase(martist.Artist):
                         or ax.xaxis.get_label_position() == 'top'):
                     bb = ax.xaxis.get_tightbbox(renderer)
                 else:
-                    bb = ax.get_window_extent(renderer)
+                    if 'outline' in ax.spines:
+                        # Special case for colorbars:
+                        bb = ax.spines['outline'].get_window_extent()
+                    else:
+                        bb = ax.get_window_extent(renderer)
                 if bb is not None:
                     top = max(top, bb.ymax)
             if top < 0:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2380,8 +2380,13 @@ class YAxis(Axis):
         Update the offset_text position based on the sequence of bounding
         boxes of all the ticklabels
         """
-        x, y = self.offsetText.get_position()
-        top = self.axes.bbox.ymax
+        x, _ = self.offsetText.get_position()
+        if 'outline' in self.axes.spines:
+            # Special case for colorbars:
+            bbox = self.axes.spines['outline'].get_window_extent()
+        else:
+            bbox = self.axes.bbox
+        top = bbox.ymax
         self.offsetText.set_position(
             (x, top + self.OFFSETTEXTPAD * self.figure.dpi / 72)
         )

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -968,3 +968,30 @@ def test_boundaries():
     fig, ax = plt.subplots(figsize=(2, 2))
     pc = ax.pcolormesh(np.random.randn(10, 10), cmap='RdBu_r')
     cb = fig.colorbar(pc, ax=ax, boundaries=np.linspace(-3, 3, 7))
+
+
+def test_offset_text_loc():
+    plt.style.use('mpl20')
+    fig, ax = plt.subplots()
+    np.random.seed(seed=19680808)
+    pc = ax.pcolormesh(np.random.randn(10, 10)*1e6)
+    cb = fig.colorbar(pc, location='right', extend='max')
+    fig.draw_without_rendering()
+    # check that the offsetText is in the proper place above the
+    # colorbar axes.  In this case the colorbar axes is the same
+    # height as the parent, so use the parents bbox.
+    assert cb.ax.yaxis.offsetText.get_position()[1] > ax.bbox.y1
+
+
+def test_title_text_loc():
+    plt.style.use('mpl20')
+    fig, ax = plt.subplots()
+    np.random.seed(seed=19680808)
+    pc = ax.pcolormesh(np.random.randn(10, 10))
+    cb = fig.colorbar(pc, location='right', extend='max')
+    cb.ax.set_title('Aardvark')
+    fig.draw_without_rendering()
+    # check that the title is in the proper place above the
+    # colorbar axes, including its extend triangles....
+    assert (cb.ax.title.get_window_extent(fig.canvas.get_renderer()).ymax >
+            cb.ax.spines['outline'].get_window_extent().ymax)

--- a/tutorials/introductory/usage.py
+++ b/tutorials/introductory/usage.py
@@ -502,7 +502,7 @@ axs[1, 0].set_title('imshow() with LogNorm()')
 
 pc = axs[1, 1].scatter(data1, data2, c=data3, cmap='RdBu_r')
 fig.colorbar(pc, ax=axs[1, 1], extend='both')
-axs[1, 1].set_title('scatter()');
+axs[1, 1].set_title('scatter()')
 
 ##############################################################################
 # Colormaps


### PR DESCRIPTION
## PR Summary

Manual backport of #22313; there were conflicts in `lib/matplotlib/axes/_base.py` (due to #21398 not being backported), and `lib/matplotlib/tests/test_colorbar.py` (due to an additional test on `main` conflicting with the new one here).

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).