### PR TITLE
Add `minor` keyword argument to `plt.x/yticks`

### DIFF
--- a/doc/users/next_whats_new/plt_xyticks_support_minor.rst
+++ b/doc/users/next_whats_new/plt_xyticks_support_minor.rst
@@ -1,0 +1,15 @@
+``plt.xticks`` and ``plt.yticks`` support *minor* keyword argument
+------------------------------------------------------------------
+
+It is now possible to set or get minor ticks using `.pyplot.xticks` and
+`.pyplot.yticks` by setting ``minor=True``.
+
+.. plot::
+    :include-source: true
+
+    import matplotlib.pyplot as plt
+    plt.figure()
+    plt.plot([1, 2, 3, 3.5], [2, 1, 0, -0.5])
+    plt.xticks([1, 2, 3], ["One", "Zwei", "Trois"])
+    plt.xticks([1.414, 2.5, 3.142],
+               [r"$\sqrt{2}$", r"$\frac{5}{2}$", r"$\pi$"], minor=True)

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1751,7 +1751,7 @@ def ylim(*args, **kwargs):
     return ret
 
 
-def xticks(ticks=None, labels=None, **kwargs):
+def xticks(ticks=None, labels=None, *, minor=False, **kwargs):
     """
     Get or set the current tick locations and labels of the x-axis.
 
@@ -1764,6 +1764,9 @@ def xticks(ticks=None, labels=None, **kwargs):
     labels : array-like, optional
         The labels to place at the given *ticks* locations.  This argument can
         only be passed if *ticks* is passed as well.
+    minor : bool, default: False
+        If ``False``, get/set the major ticks/labels; if ``True``, the minor
+        ticks/labels.
     **kwargs
         `.Text` properties can be used to control the appearance of the labels.
 
@@ -1794,24 +1797,24 @@ def xticks(ticks=None, labels=None, **kwargs):
     ax = gca()
 
     if ticks is None:
-        locs = ax.get_xticks()
+        locs = ax.get_xticks(minor=minor)
         if labels is not None:
             raise TypeError("xticks(): Parameter 'labels' can't be set "
                             "without setting 'ticks'")
     else:
-        locs = ax.set_xticks(ticks)
+        locs = ax.set_xticks(ticks, minor=minor)
 
     if labels is None:
-        labels = ax.get_xticklabels()
+        labels = ax.get_xticklabels(minor=minor)
         for l in labels:
             l._internal_update(kwargs)
     else:
-        labels = ax.set_xticklabels(labels, **kwargs)
+        labels = ax.set_xticklabels(labels, minor=minor, **kwargs)
 
     return locs, labels
 
 
-def yticks(ticks=None, labels=None, **kwargs):
+def yticks(ticks=None, labels=None, *, minor=False, **kwargs):
     """
     Get or set the current tick locations and labels of the y-axis.
 
@@ -1824,6 +1827,9 @@ def yticks(ticks=None, labels=None, **kwargs):
     labels : array-like, optional
         The labels to place at the given *ticks* locations.  This argument can
         only be passed if *ticks* is passed as well.
+    minor : bool, default: False
+        If ``False``, get/set the major ticks/labels; if ``True``, the minor
+        ticks/labels.
     **kwargs
         `.Text` properties can be used to control the appearance of the labels.
 
@@ -1854,19 +1860,19 @@ def yticks(ticks=None, labels=None, **kwargs):
     ax = gca()
 
     if ticks is None:
-        locs = ax.get_yticks()
+        locs = ax.get_yticks(minor=minor)
         if labels is not None:
             raise TypeError("yticks(): Parameter 'labels' can't be set "
                             "without setting 'ticks'")
     else:
-        locs = ax.set_yticks(ticks)
+        locs = ax.set_yticks(ticks, minor=minor)
 
     if labels is None:
-        labels = ax.get_yticklabels()
+        labels = ax.get_yticklabels(minor=minor)
         for l in labels:
             l._internal_update(kwargs)
     else:
-        labels = ax.set_yticklabels(labels, **kwargs)
+        labels = ax.set_yticklabels(labels, minor=minor, **kwargs)
 
     return locs, labels
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -383,3 +383,18 @@ def test_doc_pyplot_summary():
             f"The following functions are listed in the pyplot documentation, "
             f"but they do not exist in pyplot. "
             f"Please remove them from doc/api/pyplot_summary.rst: {extra!r}")
+
+
+def test_minor_ticks():
+    plt.figure()
+    plt.plot(np.arange(1, 10))
+    tick_pos, tick_labels = plt.xticks(minor=True)
+    assert np.all(tick_labels == np.array([], dtype=np.float64))
+    assert tick_labels == []
+
+    plt.yticks(ticks=[3.5, 6.5], labels=["a", "b"], minor=True)
+    ax = plt.gca()
+    tick_pos = ax.get_yticks(minor=True)
+    tick_labels = ax.get_yticklabels(minor=True)
+    assert np.all(tick_pos == np.array([3.5, 6.5]))
+    assert [l.get_text() for l in tick_labels] == ['a', 'b']


### PR DESCRIPTION
## PR Summary
Closes #21107

Will think about tests. Should there be a release note?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
