### PR TITLE
Correct URL area with rotated texts in PDFs

### DIFF
--- a/doc/users/next_whats_new/url_active_areas_rotate.rst
+++ b/doc/users/next_whats_new/url_active_areas_rotate.rst
@@ -1,5 +1,5 @@
 The active URL area rotates when link text is rotated
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When link text is rotated in a matplotlib figure, the active URL 
-area will now include the link area. Previously, the active area 
+When link text is rotated in a matplotlib figure, the active URL
+area will now include the link area. Previously, the active area
 remained in the original, non-rotated, position.

--- a/doc/users/next_whats_new/url_active_areas_rotate.rst
+++ b/doc/users/next_whats_new/url_active_areas_rotate.rst
@@ -1,0 +1,5 @@
+The active URL area rotates when link text is rotated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When link text is rotated in a matplotlib figure, the active URL 
+area will now include the link area. Previously, the active area 
+remained in the original, non-rotated, position.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -282,10 +282,11 @@ def _get_coordinates_of_block(x, y, width, height, angle=0):
     # outside Rect, but for Acrobat it is enough that QuadPoints is on the
     # border of Rect.
 
-    min_x = min(v[0] for v in vertices) - 0.00001
-    min_y = min(v[1] for v in vertices) - 0.00001
-    max_x = max(v[0] for v in vertices) + 0.00001
-    max_y = max(v[1] for v in vertices) + 0.00001
+    pad = 0.00001 if angle % 90  else 0
+    min_x = min(v[0] for v in vertices) - pad 
+    min_y = min(v[1] for v in vertices) - pad 
+    max_x = max(v[0] for v in vertices) + pad 
+    max_y = max(v[1] for v in vertices) + pad 
     return (tuple(itertools.chain.from_iterable(vertices)),
             (min_x, min_y, max_x, max_y))
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -282,11 +282,11 @@ def _get_coordinates_of_block(x, y, width, height, angle=0):
     # outside Rect, but for Acrobat it is enough that QuadPoints is on the
     # border of Rect.
 
-    pad = 0.00001 if angle % 90  else 0
-    min_x = min(v[0] for v in vertices) - pad 
-    min_y = min(v[1] for v in vertices) - pad 
-    max_x = max(v[0] for v in vertices) + pad 
-    max_y = max(v[1] for v in vertices) + pad 
+    pad = 0.00001 if angle % 90 else 0
+    min_x = min(v[0] for v in vertices) - pad
+    min_y = min(v[1] for v in vertices) - pad
+    max_x = max(v[0] for v in vertices) + pad
+    max_y = max(v[1] for v in vertices) + pad
     return (tuple(itertools.chain.from_iterable(vertices)),
             (min_x, min_y, max_x, max_y))
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -275,10 +275,10 @@ def _get_coordinates_of_block(x, y, width, height, angle=0):
     vertices = _calculate_quad_point_coordinates(x, y, width,
                                                     height, angle)
 
-    min_x = min(vertices[0][0], vertices[1][0], vertices[2][0], vertices[3][0])
-    min_y = min(vertices[0][1], vertices[1][1], vertices[2][1], vertices[3][1])
-    max_x = max(vertices[0][0], vertices[1][0], vertices[2][0], vertices[3][0])
-    max_y = max(vertices[0][1], vertices[1][1], vertices[2][1], vertices[3][1])
+    min_x = min(v[0] for v in vertices)
+    min_y = min(v[1] for v in vertices)
+    max_x = max(v[0] for v in vertices)
+    max_y = max(v[1] for v in vertices)
     return vertices, (min_x, min_y, max_x, max_y)
 
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -299,7 +299,7 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),
-        'Rect': [x, y, x + width, y + height],
+        'Rect': rect,
         'Border': [0, 0, 0],
         'A': {
             'S': Name('URI'),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -249,15 +249,21 @@ def _datetime_to_pdf(d):
         r += "-%02d'%02d'" % (z // 3600, z % 3600)
     return r
 
+def _get_coordinated_from_angle(x, y, width, height, phi = 0):
+    """
+    Calculate the coordinates of the URL-active area
+    and take an angle of rotation into account.
+    """
+    return (x, y, x + math.cos(phi + math.atan(height / width)), math.sin(phi + math.atan(height / width)))
 
-def _get_link_annotation(gc, x, y, width, height):
+def _get_link_annotation(gc, x, y, width, height, angle = 0):
     """
     Create a link annotation object for embedding URLs.
     """
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),
-        'Rect': (x, y, x + width, y + height),
+        'Rect': _get_coordinated_from_angle(x, y, width, height, angle),
         'Border': [0, 0, 0],
         'A': {
             'S': Name('URI'),
@@ -2172,7 +2178,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
 
         if gc.get_url() is not None:
             self.file._annotations[-1][1].append(_get_link_annotation(
-                gc, x, y, width, height))
+                gc, x, y, width, height, angle))
 
         fonttype = mpl.rcParams['pdf.fonttype']
 
