### PR TITLE
Minor cleanup of axes_grid1

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -20,7 +20,6 @@ def _tick_only(ax, bottom_on, left_on):
 class CbarAxesBase:
     def __init__(self, *args, orientation, **kwargs):
         self.orientation = orientation
-        self._default_label_on = True
         self._locator = None  # deprecated.
         super().__init__(*args, **kwargs)
 
@@ -33,7 +32,6 @@ class CbarAxesBase:
         return cb
 
     def toggle_label(self, b):
-        self._default_label_on = b
         axis = self.axis[self.orientation]
         axis.toggle(ticklabels=b, label=b)
 

--- a/lib/mpl_toolkits/axes_grid1/mpl_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/mpl_axes.py
@@ -112,14 +112,11 @@ class SimpleAxisArtist(Artist):
         if label is not None:
             _label = label
 
-        tickOn = "tick%dOn" % self._axisnum
-        labelOn = "label%dOn" % self._axisnum
-
         if _ticks is not None:
-            tickparam = {tickOn: _ticks}
+            tickparam = {f"tick{self._axisnum}On": _ticks}
             self._axis.set_tick_params(**tickparam)
         if _ticklabels is not None:
-            tickparam = {labelOn: _ticklabels}
+            tickparam = {f"label{self._axisnum}On": _ticklabels}
             self._axis.set_tick_params(**tickparam)
 
         if _label is not None:


### PR DESCRIPTION
## PR Summary

While looking into #23595 (to no avail), I found some minor things to sort out.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
