### PR TITLE
Clean up formatting of custom cmap example

### DIFF
--- a/examples/color/custom_cmap.py
+++ b/examples/color/custom_cmap.py
@@ -12,7 +12,7 @@ pass a list of RGB tuples that define the mixture of colors from 0 to 1.
 
 
 Creating custom colormaps
--------------------------
+=========================
 It is also possible to create a custom mapping for a colormap. This is
 accomplished by creating dictionary that specifies how the RGB channels
 change from one end of the cmap to the other.
@@ -21,51 +21,78 @@ Example: suppose you want red to increase from 0 to 1 over the bottom
 half, green to do the same over the middle half, and blue over the top
 half.  Then you would use::
 
-  cdict = {'red':   ((0.0,  0.0, 0.0),
-                     (0.5,  1.0, 1.0),
-                     (1.0,  1.0, 1.0)),
-
-           'green': ((0.0,  0.0, 0.0),
-                     (0.25, 0.0, 0.0),
-                     (0.75, 1.0, 1.0),
-                     (1.0,  1.0, 1.0)),
-
-           'blue':  ((0.0,  0.0, 0.0),
-                     (0.5,  0.0, 0.0),
-                     (1.0,  1.0, 1.0))}
+    cdict = {
+        'red': (
+            (0.0,  0.0, 0.0),
+            (0.5,  1.0, 1.0),
+            (1.0,  1.0, 1.0),
+        ),
+        'green': (
+            (0.0,  0.0, 0.0),
+            (0.25, 0.0, 0.0),
+            (0.75, 1.0, 1.0),
+            (1.0,  1.0, 1.0),
+        ),
+        'blue': (
+            (0.0,  0.0, 0.0),
+            (0.5,  0.0, 0.0),
+            (1.0,  1.0, 1.0),
+        )
+    }
 
 If, as in this example, there are no discontinuities in the r, g, and b
 components, then it is quite simple: the second and third element of
-each tuple, above, is the same--call it "y".  The first element ("x")
+each tuple, above, is the same--call it "``y``".  The first element ("``x``")
 defines interpolation intervals over the full range of 0 to 1, and it
-must span that whole range.  In other words, the values of x divide the
-0-to-1 range into a set of segments, and y gives the end-point color
+must span that whole range.  In other words, the values of ``x`` divide the
+0-to-1 range into a set of segments, and ``y`` gives the end-point color
 values for each segment.
 
-Now consider the green. cdict['green'] is saying that for
-0 <= x <= 0.25, y is zero; no green.
-0.25 < x <= 0.75, y varies linearly from 0 to 1.
-x > 0.75, y remains at 1, full green.
+Now consider the green, ``cdict['green']`` is saying that for:
 
-If there are discontinuities, then it is a little more complicated.
-Label the 3 elements in each row in the cdict entry for a given color as
-(x, y0, y1).  Then for values of x between x[i] and x[i+1] the color
-value is interpolated between y1[i] and y0[i+1].
+- 0 <= ``x`` <= 0.25, ``y`` is zero; no green.
+- 0.25 < ``x`` <= 0.75, ``y`` varies linearly from 0 to 1.
+- 0.75 < ``x`` <= 1, ``y`` remains at 1, full green.
 
-Going back to the cookbook example, look at cdict['red']; because y0 !=
-y1, it is saying that for x from 0 to 0.5, red increases from 0 to 1,
-but then it jumps down, so that for x from 0.5 to 1, red increases from
-0.7 to 1.  Green ramps from 0 to 1 as x goes from 0 to 0.5, then jumps
-back to 0, and ramps back to 1 as x goes from 0.5 to 1.::
+If there are discontinuities, then it is a little more complicated. Label the 3
+elements in each row in the ``cdict`` entry for a given color as ``(x, y0,
+y1)``. Then for values of ``x`` between ``x[i]`` and ``x[i+1]`` the color value
+is interpolated between ``y1[i]`` and ``y0[i+1]``.
+
+Going back to a cookbook example::
+
+    cdict = {
+        'red': (
+            (0.0,  0.0, 0.0),
+            (0.5,  1.0, 0.7),
+            (1.0,  1.0, 1.0),
+        ),
+        'green': (
+            (0.0,  0.0, 0.0),
+            (0.5,  1.0, 0.0),
+            (1.0,  1.0, 1.0),
+        ),
+        'blue': (
+            (0.0,  0.0, 0.0),
+            (0.5,  0.0, 0.0),
+            (1.0,  1.0, 1.0),
+        )
+    }
+
+and look at ``cdict['red'][1]``; because ``y0 != y1``, it is saying that for
+``x`` from 0 to 0.5, red increases from 0 to 1, but then it jumps down, so that
+for ``x`` from 0.5 to 1, red increases from 0.7 to 1.  Green ramps from 0 to 1
+as ``x`` goes from 0 to 0.5, then jumps back to 0, and ramps back to 1 as ``x``
+goes from 0.5 to 1. ::
 
   row i:   x  y0  y1
-                  /
                  /
+                /
   row i+1: x  y0  y1
 
