### PR TITLE
Add markerfacealt to pass-through arguments for error bar lines

### DIFF
--- a/doc/api/next_api_changes/behavior/23475-WLQ.rst
+++ b/doc/api/next_api_changes/behavior/23475-WLQ.rst
@@ -1,0 +1,5 @@
+The markerfacecoloralt parameter to Line2D is now supported by axes.errorbar
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+- markerfacecoloralt is now passed to the line plotter from axes.errorbar
+- Documentation for axes.errorbar how accurately lists which properties are
+  passed on to Line2D, rather than claiming that all kwargs are passed on

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3367,7 +3367,25 @@ class Axes(_AxesBase):
             property names, *markerfacecolor*, *markeredgecolor*, *markersize*
             and *markeredgewidth*.
 
-            Valid kwargs for the marker properties are `.Line2D` properties:
+            Valid kwargs for the marker properties are:
+
+                - marker
+                - markersize
+                - markerfacecolor
+                - markerfacecoloralt
+                - markeredgewidth
+                - markeredgecolor
+                - markevery
+                - linestyle
+                - fillstyle
+                - drawstyle
+                - dash_capstyle
+                - dash_joinstyle
+                - solid_capstyle
+                - solid_joinstyle
+                - dashes
+
+            Refer to the corresponding `.Line2D` property for more details:
 
             %(Line2D:kwdoc)s
         """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3467,6 +3467,7 @@ class Axes(_AxesBase):
         # Eject any line-specific information from format string, as it's not
         # needed for bars or caps.
         for key in ['marker', 'markersize', 'markerfacecolor',
+                    'markerfacecoloralt',
                     'markeredgewidth', 'markeredgecolor', 'markevery',
                     'linestyle', 'fillstyle', 'drawstyle', 'dash_capstyle',
                     'dash_joinstyle', 'solid_capstyle', 'solid_joinstyle',

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3369,21 +3369,21 @@ class Axes(_AxesBase):
 
             Valid kwargs for the marker properties are:
 
-                - *dashes*
-                - *dash_capstyle*
-                - *dash_joinstyle*
-                - *drawstyle*
-                - *fillstyle*
-                - *linestyle*
-                - *marker*
-                - *markeredgecolor*
-                - *markeredgewidth*
-                - *markerfacecolor*
-                - *markerfacecoloralt*
-                - *markersize*
-                - *markevery*
-                - *solid_capstyle*
-                - *solid_joinstyle*
+            - *dashes*
+            - *dash_capstyle*
+            - *dash_joinstyle*
+            - *drawstyle*
+            - *fillstyle*
+            - *linestyle*
+            - *marker*
+            - *markeredgecolor*
+            - *markeredgewidth*
+            - *markerfacecolor*
+            - *markerfacecoloralt*
+            - *markersize*
+            - *markevery*
+            - *solid_capstyle*
+            - *solid_joinstyle*
 
             Refer to the corresponding `.Line2D` property for more details:
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3369,21 +3369,21 @@ class Axes(_AxesBase):
 
             Valid kwargs for the marker properties are:
 
-                - marker
-                - markersize
-                - markerfacecolor
-                - markerfacecoloralt
-                - markeredgewidth
-                - markeredgecolor
-                - markevery
-                - linestyle
-                - fillstyle
-                - drawstyle
-                - dash_capstyle
-                - dash_joinstyle
-                - solid_capstyle
-                - solid_joinstyle
-                - dashes
+                - *dashes*
+                - *dash_capstyle*
+                - *dash_joinstyle*
+                - *drawstyle*
+                - *fillstyle*
+                - *linestyle*
+                - *marker*
+                - *markeredgecolor*
+                - *markeredgewidth*
+                - *markerfacecolor*
+                - *markerfacecoloralt*
+                - *markersize*
+                - *markevery*
+                - *solid_capstyle*
+                - *solid_joinstyle*
 
             Refer to the corresponding `.Line2D` property for more details:
 


### PR DESCRIPTION
 ## PR Summary

Add `markerfacealt` as a line kwarg that should be passed through when making error bars. See issue #23375 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [✔️] Has pytest style unit tests (and `pytest` passes).
- [✔️] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [✔️] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [✔️] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
