### PR TITLE
Cleanup FontProperties examples.

### DIFF
--- a/examples/text_labels_and_annotations/fonts_demo.py
+++ b/examples/text_labels_and_annotations/fonts_demo.py
@@ -11,89 +11,60 @@ See :doc:`fonts_demo_kw` to achieve the same effect using keyword arguments.
 from matplotlib.font_manager import FontProperties
 import matplotlib.pyplot as plt
 
-font0 = FontProperties()
+fig = plt.figure()
 alignment = {'horizontalalignment': 'center', 'verticalalignment': 'baseline'}
-# Show family options
-
-families = ['serif', 'sans-serif', 'cursive', 'fantasy', 'monospace']
-
-font1 = font0.copy()
-font1.set_size('large')
-
-t = plt.figtext(0.1, 0.9, 'family', fontproperties=font1, **alignment)
-
 yp = [0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2]
+heading_font = FontProperties(size='large')
 
+# Show family options
+fig.text(0.1, 0.9, 'family', fontproperties=heading_font, **alignment)
+families = ['serif', 'sans-serif', 'cursive', 'fantasy', 'monospace']
 for k, family in enumerate(families):
-    font = font0.copy()
+    font = FontProperties()
     font.set_family(family)
-    t = plt.figtext(0.1, yp[k], family, fontproperties=font, **alignment)
+    fig.text(0.1, yp[k], family, fontproperties=font, **alignment)
 
 # Show style options
-
 styles = ['normal', 'italic', 'oblique']
-
-t = plt.figtext(0.3, 0.9, 'style', fontproperties=font1, **alignment)
-
+fig.text(0.3, 0.9, 'style', fontproperties=heading_font, **alignment)
 for k, style in enumerate(styles):
-    font = font0.copy()
+    font = FontProperties()
     font.set_family('sans-serif')
     font.set_style(style)
-    t = plt.figtext(0.3, yp[k], style, fontproperties=font, **alignment)
+    fig.text(0.3, yp[k], style, fontproperties=font, **alignment)
 
 # Show variant options
-
 variants = ['normal', 'small-caps']
-
-t = plt.figtext(0.5, 0.9, 'variant', fontproperties=font1, **alignment)
-
+fig.text(0.5, 0.9, 'variant', fontproperties=heading_font, **alignment)
 for k, variant in enumerate(variants):
-    font = font0.copy()
+    font = FontProperties()
     font.set_family('serif')
     font.set_variant(variant)
-    t = plt.figtext(0.5, yp[k], variant, fontproperties=font, **alignment)
+    fig.text(0.5, yp[k], variant, fontproperties=font, **alignment)
 
 # Show weight options
-
 weights = ['light', 'normal', 'medium', 'semibold', 'bold', 'heavy', 'black']
-
-t = plt.figtext(0.7, 0.9, 'weight', fontproperties=font1, **alignment)
-
+fig.text(0.7, 0.9, 'weight', fontproperties=heading_font, **alignment)
 for k, weight in enumerate(weights):
-    font = font0.copy()
+    font = FontProperties()
     font.set_weight(weight)
-    t = plt.figtext(0.7, yp[k], weight, fontproperties=font, **alignment)
+    fig.text(0.7, yp[k], weight, fontproperties=font, **alignment)
 
 # Show size options
-
-sizes = ['xx-small', 'x-small', 'small', 'medium', 'large',
-         'x-large', 'xx-large']
-
-t = plt.figtext(0.9, 0.9, 'size', fontproperties=font1, **alignment)
-
+sizes = [
+    'xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']
+fig.text(0.9, 0.9, 'size', fontproperties=heading_font, **alignment)
 for k, size in enumerate(sizes):
-    font = font0.copy()
+    font = FontProperties()
     font.set_size(size)
-    t = plt.figtext(0.9, yp[k], size, fontproperties=font, **alignment)
+    fig.text(0.9, yp[k], size, fontproperties=font, **alignment)
 
 # Show bold italic
-
-font = font0.copy()
-font.set_style('italic')
-font.set_weight('bold')
-font.set_size('x-small')
-t = plt.figtext(0.3, 0.1, 'bold italic', fontproperties=font, **alignment)
-
-font = font0.copy()
-font.set_style('italic')
-font.set_weight('bold')
-font.set_size('medium')
-t = plt.figtext(0.3, 0.2, 'bold italic', fontproperties=font, **alignment)
-
-font = font0.copy()
-font.set_style('italic')
-font.set_weight('bold')
-font.set_size('x-large')
-t = plt.figtext(-0.4, 0.3, 'bold italic', fontproperties=font, **alignment)
+font = FontProperties(style='italic', weight='bold', size='x-small')
+fig.text(0.3, 0.1, 'bold italic', fontproperties=font, **alignment)
+font = FontProperties(style='italic', weight='bold', size='medium')
+fig.text(0.3, 0.2, 'bold italic', fontproperties=font, **alignment)
+font = FontProperties(style='italic', weight='bold', size='x-large')
+fig.text(0.3, 0.3, 'bold italic', fontproperties=font, **alignment)
 
 plt.show()

