### PR TITLE
Drop CSS styles that are in mpl-sphinx-theme

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -3,15 +3,6 @@
     --sd-color-primary-highlight: #003c63;
 }
 
-a {
-    color: #11557C;
-    text-decoration: none;
-}
-
-a:hover {
-    color:  #CA7900;
-}
-
 .simple li>p {
     margin: 0;
 }
@@ -93,10 +84,6 @@ img.sphx-glr-multi-img {
 table.property-table th,
 table.property-table td {
     padding: 4px 10px;
-}
-
-.sidebar-cheatsheets, .sidebar-donate {
-    margin: 2.75rem 0;
 }
 
 /* Fix selection of parameter names; remove when fixed in the theme


### PR DESCRIPTION
## PR Summary

As a corollary to https://github.com/matplotlib/mpl-sphinx-theme/pull/36

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).