### PR TITLE
fix and test deprecated layout method toggling

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2533,6 +2533,8 @@ class Figure(FigureBase):
         _tight_parameters = tight if isinstance(tight, dict) else {}
         if bool(tight):
             self.set_layout_engine(TightLayoutEngine(**_tight_parameters))
+        else:
+            self.set_layout_engine(None)
         self.stale = True
 
     def get_constrained_layout(self):
@@ -2569,6 +2571,8 @@ class Figure(FigureBase):
         _parameters = constrained if isinstance(constrained, dict) else {}
         if _constrained:
             self.set_layout_engine(ConstrainedLayoutEngine(**_parameters))
+        else:
+            self.set_layout_engine(None)
         self.stale = True
 
     @_api.deprecated(

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -608,3 +608,12 @@ def test_discouraged_api():
 def test_kwargs():
     fig, ax = plt.subplots(constrained_layout={'h_pad': 0.02})
     fig.draw_without_rendering()
+
+
+def test_constrained_toggle():
+    fig, ax = plt.subplots()
+    with pytest.warns(PendingDeprecationWarning):
+        fig.set_constrained_layout(True)
+        assert fig.get_constrained_layout()
+        fig.set_constrained_layout(False)
+        assert not fig.get_constrained_layout()

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -380,3 +380,12 @@ def test_tight_pads():
 def test_tight_kwargs():
     fig, ax = plt.subplots(tight_layout={'pad': 0.15})
     fig.draw_without_rendering()
+
+
+def test_tight_toggle():
+    fig, ax = plt.subplots()
+    with pytest.warns(PendingDeprecationWarning):
+        fig.set_tight_layout(True)
+        assert fig.get_tight_layout()
+        fig.set_tight_layout(False)
+        assert not fig.get_tight_layout()


### PR DESCRIPTION
## PR Summary
Fixes #22847. Not sure if there are knock-on effects, looking forward to code review.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
