### PR TITLE
Fix example "Scale invariant angle label"

### DIFF
--- a/examples/text_labels_and_annotations/angle_annotation.py
+++ b/examples/text_labels_and_annotations/angle_annotation.py
@@ -186,7 +186,7 @@ class AngleAnnotation(Arc):
         r = s / 2
         if self.textposition == "inside":
             r = s / np.interp(angle_span, [60, 90, 135, 180],
-                                          [3.3, 3.5, 3.8, 4])
+                                          [10, 3.5, 11.4, 4])
         self.text.xy = c + r * np.array([np.cos(angle), np.sin(angle)])
         if self.textposition == "outside":
             def R90(a, r, w, h):
@@ -238,10 +238,10 @@ line1, = ax.plot(*zip(*p1))
 line2, = ax.plot(*zip(*p2))
 point, = ax.plot(*center, marker="o")
 
-am1 = AngleAnnotation(center, p1[1], p2[1], ax=ax, size=75, text=r"$\alpha$")
-am2 = AngleAnnotation(center, p2[1], p1[0], ax=ax, size=35, text=r"$\beta$")
-am3 = AngleAnnotation(center, p1[0], p2[0], ax=ax, size=75, text=r"$\gamma$")
-am4 = AngleAnnotation(center, p2[0], p1[1], ax=ax, size=35, text=r"$\theta$")
+am1 = AngleAnnotation(center, p1[1], p2[1], ax=ax, size=75, textposition="inside", text=r"$\alpha$")
+am2 = AngleAnnotation(center, p2[1], p1[0], ax=ax, size=35, textposition="inside", text=r"$\beta$")
+am3 = AngleAnnotation(center, p1[0], p2[0], ax=ax, size=75, textposition="inside", text=r"$\gamma$")
+am4 = AngleAnnotation(center, p2[0], p1[1], ax=ax, size=35, textposition="inside", text=r"$\theta$")
 
 
 # Showcase some styling options for the angle arc, as well as the text.


### PR DESCRIPTION
## PR Summary
Fix f documentation  AngleLabel example where the text wasn't inside the arc.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
