### PR TITLE
DOC: document that appearance is part of our stable API

### DIFF
--- a/doc/devel/color_changes.rst
+++ b/doc/devel/color_changes.rst
@@ -4,7 +4,8 @@
 Default color changes
 *********************
 
-As discussed at length elsewhere [insert links], ``jet`` is an
+As discussed at length `elsewhere <https://bids.github.io/colormap/>`__ ,
+``jet`` is an
 empirically bad colormap and should not be the default colormap.
 Due to the position that changing the appearance of the plot breaks
 backward compatibility, this change has been put off for far longer

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -289,6 +289,12 @@ API consistency and stability are of great value. Therefore, API changes
 (e.g. signature changes, behavior changes, removals) will only be conducted
 if the added benefit is worth the user effort for adapting.
 
+Because we are a visualization library our primary output is the final
+visualization the user sees.  Thus it is our :ref:`long standing
+<color_changes>` policy that the appearance of the figure is part of the API
+and any changes, either semantic or esthetic, will be treated as a
+backwards-incompatible API change.
+
 API changes in Matplotlib have to be performed following the deprecation process
 below, except in very rare circumstances as deemed necessary by the development team.
 This ensures that users are notified before the change will take effect and thus


### PR DESCRIPTION
This is a long standing policy (the reference I found is from 2015 and I remember that being the position when I started to work on Matplotlib in 2012) and is being documented here.

This position is consistent with our testing scheme (that strives for pixel identical renderings across platforms, Python versions, and Matplotlib versions).

Changing the default colormap (and the rest of the styling) was the proximal cause of 2.0 not being 1.6 due to this policy.

----

This PR is not an opportunity to debate if this _should_ be the position we take, it documenting what it currently is.  If we want to start a discussion about changing the then that must be done in a follow on PR.