### PR TITLE
MNT: Remove cached renderer from figure

### DIFF
--- a/doc/api/next_api_changes/deprecations/23202-GL.rst
+++ b/doc/api/next_api_changes/deprecations/23202-GL.rst
@@ -1,0 +1,5 @@
+``Axes.get_renderer_cache``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The canvas now takes care of the renderer and whether to cache it
+or not. The alternative is to call ``axes.figure.canvas.get_renderer()``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3068,33 +3068,22 @@ class _AxesBase(martist.Artist):
     def draw_artist(self, a):
         """
         Efficiently redraw a single artist.
-
-        This method can only be used after an initial draw of the figure,
-        because that creates and caches the renderer needed here.
         """
-        if self.figure._cachedRenderer is None:
-            raise AttributeError("draw_artist can only be used after an "
-                                 "initial draw which caches the renderer")
-        a.draw(self.figure._cachedRenderer)
+        a.draw(self.figure.canvas.get_renderer())
 
     def redraw_in_frame(self):
         """
         Efficiently redraw Axes data, but not axis ticks, labels, etc.
-
-        This method can only be used after an initial draw which caches the
-        renderer.
         """
-        if self.figure._cachedRenderer is None:
-            raise AttributeError("redraw_in_frame can only be used after an "
-                                 "initial draw which caches the renderer")
         with ExitStack() as stack:
             for artist in [*self._axis_map.values(),
                            self.title, self._left_title, self._right_title]:
                 stack.enter_context(artist._cm_set(visible=False))
-            self.draw(self.figure._cachedRenderer)
+            self.draw(self.figure.canvas.get_renderer())
 
+    @_api.deprecated("3.6", alternative="Axes.figure.canvas.get_renderer()")
     def get_renderer_cache(self):
-        return self.figure._cachedRenderer
+        return self.figure.canvas.get_renderer()
 
     # Axes rectangle characteristics
 

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1535,8 +1535,7 @@ def _mouse_handler(event):
 
 def _get_renderer(figure, print_method=None):
     """
-    Get the renderer that would be used to save a `.Figure`, and cache it on
-    the figure.
+    Get the renderer that would be used to save a `.Figure`.
 
     If you need a renderer without any active draw methods use
     renderer._draw_disabled to temporary patch them out at your call site.
@@ -1559,7 +1558,7 @@ def _get_renderer(figure, print_method=None):
         try:
             print_method(io.BytesIO())
         except Done as exc:
-            renderer, = figure._cachedRenderer, = exc.args
+            renderer, = exc.args
             return renderer
         else:
             raise RuntimeError(f"{print_method} did not call Figure.draw, so "

--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -422,6 +422,9 @@ class FigureCanvasCairo(FigureCanvasBase):
             self._cached_renderer = RendererCairo(self.figure.dpi)
         return self._cached_renderer
 
+    def get_renderer(self):
+        return self._renderer
+
     def copy_from_bbox(self, bbox):
         surface = self._renderer.gc.ctx.get_target()
         if not isinstance(surface, cairo.ImageSurface):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -620,7 +620,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         # DC (see GraphicsContextWx._cache).
         bmp = (self.bitmap.ConvertToImage().ConvertToBitmap()
                if wx.Platform == '__WXMSW__'
-                  and isinstance(self.figure._cachedRenderer, RendererWx)
+                  and isinstance(self.figure.canvas.get_renderer(), RendererWx)
                else self.bitmap)
         drawDC.DrawBitmap(bmp, 0, 0)
         if self._rubberband_rect is not None:

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2253,7 +2253,6 @@ class SubFigure(FigureBase):
 
     def draw(self, renderer):
         # docstring inherited
-        self._cachedRenderer = renderer
 
         # draw the figure bounding box, perhaps none for white figure
         if not self.get_visible():
@@ -2493,7 +2492,6 @@ class Figure(FigureBase):
 
         self._axstack = _AxesStack()  # track all figure axes and current axes
         self.clear()
-        self._cachedRenderer = None
 
         # list of child gridspecs for this figure
         self._gridspecs = []
@@ -2655,9 +2653,7 @@ class Figure(FigureBase):
     get_axes = axes.fget
 
     def _get_renderer(self):
-        if self._cachedRenderer is not None:
-            return self._cachedRenderer
-        elif hasattr(self.canvas, 'get_renderer'):
+        if hasattr(self.canvas, 'get_renderer'):
             return self.canvas.get_renderer()
         else:
             return _get_renderer(self)
@@ -3051,7 +3047,6 @@ class Figure(FigureBase):
     @allow_rasterization
     def draw(self, renderer):
         # docstring inherited
-        self._cachedRenderer = renderer
 
         # draw the figure bounding box, perhaps none for white figure
         if not self.get_visible():
@@ -3092,14 +3087,8 @@ class Figure(FigureBase):
     def draw_artist(self, a):
         """
         Draw `.Artist` *a* only.
-
-        This method can only be used after an initial draw of the figure,
-        because that creates and caches the renderer needed here.
         """
-        if self._cachedRenderer is None:
-            raise AttributeError("draw_artist can only be used after an "
-                                 "initial draw which caches the renderer")
-        a.draw(self._cachedRenderer)
+        a.draw(self.canvas.get_renderer())
 
     def __getstate__(self):
         state = super().__getstate__()
@@ -3108,9 +3097,6 @@ class Figure(FigureBase):
         # of meaning that a figure can be detached from one canvas, and
         # re-attached to another.
         state.pop("canvas")
-
-        # Set cached renderer to None -- it can't be pickled.
-        state["_cachedRenderer"] = None
 
         # discard any changes to the dpi due to pixel ratio changes
         state["_dpi"] = state.get('_original_dpi', state['_dpi'])

--- a/lib/matplotlib/tests/test_backend_macosx.py
+++ b/lib/matplotlib/tests/test_backend_macosx.py
@@ -16,11 +16,11 @@ def test_cached_renderer():
     # a fig.canvas.draw() call
     fig = plt.figure(1)
     fig.canvas.draw()
-    assert fig._cachedRenderer is not None
+    assert fig.canvas.get_renderer()._renderer is not None
 
     fig = plt.figure(2)
     fig.draw_without_rendering()
-    assert fig._cachedRenderer is not None
+    assert fig.canvas.get_renderer()._renderer is not None
 
 
 @pytest.mark.backend('macosx')

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -984,7 +984,7 @@ def test_empty_imshow(make_norm):
     fig.canvas.draw()
 
     with pytest.raises(RuntimeError):
-        im.make_image(fig._cachedRenderer)
+        im.make_image(fig.canvas.get_renderer())
 
 
 def test_imshow_float16():

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -552,7 +552,7 @@ def test_auto_adjustable():
     pad = 0.1
     make_axes_area_auto_adjustable(ax, pad=pad)
     fig.canvas.draw()
-    tbb = ax.get_tightbbox(fig._cachedRenderer)
+    tbb = ax.get_tightbbox()
     assert tbb.x0 == pytest.approx(pad * fig.dpi)
     assert tbb.x1 == pytest.approx(fig.bbox.width - pad * fig.dpi)
     assert tbb.y0 == pytest.approx(pad * fig.dpi)


### PR DESCRIPTION
## PR Summary

Let the canvas decide whether to cache the renderer or not and let the figure request the renderer from the canvas. The canvas can either return a cached version or a new one.

This is a proof-of-concept after the discussion on the dev call last week to see if we can move the cache from the figure-level to the canvas-level.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
