### PR TITLE
BUG: Fix regression with ls=(0, ())

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -924,7 +924,7 @@ class GraphicsContextBase:
             if np.any(dl < 0.0):
                 raise ValueError(
                     "All values in the dash list must be non-negative")
-            if not np.any(dl > 0.0):
+            if dl.size and not np.any(dl > 0.0):
                 raise ValueError(
                     'At least one value in the dash list must be positive')
         self._dashes = dash_offset, dash_list

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -108,7 +108,9 @@ def test_valid_colors():
 def test_linestyle_variants():
     fig, ax = plt.subplots()
     for ls in ["-", "solid", "--", "dashed",
-               "-.", "dashdot", ":", "dotted"]:
+               "-.", "dashdot", ":", "dotted",
+               (0, None), (0, ()), (0, []),  # gh-22930
+               ]:
         ax.plot(range(10), linestyle=ls)
     fig.canvas.draw()
 


### PR DESCRIPTION
## PR Summary

Closes #22930

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

Test fails on `main` but passes on this PR