### PR TITLE
Mnt new default dates

### DIFF
--- a/doc/api/next_api_changes/behavior/23188-JMK.rst
+++ b/doc/api/next_api_changes/behavior/23188-JMK.rst
@@ -1,0 +1,9 @@
+Default date limits changed to 1970-01-01 to 1970-01-02
+-------------------------------------------------------
+
+Previously the default limits for an empty axis set up for dates
+(`.Axis.axis_date`) was 2000-01-01 to 2010-01-01.  This has been
+changed to 1970-01-01 to 1970-01-02.  With the default epoch, this
+makes the numeric limit for date axes the same as for other axes
+(0.0-1.0), and users are less likely to set a locator with far too
+many ticks.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1157,9 +1157,9 @@ class DateLocator(ticker.Locator):
         if it is too close to being singular (i.e. a range of ~0).
         """
         if not np.isfinite(vmin) or not np.isfinite(vmax):
-            # Except if there is no data, then use 2000-2010 as default.
-            return (date2num(datetime.date(2000, 1, 1)),
-                    date2num(datetime.date(2010, 1, 1)))
+            # Except if there is no data, then use 1970 as default.
+            return (date2num(datetime.date(1970, 1, 1)),
+                    date2num(datetime.date(1970, 1, 2)))
         if vmax < vmin:
             vmin, vmax = vmax, vmin
         unit = self._get_unit()
@@ -1362,9 +1362,9 @@ class AutoDateLocator(DateLocator):
         # whatever is thrown at us, we can scale the unit.
         # But default nonsingular date plots at an ~4 year period.
         if not np.isfinite(vmin) or not np.isfinite(vmax):
-            # Except if there is no data, then use 2000-2010 as default.
-            return (date2num(datetime.date(2000, 1, 1)),
-                    date2num(datetime.date(2010, 1, 1)))
+            # Except if there is no data, then use 1970 as default.
+            return (date2num(datetime.date(1970, 1, 1)),
+                    date2num(datetime.date(1970, 1, 2)))
         if vmax < vmin:
             vmin, vmax = vmax, vmin
         if vmin == vmax:
@@ -1850,8 +1850,8 @@ class DateConverter(units.ConversionInterface):
         majloc = AutoDateLocator(tz=tz,
                                  interval_multiples=self._interval_multiples)
         majfmt = AutoDateFormatter(majloc, tz=tz)
-        datemin = datetime.date(2000, 1, 1)
-        datemax = datetime.date(2010, 1, 1)
+        datemin = datetime.date(1970, 1, 1)
+        datemax = datetime.date(1970, 1, 2)
 
         return units.AxisInfo(majloc=majloc, majfmt=majfmt, label='',
                               default_limits=(datemin, datemax))
@@ -1907,8 +1907,8 @@ class ConciseDateConverter(DateConverter):
                                       zero_formats=self._zero_formats,
                                       offset_formats=self._offset_formats,
                                       show_offset=self._show_offset)
-        datemin = datetime.date(2000, 1, 1)
-        datemax = datetime.date(2010, 1, 1)
+        datemin = datetime.date(1970, 1, 1)
+        datemax = datetime.date(1970, 1, 2)
         return units.AxisInfo(majloc=majloc, majfmt=majfmt, label='',
                               default_limits=(datemin, datemax))
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7087,19 +7087,6 @@ def test_axis_extent_arg2():
     assert (ymin, ymax) == ax.get_ylim()
 
 
-def test_datetime_masked():
-    # make sure that all-masked data falls back to the viewlim
-    # set in convert.axisinfo....
-    x = np.array([datetime.datetime(2017, 1, n) for n in range(1, 6)])
-    y = np.array([1, 2, 3, 4, 5])
-    m = np.ma.masked_greater(y, 0)
-
-    fig, ax = plt.subplots()
-    ax.plot(x, m)
-    dt = mdates.date2num(np.datetime64('0000-12-31'))
-    assert ax.get_xlim() == (730120.0 + dt, 733773.0 + dt)
-
-
 def test_hist_auto_bins():
     _, bins, _ = plt.hist([[1, 2, 3], [3, 4, 5, 6]], bins='auto')
     assert bins[0] <= 1

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -77,8 +77,8 @@ def test_date_empty():
     ax.xaxis_date()
     fig.draw_without_rendering()
     np.testing.assert_allclose(ax.get_xlim(),
-                               [mdates.date2num(np.datetime64('2000-01-01')),
-                                mdates.date2num(np.datetime64('2010-01-01'))])
+                               [mdates.date2num(np.datetime64('1970-01-01')),
+                                mdates.date2num(np.datetime64('1970-01-02'))])
 
     mdates._reset_epoch_test_example()
     mdates.set_epoch('0000-12-31')
@@ -86,8 +86,8 @@ def test_date_empty():
     ax.xaxis_date()
     fig.draw_without_rendering()
     np.testing.assert_allclose(ax.get_xlim(),
-                               [mdates.date2num(np.datetime64('2000-01-01')),
-                                mdates.date2num(np.datetime64('2010-01-01'))])
+                               [mdates.date2num(np.datetime64('1970-01-01')),
+                                mdates.date2num(np.datetime64('1970-01-02'))])
     mdates._reset_epoch_test_example()
 
 
@@ -1235,7 +1235,7 @@ def test_julian2num():
 def test_DateLocator():
     locator = mdates.DateLocator()
     # Test nonsingular
-    assert locator.nonsingular(0, np.inf) == (10957.0, 14610.0)
+    assert locator.nonsingular(0, np.inf) == (0, 1)
     assert locator.nonsingular(0, 1) == (0, 1)
     assert locator.nonsingular(1, 0) == (0, 1)
     assert locator.nonsingular(0, 0) == (-2, 2)
@@ -1328,3 +1328,15 @@ def test_usetex_newline():
     fig, ax = plt.subplots()
     ax.xaxis.set_major_formatter(mdates.DateFormatter('%d/%m\n%Y'))
     fig.canvas.draw()
+
+
+def test_datetime_masked():
+    # make sure that all-masked data falls back to the viewlim
+    # set in convert.axisinfo....
+    x = np.array([datetime.datetime(2017, 1, n) for n in range(1, 6)])
+    y = np.array([1, 2, 3, 4, 5])
+    m = np.ma.masked_greater(y, 0)
+
+    fig, ax = plt.subplots()
+    ax.plot(x, m)
+    assert ax.get_xlim() == (0, 1)


### PR DESCRIPTION
## PR Summary

Closes #23151 

Currently date axes default to 2000-2010.  A 10-year default date range seems arbitrarily large, and conflicts with the default axes limits of 0-1 (days in the units of Matplotlib numbers).  This changes the default to 1970-01-01 to 1970-01-02, which for the default epoch corresponds to floats 0-1.  



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
