### PR TITLE
DOC: do not suggest to sudo pip install Matplotlib

### DIFF
--- a/doc/users/installing/index.rst
+++ b/doc/users/installing/index.rst
@@ -291,8 +291,6 @@ from the Terminal.app command line::
 
    python3 -m pip install matplotlib
 
-(``sudo python3.6 ...`` on Macports).
-
 You might also want to install IPython or the Jupyter notebook (``python3 -m pip
 install ipython notebook``).
 


### PR DESCRIPTION
## PR Summary

Skimming the discussion in #23009 I noticed that we are suggesting to use sudo + pip to install things 😱 which is something that you should never do.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
