### PR TITLE
Remove setuptools_scm_git_archive dependency and add sdist test

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,1 +1,4 @@
+node: $Format:%H$
+node-date: $Format:%cI$
+describe-name: $Format:%(describe:tags=true)$
 ref-names: $Format:%D$

--- a/.github/workflows/cibuildsdist.yml
+++ b/.github/workflows/cibuildsdist.yml
@@ -1,0 +1,64 @@
+name: Build CI sdist and wheel
+
+on:
+  # Save CI by only running this on release branches or tags.
+  push:
+    branches:
+      - main
+      - v[0-9]+.[0-9]+.x
+    tags:
+      - v*
+  # Also allow running this action on PRs if requested by applying the
+  # "Run cibuildwheel" label.
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+
+jobs:
+  build_sdist:
+    if: |
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request' && (
+        (
+          github.event.action == 'labeled' &&
+          github.event.label.name == 'Run cibuildwheel'
+        ) ||
+        contains(github.event.pull_request.labels.*.name, 'Run cibuildwheel')
+      )
+    name: Build sdist and wheel on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04]
+        python-version: ['3.8', '3.9', '3.10', '3.11.0-alpha - 3.11']
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v4
+        name: Install Python
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install build
+        run: pip install build
+
+      - name: Build sdist and wheel
+        run: python -m build .
+
+      - name: Install built matplotlib sdist
+        run: pip install dist/matplotlib*.tar.gz
+
+      - name: Check version number is not 0
+        run: python ./ci/check_version_number.py
+
+      - name: Install built matplotlib wheel
+        run: pip install dist/matplotlib*.whl --force-reinstall
+
+      - name: Check version number is not 0
+        run: python ./ci/check_version_number.py

--- a/ci/check_version_number.py
+++ b/ci/check_version_number.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""
+Check that the version number of the install Matplotlib does not start with 0
+
+To run:
+    $ python3 -m build .
+    $ pip install dist/matplotlib*.tar.gz for sdist
+    $ pip install dist/matplotlib*.whl for wheel
+    $ ./ci/check_version_number.py
+"""
+import matplotlib
+
+import sys
+
+EXIT_SUCCESS = 0
+EXIT_FAILURE = 1
+
+
+print(f"Version {matplotlib.__version__} installed")
+if matplotlib.__version__[0] == "0":
+    sys.exit(EXIT_FAILURE)
+sys.exit(EXIT_SUCCESS)

--- a/setup.py
+++ b/setup.py
@@ -302,8 +302,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
     setup_requires=[
         "certifi>=2020.06.20",
         "numpy>=1.19",
-        "setuptools_scm>=4",
-        "setuptools_scm_git_archive",
+        "setuptools_scm>=7",
     ],
     install_requires=[
         "contourpy>=1.0.1",
@@ -317,7 +316,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "python-dateutil>=2.7",
     ] + (
         # Installing from a git checkout that is not producing a wheel.
-        ["setuptools_scm>=4"] if (
+        ["setuptools_scm>=7"] if (
             Path(__file__).with_name(".git").exists() and
             os.environ.get("CIBUILDWHEEL", "0") != "1"
         ) else []


### PR DESCRIPTION
## PR Summary
Closes #23325
Closes #23386

Removes setuptools_scm_git_archive as dependency, but increases the setuptools_scm version requirement from 4 to 7.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
