### PR TITLE
Correct docs and use keyword arguments in _mathtext.py

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1045,7 +1045,7 @@ class Hlist(List):
         super().__init__(elements)
         if do_kern:
             self.kern()
-        self.hpack()
+        self.hpack(w=w, m=m)
 
     def kern(self):
         """
@@ -1156,7 +1156,7 @@ class Vlist(List):
 
     def __init__(self, elements, h=0., m='additional'):
         super().__init__(elements)
-        self.vpack()
+        self.vpack(h=h, m=m)
 
     def vpack(self, h=0., m='additional', l=np.inf):
         """
@@ -1168,8 +1168,8 @@ class Vlist(List):
         h : float, default: 0
             A height.
         m : {'exactly', 'additional'}, default: 'additional'
-            Whether to produce a box whose height is 'exactly' *w*; or a box
-            with the natural height of the contents, plus *w* ('additional').
+            Whether to produce a box whose height is 'exactly' *h*; or a box
+            with the natural height of the contents, plus *h* ('additional').
         l : float, default: np.inf
             The maximum height.
 


### PR DESCRIPTION
## PR Summary

Found a minor error in the documentation of `vpack` using the wrong argument name.

The keyword arguments for `HList` and `VList` were not used. I assume that they either should be used (here) or removed. Only makes a difference when trying to call `HList` or `VList` using those arguments, which doesn't happen in the code base (but that I tried in an attempt to fix an issue).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
