### PR TITLE
CI: try installing a different version of noto on OSX

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,7 +109,7 @@ jobs:
           macOS)
             brew install ccache
             brew tap homebrew/cask-fonts
-            brew install font-noto-sans-cjk-sc
+            brew install font-noto-sans-cjk
             ;;
           esac
 


### PR DESCRIPTION
## PR Summary

Follow on to #23610 to try installing a different font via brew.

The thing to check is that the Noto tests in `test_ft2font` are not skipped.