### PR TITLE
Tweak argument checking in tripcolor().

### DIFF
--- a/doc/api/next_api_changes/deprecations/22883-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22883-AL.rst
@@ -1,0 +1,3 @@
+Passing too many positional arguments to ``tripcolor``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is now deprecated (extra arguments were previously silently ignored).

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -242,7 +242,7 @@ def test_tripcolor_color():
     x = [-1, 0, 1, 0]
     y = [0, -1, 0, 1]
     fig, ax = plt.subplots()
-    with pytest.raises(ValueError, match="Missing color parameter"):
+    with pytest.raises(TypeError, match=r"tripcolor\(\) missing 1 required "):
         ax.tripcolor(x, y)
     with pytest.raises(ValueError, match="The length of C must match either"):
         ax.tripcolor(x, y, [1, 2, 3])
@@ -255,8 +255,8 @@ def test_tripcolor_color():
     with pytest.raises(ValueError,
                        match="'gouraud' .* at the points.* not at the faces"):
         ax.tripcolor(x, y, [1, 2], shading='gouraud')  # faces
-    with pytest.raises(ValueError,
-                       match=r"pass C positionally or facecolors via keyword"):
+    with pytest.raises(TypeError,
+                       match="positional.*'C'.*keyword-only.*'facecolors'"):
         ax.tripcolor(x, y, C=[1, 2, 3, 4])
 
     # smoke test for valid color specifications (via C or facecolors)
@@ -282,7 +282,7 @@ def test_tripcolor_warnings():
     C = [0.4, 0.5]
     fig, ax = plt.subplots()
     # additional parameters
-    with pytest.warns(UserWarning, match="Additional positional parameters"):
+    with pytest.warns(DeprecationWarning, match="Additional positional param"):
         ax.tripcolor(x, y, C, 'unused_positional')
     # facecolors takes precednced over C
     with pytest.warns(UserWarning, match="Positional parameter C .*no effect"):

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -79,12 +79,14 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
     else:
         # Color from positional parameter C
         if not args:
-            raise ValueError(
-                "Missing color parameter. Please pass C positionally or "
-                "facecolors via keyword")
+            raise TypeError(
+                "tripcolor() missing 1 required positional argument: 'C'; or "
+                "1 required keyword-only argument: 'facecolors'")
         elif len(args) > 1:
-            _api.warn_external(
-                "Additional positional parameters {args[1:]!r} are ignored")
+            _api.warn_deprecated(
+                "3.6", message=f"Additional positional parameters "
+                f"{args[1:]!r} are ignored; support for them is deprecated "
+                f"since %(since)s and will be removed %(removal)s")
         C = np.asarray(args[0])
         if len(C) == len(tri.x):
             # having this before the len(tri.triangles) comparison gives


### PR DESCRIPTION
For incorrect number of parameters, switch to raising a (standard)
TypeError and use a standard-ish signature mismatch error message.  Note
that exception type stability was already broken in 3.6 because it was
previously an IndexError (that was triggered later) and 703b574 changed
that to a ValueError.

Also deprecate support for passing extra parameters (as we now tend to
do for all such overly accepting APIs).  Note that the changelog entry
states that such parameters were previously silently ignored, even
though the patch replaces a warn_external() by a warn_deprecated(); this
is simply because the warn_external() wasn't present yet in the last
released version.

Also closes #22882.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
