### PR TITLE
`streamplot` can return start and end points. 

### DIFF
--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -249,6 +249,36 @@ class StreamplotSet:
         self.lines = lines
         self.arrows = arrows
 
+    def get_startpoints(self):
+
+        startpoints = []
+        segments = self.lines.get_segments()
+
+        for x, segment in enumerate(segments):
+            if x == 0:
+                startpoints.append(segment[0])
+            else:
+                if not(all(segment[0] == segments[x - 1][1])):
+                    startpoints.append(segment[0])
+
+        return startpoints
+
+    def get_endpoints(self):
+
+        endpoints = []
+        segments = self.lines.get_segments()
+
+        for x, segment in enumerate(segments):
+            if x == 0:
+                pass
+            else:
+                if not(all(segment[0] == segments[x - 1][1])):
+                    endpoints.append(segments[x - 1][1])
+
+        endpoints.append(segments[-1][1])
+
+        return endpoints
+
 
 # Coordinate definitions
 # ========================

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -250,7 +250,7 @@ class StreamplotSet:
         self.arrows = arrows
 
     def get_startpoints(self):
-
+        """Return a list of start points of the stream lines"""
         startpoints = []
         segments = self.lines.get_segments()
 
@@ -264,7 +264,7 @@ class StreamplotSet:
         return startpoints
 
     def get_endpoints(self):
-
+        """Return a list of end points of the stream lines"""
         endpoints = []
         segments = self.lines.get_segments()
 

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -166,3 +166,45 @@ def test_streamplot_inputs():  # test no exception occurs.
     # array-likes
     plt.streamplot(range(3), range(3),
                    np.random.rand(3, 3), np.random.rand(3, 3))
+
+
+def startpoints_test():
+    # Creating dataset
+    x = np.arange(0, 10)
+    y = np.arange(0, 10)
+    # Creating grids
+    X, Y = np.meshgrid(x, y)
+    # x-component to the right
+    u = np.ones((10, 10))
+    # y-component zero
+    v = np.zeros((10, 10))
+    plot = plt.streamplot(X, Y, u, v, density=0.2)
+    startpoints = plot.get_startpoints()
+    right_values = [[0., 0.], [0., 4.5], [0., 9.]]
+
+    res = []
+    for x, right_value in enumerate(right_values):
+        res.append(all(right_value == startpoints[x]))
+
+    assert all(res)
+
+
+def endpoints_test():
+    # Creating dataset
+    x = np.arange(0, 10)
+    y = np.arange(0, 10)
+    # Creating grids
+    X, Y = np.meshgrid(x, y)
+    # x-component to the right
+    u = np.ones((10, 10))
+    # y-component zero
+    v = np.zeros((10, 10))
+    plot = plt.streamplot(X, Y, u, v, density=0.2)
+    endpoints = plot.get_endpoints()
+    right_values = [[9., 0.], [9., 4.5], [9., 9.]]
+
+    res = []
+    for x, right_value in enumerate(right_values):
+        res.append(all(right_value == endpoints[x]))
+
+    assert all(res)


### PR DESCRIPTION
## PR Summary

I've added 2 methods to get the starting and finish points of every stream lines in streamplot as requested in the issue. Here and example of how them work:

`my_plot = plt.streamplot(X, Y, u, v)`
`startpoints = my_plot.get_startpoints()`
`endpoints = my_plot.get_endpoints()`

closes #22985

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
