### PR TITLE
Remove need to detect math mode in pgf strings

### DIFF
--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -95,7 +95,7 @@ except mpl.ExecutableNotFoundError:
 @pytest.mark.skipif(not _has_tex_package('ucs'), reason='needs ucs.sty')
 @pytest.mark.backend('pgf')
 @image_comparison(['pgf_pdflatex.pdf'], style='default',
-                  tol=11.7 if _old_gs_version else 0)
+                  tol=11.71 if _old_gs_version else 0)
 def test_pdflatex():
     if os.environ.get('APPVEYOR'):
         pytest.xfail("pdflatex test does not work on appveyor due to missing "

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -11,7 +11,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.testing import _has_tex_package, _check_for_pgf
 from matplotlib.testing.compare import compare_images, ImageComparisonFailure
-from matplotlib.backends.backend_pgf import PdfPages, _tex_escape
+from matplotlib.backends.backend_pgf import PdfPages
 from matplotlib.testing.decorators import (
     _image_directories, check_figures_equal, image_comparison)
 from matplotlib.testing._markers import (
@@ -31,13 +31,6 @@ def compare_figure(fname, savefig_kwargs={}, tol=0):
     err = compare_images(expected, actual, tol=tol)
     if err:
         raise ImageComparisonFailure(err)
-
-
-@pytest.mark.parametrize('plain_text, escaped_text', [
-    (r'quad_sum: $\sum x_i^2$', r'quad_sum: \(\displaystyle \sum x_i^2\)'),
-])
-def test_tex_escape(plain_text, escaped_text):
-    assert _tex_escape(plain_text) == escaped_text
 
 
 @needs_pgf_xelatex

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -35,19 +35,22 @@ def compare_figure(fname, savefig_kwargs={}, tol=0):
 
 @pytest.mark.parametrize('plain_text, escaped_text', [
     (r'quad_sum: $\sum x_i^2$', r'quad_sum: \(\displaystyle \sum x_i^2\)'),
-    ('% not a comment', r'\% not a comment'),
-    ('^not', r'\^not'),
 ])
 def test_tex_escape(plain_text, escaped_text):
     assert _tex_escape(plain_text) == escaped_text
 
 
 @needs_pgf_xelatex
+@needs_ghostscript
 @pytest.mark.backend('pgf')
 def test_tex_special_chars(tmp_path):
     fig = plt.figure()
-    fig.text(.5, .5, "_^ $a_b^c$")
-    fig.savefig(tmp_path / "test.pdf")  # Should not error.
+    fig.text(.5, .5, "%_^ $a_b^c$")
+    buf = BytesIO()
+    fig.savefig(buf, format="png", backend="pgf")
+    buf.seek(0)
+    t = plt.imread(buf)
+    assert not (t == 1).all()  # The leading "%" didn't eat up everything.
 
 
 def create_figure():


### PR DESCRIPTION
See https://github.com/matplotlib/matplotlib/pull/23381#issuecomment-1183758517 for motivation.  Supersedes #23381.  @painch Can you check whether this works for you?

### Directly support ^% in pgf.

Support for `^` is inspired from the support for `_` as implemented
in underscore.sty, but much simpler because 1) we don't care about
hyphenation, 2) we don't care about substituting a real underscore by
a rule box when the current font lacks an underscore (there's no real
way out if the font has no caret, anyways), and 3) we don't care about
the active character ending up in tex `\commands` because the character
is only made active in the context of matplotlib-provided strings, not
globally.

### Also handle `\displaystyle` and `\mathdefault` at the TeX level.

Note that tex_escape is still being tested by
test_minus_signs_with_tex, which explicitly checks support for unicode
minus.

-----

Edit: A test fails on the Ubuntu 18.04 texlive (and I can repro this locally) with pdflatex only because the strings get shifted a tiny bit.  I'm actually a bit at loss as to why this shift occurs, and especially only with pdflatex on an older texlive.  (In particular, I have separately checked the reported text metrics, which did not change; more debugging indicates that it's the `\everymath{\displaystyle}` which seems to very slightly shift the non-math text.)  I would be tempted to just skip this test on the old Ubuntu 18.04 texlive (considering that it's just a slight image shift, *and* that the test still passes on the more recent Ubuntu image...
Edit^2: Looks like I can just get away with bumping the test tolerance by 1-per-thousand on old ghostscripts...

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
