### PR TITLE
[Doc]: Document the position parameter in apply_aspect() #23583

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1862,8 +1862,8 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
         position : None or .Bbox
-            Possible values:
-            - If not ``None`, this defines the position of the Axes within the figure as a Bbox. See `.get_position` for further details.
+            If not ``None`, this defines the position of the Axes within the figure as a Bbox.
+            See `.get_position` for further details.
         
         Depending on `.get_adjustable` this will modify either the
         Axes box (position) or the view limits. In the former case,

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1865,7 +1865,7 @@ class _AxesBase(martist.Artist):
             If not ``None`, this defines the position of the 
             Axes within the figure as a Bbox. See `.get_position`
             for further details.
-        
+
         Depending on `.get_adjustable` this will modify either the
         Axes box (position) or the view limits. In the former case,
         `~matplotlib.axes.Axes.get_anchor` will affect the position.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1862,8 +1862,9 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
         position : None or .Bbox
-            If not ``None`, this defines the position of the Axes within the figure as a Bbox.
-            See `.get_position` for further details.
+            If not ``None`, this defines the position of the 
+            Axes within the figure as a Bbox. See `.get_position`
+            for further details.
         
         Depending on `.get_adjustable` this will modify either the
         Axes box (position) or the view limits. In the former case,

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1859,6 +1859,12 @@ class _AxesBase(martist.Artist):
         """
         Adjust the Axes for a specified data aspect ratio.
 
+        Parameters
+        ----------
+        position : None or .Bbox
+            Possible values:
+            - If not ``None`, this defines the position of the Axes within the figure as a Bbox. See `.get_position` for further details.
+        
         Depending on `.get_adjustable` this will modify either the
         Axes box (position) or the view limits. In the former case,
         `~matplotlib.axes.Axes.get_anchor` will affect the position.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1862,7 +1862,7 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
         position : None or .Bbox
-            If not ``None`, this defines the position of the 
+            If not ``None`, this defines the position of the
             Axes within the figure as a Bbox. See `.get_position`
             for further details.
 


### PR DESCRIPTION
## PR Summary
This PR documents the position parameter in apply_aspect() by updating docstring.
Issue: https://github.com/matplotlib/matplotlib/issues/23583
It 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [ N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A ] New features are documented, with examples if plot related.
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
