### PR TITLE
Remove custom backend_nbagg.show(), putting logic in manager show.

### DIFF
--- a/lib/matplotlib/backends/backend_nbagg.py
+++ b/lib/matplotlib/backends/backend_nbagg.py
@@ -96,6 +96,15 @@ class FigureManagerNbAgg(FigureManagerWebAgg):
         else:
             self.canvas.draw_idle()
         self._shown = True
+        # plt.figure adds an event which makes the figure in focus the active
+        # one. Disable this behaviour, as it results in figures being put as
+        # the active figure after they have been shown, even in non-interactive
+        # mode.
+        if hasattr(self, '_cidgcf'):
+            self.canvas.mpl_disconnect(self._cidgcf)
+        if not is_interactive():
+            from matplotlib._pylab_helpers import Gcf
+            Gcf.figs.pop(self.num, None)
 
     def reshow(self):
         """
@@ -232,27 +241,3 @@ class CommSocket:
 class _BackendNbAgg(_Backend):
     FigureCanvas = FigureCanvasNbAgg
     FigureManager = FigureManagerNbAgg
-
-    @staticmethod
-    def show(block=None):
-        ## TODO: something to do when keyword block==False ?
-        from matplotlib._pylab_helpers import Gcf
-
-        managers = Gcf.get_all_fig_managers()
-        if not managers:
-            return
-
-        interactive = is_interactive()
-
-        for manager in managers:
-            manager.show()
-
-            # plt.figure adds an event which makes the figure in focus the
-            # active one. Disable this behaviour, as it results in
-            # figures being put as the active figure after they have been
-            # shown, even in non-interactive mode.
-            if hasattr(manager, '_cidgcf'):
-                manager.canvas.mpl_disconnect(manager._cidgcf)
-
-            if not interactive:
-                Gcf.figs.pop(manager.num, None)


### PR DESCRIPTION
The _Backend class machinery can autogenerate a backend_module.show()
function, which (in short) calls manager.show() on all managers and then
calls the optionally-provided mainloop() function.

backend_nbagg currently completely bypasses this autogeneration because
it wants to additionally fiddle with callbacks and Gcf (it doesn't need
any mainloop()), but that logic can just as well go to
FigureManagerNbAgg.show() instead.  This way it benefits from the
default-generated show; moreover, it seems a bit strange that figures
shown with manager.show() (instead of plt.show()) do indeed get
displayed, but just don't have their callbacks/Gcf-ness adjusted.

This is also related to the move towards putting show()-generating
information on the canvas class for inheritability (#23090).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
