### PR TITLE
Alternative approach to organizing uniform manager creation

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1576,6 +1576,8 @@ class FigureCanvasBase:
         A high-level figure instance.
     """
 
+    manager_class = FigureManagerBase
+
     # Set to one of {"qt", "gtk3", "gtk4", "wx", "tk", "macosx"} if an
     # interactive framework is required, or None otherwise.
     required_interactive_framework = None
@@ -1666,11 +1668,8 @@ class FigureCanvasBase:
     def new_manager(cls, figure, num):
         """
         Create a new figure manager for *figure*, using this canvas class.
-
-        Backends should override this method to instantiate the correct figure
-        manager subclass, and perform any additional setup that may be needed.
         """
-        return FigureManagerBase(cls(figure), num)
+        return cls.manager_class.create_with_canvas(cls, figure, num)
 
     @contextmanager
     def _idle_draw_cntx(self):
@@ -2768,6 +2767,11 @@ class FigureManagerBase:
             # Called whenever the current Axes is changed.
             if self.toolmanager is None and self.toolbar is not None:
                 self.toolbar.update()
+
+    @classmethod
+    def create_with_canvas(cls, canvas_class, figure, num):
+        canvas = canvas_class(figure)
+        return cls(canvas, num)
 
     def show(self):
         """

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -161,6 +161,7 @@ class TimerTk(TimerBase):
 
 
 class FigureCanvasTk(FigureCanvasBase):
+    manager_class = FigureManagerTk
     required_interactive_framework = "tk"
 
     def __init__(self, figure=None, master=None):
@@ -222,43 +223,6 @@ class FigureCanvasTk(FigureCanvasBase):
             # canvas backing store on that event.
             w, h = self.get_width_height(physical=True)
             self._tkcanvas.configure(width=w, height=h)
-
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        with _restore_foreground_window_at_end():
-            if cbook._get_running_interactive_framework() is None:
-                cbook._setup_new_guiapp()
-                _c_internal_utils.Win32_SetProcessDpiAwareness_max()
-            window = tk.Tk(className="matplotlib")
-            window.withdraw()
-
-            # Put a Matplotlib icon on the window rather than the default tk
-            # icon. See https://www.tcl.tk/man/tcl/TkCmd/wm.html#M50
-            #
-            # `ImageTk` can be replaced with `tk` whenever the minimum
-            # supported Tk version is increased to 8.6, as Tk 8.6+ natively
-            # supports PNG images.
-            icon_fname = str(cbook._get_data_path(
-                'images/matplotlib.png'))
-            icon_img = ImageTk.PhotoImage(file=icon_fname, master=window)
-
-            icon_fname_large = str(cbook._get_data_path(
-                'images/matplotlib_large.png'))
-            icon_img_large = ImageTk.PhotoImage(
-                file=icon_fname_large, master=window)
-            try:
-                window.iconphoto(False, icon_img_large, icon_img)
-            except Exception as exc:
-                # log the failure (due e.g. to Tk version), but carry on
-                _log.info('Could not load matplotlib icon: %s', exc)
-
-            canvas = cls(figure, master=window)
-            manager = FigureManagerTk(canvas, num, window)
-            if mpl.is_interactive():
-                manager.show()
-                canvas.draw_idle()
-            return manager
 
     def resize(self, event):
         width, height = event.width, event.height
@@ -467,6 +431,44 @@ class FigureManagerTk(FigureManagerBase):
             window_dpi.trace_add('write', self._update_window_dpi)
 
         self._shown = False
+
+    @classmethod
+    def create_with_canvas(cls, canvas_class, figure, num):
+
+        with _restore_foreground_window_at_end():
+            if cbook._get_running_interactive_framework() is None:
+                cbook._setup_new_guiapp()
+                _c_internal_utils.Win32_SetProcessDpiAwareness_max()
+            window = tk.Tk(className="matplotlib")
+            window.withdraw()
+
+            # Put a Matplotlib icon on the window rather than the default tk
+            # icon. See https://www.tcl.tk/man/tcl/TkCmd/wm.html#M50
+            #
+            # `ImageTk` can be replaced with `tk` whenever the minimum
+            # supported Tk version is increased to 8.6, as Tk 8.6+ natively
+            # supports PNG images.
+            icon_fname = str(cbook._get_data_path(
+                'images/matplotlib.png'))
+            icon_img = ImageTk.PhotoImage(file=icon_fname, master=window)
+
+            icon_fname_large = str(cbook._get_data_path(
+                'images/matplotlib_large.png'))
+            icon_img_large = ImageTk.PhotoImage(
+                file=icon_fname_large, master=window)
+            try:
+                window.iconphoto(False, icon_img_large, icon_img)
+            except Exception as exc:
+                # log the failure (due e.g. to Tk version), but carry on
+                _log.info('Could not load matplotlib icon: %s', exc)
+
+            canvas = canvas_class(figure, master=window)
+            manager = FigureManagerTk(canvas, num, window)
+            if mpl.is_interactive():
+                manager.show()
+                canvas.draw_idle()
+            return manager
+
 
     def _update_window_dpi(self, *args):
         newdpi = self._window_dpi.get()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -71,6 +71,7 @@ def _mpl_to_gtk_cursor(mpl_cursor):
 class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
     required_interactive_framework = "gtk3"
     _timer_cls = TimerGTK3
