### PR TITLE
Deprecate position argument to Axes.apply_aspect()

### DIFF
--- a/doc/api/next_api_changes/deprecations/23629-TH.rst
+++ b/doc/api/next_api_changes/deprecations/23629-TH.rst
@@ -1,0 +1,3 @@
+The parameter *position* in ``Axes.apply_aspect()``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated. It is considered internal API and now public use case is known.

--- a/doc/api/next_api_changes/deprecations/23629-TH.rst
+++ b/doc/api/next_api_changes/deprecations/23629-TH.rst
@@ -1,3 +1,3 @@
 The parameter *position* in ``Axes.apply_aspect()``
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-... is deprecated. It is considered internal API and now public use case is known.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated. It is considered internal API and no public use case is known.

--- a/lib/matplotlib/_tight_bbox.py
+++ b/lib/matplotlib/_tight_bbox.py
@@ -30,20 +30,20 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
         current_pos = ax.get_position(original=False).frozen()
         ax.set_axes_locator(lambda a, r, _pos=current_pos: _pos)
         # override the method that enforces the aspect ratio on the Axes
-        if 'apply_aspect' in ax.__dict__:
-            old_aspect.append(ax.apply_aspect)
+        if '_apply_aspect' in ax.__dict__:
+            old_aspect.append(ax._apply_aspect)
         else:
             old_aspect.append(sentinel)
-        ax.apply_aspect = lambda pos=None: None
+        ax._apply_aspect = lambda pos=None: None
 
     def restore_bbox():
         for ax, loc, aspect in zip(fig.axes, locator_list, old_aspect):
             ax.set_axes_locator(loc)
             if aspect is sentinel:
                 # delete our no-op function which un-hides the original method
-                del ax.apply_aspect
+                del ax._apply_aspect
             else:
-                ax.apply_aspect = aspect
+                ax._apply_aspect = aspect
 
         fig.bbox = origBbox
         fig.bbox_inches = origBboxInches

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -410,7 +410,7 @@ class Axes(_AxesBase):
         inset_ax = projection_class(self.figure, bounds, zorder=zorder, **pkw)
 
         # this locator lets the axes move if in data coordinates.
-        # it gets called in `ax._apply_aspect() (of all places)
+        # it gets called in `ax.apply_aspect() (of all places)
         inset_ax.set_axes_locator(inset_locator)
 
         self.add_child_axes(inset_ax)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -410,7 +410,7 @@ class Axes(_AxesBase):
         inset_ax = projection_class(self.figure, bounds, zorder=zorder, **pkw)
 
         # this locator lets the axes move if in data coordinates.
-        # it gets called in `ax.apply_aspect() (of all places)
+        # it gets called in `ax._apply_aspect() (of all places)
         inset_ax.set_axes_locator(inset_locator)
 
         self.add_child_axes(inset_ax)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1736,7 +1736,7 @@ class _AxesBase(martist.Artist):
                 and any(getattr(ax.get_data_ratio, "__func__", None)
                         != _AxesBase.get_data_ratio
                         for ax in axs)):
-            # Limits adjustment by _apply_aspect assumes that the axes' aspect
+            # Limits adjustment by apply_aspect assumes that the axes' aspect
             # ratio can be computed from the data limits and scales.
             raise ValueError("Cannot set Axes adjustable to 'datalim' for "
                              "Axes which override 'get_data_ratio'")
@@ -1870,7 +1870,7 @@ class _AxesBase(martist.Artist):
         ysize = max(abs(tymax - tymin), 1e-30)
         return ysize / xsize
 
