### PR TITLE
Fix test_image_comparison_expect_rms

### DIFF
--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -60,12 +60,12 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms, tmp_path,
     # Copy both "baseline" and "test" image to result_dir, so that 1)
     # compare_images writes the diff to result_dir, rather than to the source
     # tree and 2) the baseline image doesn't appear missing to triage_tests.py.
-    result_im1 = make_test_filename(result_dir / im1, "expected")
-    shutil.copyfile(baseline_dir / im1, result_im1)
+    # result_im1 = make_test_filename(result_dir / im1, "expected")
+    # shutil.copyfile(baseline_dir / im1, result_im1)
     result_im2 = result_dir / im1
     shutil.copyfile(baseline_dir / im2, result_im2)
     results = compare_images(
-        result_im1, result_im2, tol=tol, in_decorator=True)
+        baseline_dir / im1, result_im2, tol=tol, in_decorator=True)
 
     if expect_rms is None:
         assert results is None

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -55,6 +55,8 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms, tmp_path,
     succeed if compare_images succeeds. Otherwise, the test will succeed if
     compare_images fails and returns an RMS error almost equal to this value.
     """
+    # Change the working directory using monkeypatch to use a temporary
+    # test specific directory
     monkeypatch.chdir(tmp_path)
     baseline_dir, result_dir = map(Path, _image_directories(lambda: "dummy"))
     # Copy "test" image to result_dir, so that compare_images writes

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -57,11 +57,8 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms, tmp_path,
     """
     monkeypatch.chdir(tmp_path)
     baseline_dir, result_dir = map(Path, _image_directories(lambda: "dummy"))
-    # Copy both "baseline" and "test" image to result_dir, so that 1)
-    # compare_images writes the diff to result_dir, rather than to the source
-    # tree and 2) the baseline image doesn't appear missing to triage_tests.py.
-    # result_im1 = make_test_filename(result_dir / im1, "expected")
-    # shutil.copyfile(baseline_dir / im1, result_im1)
+    # Copy "test" image to result_dir, so that compare_images writes
+    # the diff to result_dir, rather than to the source tree
     result_im2 = result_dir / im1
     shutil.copyfile(baseline_dir / im2, result_im2)
     results = compare_images(

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -4,7 +4,7 @@ import shutil
 import pytest
 from pytest import approx
 
-from matplotlib.testing.compare import compare_images, make_test_filename
+from matplotlib.testing.compare import compare_images
 from matplotlib.testing.decorators import _image_directories
 
 

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import shutil
-
+import uuid
 import pytest
 from pytest import approx
 
@@ -58,7 +58,8 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms):
     # Copy both "baseline" and "test" image to result_dir, so that 1)
     # compare_images writes the diff to result_dir, rather than to the source
     # tree and 2) the baseline image doesn't appear missing to triage_tests.py.
-    result_im1 = make_test_filename(result_dir / im1, "expected")
+    uid = str(uuid.uuid4())
+    result_im1 = make_test_filename(result_dir / (uid + im1), "expected")
     shutil.copyfile(baseline_dir / im1, result_im1)
     result_im2 = result_dir / im1
     shutil.copyfile(baseline_dir / im2, result_im2)

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 import shutil
-import uuid
+
 import pytest
 from pytest import approx
 
@@ -58,8 +58,7 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms):
     # Copy both "baseline" and "test" image to result_dir, so that 1)
     # compare_images writes the diff to result_dir, rather than to the source
     # tree and 2) the baseline image doesn't appear missing to triage_tests.py.
-    uid = str(uuid.uuid4())
-    result_im1 = make_test_filename(result_dir / (uid + im1), "expected")
+    result_im1 = make_test_filename(result_dir / im1, "expected")
     shutil.copyfile(baseline_dir / im1, result_im1)
     result_im2 = result_dir / im1
     shutil.copyfile(baseline_dir / im2, result_im2)

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -42,7 +42,8 @@ from matplotlib.testing.decorators import _image_directories
         # Now test the reverse comparison.
         ('all128.png', 'all127.png', 0, 1),
     ])
-def test_image_comparison_expect_rms(im1, im2, tol, expect_rms):
+def test_image_comparison_expect_rms(im1, im2, tol, expect_rms, tmp_path,
+                                                            monkeypatch):
     """
     Compare two images, expecting a particular RMS error.
 
@@ -54,6 +55,7 @@ def test_image_comparison_expect_rms(im1, im2, tol, expect_rms):
     succeed if compare_images succeeds. Otherwise, the test will succeed if
     compare_images fails and returns an RMS error almost equal to this value.
     """
+    monkeypatch.chdir(tmp_path)
     baseline_dir, result_dir = map(Path, _image_directories(lambda: "dummy"))
     # Copy both "baseline" and "test" image to result_dir, so that 1)
     # compare_images writes the diff to result_dir, rather than to the source

--- a/lib/matplotlib/tests/test_compare_images.py
+++ b/lib/matplotlib/tests/test_compare_images.py
@@ -43,7 +43,7 @@ from matplotlib.testing.decorators import _image_directories
         ('all128.png', 'all127.png', 0, 1),
     ])
 def test_image_comparison_expect_rms(im1, im2, tol, expect_rms, tmp_path,
-                                                            monkeypatch):
+                                     monkeypatch):
     """
     Compare two images, expecting a particular RMS error.
 


### PR DESCRIPTION
## PR Summary
Stick uuid onto image 1 to avoid using the same file if the tests run in parallel. ( closes #22992 )

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
