### PR TITLE
Simplify/fix save_diff_image.

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -506,21 +506,13 @@ def save_diff_image(expected, actual, output):
         raise ImageComparisonFailure(
             "Image sizes do not match expected size: {} "
             "actual size {}".format(expected_image.shape, actual_image.shape))
-    abs_diff_image = np.abs(expected_image - actual_image)
+    abs_diff = np.abs(expected_image - actual_image)
 
     # expand differences in luminance domain
-    abs_diff_image *= 255 * 10
-    save_image_np = np.clip(abs_diff_image, 0, 255).astype(np.uint8)
-    height, width, depth = save_image_np.shape
+    abs_diff *= 10
+    abs_diff = np.clip(abs_diff, 0, 255).astype(np.uint8)
 
-    # The PDF renderer doesn't produce an alpha channel, but the
-    # matplotlib PNG writer requires one, so expand the array
-    if depth == 3:
-        with_alpha = np.empty((height, width, 4), dtype=np.uint8)
-        with_alpha[:, :, 0:3] = save_image_np
-        save_image_np = with_alpha
+    if abs_diff.shape[2] == 4:  # Hard-code the alpha channel to fully solid
+        abs_diff[:, :, 3] = 255
 
-    # Hard-code the alpha channel to fully solid
-    save_image_np[:, :, 3] = 255
-
-    Image.fromarray(save_image_np).save(output, format="png")
+    Image.fromarray(abs_diff).save(output, format="png")


### PR DESCRIPTION
- The previous `*255*10` factor was necessary when using the old _png
  module to read images, which read them as 0-1 floats, the 255 factor
  was needed prior to conversion to uint8.  Now we use pillow everywhere
  in matplotlib.testing.compare and work with uint8 throughout, so the
  extra 255 is incorrect (it basically caused any slight difference to
  be fully saturated).
- We don't use _png to write the diffs anymore, and pillow handles RGB
  just fine, so we don't need to add an alpha channel if it's not there.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