-Above is an attempt to show that for x in the range x[i] to x[i+1], the
-interpolation is between y1[i] and y0[i+1].  So, y0[0] and y1[-1] are
-never used.
+Above is an attempt to show that for ``x`` in the range ``x[i]`` to ``x[i+1]``,
+the interpolation is between ``y1[i]`` and ``y0[i+1]``.  So, ``y0[0]`` and
+``y1[-1]`` are never used.
 
 """
 import numpy as np
@@ -82,7 +109,8 @@ Z = np.cos(X) * np.sin(Y) * 10
 
 
 ###############################################################################
-# --- Colormaps from a list ---
+# Colormaps from a list
+# ---------------------
 
 colors = [(1, 0, 0), (0, 1, 0), (0, 0, 1)]  # R -> G -> B
 n_bins = [3, 6, 10, 100]  # Discretizes the interpolation into bins
@@ -99,60 +127,79 @@ for n_bin, ax in zip(n_bins, axs.flat):
 
 
 ###############################################################################
-# --- Custom colormaps ---
+# Custom colormaps
+# ----------------
 
-cdict1 = {'red':   ((0.0, 0.0, 0.0),
-                    (0.5, 0.0, 0.1),
-                    (1.0, 1.0, 1.0)),
+cdict1 = {
+    'red': (
+        (0.0, 0.0, 0.0),
+        (0.5, 0.0, 0.1),
+        (1.0, 1.0, 1.0),
+    ),
+    'green': (
+        (0.0, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+    ),
+    'blue': (
+        (0.0, 0.0, 1.0),
+        (0.5, 0.1, 0.0),
+        (1.0, 0.0, 0.0),
+    )
+}
 
-          'green': ((0.0, 0.0, 0.0),
-                    (1.0, 0.0, 0.0)),
+cdict2 = {
+    'red': (
+        (0.0, 0.0, 0.0),
+        (0.5, 0.0, 1.0),
+        (1.0, 0.1, 1.0),
+    ),
+    'green': (
+        (0.0, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+    ),
+    'blue': (
+        (0.0, 0.0, 0.1),
+        (0.5, 1.0, 0.0),
+        (1.0, 0.0, 0.0),
+    )
+}
 
-          'blue':  ((0.0, 0.0, 1.0),
-                    (0.5, 0.1, 0.0),
-                    (1.0, 0.0, 0.0))
-          }
-
-cdict2 = {'red':   ((0.0, 0.0, 0.0),
-                    (0.5, 0.0, 1.0),
-                    (1.0, 0.1, 1.0)),
-
-          'green': ((0.0, 0.0, 0.0),
-                    (1.0, 0.0, 0.0)),
-
-          'blue':  ((0.0, 0.0, 0.1),
-                    (0.5, 1.0, 0.0),
-                    (1.0, 0.0, 0.0))
-          }
-
-cdict3 = {'red':  ((0.0, 0.0, 0.0),
-                   (0.25, 0.0, 0.0),
-                   (0.5, 0.8, 1.0),
-                   (0.75, 1.0, 1.0),
-                   (1.0, 0.4, 1.0)),
-
-          'green': ((0.0, 0.0, 0.0),
-                    (0.25, 0.0, 0.0),
-                    (0.5, 0.9, 0.9),
-                    (0.75, 0.0, 0.0),
-                    (1.0, 0.0, 0.0)),
-
-          'blue':  ((0.0, 0.0, 0.4),
-                    (0.25, 1.0, 1.0),
-                    (0.5, 1.0, 0.8),
-                    (0.75, 0.0, 0.0),
-                    (1.0, 0.0, 0.0))
-          }
+cdict3 = {
+    'red': (
+        (0.0, 0.0, 0.0),
+        (0.25, 0.0, 0.0),
+        (0.5, 0.8, 1.0),
+        (0.75, 1.0, 1.0),
+        (1.0, 0.4, 1.0),
+    ),
+    'green': (
+        (0.0, 0.0, 0.0),
+        (0.25, 0.0, 0.0),
+        (0.5, 0.9, 0.9),
+        (0.75, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+    ),
+    'blue': (
+        (0.0, 0.0, 0.4),
+        (0.25, 1.0, 1.0),
+        (0.5, 1.0, 0.8),
+        (0.75, 0.0, 0.0),
+        (1.0, 0.0, 0.0),
+    )
+}
 
 # Make a modified version of cdict3 with some transparency
 # in the middle of the range.
-cdict4 = {**cdict3,
-          'alpha': ((0.0, 1.0, 1.0),
-                    # (0.25, 1.0, 1.0),
-                    (0.5, 0.3, 0.3),
-                    # (0.75, 1.0, 1.0),
-                    (1.0, 1.0, 1.0)),
-          }
+cdict4 = {
+    **cdict3,
+    'alpha': (
+        (0.0, 1.0, 1.0),
+        # (0.25, 1.0, 1.0),
+        (0.5, 0.3, 0.3),
+        # (0.75, 1.0, 1.0),
+        (1.0, 1.0, 1.0),
+    ),
+}
 
 
 ###############################################################################
@@ -173,12 +220,10 @@ mpl.colormaps.register(LinearSegmentedColormap('BlueRed3', cdict3))
 mpl.colormaps.register(LinearSegmentedColormap('BlueRedAlpha', cdict4))
 
 ###############################################################################
-# Make the figure:
+# Make the figure, with 4 subplots:
 
 fig, axs = plt.subplots(2, 2, figsize=(6, 9))
 fig.subplots_adjust(left=0.02, bottom=0.06, right=0.95, top=0.94, wspace=0.05)
-
-# Make 4 subplots:
 
 im1 = axs[0, 0].imshow(Z, cmap=blue_red1)
 fig.colorbar(im1, ax=axs[0, 0])
@@ -213,7 +258,6 @@ fig.colorbar(im4, ax=axs[1, 1])
 # colorbar after they have been plotted.
 im4.set_cmap('BlueRedAlpha')
 axs[1, 1].set_title("Varying alpha")
-#
 
 fig.suptitle('Custom Blue-Red colormaps', fontsize=16)
 fig.subplots_adjust(top=0.9)


### PR DESCRIPTION
## PR Summary

Switch `-- text --` into real headers, use code style on variable names, and clean up the dictionary style.

Also, add a second example that actually shows the discontinuous setup.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).