### PR TITLE
Fix doc build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -172,30 +172,28 @@ def matplotlib_reduced_latex_scraper(block, block_vars, gallery_conf,
 
 
 sphinx_gallery_conf = {
+    'backreferences_dir': Path('api') / Path('_as_gen'),
+    # Compression is a significant effort that we skip for local and CI builds.
+    'compress_images': ('thumbnails', 'images') if is_release_build else (),
+    'doc_module': ('matplotlib', 'mpl_toolkits'),
     'examples_dirs': ['../examples', '../tutorials', '../plot_types'],
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': ['gallery', 'tutorials', 'plot_types'],
-    'doc_module': ('matplotlib', 'mpl_toolkits'),
-    'reference_url': {
-        'matplotlib': None,
-    },
-    'backreferences_dir': Path('api') / Path('_as_gen'),
-    'subsection_order': gallery_order.sectionorder,
-    'within_subsection_order': gallery_order.subsectionorder,
-    'remove_config_comments': True,
-    'min_reported_time': 1,
-    'thumbnail_size': (320, 224),
     'image_scrapers': (matplotlib_reduced_latex_scraper, ),
-    # Compression is a significant effort that we skip for local and CI builds.
-    'compress_images': ('thumbnails', 'images') if is_release_build else (),
-    'matplotlib_animations': True,
     'image_srcset': ["2x"],
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
+    'matplotlib_animations': True,
+    'min_reported_time': 1,
+    'reference_url': {'matplotlib': None},
+    'remove_config_comments': True,
     'reset_modules': (
         'matplotlib',
         # clear basic_units module to re-register with unit registry on import
         lambda gallery_conf, fname: sys.modules.pop('basic_units', None)
     ),
+    'subsection_order': gallery_order.sectionorder,
+    'thumbnail_size': (320, 224),
+    'within_subsection_order': gallery_order.subsectionorder,
 }
 
 mathmpl_fontsize = 11.0

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -191,6 +191,11 @@ sphinx_gallery_conf = {
     'matplotlib_animations': True,
     'image_srcset': ["2x"],
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
+    'reset_modules': (
+        'matplotlib',
+        # clear basic_units module to re-register with unit registry on import
+        lambda gallery_conf, fname: sys.modules.pop('basic_units', None)
+    ),
 }
 
 mathmpl_fontsize = 11.0


### PR DESCRIPTION
## PR Summary

Replaces #23508

The problem is a combination of:

 - the unit registry is managed by a dictionary at the module level of `mpl.units`
 - in sg 0.11 the default matplotlib reset reloads that module which (resets the registry).  The motivation for this on their side was to make sure that the date formatter config did not leak between examples.
 - we have a local module (`basic_units`) that lives in the examples directory that we use for the unit examples
 - the first time it is imported the example units get registered
 - on the second import call Python grabs the module from `sys.modules` (so we do not get to run any code) but `mpl.units` has been reloaded so our example units are no longer registered
 
This PR fixes the issue by telling sg to also remove `'basic_units'` from `sys.modules` so that it is effectively re-imported (and hence we register our selves) on each example.  In contrast #23508 fixes this by adding an explict re-registration step to the examples.

The argument is favor of this PR is we do not require any changes to our examples and fixes the problem via the tool that broke. The argument in favor of #23508 is that it is maybe better pedagogically and explicit unit registration (rather than implicit on import) is better documentation anyway.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
