### PR TITLE
Rename test markers

### DIFF
--- a/lib/matplotlib/testing/_markers.py
+++ b/lib/matplotlib/testing/_markers.py
@@ -34,15 +34,15 @@ def _checkdep_usetex():
 needs_ghostscript = pytest.mark.skipif(
     "eps" not in matplotlib.testing.compare.converter,
     reason="This test needs a ghostscript installation")
-needs_lualatex = pytest.mark.skipif(
+needs_pgf_lualatex = pytest.mark.skipif(
     not matplotlib.testing._check_for_pgf('lualatex'),
     reason='lualatex + pgf is required')
-needs_pdflatex = pytest.mark.skipif(
+needs_pgf_pdflatex = pytest.mark.skipif(
     not matplotlib.testing._check_for_pgf('pdflatex'),
     reason='pdflatex + pgf is required')
+needs_pgf_xelatex = pytest.mark.skipif(
+    not matplotlib.testing._check_for_pgf('xelatex'),
+    reason='xelatex + pgf is required')
 needs_usetex = pytest.mark.skipif(
     not _checkdep_usetex(),
     reason="This test needs a TeX installation")
-needs_xelatex = pytest.mark.skipif(
-    not matplotlib.testing._check_for_pgf('xelatex'),
-    reason='xelatex + pgf is required')

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -5,7 +5,7 @@ from matplotlib.backend_bases import (
     FigureCanvasBase, LocationEvent, MouseButton, MouseEvent,
     NavigationToolbar2, RendererBase)
 from matplotlib.figure import Figure
-from matplotlib.testing._markers import needs_xelatex
+from matplotlib.testing._markers import needs_pgf_xelatex
 import matplotlib.pyplot as plt
 
 import numpy as np
@@ -251,7 +251,8 @@ def test_toolbar_zoompan():
 
 
 @pytest.mark.parametrize(
-    "backend", ['svg', 'ps', 'pdf', pytest.param('pgf', marks=needs_xelatex)]
+    "backend", ['svg', 'ps', 'pdf',
+                pytest.param('pgf', marks=needs_pgf_xelatex)]
 )
 def test_draw(backend):
     from matplotlib.figure import Figure

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -15,7 +15,8 @@ from matplotlib.backends.backend_pgf import PdfPages, _tex_escape
 from matplotlib.testing.decorators import (
     _image_directories, check_figures_equal, image_comparison)
 from matplotlib.testing._markers import (
-    needs_ghostscript, needs_lualatex, needs_pdflatex, needs_xelatex)
+    needs_ghostscript, needs_pgf_lualatex, needs_pgf_pdflatex,
+    needs_pgf_xelatex)
 
 
 baseline_dir, result_dir = _image_directories(lambda: 'dummy func')
@@ -70,7 +71,7 @@ def test_tex_escape(plain_text, escaped_text):
 
 
 # test compiling a figure to pdf with xelatex
-@needs_xelatex
+@needs_pgf_xelatex
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_xelatex.pdf'], style='default')
 def test_xelatex():
@@ -88,7 +89,7 @@ except mpl.ExecutableNotFoundError:
 
 
 # test compiling a figure to pdf with pdflatex
-@needs_pdflatex
+@needs_pgf_pdflatex
 @pytest.mark.skipif(not _has_tex_package('ucs'), reason='needs ucs.sty')
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_pdflatex.pdf'], style='default',
@@ -108,8 +109,8 @@ def test_pdflatex():
 
 
 # test updating the rc parameters for each figure
-@needs_xelatex
-@needs_pdflatex
+@needs_pgf_xelatex
+@needs_pgf_pdflatex
 @mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_rcupdate():
@@ -140,7 +141,7 @@ def test_rcupdate():
 
 
 # test backend-side clipping, since large numbers are not supported by TeX
-@needs_xelatex
+@needs_pgf_xelatex
 @mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_pathclip():
@@ -160,7 +161,7 @@ def test_pathclip():
 
 
 # test mixed mode rendering
-@needs_xelatex
+@needs_pgf_xelatex
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_mixedmode.pdf'], style='default')
 def test_mixedmode():
@@ -170,7 +171,7 @@ def test_mixedmode():
 
 
 # test bbox_inches clipping
-@needs_xelatex
+@needs_pgf_xelatex
 @mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_bbox_inches():
@@ -187,9 +188,9 @@ def test_bbox_inches():
 @mpl.style.context('default')
 @pytest.mark.backend('pgf')
 @pytest.mark.parametrize('system', [
-    pytest.param('lualatex', marks=[needs_lualatex]),
-    pytest.param('pdflatex', marks=[needs_pdflatex]),
-    pytest.param('xelatex', marks=[needs_xelatex]),
+    pytest.param('lualatex', marks=[needs_pgf_lualatex]),
+    pytest.param('pdflatex', marks=[needs_pgf_pdflatex]),
+    pytest.param('xelatex', marks=[needs_pgf_xelatex]),
 ])
 def test_pdf_pages(system):
     rc_pdflatex = {
@@ -229,9 +230,9 @@ def test_pdf_pages(system):
 @mpl.style.context('default')
 @pytest.mark.backend('pgf')
 @pytest.mark.parametrize('system', [
-    pytest.param('lualatex', marks=[needs_lualatex]),
-    pytest.param('pdflatex', marks=[needs_pdflatex]),
-    pytest.param('xelatex', marks=[needs_xelatex]),
+    pytest.param('lualatex', marks=[needs_pgf_lualatex]),
+    pytest.param('pdflatex', marks=[needs_pgf_pdflatex]),
+    pytest.param('xelatex', marks=[needs_pgf_xelatex]),
 ])
 def test_pdf_pages_metadata_check(monkeypatch, system):
     # Basically the same as test_pdf_pages, but we keep it separate to leave
@@ -283,7 +284,7 @@ def test_pdf_pages_metadata_check(monkeypatch, system):
     }
 
 
-@needs_xelatex
+@needs_pgf_xelatex
 def test_tex_restart_after_error():
     fig = plt.figure()
     fig.suptitle(r"\oops")
@@ -295,14 +296,14 @@ def test_tex_restart_after_error():
     fig.savefig(BytesIO(), format="pgf")
 
 
-@needs_xelatex
+@needs_pgf_xelatex
 def test_bbox_inches_tight():
     fig, ax = plt.subplots()
     ax.imshow([[0, 1], [2, 3]])
     fig.savefig(BytesIO(), format="pdf", backend="pgf", bbox_inches="tight")
 
 
-@needs_xelatex
+@needs_pgf_xelatex
 @needs_ghostscript
 def test_png_transparency():  # Actually, also just testing that png works.
     buf = BytesIO()
@@ -312,7 +313,7 @@ def test_png_transparency():  # Actually, also just testing that png works.
     assert (t[..., 3] == 0).all()  # fully transparent.
 
 
-@needs_xelatex
+@needs_pgf_xelatex
 def test_unknown_font(caplog):
     with caplog.at_level("WARNING"):
         mpl.rcParams["font.family"] = "this-font-does-not-exist"


### PR DESCRIPTION
## PR Summary

Fixes https://github.com/matplotlib/matplotlib/pull/23045#discussion_r895001860

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
