### PR TITLE
Add functionality to label individual bars with Axes.bar()

### DIFF
--- a/doc/users/next_whats_new/bar_plot_labels
+++ b/doc/users/next_whats_new/bar_plot_labels
@@ -1,0 +1,16 @@
+Easier labelling of bars in bar plot
+------------------------------------
+
+The new ``labels`` argument of `~matplotlib.axes.Axes.bar` can now 
+be used to label each of the bars.
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    x = ["a", "b", "c"]
+    y = [10, 20, 15]
+
+    fig, ax = plt.subplots()
+    _ = ax.barh(x, y, labels=x)
+    ax.legend()

--- a/doc/users/next_whats_new/bar_plot_labels.rst
+++ b/doc/users/next_whats_new/bar_plot_labels.rst
@@ -1,8 +1,8 @@
 Easier labelling of bars in bar plot
 ------------------------------------
 
-The new ``labels`` argument of `~matplotlib.axes.Axes.bar` can now
-be used to label each of the bars.
+The ``label`` argument of `~matplotlib.axes.Axes.bar` can now
+be passed a list of labels for the bars.
 
 .. code-block:: python
 
@@ -12,5 +12,5 @@ be used to label each of the bars.
     y = [10, 20, 15]
 
     fig, ax = plt.subplots()
-    _ = ax.barh(x, y, labels=x)
-    ax.legend()
+    bar_container = ax.barh(x, y, label=x)
+    [bar.get_label() for bar in bar_container]

--- a/doc/users/next_whats_new/bar_plot_labels.rst
+++ b/doc/users/next_whats_new/bar_plot_labels.rst
@@ -1,7 +1,7 @@
 Easier labelling of bars in bar plot
 ------------------------------------
 
-The new ``labels`` argument of `~matplotlib.axes.Axes.bar` can now 
+The new ``labels`` argument of `~matplotlib.axes.Axes.bar` can now
 be used to label each of the bars.
 
 .. code-block:: python

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2256,6 +2256,13 @@ class Axes(_AxesBase):
             The tick labels of the bars.
             Default: None (Use default numeric labels.)
 
+        label : str or list of str, optional
+            A single label is attached to the resulting BarContainer as a
+            label for the whole dataset.
+            If a list is given, it must be the same length as *x* and
+            labels the individual bars. For example this may used with
+            lists of *color*.
+
         xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
             If not *None*, add horizontal / vertical errorbars to the bar tips.
             The values are +/- sizes relative to the data:
@@ -2381,13 +2388,21 @@ class Axes(_AxesBase):
             tick_label_axis = self.yaxis
             tick_label_position = y
 
-        patch_labels = np.atleast_1d(label)
+        if not isinstance(label, str) and np.iterable(label):
+            bar_container_label = '_nolegend_'
+            seen_labels = set()
+            patch_labels = label
+            for i, patch_label in enumerate(patch_labels):
+                if patch_label in seen_labels:
+                    patch_labels[i] = '_nolegend_'
+                else:
+                    seen_labels.add(patch_label)
+        else:
+            bar_container_label = label
+            patch_labels = ['_nolegend_'] * len(x)
         if len(patch_labels) != len(x):
-            if len(patch_labels) == 1:
-                patch_labels = ['_nolegend_'] * len(x)
-            else:
-                raise ValueError(f'number of labels ({len(patch_labels)}) '
-                                 f'does not match number of bars ({len(x)}).')
+            raise ValueError(f'number of labels ({len(patch_labels)}) '
+                             f'does not match number of bars ({len(x)}).')
 
         linewidth = itertools.cycle(np.atleast_1d(linewidth))
         hatch = itertools.cycle(np.atleast_1d(hatch))
@@ -2474,7 +2489,8 @@ class Axes(_AxesBase):
             datavalues = width
 
         bar_container = BarContainer(patches, errorbar, datavalues=datavalues,
-                                     orientation=orientation, label=label)
+                                     orientation=orientation,
+                                     label=bar_container_label)
         self.add_container(bar_container)
 
         if tick_labels is not None:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2257,10 +2257,10 @@ class Axes(_AxesBase):
             Default: None (Use default numeric labels.)
 
         label : str or list of str, optional
-            A single label is attached to the resulting BarContainer as a
+            A single label is attached to the resulting `.BarContainer` as a
             label for the whole dataset.
