### PR TITLE
negative_linestyles kwarg in contour.py

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1757,8 +1757,8 @@ linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, optional
     iterable is shorter than the number of contour levels
     it will be repeated as necessary.
 
-negative_linestyles : None or str, optional
-                      {'solid', 'dashed', 'dashdot', 'dotted'}
+negative_linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, \
+                       optional
     *Only applies to* `.contour`.
 
     If *negative_linestyles* is None, the default is 'dashed' for

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -701,7 +701,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                  hatches=(None,), alpha=None, origin=None, extent=None,
                  cmap=None, colors=None, norm=None, vmin=None, vmax=None,
                  extend='neither', antialiased=None, nchunk=0, locator=None,
-                 transform=None,
+                 transform=None, negative_linestyles=None,
                  **kwargs):
         """
         Draw contour lines or filled regions, depending on
@@ -785,6 +785,13 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             self.origin = mpl.rcParams['image.origin']
 
         self._transform = transform
+
+        self.negative_linestyles = negative_linestyles
+        # If negative_linestyles was not defined as a kwarg,
+        # define negative_linestyles with rcParams
+        if self.negative_linestyles is None:
+            self.negative_linestyles = \
+                mpl.rcParams['contour.negative_linestyle']
 
         kwargs = self._process_args(*args, **kwargs)
         self._process_levels()
@@ -1276,11 +1283,10 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         if linestyles is None:
             tlinestyles = ['solid'] * Nlev
             if self.monochrome:
-                neg_ls = mpl.rcParams['contour.negative_linestyle']
                 eps = - (self.zmax - self.zmin) * 1e-15
                 for i, lev in enumerate(self.levels):
                     if lev < eps:
-                        tlinestyles[i] = neg_ls
+                        tlinestyles[i] = self.negative_linestyles
         else:
             if isinstance(linestyles, str):
                 tlinestyles = [linestyles] * Nlev
@@ -1748,6 +1754,18 @@ linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, optional
 
     *linestyles* can also be an iterable of the above strings
     specifying a set of linestyles to be used. If this
+    iterable is shorter than the number of contour levels
+    it will be repeated as necessary.
+
+negative_linestyles : None or str, optional
+                      {'solid', 'dashed', 'dashdot', 'dotted'}
+    *Only applies to* `.contour`.
+
+    If *negative_linestyles* is None, the default is 'dashed' for
+    negative contours.
+
+    *negative_linestyles* can also be an iterable of the above
+    strings specifying a set of linestyles to be used. If this
     iterable is shorter than the number of contour levels
     it will be repeated as necessary.
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -605,3 +605,80 @@ def test_subfigure_clabel():
         CS = ax.contour(X, Y, Z)
         ax.clabel(CS, inline=True, fontsize=10)
         ax.set_title("Simplest default with labels")
+
+
+@pytest.mark.parametrize(
+    "style", ['solid', 'dashed', 'dashdot', 'dotted'])
+def test_linestyles(style):
+    delta = 0.025
+    x = np.arange(-3.0, 3.0, delta)
+    y = np.arange(-2.0, 2.0, delta)
+    X, Y = np.meshgrid(x, y)
+    Z1 = np.exp(-X**2 - Y**2)
+    Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
+    Z = (Z1 - Z2) * 2
+
+    # Positive contour defaults to solid
+    fig1, ax1 = plt.subplots()
+    CS1 = ax1.contour(X, Y, Z, 6, colors='k')
+    ax1.clabel(CS1, fontsize=9, inline=True)
+    ax1.set_title('Single color - positive contours solid (default)')
+    assert CS1.linestyles is None  # default
+
+    # Change linestyles using linestyles kwarg
+    fig2, ax2 = plt.subplots()
+    CS2 = ax2.contour(X, Y, Z, 6, colors='k', linestyles=style)
+    ax2.clabel(CS2, fontsize=9, inline=True)
+    ax2.set_title(f'Single color - positive contours {style}')
+    assert CS2.linestyles == style
+
+    # Ensure linestyles do not change when negative_linestyles is defined
+    fig3, ax3 = plt.subplots()
+    CS3 = ax3.contour(X, Y, Z, 6, colors='k', linestyles=style,
+                      negative_linestyles='dashdot')
+    ax3.clabel(CS3, fontsize=9, inline=True)
+    ax3.set_title(f'Single color - positive contours {style}')
+    assert CS3.linestyles == style
+
+
+@pytest.mark.parametrize(
+    "style", ['solid', 'dashed', 'dashdot', 'dotted'])
+def test_negative_linestyles(style):
+    delta = 0.025
+    x = np.arange(-3.0, 3.0, delta)
+    y = np.arange(-2.0, 2.0, delta)
+    X, Y = np.meshgrid(x, y)
+    Z1 = np.exp(-X**2 - Y**2)
+    Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
+    Z = (Z1 - Z2) * 2
+
+    # Negative contour defaults to dashed
+    fig1, ax1 = plt.subplots()
+    CS1 = ax1.contour(X, Y, Z, 6, colors='k')
+    ax1.clabel(CS1, fontsize=9, inline=True)
+    ax1.set_title('Single color - negative contours dashed (default)')
+    assert CS1.negative_linestyles == 'dashed'  # default
+
+    # Change negative_linestyles using rcParams
+    plt.rcParams['contour.negative_linestyle'] = style
+    fig2, ax2 = plt.subplots()
+    CS2 = ax2.contour(X, Y, Z, 6, colors='k')
+    ax2.clabel(CS2, fontsize=9, inline=True)
+    ax2.set_title(f'Single color - negative contours {style}'
+                   '(using rcParams)')
+    assert CS2.negative_linestyles == style
+
+    # Change negative_linestyles using negative_linestyles kwarg
+    fig3, ax3 = plt.subplots()
+    CS3 = ax3.contour(X, Y, Z, 6, colors='k', negative_linestyles=style)
+    ax3.clabel(CS3, fontsize=9, inline=True)
+    ax3.set_title(f'Single color - negative contours {style}')
+    assert CS3.negative_linestyles == style
+
+    # Ensure negative_linestyles do not change when linestyles is defined
+    fig4, ax4 = plt.subplots()
+    CS4 = ax4.contour(X, Y, Z, 6, colors='k', linestyles='dashdot',
+                      negative_linestyles=style)
+    ax4.clabel(CS4, fontsize=9, inline=True)
+    ax4.set_title(f'Single color - negative contours {style}')
+    assert CS4.negative_linestyles == style


### PR DESCRIPTION
## PR Summary
I made the `negative_linestyles` for contours toggle-able via kwarg. The only way to toggle this currently is with `rcParams`.

*I am re-opening this issue from a fresh branch. There was some discussion in #23102.*

In the attached issue, we had some discussion on whether this is a good idea or not, but I think it is worth considering. We can maintain current functionality and just apply the kwarg if it is defined. This will not break previous functionality. I wrote some tests for this, but I know they can be improved. I'm not completely certain on using baseline_images with parametrized inputs.

Please use this PR and the attached issue to discuss whether this is a good idea or not. I'm happy to take this in a different direction if there are some better ideas!

Closes #23028

### Previous
```
plt.rcParams['contour.negative_linestyle'] = 'solid'
fig, ax = plt.subplots()
CS = ax.contour(X, Y, Z, 6, colors='k')  # Negative contours default to dashed.
ax.clabel(CS, fontsize=9, inline=True)
ax.set_title('Single color - negative contours solid')
```

### With this PR
```
fig2, ax2 = plt.subplots()
CS = ax2.contour(X, Y, Z, 6, colors='k', negative_linestyles='solid')
ax2.clabel(CS, fontsize=9, inline=True)
ax2.set_title('Single color - negative contours solid')
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
