### PR TITLE
Adding the new contributor meeting

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -12,44 +12,50 @@ is expected to abide by our
 The project is hosted on
 https://github.com/matplotlib/matplotlib
 
-Do I really have something to contribute to Matplotlib?
--------------------------------------------------------
-1,000% yes. There are so many ways to contribute to our community.
-
-When in doubt, we recommend going together! Get connected with our community of active
-contributors, many of whom felt just like you when they started out and are happy to welcome
-you and support you as you get to know how we work, and where things are. Take a look at the
-next section to learn more.
-
-
 Get Connected
 =============
 
+Do I really have something to contribute to Matplotlib?
+-------------------------------------------------------
+
+100% yes. There are so many ways to contribute to our community.
+
+When in doubt, we recommend going together! Get connected with our community of
+active contributors, many of whom felt just like you when they started out and
+are happy to welcome you and support you as you get to know how we work, and
+where things are. Take a look at the next sections to learn more.
+
 Contributor incubator
 ---------------------
-The incubator is our non-public communication channel for new contributors. It is
-a private gitter room moderated by core Matplotlib developers where you can
-get guidance and support for your first few PRs. It's a place you can ask questions
-about anything: how to use git, github, how our PR review process works, technical questions
-about the code, what makes for good documentation or a blog post, how to get involved involved
-in community work, or get "pre-review" on your PR.
 
-To join, please go to our public `gitter <https://gitter.im/matplotlib/matplotlib>`_ community
-channel, and ask to be added to '#incubator'. One of our core developers will see your message
-and will add you.
+The incubator is our non-public communication channel for new contributors. It
+is a private gitter room moderated by core Matplotlib developers where you can
+get guidance and support for your first few PRs. It's a place you can ask
+questions about anything: how to use git, github, how our PR review process
+works, technical questions about the code, what makes for good documentation
+or a blog post, how to get involved in community work, or get
+"pre-review" on your PR.
+
+To join, please go to our public `gitter <https://gitter
+.im/matplotlib/matplotlib>`_ community channel, and ask to be added to
+'#incubator'. One of our core developers will see your message and will add you.
 
 New Contributors meeting
 ------------------------
-Once a month, we host a meeting to discuss topics that interest new contributors. Anyone can attend,
-present, or sit in and listen to the call. Among our attendees are fellow new contributors, as well
-as maintainers, and veteran contributors, who are keen to support onboarding of new folks and share
-their experience. You can find our community calendar link at the `Scientific Python website
-<https://scientific-python.org/calendars/>`_, and you can browse previous meeting notes on `github
-<https://github.com/matplotlib/ProjectManagement/tree/master/new_contributor_meeting>`_. We recommend
-joining the meeting to clarify any doubts, or lingering questions you might have, and to get to know a few
-of the people behind the GitHub handles 😉. You can reach out to @noatamir on `gitter
-<https://gitter.im/matplotlib/matplotlib>`_. For any clarifications or suggestions. We <3 feedback!
 
+Once a month, we host a meeting to discuss topics that interest new
+contributors. Anyone can attend, present, or sit in and listen to the call.
+Among our attendees are fellow new contributors, as well as maintainers, and
+veteran contributors, who are keen to support onboarding of new folks and
+share their experience. You can find our community calendar link at the
+`Scientific Python website <https://scientific-python.org/calendars/>`_, and
+you can browse previous meeting notes on `github <https://github
+.com/matplotlib/ProjectManagement/tree/master/new_contributor_meeting>`_. We
+recommend joining the meeting to clarify any doubts, or lingering questions
+you might have, and to get to know a few of the people behind the GitHub
+handles 😉. You can reach out to @noatamir on `gitter <https://gitter
+.im/matplotlib/matplotlib>`_. For any clarifications or suggestions. We <3
+feedback!
 
 .. _new_contributors:
 
@@ -58,19 +64,20 @@ Issues for new contributors
 
 While any contributions are welcome, we have marked some issues as
 particularly suited for new contributors by the label
-`good first issue <https://github.com/matplotlib/matplotlib/labels/good%20first%20issue>`_
-These are well documented issues, that do not require a deep understanding of
-the internals of Matplotlib. The issues may additionally be tagged with a
-difficulty. ``Difficulty: Easy`` is suited for people with little Python experience.
-``Difficulty: Medium`` and ``Difficulty: Hard`` require more programming experience.
-This could be for a variety of reasons, among them, though not necessarily all at
-the same time:
+`good first issue <https://github
+.com/matplotlib/matplotlib/labels/good%20first%20issue>`_ These are well
+documented issues, that do not require a deep understanding of the internals
+of Matplotlib. The issues may additionally be tagged with a difficulty.
+``Difficulty: Easy`` is suited for people with little Python experience.
+``Difficulty: Medium`` and ``Difficulty: Hard`` require more programming
+experience. This could be for a variety of reasons, among them, though not
+necessarily all at the same time:
 
 - The issue is in areas of the code base which have more interdependencies,
   or legacy code.
 - It has less clearly defined tasks, which require some independent
-  exploration, making suggestions, or follow-up discussions to clarify a good path
-  to resolve the issue.
+  exploration, making suggestions, or follow-up discussions to clarify a good
+  path to resolve the issue.
 - It involves Python features such as decorators and context managers, which
   have subtleties due to our implementation decisions.
 
@@ -610,3 +617,4 @@ example code you can load it into a file handle with::
 
     import matplotlib.cbook as cbook
     fh = cbook.get_sample_data('mydata.dat')
+

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -36,9 +36,10 @@ works, technical questions about the code, what makes for good documentation
 or a blog post, how to get involved in community work, or get
 "pre-review" on your PR.
 
