### PR TITLE
print version number when building docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -24,6 +24,9 @@ import sphinx
 from datetime import datetime
 import time
 
+# debug that building expected version
+print(f"Building Documentation for Matplotlib: {matplotlib.__version__}")
+
 # Release mode enables optimizations and other related options.
 is_release_build = tags.has('release')  # noqa
 


### PR DESCRIPTION
## PR Summary

Added a statement printing the version of docs being built. This is cause installing the dependencies for doc builds installs a released version of Matplotlib and at least I keep forgetting to reinstall afterwards. This seemed like a really easy way to raise a flag about which version is installed. 

attn: @QuLogic 'cause I think this was your suggestion 