### PR TITLE
Move version switcher next to the logo

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -277,3 +277,22 @@ div.twocol > div {
     display: inline-block;
     margin: 0 0.5em;
 }
+
+
+/* styling for version switcher */
+.navbar-brand {
+    /* pydata-sphinx-theme sets this as flex for some reason
+       but we cannot place the version switcher to its right then.
+     */
+    display: inline-block;
+}
+
+#version_switcher {
+    display: inline-block;
+}
+
+#version_switcher_button {
+    color: rgba(var(--pst-color-text-base),1);
+    background-color: rgba(0,0,0,.03);
+    border: 1px solid rgba(0,0,0,.125);
+}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -339,7 +339,11 @@ html_theme_options = {
     "switcher": {
         "json_url": "https://matplotlib.org/devdocs/_static/switcher.json",
         "url_template": "https://matplotlib.org/{version}/",
-        "version_match": version,
+        "version_match": (
+            # The start version to show. This must be in switcher.json.
+            # We either go to 'stable' or to 'devdocs'
+            'stable' if matplotlib.__version_info__.releaselevel == 'final'
+            else 'devdocs')
     },
     "navbar_start": ["mpl_navbar_logo", "version-switcher"],
     "navbar_end": ["mpl_icon_links"]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -341,7 +341,8 @@ html_theme_options = {
         "url_template": "https://matplotlib.org/{version}/",
         "version_match": version,
     },
-    "navbar_end": ["version-switcher", "mpl_icon_links"]
+    "navbar_start": ["mpl_navbar_logo", "version-switcher"],
+    "navbar_end": ["mpl_icon_links"]
 }
 include_analytics = is_release_build
 if include_analytics:


### PR DESCRIPTION
This is in preparation for adding the search field to the navbar (https://github.com/matplotlib/mpl-brochure-site/issues/50). IMHO
placing the version next to the logo also rhymes better.

Styling of the switcher is more muted (not the strong blue). It's colors
are taken from the panels on the index page.

New:
![grafik](https://user-images.githubusercontent.com/2836374/170554015-f5f104a0-3cc7-4d8a-9e2f-3aaa21c2934a.png)

Old:
![grafik](https://user-images.githubusercontent.com/2836374/170554114-8446d07c-0923-4d1e-99eb-c4ede9622e74.png)

