### PR TITLE
Backport PR #23174: Make sure SubFigure has _cachedRenderer

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2082,6 +2082,14 @@ class SubFigure(FigureBase):
     def dpi(self, value):
         self._parent.dpi = value
 
+    @property
+    def _cachedRenderer(self):
+        return self._parent._cachedRenderer
+
+    @_cachedRenderer.setter
+    def _cachedRenderer(self, renderer):
+        self._parent._cachedRenderer = renderer
+
     def _redo_transform_rel_fig(self, bbox=None):
         """
         Make the transSubfigure bbox relative to Figure transform.

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -520,3 +520,23 @@ def test_contour_autolabel_beyond_powerlimits():
     ax.clabel(cs)
     # Currently, the exponent is missing, but that may be fixed in the future.
     assert {text.get_text() for text in ax.texts} == {"0.25", "1.00", "4.00"}
+
+
+def test_subfigure_clabel():
+    # Smoke test for gh#23173
+    delta = 0.025
+    x = np.arange(-3.0, 3.0, delta)
+    y = np.arange(-2.0, 2.0, delta)
+    X, Y = np.meshgrid(x, y)
+    Z1 = np.exp(-(X**2) - Y**2)
+    Z2 = np.exp(-((X - 1) ** 2) - (Y - 1) ** 2)
+    Z = (Z1 - Z2) * 2
+
+    fig = plt.figure()
+    figs = fig.subfigures(nrows=1, ncols=2)
+
+    for f in figs:
+        ax = f.subplots()
+        CS = ax.contour(X, Y, Z)
+        ax.clabel(CS, inline=True, fontsize=10)
+        ax.set_title("Simplest default with labels")


### PR DESCRIPTION
Merge pull request #23174 from oscargus/clabelsubfigures

FIX: Make sure SubFigure has _cachedRenderer
(cherry picked from commit af835787ac405d6021d4ed11e57734873c401b9c)
