### PR TITLE
warning when scatter plot color settings discarded

### DIFF
--- a/doc/api/next_api_changes/behavior/23516-MS.rst
+++ b/doc/api/next_api_changes/behavior/23516-MS.rst
@@ -2,5 +2,5 @@ Warning when scatter plot color settings discarded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When making an animation of a scatter plot, if you don't set *c* (the color
 value parameter) when initializing the artist, the color settings are ignored.
-`.Axes.scatter` now raises a warning if color-related settings's are changed
-without setting *c*
+`.Axes.scatter` now raises a warning if color-related settings are changed
+without setting *c*.

--- a/doc/api/next_api_changes/behavior/23516-MS.rst
+++ b/doc/api/next_api_changes/behavior/23516-MS.rst
@@ -1,0 +1,3 @@
+Warning when scatter plot color settings discarded
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When making an animation of a scatter plot, if you don't set *c* (the color value parameter) when initializing the artist, the color settings are ignored. `.Axes.scatter` now raises a warning if color-related settings's are changed without setting *c*

--- a/doc/api/next_api_changes/behavior/23516-MS.rst
+++ b/doc/api/next_api_changes/behavior/23516-MS.rst
@@ -1,3 +1,6 @@
 Warning when scatter plot color settings discarded
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-When making an animation of a scatter plot, if you don't set *c* (the color value parameter) when initializing the artist, the color settings are ignored. `.Axes.scatter` now raises a warning if color-related settings's are changed without setting *c*
+When making an animation of a scatter plot, if you don't set *c* (the color
+value parameter) when initializing the artist, the color settings are ignored.
+`.Axes.scatter` now raises a warning if color-related settings's are changed
+without setting *c*

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4559,6 +4559,16 @@ default: :rc:`scatter.edgecolors`
             collection.set_cmap(cmap)
             collection.set_norm(norm)
             collection._scale_norm(norm, vmin, vmax)
+        else:
+            extra_kwargs = {
+                    'cmap': cmap, 'norm': norm, 'vmin': vmin, 'vmax': vmax
+                    }
+            extra_keys = [k for k, v in extra_kwargs.items() if v is not None]
+            if any(extra_keys):
+                keys_str = ", ".join(f"'{k}'" for k in extra_keys)
+                _api.warn_external(
+                        "'c' is empty or not given, "
+                        f"kwargs {keys_str} will be ignored")
         collection._internal_update(kwargs)
 
         # Classic mode only:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4567,8 +4567,8 @@ default: :rc:`scatter.edgecolors`
             if any(extra_keys):
                 keys_str = ", ".join(f"'{k}'" for k in extra_keys)
                 _api.warn_external(
-                        "'c' is empty or not given, "
-                        f"kwargs {keys_str} will be ignored")
+                    "No data for colormapping provided via 'c'. "
+                    f"Parameters {keys_str} will be ignored")
         collection._internal_update(kwargs)
 
         # Classic mode only:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2391,7 +2391,7 @@ class TestScatter:
                                     {'vmax': 0}
                                 ])
     def test_scatter_color_warning(self, kwargs):
-        warn_match = "'c' is empty or not given, "
+        warn_match = "No data for colormapping provided "
         # Warn for cases where 'cmap', 'norm', 'vmin', 'vmax'
         # kwargs are being overridden
         with pytest.warns(Warning, match=warn_match):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2383,6 +2383,25 @@ class TestScatter:
         with pytest.raises(ValueError):
             plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
 
+    @pytest.mark.parametrize('kwargs',
+                                [
+                                    {'cmap': 'gray'},
+                                    {'norm': mcolors.Normalize()},
+                                    {'vmin': 0},
+                                    {'vmax': 0}
+                                ])
+    def test_scatter_color_warning(self, kwargs):
+        warn_match = "'c' is empty or not given, "
+        # Warn for cases where 'cmap', 'norm', 'vmin', 'vmax'
+        # kwargs are being overridden
+        with pytest.warns(Warning, match=warn_match):
+            plt.scatter([], [], **kwargs)
+        with pytest.warns(Warning, match=warn_match):
+            plt.scatter([1, 2], [3, 4], c=[], **kwargs)
+        # Do not warn for cases where 'c' matches 'x' and 'y'
+        plt.scatter([], [], c=[], **kwargs)
+        plt.scatter([1, 2], [3, 4], c=[4, 5], **kwargs)
+
     def test_scatter_unfilled(self):
         coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
                            marker=mmarkers.MarkerStyle('o', fillstyle='none'),

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -280,7 +280,7 @@ def test_remove_from_figure(use_gridspec):
     Test `remove` with the specified ``use_gridspec`` setting
     """
     fig, ax = plt.subplots()
-    sc = ax.scatter([1, 2], [3, 4], cmap="spring")
+    sc = ax.scatter([1, 2], [3, 4])
     sc.set_array(np.array([5, 6]))
     pre_position = ax.get_position()
     cb = fig.colorbar(sc, use_gridspec=use_gridspec)
@@ -296,7 +296,7 @@ def test_remove_from_figure_cl():
     Test `remove` with constrained_layout
     """
     fig, ax = plt.subplots(constrained_layout=True)
-    sc = ax.scatter([1, 2], [3, 4], cmap="spring")
+    sc = ax.scatter([1, 2], [3, 4])
     sc.set_array(np.array([5, 6]))
     fig.draw_without_rendering()
     pre_position = ax.get_position()


### PR DESCRIPTION
## PR Summary
first pr, happy to add/make any necessary changes
closes #23487

The changed test in `test_colorbar.py` was related removing a colorbar from a scatter plot. I don't think the `cmap` there was necessary to test this. And running the tests on my own revealed the `cmap` wasn't changing the color of the scatter plot anyways
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
