### PR TITLE
GOV: point CoC reports at CoC steering council subcomittee mailing list

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -62,7 +62,7 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
 [matplotlib-coc@numfocus.org](mailto:matplotlib-coc@numfocus.org)
-(monitored by the [CoC subcommittee](https://matplotlib.org/governance/people.html#coc-subcommitee)) or a
+(monitored by the [CoC subcommittee](https://matplotlib.org/governance/people.html#coc-subcommittee)) or a
 report can be made using the [NumFOCUS Code of Conduct report form][numfocus
 form].  If community leaders cannot come to a resolution about enforcement,
 reports will be escalated to the NumFocus Code of Conduct committee

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -61,10 +61,13 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-matplotlib@numfocus.org (monitored by Thomas Caswell (\@tacaswell) and Hannah
-Aizenman (\@story645)) or a report can be made using the [NumFOCUS Code of Conduct report form][numfocus form].
-If community leaders cannot come to a resolution about enforcement, reports will be escalated to the NumFocus Code of Conduct committee (conduct@numfocus.org).
-All complaints will be reviewed and investigated promptly and fairly.
+[matplotlib-coc@numfocus.org](mailto:matplotlib-coc@numfocus.org)
+(monitored by the [CoC subcommittee](https://matplotlib.org/governance/people.html#coc-subcommitee)) or a
+report can be made using the [NumFOCUS Code of Conduct report form][numfocus
+form].  If community leaders cannot come to a resolution about enforcement,
+reports will be escalated to the NumFocus Code of Conduct committee
+(conduct@numfocus.org).  All complaints will be reviewed and investigated
+promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
This is the last place we had `matplotlib@numfocus.org` in the docs. 

We hand funding from CZI EOSS4 for CoC training and I intend to stand up a proper CoC sub-committee, however for now the streering-council is a reasonable standin.