### PR TITLE
TST: Update Quantity test class

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1163,7 +1163,7 @@ class QuantityND(np.ndarray):
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         func = getattr(ufunc, method)
         if "out" in kwargs:
-            raise NotImplementedError
+            return NotImplemented
         if len(inputs) == 1:
             i0 = inputs[0]
             unit = getattr(i0, "units", "dimensionless")
@@ -1184,10 +1184,10 @@ class QuantityND(np.ndarray):
             elif ufunc == np.divide:
                 unit = f"{u0}/({u1})"
             else:
-                raise NotImplementedError
+                return NotImplemented
             out_arr = func(i0.view(np.ndarray), i1.view(np.ndarray), **kwargs)
         else:
-            raise NotImplementedError
+            return NotImplemented
         if unit is None:
             out_arr = np.array(out_arr)
         else:

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1183,6 +1183,11 @@ class QuantityND(np.ndarray):
                 unit = f"{u0}*{u1}"
             elif ufunc == np.divide:
                 unit = f"{u0}/({u1})"
+            elif ufunc in (np.greater, np.greater_equal,
+                           np.equal, np.not_equal,
+                           np.less, np.less_equal):
+                # Comparisons produce unitless booleans for output
+                unit = None
             else:
                 return NotImplemented
             out_arr = func(i0.view(np.ndarray), i1.view(np.ndarray), **kwargs)


### PR DESCRIPTION
## PR Summary

1. The class should `return NotImplemented` rather than `raise NotImplementedError`: https://numpy.org/devdocs/user/basics.subclassing.html#array-ufunc-for-ufuncs

2. Allow unitless comparison operators to pass-through

Closes #23382

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
