### PR TITLE
CI: bump test limit from tkagg on osx

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -548,7 +548,9 @@ def test_figure_leak_20490(env, time_mem):
     # We haven't yet directly identified the leaks so test with a memory growth
     # threshold.
     pause_time, acceptable_memory_leakage = time_mem
-    if env["MPLBACKEND"] == "macosx":
+    if env["MPLBACKEND"] == "macosx" or (
+            env["MPLBACKEND"] == "tkagg" and sys.platform == 'darwin'
+    ):
         acceptable_memory_leakage += 11_000_000
 
     result = _run_helper(


### PR DESCRIPTION
Extension of #22959.

## PR Summary

We are still seeing intermittent failures on OSX with the memory leak check on tkagg.

This is taking the gentler approach and increasing the limits again, however there may may be a case for skipping these tests until we understand:

1. the remaining source of the leak in tk (and if this is even a real leak vs legitimately still held objects) 
2. we understand the source of the variation


## PR Checklis

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
