### PR TITLE
Add explicit registration of units in examples

### DIFF
--- a/examples/units/annotate_with_units.py
+++ b/examples/units/annotate_with_units.py
@@ -12,7 +12,10 @@ annotations using a centimeter-scale plot.
 """
 
 import matplotlib.pyplot as plt
-from basic_units import cm
+from basic_units import register_units, cm
+
+
+register_units()
 
 fig, ax = plt.subplots()
 

--- a/examples/units/artist_tests.py
+++ b/examples/units/artist_tests.py
@@ -20,9 +20,12 @@ import matplotlib.patches as patches
 import matplotlib.text as text
 import matplotlib.collections as collections
 
-from basic_units import cm, inch
+from basic_units import register_units, cm, inch
 import numpy as np
 import matplotlib.pyplot as plt
+
+
+register_units()
 
 fig, ax = plt.subplots()
 ax.xaxis.set_units(cm)

--- a/examples/units/bar_demo2.py
+++ b/examples/units/bar_demo2.py
@@ -14,8 +14,11 @@ set the xlimits using scalars (ax3, current units assumed) or units
    This example requires :download:`basic_units.py <basic_units.py>`
 """
 import numpy as np
-from basic_units import cm, inch
+from basic_units import register_units, cm, inch
 import matplotlib.pyplot as plt
+
+
+register_units()
 
 cms = cm * np.arange(0, 10, 2)
 bottom = 0 * cm

--- a/examples/units/bar_unit_demo.py
+++ b/examples/units/bar_unit_demo.py
@@ -13,9 +13,11 @@ centimeters.
 """
 
 import numpy as np
-from basic_units import cm, inch
+from basic_units import register_units, cm, inch
 import matplotlib.pyplot as plt
 
+
+register_units()
 
 N = 5
 men_means = [150*cm, 160*cm, 146*cm, 172*cm, 155*cm]

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -380,4 +380,17 @@ def cos(x):
         return math.cos(x.convert_to(radians).get_value())
 
 
-units.registry[BasicUnit] = units.registry[TaggedValue] = BasicUnitConverter()
+def register_units():
+    """
+    Explicitly register units provided here.
+
+    Normally, this will not be needed as units are registered on import.
+    However, if you reset the Matplotlib unit registry (as is done by
+    sphinx-gallery between running each example), then you will need to
+    explicitly re-register units from this module by calling this function.
+    """
+    converter = BasicUnitConverter()
+    units.registry[BasicUnit] = units.registry[TaggedValue] = converter
+
+
+register_units()

--- a/examples/units/ellipse_with_units.py
+++ b/examples/units/ellipse_with_units.py
@@ -10,11 +10,13 @@ Compare the ellipse generated with arcs versus a polygonal approximation.
    This example requires :download:`basic_units.py <basic_units.py>`
 """
 
-from basic_units import cm
+from basic_units import register_units, cm
 import numpy as np
 from matplotlib import patches
 import matplotlib.pyplot as plt
 
+
+register_units()
 
 xcenter, ycenter = 0.38*cm, 0.52*cm
 width, height = 1e-1*cm, 3e-1*cm

--- a/examples/units/radian_demo.py
+++ b/examples/units/radian_demo.py
@@ -17,7 +17,10 @@ formatting and axis labeling.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from basic_units import radians, degrees, cos
+from basic_units import register_units, radians, degrees, cos
+
+
+register_units()
 
 x = [val*radians for val in np.arange(0, 15, 0.01)]
 

--- a/examples/units/units_sample.py
+++ b/examples/units/units_sample.py
@@ -13,9 +13,12 @@ to correct units.
    This example requires :download:`basic_units.py <basic_units.py>`
 
 """
-from basic_units import cm, inch
+from basic_units import register_units, cm, inch
 import matplotlib.pyplot as plt
 import numpy as np
+
+
+register_units()
 
 cms = cm * np.arange(0, 10, 2)
 

--- a/examples/units/units_scatter.py
+++ b/examples/units/units_scatter.py
@@ -12,7 +12,10 @@ arrays.
 """
 import numpy as np
 import matplotlib.pyplot as plt
-from basic_units import secs, hertz, minutes
+from basic_units import register_units, secs, hertz, minutes
+
+
+register_units()
 
 # create masked array
 data = (1, 2, 3, 4, 5, 6, 7, 8)


### PR DESCRIPTION
## PR Summary

Starting in https://github.com/sphinx-gallery/sphinx-gallery/pull/890, sphinx-gallery started clearing Matplotlib's unit registry. But since `basic_units` was already imported, its register-on-import never happened for subsequent examples, breaking them.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).