-To join, please go to our public `gitter <https://gitter
-.im/matplotlib/matplotlib>`_ community channel, and ask to be added to
-'#incubator'. One of our core developers will see your message and will add you.
+To join, please go to our public `gitter
+<https://gitter.im/matplotlib/matplotlib>`_ community channel, and ask to be
+added to '#incubator'. One of our core developers will see your message and will
+add you.
 
 New Contributors meeting
 ------------------------
@@ -49,13 +50,14 @@ Among our attendees are fellow new contributors, as well as maintainers, and
 veteran contributors, who are keen to support onboarding of new folks and
 share their experience. You can find our community calendar link at the
 `Scientific Python website <https://scientific-python.org/calendars/>`_, and
-you can browse previous meeting notes on `github <https://github
-.com/matplotlib/ProjectManagement/tree/master/new_contributor_meeting>`_. We
-recommend joining the meeting to clarify any doubts, or lingering questions
-you might have, and to get to know a few of the people behind the GitHub
-handles 😉. You can reach out to @noatamir on `gitter <https://gitter
-.im/matplotlib/matplotlib>`_. For any clarifications or suggestions. We <3
-feedback!
+you can browse previous meeting notes on `github
+<https://github.com/matplotlib/ProjectManagement/tree/master/
+new_contributor_meeting>`_.
+We recommend joining the meeting to clarify any doubts, or lingering
+questions you might have, and to get to know a few of the people behind the
+GitHub handles 😉. You can reach out to @noatamir on `gitter
+<https://gitter.im/matplotlib/matplotlib>`_ for any clarifications or
+suggestions. We <3 feedback!
 
 .. _new_contributors:
 
@@ -63,15 +65,14 @@ Issues for new contributors
 ---------------------------
 
 While any contributions are welcome, we have marked some issues as
-particularly suited for new contributors by the label
-`good first issue <https://github
-.com/matplotlib/matplotlib/labels/good%20first%20issue>`_ These are well
-documented issues, that do not require a deep understanding of the internals
-of Matplotlib. The issues may additionally be tagged with a difficulty.
-``Difficulty: Easy`` is suited for people with little Python experience.
-``Difficulty: Medium`` and ``Difficulty: Hard`` require more programming
-experience. This could be for a variety of reasons, among them, though not
-necessarily all at the same time:
+particularly suited for new contributors by the label `good first issue
+<https://github.com/matplotlib/matplotlib/labels/good%20first%20issue>`_. These
+are well documented issues, that do not require a deep understanding of the
+internals of Matplotlib. The issues may additionally be tagged with a
+difficulty. ``Difficulty: Easy`` is suited for people with little Python
+experience. ``Difficulty: Medium`` and ``Difficulty: Hard`` require more
+programming experience. This could be for a variety of reasons, among them,
+though not necessarily all at the same time:
 
 - The issue is in areas of the code base which have more interdependencies,
   or legacy code.
@@ -617,4 +618,3 @@ example code you can load it into a file handle with::
 
     import matplotlib.cbook as cbook
     fh = cbook.get_sample_data('mydata.dat')
-

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -12,18 +12,43 @@ is expected to abide by our
 The project is hosted on
 https://github.com/matplotlib/matplotlib
 
-Contributor incubator
-=====================
+Do I really have something to contribute to Matplotlib?
+-------------------------------------------------------
+1,000% yes. There are so many ways to contribute to our community.
 
-If you are interested in becoming a regular contributor to Matplotlib, but
-don't know where to start or feel insecure about it, you can join our non-public
-communication channel for new contributors. To do so, please go to `gitter
-<https://gitter.im/matplotlib/matplotlib>`_ and ask to be added to '#incubator'.
-This is a private gitter room moderated by core Matplotlib developers where you can
-get guidance and support for your first few PRs.  This is a place you can ask questions
+When in doubt, we recommend going together! Get connected with our community of active
+contributors, many of whom felt just like you when they started out and are happy to welcome
+you and support you as you get to know how we work, and where things are. Take a look at the
+next section to learn more.
+
+
+Get Connected
+=============
+
+Contributor incubator
+---------------------
+The incubator is our non-public communication channel for new contributors. It is
+a private gitter room moderated by core Matplotlib developers where you can
+get guidance and support for your first few PRs. It's a place you can ask questions
 about anything: how to use git, github, how our PR review process works, technical questions
 about the code, what makes for good documentation or a blog post, how to get involved involved
 in community work, or get "pre-review" on your PR.
+
+To join, please go to our public `gitter <https://gitter.im/matplotlib/matplotlib>`_ community
+channel, and ask to be added to '#incubator'. One of our core developers will see your message
+and will add you.
+
+New Contributors meeting
+------------------------
+Once a month, we host a meeting to discuss topics that interest new contributors. Anyone can attend,
+present, or sit in and listen to the call. Among our attendees are fellow new contributors, as well
+as maintainers, and veteran contributors, who are keen to support onboarding of new folks and share
+their experience. You can find our community calendar link at the `Scientific Python website
+<https://scientific-python.org/calendars/>`_, and you can browse previous meeting notes on `github
+<https://github.com/matplotlib/ProjectManagement/tree/master/new_contributor_meeting>`_. We recommend
+joining the meeting to clarify any doubts, or lingering questions you might have, and to get to know a few
+of the people behind the GitHub handles 😉. You can reach out to @noatamir on `gitter
+<https://gitter.im/matplotlib/matplotlib>`_. For any clarifications or suggestions. We <3 feedback!
 
 
 .. _new_contributors:


### PR DESCRIPTION
## PR Summary
This PR adds information about the new contributor meeting, and introduces some edits to the section in which it fits to set it up.

No conflict is expected from #23588 which introduces some changes to this page as well.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).