### PR TITLE
Add location keyword argument to Colorbar

### DIFF
--- a/doc/users/next_whats_new/colorbar_has_location_argument.rst
+++ b/doc/users/next_whats_new/colorbar_has_location_argument.rst
@@ -1,0 +1,25 @@
+``colorbar`` now has a *location* keyword argument
+==================================================
+
+The ``colorbar`` method now supports a *location* keyword argument to more
+easily position the color bar. This is useful when providing your own inset
+axes using the *cax* keyword argument and behaves similar to the case where
+axes are not provided (where the *location* keyword is passed through).
+*orientation* and *ticklocation* are no longer required as they are
+determined by *location*. *ticklocation* can still be provided if the
+automatic setting is not preferred. (*orientation* can also be provided but
+must be compatible with the *location*.)
+
+An example is:
+
+.. plot::
+    :include-source: true
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+    rng = np.random.default_rng(19680801)
+    imdata = rng.random((10, 10))
+    fig, ax = plt.subplots()
+    im = ax.imshow(imdata)
+    fig.colorbar(im, cax=ax.inset_axes([0, 1.05, 1, 0.05]),
+                 location='top')

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1149,3 +1149,34 @@ def test_title_text_loc():
     # colorbar axes, including its extend triangles....
     assert (cb.ax.title.get_window_extent(fig.canvas.get_renderer()).ymax >
             cb.ax.spines['outline'].get_window_extent().ymax)
+
+
+@check_figures_equal(extensions=["png"])
+def test_passing_location(fig_ref, fig_test):
+    ax_ref = fig_ref.add_subplot()
+    im = ax_ref.imshow([[0, 1], [2, 3]])
+    ax_ref.figure.colorbar(im, cax=ax_ref.inset_axes([0, 1.05, 1, 0.05]),
+                           orientation="horizontal", ticklocation="top")
+    ax_test = fig_test.add_subplot()
+    im = ax_test.imshow([[0, 1], [2, 3]])
+    ax_test.figure.colorbar(im, cax=ax_test.inset_axes([0, 1.05, 1, 0.05]),
+                            location="top")
+
+
+@pytest.mark.parametrize("kwargs,error,message", [
+    ({'location': 'top', 'orientation': 'vertical'}, TypeError,
+     "location and orientation are mutually exclusive"),
+    ({'location': 'top', 'orientation': 'vertical', 'cax': True}, TypeError,
+     "location and orientation are mutually exclusive"),  # Different to above
+    ({'ticklocation': 'top', 'orientation': 'vertical', 'cax': True},
+     ValueError, "'top' is not a valid value for position"),
+    ({'location': 'top', 'extendfrac': (0, None)}, ValueError,
+     "invalid value for extendfrac"),
+    ])
+def test_colorbar_errors(kwargs, error, message):
+    fig, ax = plt.subplots()
+    im = ax.imshow([[0, 1], [2, 3]])
+    if kwargs.get('cax', None) is True:
+        kwargs['cax'] = ax.inset_axes([0, 1.05, 1, 0.05])
+    with pytest.raises(error, match=message):
+        fig.colorbar(im, **kwargs)


### PR DESCRIPTION
## PR Summary

Closes #22676

Is this an API change or a user change?

~Will add an unrelated test for #23260 here as well.~ Added. However, they do not look great... The png looks OK, but locally I get in Spyder:
![image](https://user-images.githubusercontent.com/8114497/173598548-b955729f-be2b-4248-8f10-5b0a4e9443eb.png)
so there it seems like there is a bit of overlap that is not visible in the test image. For the svg there is a gap instead, although this seems to depend on the renderer...

~Also, I do not understand why the test images are not just four squares as the pasted image...~

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
