### PR TITLE
make.bat: Don't override SPHINXOPTS/O from the environment

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -82,12 +82,6 @@ it, use
 
    make SPHINXOPTS= html
 
-On Windows the arguments must be at the end of the statement:
-
-.. code-block:: bat
-
-   make html SPHINXOPTS=
-
 You can use the ``O`` variable to set additional options:
 
 * ``make O=-j4 html`` runs a parallel build with 4 processes.
@@ -97,12 +91,11 @@ You can use the ``O`` variable to set additional options:
 Multiple options can be combined using e.g. ``make O='-j4 -Dplot_gallery=0'
 html``.
 
-On Windows, either put the arguments at the end of the statement or set the options as environment variables, e.g.:
+On Windows, set the options as environment variables, e.g.:
 
 .. code-block:: bat
 
-   set O=-W --keep-going -j4
-   make html
+   set SPHINXOPTS= & set O=-j4 -Dplot_gallery=0 & make html
 
 Showing locally built docs
 --------------------------

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -11,7 +11,7 @@ set SOURCEDIR=.
 set BUILDDIR=build
 set SPHINXPROJ=matplotlib
 if defined SPHINXOPTS goto skipopts
-set SPHINXOPTS=-W
+set SPHINXOPTS=-W --keep-going
 :skipopts
 
 %SPHINXBUILD% >NUL 2>NUL

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -10,8 +10,9 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=.
 set BUILDDIR=build
 set SPHINXPROJ=matplotlib
+if defined SPHINXOPTS goto skipopts
 set SPHINXOPTS=-W
-set O=
+:skipopts
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (


### PR DESCRIPTION
## PR Summary

I have not actually tested this... cc @story645

`if defined` does require command extensions to be enabled, but a) they're enabled by default, and b) we need them for `%~dp0` above already.

Fixes #23622 

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [n/a] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).