### PR TITLE
Move the common implementation of Axes.set_x/y/zscale to Axis.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3681,47 +3681,7 @@ class _AxesBase(martist.Artist):
         return self.xaxis._set_lim(left, right, emit=emit, auto=auto)
 
     get_xscale = _axis_method_wrapper("xaxis", "get_scale")
-
-    def set_xscale(self, value, **kwargs):
-        """
-        Set the x-axis scale.
-
-        Parameters
-        ----------
-        value : {"linear", "log", "symlog", "logit", ...} or `.ScaleBase`
-            The axis scale type to apply.
-
-        **kwargs
-            Different keyword arguments are accepted, depending on the scale.
-            See the respective class keyword arguments:
-
-            - `matplotlib.scale.LinearScale`
-            - `matplotlib.scale.LogScale`
-            - `matplotlib.scale.SymmetricalLogScale`
-            - `matplotlib.scale.LogitScale`
-            - `matplotlib.scale.FuncScale`
-
-        Notes
-        -----
-        By default, Matplotlib supports the above mentioned scales.
-        Additionally, custom scales may be registered using
-        `matplotlib.scale.register_scale`. These scales can then also
-        be used here.
-        """
-        old_default_lims = (self.xaxis.get_major_locator()
-                            .nonsingular(-np.inf, np.inf))
-        g = self.get_shared_x_axes()
-        for ax in g.get_siblings(self):
-            ax.xaxis._set_scale(value, **kwargs)
-            ax._update_transScale()
-            ax.stale = True
-        new_default_lims = (self.xaxis.get_major_locator()
-                            .nonsingular(-np.inf, np.inf))
-        if old_default_lims != new_default_lims:
-            # Force autoscaling now, to take advantage of the scale locator's
-            # nonsingular() before it possibly gets swapped out by the user.
-            self.autoscale_view(scaley=False)
-
+    set_xscale = _axis_method_wrapper("xaxis", "_set_axes_scale")
     get_xticks = _axis_method_wrapper("xaxis", "get_ticklocs")
     set_xticks = _axis_method_wrapper("xaxis", "set_ticks")
     get_xmajorticklabels = _axis_method_wrapper("xaxis", "get_majorticklabels")
@@ -3953,47 +3913,7 @@ class _AxesBase(martist.Artist):
         return self.yaxis._set_lim(bottom, top, emit=emit, auto=auto)
 
     get_yscale = _axis_method_wrapper("yaxis", "get_scale")
-
-    def set_yscale(self, value, **kwargs):
-        """
-        Set the y-axis scale.
-
-        Parameters
-        ----------
-        value : {"linear", "log", "symlog", "logit", ...} or `.ScaleBase`
-            The axis scale type to apply.
-
-        **kwargs
-            Different keyword arguments are accepted, depending on the scale.
-            See the respective class keyword arguments:
-
-            - `matplotlib.scale.LinearScale`
-            - `matplotlib.scale.LogScale`
-            - `matplotlib.scale.SymmetricalLogScale`
-            - `matplotlib.scale.LogitScale`
-            - `matplotlib.scale.FuncScale`
-
-        Notes
-        -----
-        By default, Matplotlib supports the above mentioned scales.
-        Additionally, custom scales may be registered using
-        `matplotlib.scale.register_scale`. These scales can then also
-        be used here.
-        """
-        old_default_lims = (self.yaxis.get_major_locator()
-                            .nonsingular(-np.inf, np.inf))
-        g = self.get_shared_y_axes()
-        for ax in g.get_siblings(self):
-            ax.yaxis._set_scale(value, **kwargs)
-            ax._update_transScale()
-            ax.stale = True
-        new_default_lims = (self.yaxis.get_major_locator()
-                            .nonsingular(-np.inf, np.inf))
-        if old_default_lims != new_default_lims:
-            # Force autoscaling now, to take advantage of the scale locator's
-            # nonsingular() before it possibly gets swapped out by the user.
-            self.autoscale_view(scalex=False)
-
+    set_yscale = _axis_method_wrapper("yaxis", "_set_axes_scale")
     get_yticks = _axis_method_wrapper("yaxis", "get_ticklocs")
     set_yticks = _axis_method_wrapper("yaxis", "set_ticks")
     get_ymajorticklabels = _axis_method_wrapper("yaxis", "get_majorticklabels")

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -679,27 +679,10 @@ class Axes3D(Axes):
         """ % (", ".join(mscale.get_scale_names()))
         return self.zaxis.get_scale()
 
-    # We need to slightly redefine these to pass scalez=False
-    # to their calls of autoscale_view.
-
-    def set_xscale(self, value, **kwargs):
-        self.xaxis._set_scale(value, **kwargs)
-        self.autoscale_view(scaley=False, scalez=False)
-        self._update_transScale()
-        self.stale = True
-
-    def set_yscale(self, value, **kwargs):
-        self.yaxis._set_scale(value, **kwargs)
-        self.autoscale_view(scalex=False, scalez=False)
-        self._update_transScale()
-        self.stale = True
-
-    def set_zscale(self, value, **kwargs):
-        self.zaxis._set_scale(value, **kwargs)
-        self.autoscale_view(scalex=False, scaley=False)
-        self._update_transScale()
-        self.stale = True
-
+    # Redefine all three methods to overwrite their docstrings.
+    set_xscale = _axis_method_wrapper("xaxis", "_set_axes_scale")
+    set_yscale = _axis_method_wrapper("yaxis", "_set_axes_scale")
+    set_zscale = _axis_method_wrapper("zaxis", "_set_axes_scale")
     set_xscale.__doc__, set_yscale.__doc__, set_zscale.__doc__ = map(
         """
         Set the {}-axis scale.


### PR DESCRIPTION
... together with an _axis_method_wrapper.

It may be worth trying to figure out later whether Axis._set_scale and
Axis._set_axes_scale need to have subtly different behaviors...

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