+    manager_class = FigureManagerGTK3
     # Setting this as a static constant prevents
     # this resulting expression from leaking
     event_mask = (Gdk.EventMask.BUTTON_PRESS_MASK
@@ -114,11 +115,6 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         style_ctx = self.get_style_context()
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")
-
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        return FigureManagerGTK3(cls(figure), num)
 
     def destroy(self):
         self.close_event()

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -115,6 +115,11 @@ class FigureCanvasGTK3(Gtk.DrawingArea, FigureCanvasBase):
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")
 
+    @classmethod
+    def new_manager(cls, figure, num):
+        # docstring inherited
+        return FigureManagerGTK3(cls(figure), num)
+
     def destroy(self):
         self.close_event()
 

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -33,6 +33,7 @@ class FigureCanvasGTK4(Gtk.DrawingArea, FigureCanvasBase):
     required_interactive_framework = "gtk4"
     supports_blit = False
     _timer_cls = TimerGTK4
+    manager_class = FigureManagerGTK4
     _context_is_scaled = False
 
     def __init__(self, figure=None):
@@ -77,11 +78,6 @@ class FigureCanvasGTK4(Gtk.DrawingArea, FigureCanvasBase):
         style_ctx = self.get_style_context()
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")
-
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        return FigureManagerGTK4(cls(figure), num)
 
     def pick(self, mouseevent):
         # GtkWidget defines pick in GTK4, so we need to override here to work

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -78,6 +78,11 @@ class FigureCanvasGTK4(Gtk.DrawingArea, FigureCanvasBase):
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")
 
+    @classmethod
+    def new_manager(cls, figure, num):
+        # docstring inherited
+        return FigureManagerGTK4(cls(figure), num)
+
     def pick(self, mouseevent):
         # GtkWidget defines pick in GTK4, so we need to override here to work
         # with the base implementation we want.

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -33,6 +33,11 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         self._draw_pending = False
         self._is_drawing = False
 
+    @classmethod
+    def new_manager(cls, figure, num):
+        # docstring inherited
+        return FigureManagerMac(cls(figure), num)
+
     def set_cursor(self, cursor):
         # docstring inherited
         _macosx.set_cursor(cursor)

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -25,6 +25,7 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
 
     required_interactive_framework = "macosx"
     _timer_cls = TimerMac
+    manager_class = FigureManagerMac
 
     def __init__(self, figure):
         FigureCanvasBase.__init__(self, figure)
@@ -32,11 +33,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         _macosx.FigureCanvas.__init__(self, width, height)
         self._draw_pending = False
         self._is_drawing = False
-
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        return FigureManagerMac(cls(figure), num)
 
     def set_cursor(self, cursor):
         # docstring inherited

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -78,6 +78,20 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
         self._shown = False
         super().__init__(canvas, num)
 
+    def create_with_canvas(self, canvas_class, figure, num):
+        canvas = canvas_class(figure)
+        manager = FigureManagerNbAgg(canvas, num)
+        if is_interactive():
+            manager.show()
+            figure.canvas.draw_idle()
+
+        def destroy(event):
+            canvas.mpl_disconnect(cid)
+            Gcf.destroy(manager)
+
+        cid = canvas.mpl_connect('close_event', destroy)
+        return manager
+
     def display_js(self):
         # XXX How to do this just once? It has to deal with multiple
         # browser instances using the same kernel (require.js - but the
@@ -143,20 +157,7 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
 
 
 class FigureCanvasNbAgg(FigureCanvasWebAggCore):
-    @classmethod
-    def new_manager(cls, figure, num):
-        canvas = cls(figure)
-        manager = FigureManagerNbAgg(canvas, num)
-        if is_interactive():
-            manager.show()
-            figure.canvas.draw_idle()
-
-        def destroy(event):
-            canvas.mpl_disconnect(cid)
-            Gcf.destroy(manager)
-
-        cid = canvas.mpl_connect('close_event', destroy)
-        return manager
+    manager_class = FigureManagerNbAgg
 
 
 class CommSocket:

--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -143,7 +143,20 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
 
 
 class FigureCanvasNbAgg(FigureCanvasWebAggCore):
-    pass
+    @classmethod
+    def new_manager(cls, figure, num):
+        canvas = cls(figure)
+        manager = FigureManagerNbAgg(canvas, num)
+        if is_interactive():
+            manager.show()
+            figure.canvas.draw_idle()
+
+        def destroy(event):
+            canvas.mpl_disconnect(cid)
+            Gcf.destroy(manager)
+
+        cid = canvas.mpl_connect('close_event', destroy)
+        return manager
 
 
 class CommSocket:
@@ -227,21 +240,6 @@ class CommSocket:
 class _BackendNbAgg(_Backend):
     FigureCanvas = FigureCanvasNbAgg
     FigureManager = FigureManagerNbAgg
-
-    @staticmethod
-    def new_figure_manager_given_figure(num, figure):
-        canvas = FigureCanvasNbAgg(figure)
-        manager = FigureManagerNbAgg(canvas, num)
-        if is_interactive():
-            manager.show()
-            figure.canvas.draw_idle()
-
-        def destroy(event):
-            canvas.mpl_disconnect(cid)
-            Gcf.destroy(manager)
-
-        cid = canvas.mpl_connect('close_event', destroy)
-        return manager
 
     @staticmethod
     def show(block=None):

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -232,6 +232,7 @@ class TimerQT(TimerBase):
 class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
     required_interactive_framework = "qt"
     _timer_cls = TimerQT
+    manager_class = FigureManagerQT
 
     buttond = {
         getattr(_enum("QtCore.Qt.MouseButton"), k): v for k, v in [
@@ -259,11 +260,6 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
 
         palette = QtGui.QPalette(QtGui.QColor("white"))
         self.setPalette(palette)
-
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        return FigureManagerQT(cls(figure), num)
 
     def _update_pixel_ratio(self):
         if self._set_device_pixel_ratio(_devicePixelRatioF(self)):

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -260,6 +260,11 @@ class FigureCanvasQT(QtWidgets.QWidget, FigureCanvasBase):
         palette = QtGui.QPalette(QtGui.QColor("white"))
         self.setPalette(palette)
 
+    @classmethod
+    def new_manager(cls, figure, num):
+        # docstring inherited
+        return FigureManagerQT(cls(figure), num)
+
     def _update_pixel_ratio(self):
         if self._set_device_pixel_ratio(_devicePixelRatioF(self)):
             # The easiest way to resize the canvas is to emit a resizeEvent

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -49,7 +49,10 @@ webagg_server_thread = ServerThread()
 
 
 class FigureCanvasWebAgg(core.FigureCanvasWebAggCore):
-    pass
+    @classmethod
+    def new_manager(cls, figure, num):
+        # docstring inherited
+        return core.FigureManagerWebAgg(cls(figure), num)
 
 
 class FigureManagerWebAgg(core.FigureManagerWebAgg):

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -49,10 +49,7 @@ webagg_server_thread = ServerThread()
 
 
 class FigureCanvasWebAgg(core.FigureCanvasWebAggCore):
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        return core.FigureManagerWebAgg(cls(figure), num)
+    manager_class = core.FigureManagerWebAgg
 
 
 class FigureManagerWebAgg(core.FigureManagerWebAgg):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -427,6 +427,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
 
     required_interactive_framework = "wx"
     _timer_cls = TimerWx
+    manager_class = FigureManagerWx
 
     keyvald = {
         wx.WXK_CONTROL: 'control',
@@ -536,17 +537,6 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
 
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)  # Reduce flicker.
         self.SetBackgroundColour(wx.WHITE)
-
-    @classmethod
-    def new_manager(cls, figure, num):
-        # docstring inherited
-        wxapp = wx.GetApp() or _create_wxapp()
-        frame = FigureFrameWx(num, figure, canvas_class=cls)
-        figmgr = frame.get_figure_manager()
-        if mpl.is_interactive():
-            figmgr.frame.Show()
-            figure.canvas.draw_idle()
-        return figmgr
 
     def Copy_to_Clipboard(self, event=None):
         """Copy bitmap of canvas to system clipboard."""
@@ -989,6 +979,16 @@ class FigureManagerWx(FigureManagerBase):
         _log.debug("%s - __init__()", type(self))
         self.frame = self.window = frame
         super().__init__(canvas, num)
+
+    @classmethod
+    def create_with_canvas(cls, canvas_class, figure, num):
+        wxapp = wx.GetApp() or _create_wxapp()
+        frame = FigureFrameWx(num, figure, canvas_class=canvas_class)
+        figmgr = frame.get_figure_manager()
+        if mpl.is_interactive():
+            figmgr.frame.Show()
+            figure.canvas.draw_idle()
+        return figmgr
 
     def show(self):
         # docstring inherited


### PR DESCRIPTION
Alternative to #18854.

Basic idea:
- The canvas feels like it should be a relatively simple widget class and not have to care about the logic of creating a manager.
- Still we want `canvas.new_manager()` for convenience.
- So let's move the responsibility of wiring everything up to the Manager class and let the Canvas class only know which manager class to ask for creating a manager.

For easier understanding of the differences, this builds on top of #18854, but commits may be squashed.

This still needs reorganization/tweaking as the Manager classes are currently defined after the Canvas classes in the backends, so setting a Canvas class variable to a manager does not work out of the box (either change the definition order or make `manager_class` a class property to delay lookup).