### PR TITLE
Update build environment and improve test

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,8 +48,7 @@ jobs:
             XVFB_RUN: xvfb-run -a
           - os: ubuntu-20.04
             python-version: '3.10'
-            # Re-add this when extra dependencies have wheels.
-            # extra-requirements: '-r requirements/testing/extra.txt'
+            extra-requirements: '-r requirements/testing/extra.txt'
             XVFB_RUN: xvfb-run -a
           - os: macos-latest
             python-version: 3.8

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -512,6 +512,10 @@ for param in _blit_backends:
         # copy_from_bbox only works when rendering to an ImageSurface
         param.marks.append(
             pytest.mark.skip("gtk3cairo does not support blitting"))
+    elif backend == "gtk4cairo":
+        # copy_from_bbox only works when rendering to an ImageSurface
+        param.marks.append(
+            pytest.mark.skip("gtk4cairo does not support blitting"))
     elif backend == "wx":
         param.marks.append(
             pytest.mark.skip("wx does not support blitting"))

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -310,5 +310,6 @@ def test_get_font_names():
             pass
     available_fonts = sorted(list(set(ttf_fonts)))
     mpl_font_names = sorted(fontManager.get_font_names())
+    assert set(available_fonts) == set(mpl_font_names)
     assert len(available_fonts) == len(mpl_font_names)
     assert available_fonts == mpl_font_names


### PR DESCRIPTION
## PR Summary

Enable the extra dependencies for ubuntu 3.10. 

Disable blitting tests for GTK4-cairo.

A minor addition to the get_font_names test to see which font actually differs.

(The things discussed below are from temporary versions that included more OS and python version tests.)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
