### PR TITLE
Change exception types, improve argument checking, and cleanups in mpl_toolkits

### DIFF
--- a/doc/api/next_api_changes/behavior/23550-OG.rst
+++ b/doc/api/next_api_changes/behavior/23550-OG.rst
@@ -1,0 +1,10 @@
+Specified exception types in Grid
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In a few cases an `Exception` was thrown when an incorrect argument value
+was set in the `mpl_toolkits.axes_grid1.axes_grid.Grid`
+(= `mpl_toolkits.axisartist.axes_grid.Grid`) constructor. These are replaced
+as follows:
+
+* Providing an incorrect value for *ngrids* now raises a `ValueError`
+* Providing an incorrect type for *rect* now raises a `TypeError`

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -250,6 +250,8 @@ class Divider:
             ny1 if ny1 is not None else ny + 1)
 
     def append_size(self, position, size):
+        _api.check_in_list(["left", "right", "bottom", "top"],
+                           position=position)
         if position == "left":
             self._horizontal.insert(0, size)
             self._xrefindex += 1
@@ -258,11 +260,8 @@ class Divider:
         elif position == "bottom":
             self._vertical.insert(0, size)
             self._yrefindex += 1
-        elif position == "top":
+        else:  # 'top'
             self._vertical.append(size)
-        else:
-            _api.check_in_list(["left", "right", "bottom", "top"],
-                               position=position)
 
     def add_auto_adjustable_area(self, use_axes, pad=0.1, adjust_dirs=None):
         """
@@ -512,6 +511,8 @@ class AxesDivider(Divider):
         **kwargs
             All extra keywords arguments are passed to the created axes.
         """
+        _api.check_in_list(["left", "right", "bottom", "top"],
+                           position=position)
         if position == "left":
             ax = self.new_horizontal(
                 size, pad, pack_start=True, axes_class=axes_class, **kwargs)
@@ -521,12 +522,9 @@ class AxesDivider(Divider):
         elif position == "bottom":
             ax = self.new_vertical(
                 size, pad, pack_start=True, axes_class=axes_class, **kwargs)
-        elif position == "top":
+        else:  # "top"
             ax = self.new_vertical(
                 size, pad, pack_start=False, axes_class=axes_class, **kwargs)
-        else:
-            _api.check_in_list(["left", "right", "bottom", "top"],
-                               position=position)
         if add_to_figure:
             self._fig.add_axes(ax)
         return ax

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -271,6 +271,7 @@ class Grid:
             - "1": Only the bottom left axes is labelled.
             - "all": all axes are labelled.
         """
+        _api.check_in_list(["all", "L", "1"], mode=mode)
         if mode == "all":
             for ax in self.axes_all:
                 _tick_only(ax, False, False)
@@ -291,7 +292,7 @@ class Grid:
                 ax = col[-1]
                 _tick_only(ax, bottom_on=False, left_on=True)
 
-        elif mode == "1":
+        else:  # "1"
             for ax in self.axes_all:
                 _tick_only(ax, bottom_on=True, left_on=True)
 
@@ -379,6 +380,10 @@ class ImageGrid(Grid):
             to associated *cbar_axes*.
         axes_class : subclass of `matplotlib.axes.Axes`, default: None
         """
+        _api.check_in_list(["each", "single", "edge", None],
+                           cbar_mode=cbar_mode)
+        _api.check_in_list(["left", "right", "bottom", "top"],
+                           cbar_location=cbar_location)
         self._colorbar_mode = cbar_mode
         self._colorbar_location = cbar_location
         self._colorbar_pad = cbar_pad

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -123,7 +123,8 @@ class Grid:
             ngrids = self._nrows * self._ncols
         else:
             if not 0 < ngrids <= self._nrows * self._ncols:
-                raise Exception("")
+                raise ValueError(
+                    "ngrids must be positive and not larger than nrows*ncols")
 
         self.ngrids = ngrids
 
@@ -147,7 +148,7 @@ class Grid:
         elif len(rect) == 4:
             self._divider = Divider(fig, rect, **kw)
         else:
