### PR TITLE
Leave out `barh` from the basic plot types.

### DIFF
--- a/plot_types/basic/bar.py
+++ b/plot_types/basic/bar.py
@@ -1,9 +1,9 @@
 """
-===============================
-bar(x, height) / barh(y, width)
-===============================
+==============
+bar(x, height)
+==============
 
-See `~matplotlib.axes.Axes.bar` / `~matplotlib.axes.Axes.barh`.
+See `~matplotlib.axes.Axes.bar`.
 """
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
`bar` / `barh` was the only plot type mentioning two
functions, but the plot only showed the vertial one
anyway.

IHMO we can leave out `barh`. It's mentionend in the
"See also" section of `bar`. (But I'm open to leaving
a comment in the plot type description if desired -
I mainly want to remove it from the title, because it's
the only one spanning two lines:

![image](https://user-images.githubusercontent.com/2836374/184714462-3977503b-c48e-4b4a-ad96-db1f348bbcef.png)
)

