### PR TITLE
Remove internal use of get/set dpi

### DIFF
--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -53,7 +53,7 @@ class MixedModeRenderer:
         # the figure dpi before and after the rasterization. Although
         # this looks ugly, I couldn't find a better solution. -JJL
         self.figure = figure
-        self._figdpi = figure.get_dpi()
+        self._figdpi = figure.dpi
 
         self._bbox_inches_restore = bbox_inches_restore
 
@@ -74,7 +74,7 @@ class MixedModeRenderer:
         `stop_rasterizing` is called) will be drawn with the raster backend.
         """
         # change the dpi of the figure temporarily.
-        self.figure.set_dpi(self.dpi)
+        self.figure.dpi = self.dpi
         if self._bbox_inches_restore:  # when tight bbox is used
             r = process_figure_for_rasterizing(self.figure,
                                                self._bbox_inches_restore)
@@ -110,7 +110,7 @@ class MixedModeRenderer:
         self._raster_renderer = None
 
         # restore the figure dpi.
-        self.figure.set_dpi(self._figdpi)
+        self.figure.dpi = self._figdpi
 
         if self._bbox_inches_restore:  # when tight bbox is used
             r = process_figure_for_rasterizing(self.figure,

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2759,7 +2759,7 @@ class FigureCanvasPdf(FigureCanvasBase):
                   bbox_inches_restore=None, metadata=None):
 
         dpi = self.figure.dpi
-        self.figure.dpi = 72            # there are 72 pdf points to an inch
+        self.figure.dpi = 72  # there are 72 pdf points to an inch
         width, height = self.figure.get_size_inches()
         if isinstance(filename, PdfPages):
             file = filename._file

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2758,8 +2758,8 @@ class FigureCanvasPdf(FigureCanvasBase):
     def print_pdf(self, filename, *,
                   bbox_inches_restore=None, metadata=None):
 
-        dpi = self.figure.get_dpi()
-        self.figure.set_dpi(72)            # there are 72 pdf points to an inch
+        dpi = self.figure.dpi
+        self.figure.dpi = 72            # there are 72 pdf points to an inch
         width, height = self.figure.get_size_inches()
         if isinstance(filename, PdfPages):
             file = filename._file

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -812,7 +812,7 @@ class FigureCanvasPgf(FigureCanvasBase):
 
         # get figure size in inch
         w, h = self.figure.get_figwidth(), self.figure.get_figheight()
-        dpi = self.figure.get_dpi()
+        dpi = self.figure.dpi
 
         # create pgfpicture environment and write the pgf code
         fh.write(header_text)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -834,7 +834,7 @@ class FigureCanvasPS(FigureCanvasBase):
             **kwargs):
 
         dpi = self.figure.dpi
-        self.figure.dpi = 72   # Override the dpi kwarg
+        self.figure.dpi = 72  # Override the dpi kwarg
 
         dsc_comments = {}
         if isinstance(outfile, (str, os.PathLike)):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -833,8 +833,8 @@ class FigureCanvasPS(FigureCanvasBase):
             metadata=None, papertype=None, orientation='portrait',
             **kwargs):
 
-        dpi = self.figure.get_dpi()
-        self.figure.set_dpi(72)  # Override the dpi kwarg
+        dpi = self.figure.dpi
+        self.figure.dpi = 72 # Override the dpi kwarg
 
         dsc_comments = {}
         if isinstance(outfile, (str, os.PathLike)):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -834,7 +834,7 @@ class FigureCanvasPS(FigureCanvasBase):
             **kwargs):
 
         dpi = self.figure.dpi
-        self.figure.dpi = 72 # Override the dpi kwarg
+        self.figure.dpi = 72   # Override the dpi kwarg
 
         dsc_comments = {}
         if isinstance(outfile, (str, os.PathLike)):

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1335,8 +1335,8 @@ class FigureCanvasSVG(FigureCanvasBase):
         with cbook.open_file_cm(filename, "w", encoding="utf-8") as fh:
             if not cbook.file_requires_unicode(fh):
                 fh = codecs.getwriter('utf-8')(fh)
-            dpi = self.figure.get_dpi()
-            self.figure.set_dpi(72)
+            dpi = self.figure.dpi
+            self.figure.dpi = 72
             width, height = self.figure.get_size_inches()
             w, h = width * 72, height * 72
             renderer = MixedModeRenderer(

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1252,7 +1252,7 @@ def test_subfigure_pdf():
     fig = plt.figure(layout='constrained')
     sub_fig = fig.subfigures()
     ax = sub_fig.add_subplot(111)
-    b = ax.bar(1,1)
+    b = ax.bar(1, 1)
     ax.bar_label(b)
     buffer = io.BytesIO()
     fig.savefig(buffer, format='pdf')

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1247,6 +1247,11 @@ def test_subfigure_scatter_size():
         ax.scatter([1, 2, 3], [1, 2, 3], s=30, marker='s', color='r')
         ax.scatter([3, 4, 5], [1, 2, 3], s=[20, 30, 40], marker='s', color='g')
 
+def test_subfigure_pdf():
+    fig = plt.figure(layout='constrained')
+    fig.subfigures()
+    buffer = io.StringIO()
+    fig.savefig(buffer, format='pdf')
 
 def test_add_subplot_kwargs():
     # fig.add_subplot() always creates new axes, even if axes kwargs differ.

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1247,11 +1247,16 @@ def test_subfigure_scatter_size():
         ax.scatter([1, 2, 3], [1, 2, 3], s=30, marker='s', color='r')
         ax.scatter([3, 4, 5], [1, 2, 3], s=[20, 30, 40], marker='s', color='g')
 
+
 def test_subfigure_pdf():
     fig = plt.figure(layout='constrained')
-    fig.subfigures()
-    buffer = io.StringIO()
+    sub_fig = fig.subfigures()
+    ax = sub_fig.add_subplot(111)
+    b = ax.bar(1,1)
+    ax.bar_label(b)
+    buffer = io.BytesIO()
     fig.savefig(buffer, format='pdf')
+
 
 def test_add_subplot_kwargs():
     # fig.add_subplot() always creates new axes, even if axes kwargs differ.

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -590,8 +590,8 @@ def test_invalid_layouts():
 
 @check_figures_equal(extensions=["png", "pdf"])
 def test_add_artist(fig_test, fig_ref):
-    fig_test.set_dpi(100)
-    fig_ref.set_dpi(100)
+    fig_test.dpi = 100
+    fig_ref.dpi = 100
 
     fig_test.subplots()
     l1 = plt.Line2D([.2, .7], [.7, .7], gid='l1')
@@ -1222,10 +1222,10 @@ def test_subfigure_ticks():
     ax2.scatter(x=[-126.5357270050049, 94.68456736755368], y=[1500, 3600])
     ax3 = subfig_bl.add_subplot(gs[0, 3:14], sharey=ax1)
 
-    fig.set_dpi(120)
+    fig.dpi = 120
     fig.draw_without_rendering()
     ticks120 = ax2.get_xticks()
-    fig.set_dpi(300)
+    fig.dpi = 300
     fig.draw_without_rendering()
     ticks300 = ax2.get_xticks()
     np.testing.assert_allclose(ticks120, ticks300)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1503,7 +1503,7 @@ class _AnnotationBase:
             ref_x, ref_y = xy0
             if unit == "points":
                 # dots per points
-                dpp = self.figure.dpi / 72.
+                dpp = self.figure.dpi / 72
                 tr = Affine2D().scale(dpp)
             elif unit == "pixels":
                 tr = Affine2D()

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1509,7 +1509,7 @@ class _AnnotationBase:
                 tr = Affine2D()
             elif unit == "fontsize":
                 fontsize = self.get_size()
-                dpp = fontsize * self.figure.dpi / 72.
+                dpp = fontsize * self.figure.dpi / 72
                 tr = Affine2D().scale(dpp)
             elif unit == "fraction":
                 w, h = bbox0.size

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1503,13 +1503,13 @@ class _AnnotationBase:
             ref_x, ref_y = xy0
             if unit == "points":
                 # dots per points
-                dpp = self.figure.get_dpi() / 72.
+                dpp = self.figure.dpi / 72.
                 tr = Affine2D().scale(dpp)
             elif unit == "pixels":
                 tr = Affine2D()
             elif unit == "fontsize":
                 fontsize = self.get_size()
-                dpp = fontsize * self.figure.get_dpi() / 72.
+                dpp = fontsize * self.figure.dpi / 72.
                 tr = Affine2D().scale(dpp)
             elif unit == "fraction":
                 w, h = bbox0.size


### PR DESCRIPTION
## PR Summary

There has been a mismatch between use dpi property and get/set methods internally. This has caused bugs for SubFigure objects. Please see my previous PR for more details on the issues.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