--- a/examples/text_labels_and_annotations/fonts_demo_kw.py
+++ b/examples/text_labels_and_annotations/fonts_demo_kw.py
@@ -10,67 +10,47 @@ See :doc:`fonts_demo` to achieve the same effect using setters.
 
 import matplotlib.pyplot as plt
 
+fig = plt.figure()
 alignment = {'horizontalalignment': 'center', 'verticalalignment': 'baseline'}
-
-# Show family options
-
-families = ['serif', 'sans-serif', 'cursive', 'fantasy', 'monospace']
-
-t = plt.figtext(0.1, 0.9, 'family', size='large', **alignment)
-
 yp = [0.8, 0.7, 0.6, 0.5, 0.4, 0.3, 0.2]
 
+# Show family options
+fig.text(0.1, 0.9, 'family', size='large', **alignment)
+families = ['serif', 'sans-serif', 'cursive', 'fantasy', 'monospace']
 for k, family in enumerate(families):
-    t = plt.figtext(0.1, yp[k], family, family=family, **alignment)
+    fig.text(0.1, yp[k], family, family=family, **alignment)
 
 # Show style options
-
+fig.text(0.3, 0.9, 'style', **alignment)
 styles = ['normal', 'italic', 'oblique']
-
-t = plt.figtext(0.3, 0.9, 'style', **alignment)
-
 for k, style in enumerate(styles):
-    t = plt.figtext(0.3, yp[k], style, family='sans-serif', style=style,
-                    **alignment)
+    fig.text(0.3, yp[k], style, family='sans-serif', style=style, **alignment)
 
 # Show variant options
-
+fig.text(0.5, 0.9, 'variant', **alignment)
 variants = ['normal', 'small-caps']
-
-t = plt.figtext(0.5, 0.9, 'variant', **alignment)
-
 for k, variant in enumerate(variants):
-    t = plt.figtext(0.5, yp[k], variant, family='serif', variant=variant,
-                    **alignment)
+    fig.text(0.5, yp[k], variant, family='serif', variant=variant, **alignment)
 
 # Show weight options
-
+fig.text(0.7, 0.9, 'weight', **alignment)
 weights = ['light', 'normal', 'medium', 'semibold', 'bold', 'heavy', 'black']
-
-t = plt.figtext(0.7, 0.9, 'weight', **alignment)
-
 for k, weight in enumerate(weights):
-    t = plt.figtext(0.7, yp[k], weight, weight=weight, **alignment)
+    fig.text(0.7, yp[k], weight, weight=weight, **alignment)
 
 # Show size options
-
-sizes = ['xx-small', 'x-small', 'small', 'medium', 'large',
-         'x-large', 'xx-large']
-
-t = plt.figtext(0.9, 0.9, 'size', **alignment)
-
+fig.text(0.9, 0.9, 'size', **alignment)
+sizes = [
+    'xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']
 for k, size in enumerate(sizes):
-    t = plt.figtext(0.9, yp[k], size, size=size, **alignment)
+    fig.text(0.9, yp[k], size, size=size, **alignment)
 
 # Show bold italic
-t = plt.figtext(0.3, 0.1, 'bold italic', style='italic',
-                weight='bold', size='x-small',
-                **alignment)
-t = plt.figtext(0.3, 0.2, 'bold italic',
-                style='italic', weight='bold', size='medium',
-                **alignment)
-t = plt.figtext(0.3, 0.3, 'bold italic',
-                style='italic', weight='bold', size='x-large',
-                **alignment)
+fig.text(0.3, 0.1, 'bold italic',
+         style='italic', weight='bold', size='x-small', **alignment)
+fig.text(0.3, 0.2, 'bold italic',
+         style='italic', weight='bold', size='medium', **alignment)
+fig.text(0.3, 0.3, 'bold italic',
+         style='italic', weight='bold', size='x-large', **alignment)
 
 plt.show()


### PR DESCRIPTION
- Unpyplot the examples; assigning the results to "t" doesn't really say
  anything (this would be different if the example was about text
  objects); other style fixes.
- In the OO example, instead of mutating a global FontProperties, create
  one locally and set the properties on it.  (Even better would be to
  just do `font = Fontproperties(prop=...)`, but
  `FontProperties(family="sans-serif")` currently fails due to confusion
  between the family kwarg and fontconfig patterns... #10249)
- x-large bold italic was misplaced in the OO example -- compare with
  the kwargs example.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
