### PR TITLE
MNT: Remove deprecated axis.cla()

### DIFF
--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -41,7 +41,6 @@ Inheritance
    :nosignatures:
 
    Axis.clear
-   Axis.cla
    Axis.get_scale
 
 

--- a/doc/api/next_api_changes/removals/23078-GL.rst
+++ b/doc/api/next_api_changes/removals/23078-GL.rst
@@ -1,0 +1,4 @@
+``Axis.cla()`` has been removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use `.Axis.clear()` instead.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -868,11 +868,6 @@ class Axis(martist.Artist):
         self.set_units(None)
         self.stale = True
 
-    @_api.deprecated("3.4", alternative="`.Axis.clear`")
-    def cla(self):
-        """Clear this axis."""
-        return self.clear()
-
     def reset_ticks(self):
         """
         Re-initialize the major and minor Tick lists.


### PR DESCRIPTION
## PR Summary

Follows the deprecation period

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
