### PR TITLE
Add tests for pan

### DIFF
--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -183,7 +183,8 @@ def test_interactive_zoom():
 @pytest.mark.parametrize("tool,button,expected",
                          [("zoom", MouseButton.LEFT, (4, 6)),  # zoom in
                           ("zoom", MouseButton.RIGHT, (-20, 30)),  # zoom out
-                          ("pan", MouseButton.LEFT, (-2, 8))])
+                          ("pan", MouseButton.LEFT, (-2, 8)),
+                          ("pan", MouseButton.RIGHT, (1.47, 7.78))])  # zoom
 def test_interactive_colorbar(plot_func, orientation, tool, button, expected):
     fig, ax = plt.subplots()
     data = np.arange(12).reshape((4, 3))
@@ -286,3 +287,57 @@ def test_draw(backend):
 
     for ref, test in zip(layed_out_pos_agg, layed_out_pos_test):
         np.testing.assert_allclose(ref, test, atol=0.005)
+
+
+@pytest.mark.parametrize(
+    "key,mouseend,expectedxlim,expectedylim",
+    [(None, (0.2, 0.2), (3.49, 12.49), (2.7, 11.7)),
+     (None, (0.2, 0.5), (3.49, 12.49), (0, 9)),
+     (None, (0.5, 0.2), (0, 9), (2.7, 11.7)),
+     (None, (0.5, 0.5), (0, 9), (0, 9)),  # No move
+     (None, (0.8, 0.25), (-3.47, 5.53), (2.25, 11.25)),
+     (None, (0.2, 0.25), (3.49, 12.49), (2.25, 11.25)),
+     (None, (0.8, 0.85), (-3.47, 5.53), (-3.14, 5.86)),
+     (None, (0.2, 0.85), (3.49, 12.49), (-3.14, 5.86)),
+     ("shift", (0.2, 0.4), (3.49, 12.49), (0, 9)),  # snap to x
+     ("shift", (0.4, 0.2), (0, 9), (2.7, 11.7)),  # snap to y
+     ("shift", (0.2, 0.25), (3.49, 12.49), (3.49, 12.49)),  # snap to diagonal
+     ("shift", (0.8, 0.25), (-3.47, 5.53), (3.47, 12.47)),  # snap to diagonal
+     ("shift", (0.8, 0.9), (-3.58, 5.41), (-3.58, 5.41)),  # snap to diagonal
+     ("shift", (0.2, 0.85), (3.49, 12.49), (-3.49, 5.51)),  # snap to diagonal
+     ("x", (0.2, 0.1), (3.49, 12.49), (0, 9)),  # only x
+     ("y", (0.1, 0.2), (0, 9), (2.7, 11.7)),  # only y
+     ("control", (0.2, 0.2), (3.49, 12.49), (3.49, 12.49)),  # diagonal
+     ("control", (0.4, 0.2), (2.72, 11.72), (2.72, 11.72)),  # diagonal
+     ])
+def test_interactive_pan(key, mouseend, expectedxlim, expectedylim):
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    assert ax.get_navigate()
+    # Set equal aspect ratio to easier see diagonal snap
+    ax.set_aspect('equal')
+
+    # Mouse move starts from 0.5, 0.5
+    mousestart = (0.5, 0.5)
+    # Convert to screen coordinates ("s").  Events are defined only with pixel
+    # precision, so round the pixel values, and below, check against the
+    # corresponding xdata/ydata, which are close but not equal to d0/d1.
+    sstart = ax.transData.transform(mousestart).astype(int)
+    send = ax.transData.transform(mouseend).astype(int)
+
+    # Set up the mouse movements
+    start_event = MouseEvent(
+        "button_press_event", fig.canvas, *sstart, button=MouseButton.LEFT,
+        key=key)
+    stop_event = MouseEvent(
+        "button_release_event", fig.canvas, *send, button=MouseButton.LEFT,
+        key=key)
+
+    tb = NavigationToolbar2(fig.canvas)
+    tb.pan()
+    tb.press_pan(start_event)
+    tb.drag_pan(stop_event)
+    tb.release_pan(stop_event)
+    # Should be close, but won't be exact due to screen integer resolution
+    assert tuple(ax.get_xlim()) == pytest.approx(expectedxlim, abs=0.02)
+    assert tuple(ax.get_ylim()) == pytest.approx(expectedylim, abs=0.02)


### PR DESCRIPTION
## PR Summary

Panning was very scarcely tested.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
