### PR TITLE
Fixed installation guide command typo

### DIFF
--- a/doc/users/installing/index.rst
+++ b/doc/users/installing/index.rst
@@ -281,11 +281,11 @@ be manually installed on Macports with ::
 Once pip is installed, you can install Matplotlib and all its dependencies with
 from the Terminal.app command line::
 
-   python3 -mpip install matplotlib
+   python3 -m pip install matplotlib
 
 (``sudo python3.6 ...`` on Macports).
 
-You might also want to install IPython or the Jupyter notebook (``python3 -mpip
+You might also want to install IPython or the Jupyter notebook (``python3 -m pip
 install ipython notebook``).
 
 Checking your installation


### PR DESCRIPTION
## PR Summary
I'm think `python -mpip ...` is supposed to be `python -m pip ...` in both of the cases in the installation guide.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
