### PR TITLE
Backport PR #23095: Try to unbreak CI by xfailing OSX Tk tests

### DIFF
--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -31,6 +31,10 @@ def _isolated_tk_test(success_count, func=None):
     # Remove decorators.
     source = re.search(r"(?ms)^def .*", inspect.getsource(func)).group(0)
 
+    @pytest.mark.xfail(  # GitHub issue #23094
+        sys.platform == 'darwin',
+        reason="Tk version mismatch on OSX CI"
+    )
     @functools.wraps(func)
     def test_func():
         try:

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -59,6 +59,9 @@ def _get_testable_interactive_backends():
         elif env["MPLBACKEND"].startswith('wx') and sys.platform == 'darwin':
             # ignore on OSX because that's currently broken (github #16849)
             marks.append(pytest.mark.xfail(reason='github #16849'))
+        elif env["MPLBACKEND"] == "tkagg" and sys.platform == 'darwin':
+            marks.append(  # GitHub issue #23094
+                pytest.mark.xfail(reason="Tk version mismatch on OSX CI"))
         envs.append(pytest.param(env, marks=marks, id=str(env)))
     return envs
 
@@ -231,6 +234,9 @@ for param in _thread_safe_backends:
                 reason='PyPy does not support Tkinter threading: '
                        'https://foss.heptapod.net/pypy/pypy/-/issues/1929',
                 strict=True))
+    elif backend == "tkagg" and sys.platform == "darwin":
+        param.marks.append(  # GitHub issue #23094
+            pytest.mark.xfail("Tk version mismatch on OSX CI"))
 
 
 @pytest.mark.parametrize("env", _thread_safe_backends)


### PR DESCRIPTION
Try to unbreak CI by xfailing OSX Tk tests (#23095)

* Try to unbreak CI by xfailing OSX Tk tests

Stopgap solution for #23094

* Update lib/matplotlib/tests/test_backend_tk.py

* Update lib/matplotlib/tests/test_backend_tk.py

Co-authored-by: Oscar Gustafsson <oscar.gustafsson@gmail.com>
(cherry picked from commit d6ee414ec175870b9fe8c65297e6c56114fe19a3)
