### PR TITLE
Upload wheel artifacts from the correct directory

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -110,4 +110,5 @@ jobs:
       - uses: actions/upload-artifact@v3
         with:
           name: wheels
-          path: ./dist/*.whl
+          path: ./wheelhouse/*.whl
+          if-no-files-found: error


### PR DESCRIPTION
## PR Summary

The cibuildwheel Action is not passed an argument specifying an output directory (as was done when installing manually), so it defaults to `wheelhouse`, not `dist`.

This broke in #23146, but I only noticed because nightly uploads failed to find anything just now. Apparently not having any artifacts to upload is not fatal by default, so I've set that to error as well.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).