### PR TITLE
Fix dash offset bug in Patch

### DIFF
--- a/doc/users/next_whats_new/fix_dash_offset_Patch.rst
+++ b/doc/users/next_whats_new/fix_dash_offset_Patch.rst
@@ -1,0 +1,6 @@
+Fix the dash offset of the Patch class
+--------------------------------------
+Traditionally, when setting the linestyle on a patch object using a dash tuple the
+offset was ignored. Now the offset is passed to the draw method of Patch as expected
+and it can be used as it is used with Line2D objects. 
+   

--- a/doc/users/next_whats_new/fix_dash_offset_Patch.rst
+++ b/doc/users/next_whats_new/fix_dash_offset_Patch.rst
@@ -1,5 +1,5 @@
 Fix the dash offset of the Patch class
 --------------------------------------
-Traditionally, when setting the linestyle on a patch object using a dash tuple the
+Traditionally, when setting the linestyle on a `.Patch` object using a dash tuple the
 offset was ignored. Now the offset is passed to the draw method of Patch as expected
 and it can be used as it is used with Line2D objects.

--- a/doc/users/next_whats_new/fix_dash_offset_Patch.rst
+++ b/doc/users/next_whats_new/fix_dash_offset_Patch.rst
@@ -2,5 +2,4 @@ Fix the dash offset of the Patch class
 --------------------------------------
 Traditionally, when setting the linestyle on a patch object using a dash tuple the
 offset was ignored. Now the offset is passed to the draw method of Patch as expected
-and it can be used as it is used with Line2D objects. 
-   
+and it can be used as it is used with Line2D objects.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -587,8 +587,7 @@ class Patch(artist.Artist):
         if not self.get_visible():
             return
 
-        with cbook._setattr_cm(
-                 self, _dash_pattern=(self._dash_pattern)), \
+        with cbook._setattr_cm(self, _dash_pattern=(self._dash_pattern)), \
              self._bind_draw_path_function(renderer) as draw_path:
             path = self.get_path()
             transform = self.get_transform()

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -586,9 +586,9 @@ class Patch(artist.Artist):
         # docstring inherited
         if not self.get_visible():
             return
-        # Patch has traditionally ignored the dashoffset.
+
         with cbook._setattr_cm(
-                 self, _dash_pattern=(0, self._dash_pattern[1])), \
+                 self, _dash_pattern=(self._dash_pattern)), \
              self._bind_draw_path_function(renderer) as draw_path:
             path = self.get_path()
             transform = self.get_transform()

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -154,31 +154,31 @@ def test_dash_offset_patch_draw(fig_test, fig_ref):
     ax_test = fig_test.add_subplot()
     ax_ref = fig_ref.add_subplot()
 
-    loc = (0, 0)
-    width, height = (1, 1)
-    edgecolor = 'b'
-    linestyle = (0, [6, 6])
-    linestyle_hacked = (0, [0, 6, 6, 0])
-    rect_ref = Rectangle(loc, width, height, edgecolor=edgecolor,
-                                                linestyle=linestyle)
-    rect_ref2 = Rectangle(loc, width, height, edgecolor=edgecolor,
-                                        linestyle=linestyle_hacked)
+    loc = (0.1, 0.1)
+    width, height = (0.8, 0.8)
+    rect_ref = Rectangle(loc, width, height, linewidth=3, edgecolor='b',
+                                                linestyle=(0, [6, 6]))
+    # fill the line gaps using a linestyle (0, [0, 6, 6, 0]), which is
+    # equivalent to (6, [6, 6]) but has 0 dash offset
+    rect_ref2 = Rectangle(loc, width, height, linewidth=3, edgecolor='r',
+                                            linestyle=(0, [0, 6, 6, 0]))
+    assert rect_ref.get_linestyle() == (0, [6, 6])
+    assert rect_ref2.get_linestyle() == (0, [0, 6, 6, 0])
+
     ax_ref.add_patch(rect_ref)
     ax_ref.add_patch(rect_ref2)
-
-    assert rect_ref.get_linestyle() == linestyle
-    assert rect_ref2.get_linestyle() == linestyle_hacked
 
     # Check that the dash offset of the rect is the same if we pass it in the
     # init method and if we create two rects with appropriate onoff sequence
     # of linestyle.
-    linestyle_test = (6, [6, 6])
-    rect_test = Rectangle(loc, width, height, edgecolor=edgecolor,
-                                                linestyle=linestyle)
-    rect_test2 = Rectangle(loc, width, height, edgecolor=edgecolor,
-                                             linestyle=linestyle_test)
-    assert rect_test.get_linestyle() == linestyle
-    assert rect_test2.get_linestyle() == linestyle_test
+
+    rect_test = Rectangle(loc, width, height, linewidth=3, edgecolor='b',
+                                                    linestyle=(0, [6, 6]))
+    rect_test2 = Rectangle(loc, width, height, linewidth=3, edgecolor='r',
+                                                    linestyle=(6, [6, 6]))
+    assert rect_test.get_linestyle() == (0, [6, 6])
+    assert rect_test2.get_linestyle() == (6, [6, 6])
+
     ax_test.add_patch(rect_test)
     ax_test.add_patch(rect_test2)
 

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -149,6 +149,40 @@ def test_rotate_rect_draw(fig_test, fig_ref):
     assert rect_test.get_angle() == angle
 
 
+@check_figures_equal(extensions=['png'])
+def test_dash_offset_patch_draw(fig_test, fig_ref):
+    ax_test = fig_test.add_subplot()
+    ax_ref = fig_ref.add_subplot()
+
+    loc = (0, 0)
+    width, height = (1, 1)
+    edgecolor = 'b'
+    linestyle = (0, [6, 6])
+    linestyle_hacked = (0, [0, 6, 6, 0])
+    rect_ref = Rectangle(loc, width, height, edgecolor=edgecolor,
+                                                linestyle=linestyle)
+    rect_ref2 = Rectangle(loc, width, height, edgecolor=edgecolor,
+                                        linestyle=linestyle_hacked)
+    ax_ref.add_patch(rect_ref)
+    ax_ref.add_patch(rect_ref2)
+
+    assert rect_ref.get_linestyle() == linestyle
+    assert rect_ref2.get_linestyle() == linestyle_hacked
+
+    # Check that the dash offset of the rect is the same if we pass it in the
+    # init method and if we create two rects with appropriate onoff sequence
+    # of linestyle.
+    linestyle_test = (6, [6, 6])
+    rect_test = Rectangle(loc, width, height, edgecolor=edgecolor,
+                                                linestyle=linestyle)
+    rect_test2 = Rectangle(loc, width, height, edgecolor=edgecolor,
+                                             linestyle=linestyle_test)
+    assert rect_test.get_linestyle() == linestyle
+    assert rect_test2.get_linestyle() == linestyle_test
+    ax_test.add_patch(rect_test)
+    ax_test.add_patch(rect_test2)
+
+
 def test_negative_rect():
     # These two rectangles have the same vertices, but starting from a
     # different point.  (We also drop the last vertex, which is a duplicate.)


### PR DESCRIPTION
## PR Summary
Pass the given offest in the draw method of the Patch class. In this way, the Patch class no longer ignores the dash offset. (closes #22977 )  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
