### PR TITLE
"Switch to Adapter instead of Subclass of Axes"

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -10,6 +10,7 @@ from .axes_divider import Size, SubplotDivider, Divider
 from matplotlib.axes import Axes
 from .mpl_axes import AxesAdapter
 
+
 def _tick_only(ax: Axes, bottom_on, left_on):
     bottom_off = not bottom_on
     left_off = not left_on

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -7,14 +7,15 @@ from matplotlib import _api, cbook
 from matplotlib.gridspec import SubplotSpec
 
 from .axes_divider import Size, SubplotDivider, Divider
-from .mpl_axes import Axes
+from matplotlib.axes import Axes
+from .mpl_axes import AxesAdapter
 
-
-def _tick_only(ax, bottom_on, left_on):
+def _tick_only(ax: Axes, bottom_on, left_on):
     bottom_off = not bottom_on
     left_off = not left_on
-    ax.axis["bottom"].toggle(ticklabels=bottom_off, label=bottom_off)
-    ax.axis["left"].toggle(ticklabels=left_off, label=left_off)
+    aax = AxesAdapter(ax)
+    aax.axis["bottom"].toggle(ticklabels=bottom_off, label=bottom_off)
+    aax.axis["left"].toggle(ticklabels=left_off, label=left_off)
 
 
 class CbarAxesBase:

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -46,9 +46,25 @@ class AxesAdapter:
         self._init_axis_artists()
 
     def __getattr__(self, attr):
-        if attr in ('axis', 'clear', '_axislines', '_init_axis_artists'):
+        if attr in ('_adapted_axes', 'axis', 'clear', '_init_axis_artists'):
             return object.__getattribute__(self, attr)
+        if attr in ('_axislines',):
+            return self._adapted_axes.__getattribute__('_adapter' + attr)
         return self._adapted_axes.__getattribute__(attr)
+
+    def __setattr__(self, attr, value):
+        if attr in ('_adapted_axes',):
+            return object.__setattr__(self, attr, value)
+        if attr in ('_axislines',):
+            return self._adapted_axes.__setattr__('_adapter' + attr, value)
+        return self._adapted_axes.__setattr__(attr, value)
+
+    def __delattr__(self, attr):
+        if attr in ('_adapted_axes',):
+            return object.__delattr__(self, attr)
+        if attr in ('_axislines',):
+            return self._adapted_axes.__delattr__('_adapter' + attr)
+        return self._adapted_axes.__delattr__(attr)
 
     def _init_axis_artists(self):
         self._axislines = self.AxisDict()

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -28,7 +28,8 @@ class AxesAdapter:
             if isinstance(k, tuple):
                 r = SimpleChainedObjects(
                     # super() within a list comprehension needs explicit args.
-                    [super(AxesAdapter.AxisDict, self).__getitem__(k1) for k1 in k])
+                    [super(AxesAdapter.AxisDict, self).__getitem__(k1)
+                        for k1 in k])
                 return r
             elif isinstance(k, slice):
                 if k.start is None and k.stop is None and k.step is None:

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -3,6 +3,7 @@ from matplotlib.artist import Artist
 from matplotlib.axis import XAxis, YAxis
 Axes = maxes.Axes
 
+
 class SimpleChainedObjects:
     def __init__(self, objects):
         self._objects = objects
@@ -14,6 +15,7 @@ class SimpleChainedObjects:
     def __call__(self, *args, **kwargs):
         for m in self._objects:
             m(*args, **kwargs)
+
 
 class AxesAdapter:
 
@@ -38,16 +40,19 @@ class AxesAdapter:
 
         def __call__(self, *v, **kwargs):
             return maxes.Axes.axis(self.axes, *v, **kwargs)
+
     def __init__(self, adapted_axes):
         if isinstance(adapted_axes, AxesAdapter):
             self._adapted_axes = adapted_axes._adapted_axes
         else:
             self._adapted_axes = adapted_axes
         self._init_axis_artists()
+
     def __getattr__(self, attr):
-        if attr in ('axis', 'clear','_axislines','_init_axis_artists'):
+        if attr in ('axis', 'clear', '_axislines', '_init_axis_artists'):
             return object.__getattribute__(self, attr)
         return self._adapted_axes.__getattribute__(attr)
