### PR TITLE
BUG:datetime list starting with none

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2176,12 +2176,12 @@ class Axes(_AxesBase):
             # removes the units from unit packages like `pint` that
             # wrap numpy arrays.
             try:
-                x0 = cbook.safe_first_element(x0)
+                x0 = cbook._safe_first_non_none(x0)
             except (TypeError, IndexError, KeyError):
                 pass
 
             try:
-                x = cbook.safe_first_element(xconv)
+                x = cbook._safe_first_non_none(xconv)
             except (TypeError, IndexError, KeyError):
                 x = xconv
 
@@ -2779,11 +2779,11 @@ class Axes(_AxesBase):
         """
         # process the unit information
         if len(xranges):
-            xdata = cbook.safe_first_element(xranges)
+            xdata = cbook._safe_first_non_none(xranges)
         else:
             xdata = None
         if len(yrange):
-            ydata = cbook.safe_first_element(yrange)
+            ydata = cbook._safe_first_non_none(yrange)
         else:
             ydata = None
         self._process_unit_info(
@@ -3424,10 +3424,10 @@ class Axes(_AxesBase):
                     # safe_first_element because getitem is index-first not
                     # location first on pandas objects so err[0] almost always
                     # fails.
-                    isinstance(cbook.safe_first_element(err), np.ndarray)
+                    isinstance(cbook._safe_first_non_none(err), np.ndarray)
             ):
                 # Get the type of the first element
-                atype = type(cbook.safe_first_element(err))
+                atype = type(cbook._safe_first_non_none(err))
                 # Promote the outer container to match the inner container
                 if atype is np.ndarray:
                     # Converts using np.asarray, because data cannot
@@ -4290,7 +4290,7 @@ class Axes(_AxesBase):
         c_is_string_or_strings = (
             isinstance(c, str)
             or (np.iterable(c) and len(c) > 0
-                and isinstance(cbook.safe_first_element(c), str)))
+                and isinstance(cbook._safe_first_non_none(c), str)))
 
         def invalid_shape_exception(csize, xsize):
             return ValueError(

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1908,7 +1908,7 @@ class DateConverter(units.ConversionInterface):
             x = x.ravel()
 
         try:
-            x = cbook.safe_first_element(x)
+            x = cbook._safe_first_non_none(x)
         except (TypeError, StopIteration):
             pass
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -4,7 +4,7 @@ import pickle
 from weakref import ref
 from unittest.mock import patch, Mock
 
-from datetime import datetime
+from datetime import datetime, date, timedelta
 
 import numpy as np
 from numpy.testing import (assert_array_equal, assert_approx_equal,
@@ -602,7 +602,7 @@ def test_flatiter():
     it = x.flat
     assert 0 == next(it)
     assert 1 == next(it)
-    ret = cbook.safe_first_element(it)
+    ret = cbook._safe_first_non_none(it)
     assert ret == 0
 
     assert 0 == next(it)
@@ -758,7 +758,7 @@ def test_contiguous_regions():
 def test_safe_first_element_pandas_series(pd):
     # deliberately create a pandas series with index not starting from 0
     s = pd.Series(range(5), index=range(10, 15))
-    actual = cbook.safe_first_element(s)
+    actual = cbook._safe_first_non_none(s)
     assert actual == 0
 
 
@@ -888,3 +888,10 @@ def test_format_approx():
     assert f(0.0012345600001, 5) == '0.00123'
     assert f(-0.0012345600001, 5) == '-0.00123'
     assert f(0.0012345600001, 8) == f(0.0012345600001, 10) == '0.00123456'
+
+
+def test_safe_first_element_with_none():
+    datetime_lst = [date.today() + timedelta(days=i) for i in range(10)]
+    datetime_lst[0] = None
+    actual = cbook._safe_first_non_none(datetime_lst)
+    assert actual is not None and actual == datetime_lst[1]

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -197,7 +197,7 @@ class Registry(dict):
             except KeyError:
                 pass
         try:  # If cache lookup fails, look up based on first element...
-            first = cbook.safe_first_element(x)
+            first = cbook._safe_first_non_none(x)
         except (TypeError, StopIteration):
             pass
         else:


### PR DESCRIPTION
## PR Summary
#23580 
- cbook/__init__.py
  - modified safe_first_element() to obtain the first non-None element
- test_cbook.py
  - added a test for safe_first_element()
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ N/A] New features are documented, with examples if plot related.
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
