### PR TITLE
Drop pytest warning config in nightly tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -221,15 +221,6 @@ jobs:
         run: |
           python -m pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple --upgrade numpy pandas
 
-          # Turn all warnings to errors, except ignore the distutils deprecations and the find_spec warning
-          cat >> pytest.ini << EOF
-          [pytest]
-          filterwarnings =
-              error
-              ignore:.*distutils:DeprecationWarning
-              ignore:DynamicImporter.find_spec\(\) not found; falling back to find_module\(\):ImportWarning
-          EOF
-
       - name: Install Matplotlib
         run: |
           ccache -s

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,7 @@
+[pytest]
+# NOTE: Because tests can be run from an installed copy, most of our Pytest
+# configuration is in the `pytest_configure` function in
+# `lib/matplotlib/testing/conftest.py`. This configuration file exists only to
+# prevent Pytest from wasting time trying to check examples and documentation
+# files that are not really tests.
+testpaths = lib


### PR DESCRIPTION
## PR Summary

Apparently, NumPy or whatever dependency has fixed the warnings that we needed to ignore. [Tests with nightlies enabled](https://github.com/QuLogic/matplotlib/actions/runs/2381432665) seem to be passing just fine.

And having this file is causing pytest to drop some config we used to have, making it load files we don't want.

Fixes #23084.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).