### PR TITLE
CI: Remove old scipy-wheels-nightly uploads to ensure space

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -63,3 +63,23 @@ jobs:
             --user scipy-wheels-nightly \
             --skip-existing \
             dist/matplotlib-*.whl
+
+      - name: Remove old uploads to save space
+        shell: bash
+        run: |
+          N_LATEST_UPLOADS=5
+
+          # Remove all _but_ the last "${N_LATEST_UPLOADS}" package versions
+          # N.B.: `anaconda show` places the newest packages at the bottom of the output
+          # of the 'Versions' section and package versions are preceded with a '   + '.
+          anaconda show scipy-wheels-nightly/matplotlib &> >(grep '+') | \
+              sed 's/.* + //' | \
+              head --lines "-${N_LATEST_UPLOADS}" > remove-package-versions.txt
+
+          if [ -s remove-package-versions.txt ]; then
+              while LANG=C IFS= read -r package_version ; do
+                  anaconda --token ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }} remove \
+                    --force \
+                    "scipy-wheels-nightly/matplotlib/${package_version}"
+              done <remove-package-versions.txt
+          fi


### PR DESCRIPTION
## PR Summary

Resolves the space problem in https://github.com/matplotlib/matplotlib/issues/22757#issuecomment-1142381595

Remove all but the last `"${N_LATEST_UPLOADS}"` package version uploads to the matplotlib scipy-wheels-nightly index to ensure space. To do this, rely on the output form of `anaconda show` to be able to filter on the item delimiter character sequence for each version currently uploaded.

As an explicit example (from today 2022-06-26):

```console
$ anaconda show scipy-wheels-nightly/matplotlib
Using Anaconda API: https://api.anaconda.org
Name:    matplotlib
Summary:
Access:  public
Package Types:  pypi
Versions:
   + 3.6.0.dev2553+g3245d395d9
   + 3.6.0.dev2569+g3522217386
   + 3.6.0.dev2573+g3eadeacc06

To install this package with pypi run:
     pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple matplotlib
```

shows that by filtering on `+`

```console
$ anaconda show scipy-wheels-nightly/matplotlib &> >(grep '+')
   + 3.6.0.dev2553+g3245d395d9
   + 3.6.0.dev2569+g3522217386
   + 3.6.0.dev2573+g3eadeacc06
```

and then stripping `' + '`

```console
$ anaconda show scipy-wheels-nightly/matplotlib &> >(grep '+') | \
    sed 's/.* + //'
3.6.0.dev2553+g3245d395d9
3.6.0.dev2569+g3522217386
3.6.0.dev2573+g3eadeacc06
```

one can obtain a newline separated list of all package uploads, where the _most recent_ uploads are listed last. After stripping off the `"${N_LATEST_UPLOADS}"` lines that correspond to the package versions to keep for testing

```console
$ anaconda show scipy-wheels-nightly/matplotlib &> >(grep '+') | \
    sed 's/.* + //' | \
    head --lines "-${N_LATEST_UPLOADS}" > remove-package-versions.txt
```

the remaining (older) package uploads can be removed with `anaconda remove`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
