### PR TITLE
Deprecate macos close handler.

### DIFF
--- a/doc/api/next_api_changes/deprecations/23464-AL.rst
+++ b/doc/api/next_api_changes/deprecations/23464-AL.rst
@@ -1,0 +1,2 @@
+``FigureManagerMac.close`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -158,9 +158,13 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
             self.show()
             self.canvas.draw_idle()
 
-    def close(self):
+    def _close_button_pressed(self):
         Gcf.destroy(self)
         self.canvas.flush_events()
+
+    @_api.deprecated("3.6")
+    def close(self):
+        return self._close_button_pressed()
 
     def show(self):
         if not self._shown:

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1132,7 +1132,7 @@ static WindowServerConnectionManager *sharedWindowServerConnectionManager = nil;
 
 - (BOOL)closeButtonPressed
 {
-    gil_call_method(manager, "close");
+    gil_call_method(manager, "_close_button_pressed");
     return YES;
 }
 


### PR DESCRIPTION
This is similar to the `_widgetclosed` handler in qt and the `_on_close`
handler in wx.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
