### PR TITLE
Point the version switcher to a name listed in switcher.json

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -339,7 +339,11 @@ html_theme_options = {
     "switcher": {
         "json_url": "https://matplotlib.org/devdocs/_static/switcher.json",
         "url_template": "https://matplotlib.org/{version}/",
-        "version_match": version,
+        "version_match": (
+            # The start version to show. This must be in switcher.json.
+            # We either go to 'stable' or to 'devdocs'
+            'stable' if matplotlib.__version_info__.releaselevel == 'final'
+            else 'devdocs')
     },
     "navbar_end": ["version-switcher", "mpl_icon_links"]
 }


### PR DESCRIPTION
The switcher default value must match a version given in `switcher.json`. We either want to go to `stable` or `devdocs`.

Extracted from #23142, because I don't want to mix this fix with position and styling discussions.


Additional question to @QuLogic: Local and CI versions will still not work after the fix, because they cannot access `switcher.json`:

> Access to XMLHttpRequest at 'https://matplotlib.org/devdocs/_static/switcher.json' from origin 'https://output.circle-artifacts.com' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource.

Is it possible to set `Access-Control-Allow-Origin` on the website (https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSMissingAllowOrigin)?