### PR TITLE
FIX/API: do not reset backend key in rc_context

### DIFF
--- a/doc/api/next_api_changes/behavior/23299-TAC.rst
+++ b/doc/api/next_api_changes/behavior/23299-TAC.rst
@@ -1,9 +1,6 @@
-mpl.rc_context no longer resests the `'backend'` key
+mpl.rc_context no longer resests the value of `rcParams['backend']`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-If you want to rest :rc:`backend` after the context, you must use
-`matplotlib.use` to change the backend.  Previously the key would be reset, but
-it would have any of the expected side-effects because internally
-`matplotlib.rc_context` side-steps the custom logic in the
-`~matplotlib.RcParams` class (because we copied the values from ``rcParamms``
-so it does not need to be re-validated.
+`matplotlib.rc_context` did incorrectly reset the value of `rcParams['backend']` if backend
+resolution was triggered in the context. This affected only the value. The actual backend
+was not reset. Now, `matpotlib.rc_context` dose not modify `rcParams['backend']` anymore.

--- a/doc/api/next_api_changes/behavior/23299-TAC.rst
+++ b/doc/api/next_api_changes/behavior/23299-TAC.rst
@@ -1,4 +1,4 @@
-mpl.rc_context no longer resets the value of :rc:`backend`
+mpl.rc_context no longer resets the value of ``'backend'``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 `matplotlib.rc_context` incorrectly reset the value of :rc:`backend` if backend

--- a/doc/api/next_api_changes/behavior/23299-TAC.rst
+++ b/doc/api/next_api_changes/behavior/23299-TAC.rst
@@ -1,6 +1,6 @@
-mpl.rc_context no longer resests the value of `rcParams['backend']`
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+mpl.rc_context no longer resets the value of :rc:`backend`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-`matplotlib.rc_context` did incorrectly reset the value of `rcParams['backend']` if backend
+`matplotlib.rc_context` incorrectly reset the value of :rc:`backend` if backend
 resolution was triggered in the context. This affected only the value. The actual backend
-was not reset. Now, `matpotlib.rc_context` dose not modify `rcParams['backend']` anymore.
+was not changed. Now, `matplotlib.rc_context` does not reset  :rc:`backend` anymore.

--- a/doc/api/next_api_changes/behavior/23299-TAC.rst
+++ b/doc/api/next_api_changes/behavior/23299-TAC.rst
@@ -1,0 +1,9 @@
+mpl.rc_context no longer resests the `'backend'` key
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+If you want to rest :rc:`backend` after the context, you must use
+`matplotlib.use` to change the backend.  Previously the key would be reset, but
+it would have any of the expected side-effects because internally
+`matplotlib.rc_context` side-steps the custom logic in the
+`~matplotlib.RcParams` class (because we copied the values from ``rcParamms``
+so it does not need to be re-validated.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1059,6 +1059,8 @@ def rc_context(rc=None, fname=None):
     """
     Return a context manager for temporarily changing rcParams.
 
+    The :rc:`backend` will not be reset by the context manager.
+
     Parameters
     ----------
     rc : dict
@@ -1087,7 +1089,8 @@ def rc_context(rc=None, fname=None):
              plt.plot(x, y)  # uses 'print.rc'
 
     """
-    orig = rcParams.copy()
+    orig = dict(rcParams.copy())
+    del orig['backend']
     try:
         if fname:
             rc_file(fname)

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -496,6 +496,13 @@ def test_keymaps():
         assert isinstance(mpl.rcParams[k], list)
 
 
+def test_no_backend_reset_rccontext():
+    assert mpl.rcParams['backend'] != 'module://aardvark'
+    with mpl.rc_context():
+        mpl.rcParams['backend'] = 'module://aardvark'
+    assert mpl.rcParams['backend'] == 'module://aardvark'
+
+
 def test_rcparams_reset_after_fail():
     # There was previously a bug that meant that if rc_context failed and
     # raised an exception due to issues in the supplied rc parameters, the


### PR DESCRIPTION
The motivating issue is that if the backend was the auto backend sentinel and
the backend was first fully resolved in an `rc_context` block, then we would
reset back to the sentinel an exit which would lead to strange behavior with
figures being erroneously closed.

~Adding a general purpose exclusion list seems like a better option than special
casing either the backend key or the backend value.~

Special case `'backend'` key to not be reset.

Closes #23298

~If people like this idea I will write the tests and docs. ~

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
