### PR TITLE
Add get/set methods for DPI in SubFigure

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2045,15 +2045,17 @@ class SubFigure(FigureBase):
     @dpi.setter
     def dpi(self, value):
         self._parent.dpi = value
-        
+
     def get_dpi(self):
-        """Return the resolution of the parent figure in dots-per-inch as a float."""
+        """
+        Return the resolution of the parent figure in dots-per-inch as a float.
+        """
         return self._parent.dpi
     
     def set_dpi(self, val):
         """
         Set the resolution of parent figure in dots-per-inch.
-        
+
         Parameters
         ----------
         val : float

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2045,6 +2045,21 @@ class SubFigure(FigureBase):
     @dpi.setter
     def dpi(self, value):
         self._parent.dpi = value
+        
+    def get_dpi(self):
+        """Return the resolution of the parent figure in dots-per-inch as a float."""
+        return self._parent.dpi
+    
+    def set_dpi(self, val):
+        """
+        Set the resolution of parent figure in dots-per-inch.
+        
+        Parameters
+        ----------
+        val : float
+        """
+        self._parent.dpi = val
+        self.stale = True
 
     def _get_renderer(self):
         return self._parent._get_renderer()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2051,7 +2051,7 @@ class SubFigure(FigureBase):
         Return the resolution of the parent figure in dots-per-inch as a float.
         """
         return self._parent.dpi
-    
+
     def set_dpi(self, val):
         """
         Set the resolution of parent figure in dots-per-inch.

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1108,6 +1108,14 @@ def test_subfigure_tightbbox():
             fig.get_tightbbox(fig.canvas.get_renderer()).width,
             8.0)
 
+def test_subfigure_dpi():
+    fig = plt.figure(dpi=100)
+    sub_fig = fig.subfigures()
+    assert sub_fig.get_dpi() == fig.get_dpi()
+    
+    sub_fig.set_dpi(200)
+    assert sub_fig.get_dpi() == 200
+    assert fig.get_dpi() == 200
 
 @image_comparison(['test_subfigure_ss.png'], style='mpl20',
                   savefig_kwarg={'facecolor': 'teal'})

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1108,14 +1108,16 @@ def test_subfigure_tightbbox():
             fig.get_tightbbox(fig.canvas.get_renderer()).width,
             8.0)
 
+
 def test_subfigure_dpi():
     fig = plt.figure(dpi=100)
     sub_fig = fig.subfigures()
     assert sub_fig.get_dpi() == fig.get_dpi()
-    
+
     sub_fig.set_dpi(200)
     assert sub_fig.get_dpi() == 200
     assert fig.get_dpi() == 200
+
 
 @image_comparison(['test_subfigure_ss.png'], style='mpl20',
                   savefig_kwarg={'facecolor': 'teal'})


### PR DESCRIPTION
## PR Summary

This fixes the following error: 

matplotlib\lib\text.py line 1489, dop = self.figure.get_dpi()/72. AttributeError: 'SubFigure' object has no attribute 'get_dpi'.

Effect: in v3.5.2 it is not possible to save a figure with a subfigure to a PDF.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A ] New features are documented, with examples if plot related.
- [N/A ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
