### PR TITLE
Fix documentation markup issues

### DIFF
--- a/doc/api/next_api_changes/removals/22107-OG.rst
+++ b/doc/api/next_api_changes/removals/22107-OG.rst
@@ -2,6 +2,7 @@ Removal of deprecated ``mathtext`` APIs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following `matplotlib.mathtext` APIs have been removed:
+
 - ``Fonts`` and all its subclasses,
 - ``FontConstantsBase`` and all its subclasses,
 - ``Node`` and all its subclasses,
@@ -18,15 +19,19 @@ Removal of various ``mathtext`` helpers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following `matplotlib.mathtext` classes:
+
 - ``MathtextBackendPdf``,
 - ``MathtextBackendPs``,
 - ``MathtextBackendSvg``,
 - ``MathtextBackendCairo``,
+
 and the ``.mathtext_parser`` attributes on
+
 - `.RendererPdf`,
 - `.RendererPS`,
 - `.RendererSVG`,
 - `.RendererCairo`
+
 have been removed. The `.MathtextBackendPath` class can be used instead.
 
 The methods ``get_depth``, ``parse``, ``to_mask``, ``to_rgba``, and ``to_png``

--- a/doc/devel/MEP/MEP27.rst
+++ b/doc/devel/MEP/MEP27.rst
@@ -13,9 +13,11 @@ Status
 Branches and Pull requests
 ==========================
 Main PR (including GTK3):
+
 + https://github.com/matplotlib/matplotlib/pull/4143
 
 Backend specific branch diffs:
+
 + https://github.com/OceanWolf/matplotlib/compare/backend-refactor...OceanWolf:backend-refactor-tkagg
 + https://github.com/OceanWolf/matplotlib/compare/backend-refactor...OceanWolf:backend-refactor-qt
 + https://github.com/OceanWolf/matplotlib/compare/backend-refactor...backend-refactor-wx
@@ -49,15 +51,14 @@ Two main places for generic code appear in the classes derived from
 
 1. ``FigureManagerBase`` has **three** jobs at the moment:
 
-    1. The documentation describes it as a *``Helper class for pyplot
-       mode, wraps everything up into a neat bundle''*
+    1. The documentation describes it as a *Helper class for pyplot
+       mode, wraps everything up into a neat bundle*
     2. But it doesn't just wrap the canvas and toolbar, it also does
        all of the windowing tasks itself.  The conflation of these two
-       tasks gets seen the best in the following line: ```python
-       self.set_window_title("Figure %d" % num) ``` This combines
+       tasks gets seen the best in the following line:
+       ``self.set_window_title("Figure %d" % num)`` This combines
        backend specific code ``self.set_window_title(title)`` with
        matplotlib generic code ``title = "Figure %d" % num``.
-
     3. Currently the backend specific subclass of ``FigureManager``
        decides when to end the mainloop.  This also seems very wrong
        as the figure should have no control over the other figures.
@@ -95,7 +96,7 @@ The description of this MEP gives us most of the solution:
    1. This allows us to break up the conversion of backends into
       separate PRs as we can keep the existing ``FigureManagerBase``
       class and its dependencies intact.
-   2. and this also anticipates MEP22 where the new
+   2. And this also anticipates MEP22 where the new
       ``NavigationBase`` has morphed into a backend independent
       ``ToolManager``.
 

