### PR TITLE
Unify set_pickradius argument

### DIFF
--- a/doc/api/axis_api.rst
+++ b/doc/api/axis_api.rst
@@ -150,6 +150,7 @@ Interactive
    :nosignatures:
 
    Axis.contains
+   Axis.pickradius
    Axis.get_pickradius
    Axis.set_pickradius
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -5,6 +5,7 @@ Classes for the ticks and x and y axis.
 import datetime
 import functools
 import logging
+from numbers import Number
 
 import numpy as np
 
@@ -1357,7 +1358,7 @@ class Axis(martist.Artist):
 
     def get_pickradius(self):
         """Return the depth of the axis used by the picker."""
-        return self.pickradius
+        return self._pickradius
 
     def get_majorticklabels(self):
         """Return this Axis' major tick labels, as a list of `~.text.Text`."""
@@ -1831,9 +1832,17 @@ class Axis(martist.Artist):
 
         Parameters
         ----------
-        pickradius :  float
+        pickradius : float
+            The acceptance radius for containment tests.
+            See also `.Axis.contains`.
         """
-        self.pickradius = pickradius
+        if not isinstance(pickradius, Number) or pickradius < 0:
+            raise ValueError("pick radius should be a distance")
+        self._pickradius = pickradius
+
+    pickradius = property(
+        get_pickradius, set_pickradius, doc="The acceptance radius for "
+        "containment tests. See also `.Axis.contains`.")
 
     # Helper for set_ticklabels. Defining it here makes it picklable.
     @staticmethod
@@ -2217,8 +2226,8 @@ class XAxis(Axis):
             return False, {}
         (l, b), (r, t) = self.axes.transAxes.transform([(0, 0), (1, 1)])
         inaxis = 0 <= xaxes <= 1 and (
-            b - self.pickradius < y < b or
-            t < y < t + self.pickradius)
+            b - self._pickradius < y < b or
+            t < y < t + self._pickradius)
         return inaxis, {}
 
     def set_label_position(self, position):
@@ -2470,8 +2479,8 @@ class YAxis(Axis):
             return False, {}
         (l, b), (r, t) = self.axes.transAxes.transform([(0, 0), (1, 1)])
         inaxis = 0 <= yaxes <= 1 and (
-            l - self.pickradius < x < l or
-            r < x < r + self.pickradius)
+            l - self._pickradius < x < l or
+            r < x < r + self._pickradius)
         return inaxis, {}
 
     def set_label_position(self, position):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -419,16 +419,17 @@ class Collection(artist.Artist, cm.ScalarMappable):
         renderer.close_group(self.__class__.__name__)
         self.stale = False
 
-    def set_pickradius(self, pr):
+    @_api.rename_parameter("3.6", "pr", "pickradius")
+    def set_pickradius(self, pickradius):
         """
         Set the pick radius used for containment tests.
 
         Parameters
         ----------
-        pr : float
+        pickradius : float
             Pick radius, in points.
         """
-        self._pickradius = pr
+        self._pickradius = pickradius
 
     def get_pickradius(self):
         return self._pickradius

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -390,11 +390,11 @@ class Line2D(Artist):
         # update kwargs before updating data to give the caller a
         # chance to init axes (and hence unit support)
         self._internal_update(kwargs)
-        self.pickradius = pickradius
+        self._pickradius = pickradius
         self.ind_offset = 0
         if (isinstance(self._picker, Number) and
                 not isinstance(self._picker, bool)):
-            self.pickradius = self._picker
+            self._pickradius = self._picker
 
         self._xorig = np.asarray([])
         self._yorig = np.asarray([])
@@ -455,9 +455,9 @@ class Line2D(Artist):
         # Convert pick radius from points to pixels
         if self.figure is None:
             _log.warning('no figure set when check if mouse is on line')
-            pixels = self.pickradius
+            pixels = self._pickradius
         else:
-            pixels = self.figure.dpi / 72. * self.pickradius
+            pixels = self.figure.dpi / 72. * self._pickradius
 
         # The math involved in checking for containment (here and inside of
         # segment_hits) assumes that it is OK to overflow, so temporarily set
@@ -488,7 +488,8 @@ class Line2D(Artist):
         """
         return self._pickradius
 
-    def set_pickradius(self, d):
+    @_api.rename_parameter("3.6", "d", "pickradius")
+    def set_pickradius(self, pickradius):
         """
         Set the pick radius used for containment tests.
 
@@ -496,12 +497,12 @@ class Line2D(Artist):
 
         Parameters
         ----------
-        d : float
+        pickradius : float
             Pick radius, in points.
         """
-        if not isinstance(d, Number) or d < 0:
+        if not isinstance(pickradius, Number) or pickradius < 0:
             raise ValueError("pick radius should be a distance")
-        self._pickradius = d
+        self._pickradius = pickradius
 
     pickradius = property(get_pickradius, set_pickradius)
 
@@ -612,7 +613,7 @@ class Line2D(Artist):
         if callable(p):
             self._contains = p
         else:
-            self.pickradius = p
+            self.set_pickradius(p)
         self._picker = p
 
     def get_bbox(self):


### PR DESCRIPTION
## PR Summary

Always store in `self._pickradius`. Added property where needed. Added check for positive number (not for Collection since a negative number can be used according to docs).

Not sure if the `rename_parameter` is really needed since these are typically not called using kwargs, but better safe than sorry.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
