### PR TITLE
Only import setuptools_scm when we are in a matplotlib git repo

### DIFF
--- a/.matplotlib-repo
+++ b/.matplotlib-repo
@@ -1,0 +1,3 @@
+The existence of this file signals that the code is a matplotlib source repo
+and not an installed version. We use this in __init__.py for gating version
+detection.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -164,11 +164,13 @@ def _parse_to_version_info(version_str):
 
 def _get_version():
     """Return the version string used for __version__."""
-    # Only shell out to a git subprocess if really needed, and not on a
-    # shallow clone, such as those used by CI, as the latter would trigger
-    # a warning from setuptools_scm.
+    # Only shell out to a git subprocess if really needed, i.e. when we are in
+    # a matplotlib git repo but not in a shallow clone, such as those used by
+    # CI, as the latter would trigger a warning from setuptools_scm.
     root = Path(__file__).resolve().parents[2]
-    if (root / ".git").exists() and not (root / ".git/shallow").exists():
+    if ((root / ".matplotlib-repo").exists()
+            and (root / ".git").exists()
+            and not (root / ".git/shallow").exists()):
         import setuptools_scm
         return setuptools_scm.get_version(
             root=root,


### PR DESCRIPTION
Closes #23114, where somebody has installed matplotlib into another
git repo.

Just checking that two levels up is a .git is not enough. We have to make sure this is the matplotlib git repo. I've now added a check that the `__init__.py` is in the folder `lib/matplotlib`. Is there maybe even a better check that this is the matplotlib git repo?