### PR TITLE
MNT: use devel version of theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,13 +99,8 @@ commands:
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> codecov coverage \
                 -r requirements/doc/doc-requirements.txt
-
-  mpl-theme-install:
-    steps:
-      - run:
-          name: Install mpl-sphinx-theme dev
-          command: |
-            pip install git+https://github.com/matplotlib/mpl-sphinx-theme.git
+            python -m pip install --user \
+                git+https://github.com/matplotlib/mpl-sphinx-theme.git
 
   mpl-install:
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,11 +96,11 @@ commands:
       - run:
           name: Install Python dependencies
           command: |
+            python -m pip install --no-deps --user \
+                git+https://github.com/matplotlib/mpl-sphinx-theme.git
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> codecov coverage \
                 -r requirements/doc/doc-requirements.txt
-            python -m pip install --user \
-                git+https://github.com/matplotlib/mpl-sphinx-theme.git
 
   mpl-install:
     steps:


### PR DESCRIPTION
The circle config I had before wasn't working because I didn't specify the step.  However, just as easy to put in the install reps rather than add another step