### PR TITLE
Derive new_figure_manager from FigureCanvas.new_manager.

### DIFF
--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -44,13 +44,13 @@ def mpl_test_settings(request):
 
         backend = None
         backend_marker = request.node.get_closest_marker('backend')
+        prev_backend = matplotlib.get_backend()
         if backend_marker is not None:
             assert len(backend_marker.args) == 1, \
                 "Marker 'backend' must specify 1 backend."
             backend, = backend_marker.args
             skip_on_importerror = backend_marker.kwargs.get(
                 'skip_on_importerror', False)
-            prev_backend = matplotlib.get_backend()
 
             # special case Qt backend importing to avoid conflicts
             if backend.lower().startswith('qt5'):
@@ -87,8 +87,7 @@ def mpl_test_settings(request):
         try:
             yield
         finally:
-            if backend is not None:
-                plt.switch_backend(prev_backend)
+            matplotlib.use(prev_backend)
 
 
 @pytest.fixture

--- a/lib/matplotlib/tests/test_backend_template.py
+++ b/lib/matplotlib/tests/test_backend_template.py
@@ -1,0 +1,23 @@
+"""
+Backend-loading machinery tests, using variations on the template backend.
+"""
+
+import sys
+from types import SimpleNamespace
+
+import matplotlib as mpl
+from matplotlib import pyplot as plt
+from matplotlib.backends import backend_template
+
+
+def test_load_template():
+    mpl.use("template")
+    assert type(plt.figure().canvas) == backend_template.FigureCanvasTemplate
+
+
+def test_new_manager(monkeypatch):
+    mpl_test_backend = SimpleNamespace(**vars(backend_template))
+    del mpl_test_backend.new_figure_manager
+    monkeypatch.setitem(sys.modules, "mpl_test_backend", mpl_test_backend)
+    mpl.use("module://mpl_test_backend")
+    assert type(plt.figure().canvas) == backend_template.FigureCanvasTemplate


### PR DESCRIPTION
Followup to the introduction of FigureCanvas.new_manager (#22925): allow backend
modules to not define new_figure_manager anymore, in which case we
derive the needed function from FigureCanvas.new_manager.  (In the
future, I plan to do the same with draw_if_interactive and show, so that
"a backend is just a module with a FigureCanvas class"; the advantage is
that the FigureCanvas subclass provided by the module can inherit
methods as needed from the parent class.)

For backcompat, the old codepath is maintained (and has priority).

To test this, manually alter backend_bases._Backend.export and remove
the new_figure_manager entry from the exported functions, which deletes
that global function from all of the builtin methods (actually, we'll
need a deprecation cycle), and check that pyplot still works fine.  Also
tweak the testing machinery to restore the original backend even if the
backend was not switched via a pytest marker.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
