### PR TITLE
Deprecate empty offsets in get_path_collection_extents

### DIFF
--- a/doc/api/next_api_changes/deprecations/23200-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23200-OG.rst
@@ -1,0 +1,6 @@
+Calling ``paths.get_path_collection_extents`` with empty *offsets*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Calling  `~.get_path_collection_extents` with an empty *offsets* parameter
+has an ambiguous interpretation and is therefore deprecated. When the
+deprecation period expires, this will produce an error.

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1068,6 +1068,11 @@ def get_path_collection_extents(
     from .transforms import Bbox
     if len(paths) == 0:
         raise ValueError("No paths provided")
+    if len(offsets) == 0:
+        _api.warn_deprecated(
+            "3.8", message="Calling get_path_collection_extents() with an"
+            " empty offsets list is deprecated since %(since)s. Support will"
+            " be removed %(removal)s.")
     extents, minpos = _path.get_path_collection_extents(
         master_transform, paths, np.atleast_3d(transforms),
         offsets, offset_transform)


### PR DESCRIPTION
## PR Summary

Closes #1735

Based on the issue, the outcome of an empty offsets is not well defined. This is now deprecated.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
