### PR TITLE
Support not embedding glyphs in svg mathtests.

### DIFF
--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -116,7 +116,11 @@ math_tests = [
     r'$\left(X\right)_{a}^{b}$',  # github issue 7615
     r'$\dfrac{\$100.00}{y}$',  # github issue #1888
 ]
-# 'Lightweight' tests test only a single fontset (dejavusans, which is the
+# 'svgastext' tests switch svg output to embed text as text (rather than as
+# paths).
+svgastext_math_tests = [
+]
+# 'lightweight' tests test only a single fontset (dejavusans, which is the
 # default) and only png outputs, in order to minimize the size of baseline
 # images.
 lightweight_math_tests = [
@@ -195,6 +199,24 @@ def baseline_images(request, fontset, index, text):
 def test_mathtext_rendering(baseline_images, fontset, index, text):
     mpl.rcParams['mathtext.fontset'] = fontset
     fig = plt.figure(figsize=(5.25, 0.75))
+    fig.text(0.5, 0.5, text,
+             horizontalalignment='center', verticalalignment='center')
+
+
+@pytest.mark.parametrize('index, text', enumerate(svgastext_math_tests),
+                         ids=range(len(svgastext_math_tests)))
+@pytest.mark.parametrize(
+    'fontset', ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif'])
+@pytest.mark.parametrize('baseline_images', ['mathtext0'], indirect=True)
+@image_comparison(
+    baseline_images=None,
+    savefig_kwarg={'metadata': {  # Minimize image size.
+        'Creator': None, 'Date': None, 'Format': None, 'Type': None}})
+def test_mathtext_rendering_svgastext(baseline_images, fontset, index, text):
+    mpl.rcParams['mathtext.fontset'] = fontset
+    mpl.rcParams['svg.fonttype'] = 'none'  # Minimize image size.
+    fig = plt.figure(figsize=(5.25, 0.75))
+    fig.patch.set(visible=False)  # Minimize image size.
     fig.text(0.5, 0.5, text,
              horizontalalignment='center', verticalalignment='center')
 


### PR DESCRIPTION
## PR Summary

Redo of #19201 (decrease size of mathtext svg baselines, by switching to embedding text as text, not as paths), but without removing the other formats or restricting fonts.  Suggested as a preliminary to #22852 (which would just need to move the affected tests to the new `svgastext_math_tests` list.

Intentionally contains an example test in a second commit, which is reverted by the third commit: checkout the second commit to test locally.  I will remove these two commits from history (and hence get rid of the "unclean PR" lint) if this PR gets approved.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
This reverts commit ce14a1b.