### PR TITLE
Fix year offset not always being added

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -796,8 +796,10 @@ class ConciseDateFormatter(ticker.Formatter):
         # mostly 0: years,  1: months,  2: days,
         # 3: hours, 4: minutes, 5: seconds, 6: microseconds
         for level in range(5, -1, -1):
-            if len(np.unique(tickdate[:, level])) > 1:
-                if level < 2:
+            unique = np.unique(tickdate[:, level])
+            if len(unique) > 1:
+                # if 1 is included in unique, the year is shown in ticks
+                if level < 2 and np.any(unique == 1):
                     show_offset = False
                 break
             elif level == 0:

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -630,6 +630,10 @@ def test_offset_changes():
     ax.set_xlim(d1, d1 + datetime.timedelta(weeks=3))
     fig.draw_without_rendering()
     assert formatter.get_offset() == '1997-Jan'
+    ax.set_xlim(d1 + datetime.timedelta(weeks=7),
+                d1 + datetime.timedelta(weeks=30))
+    fig.draw_without_rendering()
+    assert formatter.get_offset() == '1997'
     ax.set_xlim(d1, d1 + datetime.timedelta(weeks=520))
     fig.draw_without_rendering()
     assert formatter.get_offset() == ''


### PR DESCRIPTION
## PR Summary
Closes #22472

![image](https://user-images.githubusercontent.com/8114497/164464299-d2654701-3fe2-468f-bb11-04b7981d40a6.png)

Maybe this should go in 3.5.2 (previous related fix went in 3.5.1)? Marking as 3.5.2 for now.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
