### PR TITLE
Small cleanups to _find_fonts_by_props.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1396,30 +1396,21 @@ class FontManager:
         which closely match the given font properties.  Since this internally
         uses the original API, there's no change to the logic of performing the
         nearest neighbor search.  See `findfont` for more details.
-
         """
-
-        rc_params = tuple(tuple(rcParams[key]) for key in [
-            "font.serif", "font.sans-serif", "font.cursive", "font.fantasy",
-            "font.monospace"])
 
         prop = FontProperties._from_any(prop)
 
         fpaths = []
         for family in prop.get_family():
             cprop = prop.copy()
+            cprop.set_family(family)  # set current prop's family
 
-            # set current prop's family
-            cprop.set_family(family)
-
-            # do not fall back to default font
             try:
                 fpaths.append(
-                    self._findfont_cached(
+                    self.findfont(
                         cprop, fontext, directory,
-                        fallback_to_default=False,
+                        fallback_to_default=False,  # don't fallback to default
                         rebuild_if_missing=rebuild_if_missing,
-                        rc_params=rc_params,
                     )
                 )
             except ValueError:
@@ -1427,13 +1418,10 @@ class FontManager:
                     _log.warning(
                         "findfont: Generic family %r not found because "
                         "none of the following families were found: %s",
-                        family,
-                        ", ".join(self._expand_aliases(family))
+                        family, ", ".join(self._expand_aliases(family))
                     )
                 else:
-                    _log.warning(
-                        'findfont: Font family \'%s\' not found.', family
-                    )
+                    _log.warning("findfont: Font family %r not found.", family)
 
         # only add default family if no other font was found and
         # fallback_to_default is enabled
@@ -1443,16 +1431,15 @@ class FontManager:
                 cprop = prop.copy()
                 cprop.set_family(dfamily)
                 fpaths.append(
-                    self._findfont_cached(
+                    self.findfont(
                         cprop, fontext, directory,
                         fallback_to_default=True,
                         rebuild_if_missing=rebuild_if_missing,
-                        rc_params=rc_params,
                     )
                 )
             else:
                 raise ValueError("Failed to find any font, and fallback "
-                                 "to the default font was disabled.")
+                                 "to the default font was disabled")
 
         return fpaths
 


### PR DESCRIPTION
Mostly, we don't need to manage rcparams and call _findfont_cached; we
can directly rely on findfont which exactly handles that for us.  Also
some minor stylistic(ish) things.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
