### PR TITLE
Honour `panchor` keyword for colorbar on subplot

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1617,7 +1617,8 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
             aspect = 1 / aspect
 
     parent.set_subplotspec(ss_main)
-    parent.set_anchor(loc_settings["panchor"])
+    if panchor is not False:
+        parent.set_anchor(panchor)
 
     fig = parent.get_figure()
     cax = fig.add_subplot(ss_cb, label="<colorbar>")

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -211,11 +211,23 @@ def test_colorbar_positioning(use_gridspec):
 
 
 def test_colorbar_single_ax_panchor_false():
-    # Just smoketesting that this doesn't crash.  Note that this differs from
-    # the tests above with panchor=False because there use_gridspec is actually
-    # ineffective: passing *ax* as lists always disable use_gridspec.
+    # Note that this differs from the tests above with panchor=False because
+    # there use_gridspec is actually ineffective: passing *ax* as lists always
+    # disables use_gridspec.
+    ax = plt.subplot(111, anchor='N')
     plt.imshow([[0, 1]])
     plt.colorbar(panchor=False)
+    assert ax.get_anchor() == 'N'
+
+
+@pytest.mark.parametrize('constrained', [False, True],
+                         ids=['standard', 'constrained'])
+def test_colorbar_single_ax_panchor_east(constrained):
+    fig = plt.figure(constrained_layout=constrained)
+    ax = fig.add_subplot(111, anchor='N')
+    plt.imshow([[0, 1]])
+    plt.colorbar(panchor='E')
+    assert ax.get_anchor() == 'E'
 
 
 @image_comparison(['contour_colorbar.png'], remove_text=True)


### PR DESCRIPTION
## PR Summary

Fixes #23157.  Also added a test for the case where `panchor` is set to something different to the existing anchor setting on the main axes.  Both tests fail without the change in the main code.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
