### PR TITLE
Small cleanups to QuiverKey.

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -19,7 +19,7 @@ import math
 import numpy as np
 from numpy import ma
 
-from matplotlib import _api, cbook, _docstring, font_manager
+from matplotlib import _api, cbook, _docstring
 import matplotlib.artist as martist
 import matplotlib.collections as mcollections
 from matplotlib.patches import CirclePolygon
@@ -303,13 +303,11 @@ class QuiverKey(martist.Artist):
         self.labelcolor = labelcolor
         self.fontproperties = fontproperties or dict()
         self.kw = kwargs
-        _fp = self.fontproperties
         self.text = mtext.Text(
             text=label,
             horizontalalignment=self.halign[self.labelpos],
             verticalalignment=self.valign[self.labelpos],
-            fontproperties=font_manager.FontProperties._from_any(_fp))
-
+            fontproperties=self.fontproperties)
         if self.labelcolor is not None:
             self.text.set_color(self.labelcolor)
         self._dpi_at_last_init = None
@@ -346,29 +344,20 @@ class QuiverKey(martist.Artist):
             self.vector.set_figure(self.get_figure())
             self._dpi_at_last_init = self.Q.axes.figure.dpi
 
-    def _text_x(self, x):
-        if self.labelpos == 'E':
-            return x + self.labelsep
-        elif self.labelpos == 'W':
-            return x - self.labelsep
-        else:
-            return x
-
-    def _text_y(self, y):
-        if self.labelpos == 'N':
-            return y + self.labelsep
-        elif self.labelpos == 'S':
-            return y - self.labelsep
-        else:
-            return y
+    def _text_shift(self):
+        return {
+            "N": (0, +self.labelsep),
+            "S": (0, -self.labelsep),
+            "E": (+self.labelsep, 0),
+            "W": (-self.labelsep, 0),
+        }[self.labelpos]
 
     @martist.allow_rasterization
     def draw(self, renderer):
         self._init()
         self.vector.draw(renderer)
-        x, y = self.get_transform().transform((self.X, self.Y))
-        self.text.set_x(self._text_x(x))
-        self.text.set_y(self._text_y(y))
+        pos = self.get_transform().transform((self.X, self.Y))
+        self.text.set_position(pos + self._text_shift())
         self.text.draw(renderer)
         self.stale = False
 


### PR DESCRIPTION
- Text already calls FontProperties._from_any on anything passed as
  fontproperties; no need to do it ourselves again.
- Group together x and y shifts for text positioning.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
