### PR TITLE
Tweak subprocess_run_helper.

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -50,39 +50,28 @@ def setup():
     set_reproducibility_for_testing()
 
 
-def subprocess_run_helper(func, *args, timeout, **extra_env):
+def subprocess_run_helper(func, *args, timeout, extra_env=None):
     """
-    Run a function in a sub-process
+    Run a function in a sub-process.
 
     Parameters
     ----------
     func : function
         The function to be run.  It must be in a module that is importable.
-
     *args : str
         Any additional command line arguments to be passed in
-        the first argument to subprocess.run
-
-    **extra_env : Dict[str, str]
-        Any additional environment variables to be set for
-        the subprocess.
-
+        the first argument to ``subprocess.run``.
+    extra_env : dict[str, str]
+        Any additional environment variables to be set for the subprocess.
     """
     target = func.__name__
     module = func.__module__
     proc = subprocess.run(
         [sys.executable,
          "-c",
-         f"""
-from {module} import {target}
-{target}()
-""",
+         f"from {module} import {target}; {target}()",
          *args],
-        env={
-            **os.environ,
-            "SOURCE_DATE_EPOCH": "0",
-            **extra_env
-        },
+        env={**os.environ, "SOURCE_DATE_EPOCH": "0", **(extra_env or {})},
         timeout=timeout, check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -48,10 +48,8 @@ def _isolated_tk_test(success_count, func=None):
         pytest.importorskip('tkinter')
         try:
             proc = subprocess_run_helper(
-                func, timeout=_test_timeout,
-                MPLBACKEND="TkAgg",
-                MPL_TEST_ESCAPE_HATCH="1"
-            )
+                func, timeout=_test_timeout, extra_env=dict(
+                    MPLBACKEND="TkAgg", MPL_TEST_ESCAPE_HATCH="1"))
         except subprocess.TimeoutExpired:
             pytest.fail("Subprocess timed out")
         except subprocess.CalledProcessError as e:

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -175,7 +175,7 @@ def test_interactive_backend(env, toolbar):
     proc = _run_helper(_test_interactive_impl,
                        json.dumps({"toolbar": toolbar}),
                        timeout=_test_timeout,
-                       **env)
+                       extra_env=env)
 
     assert proc.stdout.count("CloseEvent") == 1
 
@@ -247,8 +247,7 @@ for param in _thread_safe_backends:
 @pytest.mark.parametrize("env", _thread_safe_backends)
 @pytest.mark.flaky(reruns=3)
 def test_interactive_thread_safety(env):
-    proc = _run_helper(_test_thread_impl,
-                       timeout=_test_timeout, **env)
+    proc = _run_helper(_test_thread_impl, timeout=_test_timeout, extra_env=env)
     assert proc.stdout.count("CloseEvent") == 1
 
 
@@ -447,7 +446,7 @@ def test_lazy_linux_headless(env):
         _lazy_headless,
         env.pop('MPLBACKEND'), env.pop("BACKEND_DEPS"),
         timeout=_test_timeout,
-        **{**env, 'DISPLAY': '', 'WAYLAND_DISPLAY': ''}
+        extra_env={**env, 'DISPLAY': '', 'WAYLAND_DISPLAY': ''}
     )
 
 
@@ -526,10 +525,8 @@ for param in _blit_backends:
 # subprocesses can struggle to get the display, so rerun a few times
 @pytest.mark.flaky(reruns=4)
 def test_blitting_events(env):
-    proc = _run_helper(_test_number_of_draws_script,
-                       timeout=_test_timeout,
-                       **env)
-
+    proc = _run_helper(
+        _test_number_of_draws_script, timeout=_test_timeout, extra_env=env)
     # Count the number of draw_events we got. We could count some initial
     # canvas draws (which vary in number by backend), but the critical
     # check here is that it isn't 10 draws, which would be called if
@@ -585,8 +582,8 @@ def test_figure_leak_20490(env, time_mem):
         acceptable_memory_leakage += 11_000_000
 
     result = _run_helper(
-        _test_figure_leak, str(pause_time), timeout=_test_timeout, **env
-    )
+        _test_figure_leak, str(pause_time),
+        timeout=_test_timeout, extra_env=env)
 
     growth = int(result.stdout)
     assert growth <= acceptable_memory_leakage


### PR DESCRIPTION
On general grounds, an API like
`subprocess_run_helper(func, *args, timeout, **extra_env)`
is problematic because it prevents one from passing an environment
variable called "timeout".

Instead, pass the extra environment variables as a dict, without
unpacking.

(Technically this has been released in 3.5.2 as public API, but 1) I'm
not really sure it should have been a public API to start with (should
we deprecate it and make it private?), and 2) hopefully tweaking that in
3.5.3 with no deprecation is not going to disrupt anyone...  I can still
put in a changelog entry if that's preferred.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