+
     def _init_axis_artists(self):
         self._axislines = self.AxisDict(self)
         self._axislines.update(

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -20,8 +20,7 @@ class SimpleChainedObjects:
 class AxesAdapter:
 
     class AxisDict(dict):
-        def __init__(self, axes):
-            self._axes = axes
+        def __init__(self):
             super().__init__()
 
         def __getitem__(self, k):
@@ -39,9 +38,6 @@ class AxesAdapter:
             else:
                 return dict.__getitem__(self, k)
 
-        def __call__(self, *v, **kwargs):
-            return maxes.Axes.axis(self.axes, *v, **kwargs)
-
     def __init__(self, adapted_axes):
         if isinstance(adapted_axes, AxesAdapter):
             self._adapted_axes = adapted_axes._adapted_axes
@@ -55,7 +51,7 @@ class AxesAdapter:
         return self._adapted_axes.__getattribute__(attr)
 
     def _init_axis_artists(self):
-        self._axislines = self.AxisDict(self)
+        self._axislines = self.AxisDict()
         self._axislines.update(
             bottom=SimpleAxisArtist(self.xaxis, 1, self.spines["bottom"]),
             top=SimpleAxisArtist(self.xaxis, 2, self.spines["top"]),

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -4,7 +4,8 @@ import matplotlib.image as mimage
 import matplotlib.transforms as mtransforms
 from matplotlib.axes import subplot_class_factory
 from matplotlib.transforms import Bbox
-from .mpl_axes import Axes
+from matplotlib.axes import Axes
+from .mpl_axes import AxesAdapter
 
 
 class ParasiteAxesBase:
@@ -158,9 +159,11 @@ class HostAxesBase:
         will have ticks on the right.
         """
         ax = self._add_twin_axes(axes_class, sharex=self)
-        self.axis["right"].set_visible(False)
-        ax.axis["right"].set_visible(True)
-        ax.axis["left", "top", "bottom"].set_visible(False)
+        aax = AxesAdapter(ax)
+        aself = AxesAdapter(self)
+        aself.axis["right"].set_visible(False)
+        aax.axis["right"].set_visible(True)
+        aax.axis["left", "top", "bottom"].set_visible(False)
         return ax
 
     def twiny(self, axes_class=None):
@@ -171,9 +174,11 @@ class HostAxesBase:
         will have ticks on the top.
         """
         ax = self._add_twin_axes(axes_class, sharey=self)
-        self.axis["top"].set_visible(False)
-        ax.axis["top"].set_visible(True)
-        ax.axis["left", "right", "bottom"].set_visible(False)
+        aself = AxesAdapter(self)
+        aax = AxesAdapter(ax)
+        aself.axis["top"].set_visible(False)
+        aax.axis["top"].set_visible(True)
+        aax.axis["left", "right", "bottom"].set_visible(False)
         return ax
 
     def twin(self, aux_trans=None, axes_class=None):
@@ -187,9 +192,11 @@ class HostAxesBase:
             aux_trans = mtransforms.IdentityTransform()
         ax = self._add_twin_axes(
             axes_class, aux_transform=aux_trans, viewlim_mode="transform")
-        self.axis["top", "right"].set_visible(False)
-        ax.axis["top", "right"].set_visible(True)
-        ax.axis["left", "bottom"].set_visible(False)
+        aself = AxesAdapter(self)
+        aself.axis["top", "right"].set_visible(False)
+        aax = AxesAdapter(ax)
+        aax.axis["top", "right"].set_visible(True)
+        aax.axis["left", "bottom"].set_visible(False)
         return ax
 
     def _add_twin_axes(self, axes_class, **kwargs):
@@ -212,8 +219,9 @@ class HostAxesBase:
             restore.remove("top")
         if ax._sharey:
             restore.remove("right")
-        self.axis[tuple(restore)].set_visible(True)
-        self.axis[tuple(restore)].toggle(ticklabels=False, label=False)
+        aself = AxesAdapter(self)
+        aself.axis[tuple(restore)].set_visible(True)
+        aself.axis[tuple(restore)].toggle(ticklabels=False, label=False)
 
     def get_tightbbox(self, renderer=None, call_axes_locator=True,
                       bbox_extra_artists=None):

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -466,7 +466,7 @@ class Axes(maxes.Axes):
         if axes is None:
             axes = self
 
-        self._axislines = mpl_axes.Axes.AxisDict(self)
+        self._axislines = mpl_axes.AxesAdapter.AxisDict()
         new_fixed_axis = self.get_grid_helper().new_fixed_axis
         for loc in ["bottom", "top", "left", "right"]:
             self._axislines[loc] = new_fixed_axis(loc=loc, axes=axes,

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -21,6 +21,7 @@ from mpl_toolkits.axes_grid1.axes_divider import (
 from mpl_toolkits.axes_grid1.inset_locator import (
     zoomed_inset_axes, mark_inset, inset_axes, BboxConnectorPatch)
 import mpl_toolkits.axes_grid1.mpl_axes
+from mpl_toolkits.axes_grid1.mpl_axes import AxesAdapter
 
 import pytest
 
@@ -74,11 +75,13 @@ def test_twin_axes_empty_and_removed():
         h = host_subplot(len(modifiers)+1, len(generators), i)
         t = getattr(h, gen)()
         if "twin invisible" in mod:
-            t.axis[:].set_visible(False)
+            at = AxesAdapter(t)
+            at.axis[:].set_visible(False)
         if "twin removed" in mod:
             t.remove()
         if "host invisible" in mod:
-            h.axis[:].set_visible(False)
+            ah = AxesAdapter(h)
+            ah.axis[:].set_visible(False)
         h.text(0.5, 0.5, gen + ("\n" + mod if mod else ""),
                horizontalalignment="center", verticalalignment="center")
     plt.subplots_adjust(wspace=0.5, hspace=1)


### PR DESCRIPTION
## PR Summary
Use an Adapter named toolkits.axesgrid1.mpl_axes.AxesAdapter instead of old toolkits.axesgrid1.mpl_axes.Axes, because the Adapter can provide .axes dick-like property by simple wrapping matplotlib.axes.Axes object, so it can not only support Axes of matplotlib but also the subclass of Axes in other python package ( like GeoAxes in cartopy ).
## PR Checklist
 python -m pytest ./lib/mpl_toolkits/tests/test_axes_grid1.py
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
[-] Has pytest style unit tests (and `pytest` passes).
[-] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
