### PR TITLE
FIX: Decrease figure refcount on close of a macosx figure

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -193,7 +193,6 @@ static int wait_for_stdin(void)
 - (Window*)initWithContentRect:(NSRect)rect styleMask:(unsigned int)mask backing:(NSBackingStoreType)bufferingType defer:(BOOL)deferCreation withManager: (PyObject*)theManager;
 - (NSRect)constrainFrameRect:(NSRect)rect toScreen:(NSScreen*)screen;
 - (BOOL)closeButtonPressed;
-- (void)dealloc;
 @end
 
 @interface View : NSView <NSWindowDelegate>
@@ -1239,19 +1238,9 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
     /* This is needed for show(), which should exit from [NSApp run]
      * after all windows are closed.
      */
-}
-
-- (void)dealloc
-{
-    PyGILState_STATE gstate;
-    gstate = PyGILState_Ensure();
+    // For each new window, we have incremented the manager reference, so
+    // we need to bring that down during close and not just dealloc.
     Py_DECREF(manager);
-    PyGILState_Release(gstate);
-    /* The reference count of the view that was added as a subview to the
-     * content view of this window was increased during the call to addSubview,
-     * and is decreased during the call to [super dealloc].
-     */
-    [super dealloc];
 }
 @end
 


### PR DESCRIPTION
## PR Summary

We need to take the refcount of the figuremanager down when we close a window. (apparently dealloc on the Window isn't being called?) We could call this within the FigureManager_dealloc method, or just inline it here because close gets called during the FigureManager_dealloc already, so I decided this simplifies the code.

This was causing leaking figures before, per: https://github.com/matplotlib/matplotlib/issues/19769
and this PR does fix the issue on v3.5.x, but unfortunately there is a new leak that I introduced in https://github.com/matplotlib/matplotlib/pull/21790 :( There are no leaks when we `plt.show()` figures and fire up the GUI mainloop. However, when we are calling `savefig()` without ever showing we are now creating singleshot Timers in the app, but the callback never gets triggered due to the event loop not being active/listening for these timers. This is then keeping a reference from the Timer to the Figure on every close, causing a leak when calling a bunch of savefig's.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
