### PR TITLE
Add zorder option in QuiverKey

### DIFF
--- a/doc/api/next_api_changes/behavior/23116-YN.rst
+++ b/doc/api/next_api_changes/behavior/23116-YN.rst
@@ -1,0 +1,5 @@
+Add zorder option in QuiverKey
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It has been needed to use ``set_zorder`` when you set zorder in the QuiverKey.
+This change can set zorder with ``zorder`` argument in the QuiverKey
+in the same way as other plots.

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -241,7 +241,8 @@ class QuiverKey(martist.Artist):
 
     def __init__(self, Q, X, Y, U, label,
                  *, angle=0, coordinates='axes', color=None, labelsep=0.1,
-                 labelpos='N', labelcolor=None, fontproperties=None, **kwargs):
+                 labelpos='N', labelcolor=None, fontproperties=None,
+                 zorder=None, **kwargs):
         """
         Add a key to a quiver plot.
 
@@ -285,6 +286,8 @@ class QuiverKey(martist.Artist):
             A dictionary with keyword arguments accepted by the
             `~matplotlib.font_manager.FontProperties` initializer:
             *family*, *style*, *variant*, *size*, *weight*.
+        zorder : float or None
+            The zorder of the key. The default is 0.1 above *Q*.
         **kwargs
             Any additional keyword arguments are used to override vector
             properties taken from *Q*.
@@ -312,7 +315,9 @@ class QuiverKey(martist.Artist):
         if self.labelcolor is not None:
             self.text.set_color(self.labelcolor)
         self._dpi_at_last_init = None
-        self.zorder = Q.zorder + 0.1
+        self.zorder = zorder
+        if self.zorder is None:
+            self.zorder = Q.zorder + 0.1
 
     @property
     def labelsep(self):

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -287,6 +287,8 @@ class QuiverKey(martist.Artist):
             `~matplotlib.font_manager.FontProperties` initializer:
             *family*, *style*, *variant*, *size*, *weight*.
         zorder : float, default: None
+        zorder : float or None
+            zorder of the key.
             The zorder of the key. The default is 0.1 above *Q*.
         **kwargs
             Any additional keyword arguments are used to override vector

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -286,8 +286,7 @@ class QuiverKey(martist.Artist):
             A dictionary with keyword arguments accepted by the
             `~matplotlib.font_manager.FontProperties` initializer:
             *family*, *style*, *variant*, *size*, *weight*.
-        zorder : float, default: None
-        zorder : float or None
+        zorder : float
             The zorder of the key. The default is 0.1 above *Q*.
         **kwargs
             Any additional keyword arguments are used to override vector

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -288,7 +288,6 @@ class QuiverKey(martist.Artist):
             *family*, *style*, *variant*, *size*, *weight*.
         zorder : float, default: None
         zorder : float or None
-            zorder of the key.
             The zorder of the key. The default is 0.1 above *Q*.
         **kwargs
             Any additional keyword arguments are used to override vector

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -286,7 +286,7 @@ class QuiverKey(martist.Artist):
             A dictionary with keyword arguments accepted by the
             `~matplotlib.font_manager.FontProperties` initializer:
             *family*, *style*, *variant*, *size*, *weight*.
-        zorder : float or None
+        zorder : float, default: None
             The zorder of the key. The default is 0.1 above *Q*.
         **kwargs
             Any additional keyword arguments are used to override vector

--- a/lib/matplotlib/quiver.pyi
+++ b/lib/matplotlib/quiver.pyi
@@ -45,6 +45,7 @@ class QuiverKey(martist.Artist):
         labelpos: Literal["N", "S", "E", "W"] = ...,
         labelcolor: ColorType | None = ...,
         fontproperties: dict[str, Any] | None = ...,
+        zorder: float,
         **kwargs
     ) -> None: ...
     @property

--- a/lib/matplotlib/quiver.pyi
+++ b/lib/matplotlib/quiver.pyi
@@ -45,7 +45,7 @@ class QuiverKey(martist.Artist):
         labelpos: Literal["N", "S", "E", "W"] = ...,
         labelcolor: ColorType | None = ...,
         fontproperties: dict[str, Any] | None = ...,
-        zorder: float,
+        zorder: float | None = ...,
         **kwargs
     ) -> None: ...
     @property

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -6,6 +6,7 @@ import pytest
 
 from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal
 
 
 def draw_quiver(ax, **kwargs):
@@ -333,3 +334,19 @@ def test_quiver_setuvc_numbers():
 
     q = ax.quiver(X, Y, U, V)
     q.set_UVC(0, 1)
+
+
+@check_figures_equal()
+def test_zorder(fig_test, fig_ref):
+    """Check QuiverKey zorder option"""
+    X, Y, U, V = 1, 1, 2, 2
+
+    ax_test = fig_test.subplots()
+    zorder_value = 5.
+    q_test = ax_test.quiver(X, Y, U, V)
+    ax_test.quiverkey(q_test, 0.8, 0.3, U, label='U', zorder=zorder_value)
+
+    ax_ref = fig_ref.subplots()
+    q_ref = ax_ref.quiver(X, Y, U, V)
+    qk_ref = ax_ref.quiverkey(q_ref, 0.8, 0.3, U, label='U')
+    qk_ref.set_zorder(zorder_value)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -337,7 +337,7 @@ def test_quiver_setuvc_numbers():
 
 
 def draw_quiverkey_zorder_argument(fig, zorder=None):
-    """Draw Quiver and QuiverKey with zorder argment"""
+    """Draw Quiver and QuiverKey using zorder argument"""
     x = np.arange(1, 6, 1)
     y = np.arange(1, 6, 1)
     X, Y = np.meshgrid(x, y)
@@ -360,7 +360,7 @@ def draw_quiverkey_zorder_argument(fig, zorder=None):
 
 
 def draw_quiverkey_setzorder(fig, zorder=None):
-    """Draw Quiver and QuiverKey with set_zorder"""
+    """Draw Quiver and QuiverKey using set_zorder"""
     x = np.arange(1, 6, 1)
     y = np.arange(1, 6, 1)
     X, Y = np.meshgrid(x, y)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -349,14 +349,14 @@ def draw_quiverkey_zorder_argument(fig, zorder=None):
     ax.set_ylim(0.5, 5.5)
     if zorder is None:
         ax.quiverkey(q, 4, 4, 25,
-                          coordinates='data', label="U", color="blue")
+                          coordinates='data', label='U', color='blue')
         ax.quiverkey(q, 5.5, 2, 20,
-                          coordinates='data', label="V", color="blue", angle=90)
+                          coordinates='data', label='V', color='blue', angle=90)
     else:
         ax.quiverkey(q, 4, 4, 25,
-                          coordinates='data', label="U", color="blue", zorder=zorder)
+                          coordinates='data', label='U', color='blue', zorder=zorder)
         ax.quiverkey(q, 5.5, 2, 20,
-                          coordinates='data', label="V", color="blue", angle=90, zorder=zorder)
+                          coordinates='data', label='V', color='blue', angle=90, zorder=zorder)
 
 
 def draw_quiverkey_setzorder(fig, zorder=None):
@@ -371,9 +371,9 @@ def draw_quiverkey_setzorder(fig, zorder=None):
     ax.set_xlim(0.5, 5.5)
     ax.set_ylim(0.5, 5.5)
     qk1 = ax.quiverkey(q, 4, 4, 25,
-                       coordinates='data', label="U", color="blue")
+                       coordinates='data', label='U', color='blue')
     qk2 = ax.quiverkey(q, 5.5, 2, 20,
-                       coordinates='data', label="V", color="blue", angle=90)
+                       coordinates='data', label='V', color='blue', angle=90)
     if zorder is not None:
         qk1.set_zorder(zorder)
         qk2.set_zorder(zorder)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -336,17 +336,91 @@ def test_quiver_setuvc_numbers():
     q.set_UVC(0, 1)
 
 
+def draw_quiverkey_zorder_argument(fig, zorder=None):
+    """Draw Quiver and QuiverKey with zorder argment"""
+    x = np.arange(1, 6, 1)
+    y = np.arange(1, 6, 1)
+    X, Y = np.meshgrid(x, y)
+    U, V = 2, 2
+
+    ax = fig.subplots()
+    q = ax.quiver(X, Y, U, V, pivot='middle')
+    ax.set_xlim(0.5, 5.5)
+    ax.set_ylim(0.5, 5.5)
+    if zorder is None:
+        ax.quiverkey(q, 4, 4, 25,
+                          coordinates='data', label="U", color="blue")
+        ax.quiverkey(q, 5.5, 2, 20,
+                          coordinates='data', label="V", color="blue", angle=90)
+    else:
+        ax.quiverkey(q, 4, 4, 25,
+                          coordinates='data', label="U", color="blue", zorder=zorder)
+        ax.quiverkey(q, 5.5, 2, 20,
+                          coordinates='data', label="V", color="blue", angle=90, zorder=zorder)
+
+
+def draw_quiverkey_setzorder(fig, zorder=None):
+    """Draw Quiver and QuiverKey with set_zorder"""
+    x = np.arange(1, 6, 1)
+    y = np.arange(1, 6, 1)
+    X, Y = np.meshgrid(x, y)
+    U, V = 2, 2
+
+    ax = fig.subplots()
+    q = ax.quiver(X, Y, U, V, pivot='middle')
+    ax.set_xlim(0.5, 5.5)
+    ax.set_ylim(0.5, 5.5)
+    qk1 = ax.quiverkey(q, 4, 4, 25,
+                       coordinates='data', label="U", color="blue")
+    qk2 = ax.quiverkey(q, 5.5, 2, 20,
+                       coordinates='data', label="V", color="blue", angle=90)
+    if zorder is not None:
+        qk1.set_zorder(zorder)
+        qk2.set_zorder(zorder)
+
+
 @check_figures_equal(extensions=['png'])
-def test_zorder(fig_test, fig_ref):
+def test_quiverkey_zorder_default(fig_test, fig_ref):
     """Check QuiverKey zorder option"""
-    X, Y, U, V = 1, 1, 2, 2
+    draw_quiverkey_zorder_argument(fig_test)
+    draw_quiverkey_setzorder(fig_ref)
 
-    ax_test = fig_test.subplots()
-    zorder_value = 5.
-    q_test = ax_test.quiver(X, Y, U, V)
-    ax_test.quiverkey(q_test, 0.8, 0.3, U, label='U', zorder=zorder_value)
 
-    ax_ref = fig_ref.subplots()
-    q_ref = ax_ref.quiver(X, Y, U, V)
-    qk_ref = ax_ref.quiverkey(q_ref, 0.8, 0.3, U, label='U')
-    qk_ref.set_zorder(zorder_value)
+@check_figures_equal(extensions=['png'])
+def test_quiverkey_zorder_zero(fig_test, fig_ref):
+    """
+    Check QuiverKey zorder option
+    zorder=0 means quiverkey is under quiver.
+    """
+    draw_quiverkey_zorder_argument(fig_test, zorder=0)
+    draw_quiverkey_setzorder(fig_ref, zorder=0)
+
+
+@check_figures_equal(extensions=['png'])
+def test_quiverkey_zorder_two(fig_test, fig_ref):
+    """
+    Check QuiverKey zorder option
+    zorder=2 means quiverkey is same as default.
+    """
+    draw_quiverkey_zorder_argument(fig_test, zorder=2)
+    draw_quiverkey_setzorder(fig_ref, zorder=2)
+
+
+@check_figures_equal(extensions=['png'])
+def test_quiverkey_zorder_five(fig_test, fig_ref):
+    """
+    Check QuiverKey zorder option
+    zorder=5 means quiverkey is over ticks.
+    """
+    draw_quiverkey_zorder_argument(fig_test, zorder=5)
+    draw_quiverkey_setzorder(fig_ref, zorder=5)
+
+
+@check_figures_equal(extensions=['png'])
+def test_quiverkey_zorder_None(fig_test, fig_ref):
+    """
+    Check QuiverKey zorder option
+    zorder=None means quiverkey is over ticks.
+    """
+    draw_quiverkey_zorder_argument(fig_test, zorder=None)
+    draw_quiverkey_setzorder(fig_ref, zorder=None)

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -336,7 +336,7 @@ def test_quiver_setuvc_numbers():
     q.set_UVC(0, 1)
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_zorder(fig_test, fig_ref):
     """Check QuiverKey zorder option"""
     X, Y, U, V = 1, 1, 2, 2

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -348,15 +348,15 @@ def draw_quiverkey_zorder_argument(fig, zorder=None):
     ax.set_xlim(0.5, 5.5)
     ax.set_ylim(0.5, 5.5)
     if zorder is None:
-        ax.quiverkey(q, 4, 4, 25,
-                          coordinates='data', label='U', color='blue')
-        ax.quiverkey(q, 5.5, 2, 20,
-                          coordinates='data', label='V', color='blue', angle=90)
+        ax.quiverkey(q, 4, 4, 25, coordinates='data',
+                     label='U', color='blue')
+        ax.quiverkey(q, 5.5, 2, 20, coordinates='data',
+                     label='V', color='blue', angle=90)
     else:
-        ax.quiverkey(q, 4, 4, 25,
-                          coordinates='data', label='U', color='blue', zorder=zorder)
-        ax.quiverkey(q, 5.5, 2, 20,
-                          coordinates='data', label='V', color='blue', angle=90, zorder=zorder)
+        ax.quiverkey(q, 4, 4, 25, coordinates='data',
+                     label='U', color='blue', zorder=zorder)
+        ax.quiverkey(q, 5.5, 2, 20, coordinates='data',
+                     label='V', color='blue', angle=90, zorder=zorder)
 
 
 def draw_quiverkey_setzorder(fig, zorder=None):
@@ -370,10 +370,10 @@ def draw_quiverkey_setzorder(fig, zorder=None):
     q = ax.quiver(X, Y, U, V, pivot='middle')
     ax.set_xlim(0.5, 5.5)
     ax.set_ylim(0.5, 5.5)
-    qk1 = ax.quiverkey(q, 4, 4, 25,
-                       coordinates='data', label='U', color='blue')
-    qk2 = ax.quiverkey(q, 5.5, 2, 20,
-                       coordinates='data', label='V', color='blue', angle=90)
+    qk1 = ax.quiverkey(q, 4, 4, 25, coordinates='data',
+                       label='U', color='blue')
+    qk2 = ax.quiverkey(q, 5.5, 2, 20, coordinates='data',
+                       label='V', color='blue', angle=90)
     if zorder is not None:
         qk1.set_zorder(zorder)
         qk2.set_zorder(zorder)


### PR DESCRIPTION
## PR Summary
Add zorder option in QuiverKey. So far, if you want to set zorder, you need `set_zorder`. Therefore, I can make `zorder` option available.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
