### PR TITLE
Remove old handling for factor=None in axisartist.

### DIFF
--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -54,22 +54,12 @@ class FixedAxisArtistHelper(grid_helper_curvelinear.FloatingAxisArtistHelper):
         grid_finder = self.grid_helper.grid_finder
 
         lat_levs, lat_n, lat_factor = self._grid_info["lat_info"]
+        yy0 = lat_levs / lat_factor
+        dy = 0.001 / lat_factor
+
         lon_levs, lon_n, lon_factor = self._grid_info["lon_info"]
-
-        lon_levs, lat_levs = np.asarray(lon_levs), np.asarray(lat_levs)
-        if lat_factor is not None:
-            yy0 = lat_levs / lat_factor
-            dy = 0.001 / lat_factor
-        else:
-            yy0 = lat_levs
-            dy = 0.001
-
-        if lon_factor is not None:
-            xx0 = lon_levs / lon_factor
-            dx = 0.001 / lon_factor
-        else:
-            xx0 = lon_levs
-            dx = 0.001
+        xx0 = lon_levs / lon_factor
+        dx = 0.001 / lon_factor
 
         extremes = self.grid_helper._extremes
         xmin, xmax = sorted(extremes[:2])
@@ -242,31 +232,25 @@ class GridHelperCurveLinear(grid_helper_curvelinear.GridHelperCurveLinear):
 
         lon_min, lon_max = sorted(extremes[:2])
         lat_min, lat_max = sorted(extremes[2:])
+        grid_info["extremes"] = lon_min, lon_max, lat_min, lat_max  # extremes
+
         lon_levs, lon_n, lon_factor = \
             grid_finder.grid_locator1(lon_min, lon_max)
+        lon_levs = np.asarray(lon_levs)
         lat_levs, lat_n, lat_factor = \
             grid_finder.grid_locator2(lat_min, lat_max)
-        grid_info["extremes"] = lon_min, lon_max, lat_min, lat_max  # extremes
+        lat_levs = np.asarray(lat_levs)
 
         grid_info["lon_info"] = lon_levs, lon_n, lon_factor
         grid_info["lat_info"] = lat_levs, lat_n, lat_factor
 
-        grid_info["lon_labels"] = grid_finder.tick_formatter1("bottom",
-                                                              lon_factor,
-                                                              lon_levs)
+        grid_info["lon_labels"] = grid_finder.tick_formatter1(
+            "bottom", lon_factor, lon_levs)
+        grid_info["lat_labels"] = grid_finder.tick_formatter2(
+            "bottom", lat_factor, lat_levs)
 
-        grid_info["lat_labels"] = grid_finder.tick_formatter2("bottom",
-                                                              lat_factor,
-                                                              lat_levs)
-
-        if lon_factor is None:
-            lon_values = np.asarray(lon_levs[:lon_n])
-        else:
-            lon_values = np.asarray(lon_levs[:lon_n]/lon_factor)
-        if lat_factor is None:
-            lat_values = np.asarray(lat_levs[:lat_n])
-        else:
-            lat_values = np.asarray(lat_levs[:lat_n]/lat_factor)
+        lon_values = lon_levs[:lon_n] / lon_factor
+        lat_values = lat_levs[:lat_n] / lat_factor
 
         lon_lines, lat_lines = grid_finder._get_raw_grid_lines(
             lon_values[(lon_min < lon_values) & (lon_values < lon_max)],

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -166,7 +166,9 @@ class GridFinder:
 
         lon_min, lon_max, lat_min, lat_max = extremes
         lon_levs, lon_n, lon_factor = self.grid_locator1(lon_min, lon_max)
+        lon_levs = np.asarray(lon_levs)
         lat_levs, lat_n, lat_factor = self.grid_locator2(lat_min, lat_max)
+        lat_levs = np.asarray(lat_levs)
 
         lon_values = lon_levs[:lon_n] / lon_factor
         lat_values = lat_levs[:lat_n] / lat_factor

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -120,8 +120,8 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
         self._grid_info = {
             "extremes": (lon_min, lon_max, lat_min, lat_max),
-            "lon_info": (lon_levs, lon_n, lon_factor),
-            "lat_info": (lat_levs, lat_n, lat_factor),
+            "lon_info": (lon_levs, lon_n, np.asarray(lon_factor)),
+            "lat_info": (lat_levs, lat_n, np.asarray(lat_factor)),
             "lon_labels": grid_finder.tick_formatter1(
                 "bottom", lon_factor, lon_levs),
             "lat_labels": grid_finder.tick_formatter2(
@@ -170,12 +170,10 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
         grid_finder = self.grid_helper.grid_finder
 
         lat_levs, lat_n, lat_factor = self._grid_info["lat_info"]
-        lat_levs = np.asarray(lat_levs)
         yy0 = lat_levs / lat_factor
         dy = 0.01 / lat_factor
 
         lon_levs, lon_n, lon_factor = self._grid_info["lon_info"]
-        lon_levs = np.asarray(lon_levs)
         xx0 = lon_levs / lon_factor
         dx = 0.01 / lon_factor
 


### PR DESCRIPTION
factor=None (meaning =1) was deprecated in e900be3 (3.2) and support for
factor=None was removed everywhere else in 3.4; the changes here had
just been missed.

Also normalize lon_levs, lat_levs to arrays early, rather than having to
do this multiple times.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
