### PR TITLE
CI: Add concurrency skips for GH Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,7 @@
 name: Tests
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
+  cancel-in-progress: true
 
 on:
   push:


### PR DESCRIPTION
## PR Summary

If people push multiple commits to PRs (like I did in https://github.com/matplotlib/matplotlib/pull/22912) this will cancel the runs. I've used this for months in other repos and it seems to work well. It could be added to other GH actions workflows but I'm assuming `tests.yml` is the only one slow enough to really matter, but I'm happy to add this elsewhere if desired!

## PR Checklist

N/A