### PR TITLE
ENH: update ticks when requesting labels

### DIFF
--- a/doc/api/next_api_changes/behavior/23170-JMK.rst
+++ b/doc/api/next_api_changes/behavior/23170-JMK.rst
@@ -1,0 +1,6 @@
+``get_ticklabels`` now always populates labels
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously `.Axis.get_ticklabels` (and `.Axes.get_xticklabels`,
+`.Axes.get_yticklabels`) would only return empty strings unless a draw had
+already been performed.  Now the ticks and their labels are updated when the
+labels are requested.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1312,6 +1312,7 @@ class Axis(martist.Artist):
 
     def get_majorticklabels(self):
         """Return this Axis' major tick labels, as a list of `~.text.Text`."""
+        self._update_ticks()
         ticks = self.get_major_ticks()
         labels1 = [tick.label1 for tick in ticks if tick.label1.get_visible()]
         labels2 = [tick.label2 for tick in ticks if tick.label2.get_visible()]
@@ -1319,6 +1320,7 @@ class Axis(martist.Artist):
 
     def get_minorticklabels(self):
         """Return this Axis' minor tick labels, as a list of `~.text.Text`."""
+        self._update_ticks()
         ticks = self.get_minor_ticks()
         labels1 = [tick.label1 for tick in ticks if tick.label1.get_visible()]
         labels2 = [tick.label2 for tick in ticks if tick.label2.get_visible()]

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1343,13 +1343,6 @@ class Axis(martist.Artist):
         Returns
         -------
         list of `~matplotlib.text.Text`
-
-        Notes
-        -----
-        The tick label strings are not populated until a ``draw`` method has
-        been called.
-
-        See also: `~.pyplot.draw` and `~.FigureCanvasBase.draw`.
         """
         if which is not None:
             if which == 'minor':

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7773,3 +7773,4 @@ def test_get_xticklabel():
     ax.plot(np.arange(10))
     for ind in range(10):
         assert ax.get_xticklabels()[ind].get_text() == f'{ind}'
+        assert ax.get_yticklabels()[ind].get_text() == f'{ind}'

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7766,3 +7766,10 @@ def test_bezier_autoscale():
     # Bottom ylim should be at the edge of the curve (-0.5), and not include
     # the control point (at -1)
     assert ax.get_ylim()[0] == -0.5
+
+
+def test_get_xticklabel():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    for ind in range(10):
+        assert ax.get_xticklabels()[ind].get_text() == f'{ind}'


### PR DESCRIPTION
## PR Summary

I think if the user asks for the tick labels, they should be allowed to waste a few cpu cycles actually getting the tick labels rather than forcing a whole draw.  However, its possible I don't understand some subtlety.  

Ref: #6103. Probably a lot more, and many stack overflow issues.  


```python
import matplotlib.pyplot as plt
import numpy as np

fig, ax = plt.subplots()
ax.plot(range(10))
labels = ax.xaxis.get_majorticklabels()
print(labels)
```


### Current behaviour

```
[Text(0, 0, ''), Text(0, 0, ''), Text(0, 0, ''), Text(0, 0, ''), Text(0, 0, ''), Text(0, 0, ''), Text(0, 0, '')]
```

### Proposed behaviour

```
[Text(-2.0, 0, '−2'), Text(0.0, 0, '0'), Text(2.0, 0, '2'), Text(4.0, 0, '4'), Text(6.0, 0, '6'), Text(8.0, 0, '8'), Text(10.0, 0, '10')]
```


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
