### PR TITLE
Rename/change signature of PyGlyph_new.

### DIFF
--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -93,7 +93,7 @@ class FT2Font
     long get_name_index(char *name);
     PyObject* get_path();
 
-    FT_Face &get_face()
+    FT_Face const &get_face() const
     {
         return face;
     }
@@ -101,19 +101,19 @@ class FT2Font
     {
         return image;
     }
-    FT_Glyph &get_last_glyph()
+    FT_Glyph const &get_last_glyph() const
     {
         return glyphs.back();
     }
-    size_t get_last_glyph_index()
+    size_t get_last_glyph_index() const
     {
         return glyphs.size() - 1;
     }
-    size_t get_num_glyphs()
+    size_t get_num_glyphs() const
     {
         return glyphs.size();
     }
-    long get_hinting_factor()
+    long get_hinting_factor() const
     {
         return hinting_factor;
     }

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -179,8 +179,13 @@ typedef struct
 static PyTypeObject PyGlyphType;
 
 static PyObject *
-PyGlyph_new(const FT_Face &face, const FT_Glyph &glyph, size_t ind, long hinting_factor)
+PyGlyph_from_FT2Font(const FT2Font *font)
 {
+    const FT_Face &face = font->get_face();
+    const FT_Glyph &glyph = font->get_last_glyph();
+    size_t ind = font->get_last_glyph_index();
+    long hinting_factor = font->get_hinting_factor();
+
     PyGlyph *self;
     self = (PyGlyph *)PyGlyphType.tp_alloc(&PyGlyphType, 0);
 
@@ -625,10 +630,7 @@ static PyObject *PyFT2Font_load_char(PyFT2Font *self, PyObject *args, PyObject *
 
     CALL_CPP("load_char", (self->x->load_char(charcode, flags)));
 
-    return PyGlyph_new(self->x->get_face(),
-                       self->x->get_last_glyph(),
-                       self->x->get_last_glyph_index(),
-                       self->x->get_hinting_factor());
+    return PyGlyph_from_FT2Font(self->x);
 }
 
 const char *PyFT2Font_load_glyph__doc__ =
@@ -664,10 +666,7 @@ static PyObject *PyFT2Font_load_glyph(PyFT2Font *self, PyObject *args, PyObject 
 
     CALL_CPP("load_glyph", (self->x->load_glyph(glyph_index, flags)));
 
-    return PyGlyph_new(self->x->get_face(),
-                       self->x->get_last_glyph(),
-                       self->x->get_last_glyph_index(),
-                       self->x->get_hinting_factor());
+    return PyGlyph_from_FT2Font(self->x);
 }
 
 const char *PyFT2Font_get_width_height__doc__ =


### PR DESCRIPTION
Unlike all other ExtensionType_new functions, PyGlyph_new is not a
tp_new (https://docs.python.org/3/c-api/typeobj.html#c.PyTypeObject.tp_new)
but simply a plain C function used to construct a struct from the fields
of a FT2Font.  Rename it to avoid confusion, and make it take a single
FT2Font as argument, too (with some additional fixes for
const-correctness).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
