### PR TITLE
Fix argument checking for set_interpolation_stage

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -120,6 +120,8 @@ def check_in_list(_values, *, _print_supported_values=True, **kwargs):
     --------
     >>> _api.check_in_list(["foo", "bar"], arg=arg, other_arg=other_arg)
     """
+    if not kwargs:
+        raise TypeError("No argument to check!")
     values = _values
     for key, val in kwargs.items():
         if val not in values:

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -787,7 +787,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """
         if s is None:
             s = "data"  # placeholder for maybe having rcParam
-        _api.check_in_list(['data', 'rgba'])
+        _api.check_in_list(['data', 'rgba'], s=s)
         self._interpolation_stage = s
         self.stale = True
 

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -93,3 +93,8 @@ def test_deprecation_alternative():
     def f():
         pass
     assert alternative in f.__doc__
+
+
+def test_empty_check_in_list():
+    with pytest.raises(TypeError, match="No argument to check!"):
+        _api.check_in_list(["a"])


### PR DESCRIPTION
## PR Summary

Found a minor issue basically disabling argument checking.

Also added a check to avoid this type of errors in the code.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
