### PR TITLE
Backport PR #23462: Fix AttributeError for pickle load of Figure class

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2919,7 +2919,8 @@ class Figure(FigureBase):
             import matplotlib._pylab_helpers as pylab_helpers
             allnums = plt.get_fignums()
             num = max(allnums) + 1 if allnums else 1
-            mgr = plt._backend_mod.new_figure_manager_given_figure(num, self)
+            backend = plt._get_backend_mod()
+            mgr = backend.new_figure_manager_given_figure(num, self)
             pylab_helpers.Gcf._set_new_active_manager(mgr)
             plt.draw_if_interactive()
 


### PR DESCRIPTION
There were a number of complications with the backport:

 - the new test generalized an existing test that had picked up
   additional changes on the main branch
 - the signature of the subproccess helper has changed on the main branch