-            If a list is given, it must be the same length as *x* and
-            labels the individual bars. For example this may used with
+            If a list is provided, it must be the same length as *x* and
+            labels the individual bars. For example, this may used with
             lists of *color*.
 
         xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2390,13 +2390,7 @@ class Axes(_AxesBase):
 
         if not isinstance(label, str) and np.iterable(label):
             bar_container_label = '_nolegend_'
-            seen_labels = set()
             patch_labels = label
-            for i, patch_label in enumerate(patch_labels):
-                if patch_label in seen_labels:
-                    patch_labels[i] = '_nolegend_'
-                else:
-                    seen_labels.add(patch_label)
         else:
             bar_container_label = label
             patch_labels = ['_nolegend_'] * len(x)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2261,7 +2261,8 @@ class Axes(_AxesBase):
             label for the whole dataset.
             If a list is provided, it must be the same length as *x* and
             labels the individual bars. For example, this may used with
-            lists of *color*.
+            lists of *color*. Note that behavior for repeated labels is
+            not defined and may change in the future.
 
         xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
             If not *None*, add horizontal / vertical errorbars to the bar tips.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2260,9 +2260,9 @@ class Axes(_AxesBase):
             A single label is attached to the resulting `.BarContainer` as a
             label for the whole dataset.
             If a list is provided, it must be the same length as *x* and
-            labels the individual bars. For example, this may used with
-            lists of *color*. Note that behavior for repeated labels is
-            not defined and may change in the future.
+            labels the individual bars. Repeated labels are not de-duplicated
+            and will cause repeated label entries, so this is best used when
+            bars also differ in style (e.g., by passing a list to *color*.)
 
         xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
             If not *None*, add horizontal / vertical errorbars to the bar tips.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2236,10 +2236,6 @@ class Axes(_AxesBase):
             To align the bars on the right edge pass a negative *width* and
             ``align='edge'``.
 
-        labels : str or list of str, optional
-            A sequence of labels to assign to each data series.
-            If unspecified, then ``'_nolegend_'`` will be applied to each bar.
-
         Returns
         -------
         `.BarContainer`
@@ -2306,6 +2302,8 @@ class Axes(_AxesBase):
         """
         kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
         color = kwargs.pop('color', None)
+        if color is None:
+            color = self._get_patches_for_fill.get_next_color()
         edgecolor = kwargs.pop('edgecolor', None)
         linewidth = kwargs.pop('linewidth', None)
         hatch = kwargs.pop('hatch', None)
@@ -2383,17 +2381,13 @@ class Axes(_AxesBase):
             tick_label_axis = self.yaxis
             tick_label_position = y
 
-        patch_labels = kwargs.pop('labels', ['_nolegend_'] * len(x))
+        patch_labels = np.atleast_1d(label)
         if len(patch_labels) != len(x):
-            raise ValueError(f'number of labels ({len(patch_labels)}) '
-                             f'does not match number of bars ({len(x)}).')
-        if patch_labels[0] != '_nolegend_' and color is None:
-            color = [
-                self._get_patches_for_fill.get_next_color()
-                for _ in patch_labels
-            ]
-        elif color is None:
-            color = self._get_patches_for_fill.get_next_color()
+            if len(patch_labels) == 1:
+                patch_labels = ['_nolegend_'] * len(x)
+            else:
+                raise ValueError(f'number of labels ({len(patch_labels)}) '
+                                 f'does not match number of bars ({len(x)}).')
 
         linewidth = itertools.cycle(np.atleast_1d(linewidth))
         hatch = itertools.cycle(np.atleast_1d(hatch))

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2236,6 +2236,10 @@ class Axes(_AxesBase):
             To align the bars on the right edge pass a negative *width* and
             ``align='edge'``.
 
+        labels : str or list of str, optional
+            A sequence of labels to assign to each data series.
+            If unspecified, then ``'_nolegend_'`` will be applied to each bar.
+
         Returns
         -------
         `.BarContainer`
@@ -2302,8 +2306,6 @@ class Axes(_AxesBase):
         """
         kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
         color = kwargs.pop('color', None)
-        if color is None:
-            color = self._get_patches_for_fill.get_next_color()
         edgecolor = kwargs.pop('edgecolor', None)
         linewidth = kwargs.pop('linewidth', None)
         hatch = kwargs.pop('hatch', None)
@@ -2381,6 +2383,18 @@ class Axes(_AxesBase):
             tick_label_axis = self.yaxis
             tick_label_position = y
 
