### PR TITLE
FIX: make sure addFont test removes the test font

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -180,7 +180,16 @@ def test_addfont_as_path():
     """Smoke test that addfont() accepts pathlib.Path."""
     font_test_file = 'mpltest.ttf'
     path = Path(__file__).parent / font_test_file
-    fontManager.addfont(path)
+    try:
+        fontManager.addfont(path)
+        added, = [font for font in fontManager.ttflist
+                  if font.fname.endswith('mpltest.ttf')]
+        fontManager.ttflist.remove(added)
+    finally:
+        to_remove = [font for font in fontManager.ttflist
+                     if font.fname.endswith('mpltest.ttf')]
+        for font in to_remove:
+            fontManager.ttflist.remove(font)
 
 
 @pytest.mark.skipif(sys.platform != 'win32', reason='Windows only')

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -183,11 +183,11 @@ def test_addfont_as_path():
     try:
         fontManager.addfont(path)
         added, = [font for font in fontManager.ttflist
-                  if font.fname.endswith('mpltest.ttf')]
+                  if font.fname.endswith(font_test_file)]
         fontManager.ttflist.remove(added)
     finally:
         to_remove = [font for font in fontManager.ttflist
-                     if font.fname.endswith('mpltest.ttf')]
+                     if font.fname.endswith(font_test_file)]
         for font in to_remove:
             fontManager.ttflist.remove(font)
 


### PR DESCRIPTION
## PR Summary

This should fix the intermittent failures on CI.

The issue is that the test `test_addfont_as_path` was adding an extra font (on top of what we normally discover).  When the test are run in parallel it random if this test and `test_get_font_names` run on the same worker or not. 


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
