### PR TITLE
Add workflow dispatch GitHub CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,8 @@ on:
   schedule:
     # 3:47 UTC on Saturdays
     - cron: "47 3 * * 6"
+  workflow_dispatch:
+    workflow: "*"
 
 env:
   NO_AT_BRIDGE: 1  # Necessary for GTK3 interactive test.
@@ -22,7 +24,7 @@ env:
 
 jobs:
   test:
-    if: "github.repository == 'matplotlib/matplotlib' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    if: "github.event_name == 'workflow_dispatch' || github.repository == 'matplotlib/matplotlib' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} ${{ matrix.name-suffix }}"
     runs-on: ${{ matrix.os }}
 

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -159,9 +159,9 @@ workflows
 GitHub Actions should be automatically enabled for your personal Matplotlib
 fork once the YAML workflow files are in it. It generally isn't necessary to
 look at these workflows, since any pull request submitted against the main
-Matplotlib repository will be tested. The tests workflow is skipped in fork
-repositories but you can trigger a run manually from the `github web
-interface <https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow>`_.
+Matplotlib repository will be tested. The Tests workflow is skipped in forked
+repositories but you can trigger a run manually from the `GitHub web interface
+<https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow>`_.
 
 You can see the GitHub Actions results at
 https://github.com/your_GitHub_user_name/matplotlib/actions -- here's `an

--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -159,7 +159,9 @@ workflows
 GitHub Actions should be automatically enabled for your personal Matplotlib
 fork once the YAML workflow files are in it. It generally isn't necessary to
 look at these workflows, since any pull request submitted against the main
-Matplotlib repository will be tested.
+Matplotlib repository will be tested. The tests workflow is skipped in fork
+repositories but you can trigger a run manually from the `github web
+interface <https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow>`_.
 
 You can see the GitHub Actions results at
 https://github.com/your_GitHub_user_name/matplotlib/actions -- here's `an


### PR DESCRIPTION
## PR Summary

Add run workflow trigger to test github workflow to allow running the test suite in fork repository.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
