### PR TITLE
Default animation.convert_args to ["-layers", "OptimizePlus"].

### DIFF
--- a/doc/api/next_api_changes/behavior/23371-AL.rst
+++ b/doc/api/next_api_changes/behavior/23371-AL.rst
@@ -1,0 +1,4 @@
+The default ``rcParams["animation.convert_args"]`` changed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It now defaults to ``["-layers", "OptimizePlus"]`` to try to generate smaller
+GIFs.  Set it back to an empty list to recover the previous behavior.

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -779,7 +779,7 @@
 ## ImageMagick in the registry (as convert is also the name of a system tool).
 #animation.convert_path: convert
 ## Additional arguments to pass to convert.
-#animation.convert_args:
+#animation.convert_args: -layers, OptimizePlus
 #
 #animation.embed_limit:  20.0     # Limit, in MB, of size of base64 encoded
                                   # animation in HTML (i.e. IPython notebook)


### PR DESCRIPTION
On the simple_anim.py example, adding e.g.
```python
plt.rcParams["animation.writer"] = "imagemagick"
plt.rcParams["animation.convert_args"] = []
ani.save("old.gif")
plt.rcParams["animation.convert_args"] = ["-layers", "OptimizePlus"]
ani.save("new.gif")
```
shows that OptimizePlus yields a >2.5x decrease in gif size.  (Admittedly I haven't tried more examples.)

Goes on top of #23370.  Supersedes #15784.  Thanks to @erelson for suggesting to use `-layers`.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
