### PR TITLE
Skip additional backend tests on import error

### DIFF
--- a/lib/matplotlib/tests/test_backend_gtk3.py
+++ b/lib/matplotlib/tests/test_backend_gtk3.py
@@ -6,7 +6,7 @@ import pytest
 pytest.importorskip("matplotlib.backends.backend_gtk3agg")
 
 
-@pytest.mark.backend("gtk3agg")
+@pytest.mark.backend("gtk3agg", skip_on_importerror=True)
 def test_correct_key():
     pytest.xfail("test_widget_send_event is not triggering key_press_event")
 

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -193,7 +193,7 @@ def test_other_signal_before_sigint(target, kwargs):
     plt.figure()
 
 
-@pytest.mark.backend('Qt5Agg')
+@pytest.mark.backend('Qt5Agg', skip_on_importerror=True)
 def test_fig_sigint_override(qt_core):
     from matplotlib.backends.backend_qt5 import _BackendQT5
     # Create a figure


### PR DESCRIPTION
## PR Summary

All the Qt tests in this file already do this, and the remaining one fails if running headless. Similarly for the GTK3 test.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).