### PR TITLE
Fix RangeSlider for same init values #22686

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1127,16 +1127,6 @@ def test_range_slider(orientation):
 
     slider = widgets.RangeSlider(
         ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
-        valinit=[0.0, 0.0]
-    )
-    box = slider.poly.get_extents().transformed(ax.transAxes.inverted())
-    assert_allclose(box.get_points().flatten()[idx], [0, 0.25, 0, 0.75])
-
-    # Check initial value is set correctly
-    assert_allclose(slider.val, (0.0, 0.0))
-
-    slider = widgets.RangeSlider(
-        ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
         valinit=[0.1, 0.34]
     )
     box = slider.poly.get_extents().transformed(ax.transAxes.inverted())

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1161,6 +1161,23 @@ def test_range_slider(orientation):
     assert_allclose(handle_positions(slider), (0.1, 0.34))
 
 
+@pytest.mark.parametrize("orientation", ["horizontal", "vertical"])
+def test_range_slider_same_init_values(orientation):
+    if orientation == "vertical":
+        idx = [1, 0, 3, 2]
+    else:
+        idx = [0, 1, 2, 3]
+
+    fig, ax = plt.subplots()
+
+    slider = widgets.RangeSlider(
+         ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
+         valinit=[0, 0]
+     )
+    box = slider.poly.get_extents().transformed(ax.transAxes.inverted())
+    assert_allclose(box.get_points().flatten()[idx], [0, 0.25, 0, 0.75])
+
+
 def check_polygon_selector(event_sequence, expected_result, selections_count,
                            **kwargs):
     """

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1125,12 +1125,12 @@ def test_range_slider(orientation):
 
     fig, ax = plt.subplots()
 
-    slider = widgets.RangeSlider( 
-    ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
-    valinit=[0.0, 0.0]
-    ) 
-    box = slider.poly.get_extents().transformed(ax.transAxes.inverted()) 
-    assert_allclose(box.get_points().flatten()[idx], [0, 0.25, 0, 0.75]) 
+    slider = widgets.RangeSlider(
+        ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
+        valinit=[0.0, 0.0]
+    )
+    box = slider.poly.get_extents().transformed(ax.transAxes.inverted())
+    assert_allclose(box.get_points().flatten()[idx], [0, 0.25, 0, 0.75])
 
     # Check initial value is set correctly
     assert_allclose(slider.val, (0.0, 0.0))

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1125,6 +1125,16 @@ def test_range_slider(orientation):
 
     fig, ax = plt.subplots()
 
+    slider = widgets.RangeSlider( 
+    ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
+    valinit=[0.0, 0.0]
+    ) 
+    box = slider.poly.get_extents().transformed(ax.transAxes.inverted()) 
+    assert_allclose(box.get_points().flatten()[idx], [0, 0.25, 0, 0.75]) 
+
+    # Check initial value is set correctly
+    assert_allclose(slider.val, (0.0, 0.0))
+
     slider = widgets.RangeSlider(
         ax=ax, label="", valmin=0.0, valmax=1.0, orientation=orientation,
         valinit=[0.1, 0.34]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -944,7 +944,7 @@ class RangeSlider(SliderBase):
         _api.check_shape((2,), val=val)
         val[0] = self._min_in_bounds(val[0])
         val[1] = self._max_in_bounds(val[1])
-        xy = self._fill_verts(self.poly.xy, val)
+        self.poly.xy = self._fill_verts(self.poly.xy, val)
         if self.orientation == "vertical":
             self._handles[0].set_ydata([val[0]])
             self._handles[1].set_ydata([val[1]])
@@ -952,7 +952,6 @@ class RangeSlider(SliderBase):
             self._handles[0].set_xdata([val[0]])
             self._handles[1].set_xdata([val[1]])
 
-        self.poly.xy = xy
         self.valtext.set_text(self._format(val))
 
         if self.drawon:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -731,7 +731,17 @@ class RangeSlider(SliderBase):
                 facecolor=track_color
             )
             ax.add_patch(self.track)
-            self.poly = ax.axvspan(valinit[0], valinit[1], 0, 1, **kwargs)
+            verts[0] = valinit[0], .25
+            verts[1] = valinit[0], .75
+            verts[2] = valinit[1], .75
+            verts[3] = valinit[1], .25
+            verts[4] = valinit[0] ,.25
+            poly = Polygon(verts, **kwargs)
+            poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
+            poly.get_path()._interpolation_steps = 100
+            self.ax.add_patch(poly)
+            self.ax._request_autoscale_view()
+            self.poly=poly
             handleXY_1 = [valinit[0], .5]
             handleXY_2 = [valinit[1], .5]
         self._handles = [

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -717,7 +717,7 @@ class RangeSlider(SliderBase):
             verts[3] = .75, valinit[0]
             verts[4] = .25, valinit[0]
             poly = Polygon(verts, **kwargs)
-            poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
+            poly.set_transform(self.ax.get_yaxis_transform(which="grid"))
             poly.get_path()._interpolation_steps = 100
             self.ax.add_patch(poly)
             self.ax._request_autoscale_view()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -785,7 +785,23 @@ class RangeSlider(SliderBase):
         self.set_val(valinit)
 
     def _fill_verts(self, verts, val):
-        """Fills the *verts* Nx2 shaped numpy array."""
+        """
+        Update the *verts* of the *self.poly* slider according to the current
+        value and slider orientation.
+
+        Parameters
+        ----------------
+        verts : (5, 2) np.ndarray
+                The vertices to fill. Note that these will be modified in
+                place.
+        val : (2,) array_like
+             The new min and max values.
+
+        Returns
+        ----------
+        verts : np.ndarray
+                The original array with updated values
+        """
         if self.orientation == "vertical":
             verts[0] = .25, val[0]
             verts[1] = .25, val[1]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -718,10 +718,6 @@ class RangeSlider(SliderBase):
             verts[4] = .25, valinit[0]
             poly = Polygon(verts, **kwargs)
             poly.set_transform(self.ax.get_yaxis_transform(which="grid"))
-            poly.get_path()._interpolation_steps = 100
-            self.ax.add_patch(poly)
-            self.ax._request_autoscale_view()
-            self.poly = poly
             handleXY_1 = [.5, valinit[0]]
             handleXY_2 = [.5, valinit[1]]
         else:
@@ -738,12 +734,12 @@ class RangeSlider(SliderBase):
             verts[4] = valinit[0], .25
             poly = Polygon(verts, **kwargs)
             poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
-            poly.get_path()._interpolation_steps = 100
-            self.ax.add_patch(poly)
-            self.ax._request_autoscale_view()
-            self.poly = poly
             handleXY_1 = [valinit[0], .5]
             handleXY_2 = [valinit[1], .5]
+        poly.get_path()._interpolation_steps = 100
+        self.ax.add_patch(poly)
+        self.ax._request_autoscale_view()
+        self.poly = poly
         self._handles = [
             ax.plot(
                 *handleXY_1,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -19,7 +19,7 @@ import matplotlib as mpl
 from . import (_api, _docstring, backend_tools, cbook, colors, ticker,
                transforms)
 from .lines import Line2D
-from .patches import Circle, Rectangle, Ellipse
+from .patches import Circle, Rectangle, Ellipse, Polygon
 from .transforms import TransformedPatchPath, Affine2D
 
 
@@ -702,6 +702,8 @@ class RangeSlider(SliderBase):
             f'marker{k}': v for k, v in {**defaults, **handle_style}.items()
         }
 
+        verts = np.zeros([5,2])
+
         if orientation == "vertical":
             self.track = Rectangle(
                 (.25, 0), .5, 2,
@@ -709,7 +711,17 @@ class RangeSlider(SliderBase):
                 facecolor=track_color
             )
             ax.add_patch(self.track)
-            self.poly = ax.axhspan(valinit[0], valinit[1], 0, 1, **kwargs)
+            verts[0] = .25, valinit[0]
+            verts[1] = .25, valinit[1]
+            verts[2] = .75, valinit[1]
+            verts[3] = .75, valinit[0]
+            verts[4] = .25, valinit[0]
+            poly = Polygon(verts, **kwargs)
+            poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
+            poly.get_path()._interpolation_steps = 100
+            self.ax.add_patch(poly)
+            self.ax._request_autoscale_view()
+            self.poly=poly
             handleXY_1 = [.5, valinit[0]]
             handleXY_2 = [.5, valinit[1]]
         else:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -792,15 +792,15 @@ class RangeSlider(SliderBase):
        Parameters
        ----------
        verts : (5, 2) np.ndarray
-                 The vertices to fill. Note that these will be modified in
-                 place.
+            The vertices to fill. Note that these will be modified in
+            place.
        val : (2,) array_like
-             The new min and max values.
+            The new min and max values.
 
        Returns
        -------
        verts : np.ndarray
-                The original array with updated values.
+            The original array with updated values.
         """
         if self.orientation == "vertical":
             verts[0] = .25, val[0]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -930,23 +930,24 @@ class RangeSlider(SliderBase):
         """
         val = np.sort(val)
         _api.check_shape((2,), val=val)
-        val[0] = self._min_in_bounds(val[0])
-        val[1] = self._max_in_bounds(val[1])
-        self._update_selection_poly(val[0], val[1])
+        vmin, vmax = val
+        vmin = self._min_in_bounds(vmin)
+        vmax = self._max_in_bounds(vmax)
+        self._update_selection_poly(vmin, vmax)
         if self.orientation == "vertical":
-            self._handles[0].set_ydata([val[0]])
-            self._handles[1].set_ydata([val[1]])
+            self._handles[0].set_ydata([vmin])
+            self._handles[1].set_ydata([vmax])
         else:
-            self._handles[0].set_xdata([val[0]])
-            self._handles[1].set_xdata([val[1]])
+            self._handles[0].set_xdata([vmin])
+            self._handles[1].set_xdata([vmax])
 
-        self.valtext.set_text(self._format(val))
+        self.valtext.set_text(self._format((vmin, vmax)))
 
         if self.drawon:
             self.ax.figure.canvas.draw_idle()
-        self.val = val
+        self.val = (vmin, vmax)
         if self.eventson:
-            self._observers.process("changed", val)
+            self._observers.process("changed", (vmin, vmax))
 
     def on_changed(self, func):
         """

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -711,11 +711,7 @@ class RangeSlider(SliderBase):
                 facecolor=track_color
             )
             ax.add_patch(self.track)
