### PR TITLE
DOC: improve spines crosslinking

### DIFF
--- a/examples/spines/spines.py
+++ b/examples/spines/spines.py
@@ -8,6 +8,9 @@ This demo compares:
 - normal Axes, with spines on all four sides;
 - an Axes with spines only on the left and bottom;
 - an Axes using custom bounds to limit the extent of the spine.
+
+Each `.axes.Axes` has a list of `.Spine` objects, accessible
+via the container ``ax.spines``.
 """
 import numpy as np
 import matplotlib.pyplot as plt
@@ -44,3 +47,12 @@ ax2.yaxis.set_ticks_position('left')
 ax2.xaxis.set_ticks_position('bottom')
 
 plt.show()
+
+# .. admonition:: References
+#
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.Spines.set_visible`
+#    - `matplotlib.Spines.set_bounds`
+#    - `matplotlib.axis.set_ticks_position`

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -27,6 +27,7 @@ class Spine(mpatches.Patch):
     `~.Spine.set_patch_line`, `~.Spine.set_patch_circle`, or
     `~.Spine.set_patch_arc` has been called. Line-like is the default.
 
+    For examples see :ref:`spines_examples`.
     """
     def __str__(self):
         return "Spine"


### PR DESCRIPTION
## PR Summary

It is really hard to find the Spine class  from the examples given, and it is hard to find the examples from the Spine class.  This attempts to improve that...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
