### PR TITLE
Backport PR #23476: FIX: reset to original DPI in getstate

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2886,6 +2886,9 @@ class Figure(FigureBase):
         # Set cached renderer to None -- it can't be pickled.
         state["_cachedRenderer"] = None
 
+        # discard any changes to the dpi due to pixel ratio changes
+        state["_dpi"] = state.get('_original_dpi', state['_dpi'])
+
         # add version information to the state
         state['__mpl_version__'] = mpl.__version__
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 import io
 from pathlib import Path
+import pickle
 import platform
 from threading import Timer
 from types import SimpleNamespace
@@ -1360,3 +1361,11 @@ def test_kwargs_pass():
 
     assert fig.get_label() == 'whole Figure'
     assert sub_fig.get_label() == 'sub figure'
+
+
+def test_unpickle_with_device_pixel_ratio():
+    fig = Figure(dpi=42)
+    fig.canvas._set_device_pixel_ratio(7)
+    assert fig.dpi == 42*7
+    fig2 = pickle.loads(pickle.dumps(fig))
+    assert fig2.dpi == 42


### PR DESCRIPTION
Merge pull request #23476 from tacaswell/fix/unpickle_dpi

FIX: reset to original DPI in getstate
(cherry picked from commit 330124862b46dc003ff3e38427efcc9000b9d7ab)