-            verts[0] = .25, valinit[0]
-            verts[1] = .25, valinit[1]
-            verts[2] = .75, valinit[1]
-            verts[3] = .75, valinit[0]
-            verts[4] = .25, valinit[0]
+            verts = self._fill_verts(verts, valinit)
             poly = Polygon(verts, **kwargs)
             poly.set_transform(self.ax.get_yaxis_transform(which="grid"))
             handleXY_1 = [.5, valinit[0]]
@@ -727,11 +723,7 @@ class RangeSlider(SliderBase):
                 facecolor=track_color
             )
             ax.add_patch(self.track)
-            verts[0] = valinit[0], .25
-            verts[1] = valinit[0], .75
-            verts[2] = valinit[1], .75
-            verts[3] = valinit[1], .25
-            verts[4] = valinit[0], .25
+            verts = self._fill_verts(verts, valinit)
             poly = Polygon(verts, **kwargs)
             poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
             handleXY_1 = [valinit[0], .5]
@@ -794,6 +786,22 @@ class RangeSlider(SliderBase):
 
         self._active_handle = None
         self.set_val(valinit)
+
+    def _fill_verts(self, verts, val):
+        """Fills the *verts* Nx2 shaped numpy array."""
+        if self.orientation == "vertical":
+            verts[0] = .25, val[0]
+            verts[1] = .25, val[1]
+            verts[2] = .75, val[1]
+            verts[3] = .75, val[0]
+            verts[4] = .25, val[0]
+        else:
+            verts[0] = val[0], .25
+            verts[1] = val[0], .75
+            verts[2] = val[1], .75
+            verts[3] = val[1], .25
+            verts[4] = val[0], .25
+        return verts
 
     def _min_in_bounds(self, min):
         """Ensure the new min value is between valmin and self.val[1]."""
