### PR TITLE
Unpin coverage again

### DIFF
--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -1,7 +1,7 @@
 # pip requirements for all the CI builds
 
 certifi
-coverage<6.3
+coverage
 psutil
 pytest!=4.6.0,!=5.4.0
 pytest-cov

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -1,7 +1,7 @@
 # pip requirements for all the CI builds
 
 certifi
-coverage
+coverage!=6.3
 psutil
 pytest!=4.6.0,!=5.4.0
 pytest-cov


### PR DESCRIPTION
## PR Summary

The upstream issue [1] has been fixed and released in 6.4.

[1] https://github.com/nedbat/coveragepy/issues/1310

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).