### PR TITLE
Make module deprecation messages consistent

### DIFF
--- a/lib/matplotlib/afm.py
+++ b/lib/matplotlib/afm.py
@@ -1,5 +1,3 @@
 from matplotlib._afm import *  # noqa: F401, F403
 from matplotlib import _api
-_api.warn_deprecated(
-    "3.6", message="The module %(name)s is deprecated since %(since)s.",
-    name=f"{__name__}")
+_api.warn_deprecated("3.6", name=__name__, obj_type="module")

--- a/lib/matplotlib/fontconfig_pattern.py
+++ b/lib/matplotlib/fontconfig_pattern.py
@@ -1,5 +1,3 @@
 from matplotlib._fontconfig_pattern import *  # noqa: F401, F403
 from matplotlib import _api
-_api.warn_deprecated(
-    "3.6", message="The module %(name)s is deprecated since %(since)s.",
-    name=f"{__name__}")
+_api.warn_deprecated("3.6", name=__name__, obj_type="module")

--- a/lib/matplotlib/tight_bbox.py
+++ b/lib/matplotlib/tight_bbox.py
@@ -1,5 +1,3 @@
 from matplotlib._tight_bbox import *  # noqa: F401, F403
 from matplotlib import _api
-_api.warn_deprecated(
-    "3.6", message="The module %(name)s is deprecated since %(since)s.",
-    name=f"{__name__}")
+_api.warn_deprecated("3.6", name=__name__, obj_type="module")

--- a/lib/matplotlib/tight_layout.py
+++ b/lib/matplotlib/tight_layout.py
@@ -1,5 +1,3 @@
 from matplotlib._tight_layout import *  # noqa: F401, F403
 from matplotlib import _api
-_api.warn_deprecated(
-    "3.6", message="The module %(name)s is deprecated since %(since)s.",
-    name=f"{__name__}")
+_api.warn_deprecated("3.6", name=__name__, obj_type="module")

--- a/lib/matplotlib/type1font.py
+++ b/lib/matplotlib/type1font.py
@@ -1,5 +1,3 @@
 from matplotlib._type1font import *  # noqa: F401, F403
 from matplotlib import _api
-_api.warn_deprecated(
-    "3.6", message="The module %(name)s is deprecated since %(since)s.",
-    name=f"{__name__}")
+_api.warn_deprecated("3.6", name=__name__, obj_type="module")


### PR DESCRIPTION
## PR Summary

The default message already says more than enough over the manually created one, e.g.,
```
The module matplotlib.afm is deprecated since 3.6.
```
vs.
```
The matplotlib.blocking_input module was deprecated in Matplotlib 3.5 and will be removed two minor releases later.
```

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).