### PR TITLE
Enable wheels for PyPy 3.8+

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -107,14 +107,13 @@ jobs:
       - name: Build wheels for PyPy
         uses: pypa/cibuildwheel@v2.9.0
         env:
-          CIBW_BUILD: "pp38-*"
+          CIBW_BUILD: "pp38-* pp39-*"
           CIBW_SKIP: "*-musllinux*"
           CIBW_BEFORE_BUILD: >-
             pip install certifi oldest-supported-numpy &&
             git clean -fxd build
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          PIP_USE_FEATURE: in-tree-build
-        if: false && matrix.cibw_archs != 'aarch64'
+        if: matrix.cibw_archs != 'aarch64'
 
       - name: Validate that LICENSE files are included in wheels
         run: |


### PR DESCRIPTION
## PR Summary

Another followup to #23146.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).