### PR TITLE
CI: try and run job on macstadium mac

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,9 @@ jobs:
           - os: macos-latest
             python-version: 3.8
             XVFB_RUN: ""
+          - os: self-hosted
+            python-version: "3.10"
+            XVFB_RUN: ""
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
## PR Summary

This is trying to run jobs on the hosted mac-mini we have.  Unfortunately M1's can not be used yet, but hopefully that is coming soon?

