### PR TITLE
Small improvements to WebAgg example

### DIFF
--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -16,6 +16,7 @@ import io
 import json
 import mimetypes
 from pathlib import Path
+import signal
 import socket
 
 try:
@@ -259,4 +260,17 @@ if __name__ == "__main__":
         print(f"Listening on http://{addr}:{port}/")
     print("Press Ctrl+C to quit")
 
-    tornado.ioloop.IOLoop.instance().start()
+    ioloop = tornado.ioloop.IOLoop.instance()
+
+    def shutdown():
+        ioloop.stop()
+        print("Server stopped")
+
+    old_handler = signal.signal(
+        signal.SIGINT,
+        lambda sig, frame: ioloop.add_callback_from_signal(shutdown))
+
+    try:
+        ioloop.start()
+    finally:
+        signal.signal(signal.SIGINT, old_handler)


### PR DESCRIPTION
## PR Summary

Allow specifying a port, and gracefully handle Ctrl+C.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).