### PR TITLE
Add stackplot to plot types listing

### DIFF
--- a/lib/matplotlib/mpl-data/stylelib/_mpl-gallery-nogrid.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_mpl-gallery-nogrid.mplstyle
@@ -16,4 +16,4 @@ ytick.major.size: 0.0
 
 # colors:
 image.cmap    : Blues
-# axes.prop_cycle: cycler('color', ['FF7F0E', '1F77B4', '2CA02C'])
+axes.prop_cycle: cycler('color', ['1f77b4', '82bbdb', 'ccdff1'])

--- a/lib/matplotlib/mpl-data/stylelib/_mpl-gallery.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/_mpl-gallery.mplstyle
@@ -16,4 +16,4 @@ ytick.major.size: 0.0
 
 # colors:
 image.cmap    : Blues
-# axes.prop_cycle: cycler('color', ['FF7F0E', '1F77B4', '2CA02C'])
+axes.prop_cycle: cycler('color', ['1f77b4', '58a1cf', 'abd0e6'])

--- a/plot_types/basic/stackplot.py
+++ b/plot_types/basic/stackplot.py
@@ -1,0 +1,27 @@
+"""
+===============
+stackplot(x, y)
+===============
+See `~matplotlib.axes.Axes.stackplot`
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# make data
+x = np.arange(0, 10, 2)
+ay = [1, 1.25, 2, 2.75, 3]
+by = [1, 1, 1, 1, 1]
+cy = [2, 1, 2, 1, 2]
+y = np.vstack([ay, by, cy])
+
+# plot
+fig, ax = plt.subplots()
+
+ax.stackplot(x, y)
+
+ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
+       ylim=(0, 8), yticks=np.arange(1, 8))
+
+plt.show()


### PR DESCRIPTION
Area plots (stackplots) are a fairly common plot type, so I figure should be included in the plot type listing. They're structurally similar to fill_between, which is why I put this in the same 'basic' section

eta: no idea why my rebase/squash isn't working (it is locally) so folks are welcome squash. 
eta2: no idea what combination of button mashing got me to a clean commit