### PR TITLE
Allow any color format to be used for axis3d.Axis.set_pane_color

### DIFF
--- a/doc/api/next_api_changes/deprecations/23647-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23647-OG.rst
@@ -1,0 +1,6 @@
+``mplot3d.axis3d.Axis.set_pane_pos``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... is deprecated. This is an internal method where the provided values are
+overwritten during drawing. Hence, it does not serve any purpose to be
+directly accessible.

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from matplotlib import (
     _api, artist, lines as mlines, axis as maxis, patches as mpatches,
-    transforms as mtransforms, rcParams)
+    transforms as mtransforms, rcParams, colors as mcolors)
 from . import art3d, proj3d
 
 
@@ -191,8 +191,18 @@ class Axis(maxis.XAxis):
         self.pane.xy = xys
         self.stale = True
 
-    def set_pane_color(self, color):
-        """Set pane color to a RGBA tuple."""
+    def set_pane_color(self, color, alpha=None):
+        """
+        Set pane color.
+
+        Parameters
+        ----------
+        color : color
+            Color for axis pane.
+        alpha : float, optional
+            Alpha value for axis pane. If None, base it on *color*.
+        """
+        color = mcolors.to_rgba(color, alpha)
         self._axinfo['color'] = color
         self.pane.set_edgecolor(color)
         self.pane.set_facecolor(color)

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -182,7 +182,11 @@ class Axis(maxis.XAxis):
                 obj.set_transform(self.axes.transData)
         return ticks
 
+    @_api.deprecated("3.6")
     def set_pane_pos(self, xys):
+        self._set_pane_pos(xys)
+
+    def _set_pane_pos(self, xys):
         xys = np.asarray(xys)
         xys = xys[:, :2]
         self.pane.xy = xys
@@ -290,7 +294,7 @@ class Axis(maxis.XAxis):
         else:
             plane = self._PLANES[2 * index + 1]
         xys = [tc[p] for p in plane]
-        self.set_pane_pos(xys)
+        self._set_pane_pos(xys)
         self.pane.draw(renderer)
 
         renderer.close_group('pane3d')

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -148,8 +148,7 @@ class Axis(maxis.XAxis):
 
         # Store dummy data in Polygon object
         self.pane = mpatches.Polygon(
-            np.array([[0, 0], [0, 1], [1, 0], [0, 0]]),
-            closed=False, alpha=0.8, facecolor='k', edgecolor='k')
+            np.array([[0, 0], [0, 1]]), closed=False)
         self.set_pane_color(self._axinfo['color'])
 
         self.axes._set_artist_props(self.line)


### PR DESCRIPTION
## PR Summary

There are three distinct commits in this PR:
1. Deprecate `set_pane_pos`: the set value is not used and overwritten at draw time, so should not be public.
2. Simplify the pane creation (removed properties overwritten anyway)
3. Allow any color to be used when setting pane color.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
