### PR TITLE
Deprecate passing most Legend arguments positionally

### DIFF
--- a/doc/api/next_api_changes/deprecations/23166-ES.rst
+++ b/doc/api/next_api_changes/deprecations/23166-ES.rst
@@ -1,0 +1,5 @@
+``Legend`` constructor
+~~~~~~~~~~~~~~~~~~~~~~
+
+All arguments to `.legend.Legend` other than *parent*, *handles*, and *labels*
+will become keyword-only in a future version.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -294,6 +294,7 @@ class Legend(Artist):
     def __str__(self):
         return "Legend"
 
+    @_api.make_keyword_only("3.6", "loc")
     @_docstring.dedent_interpd
     def __init__(
         self, parent, handles, labels,


### PR DESCRIPTION
## PR Summary

There are so many of them, it really doesn't make sense to do positionally.

## PR Checklist

**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).