### PR TITLE
Remove direct manipulation of HostAxes.parasites by end users.

### DIFF
--- a/doc/api/next_api_changes/behavior/23579-AL.rst
+++ b/doc/api/next_api_changes/behavior/23579-AL.rst
@@ -1,0 +1,5 @@
+``HostAxesBase.get_aux_axes`` now defaults to using the same base axes class as the host axes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+If using an ``mpl_toolkits.axisartist``-based host Axes, the parasite Axes will
+also be based on ``mpl_toolkits.axisartist``.  This behavior is consistent with
+``HostAxesBase.twin``, ``HostAxesBase.twinx``, and ``HostAxesBase.twiny``.

--- a/examples/axisartist/demo_curvelinear_grid.py
+++ b/examples/axisartist/demo_curvelinear_grid.py
@@ -95,7 +95,6 @@ def curvelinear_test2(fig):
     ax2 = ax1.get_aux_axes(tr)
     # note that ax2.transData == tr + ax1.transData
     # Anything you draw in ax2 will match the ticks and grids of ax1.
-    ax1.parasites.append(ax2)
     ax2.plot(np.linspace(0, 30, 51), np.linspace(10, 10, 51), linewidth=2)
 
     ax2.pcolor(np.linspace(0, 90, 4), np.linspace(0, 10, 4),

--- a/examples/axisartist/demo_parasite_axes.py
+++ b/examples/axisartist/demo_parasite_axes.py
@@ -17,17 +17,15 @@ and :mod:`mpl_toolkits.axisartist` is found in the
 :doc:`/gallery/axisartist/demo_parasite_axes2` example.
 """
 
-from mpl_toolkits.axisartist.parasite_axes import HostAxes, ParasiteAxes
+from mpl_toolkits.axisartist.parasite_axes import HostAxes
 import matplotlib.pyplot as plt
 
 
 fig = plt.figure()
 
 host = fig.add_axes([0.15, 0.1, 0.65, 0.8], axes_class=HostAxes)
-par1 = ParasiteAxes(host, sharex=host)
-par2 = ParasiteAxes(host, sharex=host)
-host.parasites.append(par1)
-host.parasites.append(par2)
+par1 = host.get_aux_axes(viewlim_mode=None, sharex=host)
+par2 = host.get_aux_axes(viewlim_mode=None, sharex=host)
 
 host.axis["right"].set_visible(False)
 

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -99,20 +99,35 @@ class HostAxesBase:
         self.parasites = []
         super().__init__(*args, **kwargs)
 
-    def get_aux_axes(self, tr=None, viewlim_mode="equal", axes_class=Axes):
+    def get_aux_axes(
+            self, tr=None, viewlim_mode="equal", axes_class=None, **kwargs):
         """
         Add a parasite axes to this host.
 
         Despite this method's name, this should actually be thought of as an
         ``add_parasite_axes`` method.
 
-        *tr* may be `.Transform`, in which case the following relation will
-        hold: ``parasite.transData = tr + host.transData``.  Alternatively, it
-        may be None (the default), no special relationship will hold between
-        the parasite's and the host's ``transData``.
+        Parameters
+        ----------
+        tr : `.Transform` or None, default: None
+            If a `.Transform`, the following relation will hold:
+            ``parasite.transData = tr + host.transData``.
+            If None, the parasite's and the host's ``transData`` are unrelated.
+        viewlim_mode : {"equal", "transform", None}, default: "equal"
+            How the parasite's view limits are set: directly equal to the
+            parent axes ("equal"), equal after application of *tr*
+            ("transform"), or independently (None).
+        axes_class : subclass type of `~.axes.Axes`, optional
+            The `.axes.Axes` subclass that is instantiated.  If None, the base
+            class of the host axes is used.
+        kwargs
+            Other parameters are forwarded to the parasite axes constructor.
         """
+        if axes_class is None:
+            axes_class = self._base_axes_class
         parasite_axes_class = parasite_axes_class_factory(axes_class)
-        ax2 = parasite_axes_class(self, tr, viewlim_mode=viewlim_mode)
+        ax2 = parasite_axes_class(
+            self, tr, viewlim_mode=viewlim_mode, **kwargs)
         # note that ax2.transData == tr + ax1.transData
         # Anything you draw in ax2 will match the ticks and grids of ax1.
         self.parasites.append(ax2)

--- a/lib/mpl_toolkits/tests/test_axisartist_axislines.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_axislines.py
@@ -4,7 +4,7 @@ from matplotlib.testing.decorators import image_comparison
 from matplotlib.transforms import IdentityTransform
 
 from mpl_toolkits.axisartist.axislines import SubplotZero, Subplot
-from mpl_toolkits.axisartist import Axes, SubplotHost, ParasiteAxes
+from mpl_toolkits.axisartist import Axes, SubplotHost
 
 
 @image_comparison(['SubplotZero.png'], style='default')
@@ -81,8 +81,7 @@ def test_ParasiteAxesAuxTrans():
         ax1 = SubplotHost(fig, 1, 3, i+1)
         fig.add_subplot(ax1)
 
-        ax2 = ParasiteAxes(ax1, IdentityTransform())
-        ax1.parasites.append(ax2)
+        ax2 = ax1.get_aux_axes(IdentityTransform(), viewlim_mode=None)
         if name.startswith('pcolor'):
             getattr(ax2, name)(xx, yy, data[:-1, :-1])
         else:

--- a/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/tests/test_axisartist_grid_helper_curvelinear.py
@@ -6,7 +6,6 @@ from matplotlib.projections import PolarAxes
 from matplotlib.transforms import Affine2D, Transform
 from matplotlib.testing.decorators import image_comparison
 
-from mpl_toolkits.axes_grid1.parasite_axes import ParasiteAxes
 from mpl_toolkits.axisartist import SubplotHost
 from mpl_toolkits.axes_grid1.parasite_axes import host_subplot_class_factory
 from mpl_toolkits.axisartist import angle_helper
@@ -66,8 +65,7 @@ def test_custom_transform():
     ax1 = SubplotHost(fig, 1, 1, 1, grid_helper=grid_helper)
     fig.add_subplot(ax1)
 
-    ax2 = ParasiteAxes(ax1, tr, viewlim_mode="equal")
-    ax1.parasites.append(ax2)
+    ax2 = ax1.get_aux_axes(tr, viewlim_mode="equal")
     ax2.plot([3, 6], [5.0, 10.])
 
     ax1.set_aspect(1.)
@@ -127,10 +125,9 @@ def test_polar_box():
     axis.get_helper().set_extremes(-180, 90)
 
     # A parasite axes with given transform
-    ax2 = ParasiteAxes(ax1, tr, viewlim_mode="equal")
+    ax2 = ax1.get_aux_axes(tr, viewlim_mode="equal")
     assert ax2.transData == tr + ax1.transData
     # Anything you draw in ax2 will match the ticks and grids of ax1.
-    ax1.parasites.append(ax2)
     ax2.plot(np.linspace(0, 30, 50), np.linspace(10, 10, 50))
 
     ax1.set_aspect(1.)

--- a/tutorials/toolkits/axisartist.py
+++ b/tutorials/toolkits/axisartist.py
@@ -519,10 +519,9 @@ coordinates, or you may use Parasite Axes for convenience.::
     ax1 = SubplotHost(fig, 1, 2, 2, grid_helper=grid_helper)
 
     # A parasite axes with given transform
-    ax2 = ParasiteAxesAuxTrans(ax1, tr, "equal")
+    ax2 = ax1.get_aux_axes(tr, "equal")
     # note that ax2.transData == tr + ax1.transData
     # Anything you draw in ax2 will match the ticks and grids of ax1.
-    ax1.parasites.append(ax2)
 
 .. figure:: ../../gallery/axisartist/images/sphx_glr_demo_curvelinear_grid_001.png
    :target: ../../gallery/axisartist/demo_curvelinear_grid.html


### PR DESCRIPTION
Directly manipulating a list of child axes is strange compared to the
standard Matplotlib axes creation API, so don't use that in mpl_toolkits
parasite axes either.  Instead, use the already existing get_aux_axes
API.  However, that API needs to be improved to support arbitrary
kwargs that get forwarded to the Axes constructor, which is easy to do.

Also replace the default axes_class in that API by _base_axes_class,
which is consistent with HostAxes.twin()/twinx()/twiny(), and also
corresponds to the practical use cases demonstrated in the examples: if
the host axes class is from axisartist, the parasite axes class is also
from axisartist (see examples/axisartist/demo_parasite_axes.py); using
another parasite axes class won't work.

This is preliminary work for making parasite_axes a thin wrapper around
standard child_axes.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
