### PR TITLE
Maintain color of tick labels

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -318,8 +318,16 @@ class Spine(mpatches.Patch):
                                  "'axes', or 'data' ")
         self._position = position
         self.set_transform(self.get_spine_transform())
-        if self.axis is not None:
+        if self.axis is not None and position != ('outward', 0.0):
+            major_labels = self.axis.get_majorticklabels()
+            minor_labels = self.axis.get_minorticklabels()
+            major_cols = [lab.get_color() for lab in major_labels]
+            minor_cols = [lab.get_color() for lab in minor_labels]
             self.axis.reset_ticks()
+            for col, label in zip(major_cols, self.axis.get_majorticklabels()):
+                label.set_color(col)
+            for col, label in zip(minor_cols, self.axis.get_minorticklabels()):
+                label.set_color(col)
         self.stale = True
 
     def get_position(self):

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -134,3 +134,19 @@ def test_label_without_ticks():
         spine.get_path()).get_extents()
     assert ax.xaxis.label.get_position()[1] < spinebbox.ymin, \
         "X-Axis label not below the spine"
+
+
+@check_figures_equal(extensions=['png'])
+def test_set_position_maintains_label_color(fig_test, fig_ref):
+    # set_position should not change the label color
+    ax = fig_test.subplots()
+    ax.plot([1, 2, 3])
+    for lab in ax.get_xticklabels():
+        lab.set_color("r")
+    ax.spines.left.set_position(("outward", 10))
+
+    ax = fig_ref.subplots()
+    ax.plot([1, 2, 3])
+    ax.spines.left.set_position(("outward", 10))
+    for lab in ax.get_xticklabels():
+        lab.set_color("r")


### PR DESCRIPTION
## PR Summary
Fixes [this issue](https://github.com/matplotlib/matplotlib/issues/22672). spine.set_position currently resets the axis's ticks, thereby resetting the color of the tick labels. I made it so the color is saved before and restored after reset_ticks is called. Also, reset_ticks is now only called when the position is not equal to ('outward', 0.0). This is to prevent resetting and applying color during the subplot initialization (during which set_position is called four times), because applying color before the initialization is done seems to break things and resetting the ticks isn't necessary then.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
