### PR TITLE
Backport PR #23057 and #23106

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -215,12 +215,6 @@ def _get_backend_mod():
         # will (re)import pyplot and then call switch_backend if we need to
         # resolve the auto sentinel)
         switch_backend(dict.__getitem__(rcParams, "backend"))
-        # Just to be safe.  Interactive mode can be turned on without calling
-        # `plt.ion()` so register it again here.  This is safe because multiple
-        # calls to `install_repl_displayhook` are no-ops and the registered
-        # function respects `mpl.is_interactive()` to determine if it should
-        # trigger a draw.
-        install_repl_displayhook()
     return _backend_mod
 
 
@@ -310,6 +304,10 @@ def switch_backend(newbackend):
     # Need to keep a global reference to the backend for compatibility reasons.
     # See https://github.com/matplotlib/matplotlib/issues/6092
     matplotlib.backends.backend = newbackend
+
+    # make sure the repl display hook is installed in case we become
+    # interactive
+    install_repl_displayhook()
 
 
 def _warn_if_gui_out_of_main_thread():

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -1,5 +1,6 @@
 import difflib
 import numpy as np
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -335,3 +336,26 @@ def test_fallback_position():
     axtest = plt.axes([0.2, 0.2, 0.5, 0.5], position=[0.1, 0.1, 0.8, 0.8])
     np.testing.assert_allclose(axtest.bbox.get_points(),
                                axref.bbox.get_points())
+
+
+def test_pylab_integration():
+    pytest.importorskip("IPython")
+    subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "IPython",
+            "--pylab",
+            "-c",
+            ";".join((
+                "import matplotlib.pyplot as plt",
+                "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
+            )),
+        ],
+        env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+        timeout=60,
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        universal_newlines=True,
+    )

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -345,7 +345,7 @@ def test_pylab_integration():
         "-c",
         ";".join((
             "import matplotlib.pyplot as plt",
-            "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
+            "assert plt._IP_REGISTERED is not None",
         )),
         timeout=60,
     )

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -1,6 +1,5 @@
 import difflib
 import numpy as np
-import os
 import subprocess
 import sys
 from pathlib import Path
@@ -339,23 +338,14 @@ def test_fallback_position():
 
 
 def test_pylab_integration():
-    pytest.importorskip("IPython")
-    subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "IPython",
-            "--pylab",
-            "-c",
-            ";".join((
-                "import matplotlib.pyplot as plt",
-                "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
-            )),
-        ],
-        env={**os.environ, "SOURCE_DATE_EPOCH": "0"},
+    IPython = pytest.importorskip("IPython")
+    mpl.testing.subprocess_run_helper(
+        IPython.start_ipython,
+        "--pylab",
+        "-c",
+        ";".join((
+            "import matplotlib.pyplot as plt",
+            "assert plt._REPL_DISPLAYHOOK == plt._ReplDisplayHook.IPYTHON",
+        )),
         timeout=60,
-        check=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        universal_newlines=True,
     )


### PR DESCRIPTION
- Backport PR #23057: FIX: ensure switching the backend installs repl hook
- Merge pull request #23106 from anntzer/tpi

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (run `flake8` on changed files to check).
- [ ] New features are documented, with examples if plot related.
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] Conforms to Matplotlib style conventions (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of master, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
