### PR TITLE
Add hint when More than {max_open_warning} figures have been opened

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -815,7 +815,8 @@ def figure(num=None,  # autoincrement if None, else integer from 1-N
                 f"Figures created through the pyplot interface "
                 f"(`matplotlib.pyplot.figure`) are retained until explicitly "
                 f"closed and may consume too much memory. (To control this "
-                f"warning, see the rcParam `figure.max_open_warning`).",
+                f"warning, see the rcParam `figure.max_open_warning`). "
+                f"Consider using `matplotlib.pyplot.close()`.",
                 RuntimeWarning)
 
         manager = new_figure_manager(


### PR DESCRIPTION
## PR Summary
I tried to plot a couple of figures in a quick succession in a for loop and I got the warning
```
RuntimeWarning: More than 20 figures have been opened. Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are retained until explicitly closed and may consume too much memory. (To control this warning, see the rcParam `figure.max_open_warning`).
  fig, axes = plt.subplots(rows, cols, figsize=(fig_width, fig_height))
```

I do not use matplotlib often, so I naturally started googling as I did not know how to solve this situation efficiently and I came across this [stack overflow](https://stackoverflow.com/questions/24500065/closing-matplotlib-figures) question with a great answer.

I thought we could save users a bit of hassle by providing a better error message with a hint. This is particularly useful for people who aren't very familiar with matplotlib.

If there's an alternative way to resolve `More than {max_open_warning} figures have been opened.` warning, I am open to suggestions and happy to change the string as necessary.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- N/A Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- N/A New features are documented, with examples if plot related.
- N/A New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- N/A API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- N/A Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
