### PR TITLE
STY: Fix typos in colormap

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -154,7 +154,7 @@ class ColormapRegistry(Mapping):
                 raise ValueError("Re-registering the builtin cmap "
                                  f"{name!r} is not allowed.")
 
-            # Warn that we are updating an already exisiting colormap
+            # Warn that we are updating an already existing colormap
             _api.warn_external(f"Overwriting the cmap {name!r} "
                                "that was already in the registry.")
 
@@ -235,7 +235,7 @@ def register_cmap(name=None, cmap=None, *, override_builtin=False):
         except AttributeError as err:
             raise ValueError("Arguments must include a name or a "
                              "Colormap") from err
-    # override_builtin is allowed here for backward compatbility
+    # override_builtin is allowed here for backward compatibility
     # this is just a shim to enable that to work privately in
     # the global ColormapRegistry
     _colormaps._allow_override_builtin = override_builtin


### PR DESCRIPTION
## PR Summary

PR #22298 got merged with typos before PR #22777, which introduced the codespell pre-commit hook, which would have caught them. This simply fixes those typos. :+1: 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
