### PR TITLE
In the new/simplified backend API, don't customize draw_if_interactive.

### DIFF
--- a/doc/api/next_api_changes/removals/23291-AL.rst
+++ b/doc/api/next_api_changes/removals/23291-AL.rst
@@ -1,0 +1,4 @@
+``backend_template.new_figure_manager``, ``backend_template.new_figure_manager_given_figure``, and ``backend_template.draw_if_interactive``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... have been removed, as part of the introduction of the simplified backend
+API.

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -136,14 +136,6 @@ class GraphicsContextTemplate(GraphicsContextBase):
 ########################################################################
 
 
-def draw_if_interactive():
-    """
-    For image backends - is not required.
-    For GUI backends - this should be overridden if drawing should be done in
-    interactive python mode.
-    """
-
-
 def show(*, block=None):
     """
     For image backends - is not required.
@@ -154,24 +146,6 @@ def show(*, block=None):
     for manager in Gcf.get_all_fig_managers():
         # do something to display the GUI
         pass
-
-
-def new_figure_manager(num, *args, FigureClass=Figure, **kwargs):
-    """Create a new figure manager instance."""
-    thisFig = FigureClass(*args, **kwargs)
-    return new_figure_manager_given_figure(num, thisFig)
-
-
-def new_figure_manager_given_figure(num, figure):
-    """Create a new figure manager instance for the given figure."""
-    # If a main-level app must be created, this is the usual place to do it
-    # -- see the wx and tk backends for examples (the default implementation
-    # of new_figure_manager defers to new_figure_manager_given_figure, so it
-    # also benefits from this instantiation).  Not all GUIs require explicit
-    # instantiation of a main-level app (e.g., backend_gtk3) for pylab.
-    canvas = FigureCanvasTemplate(figure)
-    manager = FigureManagerTemplate(canvas, num)
-    return manager
 
 
 class FigureManagerTemplate(FigureManagerBase):
@@ -199,6 +173,9 @@ class FigureCanvasTemplate(FigureCanvasBase):
         A high-level Figure instance
     """
 
+    # The instantiated manager class.  For further customization,
+    # ``FigureManager.create_with_canvas`` can also be overridden; see the
+    # wx-based backends for an example.
     manager_class = FigureManagerTemplate
 
     def draw(self):

--- a/lib/matplotlib/tests/test_backend_template.py
+++ b/lib/matplotlib/tests/test_backend_template.py
@@ -8,16 +8,22 @@ from types import SimpleNamespace
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib.backends import backend_template
+from matplotlib.backends.backend_template import (
+    FigureCanvasTemplate, FigureManagerTemplate)
 
 
 def test_load_template():
     mpl.use("template")
-    assert type(plt.figure().canvas) == backend_template.FigureCanvasTemplate
+    assert type(plt.figure().canvas) == FigureCanvasTemplate
 
 
-def test_new_manager(monkeypatch):
+def test_load_old_api(monkeypatch):
     mpl_test_backend = SimpleNamespace(**vars(backend_template))
-    del mpl_test_backend.new_figure_manager
+    mpl_test_backend.new_figure_manager = (
+        lambda num, *args, FigureClass=mpl.figure.Figure, **kwargs:
+        FigureManagerTemplate(
+            FigureCanvasTemplate(FigureClass(*args, **kwargs)), num))
     monkeypatch.setitem(sys.modules, "mpl_test_backend", mpl_test_backend)
     mpl.use("module://mpl_test_backend")
-    assert type(plt.figure().canvas) == backend_template.FigureCanvasTemplate
+    assert type(plt.figure().canvas) == FigureCanvasTemplate
+    plt.draw_if_interactive()


### PR DESCRIPTION
The customization point is not really needed (it can go into the canvas
constructor or manager.show or a few other places), but removing support
for it would be a bit tricky if not coupled with the introduction of a
new API (manager_class).  This way, we can simply say "if you want to
use the new API, then you cannot customize draw_if_interactive".

backend_template gets updated without deprecation as the point of that
backend is really to be documentation for what a backend module is;
moreover, putting a deprecation on new_figure_manager (for example)
would actually be counter-productive as pyplot would still try to call
that function (and thus emit a warning, even though the backend itself
is not deprecated).

Closes #23105.  See that PR for a more detailed discussion.

Once merged, the documentation added at #23101 will need a slight tweak as well.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
