### PR TITLE
FIX: macosx flush_events should process all events

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -391,9 +391,20 @@ FigureCanvas_update(FigureCanvas* self)
 static PyObject*
 FigureCanvas_flush_events(FigureCanvas* self)
 {
-    // We need to allow the runloop to run very briefly
-    // to allow the view to be displayed when used in a fast updating animation
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:0.0]];
+    // We run the app, matching any events that are waiting in the queue
+    // to process, breaking out of the loop when no events remain and
+    // displaying the canvas if needed.
+    NSEvent *event;
+    while (true) {
+        event = [NSApp nextEventMatchingMask: NSEventMaskAny
+                                   untilDate: [NSDate distantPast]
+                                      inMode: NSDefaultRunLoopMode
+                                     dequeue: YES];
+        if (!event) {
+            break;
+        }
+        [NSApp sendEvent:event];
+    }
     [self->view displayIfNeeded];
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
## PR Summary

Rather than just bursting the runloop for a short amount of time, we can run it until all pending events have been processed. In this example on main, the buttons are all unable to be pushed and close/minimize are grayed out. The buttons should all work with this update.

```python
import matplotlib, random
import matplotlib.pyplot as plt

matplotlib.use('macosx') #Works fine with tkagg
data = []

#Initial Draw
fig, axes = plt.subplots(1)
line, = axes.plot(data, label='Some data', color='#CC0000')
fig.canvas.draw_idle()
plt.show(block=False)

while True:
	data += [random.randint(0,50) for i in range(20)]

	tseries = range(0, len(data))
	line.set_ydata(data)
	line.set_xdata(tseries)
	axes.relim()
	axes.autoscale_view(tight=False)

	if fig.stale: fig.canvas.draw()
	fig.canvas.flush_events() #Listen for user input
```

closes #23327

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
