### PR TITLE
Fix divide by 0 runtime warning

### DIFF
--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -21,7 +21,7 @@ def _line2d_seg_dist(p1, p2, p0):
 
     x01 = np.asarray(p0[0]) - p1[0]
     y01 = np.asarray(p0[1]) - p1[1]
-    if np.all(p1 == p2):
+    if np.all(p1[0:2] == p2[0:2]):
         return np.hypot(x01, y01)
 
     x21 = p2[0] - p1[0]

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1011,11 +1011,13 @@ def test_lines_dists():
 def test_lines_dists_nowarning():
     # Smoke test to see that no RuntimeWarning is emitted when two first
     # arguments are the same, see GH#22624
-    p0 = (10, 30)
-    p1 = (20, 150)
-    proj3d._line2d_seg_dist(p0, p0, p1)
+    p0 = (10, 30, 50)
+    p1 = (10, 30, 20)
+    p2 = (20, 150)
+    proj3d._line2d_seg_dist(p0, p0, p2)
+    proj3d._line2d_seg_dist(p0, p1, p2)
     p0 = np.array(p0)
-    proj3d._line2d_seg_dist(p0, p0, p1)
+    proj3d._line2d_seg_dist(p0, p0, p2)
 
 
 def test_autoscale():


### PR DESCRIPTION
## PR Summary
PR https://github.com/matplotlib/matplotlib/issues/22624/ didn't fix the runtime error popping up when the two points have the same X and Y but differing Z coordinates. This fixes that.

```
Traceback (most recent call last):
  File "/mnt/c/Users/Scott/Documents/Documents/Coding/matplotlib/lib/mpl_toolkits/mplot3d/proj3d.py", line 30, in _line2d_seg_dist
    u = (x01*x21 + y01*y21) / (x21**2 + y21**2)
FloatingPointError: invalid value encountered in double_scalars
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
