### PR TITLE
Add test to close legend issue

### DIFF
--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -910,3 +910,20 @@ def test_setting_alpha_keeps_polycollection_color():
     patch.set_alpha(0.5)
     assert patch.get_facecolor()[:3] == tuple(pc.get_facecolor()[0][:3])
     assert patch.get_edgecolor()[:3] == tuple(pc.get_edgecolor()[0][:3])
+
+
+def test_legend_markers_from_line2d():
+    # Test that markers can be copied for legend lines (#17960)
+    _markers = ['.', '*', 'v']
+    fig, ax = plt.subplots()
+    lines = [mlines.Line2D([0], [0], ls='None', marker=mark)
+             for mark in _markers]
+    labels = ["foo", "bar", "xyzzy"]
+    markers = [line.get_marker() for line in lines]
+    legend = ax.legend(lines, labels)
+
+    new_markers = [line.get_marker() for line in legend.get_lines()]
+    new_labels = [text.get_text() for text in legend.get_texts()]
+
+    assert markers == new_markers == _markers
+    assert labels == new_labels


### PR DESCRIPTION
## PR Summary
Fixed elsewhere. Closes #17960 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
