### PR TITLE
add pikepdf  and visual c++ dependency

### DIFF
--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -106,6 +106,10 @@ necessary to run the test suite, because different versions of FreeType
 rasterize characters differently) and of Qhull.  As an exception, Matplotlib
 defaults to the system version of FreeType on AIX.
 
+When on Windows and using the Microsoft Build tools,
+`Visual C++ 14.0 or greater <https://visualstudio.microsoft.com/visual-cpp-build-tools>`_
+is required.
+
 To force Matplotlib to use a copy of FreeType or Qhull already installed in
 your system, create a :file:`mplsetup.cfg` file with the following contents:
 
@@ -167,7 +171,6 @@ remember to clear your artifacts before re-building::
 
   git clean -xfd
 
-
 .. _development-dependencies:
 
 Additional dependencies for development
@@ -194,6 +197,7 @@ Required:
 
 Optional:
 
+- pikepdf_ test pdf and pgf backends
 - pytest-cov_ (>=2.3.1) to collect coverage information
 - pytest-flake8_ to test coding standards using flake8_
 - pytest-timeout_ to limit runtime in case of stuck tests
@@ -203,6 +207,7 @@ Optional:
 .. _pytest: http://doc.pytest.org/en/latest/
 .. _Ghostscript: https://www.ghostscript.com/
 .. _Inkscape: https://inkscape.org
+.. _pikepdf: https://pikepdf.readthedocs.io/en/latest/
 .. _pytest-cov: https://pytest-cov.readthedocs.io/en/latest/
 .. _pytest-flake8: https://pypi.org/project/pytest-flake8/
 .. _pytest-timeout: https://pypi.org/project/pytest-timeout/


### PR DESCRIPTION
@timhoffm noticed that pikepdf is missing from the dependencies list - I have no idea if it's optional or required for testing, but figured getting the ball rolling was a good start. 

Also I can't find any mention of windows dependencies on the page and the error message I got was `Microsoft Visual C++ 14.0 or greater is required. Get it with "Microsoft C++ Build Tools": https://visualstudio.microsoft.com/visual-cpp-build-tools` and seemed like a safe requirement to mention. (Also should we document minimum version of C++ needed for linux and os/x?)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
