### PR TITLE
Make margins error as claimed in doc-string

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2705,7 +2705,7 @@ class _AxesBase(martist.Artist):
         before calling :meth:`margins`.
         """
 
-        if margins and x is not None and y is not None:
+        if margins and (x is not None or y is not None):
             raise TypeError('Cannot pass both positional and keyword '
                             'arguments for x and/or y.')
         elif len(margins) == 1:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5734,21 +5734,17 @@ def test_set_margin_updates_limits():
     assert ax.get_xlim() == (1, 2)
 
 
-@pytest.mark.parametrize('err, args, kwargs, match',
-                         ((ValueError, (-1,), {},
-                           'margin must be greater than -0.5'),
-                          (ValueError, (1, -1), {},
-                           'margin must be greater than -0.5'),
-                          (ValueError, tuple(), {'x': -1},
-                           'margin must be greater than -0.5'),
-                          (ValueError, tuple(), {'y': -1},
-                           'margin must be greater than -0.5'),
-                          (TypeError, (1, ), {'x': 1, 'y': 1},
-                           'Cannot pass both positional and keyword '
-                           'arguments for x and/or y.'),
-                          (TypeError, (1, 1, 1), {},
-                           'Must pass a single positional argument for all*'),
-                          ))
+@pytest.mark.parametrize('err, args, kwargs, match', (
+        (ValueError, (-1,), {}, r'margin must be greater than -0\.5'),
+        (ValueError, (1, -1), {}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'x': -1}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'y': -1}, r'margin must be greater than -0\.5'),
+        (TypeError, (1, ), {'x': 1, 'y': 1},
+         'Cannot pass both positional and keyword arguments for x and/or y'),
+        (TypeError, (1, ), {'x': 1},
+         'Cannot pass both positional and keyword arguments for x and/or y'),
+        (TypeError, (1, 1, 1), {}, 'Must pass a single positional argument'),
+))
 def test_margins_errors(err, args, kwargs, match):
     with pytest.raises(err, match=match):
         fig = plt.figure()

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -489,7 +489,7 @@ class Axes3D(Axes):
         applies to 3D Axes, it also takes a *z* argument, and returns
         ``(xmargin, ymargin, zmargin)``.
         """
-        if margins and x is not None and y is not None and z is not None:
+        if margins and (x is not None or y is not None or z is not None):
             raise TypeError('Cannot pass both positional and keyword '
                             'arguments for x, y, and/or z.')
         elif len(margins) == 1:

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -1713,13 +1713,26 @@ def test_margins():
     assert ax.margins() == (0, 0.1, 0)
 
 
-def test_margins_errors():
-    fig = plt.figure()
-    ax = fig.add_subplot(projection='3d')
-    with pytest.raises(TypeError, match="Cannot pass"):
-        ax.margins(0.2, x=0.4, y=0.4, z=0.4)
-    with pytest.raises(TypeError, match="Must pass"):
-        ax.margins(0.2, 0.4)
+@pytest.mark.parametrize('err, args, kwargs, match', (
+        (ValueError, (-1,), {}, r'margin must be greater than -0\.5'),
+        (ValueError, (1, -1, 1), {}, r'margin must be greater than -0\.5'),
+        (ValueError, (1, 1, -1), {}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'x': -1}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'y': -1}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'z': -1}, r'margin must be greater than -0\.5'),
+        (TypeError, (1, ), {'x': 1},
+         'Cannot pass both positional and keyword'),
+        (TypeError, (1, ), {'x': 1, 'y': 1, 'z': 1},
+         'Cannot pass both positional and keyword'),
+        (TypeError, (1, ), {'x': 1, 'y': 1},
+         'Cannot pass both positional and keyword'),
+        (TypeError, (1, 1), {}, 'Must pass a single positional argument for'),
+))
+def test_margins_errors(err, args, kwargs, match):
+    with pytest.raises(err, match=match):
+        fig = plt.figure()
+        ax = fig.add_subplot(projection='3d')
+        ax.margins(*args, **kwargs)
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
## PR Summary

Built on top of #23453 so better merge that first.

The documentation says:
```
Passing both positional and keyword
arguments is invalid and will raise a TypeError.
```

But it is currently possible to pass e.g. `margins(0.2, x=0)` which will set both margins to 0.2.

As this corrects the stated behaviour of the doc-string I assume that no change note is required?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