@@ -924,22 +932,11 @@ class RangeSlider(SliderBase):
         val[0] = self._min_in_bounds(val[0])
         val[1] = self._max_in_bounds(val[1])
         xy = self.poly.xy
+        xy = self._fill_verts(xy, val)
         if self.orientation == "vertical":
-            xy[0] = .25, val[0]
-            xy[1] = .25, val[1]
-            xy[2] = .75, val[1]
-            xy[3] = .75, val[0]
-            xy[4] = .25, val[0]
-
             self._handles[0].set_ydata([val[0]])
             self._handles[1].set_ydata([val[1]])
         else:
-            xy[0] = val[0], .25
-            xy[1] = val[0], .75
-            xy[2] = val[1], .75
-            xy[3] = val[1], .25
-            xy[4] = val[0], .25
-
             self._handles[0].set_xdata([val[0]])
             self._handles[1].set_xdata([val[1]])
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -789,18 +789,18 @@ class RangeSlider(SliderBase):
         Update the *verts* of the *self.poly* slider according to the current
         value and slider orientation.
 
-        Parameters
-        ----------------
-        verts : (5, 2) np.ndarray
-                The vertices to fill. Note that these will be modified in
-                place.
-        val : (2,) array_like
+       Parameters
+       ----------
+       verts : (5, 2) np.ndarray
+                 The vertices to fill. Note that these will be modified in
+                 place.
+       val : (2,) array_like
              The new min and max values.
 
