### PR TITLE
doc: mathtext example: use axhspan() instead of fill_between() for backdrop rectangle shading

### DIFF
--- a/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/examples/text_labels_and_annotations/mathtext_examples.py
@@ -89,9 +89,7 @@ def doall():
         baseline = 1 - i_line * line_axesfrac
         baseline_next = baseline - line_axesfrac
         fill_color = ['white', 'tab:blue'][i_line % 2]
-        ax.fill_between([0, 1], [baseline, baseline],
-                        [baseline_next, baseline_next],
-                        color=fill_color, alpha=0.2)
+        ax.axhspan(baseline, baseline_next, color=fill_color, alpha=0.2)
         ax.annotate(f'{title}:',
                     xy=(0.06, baseline - 0.3 * line_axesfrac),
                     color=mpl_grey_rgb, weight='bold')


### PR DESCRIPTION
## PR Summary

This changes the "mathtext example" code snippet to not use `ax.fill_between()` to place rectangular background shades but rather use `ax.axhspan()` instead.

https://matplotlib.org/devdocs/gallery/text_labels_and_annotations/mathtext_examples.html

`fill_between()` isn't the right thing to use here, I think. It might do the same thing (as long as the plot isn't interacted with / zoomed out), but it feels real clunky and I think it should not be encouraged to be used like that in this user facing example. I only encountered this because this plot actually was showing up as a usage example on the `plt.fill_between()` API docs page (older version, 3.1.1, changed in current docs it seems) and I found this real odd.

Can rebase if it should go in a different branch.

From 3.1.1 docs screenshot:

![Screenshot from 2022-05-18 11-26-51](https://user-images.githubusercontent.com/1842780/169007192-997a51bc-14c3-4fe4-b8c4-8439d8bdb758.png)



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
