### PR TITLE
Do not create a group for a single text object

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -682,8 +682,6 @@ class Text(Artist):
         if self.get_text() == '':
             return
 
-        renderer.open_group('text', self.get_gid())
-
         with self._cm_set(text=self._get_wrapped_text()):
             bbox, info, descent = self._get_layout(renderer)
             trans = self.get_transform()
@@ -712,6 +710,9 @@ class Text(Artist):
 
             angle = self.get_rotation()
 
+            if len(info) > 1:
+                renderer.open_group('text', self.get_gid())
+
             for line, wh, x, y in info:
 
                 mtext = self if len(info) == 1 else None
@@ -737,8 +738,9 @@ class Text(Artist):
                                            self._fontproperties, angle,
                                            ismath=ismath, mtext=mtext)
 
+            if len(info) > 1:
+                renderer.close_group('text')
         gc.restore()
-        renderer.close_group('text')
         self.stale = False
 
     def get_color(self):


### PR DESCRIPTION
## PR Summary

Text objects are always in a group which is a bit un-intuitive in some cases (like manually editing things). Grouping makes sense for multiple lines, but not so much for a single line.

Primarily testing if something breaks at this stage.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
