### PR TITLE
DOC: Fix calculation of bin centers in multi-histogram

### DIFF
--- a/examples/statistics/multiple_histograms_side_by_side.py
+++ b/examples/statistics/multiple_histograms_side_by_side.py
@@ -45,8 +45,8 @@ x_locations = np.arange(0, sum(binned_maximums), np.max(binned_maximums))
 
 # The bin_edges are the same for all of the histograms
 bin_edges = np.linspace(hist_range[0], hist_range[1], number_of_bins + 1)
-centers = 0.5 * (bin_edges + np.roll(bin_edges, 1))[:-1]
 heights = np.diff(bin_edges)
+centers = bin_edges[:-1] + heights / 2
 
 # Cycle through and plot each histogram
 fig, ax = plt.subplots()


### PR DESCRIPTION
## PR Summary

As noted in https://discourse.matplotlib.org/t/tiny-error-in-matplotlib-gallery/22978

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).