### PR TITLE
Fix pan/zoom crashing when widget lock is unavailable

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3042,6 +3042,9 @@ class NavigationToolbar2:
 
         Pan with left button, zoom with right.
         """
+        if not self.canvas.widgetlock.available(self):
+            self.set_message("pan unavailable")
+            return
         if self.mode == _Mode.PAN:
             self.mode = _Mode.NONE
             self.canvas.widgetlock.release(self)
@@ -3094,6 +3097,9 @@ class NavigationToolbar2:
         self.push_current()
 
     def zoom(self, *args):
+        if not self.canvas.widgetlock.available(self):
+            self.set_message("zoom unavailable")
+            return
         """Toggle zoom to rect mode."""
         if self.mode == _Mode.ZOOM:
             self.mode = _Mode.NONE

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -175,6 +175,17 @@ def test_interactive_zoom():
     assert not ax.get_autoscalex_on() and not ax.get_autoscaley_on()
 
 
+def test_widgetlock_zoompan():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+    fig.canvas.widgetlock(ax)
+    tb = NavigationToolbar2(fig.canvas)
+    tb.zoom()
+    assert ax.get_navigate_mode() is None
+    tb.pan()
+    assert ax.get_navigate_mode() is None
+
+
 @pytest.mark.parametrize("plot_func", ["imshow", "contourf"])
 @pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
 @pytest.mark.parametrize("tool,button,expected",


### PR DESCRIPTION
## PR Summary
Closes #23324 
To fix the crash, when toggling zoom or pan tools, first check if widgetlock is available to proceed.

Btw, I only could test it with MACOSX backend and it was ok.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**

- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
