### PR TITLE
Fixed decimal points not appearing at end of Mathtext string.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2000,16 +2000,16 @@ class Parser:
                                self._make_space(0.2)],
                               do_kern=True)]
         elif c in self._punctuation_symbols:
+            prev_char = next((c for c in s[:loc][::-1] if c != ' '), '')
+            next_char = next((c for c in s[loc + 1:] if c != ' '), '')
 
             # Do not space commas between brackets
             if c == ',':
-                prev_char = next((c for c in s[:loc][::-1] if c != ' '), '')
-                next_char = next((c for c in s[loc + 1:] if c != ' '), '')
                 if prev_char == '{' and next_char == '}':
                     return [char]
 
             # Do not space dots as decimal separators
-            if c == '.' and s[loc - 1].isdigit() and s[loc + 1].isdigit():
+            if c == '.' and prev_char.isdigit() and next_char.isdigit():
                 return [char]
             else:
                 return [Hlist([char, self._make_space(0.2)], do_kern=True)]


### PR DESCRIPTION
## PR Summary
Numeric strings ending with a decimal point are rendered without the decimal point by Mathtext.
```
import matplotlib.pyplot as plt
# plt.rcdefaults()
plt.text(.4, .4, '$123.$', usetex=True)
plt.text(.6, .4, '$abc.$', usetex=True)
plt.text(.4, .6, '$123.$', usetex=False)
plt.text(.6, .6, '$abc.$', usetex=False)
plt.show()
```
Before:
![no_decimal_point](https://user-images.githubusercontent.com/19171016/176134669-aee364ae-7e36-40fb-b436-41332252760a.png)

After:
![yes_decimal_point](https://user-images.githubusercontent.com/19171016/176134708-aa9f3249-2847-4fdc-a5c9-323e737f8048.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).