### PR TITLE
supporting IBM i OS

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -199,8 +199,7 @@ options = {
     'backend': config.get('rc_options', 'backend', fallback=None),
     'system_freetype': config.getboolean(
         'libs', 'system_freetype',
-        fallback=(sys.platform.startswith('aix') or
-                  sys.platform.startswith('os400'))),
+        fallback=sys.platform.startswith(('aix', 'os400')),
     'system_qhull': config.getboolean(
         'libs', 'system_qhull', fallback=sys.platform.startswith('os400')),
 }

--- a/setupext.py
+++ b/setupext.py
@@ -198,9 +198,11 @@ if os.path.exists(mplsetup_cfg):
 options = {
     'backend': config.get('rc_options', 'backend', fallback=None),
     'system_freetype': config.getboolean(
-        'libs', 'system_freetype', fallback=sys.platform.startswith('aix')),
+        'libs', 'system_freetype',
+        fallback=(sys.platform.startswith('aix') or
+                  sys.platform.startswith('os400'))),
     'system_qhull': config.getboolean(
-        'libs', 'system_qhull', fallback=False),
+        'libs', 'system_qhull', fallback=sys.platform.startswith('os400')),
 }
 
 

--- a/setupext.py
+++ b/setupext.py
@@ -199,9 +199,11 @@ options = {
     'backend': config.get('rc_options', 'backend', fallback=None),
     'system_freetype': config.getboolean(
         'libs', 'system_freetype',
-        fallback=sys.platform.startswith(('aix', 'os400')),
+        fallback=sys.platform.startswith(('aix', 'os400'))
+    ),
     'system_qhull': config.getboolean(
-        'libs', 'system_qhull', fallback=sys.platform.startswith('os400')),
+        'libs', 'system_qhull', fallback=sys.platform.startswith('os400')
+    ),
 }
 
 


### PR DESCRIPTION
## PR Summary
This is to make it support IBM i OS.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [Y] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
