### PR TITLE
DOC: Better doc of colors

### DIFF
--- a/examples/color/named_colors.py
+++ b/examples/color/named_colors.py
@@ -12,6 +12,14 @@ For more information on colors in matplotlib see
 * the :doc:`/tutorials/colors/colors` tutorial;
 * the `matplotlib.colors` API;
 * the :doc:`/gallery/color/color_demo`.
+
+.. contents::
+
+----------------------------
+Helper Function for Plotting
+----------------------------
+First we define a helper function for making a table of colors, then we use it
+on some common color categories.
 """
 
 from matplotlib.patches import Rectangle
@@ -73,10 +81,26 @@ def plot_colortable(colors, title, sort_colors=True, emptycols=0):
 
     return fig
 
+#############################################################################
+# -----------
+# Base colors
+# -----------
+
 plot_colortable(mcolors.BASE_COLORS, "Base Colors",
                 sort_colors=False, emptycols=1)
+
+#############################################################################
+# ---------------
+# Tableau Palette
+# ---------------
+
 plot_colortable(mcolors.TABLEAU_COLORS, "Tableau Palette",
                 sort_colors=False, emptycols=2)
+
+#############################################################################
+# ----------
+# CSS Colors
+# ----------
 
 # sphinx_gallery_thumbnail_number = 3
 plot_colortable(mcolors.CSS4_COLORS, "CSS Colors")


### PR DESCRIPTION
## PR Summary

Improve https://matplotlib.org/3.5.0/gallery/color/named_colors.html by:

1. Splitting colors into three sections so that they don't get put in a `multiimg` where each takes up half the horizontal space. This should make it much more readable.
2. Add a `.. contents` so that each color category is easily accessible from the top.

You'll have to ignore my dark mode below since I took the `3.5` one from the actual URL but built my changes locally:

| | 3.5 | PR |
| -- | -- | -- |
| contents | N/A | ![Screenshot from 2022-04-26 17-18-28](https://user-images.githubusercontent.com/2365790/165394166-d10546d8-1a71-4db1-992e-600b17b54b48.png) |
| colors | ![Screenshot from 2022-04-26 16-49-16](https://user-images.githubusercontent.com/2365790/165394373-66c51583-2116-4b12-a11c-7783e6d5e0ab.png) | ![Screenshot from 2022-04-26 17-18-36](https://user-images.githubusercontent.com/2365790/165394335-897a8d8b-7b11-4816-9d50-ddd45c76ad40.png) |


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] ~~Has pytest style unit tests (and `pytest` passes).~~
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] ~~New features are documented, with examples if plot related.~~
- [ ] ~~New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).~~
- [ ] ~~API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).~~
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).