### PR TITLE
Fix issue with tex-encoding on non-Unicode platforms

### DIFF
--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -3,6 +3,7 @@ import re
 
 import matplotlib.pyplot as plt
 from matplotlib.texmanager import TexManager
+from matplotlib.testing._markers import needs_usetex
 import pytest
 
 
@@ -39,3 +40,20 @@ def test_font_selection(rc, preamble, family):
     src = Path(tm.make_tex("hello, world", fontsize=12)).read_text()
     assert preamble in src
     assert [*re.findall(r"\\\w+family", src)] == [family]
+
+
+@needs_usetex
+def test_unicode_characters():
+    # Smoke test to see that Unicode characters does not cause issues
+    # See #23019
+    plt.rcParams['text.usetex'] = True
+    fig, ax = plt.subplots()
+    ax.set_ylabel('\\textit{Velocity (\N{DEGREE SIGN}/sec)}')
+    ax.set_xlabel('\N{VULGAR FRACTION ONE QUARTER}Öøæ')
+    fig.canvas.draw()
+
+    # But not all characters.
+    # Should raise RuntimeError, not UnicodeDecodeError
+    with pytest.raises(RuntimeError):
+        ax.set_title('\N{SNOWMAN}')
+        fig.canvas.draw()

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -243,7 +243,8 @@ class TexManager:
         Return the file name.
         """
         texfile = cls.get_basefile(tex, fontsize) + ".tex"
-        Path(texfile).write_text(cls._get_tex_source(tex, fontsize))
+        Path(texfile).write_text(cls._get_tex_source(tex, fontsize),
+                                 encoding='utf-8')
         return texfile
 
     @classmethod
@@ -267,7 +268,8 @@ class TexManager:
                     prog=command[0],
                     format_command=cbook._pformat_subprocess(command),
                     tex=tex.encode('unicode_escape'),
-                    exc=exc.output.decode('utf-8'))) from None
+                    exc=exc.output.decode('utf-8', 'backslashreplace'))
+                ) from None
         _log.debug(report)
         return report
 


### PR DESCRIPTION
## PR Summary

Closes #23019

Thanks @anntzer for the rapid fix.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
