### PR TITLE
FIX: ensure switching the backend installs repl hook

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -206,12 +206,6 @@ def _get_backend_mod():
         # will (re)import pyplot and then call switch_backend if we need to
         # resolve the auto sentinel)
         switch_backend(dict.__getitem__(rcParams, "backend"))
-        # Just to be safe.  Interactive mode can be turned on without calling
-        # `plt.ion()` so register it again here.  This is safe because multiple
-        # calls to `install_repl_displayhook` are no-ops and the registered
-        # function respects `mpl.is_interactive()` to determine if it should
-        # trigger a draw.
-        install_repl_displayhook()
     return _backend_mod
 
 
@@ -301,6 +295,10 @@ def switch_backend(newbackend):
     # Need to keep a global reference to the backend for compatibility reasons.
     # See https://github.com/matplotlib/matplotlib/issues/6092
     matplotlib.backends.backend = newbackend
+
+    # make sure the repl display hook is installed in case we become
+    # interactive
+    install_repl_displayhook()
 
 
 def _warn_if_gui_out_of_main_thread():

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -385,7 +385,7 @@ def test_pylab_integration():
             )),
         ],
         env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
-        timeout=5,
+        timeout=60,
         check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -1,5 +1,6 @@
 import difflib
 import numpy as np
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -367,3 +368,26 @@ def test_set_current_axes_on_subfigure():
     assert plt.gca() != ax
     plt.sca(ax)
     assert plt.gca() == ax
+
+
+def test_pylab_integration():
+    pytest.importorskip("IPython")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "IPython",
+            "--pylab",
+            "-c",
+            ";".join((
+                "import matplotlib.pyplot as plt",
+                "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
+            )),
+        ],
+        env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+        timeout=5,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )


### PR DESCRIPTION

## PR Summary

closes #23042

In #22005 we change `pyplot` so that at import time we do not force a switch of
the backend and install the repl displayhook.

However, this meant that in some cases (primarily through `ipython --pylab`) to
end up with a session where `install_repl_displayhook` had never been called.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

I'm still thinking about how to test this.