### PR TITLE
Add eps to extension list in image triager

### DIFF
--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -46,7 +46,7 @@ BASELINE_IMAGES = [
 
 # Non-png image extensions
 
-exts = ['pdf', 'svg']
+exts = ['pdf', 'svg', 'eps']
 
 
 class Thumbnail(QtWidgets.QFrame):


### PR DESCRIPTION
## PR Summary

Otherwise it cannot find the expected result file for failing EPS tests.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).