### PR TITLE
Tweak pgf escapes.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -310,8 +310,10 @@ class LatexManager:
         test_input = self.latex_header + latex_end
         stdout, stderr = latex.communicate(test_input)
         if latex.returncode != 0:
-            raise LatexError("LaTeX returned an error, probably missing font "
-                             "or error in preamble.", stdout)
+            raise LatexError(
+                f"LaTeX errored (probably missing font or error in preamble) "
+                f"while processing the following input:\n{test_input}",
+                stdout)
 
         self.latex = None  # Will be set up on first use.
         # Per-instance cache.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -70,6 +70,8 @@ def _get_preamble():
                 path = pathlib.Path(fm.findfont(family))
                 preamble.append(r"\%s{%s}[Path=\detokenize{%s/}]" % (
                     command, path.name, path.parent.as_posix()))
+    preamble.append(mpl.texmanager._usepackage_if_not_loaded(
+        "underscore", option="strings"))  # Documented as "must come last".
     return "\n".join(preamble)
 
 
@@ -84,9 +86,8 @@ mpl_in_to_pt = 1. / mpl_pt_to_in
 _NO_ESCAPE = r"(?<!\\)(?:\\\\)*"
 _split_math = re.compile(_NO_ESCAPE + r"\$").split
 _replace_escapetext = functools.partial(
-    # When the next character is _, ^, $, or % (not preceded by an escape),
-    # insert a backslash.
-    re.compile(_NO_ESCAPE + "(?=[_^$%])").sub, "\\\\")
+    # When the next character is an unescaped % or ^, insert a backslash.
+    re.compile(_NO_ESCAPE + "(?=[%^])").sub, "\\\\")
 _replace_mathdefault = functools.partial(
     # Replace \mathdefault (when not preceded by an escape) by empty string.
     re.compile(_NO_ESCAPE + r"(\\mathdefault)").sub, "")
@@ -106,7 +107,7 @@ def _tex_escape(text):
     ``$`` with ``\(\displaystyle %s\)``. Escaped math separators (``\$``)
     are ignored.
 
-    The following characters are escaped in text segments: ``_^$%``
+    The following characters are escaped in text segments: ``^%``
     """
     # Sometimes, matplotlib adds the unknown command \mathdefault.
     # Not using \mathnormal instead since this looks odd for the latex cm font.
@@ -358,14 +359,16 @@ class LatexManager:
         try:
             answer = self._expect_prompt()
         except LatexError as err:
-            raise ValueError("Error measuring {!r}\nLaTeX Output:\n{}"
+            # Here and below, use '{}' instead of {!r} to avoid doubling all
+            # backslashes.
+            raise ValueError("Error measuring {}\nLaTeX Output:\n{}"
                              .format(tex, err.latex_output)) from err
         try:
             # Parse metrics from the answer string.  Last line is prompt, and
             # next-to-last-line is blank line from \typeout.
             width, height, offset = answer.splitlines()[-3].split(",")
         except Exception as err:
-            raise ValueError("Error measuring {!r}\nLaTeX Output:\n{}"
+            raise ValueError("Error measuring {}\nLaTeX Output:\n{}"
                              .format(tex, answer)) from err
         w, h, o = float(width[:-2]), float(height[:-2]), float(offset[:-2])
         # The height returned from LaTeX goes from base to top;
@@ -864,8 +867,8 @@ class FigureCanvasPgf(FigureCanvasBase):
                     r"\documentclass[12pt]{minimal}",
                     r"\usepackage[papersize={%fin,%fin}, margin=0in]{geometry}"
                     % (w, h),
-                    _get_preamble(),
                     r"\usepackage{pgf}",
+                    _get_preamble(),
                     r"\begin{document}",
                     r"\centering",
                     r"\input{figure.pgf}",
@@ -975,8 +978,8 @@ class PdfPages:
             r"\documentclass[12pt]{minimal}",
             r"\usepackage[papersize={%fin,%fin}, margin=0in]{geometry}"
             % (width_inches, height_inches),
-            _get_preamble(),
             r"\usepackage{pgf}",
+            _get_preamble(),
             r"\setlength{\parindent}{0pt}",
             r"\begin{document}%",
         ])

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -33,6 +33,23 @@ def compare_figure(fname, savefig_kwargs={}, tol=0):
         raise ImageComparisonFailure(err)
 
 
+@pytest.mark.parametrize('plain_text, escaped_text', [
+    (r'quad_sum: $\sum x_i^2$', r'quad_sum: \(\displaystyle \sum x_i^2\)'),
+    ('% not a comment', r'\% not a comment'),
+    ('^not', r'\^not'),
+])
+def test_tex_escape(plain_text, escaped_text):
+    assert _tex_escape(plain_text) == escaped_text
+
+
+@needs_pgf_xelatex
+@pytest.mark.backend('pgf')
+def test_tex_special_chars(tmp_path):
+    fig = plt.figure()
+    fig.text(.5, .5, "_^ $a_b^c$")
+    fig.savefig(tmp_path / "test.pdf")  # Should not error.
+
+
 def create_figure():
     plt.figure()
     x = np.linspace(0, 1, 15)
@@ -57,17 +74,6 @@ def create_figure():
 
     plt.xlim(0, 1)
     plt.ylim(0, 1)
-
-
-@pytest.mark.parametrize('plain_text, escaped_text', [
-    (r'quad_sum: $\sum x_i^2$', r'quad\_sum: \(\displaystyle \sum x_i^2\)'),
-    (r'no \$splits \$ here', r'no \$splits \$ here'),
-    ('with_underscores', r'with\_underscores'),
-    ('% not a comment', r'\% not a comment'),
-    ('^not', r'\^not'),
-])
-def test_tex_escape(plain_text, escaped_text):
-    assert _tex_escape(plain_text) == escaped_text
 
 
 # test compiling a figure to pdf with xelatex


### PR DESCRIPTION
- We don't need to escape underscores manually, but can rely on the
  underscore package like we already do for usetex.
- We don't actually escape dollars (we parse them as math delimiters
  first).
- Slightly tweak error message generation.
- Move escaping tests before the big `create_figure` definition, which
  is used for further tests below.

(Moves towards https://github.com/matplotlib/matplotlib/pull/23381#issuecomment-1183758517, where I suggest to try to do away with pgf escapes entirely.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