-    @_api.delete_parameter("3.6", "position")
+    @_api.delete_parameter("3.10", "position")
     def apply_aspect(self, position=None):
         """
         Adjust the Axes for a specified data aspect ratio.
@@ -1882,12 +1882,11 @@ class _AxesBase(martist.Artist):
         Parameters
         ----------
         position : None or .Bbox
-
             If not ``None``, this defines the position of the
             Axes within the figure as a Bbox. See `~.Axes.get_position`
             for further details.
 
-            .. admonition:: Deprecated
+            .. deprecated:: 3.10
 
                 Changing the *position* through ``apply_aspect`` is
                 considered internal API. This parameter will be removed
@@ -1917,6 +1916,19 @@ class _AxesBase(martist.Artist):
         Adjust the Axes for a specified data aspect ratio.
 
         See the docstring of the public `apply_aspect` method.
+
+        .. note::
+
+            It is somewhat surprising that "_apply_aspect" takes an optional
+            position as input, which seems more functionality than what the
+            name suggests.
+
+            Generally, applying an aspect will modify the size and position
+            of an Axes. I haven't been able to reconstruct the history but
+            assume, the fact that position is updated anyway was used to
+            funnel additional position constraints into the already existing
+            code. Likely, this function should better be called
+            _update_geometry() nowadays.
 
         Parameters
         ----------

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -136,13 +136,13 @@ class SecondaryAxis(_AxesBase):
         # this locator lets the axes move in the parent axes coordinates.
         # so it never needs to know where the parent is explicitly in
         # figure coordinates.
-        # it gets called in ax.apply_aspect() (of all places)
+        # it gets called in ax._apply_aspect() (of all places)
         self.set_axes_locator(_TransformedBoundsLocator(bounds, transform))
 
-    def apply_aspect(self, position=None):
+    def _apply_aspect(self, position=None):
         # docstring inherited.
         self._set_lims()
-        super().apply_aspect(position)
+        super()._apply_aspect(position)
 
     @_docstring.copy(Axis.set_ticks)
     def set_ticks(self, ticks, labels=None, *, minor=False, **kwargs):

--- a/lib/matplotlib/axes/_secondary_axes.py
+++ b/lib/matplotlib/axes/_secondary_axes.py
@@ -139,10 +139,10 @@ class SecondaryAxis(_AxesBase):
         # it gets called in ax._apply_aspect() (of all places)
         self.set_axes_locator(_TransformedBoundsLocator(bounds, transform))
 
-    def _apply_aspect(self, position=None):
+    def apply_aspect(self, position=None):
         # docstring inherited.
         self._set_lims()
-        super()._apply_aspect(position)
+        super().apply_aspect(position)
 
     @_docstring.copy(Axis.set_ticks)
     def set_ticks(self, ticks, labels=None, *, minor=False, **kwargs):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -154,7 +154,7 @@ class FigureBase(Artist):
         self.set(**kwargs)
 
     def _get_draw_artists(self, renderer):
-        """Also runs apply_aspect"""
+        """Also runs _apply_aspect"""
         artists = self.get_children()
 
         artists.remove(self.patch)
@@ -163,12 +163,12 @@ class FigureBase(Artist):
             key=lambda artist: artist.get_zorder())
         for ax in self._localaxes:
             locator = ax.get_axes_locator()
-            ax.apply_aspect(locator(ax, renderer) if locator else None)
+            ax._apply_aspect(locator(ax, renderer) if locator else None)
 
             for child in ax.get_children():
-                if hasattr(child, 'apply_aspect'):
+                if hasattr(child, '_apply_aspect'):
                     locator = child.get_axes_locator()
-                    child.apply_aspect(
+                    child._apply_aspect(
                         locator(child, renderer) if locator else None)
         return artists
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5700,7 +5700,7 @@ def test_shared_with_aspect_2():
     axs[0].set_aspect(2, share=True)
     axs[0].plot([1, 2], [3, 4])
     axs[1].plot([3, 4], [1, 2])
-    plt.draw()  # Trigger apply_aspect().
+    plt.draw()  # Trigger _apply_aspect().
     assert axs[0].get_xlim() == axs[1].get_xlim()
     assert axs[0].get_ylim() == axs[1].get_ylim()
 
@@ -5713,7 +5713,7 @@ def test_shared_with_aspect_3():
         axs[1].set_aspect(0.5, adjustable=adjustable)
         axs[0].plot([1, 2], [3, 4])
         axs[1].plot([3, 4], [1, 2])
-        plt.draw()  # Trigger apply_aspect().
+        plt.draw()  # Trigger _apply_aspect().
         assert axs[0].get_xlim() != axs[1].get_xlim()
         assert axs[0].get_ylim() == axs[1].get_ylim()
         fig_aspect = fig.bbox_inches.height / fig.bbox_inches.width

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -126,13 +126,13 @@ class HostAxesBase:
         if locator:
             pos = locator(self, renderer)
             self.set_position(pos, which="active")
-            self.apply_aspect(pos)
+            self._apply_aspect(pos)
         else:
-            self.apply_aspect()
+            self._apply_aspect()
 
         rect = self.get_position()
         for ax in self.parasites:
-            ax.apply_aspect(rect)
+            ax._apply_aspect(rect)
             self._children.extend(ax.get_children())
 
         super().draw(renderer)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -386,7 +386,7 @@ class Axes3D(Axes):
         self._box_aspect = self._roll_to_vertical(aspect, reverse=True)
         self.stale = True
 
-    def apply_aspect(self, position=None):
+    def _apply_aspect(self, position=None):
         if position is None:
             position = self.get_position(original=True)
 
@@ -419,7 +419,7 @@ class Axes3D(Axes):
         # it adjusts the view limits and the size of the bounding box
         # of the Axes
         locator = self.get_axes_locator()
-        self.apply_aspect(locator(self, renderer) if locator else None)
+        self._apply_aspect(locator(self, renderer) if locator else None)
 
         # add the projection matrix to the renderer
         self.M = self.get_proj()


### PR DESCRIPTION
## PR Summary

In itself `apply_aspect()` feels too low level to be needed by an end-user. I'm not sure if it reasonably works at all on its own. It might be that the result is influenced by other artists and if something is left stale, then the application result is still not final. In that case, one would need a full draw (without rendering) anyway. OTOH if `apply_aspect()` was really standalone, I don't know why we defer the application and don't apply it immediately when setting the aspect.

Also, the *position* parameter of `apply_aspect` does not seem a user-facing API. It is used internally by layout mechanisms. But shifting the position explicitly as part of aspect application seems overreach of the scope of the function and at least not something a user should do. 

I'm 99% percent sure `apply_aspect()` does not need to be public API, but please speak up if you think otherwise. And even if we miss a justified use-case for a user. They should be able to give feedback during the deprecation period and we would reconsider then.