### PR TITLE
TST: Add missing warning type to pytest.warns

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3871,7 +3871,7 @@ def test_stem(use_line_collection):
         ax.stem(x, np.cos(x),
                 linefmt='C2-.', markerfmt='k+', basefmt='C1-.', label=' ')
     else:
-        with pytest.warns(match='deprecated'):
+        with pytest.warns(MatplotlibDeprecationWarning, match='deprecated'):
             ax.stem(x, np.cos(x),
                     linefmt='C2-.', markerfmt='k+', basefmt='C1-.', label=' ',
                     use_line_collection=False)
@@ -3919,7 +3919,7 @@ def test_stem_orientation(use_line_collection):
                 linefmt='C2-.', markerfmt='kx', basefmt='C1-.',
                 orientation='horizontal')
     else:
-        with pytest.warns(match='deprecated'):
+        with pytest.warns(MatplotlibDeprecationWarning, match='deprecated'):
             ax.stem(x, np.cos(x),
                     linefmt='C2-.', markerfmt='kx', basefmt='C1-.',
                     use_line_collection=False,


### PR DESCRIPTION
## PR Summary

Not sure why this didn't fail in CI, but it fails with pytest 6.2.5.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).