### PR TITLE
Minor improvements to units_sample example

### DIFF
--- a/examples/units/units_sample.py
+++ b/examples/units/units_sample.py
@@ -19,14 +19,14 @@ import numpy as np
 
 cms = cm * np.arange(0, 10, 2)
 
-fig, axs = plt.subplots(2, 2)
+fig, axs = plt.subplots(2, 2, constrained_layout=True)
 
 axs[0, 0].plot(cms, cms)
 
 axs[0, 1].plot(cms, cms, xunits=cm, yunits=inch)
 
 axs[1, 0].plot(cms, cms, xunits=inch, yunits=cm)
-axs[1, 0].set_xlim(3, 6)  # scalars are interpreted in current units
+axs[1, 0].set_xlim(-1, 4)  # scalars are interpreted in current units
 
 axs[1, 1].plot(cms, cms, xunits=inch, yunits=inch)
 axs[1, 1].set_xlim(3*cm, 6*cm)  # cm are converted to inches


### PR DESCRIPTION
## PR Summary
- Use tight layout so axis labels aren't hidden
- Set the x-limits to values that show the actual plot (before this it was just a little bit of the plot in the top left corner of the axes)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
