### PR TITLE
docs: add subplot-mosaic string compact notation

### DIFF
--- a/tutorials/provisional/mosaic.py
+++ b/tutorials/provisional/mosaic.py
@@ -105,7 +105,7 @@ print(ax_dict)
 # String short-hand
 # =================
 #
-# By restricting our axes labels to single characters we can use Using we can
+# By restricting our axes labels to single characters we can
 # "draw" the Axes we want as "ASCII art".  The following
 
 
@@ -123,14 +123,30 @@ fig = plt.figure(constrained_layout=True)
 ax_dict = fig.subplot_mosaic(mosaic)
 identify_axes(ax_dict)
 
+###############################################################################
+# Alternatively, you can use the more compact string notation
+mosaic = "AB;CD"
 
 ###############################################################################
+# will give you the same composition, where the ``";"`` is used
+# as the separator instead.
+
+fig = plt.figure(constrained_layout=True)
+ax_dict = fig.subplot_mosaic(mosaic)
+identify_axes(ax_dict)
+
+###############################################################################
+# Axes spanning multiple rows/columns
+# ===================================
+#
 # Something we can do with `.Figure.subplot_mosaic` that you can not
 # do with `.Figure.subplots` is specify that an Axes should span
 # several rows or columns.
-#
-# If we want to re-arrange our four Axes to have C be a horizontal
-# span on the bottom and D be a vertical span on the right we would do
+
+
+###############################################################################
+# If we want to re-arrange our four Axes to have ``"C"`` be a horizontal
+# span on the bottom and ``"D"`` be a vertical span on the right we would do
 
 axd = plt.figure(constrained_layout=True).subplot_mosaic(
     """

--- a/tutorials/provisional/mosaic.py
+++ b/tutorials/provisional/mosaic.py
@@ -129,7 +129,7 @@ mosaic = "AB;CD"
 
 ###############################################################################
 # will give you the same composition, where the ``";"`` is used
-# as the separator instead.
+# as the row separator instead of newline.
 
 fig = plt.figure(constrained_layout=True)
 ax_dict = fig.subplot_mosaic(mosaic)


### PR DESCRIPTION
## PR Summary
This PR would close #22917 which adds a small paragraph to the docs that shows the string compact notation for `suplot_mosaic`. Additionally, I took the liberty to fix a typo and add a section title to the current tutorial that I believe improves readability a bit.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
