### PR TITLE
Clean up test_chunksize_fails()

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -276,6 +276,11 @@ def test_draw_path_collection_error_handling():
 
 
 def test_chunksize_fails():
+    # NOTE: This test covers multiple independent test scenarios in a single
+    #       function, because each scenario uses ~2GB of memory and we don't
+    #       want parallel test executors to accidentally run multiple of these
+    #       at the same time.
+
     N = 100_000
     dpi = 500
     w = 5*dpi

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -7,7 +7,7 @@ import pytest
 
 
 from matplotlib import (
-    collections, path, patheffects, pyplot as plt, transforms as mtransforms,
+    collections, patheffects, pyplot as plt, transforms as mtransforms,
     rcParams, rc_context)
 from matplotlib.backends.backend_agg import RendererAgg
 from matplotlib.figure import Figure
@@ -56,7 +56,7 @@ def test_large_single_path_collection():
     # applied.
     f, ax = plt.subplots()
     collection = collections.PathCollection(
-        [path.Path([[-10, 5], [10, 5], [10, -5], [-10, -5], [-10, 5]])])
+        [Path([[-10, 5], [10, 5], [10, -5], [-10, -5], [-10, 5]])])
     ax.add_artist(collection)
     ax.set_xlim(10**-3, 1)
     plt.savefig(buff)
@@ -270,7 +270,7 @@ def test_webp_alpha():
 
 def test_draw_path_collection_error_handling():
     fig, ax = plt.subplots()
-    ax.scatter([1], [1]).set_paths(path.Path([(0, 1), (2, 3)]))
+    ax.scatter([1], [1]).set_paths(Path([(0, 1), (2, 3)]))
     with pytest.raises(TypeError):
         fig.canvas.draw()
 


### PR DESCRIPTION
## PR Summary

Follow up to #23413.

- Add a note why test_chunksize_fails() covers multiple test scenarios
- Don't use path.Path if we have Path already imported
- Reorder commands to make the function more understandable.