### PR TITLE
Try to unbreak CI by xfailing OSX Tk tests

### DIFF
--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -37,6 +37,10 @@ def _isolated_tk_test(success_count, func=None):
         sys.platform == "linux" and not _c_internal_utils.display_is_valid(),
         reason="$DISPLAY and $WAYLAND_DISPLAY are unset"
     )
+    @pytest.xfail(  # GitHub issue #23094
+        reason="Tk version mismatch on OSX CI",
+        condition=sys.platform == 'darwin'
+    )
     @functools.wraps(func)
     def test_func():
         # even if the package exists, may not actually be importable this can

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -38,8 +38,8 @@ def _isolated_tk_test(success_count, func=None):
         reason="$DISPLAY and $WAYLAND_DISPLAY are unset"
     )
     @pytest.xfail(  # GitHub issue #23094
-        reason="Tk version mismatch on OSX CI",
-        condition=sys.platform == 'darwin'
+        sys.platform == 'darwin',
+        reason="Tk version mismatch on OSX CI"
     )
     @functools.wraps(func)
     def test_func():

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -37,7 +37,7 @@ def _isolated_tk_test(success_count, func=None):
         sys.platform == "linux" and not _c_internal_utils.display_is_valid(),
         reason="$DISPLAY and $WAYLAND_DISPLAY are unset"
     )
-    @pytest.xfail(  # GitHub issue #23094
+    @pytest.mark.xfail(  # GitHub issue #23094
         sys.platform == 'darwin',
         reason="Tk version mismatch on OSX CI"
     )

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -59,6 +59,9 @@ def _get_testable_interactive_backends():
         elif env["MPLBACKEND"].startswith('wx') and sys.platform == 'darwin':
             # ignore on OSX because that's currently broken (github #16849)
             marks.append(pytest.mark.xfail(reason='github #16849'))
+        elif env["MPLBACKEND"] == "tkagg" and sys.platform == 'darwin':
+            marks.append(  # GitHub issue #23094
+                pytest.mark.xfail(reason="Tk version mismatch on OSX CI"))
         envs.append(
             pytest.param(
                 {**env, 'BACKEND_DEPS': ','.join(deps)},
@@ -236,6 +239,9 @@ for param in _thread_safe_backends:
                 reason='PyPy does not support Tkinter threading: '
                        'https://foss.heptapod.net/pypy/pypy/-/issues/1929',
                 strict=True))
+    elif backend == "tkagg" and sys.platform == "darwin":
+        param.marks.append(  # GitHub issue #23094
+            pytest.mark.xfail("Tk version mismatch on OSX CI"))
 
 
 @pytest.mark.parametrize("env", _thread_safe_backends)
@@ -510,6 +516,10 @@ for param in _blit_backends:
     elif backend == "wx":
         param.marks.append(
             pytest.mark.skip("wx does not support blitting"))
+    elif backend == "tkagg" and sys.platform == "darwin":
+        param.marks.append(  # GitHub issue #23094
+            pytest.mark.xfail("Tk version mismatch on OSX CI")
+        )
 
 
 @pytest.mark.parametrize("env", _blit_backends)


### PR DESCRIPTION
Stopgap solution for #23094.

Mid-term we should get the CI environment sorted out to have a working Tk setup. But until then, it's better to xfail than to have all PRs cluttered with these failures.

This is a blind attempt. - CI will decide whether I did everything correctly.