### PR TITLE
Replace hardcoded parameter names when creating error bars

### DIFF
--- a/doc/api/next_api_changes/behavior/23376-WLQ.rst
+++ b/doc/api/next_api_changes/behavior/23376-WLQ.rst
@@ -1,0 +1,4 @@
+All `kwargs` parameters to Line2D are now appropriately supported by axes.errorbar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Keys are now detected through the signature of Line2D, rather than through a
+hardcoded list.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3452,10 +3452,11 @@ class Axes(_AxesBase):
         if ecolor is None:
             ecolor = base_style['color']
 
-        # Eject any line-specific information from format string, as it's not
-        # needed for bars or caps.
-        for key in inspect.signature(mlines.Line2D).parameters:
-            base_style.pop(key, None)
+        # Eject anything that's not acceptable by LineCollection.set()
+        lc_keys = inspect.signature(mcoll.LineCollection.set).parameters
+        for key in tuple(base_style.keys()):  # Because we're resizing base_style
+            if key not in lc_keys:
+                base_style.pop(key, None)
 
         # Make the style dict for the line collections (the bars).
         eb_lines_style = {**base_style, 'color': ecolor}

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3454,8 +3454,14 @@ class Axes(_AxesBase):
 
         # Eject anything that's not acceptable by LineCollection.set()
         lc_keys = inspect.signature(mcoll.LineCollection.set).parameters
-        for key in tuple(base_style.keys()):  # Because we're resizing base_style
-            if key not in lc_keys:
+        rej_keys = ['marker', 'markersize', 'markerfacecolor',
+                    'markeredgewidth', 'markeredgecolor', 'markevery',
+                    'linestyle', 'fillstyle', 'drawstyle', 'dash_capstyle',
+                    'dash_joinstyle', 'solid_capstyle', 'solid_joinstyle',
+                    'dashes']
+        # Because we're resizing base_style
+        for key in tuple(base_style.keys()):
+            if key not in lc_keys or key in rej_keys:
                 base_style.pop(key, None)
 
         # Make the style dict for the line collections (the bars).

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1,4 +1,5 @@
 import functools
+import inspect
 import itertools
 import logging
 import math
@@ -3453,11 +3454,7 @@ class Axes(_AxesBase):
 
         # Eject any line-specific information from format string, as it's not
         # needed for bars or caps.
-        for key in ['marker', 'markersize', 'markerfacecolor',
-                    'markeredgewidth', 'markeredgecolor', 'markevery',
-                    'linestyle', 'fillstyle', 'drawstyle', 'dash_capstyle',
-                    'dash_joinstyle', 'solid_capstyle', 'solid_joinstyle',
-                    'dashes']:
+        for key in inspect.signature(mlines.Line2D).parameters:
             base_style.pop(key, None)
 
         # Make the style dict for the line collections (the bars).


### PR DESCRIPTION
## PR Summary

Use `inspect.signature` to automagically check whether a `kwarg` is a
line argument, rather than relying on a hardcoded list. See issue #23375 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [❌] Has pytest style unit tests (and `pytest` passes).
- [✔️] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [✔️] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