-        Returns
-        ----------
-        verts : np.ndarray
-                The original array with updated values
+       Returns
+       -------
+       verts : np.ndarray
+                The original array with updated values.
         """
         if self.orientation == "vertical":
             verts[0] = .25, val[0]

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -944,8 +944,7 @@ class RangeSlider(SliderBase):
         _api.check_shape((2,), val=val)
         val[0] = self._min_in_bounds(val[0])
         val[1] = self._max_in_bounds(val[1])
-        xy = self.poly.xy
-        xy = self._fill_verts(xy, val)
+        xy = self._fill_verts(self.poly.xy, val)
         if self.orientation == "vertical":
             self._handles[0].set_ydata([val[0]])
             self._handles[1].set_ydata([val[1]])

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -702,7 +702,7 @@ class RangeSlider(SliderBase):
             f'marker{k}': v for k, v in {**defaults, **handle_style}.items()
         }
 
-        verts = np.zeros([5, 2])
+        verts = self._fill_verts(np.zeros([5, 2]), valinit)
 
         if orientation == "vertical":
             self.track = Rectangle(
@@ -711,9 +711,7 @@ class RangeSlider(SliderBase):
                 facecolor=track_color
             )
             ax.add_patch(self.track)
-            verts = self._fill_verts(verts, valinit)
-            poly = Polygon(verts, **kwargs)
-            poly.set_transform(self.ax.get_yaxis_transform(which="grid"))
+            poly_transform = self.ax.get_yaxis_transform(which="grid")
             handleXY_1 = [.5, valinit[0]]
             handleXY_2 = [.5, valinit[1]]
         else:
@@ -723,15 +721,14 @@ class RangeSlider(SliderBase):
                 facecolor=track_color
             )
             ax.add_patch(self.track)
-            verts = self._fill_verts(verts, valinit)
-            poly = Polygon(verts, **kwargs)
-            poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
+            poly_transform = self.ax.get_xaxis_transform(which="grid")
             handleXY_1 = [valinit[0], .5]
             handleXY_2 = [valinit[1], .5]
-        poly.get_path()._interpolation_steps = 100
-        self.ax.add_patch(poly)
+        self.poly = Polygon(verts, **kwargs)
+        self.poly.set_transform(poly_transform)
+        self.poly.get_path()._interpolation_steps = 100
+        self.ax.add_patch(self.poly)
         self.ax._request_autoscale_view()
-        self.poly = poly
         self._handles = [
             ax.plot(
                 *handleXY_1,

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -702,7 +702,7 @@ class RangeSlider(SliderBase):
             f'marker{k}': v for k, v in {**defaults, **handle_style}.items()
         }
 
-        verts = np.zeros([5,2])
+        verts = np.zeros([5, 2])
 
         if orientation == "vertical":
             self.track = Rectangle(
@@ -721,7 +721,7 @@ class RangeSlider(SliderBase):
             poly.get_path()._interpolation_steps = 100
             self.ax.add_patch(poly)
             self.ax._request_autoscale_view()
-            self.poly=poly
+            self.poly = poly
             handleXY_1 = [.5, valinit[0]]
             handleXY_2 = [.5, valinit[1]]
         else:
@@ -735,13 +735,13 @@ class RangeSlider(SliderBase):
             verts[1] = valinit[0], .75
             verts[2] = valinit[1], .75
             verts[3] = valinit[1], .25
-            verts[4] = valinit[0] ,.25
+            verts[4] = valinit[0], .25
             poly = Polygon(verts, **kwargs)
             poly.set_transform(self.ax.get_xaxis_transform(which="grid"))
             poly.get_path()._interpolation_steps = 100
             self.ax.add_patch(poly)
             self.ax._request_autoscale_view()
-            self.poly=poly
+            self.poly = poly
             handleXY_1 = [valinit[0], .5]
             handleXY_2 = [valinit[1], .5]
         self._handles = [


### PR DESCRIPTION
## PR Summary
Change the way that polygon is initilized to cover edge case of same init values. The method axhspan is no longer used and the polygon is created manually. (closes #22686 )

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
