### PR TITLE
Expire deprecation on passing bytes to FT2Font.set_text

### DIFF
--- a/doc/api/next_api_changes/removals/23594-OG.rst
+++ b/doc/api/next_api_changes/removals/23594-OG.rst
@@ -1,0 +1,4 @@
+Passing bytes to ``FT2Font.set_text``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... is no longer supported. Pass str instead.

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -596,22 +596,8 @@ static PyObject *PyFT2Font_set_text(PyFT2Font *self, PyObject *args, PyObject *k
             codepoints[i] = PyUnicode_ReadChar(textobj, i);
         }
 #endif
-    } else if (PyBytes_Check(textobj)) {
-        if (PyErr_WarnEx(
-            PyExc_FutureWarning,
-            "Passing bytes to FTFont.set_text is deprecated since Matplotlib "
-            "3.4 and support will be removed in Matplotlib 3.6; pass str instead",
-            1)) {
-            return NULL;
-        }
-        size = PyBytes_Size(textobj);
-        codepoints.resize(size);
-        char *bytestr = PyBytes_AsString(textobj);
-        for (size_t i = 0; i < size; ++i) {
-            codepoints[i] = bytestr[i];
-        }
     } else {
-        PyErr_SetString(PyExc_TypeError, "String must be str or bytes");
+        PyErr_SetString(PyExc_TypeError, "set_text requires str-input.");
         return NULL;
     }
 


### PR DESCRIPTION
## PR Summary

There was actually one more deprecation to expire. (I thought all was done.)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