--- a/doc/users/explain/interactive_guide.rst
+++ b/doc/users/explain/interactive_guide.rst
@@ -431,10 +431,10 @@ method.  The source for the ``prompt_toolkit`` input hooks lives at
 .. rubric:: Footnotes
 
 .. [#f1] A limitation of this design is that you can only wait for one
-	 input, if there is a need to multiplex between multiple sources
-	 then the loop would look something like ::
+     input, if there is a need to multiplex between multiple sources
+     then the loop would look something like ::
 
-	   fds = [...]
+       fds = [...]
            while True:                    # Loop
                inp = select(fds).read()   # Read
                eval(inp)                  # Evaluate / Print
@@ -443,6 +443,6 @@ method.  The source for the ``prompt_toolkit`` input hooks lives at
          <https://www.youtube.com/watch?v=ZzfHjytDceU>`__ if you must.
 
 .. [#f3] These examples are aggressively dropping many of the
-	 complexities that must be dealt with in the real world such as
-	 keyboard interrupts, timeouts, bad input, resource
-	 allocation and cleanup, etc.
+     complexities that must be dealt with in the real world such as
+     keyboard interrupts, timeouts, bad input, resource
+     allocation and cleanup, etc.


### PR DESCRIPTION
## PR Summary

Tried the sphinx-lint tool, https://github.com/sphinx-contrib/sphinx-lint,  and found some issues (and I knew of an issue with one of my previous removal notes so I added it here).

There are still a bunch of warnings about trailing whitespaces and tab usage (primarily in old release notes and copied git output), but in the long run, it may be an idea to consider using this for checking the rst-files.

<details><summary>Output from sphinx-lint after this PR</summary>
<p>

```
[2] doc/devel/MEP/MEP22.rst:170: code sample missing surrogate space before plural: '``set_tool_keymap(self, name, ``*'
[2] doc/users/prev_whats_new/whats_new_1.3.rst:166: code sample missing surrogate space before plural: '```\nA call to  without any arguments now\nacts the same as ``s'
[2] doc/users/prev_whats_new/whats_new_1.3.rst:167: code sample missing surrogate space before plural: '`` or ``s'
[2] doc/users/prev_whats_new/whats_new_1.3.rst:211: code sample missing surrogate space before plural: '``\nPassing ``b'
[1] doc/devel/gitwash/set_up_fork.rst:63: OMG TABS!!!1
[1] doc/devel/gitwash/set_up_fork.rst:64: OMG TABS!!!1
[1] doc/devel/gitwash/set_up_fork.rst:65: OMG TABS!!!1
[1] doc/devel/gitwash/set_up_fork.rst:66: OMG TABS!!!1
[1] doc/devel/gitwash/configure_git.rst:155: trailing whitespace
[1] doc/devel/gitwash/configure_git.rst:157: trailing whitespace
[1] doc/devel/gitwash/configure_git.rst:161: trailing whitespace
[1] doc/devel/gitwash/configure_git.rst:167: trailing whitespace
[2] doc/devel/documenting_mpl.rst:603: code sample missing surrogate space before plural: '`` yields ``r'
[2] doc/users/prev_whats_new/github_stats_3.3.0.rst:1041: role with no backticks: ' :func:, '
[1] doc/devel/gitwash/development_workflow.rst:130: OMG TABS!!!1
[1] doc/devel/gitwash/development_workflow.rst:135: OMG TABS!!!1
[1] doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst:63: OMG TABS!!!1
[1] doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst:71: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:208: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:209: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:211: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:212: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:214: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:215: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:216: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:217: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:219: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:220: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:222: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:223: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:224: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:225: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:226: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:228: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:229: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:230: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:231: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:232: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:233: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:234: OMG TABS!!!1
[1] doc/users/prev_whats_new/whats_new_3.1.0.rst:236: OMG TABS!!!1
[1] doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst:340: trailing whitespace
[2] doc/users/prev_whats_new/whats_new_1.5.rst:485: code sample missing surrogate space before plural: "``\n\\ 's ``_"
[2] doc/users/prev_whats_new/github_stats_3.0.0.rst:508: role with no backticks: ' :mathmpl:.\n'
[2] doc/users/prev_whats_new/whats_new_1.4.rst:112: code sample missing surrogate space before plural: '``\nTodd Jennings added support for 2D arrays in the\n, ,\nand , as well as adding\n``m'
[2] doc/users/prev_whats_new/whats_new_1.4.rst:119: code sample missing surrogate space before plural: '```\nTodd Jennings added some functions to mlab to make it easier to use NumPy\nstrides to create memory-efficient 2D arrays.  This includes\n``m'
[2] doc/users/prev_whats_new/github_stats_3.2.0.rst:970: role with no backticks: ' :class:/:func: '
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:238: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:254: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:305: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:341: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:346: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:358: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:372: trailing whitespace
[1] doc/users/prev_whats_new/github_stats_3.0.2.rst:409: trailing whitespace
[1] doc/users/prev_whats_new/changelog.rst:4276: trailing whitespace
[1] doc/users/prev_whats_new/whats_new_3.0.rst:112: trailing whitespace
46 problems with severity 1 found.
11 problems with severity 2 found.
```

</p>
</details>

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
