### PR TITLE
Fixed dpi bug in rainbow text example

### DIFF
--- a/examples/text_labels_and_annotations/rainbow_text.py
+++ b/examples/text_labels_and_annotations/rainbow_text.py
@@ -24,7 +24,7 @@ The solution below is modified from Paul Ivanov's original answer.
 """
 
 import matplotlib.pyplot as plt
-from matplotlib.transforms import Affine2D
+from matplotlib.transforms import Affine2D, offset_copy
 
 
 def rainbow_text(x, y, strings, colors, orientation='horizontal',
@@ -51,7 +51,8 @@ def rainbow_text(x, y, strings, colors, orientation='horizontal',
     if ax is None:
         ax = plt.gca()
     t = ax.transData
-    canvas = ax.figure.canvas
+    fig = ax.figure
+    canvas = fig.canvas
 
     assert orientation in ['horizontal', 'vertical']
     if orientation == 'vertical':
@@ -63,10 +64,16 @@ def rainbow_text(x, y, strings, colors, orientation='horizontal',
         # Need to draw to update the text position.
         text.draw(canvas.get_renderer())
         ex = text.get_window_extent()
+        # Convert window extent from pixels to inches
+        # to avoid issues displaying at different dpi
+        ex = fig.dpi_scale_trans.inverted().transform_bbox(ex)
+
         if orientation == 'horizontal':
-            t = text.get_transform() + Affine2D().translate(ex.width, 0)
+            t = text.get_transform() + \
+                offset_copy(Affine2D(), fig=fig, x=ex.width, y=0)
         else:
-            t = text.get_transform() + Affine2D().translate(0, ex.height)
+            t = text.get_transform() + \
+                offset_copy(Affine2D(), fig=fig, x=0, y=ex.height)
 
 
 words = "all unicorns poop rainbows ! ! !".split()


### PR DESCRIPTION
## PR Summary
The issue was the transformation was done in pixels, which caused issues with dpi changes. I adjusted it by using ```offset_copy``` and converted pixels to inches in the transforms.

I tried to base the solution off what was said in #22893. I am still new to a lot of parts of matplotlib, so if there is a better way to write this process, please let me know!

Previous issue:
![image](https://user-images.githubusercontent.com/28690153/166011173-d2357d0a-0c9e-42c0-8a45-34142d46890b.png)

Fix (that looks the same on any dpi):
![image](https://user-images.githubusercontent.com/28690153/166010938-52ecf035-f89b-4178-9328-3589e2c39826.png)

Closes #22893 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
