### PR TITLE
DOC fixed duplicate/wrong default

### DIFF
--- a/tutorials/text/text_intro.py
+++ b/tutorials/text/text_intro.py
@@ -212,8 +212,8 @@ for ax, loc in zip(axs, locs):
 plt.show()
 
 ##############################################################################
-# Vertical spacing for titles is controlled via :rc:`axes.titlepad`, which
-# defaults to 5 points.  Setting to a different value moves the title.
+# Vertical spacing for titles is controlled via :rc:`axes.titlepad`.
+# Setting to a different value moves the title.
 
 fig, ax = plt.subplots(figsize=(5, 3))
 fig.subplots_adjust(top=0.8)


### PR DESCRIPTION
Seems that when the docs are generated ([here](https://matplotlib.org/3.5.0/tutorials/text/text_intro.html#titles)), it outputs the default (which is actually 6) so this bit of text is wrong and redundant.
