### PR TITLE
Update cibuildwheel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -53,40 +53,52 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels for CPython 3.10
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: "cp310-*"
+          CIBW_SKIP: "*-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD: pip install certifi oldest-supported-numpy
+          CIBW_BEFORE_BUILD: >-
+            pip install certifi oldest-supported-numpy &&
+            git clean -fxd build
           MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: "cp39-*"
+          CIBW_SKIP: "*-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: pip install certifi oldest-supported-numpy
+          CIBW_BEFORE_BUILD: >-
+            pip install certifi oldest-supported-numpy &&
+            git clean -fxd build
           MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.8
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: "cp38-*"
+          CIBW_SKIP: "*-musllinux*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_MANYLINUX_I686_IMAGE: manylinux1
-          CIBW_BEFORE_BUILD: pip install certifi numpy==1.19.2
+          CIBW_BEFORE_BUILD: >-
+            pip install certifi numpy==1.19.2 &&
+            git clean -fxd build
           MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_BUILD: "pp38-*"
-          CIBW_BEFORE_BUILD: pip install certifi oldest-supported-numpy
+          CIBW_SKIP: "*-musllinux*"
+          CIBW_BEFORE_BUILD: >-
+            pip install certifi oldest-supported-numpy &&
+            git clean -fxd build
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           PIP_USE_FEATURE: in-tree-build
         if: false && matrix.cibw_archs != 'aarch64'

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -52,18 +52,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
-        name: Install Python
-        with:
-          python-version: '3.8'
-
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel==2.1.1
-
       - name: Build wheels for CPython 3.10
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.1.1
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
@@ -73,8 +63,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.1.1
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
@@ -84,8 +73,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.8
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.1.1
         env:
           CIBW_BUILD: "cp38-*"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
@@ -95,8 +83,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
-        run: |
-          python -m cibuildwheel --output-dir dist
+        uses: pypa/cibuildwheel@v2.1.1
         env:
           CIBW_BUILD: "pp38-*"
           CIBW_BEFORE_BUILD: pip install certifi oldest-supported-numpy
@@ -106,7 +93,7 @@ jobs:
 
       - name: Validate that LICENSE files are included in wheels
         run: |
-          python ./ci/check_wheel_licenses.py
+          python3 ./ci/check_wheel_licenses.py
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels for CPython 3.10
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.4.0
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_SKIP: "*-musllinux*"
@@ -66,7 +66,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.4.0
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-musllinux*"
@@ -79,7 +79,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.8
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.4.0
         env:
           CIBW_BUILD: "cp38-*"
           CIBW_SKIP: "*-musllinux*"
@@ -92,7 +92,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.4.0
         env:
           CIBW_BUILD: "pp38-*"
           CIBW_SKIP: "*-musllinux*"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels for CPython 3.10
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.5.0
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_SKIP: "*-musllinux*"
@@ -66,7 +66,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.5.0
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-musllinux*"
@@ -79,7 +79,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.8
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.5.0
         env:
           CIBW_BUILD: "cp38-*"
           CIBW_SKIP: "*-musllinux*"
@@ -92,7 +92,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
-        uses: pypa/cibuildwheel@v2.4.0
+        uses: pypa/cibuildwheel@v2.5.0
         env:
           CIBW_BUILD: "pp38-*"
           CIBW_SKIP: "*-musllinux*"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels for CPython 3.10
-        uses: pypa/cibuildwheel@v2.6.0
+        uses: pypa/cibuildwheel@v2.7.0
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_SKIP: "*-musllinux*"
@@ -66,7 +66,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
-        uses: pypa/cibuildwheel@v2.6.0
+        uses: pypa/cibuildwheel@v2.7.0
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-musllinux*"
@@ -79,7 +79,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.8
-        uses: pypa/cibuildwheel@v2.6.0
+        uses: pypa/cibuildwheel@v2.7.0
         env:
           CIBW_BUILD: "cp38-*"
           CIBW_SKIP: "*-musllinux*"
@@ -92,7 +92,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
-        uses: pypa/cibuildwheel@v2.6.0
+        uses: pypa/cibuildwheel@v2.7.0
         env:
           CIBW_BUILD: "pp38-*"
           CIBW_SKIP: "*-musllinux*"

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 0
 
       - name: Build wheels for CPython 3.10
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.6.0
         env:
           CIBW_BUILD: "cp310-*"
           CIBW_SKIP: "*-musllinux*"
@@ -66,7 +66,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.6.0
         env:
           CIBW_BUILD: "cp39-*"
           CIBW_SKIP: "*-musllinux*"
@@ -79,7 +79,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.8
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.6.0
         env:
           CIBW_BUILD: "cp38-*"
           CIBW_SKIP: "*-musllinux*"
@@ -92,7 +92,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
-        uses: pypa/cibuildwheel@v2.5.0
+        uses: pypa/cibuildwheel@v2.6.0
         env:
           CIBW_BUILD: "pp38-*"
           CIBW_SKIP: "*-musllinux*"

--- a/setupext.py
+++ b/setupext.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 import sysconfig
 import tarfile
+from tempfile import TemporaryDirectory
 import textwrap
 import urllib.request
 
@@ -691,7 +692,23 @@ class FreeType(SetupPackage):
                 f.write(vcxproj)
 
             cc = get_ccompiler()
-            cc.initialize()  # Get msbuild in the %PATH% of cc.spawn.
+            cc.initialize()
+            # On setuptools versions that use "local" distutils,
+            # ``cc.spawn(["msbuild", ...])`` no longer manages to locate the
+            # right executable, even though they are correctly on the PATH,
+            # because only the env kwarg to Popen() is updated, and not
+            # os.environ["PATH"]. Instead, use shutil.which to walk the PATH
+            # and get absolute executable paths.
+            with TemporaryDirectory() as tmpdir:
+                dest = Path(tmpdir, "path")
+                cc.spawn([
+                    sys.executable, "-c",
+                    "import pathlib, shutil, sys\n"
+                    "dest = pathlib.Path(sys.argv[1])\n"
+                    "dest.write_text(shutil.which('msbuild'))\n",
+                    str(dest),
+                ])
+                msbuild_path = dest.read_text()
             # Freetype 2.10.0+ support static builds.
             msbuild_config = (
                 "Release Static"
@@ -699,7 +716,7 @@ class FreeType(SetupPackage):
                 else "Release"
             )
 
-            cc.spawn(["msbuild", str(sln_path),
+            cc.spawn([msbuild_path, str(sln_path),
                       "/t:Clean;Build",
                       f"/p:Configuration={msbuild_config};"
                       f"Platform={msbuild_platform}"])


### PR DESCRIPTION
## PR Summary

In addition, switch from manual install to the GitHub Action they provide.

For the time being, this does _not_ enable any new builds. We can discuss that in a separate PR.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).