### PR TITLE
DOC: make "family" less ambiguous in FontProperties docs

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -626,10 +626,10 @@ class FontProperties:
     specification and *math_fontfamily* for math fonts:
 
     - family: A list of font names in decreasing order of priority.
-      The items may include a generic font family name, either
-      'sans-serif', 'serif', 'cursive', 'fantasy', or 'monospace'.
-      In that case, the actual font to be used will be looked up
-      from the associated rcParam. Default: :rc:`font.family`
+      The items may include a generic font family name, either 'sans-serif',
+      'serif', 'cursive', 'fantasy', or 'monospace'.  In that case, the actual
+      font to be used will be looked up from the associated rcParam during the
+      search process in `.findfont`. Default: :rc:`font.family`
 
     - style: Either 'normal', 'italic' or 'oblique'.
       Default: :rc:`font.style`
@@ -741,7 +741,11 @@ class FontProperties:
 
     def get_family(self):
         """
-        Return a list of font names that comprise the font family.
+        Return a list of individual font family names or generic family names.
+
+        The font families or generic font families (which will be resolved
+        from their respective rcParams when searching for a matching font) in
+        the order of preference.
         """
         return self._family
 


### PR DESCRIPTION
Address part of  #23492

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A]] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A]] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
