### PR TITLE
Simplify tick creation

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -635,6 +635,9 @@ class Axis(martist.Artist):
         The minor ticks.
     """
     OFFSETTEXTPAD = 3
+    # The class used in _get_tick() to create tick instances. Must either be
+    # overwritten in subclasses, or subclasses must reimplement _get_tick().
+    _tick_class = None
 
     def __str__(self):
         return "{}({},{})".format(
@@ -1437,7 +1440,12 @@ class Axis(martist.Artist):
 
     def _get_tick(self, major):
         """Return the default tick instance."""
-        raise NotImplementedError('derived must override')
+        if self._tick_class is None:
+            raise NotImplementedError(
+                f"The Axis subclass {self.__class__.__name__} must define "
+                "_tick_class or reimplement _get_tick()")
+        tick_kw = self._major_tick_kw if major else self._minor_tick_kw
+        return self._tick_class(self.axes, 0, major=major, **tick_kw)
 
     def _get_tick_label_size(self, axis_name):
         """
@@ -2133,6 +2141,7 @@ def _make_getset_interval(method_name, lim_name, attr_name):
 class XAxis(Axis):
     __name__ = 'xaxis'
     axis_name = 'x'  #: Read-only name identifying the axis.
+    _tick_class = XTick
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2172,13 +2181,6 @@ class XAxis(Axis):
             b - self.pickradius < y < b or
             t < y < t + self.pickradius)
         return inaxis, {}
-
-    def _get_tick(self, major):
-        if major:
-            tick_kw = self._major_tick_kw
-        else:
-            tick_kw = self._minor_tick_kw
-        return XTick(self.axes, 0, major=major, **tick_kw)
 
     def set_label_position(self, position):
         """
@@ -2389,6 +2391,7 @@ class XAxis(Axis):
 class YAxis(Axis):
     __name__ = 'yaxis'
     axis_name = 'y'  #: Read-only name identifying the axis.
+    _tick_class = YTick
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -2430,13 +2433,6 @@ class YAxis(Axis):
             l - self.pickradius < x < l or
             r < x < r + self.pickradius)
         return inaxis, {}
-
-    def _get_tick(self, major):
-        if major:
-            tick_kw = self._major_tick_kw
-        else:
-            tick_kw = self._minor_tick_kw
-        return YTick(self.axes, 0, major=major, **tick_kw)
 
     def set_label_position(self, position):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -358,13 +358,7 @@ class ThetaAxis(maxis.XAxis):
     """
     __name__ = 'thetaaxis'
     axis_name = 'theta'  #: Read-only name identifying the axis.
-
-    def _get_tick(self, major):
-        if major:
-            tick_kw = self._major_tick_kw
-        else:
-            tick_kw = self._minor_tick_kw
-        return ThetaTick(self.axes, 0, major=major, **tick_kw)
+    _tick_class = ThetaTick
 
     def _wrap_locator_formatter(self):
         self.set_major_locator(ThetaLocator(self.get_major_locator()))
@@ -653,17 +647,11 @@ class RadialAxis(maxis.YAxis):
     """
     __name__ = 'radialaxis'
     axis_name = 'radius'  #: Read-only name identifying the axis.
+    _tick_class = RadialTick
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.sticky_edges.y.append(0)
-
-    def _get_tick(self, major):
-        if major:
-            tick_kw = self._major_tick_kw
-        else:
-            tick_kw = self._minor_tick_kw
-        return RadialTick(self.axes, 0, major=major, **tick_kw)
 
     def _wrap_locator_formatter(self):
         self.set_major_locator(RadialLocator(self.get_major_locator(),


### PR DESCRIPTION
The tick class hierarchy has a standard mechanism for creating ticks
via `_get_tick()` The only element that is changing in these functions
is the tick class. All other logic is identical.

This PR makes the tick class a class attribute of Axis so that we can
use one generic `_get_tick` implementation across all Axis subclasses.

Note that users/downstream libraries can still define their own
`_get_tick()` methods on subclasses if they want to have a different
behavior.
