### PR TITLE
ENH: Add option to disable raising the window for macosx

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -140,6 +140,7 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     _toolbar2_class = NavigationToolbar2Mac
 
     def __init__(self, canvas, num):
+        self._shown = False
         _macosx.FigureManager.__init__(self, canvas)
         icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
         _macosx.FigureManager.set_icon(icon_path)
@@ -153,6 +154,13 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
     def close(self):
         Gcf.destroy(self)
         self.canvas.flush_events()
+
+    def show(self):
+        if not self._shown:
+            self._show()
+            self._shown = True
+        if mpl.rcParams["figure.raise_window"]:
+            self._raise()
 
 
 @_Backend.export

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -586,9 +586,15 @@ FigureManager_dealloc(FigureManager* self)
 }
 
 static PyObject*
-FigureManager_show(FigureManager* self)
+FigureManager__show(FigureManager* self)
 {
     [self->window makeKeyAndOrderFront: nil];
+    Py_RETURN_NONE;
+}
+
+static PyObject*
+FigureManager__raise(FigureManager* self)
+{
     [self->window orderFrontRegardless];
     Py_RETURN_NONE;
 }
@@ -695,8 +701,11 @@ static PyTypeObject FigureManagerType = {
     .tp_new = (newfunc)FigureManager_new,
     .tp_doc = "A FigureManager object wraps a Cocoa NSWindow object.",
     .tp_methods = (PyMethodDef[]){  // All docstrings are inherited.
-        {"show",
-         (PyCFunction)FigureManager_show,
+        {"_show",
+         (PyCFunction)FigureManager__show,
+         METH_NOARGS},
+        {"_raise",
+         (PyCFunction)FigureManager__raise,
          METH_NOARGS},
         {"destroy",
          (PyCFunction)FigureManager_destroy,


### PR DESCRIPTION
## PR Summary

This enables the rcParam "figure.raise_window" to control whether the macosx backend raises the window to the foreground or not, keeping consistency with the other backends.

closes #22915

To test this, move the window to the back and it should stay hidden.

```python
from matplotlib import pyplot as plt
from matplotlib import rcParams

rcParams['figure.raise_window'] = False
while True:
    plt.plot()
    plt.pause(.1)
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