@@ -2229,7 +2235,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
 
         if gc.get_url() is not None:
             self.file._annotations[-1][1].append(_get_link_annotation(
-                gc, x, y, page.width, page.height))
+                gc, x, y, page.width, page.height, angle))
 
         # Gather font information and do some setup for combining
         # characters into strings. The variable seq will contain a
@@ -2330,7 +2336,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             font.set_text(s)
             width, height = font.get_width_height()
             self.file._annotations[-1][1].append(_get_link_annotation(
-                gc, x, y, width / 64, height / 64))
+                gc, x, y, width / 64, height / 64, angle))
 
         # If fonttype is neither 3 nor 42, emit the whole string at once
         # without manual kerning.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -286,6 +286,7 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
     """
     Create a link annotation object for embedding URLs.
     """
+    quadpoints, rect = _get_coordinates_of_block(x, y, width, height, angle)
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -295,6 +295,7 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
     """
     Create a link annotation object for embedding URLs.
     """
+    quadpoints, rect = _get_coordinates_of_block(x, y, width, height, angle)
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -291,7 +291,7 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
         'Type': Name('Annot'),
         'Subtype': Name('Link'),
         'Rect': rect,
-        'QuadPoint': quadpoint,
+        'QuadPoint': quadpoints,
         'Border': [0, 0, 0],
         'A': {
             'S': Name('URI'),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -263,7 +263,7 @@ def _calculate_quad_point_coordinates(x, y, width, height, angle=0):
     d = y - width * math.sin(angle) + height * math.cos(angle)
     e = x + width * math.cos(angle)
     f = y - width * math.sin(angle)
-    return ((a, b), (c, d), (e, f))
+    return ((x, y), (a, b), (c, d), (e, f))
 
 
 def _get_coordinates_of_block(x, y, width, height, angle=0):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -257,12 +257,12 @@ def _calculate_quad_point_coordinates(x, y, width, height, angle=0):
     """
 
     angle = math.radians(angle)
-    a = x - x * math.cos(angle) + (height - y) * math.sin(angle)
-    b = y + x * math.sin(angle) + (height - y) * math.cos(angle)
-    c = x + (width - x) * math.cos(angle) + (height - y) * math.sin(angle)
-    d = y - (width - x) * math.sin(angle) + (height - y) * math.cos(angle)
-    e = x + (width - x) * math.cos(angle) - y * math.sin(angle)
-    f = y - (width - x) * math.sin(angle) - y * math.cos(angle)
+    a = x + height * math.sin(angle)
+    b = y + height * math.cos(angle)
+    c = x + width * math.cos(angle) + height * math.sin(angle)
+    d = y - width * math.sin(angle) + height * math.cos(angle)
+    e = x + width * math.cos(angle)
+    f = y - width * math.sin(angle)
     return ((a, b), (c, d), (e, f))
 
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -266,17 +266,20 @@ def _calculate_quad_point_coordinates(x, y, width, height, angle=0):
     return ((a, b), (c, d), (e, f))
 
 
-def _get_coordinates_from_angle(x, y, width, height, angle=0):
+def _get_coordinates_of_block(x, y, width, height, angle=0):
     """
-    Calculate the coordinates of the URL-active area
-    and take an angle of rotation into account.
+    Get the coordinates of a rectange that contains the URL text.
+    This is for use in PDF < v1.6
     """
 
-    hypot = math.hypot(width, height)
-    angle = math.radians(angle)
+    vertices = _calculate_quad_point_coordinates(x, y, width,
+                                                    height, angle)
 
-    return (x, y, x + hypot * math.cos(angle + math.atan(height / width)),
-            hypot * math.sin(angle + math.atan(height / width)))
+    min_x = min(vertices[0][0], vertices[1][0], vertices[2][0], vertices[3][0])
+    min_y = min(vertices[0][1], vertices[1][1], vertices[2][1], vertices[3][1])
+    max_x = max(vertices[0][0], vertices[1][0], vertices[2][0], vertices[3][0])
+    max_y = max(vertices[0][1], vertices[1][1], vertices[2][1], vertices[3][1])
+    return (min_x, min_y, max_x, max_y)
 
 
 def _get_link_annotation(gc, x, y, width, height, angle=0):
@@ -286,7 +289,7 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),
-        'Rect': _get_coordinates_from_angle(x, y, width, height, angle),
+        'Rect': _get_coordinates_of_block(x, y, width, height, angle),
         'QuadPoint': _calculate_quad_point_coordinates(x, y, width,
                                                         height, angle),
         'Border': [0, 0, 0],

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -249,14 +249,17 @@ def _datetime_to_pdf(d):
         r += "-%02d'%02d'" % (z // 3600, z % 3600)
     return r
 
-def _get_coordinated_from_angle(x, y, width, height, phi = 0):
+
+def _get_coordinated_from_angle(x, y, width, height, angle=0):
     """
     Calculate the coordinates of the URL-active area
     and take an angle of rotation into account.
     """
-    return (x, y, x + math.cos(phi + math.atan(height / width)), math.sin(phi + math.atan(height / width)))
+    return (x, y, x + math.cos(angle + math.atan(height / width)), 
+            math.sin(angle + math.atan(height / width)))
 
-def _get_link_annotation(gc, x, y, width, height, angle = 0):
+
+def _get_link_annotation(gc, x, y, width, height, angle=0):
     """
     Create a link annotation object for embedding URLs.
     """

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -279,7 +279,7 @@ def _get_coordinates_of_block(x, y, width, height, angle=0):
     min_y = min(vertices[0][1], vertices[1][1], vertices[2][1], vertices[3][1])
     max_x = max(vertices[0][0], vertices[1][0], vertices[2][0], vertices[3][0])
     max_y = max(vertices[0][1], vertices[1][1], vertices[2][1], vertices[3][1])
-    return (min_x, min_y, max_x, max_y)
+    return vertices, (min_x, min_y, max_x, max_y)
 
 
 def _get_link_annotation(gc, x, y, width, height, angle=0):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -250,6 +250,23 @@ def _datetime_to_pdf(d):
     return r
 
 
+def _get_link_annotation(gc, x, y, width, height):
+    """
+    Create a link annotation object for embedding URLs.
+    """
+    link_annotation = {
+        'Type': Name('Annot'),
+        'Subtype': Name('Link'),
+        'Rect': (x, y, x + width, y + height),
+        'Border': [0, 0, 0],
+        'A': {
+            'S': Name('URI'),
+            'URI': gc.get_url(),
+        },
+    }
+    return link_annotation
+
+
 def pdfRepr(obj):
     """Map Python objects to PDF syntax."""
 
@@ -2154,17 +2171,8 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             self._text2path.mathtext_parser.parse(s, 72, prop)
 
         if gc.get_url() is not None:
-            link_annotation = {
-                'Type': Name('Annot'),
-                'Subtype': Name('Link'),
-                'Rect': (x, y, x + width, y + height),
-                'Border': [0, 0, 0],
-                'A': {
-                    'S': Name('URI'),
-                    'URI': gc.get_url(),
-                },
-            }
-            self.file._annotations[-1][1].append(link_annotation)
+            self.file._annotations[-1][1].append(_get_link_annotation(
+                gc, x, y, width, height))
 
         fonttype = mpl.rcParams['pdf.fonttype']
 
@@ -2220,17 +2228,8 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             page, = dvi
 
         if gc.get_url() is not None:
-            link_annotation = {
-                'Type': Name('Annot'),
-                'Subtype': Name('Link'),
-                'Rect': (x, y, x + page.width, y + page.height),
-                'Border': [0, 0, 0],
-                'A': {
-                    'S': Name('URI'),
-                    'URI': gc.get_url(),
-                },
-            }
-            self.file._annotations[-1][1].append(link_annotation)
+            self.file._annotations[-1][1].append(_get_link_annotation(
+                gc, x, y, page.width, page.height))
 
         # Gather font information and do some setup for combining
         # characters into strings. The variable seq will contain a
@@ -2330,17 +2329,8 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         if gc.get_url() is not None:
             font.set_text(s)
             width, height = font.get_width_height()
-            link_annotation = {
-                'Type': Name('Annot'),
-                'Subtype': Name('Link'),
-                'Rect': (x, y, x + width / 64, y + height / 64),
-                'Border': [0, 0, 0],
-                'A': {
-                    'S': Name('URI'),
-                    'URI': gc.get_url(),
-                },
-            }
-            self.file._annotations[-1][1].append(link_annotation)
+            self.file._annotations[-1][1].append(_get_link_annotation(
+                gc, x, y, width / 64, height / 64))
 
         # If fonttype is neither 3 nor 42, emit the whole string at once
         # without manual kerning.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -268,7 +268,7 @@ def _calculate_quad_point_coordinates(x, y, width, height, angle=0):
 
 def _get_coordinates_of_block(x, y, width, height, angle=0):
     """
-    Get the coordinates of a rectange that contains the URL text.
+    Get the coordinates of a rectangle that contains the URL text.
     This is for use in PDF < v1.6
     """
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -290,9 +290,8 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),
-        'Rect': _get_coordinates_of_block(x, y, width, height, angle),
-        'QuadPoint': _calculate_quad_point_coordinates(x, y, width,
-                                                        height, angle),
+        'Rect': rect,
+        'QuadPoint': quadpoint,
         'Border': [0, 0, 0],
         'A': {
             'S': Name('URI'),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -307,10 +307,8 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
         },
     }
     if angle % 90:
-        # Get QuadPoints and new rect
-        quadpoints, rect = _get_coordinates_of_block(x, y, width,
-                                                     height, angle)
-        link_annotation.update({'Rect': rect, 'QuadPoints': quadpoints})
+        # Add QuadPoints
+        link_annotation['QuadPoints'] = quadpoints
     return link_annotation
 
 

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -250,13 +250,33 @@ def _datetime_to_pdf(d):
     return r
 
 
-def _get_coordinated_from_angle(x, y, width, height, angle=0):
+def _calculate_quad_point_coordinates(x, y, width, height, angle=0):
+    """
+    Uses matrix maths to calculate the coordinates of a
+    rectangle when rotated by angle around x, y
+    """
+
+    angle = math.radians(angle)
+    a = x - x * math.cos(angle) + (height - y) * math.sin(angle)
+    b = y + x * math.sin(angle) + (height - y) * math.cos(angle)
+    c = x + (width - x) * math.cos(angle) + (height - y) * math.sin(angle)
+    d = y - (width - x) * math.sin(angle) + (height - y) * math.cos(angle)
+    e = x + (width - x) * math.cos(angle) - y * math.sin(angle)
+    f = y - (width - x) * math.sin(angle) - y * math.cos(angle)
+    return ((a, b), (c, d), (e, f))
+
+
+def _get_coordinates_from_angle(x, y, width, height, angle=0):
     """
     Calculate the coordinates of the URL-active area
     and take an angle of rotation into account.
     """
-    return (x, y, x + math.cos(angle + math.atan(height / width)), 
-            math.sin(angle + math.atan(height / width)))
+
+    hypot = math.hypot(width, height)
+    angle = math.radians(angle)
+
+    return (x, y, x + hypot * math.cos(angle + math.atan(height / width)),
+            hypot * math.sin(angle + math.atan(height / width)))
 
 
 def _get_link_annotation(gc, x, y, width, height, angle=0):
@@ -266,7 +286,9 @@ def _get_link_annotation(gc, x, y, width, height, angle=0):
     link_annotation = {
         'Type': Name('Annot'),
         'Subtype': Name('Link'),
-        'Rect': _get_coordinated_from_angle(x, y, width, height, angle),
+        'Rect': _get_coordinates_from_angle(x, y, width, height, angle),
+        'QuadPoint': _calculate_quad_point_coordinates(x, y, width,
+                                                        height, angle),
         'Border': [0, 0, 0],
         'A': {
             'S': Name('URI'),

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -256,13 +256,15 @@ def _calculate_quad_point_coordinates(x, y, width, height, angle=0):
     rectangle when rotated by angle around x, y
     """
 
-    angle = math.radians(angle)
-    a = x + height * math.sin(angle)
-    b = y + height * math.cos(angle)
-    c = x + width * math.cos(angle) + height * math.sin(angle)
-    d = y - width * math.sin(angle) + height * math.cos(angle)
-    e = x + width * math.cos(angle)
-    f = y - width * math.sin(angle)
+    angle = math.radians(-angle)
+    sin_angle = math.sin(angle)
+    cos_angle = math.cos(angle)
+    a = x + height * sin_angle
+    b = y + height * cos_angle
+    c = x + width * cos_angle + height * sin_angle
+    d = y - width * sin_angle + height * cos_angle
+    e = x + width * cos_angle
+    f = y - width * sin_angle
     return ((x, y), (a, b), (c, d), (e, f))
 
 

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -253,8 +253,8 @@ def test_text_rotated_urls():
     test_url = 'https://test_text_urls.matplotlib.org/'
 
     fig = plt.figure(figsize=(2, 1))
-    text = fig.text(0.1, 0.1, 'test plain 123', rotation=45, url=f'{test_url}')
-    
+    fig.text(0.1, 0.1, 'test plain 123', rotation=45, url=f'{test_url}')
+
     with io.BytesIO() as fd:
         fig.savefig(fd, format='pdf')
 

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -270,7 +270,8 @@ def test_text_rotated_urls():
             assert annot is not None
             assert getattr(annot, 'QuadPoints', None) is not None
             # Positions in points (72 per inch)
-            assert annot.Rect[0] == annot.QuadPoints[6] - decimal.Decimal('0.00001')
+            assert annot.Rect[0] == \
+               annot.QuadPoints[6] - decimal.Decimal('0.00001')
 
 
 @needs_usetex

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -268,8 +268,10 @@ def test_text_rotated_urls():
                 None)
             assert annot is not None
             # Positions in points (72 per inch.) Figure is 2 inches
-            assert annot.QuadPoint[0][0] / 72 / 2 == pytest.approx(decimal.Decimal('0.1'), abs=1e-1)
-            assert annot.QuadPoint[1][0] / 72 / 2 == pytest.approx(decimal.Decimal('0.08'), abs=1e-1)
+            assert annot.QuadPoint[0][0] / 72 / 2 ==  \
+                pytest.approx(decimal.Decimal('0.1'), abs=1e-1)
+            assert annot.QuadPoint[1][0] / 72 / 2 == \
+                pytest.approx(decimal.Decimal('0.08'), abs=1e-1)
             assert annot.Rect[0] == annot.QuadPoint[1][0]
 
 


### PR DESCRIPTION
## PR Summary
This ticket closes #23205
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
