### PR TITLE
Mathtext spaces must be independent of font style.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1935,13 +1935,17 @@ class Parser:
     float_literal = staticmethod(pyparsing_common.convertToFloat)
 
     def _make_space(self, percentage):
-        # All spaces are relative to em width
+        # In TeX, an em (the unit usually used to measure horizontal lengths)
+        # is not the width of the character 'm'; it is the same in different
+        # font styles (e.g. roman or italic). Mathtext, however, uses 'm' in
+        # the italic style so that horizontal spaces don't depend on the
+        # current font style.
         state = self.get_state()
         key = (state.font, state.fontsize, state.dpi)
         width = self._em_width_cache.get(key)
         if width is None:
             metrics = state.font_output.get_metrics(
-                state.font, mpl.rcParams['mathtext.default'], 'm',
+                'it', mpl.rcParams['mathtext.default'], 'm',
                 state.fontsize, state.dpi)
             width = metrics.advance
             self._em_width_cache[key] = width


### PR DESCRIPTION
## PR Summary
Fixes https://github.com/matplotlib/matplotlib/issues/23474.
![before](https://user-images.githubusercontent.com/19171016/180591457-ee39637b-f61b-4977-9c70-18f39b4f3d1c.svg)

The width of the space inserted by, for instance, `\,` and `\mathrm{\,}`, is now the same.
![after](https://user-images.githubusercontent.com/19171016/180591468-ef971604-db89-4372-98b1-43c391d2ddb5.svg)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
