### PR TITLE
Add a helper to generate mathtext error strings.

### DIFF
--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -234,8 +234,8 @@ def test_fontinfo():
 @pytest.mark.parametrize(
     'math, msg',
     [
-        (r'$\hspace{}$', r'Expected \hspace{n}'),
-        (r'$\hspace{foo}$', r'Expected \hspace{n}'),
+        (r'$\hspace{}$', r'Expected \hspace{space}'),
+        (r'$\hspace{foo}$', r'Expected \hspace{space}'),
         (r'$\frac$', r'Expected \frac{num}{den}'),
         (r'$\frac{}{}$', r'Expected \frac{num}{den}'),
         (r'$\binom$', r'Expected \binom{num}{den}'),
@@ -246,8 +246,8 @@ def test_fontinfo():
          r'Expected \genfrac{ldelim}{rdelim}{rulesize}{style}{num}{den}'),
         (r'$\sqrt$', r'Expected \sqrt{value}'),
         (r'$\sqrt f$', r'Expected \sqrt{value}'),
-        (r'$\overline$', r'Expected \overline{value}'),
-        (r'$\overline{}$', r'Expected \overline{value}'),
+        (r'$\overline$', r'Expected \overline{body}'),
+        (r'$\overline{}$', r'Expected \overline{body}'),
         (r'$\leftF$', r'Expected a delimiter'),
         (r'$\rightF$', r'Unknown symbol: \rightF'),
         (r'$\left(\right$', r'Expected a delimiter'),


### PR DESCRIPTION
This also ensures consistency in the names in the error strings; see
e.g. changes in test_mathtext (the contents of `\overline` are indeed a
"body", not a "value").

Renaming "simple_group" to "opt_group" is not only to make definitions
of over/underset fit in a single line, but also because the name seems
semantically more meaningful too.  (req_group, OTOH, is just for
conciseness.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
