### PR TITLE
Small simplifications to mathtext tests.

### DIFF
--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -303,24 +303,17 @@ def test_get_unicode_index_exception():
 
 
 def test_single_minus_sign():
-    plt.figure(figsize=(0.3, 0.3))
-    plt.text(0.5, 0.5, '$-$')
-    plt.gca().spines[:].set_visible(False)
-    plt.gca().set_xticks([])
-    plt.gca().set_yticks([])
-
-    buff = io.BytesIO()
-    plt.savefig(buff, format="rgba", dpi=1000)
-    array = np.frombuffer(buff.getvalue(), dtype=np.uint8)
-
-    # If this fails, it would be all white
-    assert not np.all(array == 0xff)
+    fig = plt.figure()
+    fig.text(0.5, 0.5, '$-$')
+    fig.canvas.draw()
+    t = np.asarray(fig.canvas.renderer.buffer_rgba())
+    assert (t != 0xff).any()  # assert that canvas is not all white.
 
 
 @check_figures_equal(extensions=["png"])
 def test_spaces(fig_test, fig_ref):
-    fig_test.subplots().set_title(r"$1\,2\>3\ 4$")
-    fig_ref.subplots().set_title(r"$1\/2\:3~4$")
+    fig_test.text(.5, .5, r"$1\,2\>3\ 4$")
+    fig_ref.text(.5, .5, r"$1\/2\:3~4$")
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