-            raise Exception("")
+            raise TypeError("Incorrect rect format")
 
         rect = self._divider.get_position()
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -813,7 +813,7 @@ class Axes3D(Axes):
                 raise ValueError(f"focal_length = {focal_length} must be "
                                  "greater than 0")
             self._focal_length = focal_length
-        elif proj_type == 'ortho':
+        else:  # 'ortho':
             if focal_length not in (None, np.inf):
                 raise ValueError(f"focal_length = {focal_length} must be "
                                  f"None for proj_type = {proj_type}")

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -17,7 +17,7 @@ from mpl_toolkits.axes_grid1 import (
 from mpl_toolkits.axes_grid1.anchored_artists import (
     AnchoredSizeBar, AnchoredDirectionArrows)
 from mpl_toolkits.axes_grid1.axes_divider import (
-    HBoxDivider, make_axes_area_auto_adjustable)
+    Divider, HBoxDivider, make_axes_area_auto_adjustable)
 from mpl_toolkits.axes_grid1.axes_rgb import RGBAxes
 from mpl_toolkits.axes_grid1.inset_locator import (
     zoomed_inset_axes, mark_inset, inset_axes, BboxConnectorPatch)
@@ -516,6 +516,18 @@ def test_grid_errors(rect, ngrids, error, message):
     fig = plt.figure()
     with pytest.raises(error, match=message):
         Grid(fig, rect, (2, 3), ngrids=ngrids)
+
+
+@pytest.mark.parametrize('anchor, error, message', (
+    (None, TypeError, "anchor must be str"),
+    ("CC", ValueError, "'CC' is not a valid value for anchor"),
+    ((1, 1, 1), TypeError, "anchor must be str"),
+))
+def test_divider_errors(anchor, error, message):
+    fig = plt.figure()
+    with pytest.raises(error, match=message):
+        Divider(fig, [0, 0, 1, 1], [Size.Fixed(1)], [Size.Fixed(1)],
+                anchor=anchor)
 
 
 @check_figures_equal(extensions=["png"])

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -376,10 +376,9 @@ def test_image_grid():
 
     fig = plt.figure(1, (4, 4))
     grid = ImageGrid(fig, 111, nrows_ncols=(2, 2), axes_pad=0.1)
-
+    assert grid.get_axes_pad() == (0.1, 0.1)
     for i in range(4):
         grid[i].imshow(im, interpolation='nearest')
-        grid[i].set_title('test {0}{0}'.format(i))
 
 
 def test_gettightbbox():
@@ -492,6 +491,7 @@ def test_grid_axes_lists():
     assert_array_equal(grid, grid.axes_all)
     assert_array_equal(grid.axes_row, np.transpose(grid.axes_column))
     assert_array_equal(grid, np.ravel(grid.axes_row), "row")
+    assert grid.get_geometry() == (2, 3)
     grid = Grid(fig, 111, (2, 3), direction="column")
     assert_array_equal(grid, np.ravel(grid.axes_column), "column")
 
@@ -505,6 +505,17 @@ def test_grid_axes_position(direction):
     assert loc[1]._nx > loc[0]._nx and loc[2]._ny < loc[0]._ny
     assert loc[0]._nx == loc[2]._nx and loc[0]._ny == loc[1]._ny
     assert loc[3]._nx == loc[1]._nx and loc[3]._ny == loc[2]._ny
+
+
+@pytest.mark.parametrize('rect, ngrids, error, message', (
+    ((1, 1), None, TypeError, "Incorrect rect format"),
+    (111, -1, ValueError, "ngrids must be positive"),
+    (111, 7, ValueError, "ngrids must be positive"),
+))
+def test_grid_errors(rect, ngrids, error, message):
+    fig = plt.figure()
+    with pytest.raises(error, match=message):
+        Grid(fig, rect, (2, 3), ngrids=ngrids)
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
## PR Summary

Raise a more exact type.

Better argument checking.

Minor cleanups.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
