### PR TITLE
MNT: Merge locally defined test marks

### DIFF
--- a/doc/api/next_api_changes/deprecations/23045-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23045-OG.rst
@@ -1,0 +1,7 @@
+``checkdep_usetex`` deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This method was only intended to disable tests in case no latex install was
+found. As such, it is considered to be private and for internal use only.
+
+Please vendor the code if you need this.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -434,6 +434,7 @@ def _get_executable_info(name):
         raise ValueError("Unknown executable: {!r}".format(name))
 
 
+@_api.deprecated("3.6", alternative="Vendor the code")
 def checkdep_usetex(s):
     if not s:
         return False

--- a/lib/matplotlib/testing/_markers.py
+++ b/lib/matplotlib/testing/_markers.py
@@ -1,0 +1,48 @@
+"""
+pytest markers for the internal Matplotlib test suite.
+"""
+
+import logging
+import shutil
+
+import pytest
+
+import matplotlib.testing
+from matplotlib import _get_executable_info, ExecutableNotFoundError
+
+
+_log = logging.getLogger(__name__)
+
+
+def _checkdep_usetex():
+    if not shutil.which("tex"):
+        _log.warning("usetex mode requires TeX.")
+        return False
+    try:
+        _get_executable_info("dvipng")
+    except ExecutableNotFoundError:
+        _log.warning("usetex mode requires dvipng.")
+        return False
+    try:
+        _get_executable_info("gs")
+    except ExecutableNotFoundError:
+        _log.warning("usetex mode requires ghostscript.")
+        return False
+    return True
+
+
+needs_ghostscript = pytest.mark.skipif(
+    "eps" not in matplotlib.testing.compare.converter,
+    reason="This test needs a ghostscript installation")
+needs_lualatex = pytest.mark.skipif(
+    not matplotlib.testing._check_for_pgf('lualatex'),
+    reason='lualatex + pgf is required')
+needs_pdflatex = pytest.mark.skipif(
+    not matplotlib.testing._check_for_pgf('pdflatex'),
+    reason='pdflatex + pgf is required')
+needs_usetex = pytest.mark.skipif(
+    not _checkdep_usetex(),
+    reason="This test needs a TeX installation")
+needs_xelatex = pytest.mark.skipif(
+    not matplotlib.testing._check_for_pgf('xelatex'),
+    reason='xelatex + pgf is required')

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,18 +1,15 @@
 import re
 
 from matplotlib import path, transforms
-from matplotlib.testing import _check_for_pgf
 from matplotlib.backend_bases import (
     FigureCanvasBase, LocationEvent, MouseButton, MouseEvent,
     NavigationToolbar2, RendererBase)
 from matplotlib.figure import Figure
+from matplotlib.testing._markers import needs_xelatex
 import matplotlib.pyplot as plt
 
 import numpy as np
 import pytest
-
-needs_xelatex = pytest.mark.skipif(not _check_for_pgf('xelatex'),
-                                   reason='xelatex + pgf is required')
 
 
 def test_uses_per_path():

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -9,7 +9,7 @@ import numpy as np
 import pytest
 
 import matplotlib as mpl
-from matplotlib import pyplot as plt, checkdep_usetex, rcParams
+from matplotlib import pyplot as plt, rcParams
 from matplotlib.cbook import _get_data_path
 from matplotlib.ft2font import FT2Font
 from matplotlib.font_manager import findfont, FontProperties
