### PR TITLE
DOC: Fix charset declaration in redirects

### DIFF
--- a/doc/sphinxext/redirect_from.py
+++ b/doc/sphinxext/redirect_from.py
@@ -15,9 +15,9 @@ directive in ``doc/topic/new-page.rst``::
 This creates in the build directory a file ``build/html/topic/old-page.html``
 that contains a relative refresh::
 
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <html>
       <head>
+        <meta charset="utf-8">
         <meta http-equiv="refresh" content="0; url=new-page.html">
       </head>
     </html>
@@ -40,9 +40,9 @@ logger = logging.getLogger(__name__)
 
 
 HTML_TEMPLATE = """\
-<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 <html>
   <head>
+    <meta charset="utf-8">
     <meta http-equiv="refresh" content="0; url={v}">
   </head>
 </html>


### PR DESCRIPTION
## PR Summary

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).