### PR TITLE
Deduplicate common parts in LatexManager.{__init__,_setup_latex_process}

### DIFF
--- a/doc/api/next_api_changes/deprecations/23444-AL.rst
+++ b/doc/api/next_api_changes/deprecations/23444-AL.rst
@@ -1,0 +1,3 @@
+The ``texcommand`` and ``latex_header`` attributes of ``backend_pgf.LatexManager``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -291,28 +291,22 @@ class LatexManager:
         self._finalize_tmpdir = weakref.finalize(self, self._tmpdir.cleanup)
 
         # test the LaTeX setup to ensure a clean startup of the subprocess
-        self.texcommand = mpl.rcParams["pgf.texsystem"]
-        self.latex_header = LatexManager._build_latex_header()
-        latex_end = "\n\\makeatletter\n\\@@end\n"
         try:
-            latex = subprocess.Popen(
-                [self.texcommand, "-halt-on-error"],
-                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                encoding="utf-8", cwd=self.tmpdir)
+            self._setup_latex_process(expect_reply=False)
         except FileNotFoundError as err:
             raise RuntimeError(
-                f"{self.texcommand} not found.  Install it or change "
+                f"{self.latex.args[0]!r} not found.  Install it or change "
                 f"rcParams['pgf.texsystem'] to an available TeX "
                 f"implementation.") from err
         except OSError as err:
-            raise RuntimeError("Error starting process %r" %
-                               self.texcommand) from err
-        test_input = self.latex_header + latex_end
-        stdout, stderr = latex.communicate(test_input)
-        if latex.returncode != 0:
+            raise RuntimeError(
+                f"Error starting process {self.latex.args[0]!r}") from err
+        stdout, stderr = self.latex.communicate("\n\\makeatletter\\@@end\n")
+        if self.latex.returncode != 0:
             raise LatexError(
                 f"LaTeX errored (probably missing font or error in preamble) "
-                f"while processing the following input:\n{test_input}",
+                f"while processing the following input:\n"
+                f"{self._build_latex_header()}",
                 stdout)
 
         self.latex = None  # Will be set up on first use.
@@ -320,14 +314,18 @@ class LatexManager:
         self._get_box_metrics = functools.lru_cache()(self._get_box_metrics)
 
     str_cache = _api.deprecated("3.5")(property(lambda self: {}))
+    texcommand = _api.deprecated("3.6")(
+        property(lambda self: mpl.rcParams["pgf.texsystem"]))
+    latex_header = _api.deprecated("3.6")(
+        property(lambda self: self._build_latex_header()))
 
-    def _setup_latex_process(self):
+    def _setup_latex_process(self, *, expect_reply=True):
         # Open LaTeX process for real work; register it for deletion.  On
         # Windows, we must ensure that the subprocess has quit before being
         # able to delete the tmpdir in which it runs; in order to do so, we
         # must first `kill()` it, and then `communicate()` with it.
         self.latex = subprocess.Popen(
-            [self.texcommand, "-halt-on-error"],
+            [mpl.rcParams["pgf.texsystem"], "-halt-on-error"],
             stdin=subprocess.PIPE, stdout=subprocess.PIPE,
             encoding="utf-8", cwd=self.tmpdir)
 
@@ -339,9 +337,9 @@ class LatexManager:
             self, finalize_latex, self.latex)
         # write header with 'pgf_backend_query_start' token
         self._stdin_writeln(self._build_latex_header())
-        # read all lines until our 'pgf_backend_query_start' token appears
-        self._expect("*pgf_backend_query_start")
-        self._expect_prompt()
+        if expect_reply:  # read until 'pgf_backend_query_start' token appears
+            self._expect("*pgf_backend_query_start")
+            self._expect_prompt()
 
     def get_width_height_descent(self, text, prop):
         """


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
