### PR TITLE
Tweak callbacks to generate pick events.

### DIFF
--- a/doc/api/next_api_changes/deprecations/23448-AL.rst
+++ b/doc/api/next_api_changes/deprecations/23448-AL.rst
@@ -1,0 +1,4 @@
+``FigureCanvasBase.pick``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.  Directly call `.Figure.pick`, which has taken over the
+responsibility of checking the canvas widgetlock as well.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1697,6 +1697,7 @@ class FigureCanvasBase:
         """
         return self._is_saving
 
+    @_api.deprecated("3.6", alternative="canvas.figure.pick")
     def pick(self, mouseevent):
         if not self.widgetlock.locked():
             self.figure.pick(mouseevent)

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -79,11 +79,6 @@ class FigureCanvasGTK4(FigureCanvasBase, Gtk.DrawingArea):
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")
 
-    def pick(self, mouseevent):
-        # GtkWidget defines pick in GTK4, so we need to override here to work
-        # with the base implementation we want.
-        FigureCanvasBase.pick(self, mouseevent)
-
     def destroy(self):
         self.close_event()
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2372,10 +2372,10 @@ class Figure(FigureBase):
         # pickling.
         self._canvas_callbacks = cbook.CallbackRegistry(
             signals=FigureCanvasBase.events)
-        self._button_pick_id = self._canvas_callbacks.connect(
-            'button_press_event', lambda event: self.canvas.pick(event))
-        self._scroll_pick_id = self._canvas_callbacks.connect(
-            'scroll_event', lambda event: self.canvas.pick(event))
+        self._button_pick_id = self._canvas_callbacks._connect_picklable(
+            'button_press_event', self.pick)
+        self._scroll_pick_id = self._canvas_callbacks._connect_picklable(
+            'scroll_event', self.pick)
 
         if figsize is None:
             figsize = mpl.rcParams['figure.figsize']
@@ -2422,6 +2422,10 @@ class Figure(FigureBase):
 
         # list of child gridspecs for this figure
         self._gridspecs = []
+
+    def pick(self, mouseevent):
+        if not self.canvas.widgetlock.locked():
+            super().pick(mouseevent)
 
     def _check_layout_engines_compat(self, old, new):
         """


### PR DESCRIPTION
Currently, pick events are generated by button_press and scroll events,
which call canvas.pick, which itself checks the widgetlock and then
calls Figure.pick, which is actually Artist.pick; Artist.pick checks
whether to emit a PickEvent for the current artist, then calls itself
recursively on children artists.

This PR gets rid of the intermediate canvas.pick layer, moving the
widgetlock check to Figure.pick (Figure.pick still calls the super()
pick, i.e. Artist.pick, after the check).  The advantages are that 1)
this avoids colliding with pick methods that may be present in the
native GUI classes (this is not a theoretical case: see the changes in
the GTK4 case) and 2) this makes it easier to fix button_pick_id and
scroll_pick_id to use picklable connections (which they should do).  In
the old implementation, lambdas were not picklable, and one could not
write e.g. `mpl_connect("button_press_event", self.canvas.pick)` because
that would not handle canvas swapping.

TL;DR: pick callback handlers are now correctly restored upon unpickling.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
