### PR TITLE
Increase tolerance on multi-font tests

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -387,7 +387,7 @@ def test_glyphs_subset():
     assert subfont.get_num_glyphs() == nosubfont.get_num_glyphs()
 
 
-@image_comparison(["multi_font_type3.pdf"])
+@image_comparison(["multi_font_type3.pdf"], tol=4.6)
 def test_multi_font_type3():
     fp = fm.FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(fm.findfont(fp)).name != "wqy-zenhei.ttc":
@@ -400,7 +400,7 @@ def test_multi_font_type3():
     fig.text(0.15, 0.475, "There are 几个汉字 in between!")
 
 
-@image_comparison(["multi_font_type42.pdf"])
+@image_comparison(["multi_font_type42.pdf"], tol=2.2)
 def test_multi_font_type42():
     fp = fm.FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(fm.findfont(fp)).name != "wqy-zenhei.ttc":

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -274,7 +274,7 @@ def test_no_duplicate_definition():
     assert max(Counter(wds).values()) == 1
 
 
-@image_comparison(["multi_font_type3.eps"])
+@image_comparison(["multi_font_type3.eps"], tol=0.51)
 def test_multi_font_type3():
     fp = fm.FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(fm.findfont(fp)).name != "wqy-zenhei.ttc":
@@ -287,7 +287,7 @@ def test_multi_font_type3():
     fig.text(0.15, 0.475, "There are 几个汉字 in between!")
 
 
-@image_comparison(["multi_font_type42.eps"])
+@image_comparison(["multi_font_type42.eps"], tol=1.6)
 def test_multi_font_type42():
     fp = fm.FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(fm.findfont(fp)).name != "wqy-zenhei.ttc":

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -470,7 +470,7 @@ def test_svg_metadata():
     assert values == metadata['Keywords']
 
 
-@image_comparison(["multi_font_aspath.svg"])
+@image_comparison(["multi_font_aspath.svg"], tol=1.8)
 def test_multi_font_type3():
     fp = fm.FontProperties(family=["WenQuanYi Zen Hei"])
     if Path(fm.findfont(fp)).name != "wqy-zenhei.ttc":


### PR DESCRIPTION
## PR Summary

Apparently Ubuntu 20.04 (our CI system) has Zen Hei 0.9.45, while Fedora has 0.9.46. These versions have slight differences in the glyphs. This tolerance should still be small enough to catch completely missing glyphs though.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).