### PR TITLE
Fix sgskip'd examples

### DIFF
--- a/examples/misc/image_thumbnail_sgskip.py
+++ b/examples/misc/image_thumbnail_sgskip.py
@@ -20,7 +20,7 @@ parser = ArgumentParser(
     description="Build thumbnails of all images in a directory.")
 parser.add_argument("imagedir", type=Path)
 args = parser.parse_args()
-if not args.imagedir.isdir():
+if not args.imagedir.is_dir():
     sys.exit(f"Could not find input directory {args.imagedir}")
 
 outdir = Path("thumbs")

--- a/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
@@ -36,7 +36,7 @@ canvas = FigureCanvas(fig)  # a Gtk.DrawingArea
 vbox.pack_start(canvas, True, True, 0)
 
 # Create toolbar
-toolbar = NavigationToolbar(canvas, win)
+toolbar = NavigationToolbar(canvas)
 vbox.pack_start(toolbar, False, False, 0)
 
 win.show_all()

--- a/examples/user_interfaces/embedding_in_gtk4_panzoom_sgskip.py
+++ b/examples/user_interfaces/embedding_in_gtk4_panzoom_sgskip.py
@@ -39,7 +39,7 @@ def on_activate(app):
     vbox.append(canvas)
 
     # Create toolbar
-    toolbar = NavigationToolbar(canvas, win)
+    toolbar = NavigationToolbar(canvas)
     vbox.append(toolbar)
 
     win.show()

--- a/examples/user_interfaces/embedding_in_wx5_sgskip.py
+++ b/examples/user_interfaces/embedding_in_wx5_sgskip.py
@@ -9,7 +9,7 @@ import wx
 import wx.lib.agw.aui as aui
 import wx.lib.mixins.inspection as wit
 
-import matplotlib as mpl
+from matplotlib.figure import Figure
 from matplotlib.backends.backend_wxagg import (
     FigureCanvasWxAgg as FigureCanvas,
     NavigationToolbar2WxAgg as NavigationToolbar)
@@ -18,7 +18,7 @@ from matplotlib.backends.backend_wxagg import (
 class Plot(wx.Panel):
     def __init__(self, parent, id=-1, dpi=None, **kwargs):
         super().__init__(parent, id=id, **kwargs)
-        self.figure = mpl.figure.Figure(dpi=dpi, figsize=(2, 2))
+        self.figure = Figure(dpi=dpi, figsize=(2, 2))
         self.canvas = FigureCanvas(self, -1, self.figure)
         self.toolbar = NavigationToolbar(self.canvas)
         self.toolbar.Realize()

--- a/examples/user_interfaces/fourier_demo_wx_sgskip.py
+++ b/examples/user_interfaces/fourier_demo_wx_sgskip.py
@@ -75,10 +75,10 @@ class SliderGroup(Knob):
 
         sizer = wx.BoxSizer(wx.HORIZONTAL)
         sizer.Add(self.sliderLabel, 0,
-                  wx.EXPAND | wx.ALIGN_CENTER | wx.ALL,
+                  wx.EXPAND | wx.ALL,
                   border=2)
         sizer.Add(self.sliderText, 0,
-                  wx.EXPAND | wx.ALIGN_CENTER | wx.ALL,
+                  wx.EXPAND | wx.ALL,
                   border=2)
         sizer.Add(self.slider, 1, wx.EXPAND)
         self.sizer = sizer
@@ -115,9 +115,9 @@ class FourierDemoFrame(wx.Frame):
         sizer = wx.BoxSizer(wx.VERTICAL)
         sizer.Add(self.canvas, 1, wx.EXPAND)
         sizer.Add(self.frequencySliderGroup.sizer, 0,
-                  wx.EXPAND | wx.ALIGN_CENTER | wx.ALL, border=5)
+                  wx.EXPAND | wx.ALL, border=5)
         sizer.Add(self.amplitudeSliderGroup.sizer, 0,
-                  wx.EXPAND | wx.ALIGN_CENTER | wx.ALL, border=5)
+                  wx.EXPAND | wx.ALL, border=5)
         panel.SetSizer(sizer)
 
     def createCanvas(self, parent):

--- a/examples/user_interfaces/mathtext_wx_sgskip.py
+++ b/examples/user_interfaces/mathtext_wx_sgskip.py
@@ -15,7 +15,6 @@ from matplotlib.figure import Figure
 import numpy as np
 import wx
 
-IS_GTK = 'wxGTK' in wx.PlatformInfo
 IS_WIN = 'wxMSW' in wx.PlatformInfo
 
 
@@ -66,7 +65,7 @@ class CanvasFrame(wx.Frame):
         menuBar.Append(menu, "&File")
         self.Bind(wx.EVT_MENU, self.OnClose, m_exit)
 
-        if IS_GTK or IS_WIN:
+        if IS_WIN:
             # Equation Menu
             menu = wx.Menu()
             for i, (mt, func) in enumerate(functions):


### PR DESCRIPTION
## PR Summary

Some do not run, and some have minor breakage.

`examples/user_interfaces/embedding_webagg_sgskip.py` is also broken due to some manager/canvas API change, but I'm not sure how to fix; cc @anntzer.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).