@@ -17,11 +17,7 @@ from matplotlib.backends._backend_pdf_ps import get_glyphs_subset
 from matplotlib.backends.backend_pdf import PdfPages
 from matplotlib.patches import Rectangle
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
-
-
-needs_usetex = pytest.mark.skipif(
-    not checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+from matplotlib.testing._markers import needs_usetex
 
 
 @image_comparison(['pdf_use14corefonts.pdf'])

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -12,21 +12,13 @@ import matplotlib.pyplot as plt
 from matplotlib.testing import _has_tex_package, _check_for_pgf
 from matplotlib.testing.compare import compare_images, ImageComparisonFailure
 from matplotlib.backends.backend_pgf import PdfPages, _tex_escape
-from matplotlib.testing.decorators import (_image_directories,
-                                           check_figures_equal,
-                                           image_comparison)
+from matplotlib.testing.decorators import (
+    _image_directories, check_figures_equal, image_comparison)
+from matplotlib.testing._markers import (
+    needs_ghostscript, needs_lualatex, needs_pdflatex, needs_xelatex)
+
 
 baseline_dir, result_dir = _image_directories(lambda: 'dummy func')
-
-needs_xelatex = pytest.mark.skipif(not _check_for_pgf('xelatex'),
-                                   reason='xelatex + pgf is required')
-needs_pdflatex = pytest.mark.skipif(not _check_for_pgf('pdflatex'),
-                                    reason='pdflatex + pgf is required')
-needs_lualatex = pytest.mark.skipif(not _check_for_pgf('lualatex'),
-                                    reason='lualatex + pgf is required')
-needs_ghostscript = pytest.mark.skipif(
-    "eps" not in mpl.testing.compare.converter,
-    reason="This test needs a ghostscript installation")
 
 
 def compare_figure(fname, savefig_kwargs={}, tol=0):

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -11,15 +11,9 @@ from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.figure import Figure
 from matplotlib.patches import Ellipse
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib.testing._markers import needs_ghostscript, needs_usetex
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
-needs_ghostscript = pytest.mark.skipif(
-    "eps" not in mpl.testing.compare.converter,
-    reason="This test needs a ghostscript installation")
-needs_usetex = pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
 
 
 # This tests tends to hit a TeX cache lock on AppVeyor.

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -4,18 +4,13 @@ import xml.etree.ElementTree
 import xml.parsers.expat
 
 import numpy as np
-import pytest
 
 import matplotlib as mpl
 from matplotlib.figure import Figure
 from matplotlib.text import Text
 import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison, check_figures_equal
-
-
-needs_usetex = pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib.testing._markers import needs_usetex
 
 
 def test_visibility():

--- a/lib/matplotlib/tests/test_determinism.py
+++ b/lib/matplotlib/tests/test_determinism.py
@@ -11,14 +11,7 @@ import pytest
 import matplotlib as mpl
 import matplotlib.testing.compare
 from matplotlib import pyplot as plt
-
-
-needs_ghostscript = pytest.mark.skipif(
-    "eps" not in mpl.testing.compare.converter,
-    reason="This test needs a ghostscript installation")
-needs_usetex = pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+from matplotlib.testing._markers import needs_ghostscript, needs_usetex
 
 
 def _save_figure(objects='mhi', fmt="pdf", usetex=False):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -6,6 +6,7 @@ import numpy as np
 import pytest
 
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing._markers import needs_usetex
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 import matplotlib.transforms as mtransforms
@@ -764,9 +765,7 @@ def test_alpha_handles():
     assert lh.get_edgecolor()[:-1] == hh[1].get_edgecolor()[:-1]
 
 
-@pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
+@needs_usetex
 def test_usetex_no_warn(caplog):
     mpl.rcParams['font.family'] = 'serif'
     mpl.rcParams['font.serif'] = 'Computer Modern'

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -13,12 +13,8 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib.testing._markers import needs_usetex
 from matplotlib.text import Text
-
-
-needs_usetex = pytest.mark.skipif(
-    not mpl.checkdep_usetex(True),
-    reason="This test needs a TeX installation")
 
 
 @image_comparison(['font_styles'])

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -7,11 +7,11 @@ import matplotlib as mpl
 from matplotlib import dviread
 from matplotlib.testing import _has_tex_package
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
+from matplotlib.testing._markers import needs_usetex
 import matplotlib.pyplot as plt
 
 
-if not mpl.checkdep_usetex(True):
-    pytestmark = pytest.mark.skip('Missing TeX of Ghostscript or dvipng')
+pytestmark = needs_usetex
 
 
 @image_comparison(


### PR DESCRIPTION
## PR Summary

Identical test marks were defined in multiple files. This moves them to `testing.marks` (for consistency, even if they were only defined in a single file).

Also deprecates `matplotlib.checkdep_usetex`.

Closes #14455

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
