### PR TITLE
MNT: remove _girdspecs attribute on Figure classes

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -178,8 +178,6 @@ class FigureBase(Artist):
         self._align_label_groups = {"x": cbook.Grouper(), "y": cbook.Grouper()}
 
         self.figure = self
-        # list of child gridspecs for this figure
-        self._gridspecs = []
         self._localaxes = []  # track all axes
         self.artists = []
         self.lines = []
@@ -1508,7 +1506,6 @@ default: %(va)s
 
         _ = kwargs.pop('figure', None)  # pop in case user has added this...
         gs = GridSpec(nrows=nrows, ncols=ncols, figure=self, **kwargs)
-        self._gridspecs.append(gs)
         return gs
 
     def subfigures(self, nrows=1, ncols=1, squeeze=True,
@@ -2492,9 +2489,6 @@ class Figure(FigureBase):
 
         self._axstack = _AxesStack()  # track all figure axes and current axes
         self.clear()
-
-        # list of child gridspecs for this figure
-        self._gridspecs = []
 
     def pick(self, mouseevent):
         if not self.canvas.widgetlock.locked():


### PR DESCRIPTION
## PR Summary

This attribute came in via 2977f37d46bf5db2756279e6691b517714de3632 but does
not appear to have ever been accessed, only had gridspec added to it.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A ] New features are documented, with examples if plot related.
- [ N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
