### PR TITLE
Let Axes.clear iterate over Axises.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1212,34 +1212,22 @@ class _AxesBase(martist.Artist):
         xaxis_visible = self.xaxis.get_visible()
         yaxis_visible = self.yaxis.get_visible()
 
-        self.xaxis.clear()
-        self.yaxis.clear()
-
-        for name, spine in self.spines.items():
+        for axis in self._axis_map.values():
+            axis.clear()  # Also resets the scale to linear.
+        for spine in self.spines.values():
             spine.clear()
 
         self.ignore_existing_data_limits = True
         self.callbacks = cbook.CallbackRegistry(
             signals=["xlim_changed", "ylim_changed", "zlim_changed"])
 
-        if self._sharex is not None:
-            self.sharex(self._sharex)
-        else:
-            self.xaxis._set_scale('linear')
-            try:
-                self.set_xlim(0, 1)
-            except TypeError:
-                pass
-            self.set_autoscalex_on(True)
-        if self._sharey is not None:
-            self.sharey(self._sharey)
-        else:
-            self.yaxis._set_scale('linear')
-            try:
-                self.set_ylim(0, 1)
-            except TypeError:
-                pass
-            self.set_autoscaley_on(True)
+        for name, axis in self._axis_map.items():
+            share = getattr(self, f"_share{name}")
+            if share is not None:
+                getattr(self, f"share{name}")(share)
+            else:
+                axis._set_scale("linear")
+                axis._set_lim(0, 1, auto=True)
 
         # update the minor locator for x and y axis based on rcParams
         if mpl.rcParams['xtick.minor.visible']:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -689,7 +689,6 @@ class Axis(martist.Artist):
         self._minor_tick_kw = dict()
 
         self.clear()
-        self._set_scale('linear')
         self._autoscale_on = True
 
     @property

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -933,30 +933,32 @@ class Axes3D(Axes):
         """
         return False
 
+    def sharez(self, other):
+        """
+        Share the z-axis with *other*.
+
+        This is equivalent to passing ``sharex=other`` when constructing the
+        Axes, and cannot be used if the z-axis is already being shared with
+        another Axes.
+        """
+        _api.check_isinstance(maxes._base._AxesBase, other=other)
+        if self._sharez is not None and other is not self._sharez:
+            raise ValueError("z-axis is already shared")
+        self._shared_axes["z"].join(self, other)
+        self._sharez = other
+        self.zaxis.major = other.zaxis.major  # Ticker instances holding
+        self.zaxis.minor = other.zaxis.minor  # locator and formatter.
+        z0, z1 = other.get_zlim()
+        self.set_zlim(z0, z1, emit=False, auto=other.get_autoscalez_on())
+        self.zaxis._scale = other.zaxis._scale
+
     def clear(self):
         # docstring inherited.
         super().clear()
-        self.zaxis.clear()
-
-        if self._sharez is not None:
-            self.zaxis.major = self._sharez.zaxis.major
-            self.zaxis.minor = self._sharez.zaxis.minor
-            z0, z1 = self._sharez.get_zlim()
-            self.set_zlim(z0, z1, emit=False, auto=None)
-            self.zaxis._set_scale(self._sharez.zaxis.get_scale())
-        else:
-            self.zaxis._set_scale('linear')
-            try:
-                self.set_zlim(0, 1)
-            except TypeError:
-                pass
-
-        self.set_autoscalez_on(True)
         if self._focal_length == np.inf:
             self._zmargin = rcParams['axes.zmargin']
         else:
             self._zmargin = 0.
-
         self.grid(rcParams['axes3d.grid'])
 
     def _button_press(self, event):


### PR DESCRIPTION
... so that the implementation also works for 3D.  This means also
adding a sharez() method, which is copy-pasted from sharex()/sharey()
(note that it is resolves a slight inconsistency in the old
Axes3D.clear, which would previously not copy the z-autoscaleness status
of a z-shared axes).

Using Axis._set_lim in the loop also means that we need to pass auto
explicitly to it anyways (it is a required parameter), so we can get rid
of the set_autoscalex/y/z calls.

Also, note that Axis.clear() explicitly resets the scale to "linear", so
the extra `_set_scale("linear")` calls are unneeded.

Finally, remove the silencing of TypeErrors when setting limits in
clear(), which was added in 917de33 to handle initialization order
problems in Axes3D but which seem not needed anymore (and are rather
unsightly, as it's not immediately clear what we're really catching).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
