### PR TITLE
Fix handling of nonmath hyphens in mathtext.

### DIFF
--- a/doc/api/next_api_changes/behavior/23270-AL.rst
+++ b/doc/api/next_api_changes/behavior/23270-AL.rst
@@ -1,0 +1,5 @@
+The *math* parameter of ``mathtext.get_unicode_index`` is deprecated and defaults to False
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In math mode, ASCII hyphens (U+002D) are now replaced by unicode minus signs
+(U+2212) at the parsing stage.

--- a/doc/api/next_api_changes/deprecations/22507-AL.rst
+++ b/doc/api/next_api_changes/deprecations/22507-AL.rst
@@ -1,5 +1,0 @@
-The *math* parameter of ``mathtext.get_unicode_index``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In math mode, ASCII hyphens (U+002D) are now replaced by unicode minus signs
-(U+2212) at the parsing stage.

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -34,7 +34,7 @@ _log = logging.getLogger("matplotlib.mathtext")
 
 
 @_api.delete_parameter("3.6", "math")
-def get_unicode_index(symbol, math=True):  # Publicly exported.
+def get_unicode_index(symbol, math=False):  # Publicly exported.
     r"""
     Return the integer index (from the Unicode table) of *symbol*.
 
@@ -43,8 +43,8 @@ def get_unicode_index(symbol, math=True):  # Publicly exported.
     symbol : str
         A single (Unicode) character, a TeX command (e.g. r'\pi') or a Type1
         symbol name (e.g. 'phi').
-    math : bool, default: True
-        If False, always treat as a single Unicode character.
+    math : bool, default: False
+        If True (deprecated), replace ASCII hyphen-minus by Unicode minus.
     """
     # From UTF #25: U+2212 minus sign is the preferred
     # representation of the unary and binary minus sign rather than

--- a/lib/matplotlib/tests/baseline_images/test_mathtext/mathtext0_cm_00.svg
+++ b/lib/matplotlib/tests/baseline_images/test_mathtext/mathtext0_cm_00.svg
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="378pt" height="54pt" viewBox="0 0 378 54" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="text_1">
+   <!-- $-$- -->
+   <g transform="translate(182.16 30.31125)">
+    <text>
+     <tspan style="font: 12px 'cmsy10'" x="0" y="-0.234375">¡</tspan>
+     <tspan style="font: 12px 'DejaVu Sans'" x="9.322266" y="-0.234375">-</tspan>
+    </text>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/lib/matplotlib/tests/baseline_images/test_mathtext/mathtext0_dejavusans_00.svg
+++ b/lib/matplotlib/tests/baseline_images/test_mathtext/mathtext0_dejavusans_00.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN"
+  "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg xmlns:xlink="http://www.w3.org/1999/xlink" width="378pt" height="54pt" viewBox="0 0 378 54" xmlns="http://www.w3.org/2000/svg" version="1.1">
+ <defs>
+  <style type="text/css">*{stroke-linejoin: round; stroke-linecap: butt}</style>
+ </defs>
+ <g id="figure_1">
+  <g id="text_1">
+   <!-- $-$- -->
+   <g transform="translate(181.8 30.31125)">
+    <text>
+     <tspan style="font: 12px 'DejaVu Sans'" x="0 10.054688" y="-0.734375">−-</tspan>
+    </text>
+   </g>
+  </g>
+ </g>
+</svg>

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -119,6 +119,7 @@ math_tests = [
 # 'svgastext' tests switch svg output to embed text as text (rather than as
 # paths).
 svgastext_math_tests = [
+    r'$-$-',
 ]
 # 'lightweight' tests test only a single fontset (dejavusans, which is the
 # default) and only png outputs, in order to minimize the size of baseline
@@ -206,11 +207,10 @@ def test_mathtext_rendering(baseline_images, fontset, index, text):
 
 @pytest.mark.parametrize('index, text', enumerate(svgastext_math_tests),
                          ids=range(len(svgastext_math_tests)))
-@pytest.mark.parametrize(
-    'fontset', ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif'])
+@pytest.mark.parametrize('fontset', ['cm', 'dejavusans'])
 @pytest.mark.parametrize('baseline_images', ['mathtext0'], indirect=True)
 @image_comparison(
-    baseline_images=None,
+    baseline_images=None, extensions=['svg'],
     savefig_kwarg={'metadata': {  # Minimize image size.
         'Creator': None, 'Date': None, 'Format': None, 'Type': None}})
 def test_mathtext_rendering_svgastext(baseline_images, fontset, index, text):


### PR DESCRIPTION
hyphen-to-unicode-minus replacement now occurs at the parsing stage, and
thus does not need to be done again in get_unicode_index (otherwise,
text hyphens also get incorrectly substituted.

Strictly speaking, one would need either to fully deprecate
get_unicode_index and replace it by a private helper (for which `math`
is always False), or introduce a deprecation period during which users
*must* pass the `math` kwarg (any value other than False results in a
warning) and then another one that deprecates that kwarg; which is quite
long; hopefully the change is in a private-enough part of the library
that we can just do it as is.

Also do some more changes to the mathtext-svg-text-only-tests that I
missed when the feature first went in: only test svg (that's the
point of it...) and only test two fonts: a "standard" truetype font --
the default dejavusans -- and the "cm" font, which has a very specific
encoding (see the BakomaFonts class).

Closes https://github.com/matplotlib/matplotlib/issues/23268, sorry about that :)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
