### PR TITLE
Backport PR #22946: FIX: Handle no-offsets in collection datalim

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -61,7 +61,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
     mappable will be used to set the ``facecolors`` and ``edgecolors``,
     ignoring those that were manually passed in.
     """
-    _offsets = np.zeros((0, 2))
     #: Either a list of 3x3 arrays or an Nx3x3 array (representing N
     #: transforms), suitable for the `all_transforms` argument to
     #: `~matplotlib.backend_bases.RendererBase.draw_path_collection`;
@@ -193,15 +192,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
         else:
             self._joinstyle = None
 
-        # default to zeros
-        self._offsets = np.zeros((1, 2))
-
         if offsets is not None:
             offsets = np.asanyarray(offsets, float)
             # Broadcast (2,) -> (1, 2) but nothing else.
             if offsets.shape == (2,):
                 offsets = offsets[None, :]
-            self._offsets = offsets
         elif transOffset is not None:
             _api.warn_deprecated(
                 '3.5',
@@ -215,6 +210,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                         'explicitly.')
             transOffset = None
 
+        self._offsets = offsets
         self._transOffset = transOffset
 
         self._path_effects = None
@@ -273,9 +269,12 @@ class Collection(artist.Artist, cm.ScalarMappable):
             # if there are offsets but in some coords other than data,
             # then don't use them for autoscaling.
             return transforms.Bbox.null()
-        offsets = self._offsets
+        offsets = self.get_offsets()
 
         paths = self.get_paths()
+        if not len(paths):
+            # No paths to transform
+            return transforms.Bbox.null()
 
         if not transform.is_affine:
             paths = [transform.transform_path_non_affine(p) for p in paths]
@@ -284,22 +283,22 @@ class Collection(artist.Artist, cm.ScalarMappable):
             # transforms.get_affine().contains_branch(transData).  But later,
             # be careful to only apply the affine part that remains.
 
-        if isinstance(offsets, np.ma.MaskedArray):
-            offsets = offsets.filled(np.nan)
+        if any(transform.contains_branch_seperately(transData)):
+            if isinstance(offsets, np.ma.MaskedArray):
+                offsets = offsets.filled(np.nan)
             # get_path_collection_extents handles nan but not masked arrays
+            # collections that are just in data units (like quiver)
+            # can properly have the axes limits set by their shape +
+            # offset.  LineCollections that have no offsets can
+            # also use this algorithm (like streamplot).
+            return mpath.get_path_collection_extents(
+                transform.get_affine() - transData, paths,
+                self.get_transforms(),
+                transOffset.transform_non_affine(offsets),
+                transOffset.get_affine().frozen())
 
-        if len(paths) and len(offsets):
-            if any(transform.contains_branch_seperately(transData)):
-                # collections that are just in data units (like quiver)
-                # can properly have the axes limits set by their shape +
-                # offset.  LineCollections that have no offsets can
-                # also use this algorithm (like streamplot).
-                return mpath.get_path_collection_extents(
-                    transform.get_affine() - transData, paths,
-                    self.get_transforms(),
-                    transOffset.transform_non_affine(offsets),
-                    transOffset.get_affine().frozen())
-
+        # NOTE: None is the default case where no offsets were passed in
+        if self._offsets is not None:
             # this is for collections that have their paths (shapes)
             # in physical, axes-relative, or figure-relative units
             # (i.e. like scatter). We can't uniquely set limits based on
@@ -325,7 +324,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
         transform = self.get_transform()
         transOffset = self.get_offset_transform()
-        offsets = self._offsets
+        offsets = self.get_offsets()
         paths = self.get_paths()
 
         if self.have_units():
@@ -336,10 +335,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
                 xs = self.convert_xunits(xs)
                 ys = self.convert_yunits(ys)
                 paths.append(mpath.Path(np.column_stack([xs, ys]), path.codes))
-            if offsets.size:
-                xs = self.convert_xunits(offsets[:, 0])
-                ys = self.convert_yunits(offsets[:, 1])
-                offsets = np.column_stack([xs, ys])
+            xs = self.convert_xunits(offsets[:, 0])
+            ys = self.convert_yunits(offsets[:, 1])
+            offsets = np.column_stack([xs, ys])
 
         if not transform.is_affine:
             paths = [transform.transform_path_non_affine(path)
@@ -569,7 +567,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
 
     def get_offsets(self):
         """Return the offsets for the collection."""
-        return self._offsets
+        # Default to zeros in the no-offset (None) case
+        return np.zeros((1, 2)) if self._offsets is None else self._offsets
 
     def _get_default_linewidth(self):
         # This may be overridden in a subclass.
@@ -2166,13 +2165,12 @@ class QuadMesh(Collection):
         renderer.open_group(self.__class__.__name__, self.get_gid())
         transform = self.get_transform()
         transOffset = self.get_offset_transform()
-        offsets = self._offsets
+        offsets = self.get_offsets()
 
         if self.have_units():
-            if len(self._offsets):
-                xs = self.convert_xunits(self._offsets[:, 0])
-                ys = self.convert_yunits(self._offsets[:, 1])
-                offsets = np.column_stack([xs, ys])
+            xs = self.convert_xunits(offsets[:, 0])
+            ys = self.convert_yunits(offsets[:, 1])
+            offsets = np.column_stack([xs, ys])
 
         self.update_scalarmappable()
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -9,6 +9,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.collections as mcollections
 import matplotlib.colors as mcolors
+import matplotlib.path as mpath
 import matplotlib.transforms as mtransforms
 from matplotlib.collections import (Collection, LineCollection,
                                     EventCollection, PolyCollection)
@@ -288,6 +289,17 @@ def test_null_collection_datalim():
     col = mcollections.PathCollection([])
     col_data_lim = col.get_datalim(mtransforms.IdentityTransform())
     assert_array_equal(col_data_lim.get_points(),
+                       mtransforms.Bbox.null().get_points())
+
+
+def test_no_offsets_datalim():
+    # A collection with no offsets and a non transData
+    # transform should return a null bbox
+    ax = plt.axes()
+    coll = mcollections.PathCollection([mpath.Path([(0, 0), (1, 0)])])
+    ax.add_collection(coll)
+    coll_data_lim = coll.get_datalim(mtransforms.IdentityTransform())
+    assert_array_equal(coll_data_lim.get_points(),
                        mtransforms.Bbox.null().get_points())
 
 


### PR DESCRIPTION
## PR Summary

Manual backport of #22946

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
