### PR TITLE
No need to return OrderedDict from _gen_axes_spines.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 from collections.abc import MutableSequence
 from contextlib import ExitStack
 import functools
@@ -1160,8 +1159,8 @@ class _AxesBase(martist.Artist):
         -----
         Intended to be overridden by new projection types.
         """
-        return OrderedDict((side, mspines.Spine.linear_spine(self, side))
-                           for side in ['left', 'right', 'bottom', 'top'])
+        return {side: mspines.Spine.linear_spine(self, side)
+                for side in ['left', 'right', 'bottom', 'top']}
 
     def sharex(self, other):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import math
 import types
 
@@ -12,7 +11,7 @@ import matplotlib.patches as mpatches
 from matplotlib.path import Path
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
-import matplotlib.spines as mspines
+from matplotlib.spines import Spine
 
 
 class PolarTransform(mtransforms.Transform):
@@ -964,14 +963,12 @@ class PolarAxes(Axes):
         return mpatches.Wedge((0.5, 0.5), 0.5, 0.0, 360.0)
 
     def _gen_axes_spines(self):
-        spines = OrderedDict([
-            ('polar', mspines.Spine.arc_spine(self, 'top',
-                                              (0.5, 0.5), 0.5, 0.0, 360.0)),
-            ('start', mspines.Spine.linear_spine(self, 'left')),
-            ('end', mspines.Spine.linear_spine(self, 'right')),
-            ('inner', mspines.Spine.arc_spine(self, 'bottom',
-                                              (0.5, 0.5), 0.0, 0.0, 360.0))
-        ])
+        spines = {
+            'polar': Spine.arc_spine(self, 'top', (0.5, 0.5), 0.5, 0, 360),
+            'start': Spine.linear_spine(self, 'left'),
+            'end': Spine.linear_spine(self, 'right'),
+            'inner': Spine.arc_spine(self, 'bottom', (0.5, 0.5), 0.0, 0, 360),
+        }
         spines['polar'].set_transform(self.transWedge + self.transAxes)
         spines['inner'].set_transform(self.transWedge + self.transAxes)
         spines['start'].set_transform(self._yaxis_transform)


### PR DESCRIPTION
There's already some subclasses that return a plain dict (e.g., geo
axes); moreover, the return value is passed to Spine.from_dict which
anyways `**kwargs`-expands it, so that stage also affects whether order
is maintained.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
