### PR TITLE
MNT: Rename example files with 'test' in name

### DIFF
--- a/examples/scales/semilogx_demo.py
+++ b/examples/scales/semilogx_demo.py
@@ -3,6 +3,8 @@
 Log Axis
 ========
 
+.. redirect-from:: /gallery/scales/log_test
+
 This is an example of assigning a log-scale for the x-axis using
 `~.axes.Axes.semilogx`.
 """


### PR DESCRIPTION
## PR Summary

* Resolves #23214 
* [Requested on Gitter](https://gitter.im/matplotlib/matplotlib?at=629ec382da83520ac36ae8f2)

In PR #23130 it was noticed that certain example files had 'test' in their name and were getting picked up automatically by `pytest` accidentally. To avoid this,

https://github.com/matplotlib/matplotlib/blob/8e2987b9804b6eaa32b8ffa40059e0d5267960ee/pytest.ini#L10

was added to `pytest.ini`. While this is sufficient to avoid future problems, removing the word 'test' from example files and replacing it with 'demo', which is commonly used in other matplotlib examples, provides future safeguards.

~~To further this idea, uses of the phrase 'test' in the example docstrings are replaced with 'demo'.~~ (do this later on given https://github.com/matplotlib/matplotlib/pull/23219#issuecomment-1150458177)

To avoid causing broken links in the [example documentation](https://matplotlib.org/stable/gallery/index.html) add `redirect-from` statements to the old file names as [directed in the dev docs](https://matplotlib.org/stable/devel/documenting_mpl.html#moving-documentation).

**edit**: There are additional examples beyond `examples/scales/log_test.py` with `test` in the name:

* `examples/text_labels_and_annotations/usetex_baseline_test.py`
* `examples/units/artist_tests.py`
* `examples/units/evans_test.py`

but it was decided these examples should be removed or turned into actual tests, and so to avoid the noise of renaming and then removing these are left alone for the scope of this PR.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
