### PR TITLE
STY: fix whitespace on an assert

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -273,7 +273,7 @@ def test_tripcolor_clim():
     ax = plt.figure().add_subplot()
     clim = (0.25, 0.75)
     norm = ax.tripcolor(a, b, c, clim=clim).norm
-    assert((norm.vmin, norm.vmax) == clim)
+    assert (norm.vmin, norm.vmax) == clim
 
 
 def test_tripcolor_warnings():


### PR DESCRIPTION
This was caught by new version of linter.

Either flake8 4.0.1 -> 5.0.0 or pycodestyle 2.8.0 -> 2.9.0

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