+        patch_labels = kwargs.pop('labels', ['_nolegend_'] * len(x))
+        if len(patch_labels) != len(x):
+            raise ValueError(f'number of labels ({len(patch_labels)}) '
+                             f'does not match number of bars ({len(x)}).')
+        if patch_labels[0] != '_nolegend_' and color is None:
+            color = [
+                self._get_patches_for_fill.get_next_color()
+                for _ in patch_labels
+            ]
+        elif color is None:
+            color = self._get_patches_for_fill.get_next_color()
+
         linewidth = itertools.cycle(np.atleast_1d(linewidth))
         hatch = itertools.cycle(np.atleast_1d(hatch))
         color = itertools.chain(itertools.cycle(mcolors.to_rgba_array(color)),
@@ -2420,14 +2434,14 @@ class Axes(_AxesBase):
 
         patches = []
         args = zip(left, bottom, width, height, color, edgecolor, linewidth,
-                   hatch)
-        for l, b, w, h, c, e, lw, htch in args:
+                   hatch, patch_labels)
+        for l, b, w, h, c, e, lw, htch, lbl in args:
             r = mpatches.Rectangle(
                 xy=(l, b), width=w, height=h,
                 facecolor=c,
                 edgecolor=e,
                 linewidth=lw,
-                label='_nolegend_',
+                label=lbl,
                 hatch=htch,
                 )
             r._internal_update(kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1886,6 +1886,22 @@ def test_bar_hatches(fig_test, fig_ref):
     ax_test.bar(x, y, hatch=hatches)
 
 
+@pytest.mark.parametrize(
+    ("x", "width", "labels", "color"),
+    [
+        ("x", 1, "x", None),
+        ("x", 1, "x", "black"),
+        (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"], None),
+        (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"],
+         ["black", "blue", "orange"]),
+    ]
+)
+def test_bar_labels(x, width, labels, color):
+    _, ax = plt.subplots()
+    ax.bar(x, width, labels=labels, color=color)
+    ax.legend()
+
+
 def test_pandas_minimal_plot(pd):
     # smoke test that series and index objects do not warn
     for x in [pd.Series([1, 2], dtype="float64"),

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1892,7 +1892,7 @@ def test_bar_hatches(fig_test, fig_ref):
         ("x", 1, "x", ["_nolegend_"], "x"),
         (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"],
          ["A", "B", "C"], "_nolegend_"),
-        (["a", "b", "c"], [10, 20, 15], ["R", "Y", "R"],
+        (["a", "b", "c"], [10, 20, 15], ["R", "Y", "_nolegend_"],
          ["R", "Y", "_nolegend_"], "_nolegend_"),
         (["a", "b", "c"], [10, 20, 15], "bars",
          ["_nolegend_", "_nolegend_", "_nolegend_"], "bars"),
@@ -1913,15 +1913,6 @@ def test_bar_labels_length():
     _, ax = plt.subplots()
     with pytest.raises(ValueError):
         ax.bar(["x", "y"], [1, 2], label=["X"])
-
-
-def test_duplicate_bar_labels_in_legend():
-    _, ax = plt.subplots()
-    x = ["a", "b", "c"]
-    y = [2, 1, 3]
-    labels = ["Red", "Yellow", "Red"]
-    ax.bar(x, y, label=labels)
-    assert [text.get_text() for text in ax.legend().texts] == labels[:2]
 
 
 def test_pandas_minimal_plot(pd):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1902,6 +1902,12 @@ def test_bar_labels(x, width, labels, color):
     ax.legend()
 
 
+def test_bar_labels_length():
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.bar(["x", "y"], [1, 2], labels="X")
+
+
 def test_pandas_minimal_plot(pd):
     # smoke test that series and index objects do not warn
     for x in [pd.Series([1, 2], dtype="float64"),

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1887,25 +1887,26 @@ def test_bar_hatches(fig_test, fig_ref):
 
 
 @pytest.mark.parametrize(
-    ("x", "width", "labels", "color"),
+    ("x", "width", "label", "expected_labels"),
     [
-        ("x", 1, "x", None),
-        ("x", 1, "x", "black"),
-        (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"], None),
+        ("x", 1, "x", ["x"]),
         (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"],
-         ["black", "blue", "orange"]),
+         ["A", "B", "C"]),
+        (["a", "b", "c"], [10, 20, 15], "bars",
+         ["_nolegend_", "_nolegend_", "_nolegend_"]),
     ]
 )
-def test_bar_labels(x, width, labels, color):
+def test_bar_labels(x, width, label, expected_labels):
     _, ax = plt.subplots()
-    ax.bar(x, width, labels=labels, color=color)
-    ax.legend()
+    bar_container = ax.bar(x, width, label=label)
+    bar_labels = [bar.get_label() for bar in bar_container]
+    assert expected_labels == bar_labels
 
 
 def test_bar_labels_length():
     _, ax = plt.subplots()
     with pytest.raises(ValueError):
-        ax.bar(["x", "y"], [1, 2], labels="X")
+        ax.bar(["x", "y"], [1, 2], label=["X", "Y", "Z"])
 
 
 def test_pandas_minimal_plot(pd):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1887,26 +1887,41 @@ def test_bar_hatches(fig_test, fig_ref):
 
 
 @pytest.mark.parametrize(
-    ("x", "width", "label", "expected_labels"),
+    ("x", "width", "label", "expected_labels", "container_label"),
     [
-        ("x", 1, "x", ["x"]),
+        ("x", 1, "x", ["_nolegend_"], "x"),
         (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"],
-         ["A", "B", "C"]),
+         ["A", "B", "C"], "_nolegend_"),
+        (["a", "b", "c"], [10, 20, 15], ["R", "Y", "R"],
+         ["R", "Y", "_nolegend_"], "_nolegend_"),
         (["a", "b", "c"], [10, 20, 15], "bars",
-         ["_nolegend_", "_nolegend_", "_nolegend_"]),
+         ["_nolegend_", "_nolegend_", "_nolegend_"], "bars"),
     ]
 )
-def test_bar_labels(x, width, label, expected_labels):
+def test_bar_labels(x, width, label, expected_labels, container_label):
     _, ax = plt.subplots()
     bar_container = ax.bar(x, width, label=label)
     bar_labels = [bar.get_label() for bar in bar_container]
     assert expected_labels == bar_labels
+    assert bar_container.get_label() == container_label
 
 
 def test_bar_labels_length():
     _, ax = plt.subplots()
     with pytest.raises(ValueError):
         ax.bar(["x", "y"], [1, 2], label=["X", "Y", "Z"])
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.bar(["x", "y"], [1, 2], label=["X"])
+
+
+def test_duplicate_bar_labels_in_legend():
+    _, ax = plt.subplots()
+    x = ["a", "b", "c"]
+    y = [2, 1, 3]
+    labels = ["Red", "Yellow", "Red"]
+    ax.bar(x, y, label=labels)
+    assert [text.get_text() for text in ax.legend().texts] == labels[:2]
 
 
 def test_pandas_minimal_plot(pd):


### PR DESCRIPTION
## PR Summary
Currently, if you need to label each bar in a plot say for an animation, you have to loop over the bars in the bar container that `Axes.bar()` returns and call `set_label()` on each bar. I have an example [here](https://stefmolin.github.io/python-data-viz-workshop/slides/html/workshop.slides.html#/26/7) in a workshop I deliver. When compared with `stackplot()` (which has a `labels` argument for this) this can be a gotcha for newcomers. There is a `label` key shown in the docs as available on the `Rectangle`, but it doesn't have the expected effect of labeling the bars, rather it labels the `BarContainer`:

```python
>>> import matplotlib.pyplot as plt
>>> x = ["a", "b", "c"]
>>> y = [10, 20, 15]
>>> fig, ax = plt.subplots()
>>> bar_container = ax.barh(x, y, label=x)
>>> print([bar.get_label() for bar in bar_container])
['_nolegend_', '_nolegend_', '_nolegend_']
>>> bar_container.get_label()
"['a', 'b', 'c']
```

This PR adds a `labels` argument to `Axes.bar()`, which makes it possible to easily label each bar and color them differently, making it possible to create a legend immediately after calling the `bar()`/`barh()` method.
```python
x = ["a", "b", "c"]
y = [10, 20, 15]

fig, ax = plt.subplots()
_ = ax.barh(x, y, labels=x)
ax.legend()
```
<img width="355" alt="Screen Shot 2022-07-30 at 6 09 23 PM" src="https://user-images.githubusercontent.com/24376333/182001836-d7d64437-e1e0-46cc-a80f-de838f470743.png">

Default color behavior is preserved when `labels` isn't passed in:
```python
x = ["a", "b", "c"]
y = [10, 20, 15]

fig, ax = plt.subplots()
_ = ax.barh(x, y)
```
<img width="358" alt="Screen Shot 2022-07-30 at 6 12 38 PM" src="https://user-images.githubusercontent.com/24376333/182001882-693f2624-107d-4e00-8894-dc04d6959af8.png">


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [X] New features are documented, with examples if plot related.
- [X] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
