### PR TITLE
Restore matplotlib.__doc__ in Sphinx docs

### DIFF
--- a/doc/api/index_backend_api.rst
+++ b/doc/api/index_backend_api.rst
@@ -2,6 +2,8 @@
 ``matplotlib.backends``
 ***********************
 
+.. module:: matplotlib.backends
+
 .. toctree::
    :maxdepth: 1
 

--- a/doc/api/matplotlib_configuration_api.rst
+++ b/doc/api/matplotlib_configuration_api.rst
@@ -4,6 +4,11 @@
 
 .. py:currentmodule:: matplotlib
 
+.. automodule:: matplotlib
+   :no-members:
+   :no-undoc-members:
+   :noindex:
+
 Backend management
 ==================
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -63,7 +63,7 @@ Modules include:
     :mod:`matplotlib.ticker`
         Calculation of tick mark locations and formatting of tick labels.
 
-    :mod:`matplotlib.backends`
+    :doc:`matplotlib.backends </api/index_backend_api>`
         A subpackage with modules for various GUI libraries and output formats.
 
 The base matplotlib namespace includes:
@@ -81,7 +81,7 @@ Matplotlib was initially written by John D. Hunter (1968-2012) and is now
 developed and maintained by a host of others.
 
 Occasionally the internal documentation (python docstrings) will refer
-to MATLAB&reg;, a registered trademark of The MathWorks, Inc.
+to MATLAB®, a registered trademark of The MathWorks, Inc.
 
 """
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -63,7 +63,7 @@ Modules include:
     :mod:`matplotlib.ticker`
         Calculation of tick mark locations and formatting of tick labels.
 
-    :doc:`matplotlib.backends </api/index_backend_api>`
+    :mod:`matplotlib.backends`
         A subpackage with modules for various GUI libraries and output formats.
 
 The base matplotlib namespace includes:


### PR DESCRIPTION
## PR Summary

Since we already have an explicit listing of module members, that needs to be turned off here. Also, don't add it to the index as we already have `matplotlib` pointing to the top level page (though maybe that should change?)

Fixes #17973

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).