### PR TITLE
MNT: Move set_cursor to the FigureCanvas

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -34,10 +34,6 @@ class FigureCanvasMac(_macosx.FigureCanvas, FigureCanvasAgg):
         self._draw_pending = False
         self._is_drawing = False
 
-    def set_cursor(self, cursor):
-        # docstring inherited
-        _macosx.set_cursor(cursor)
-
     def draw(self):
         """Render the figure and update the macosx canvas."""
         # The renderer draw is done here; delaying causes problems with code

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -362,6 +362,25 @@ FigureCanvas_flush_events(FigureCanvas* self)
 }
 
 static PyObject*
+FigureCanvas_set_cursor(PyObject* unused, PyObject* args)
+{
+    int i;
+    if (!PyArg_ParseTuple(args, "i", &i)) { return NULL; }
+    switch (i) {
+      case 1: [[NSCursor arrowCursor] set]; break;
+      case 2: [[NSCursor pointingHandCursor] set]; break;
+      case 3: [[NSCursor crosshairCursor] set]; break;
+      case 4: [[NSCursor openHandCursor] set]; break;
+      /* OSX handles busy state itself so no need to set a cursor here */
+      case 5: break;
+      case 6: [[NSCursor resizeLeftRightCursor] set]; break;
+      case 7: [[NSCursor resizeUpDownCursor] set]; break;
+      default: return NULL;
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject*
 FigureCanvas_set_rubberband(FigureCanvas* self, PyObject *args)
 {
     View* view = self->view;
@@ -489,14 +508,18 @@ static PyTypeObject FigureCanvasType = {
          (PyCFunction)FigureCanvas_flush_events,
          METH_NOARGS,
          NULL},  // docstring inherited
+        {"set_cursor",
+         (PyCFunction)FigureCanvas_set_cursor,
+         METH_VARARGS,
+         "Set the active cursor."},
         {"set_rubberband",
          (PyCFunction)FigureCanvas_set_rubberband,
          METH_VARARGS,
-         "Specifies a new rubberband rectangle and invalidates it."},
+         "Specify a new rubberband rectangle and invalidate it."},
         {"remove_rubberband",
          (PyCFunction)FigureCanvas_remove_rubberband,
          METH_NOARGS,
-         "Removes the current rubberband rectangle."},
+         "Remove the current rubberband rectangle."},
         {"start_event_loop",
          (PyCFunction)FigureCanvas_start_event_loop,
          METH_KEYWORDS | METH_VARARGS,
@@ -1016,25 +1039,6 @@ choose_save_file(PyObject* unused, PyObject* args)
         PyObject* string = PyUnicode_FromKindAndData(PyUnicode_2BYTE_KIND, buffer, n);
         free(buffer);
         return string;
-    }
-    Py_RETURN_NONE;
-}
-
-static PyObject*
-set_cursor(PyObject* unused, PyObject* args)
-{
-    int i;
-    if (!PyArg_ParseTuple(args, "i", &i)) { return NULL; }
-    switch (i) {
-      case 1: [[NSCursor arrowCursor] set]; break;
-      case 2: [[NSCursor pointingHandCursor] set]; break;
-      case 3: [[NSCursor crosshairCursor] set]; break;
-      case 4: [[NSCursor openHandCursor] set]; break;
-      /* OSX handles busy state itself so no need to set a cursor here */
-      case 5: break;
-      case 6: [[NSCursor resizeLeftRightCursor] set]; break;
-      case 7: [[NSCursor resizeUpDownCursor] set]; break;
-      default: return NULL;
     }
     Py_RETURN_NONE;
 }
@@ -1916,10 +1920,6 @@ static struct PyModuleDef moduledef = {
          (PyCFunction)choose_save_file,
          METH_VARARGS,
          "Query the user for a location where to save a file."},
-        {"set_cursor",
-         (PyCFunction)set_cursor,
-         METH_VARARGS,
-         "Set the active cursor."},
         {}  /* Sentinel */
     },
 };


### PR DESCRIPTION
## PR Summary

This moves the `set_cursor` definition over to the FigureCanvas rather than requiring a separate module-level call.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
