### PR TITLE
Deprecate two-layered backend_pdf.Op enum.

### DIFF
--- a/doc/api/next_api_changes/deprecations/22885-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22885-AL.rst
@@ -1,0 +1,4 @@
+``backend_pdf.Operator`` and ``backend_pdf.Op.op``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated in favor of a single standard `enum.Enum` interface on
+`.backend_pdf.Op`.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -399,8 +399,8 @@ class Name:
         return b'/' + self.name
 
 
+@_api.deprecated("3.6")
 class Operator:
-    """PDF operator object."""
     __slots__ = ('op',)
 
     def __init__(self, op):
@@ -422,45 +422,51 @@ class Verbatim:
         return self._x
 
 
-# PDF operators (not an exhaustive list)
-class Op(Operator, Enum):
+class Op(Enum):
+    """PDF operators (not an exhaustive list)."""
+
     close_fill_stroke = b'b'
     fill_stroke = b'B'
     fill = b'f'
-    closepath = b'h',
+    closepath = b'h'
     close_stroke = b's'
     stroke = b'S'
     endpath = b'n'
-    begin_text = b'BT',
+    begin_text = b'BT'
     end_text = b'ET'
     curveto = b'c'
     rectangle = b're'
     lineto = b'l'
-    moveto = b'm',
+    moveto = b'm'
     concat_matrix = b'cm'
     use_xobject = b'Do'
-    setgray_stroke = b'G',
+    setgray_stroke = b'G'
     setgray_nonstroke = b'g'
     setrgb_stroke = b'RG'
-    setrgb_nonstroke = b'rg',
+    setrgb_nonstroke = b'rg'
     setcolorspace_stroke = b'CS'
-    setcolorspace_nonstroke = b'cs',
+    setcolorspace_nonstroke = b'cs'
     setcolor_stroke = b'SCN'
     setcolor_nonstroke = b'scn'
-    setdash = b'd',
+    setdash = b'd'
     setlinejoin = b'j'
     setlinecap = b'J'
     setgstate = b'gs'
-    gsave = b'q',
+    gsave = b'q'
     grestore = b'Q'
     textpos = b'Td'
     selectfont = b'Tf'
-    textmatrix = b'Tm',
+    textmatrix = b'Tm'
     show = b'Tj'
     showkern = b'TJ'
     setlinewidth = b'w'
     clip = b'W'
     shading = b'sh'
+
+    op = _api.deprecated('3.6')(property(lambda self: self.value))
+
+    def pdfRepr(self):
+        return self.value
 
     @classmethod
     def paint_path(cls, fill, stroke):
@@ -1833,7 +1839,8 @@ end"""
         return [Verbatim(_path.convert_to_string(
             path, transform, clip, simplify, sketch,
             6,
-            [Op.moveto.op, Op.lineto.op, b'', Op.curveto.op, Op.closepath.op],
+            [Op.moveto.value, Op.lineto.value, b'', Op.curveto.value,
+             Op.closepath.value],
             True))]
 
     def writePath(self, path, transform, clip=False, sketch=None):


### PR DESCRIPTION
When Op was converted to an enum, the Operator class could have been
folded into it; this PR implements that.  Also deprecate `.op` in favor
of the standard `enum.value` interface.  Also fix "extra" commas in the
enum definition (which didn't actually matter, as enum init unpacks
tuple args, but we may just as well do things properly).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
