### PR TITLE
MNT: Deprecate date_ticker_factory

### DIFF
--- a/doc/api/next_api_changes/deprecations/23081-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23081-OG.rst
@@ -1,0 +1,8 @@
+``date_ticker_factory`` deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``date_ticker_factory`` method in the `matplotlib.dates` module is
+deprecated. Instead use `~.AutoDateLocator` and `~.AutoDateFormatter` for a
+more flexible and scalable locator and formatter.
+
+The code can also be vendored if the fixed behaviour is expected.

--- a/doc/api/next_api_changes/deprecations/23081-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23081-OG.rst
@@ -5,4 +5,4 @@ The ``date_ticker_factory`` method in the `matplotlib.dates` module is
 deprecated. Instead use `~.AutoDateLocator` and `~.AutoDateFormatter` for a
 more flexible and scalable locator and formatter.
 
-The code can also be vendored if the fixed behaviour is expected.
+If you need the exact ``date_ticker_factory`` behavior, please copy the code.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1782,6 +1782,8 @@ def num2epoch(d):
     return np.asarray(d) * SEC_PER_DAY - dt
 
 
+@_api.deprecated("3.6", alternative="`AutoDateLocator` and `AutoDateFormatter`"
+                 " or vendor the code")
 def date_ticker_factory(span, tz=None, numticks=5):
     """
     Create a date locator with *numticks* (approx) and a date formatter

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1319,8 +1319,9 @@ def test_concise_formatter_call():
                           (200, mdates.MonthLocator),
                           (2000, mdates.YearLocator)))
 def test_date_ticker_factory(span, expected_locator):
-    locator, _ = mdates.date_ticker_factory(span)
-    assert isinstance(locator, expected_locator)
+    with pytest.warns(_api.MatplotlibDeprecationWarning):
+        locator, _ = mdates.date_ticker_factory(span)
+        assert isinstance(locator, expected_locator)
 
 
 def test_usetex_newline():


### PR DESCRIPTION
## PR Summary

As discussed in #23013 it may make sense to deprecate `date_ticker_factory` since `AutoDateLocator` and `AutoDateFormatter` has been available for 15-16 years.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
