### PR TITLE
Remove newline from start of deprecation warnings

### DIFF
--- a/lib/matplotlib/_api/deprecation.py
+++ b/lib/matplotlib/_api/deprecation.py
@@ -32,7 +32,7 @@ def _generate_deprecation_warning(
         removal = f"in {removal}" if removal else "two minor releases later"
     if not message:
         message = (
-            ("\nThe %(name)s %(obj_type)s" if obj_type else "%(name)s")
+            ("The %(name)s %(obj_type)s" if obj_type else "%(name)s")
             + (" will be deprecated in a future version"
                if pending else
                (" was deprecated in Matplotlib %(since)s"


### PR DESCRIPTION
## PR Summary

This breaks the summary from Pytest when warnings are errors, as then you just get a bunch of:
```
FAILED lib/matplotlib/tests/test_getattr.py::test_getattr[matplotlib.afm] - matplotlib._api.deprecation.MatplotlibDeprecationWarning:
```
with no real context as to the problem.

Also, as noted at the original PR [1], it makes setting `filterwarnings` more complicated.

[1] https://github.com/matplotlib/matplotlib/pull/11224#issuecomment-435167674

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [?] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).