### PR TITLE
Legend: don't apply transform when a `bbox` instance is provided to `bbox_to_anchor` argument

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -145,8 +145,8 @@ bbox_to_anchor : `.BboxBase`, 2-tuple, or 4-tuple of floats
     `figure.bbox` (if `.Figure.legend`).  This argument allows arbitrary
     placement of the legend.
 
-    Bbox coordinates are interpreted in the coordinate system given by
-    *bbox_transform*, with the default transform
+    If 2- or 4-tuple is given, bbox coordinates are interpreted in the
+    coordinate system given by *bbox_transform*, with the default transform
     Axes or Figure coordinates, depending on which ``legend`` is called.
 
     If a 4-tuple or `.BboxBase` is given, then it specifies the bbox
@@ -959,11 +959,11 @@ class Legend(Artist):
 
             self._bbox_to_anchor = Bbox.from_bounds(*bbox)
 
-        if transform is None:
-            transform = BboxTransformTo(self.parent.bbox)
+            if transform is None:
+                transform = BboxTransformTo(self.parent.bbox)
 
-        self._bbox_to_anchor = TransformedBbox(self._bbox_to_anchor,
-                                               transform)
+            self._bbox_to_anchor = TransformedBbox(self._bbox_to_anchor,
+                                                   transform)
         self.stale = True
 
     def _get_anchored_bbox(self, loc, bbox, parentbbox, renderer):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -935,3 +935,19 @@ def test_ncol_ncols(fig_test, fig_ref):
     ncols = 3
     fig_test.legend(strings, ncol=ncols)
     fig_ref.legend(strings, ncols=ncols)
+
+
+def test_fig_legend_method_bbox_to_anchor():
+    # Check passing Axes.bbox to bbox_to_anchor argument behaviour
+    data_left = np.arange(10)
+    data_right = np.random.random(10)
+    fig, ax = plt.subplots()
+    ax.plot(data_left, label='left axis', color='C0')
+    ax2 = ax.twinx()
+    ax2.plot(data_right, label='right axis', color='C1')
+    legend = fig.legend(bbox_to_anchor=ax.bbox)
+
+    colors = [line.get_color() for line in ax.lines + ax2.lines]
+    legend_colors = [line.get_color() for line in legend.get_lines()]
+    assert colors == legend_colors
+    assert legend.get_bbox_to_anchor() == ax.bbox


### PR DESCRIPTION
## PR Summary

Simplify passing `bbox` instance to legend `bbox_to_anchor` argument:

```python
import matplotlib.pyplot as plt
import numpy as np


data_left = np.arange(100)
data_right = np.random.random(100)

fig, ax = plt.subplots()

ax.plot(data_left, label='left axis')
ax2 = ax.twinx()
ax2.plot(data_right, label='right axis', color='C1')

fig.legend(bbox_to_anchor=ax.bbox)
# Same as above but more convoluted
# fig.legend(bbox_transform=ax.transAxes, bbox_to_anchor=[0, 0, 1, 1])
```

When passing a `bbox` instance to `bbox_to_anchor` argument, I don't know what use cases are expected to be supported, which means that I don't know if the current implementation is a bug, a feature or simply as it is unintentionally. In any case, I am opening this PR to discuss it and to try the API to support the example given above.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
