### PR TITLE
Reuse subprocess_run_helper in test_pylab_integration.

### DIFF
--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -1,6 +1,5 @@
 import difflib
 import numpy as np
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -371,23 +370,14 @@ def test_set_current_axes_on_subfigure():
 
 
 def test_pylab_integration():
-    pytest.importorskip("IPython")
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "IPython",
-            "--pylab",
-            "-c",
-            ";".join((
-                "import matplotlib.pyplot as plt",
-                "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
-            )),
-        ],
-        env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+    IPython = pytest.importorskip("IPython")
+    mpl.testing.subprocess_run_helper(
+        IPython.start_ipython,
+        "--pylab",
+        "-c",
+        ";".join((
+            "import matplotlib.pyplot as plt",
+            "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
+        )),
         timeout=60,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
     )


### PR DESCRIPTION
It's basically here for that purpose...

Followup to #23057.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
