### PR TITLE
Fix variable initialization due to jump bypassing it

### DIFF
--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -259,6 +259,7 @@ void load_tkinter_funcs(void)
     HANDLE process = GetCurrentProcess();  // Pseudo-handle, doesn't need closing.
     HMODULE* modules = NULL;
     DWORD size;
+    bool tcl_ok = false, tk_ok = false;
     if (!EnumProcessModules(process, NULL, 0, &size)) {
         PyErr_SetFromWindowsErr(0);
         goto exit;
@@ -271,7 +272,6 @@ void load_tkinter_funcs(void)
         PyErr_SetFromWindowsErr(0);
         goto exit;
     }
-    bool tcl_ok = false, tk_ok = false;
     for (unsigned i = 0; i < size / sizeof(HMODULE); ++i) {
         if (!tcl_ok) {
             tcl_ok = load_tcl(modules[i]);


### PR DESCRIPTION
## PR Summary

This fixes the following error in mingw gcc toolchain. Also clang
also have same error.

```
src/_tkagg.cpp:274:26: note:   crosses initialization of 'bool tk_ok'
  274 |     bool tcl_ok = false, tk_ok = false;
      |                          ^~~~~
src/_tkagg.cpp:274:10: note:   crosses initialization of 'bool tcl_ok'
  274 |     bool tcl_ok = false, tk_ok = false;
      |          ^~~~~~

```

According to C++ standard (6.7.3):

> It is possible to transfer into a block, but not in a way that bypasses
> declarations with initialization. A program that jumps from a point where
> a variable with automatic storage duration is not in scope to a point
> where it is in scope is ill-formed unless the variable has scalar type...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
