### PR TITLE
Move test that fig.add_axes() needs parameters

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -189,9 +189,6 @@ def test_figure_legend():
 def test_gca():
     fig = plt.figure()
 
-    with pytest.raises(TypeError):
-        assert fig.add_axes() is None
-
     ax0 = fig.add_axes([0, 0, 1, 1])
     with pytest.warns(
             MatplotlibDeprecationWarning,
@@ -476,6 +473,10 @@ def test_invalid_figure_size(width, height):
 
 def test_invalid_figure_add_axes():
     fig = plt.figure()
+    with pytest.raises(TypeError,
+                       match="missing 1 required positional argument: 'rect'"):
+        fig.add_axes()
+
     with pytest.raises(ValueError):
         fig.add_axes((.1, .1, .5, np.nan))
 


### PR DESCRIPTION
For historic reasons, this test was in `test_gca()`: Originally the test test tested that `gca()` picks up the Axes created by `add_axes()`. But not passing a parameter was deprecated and the test turned into a check that is
doesn't work anymore. The test is now better placed in `test_invalid_figure_add_axes()`.

The `assert ... is None` stems also from the deprecation period. I does not make sense now that an exception is raised.

