### PR TITLE
Fix issue with colorbar extend and drawedges

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -651,8 +651,14 @@ class Colorbar:
             if not self.drawedges:
                 if len(self._y) >= self.n_rasterize:
                     self.solids.set_rasterized(True)
-        self.dividers.set_segments(
-            np.dstack([X, Y])[1:-1] if self.drawedges else [])
+        if self.drawedges:
+            start_idx = 0 if self._extend_lower() else 1
+            if self._extend_upper():
+                self.dividers.set_segments(np.dstack([X, Y])[start_idx:])
+            else:
+                self.dividers.set_segments(np.dstack([X, Y])[start_idx:-1])
+        else:
+            self.dividers.set_segments([])
 
     def _add_solids_patches(self, X, Y, C, mappable):
         hatches = mappable.hatches * len(C)  # Have enough hatches.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -653,10 +653,8 @@ class Colorbar:
                     self.solids.set_rasterized(True)
         if self.drawedges:
             start_idx = 0 if self._extend_lower() else 1
-            if self._extend_upper():
-                self.dividers.set_segments(np.dstack([X, Y])[start_idx:])
-            else:
-                self.dividers.set_segments(np.dstack([X, Y])[start_idx:-1])
+            end_idx = len(X) if self._extend_upper() else -1
+            self.dividers.set_segments(np.dstack([X, Y])[start_idx:end_idx])
         else:
             self.dividers.set_segments([])
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -919,6 +919,30 @@ def test_proportional_colorbars():
             fig.colorbar(CS3, spacing=spacings[j], ax=axs[i, j])
 
 
+@pytest.mark.parametrize("extend, coloroffset, res", [
+    ('both', 1, [np.array([[0., 0.], [0., 1.]]),
+                 np.array([[1., 0.], [1., 1.]]),
+                 np.array([[2., 0.], [2., 1.]])]),
+    ('min', 0, [np.array([[0., 0.], [0., 1.]]),
+                np.array([[1., 0.], [1., 1.]])]),
+    ('max', 0, [np.array([[1., 0.], [1., 1.]]),
+                np.array([[2., 0.], [2., 1.]])]),
+    ('neither', -1, [np.array([[1., 0.], [1., 1.]])])
+    ])
+def test_colorbar_extend_drawedges(extend, coloroffset, res):
+    cmap = plt.get_cmap("viridis")
+    bounds = np.arange(3)
+    nb_colors = len(bounds) + coloroffset
+    colors = cmap(np.linspace(100, 255, nb_colors).astype(int))
+    cmap, norm = mcolors.from_levels_and_colors(bounds, colors, extend=extend)
+
+    plt.figure(figsize=(5, 1))
+    ax = plt.subplot(111)
+    cbar = Colorbar(ax, cmap=cmap, norm=norm, orientation='horizontal',
+                    drawedges=True)
+    assert np.all(np.equal(cbar.dividers.get_segments(), res))
+
+
 def test_negative_boundarynorm():
     fig, ax = plt.subplots(figsize=(1, 3))
     cmap = plt.get_cmap("viridis")


### PR DESCRIPTION
## PR Summary

Closes #22864

Maybe the test can be simplified/written in a better way?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
