### PR TITLE
MNT: remove redundant imports

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1,8 +1,7 @@
 from collections import namedtuple
 import contextlib
 from functools import wraps
-import inspect
-from inspect import Signature, Parameter
+from inspect import getdoc, Parameter, signature, Signature
 import logging
 from numbers import Number
 import re
@@ -1411,7 +1410,7 @@ class ArtistInspector:
             if not self.is_alias(func):
                 continue
             propname = re.search("`({}.*)`".format(name[:4]),  # get_.*/set_.*
-                                 inspect.getdoc(func)).group(1)
+                                 getdoc(func)).group(1)
             aliases.setdefault(propname[4:], set()).add(name[4:])
         return aliases
 
@@ -1433,7 +1432,7 @@ class ArtistInspector:
             raise AttributeError('%s has no function %s' % (self.o, name))
         func = getattr(self.o, name)
 
-        docstring = inspect.getdoc(func)
+        docstring = getdoc(func)
         if docstring is None:
             return 'unknown'
 
@@ -1479,7 +1478,7 @@ class ArtistInspector:
                 continue
             func = getattr(self.o, name)
             if (not callable(func)
-                    or len(inspect.signature(func).parameters) < 2
+                    or len(signature(func).parameters) < 2
                     or self.is_alias(func)):
                 continue
             setters.append(name[4:])
@@ -1487,7 +1486,7 @@ class ArtistInspector:
 
     def is_alias(self, o):
         """Return whether method object *o* is an alias for another method."""
-        ds = inspect.getdoc(o)
+        ds = getdoc(o)
         if ds is None:
             return False
         return ds.startswith('Alias for ')

--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -9,10 +9,10 @@ import functools
 
 import numpy as np
 
-import matplotlib as mpl
 from matplotlib import _api, cbook
 import matplotlib.axes as maxes
 import matplotlib.patches as mpatches
+from matplotlib.transforms import _interval_contains_close
 from matplotlib.path import Path
 
 from mpl_toolkits.axes_grid1.parasite_axes import host_axes_class_factory
@@ -124,8 +124,7 @@ class FixedAxisArtistHelper(grid_helper_curvelinear.FloatingAxisArtistHelper):
             dd[mm] = dd2[mm] + np.pi / 2
 
             tick_to_axes = self.get_tick_transform(axes) - axes.transAxes
-            in_01 = functools.partial(
-                mpl.transforms._interval_contains_close, (0, 1))
+            in_01 = functools.partial(_interval_contains_close, (0, 1))
             for x, y, d, d2, lab in zip(xx1, yy1, dd, dd2, labels):
                 c2 = tick_to_axes.transform((x, y))
                 if in_01(c2[0]) and in_01(c2[1]):

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -7,10 +7,10 @@ from itertools import chain
 
 import numpy as np
 
-import matplotlib as mpl
 from matplotlib import _api
 from matplotlib.path import Path
-from matplotlib.transforms import Affine2D, IdentityTransform
+from matplotlib.transforms import (Affine2D, IdentityTransform,
+                                   _interval_contains_close)
 from .axislines import AxisArtistHelper, GridHelperBase
 from .axis_artist import AxisArtist
 from .grid_finder import GridFinder
@@ -234,8 +234,7 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
             dd[mm] = dd2[mm] + np.pi / 2
 
             tick_to_axes = self.get_tick_transform(axes) - axes.transAxes
-            in_01 = functools.partial(
-                mpl.transforms._interval_contains_close, (0, 1))
+            in_01 = functools.partial(_interval_contains_close, (0, 1))
             for x, y, d, d2, lab in zip(xx1, yy1, dd, dd2, labels):
                 c2 = tick_to_axes.transform((x, y))
                 if in_01(c2[0]) and in_01(c2[1]):


### PR DESCRIPTION
## PR Summary

Should lead to faster (at least not slower) imports. And fix LGTM issues.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
