### PR TITLE
Numpy-related cleanups

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1309,7 +1309,7 @@ def test_pcolorargs():
         ax.pcolormesh(x, y, Z[:-1, :-1], shading="gouraud")
     with pytest.raises(TypeError):
         ax.pcolormesh(X, Y, Z[:-1, :-1], shading="gouraud")
-    x[0] = np.NaN
+    x[0] = np.nan
     with pytest.raises(ValueError):
         ax.pcolormesh(x, y, Z[:-1, :-1])
     with np.errstate(invalid='ignore'):
@@ -6921,7 +6921,7 @@ def test_spines_properbbox_after_zoom():
 def test_gettightbbox_ignore_nan():
     fig, ax = plt.subplots()
     remove_ticks_and_titles(fig)
-    ax.text(np.NaN, 1, 'Boo')
+    ax.text(np.nan, 1, 'Boo')
     renderer = fig.canvas.get_renderer()
     np.testing.assert_allclose(ax.get_tightbbox(renderer).width, 496)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -153,9 +153,9 @@ def test_label_shift():
 
 @check_figures_equal(extensions=["png"])
 def test_acorr(fig_test, fig_ref):
-    np.random.seed(19680801)
+    rng = np.random.default_rng(19680801)
     Nx = 512
-    x = np.random.normal(0, 1, Nx).cumsum()
+    x = rng.normal(0, 1, Nx).cumsum()
     maxlags = Nx-1
 
     ax_test = fig_test.subplots()
@@ -172,10 +172,10 @@ def test_acorr(fig_test, fig_ref):
 
 @check_figures_equal(extensions=["png"])
 def test_spy(fig_test, fig_ref):
-    np.random.seed(19680801)
+    rng = np.random.default_rng(19680801)
     a = np.ones(32 * 32)
     a[:16 * 32] = 0
-    np.random.shuffle(a)
+    rng.shuffle(a)
     a = a.reshape((32, 32))
 
     axs_test = fig_test.subplots(2)
@@ -1362,7 +1362,6 @@ def test_pcolorflaterror():
     fig, ax = plt.subplots()
     x = np.arange(0, 9)
     y = np.arange(0, 3)
-    np.random.seed(19680801)
     Z = np.random.randn(3, 9)
     with pytest.raises(TypeError, match='Dimensions of C'):
         ax.pcolormesh(x, y, Z, shading='flat')
@@ -1941,9 +1940,9 @@ def test_hist_bar_empty():
 
 
 def test_hist_float16():
-    np.random.seed(19680801)
+    rng = np.random.default_rng(19680801)
     values = np.clip(
-        np.random.normal(0.5, 0.3, size=1000), 0, 1).astype(np.float16)
+        rng.normal(0.5, 0.3, size=1000), 0, 1).astype(np.float16)
     h = plt.hist(values, bins=3, alpha=0.5)
     bc = h[2]
     # Check that there are no overlapping rectangles
@@ -3473,8 +3472,8 @@ def test_violinplot_outofrange_quantiles():
 def test_violinplot_single_list_quantiles(fig_test, fig_ref):
     # Ensures quantile list for 1D can be passed in as single list
     # First 9 digits of frac(sqrt(83))
-    np.random.seed(110433579)
-    data = [np.random.normal(size=100)]
+    rng = np.random.default_rng(110433579)
+    data = [rng.normal(size=100)]
 
     # Test image
     ax = fig_test.subplots()
@@ -3487,10 +3486,10 @@ def test_violinplot_single_list_quantiles(fig_test, fig_ref):
 
 @check_figures_equal(extensions=["png"])
 def test_violinplot_pandas_series(fig_test, fig_ref, pd):
-    np.random.seed(110433579)
-    s1 = pd.Series(np.random.normal(size=7), index=[9, 8, 7, 6, 5, 4, 3])
-    s2 = pd.Series(np.random.normal(size=9), index=list('ABCDEFGHI'))
-    s3 = pd.Series(np.random.normal(size=11))
+    rng = np.random.default_rng(110433579)
+    s1 = pd.Series(rng.normal(size=7), index=[9, 8, 7, 6, 5, 4, 3])
+    s2 = pd.Series(rng.normal(size=9), index=list('ABCDEFGHI'))
+    s3 = pd.Series(rng.normal(size=11))
     fig_test.subplots().violinplot([s1, s2, s3])
     fig_ref.subplots().violinplot([s1.values, s2.values, s3.values])
 

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -151,7 +151,7 @@ def test_rcupdate():
 @mpl.style.context('default')
 @pytest.mark.backend('pgf')
 def test_pathclip():
-    np.random.seed(19680801)
+    rng = np.random.default_rng(19680801)
     mpl.rcParams.update({'font.family': 'serif', 'pgf.rcfonts': False})
     fig, axs = plt.subplots(1, 2)
 
@@ -160,7 +160,7 @@ def test_pathclip():
     axs[0].set_ylim(0, 1)
 
     axs[1].scatter([0, 1], [1, 1])
-    axs[1].hist(np.random.normal(size=1000), bins=20, range=[-10, 10])
+    axs[1].hist(rng.normal(size=1000), bins=20, range=[-10, 10])
     axs[1].set_xscale('log')
 
     fig.savefig(BytesIO(), format="pdf")  # No image comparison.

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -283,7 +283,7 @@ def test_BoundaryNorm():
 
     # Masked arrays
     boundaries = [0, 1.1, 2.2]
-    vals = np.ma.masked_invalid([-1., np.NaN, 0, 1.4, 9])
+    vals = np.ma.masked_invalid([-1., np.nan, 0, 1.4, 9])
 
     # Without interpolation
     ncolors = len(boundaries) - 1
@@ -297,9 +297,9 @@ def test_BoundaryNorm():
     assert_array_equal(bn(vals), expected)
 
     # Non-trivial masked arrays
-    vals = np.ma.masked_invalid([np.Inf, np.NaN])
+    vals = np.ma.masked_invalid([np.inf, np.nan])
     assert np.all(bn(vals).mask)
-    vals = np.ma.masked_invalid([np.Inf])
+    vals = np.ma.masked_invalid([np.inf])
     assert np.all(bn(vals).mask)
 
     # Incompatible extend and clip

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1347,7 +1347,7 @@ def test_rgba_antialias():
     aa[:, int(N/2):] = a[:, int(N/2):]
 
     # set some over/unders and NaNs
-    aa[20:50, 20:50] = np.NaN
+    aa[20:50, 20:50] = np.nan
     aa[70:90, 70:90] = 1e6
     aa[70:90, 20:30] = -1e6
     aa[70:90, 195:215] = 1e6


### PR DESCRIPTION
## PR Summary

1. Change `Inf/NaN` to `inf/nan` (except the one in #23577)
2. Use new style random number generator in a few test files.

(I have Pandas problems on my local computer so tries to test on CI.)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
