### PR TITLE
Only set Tk scaling-on-map for Windows systems

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -175,7 +175,8 @@ class FigureCanvasTk(FigureCanvasBase):
             master=self._tkcanvas, width=w, height=h)
         self._tkcanvas.create_image(w//2, h//2, image=self._tkphoto)
         self._tkcanvas.bind("<Configure>", self.resize)
-        self._tkcanvas.bind("<Map>", self._update_device_pixel_ratio)
+        if sys.platform == 'win32':
+            self._tkcanvas.bind("<Map>", self._update_device_pixel_ratio)
         self._tkcanvas.bind("<Key>", self.key_press)
         self._tkcanvas.bind("<Motion>", self.motion_notify_event)
         self._tkcanvas.bind("<Enter>", self.enter_notify_event)
@@ -212,7 +213,7 @@ class FigureCanvasTk(FigureCanvasBase):
         self._rubberband_rect = None
 
     def _update_device_pixel_ratio(self, event=None):
-        # Tk gives scaling with respect to 72 DPI, but most (all?) screens are
+        # Tk gives scaling with respect to 72 DPI, but Windows screens are
         # scaled vs 96 dpi, and pixel ratio settings are given in whole
         # percentages, so round to 2 digits.
         ratio = round(self._tkcanvas.tk.call('tk', 'scaling') / (96 / 72), 2)


### PR DESCRIPTION
## PR Summary

On Windows, the DPI that Tk sees is 96 for regular screens and some multiple of that for HiDPI screens.

On Linux, the DPI is the true DPI (or at least what the display server tells it is true), and doesn't have anything to do with HiDPI. 

On macOS, the DPI appears closer to 72 by default. If anyone with a retina screen could check what the value of `self._tkcanvas.tk.call('tk', 'scaling')` is in `FigureCanvasTk._update_device_pixel_ratio`, then perhaps we could enable HiDPI-on-startup there, at least.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).