### PR TITLE
TST: be more forgiving about IDing Noto

### DIFF
--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -56,13 +56,13 @@ def test_fallback_smoke():
 
 
 @pytest.mark.parametrize('family_name, file_name',
-                         [("WenQuanYi Zen Hei",  "wqy-zenhei.ttc"),
-                          ("Noto Sans CJK JP", "NotoSansCJK-Regular.ttc")]
+                         [("WenQuanYi Zen Hei",  "wqy-zenhei"),
+                          ("Noto Sans CJK JP", "NotoSansCJK")]
                          )
 @check_figures_equal(extensions=["png", "pdf", "eps", "svg"])
 def test_font_fallback_chinese(fig_test, fig_ref, family_name, file_name):
     fp = fm.FontProperties(family=[family_name])
-    if Path(fm.findfont(fp)).name != file_name:
+    if file_name not in Path(fm.findfont(fp)).name:
         pytest.skip(f"Font {family_name} ({file_name}) is missing")
 
     text = ["There are", "几个汉字", "in between!"]
@@ -81,13 +81,14 @@ def test_font_fallback_chinese(fig_test, fig_ref, family_name, file_name):
 @pytest.mark.parametrize(
     "family_name, file_name",
     [
-        ("WenQuanYi Zen Hei", "wqy-zenhei.ttc"),
-        ("Noto Sans CJK JP", "NotoSansCJK-Regular.ttc"),
+        ("WenQuanYi Zen Hei", "wqy-zenhei"),
+        ("Noto Sans CJK JP", "NotoSansCJK"),
     ],
 )
 def test__get_fontmap(family_name, file_name):
     fp = fm.FontProperties(family=[family_name])
-    if Path(fm.findfont(fp)).name != file_name:
+    found_file_name = Path(fm.findfont(fp)).name
+    if file_name not in found_file_name:
         pytest.skip(f"Font {family_name} ({file_name}) is missing")
 
     text = "There are 几个汉字 in between!"
@@ -100,6 +101,6 @@ def test__get_fontmap(family_name, file_name):
     fontmap = ft._get_fontmap(text)
     for char, font in fontmap.items():
         if ord(char) > 127:
-            assert Path(font.fname).name == file_name
+            assert Path(font.fname).name == found_file_name
         else:
             assert Path(font.fname).name == "DejaVuSans.ttf"


### PR DESCRIPTION
## PR Summary

Following up on #23559 to relax the tests on discovering that Noto Sans is installed.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
