### PR TITLE
Migrate cibuildwheel workflow to macos-11

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,7 +35,7 @@ jobs:
       MACOSX_DEPLOYMENT_TARGET: "10.12"
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-10.15]
+        os: [ubuntu-20.04, windows-latest, macos-11]
         cibw_archs: ["auto"]
         include:
           - os: ubuntu-20.04


### PR DESCRIPTION
## PR Summary

The macos-10.15 runner is deprecated:
https://github.com/actions/virtual-environments/issues/5583

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).