### PR TITLE
Deprecate helper functions in axis3d

### DIFF
--- a/doc/api/next_api_changes/deprecations/23675-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23675-OG.rst
@@ -1,0 +1,7 @@
+Helper functions in ``mplot3d.axis3d``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The two helper functions ``move_from_center`` and ``tick_update_position`` are
+considered internal and deprecated. If these are required, please vendor the
+code from the corresponding private methods ``_move_from_center`` and
+``_tick_update_position``.

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -12,7 +12,16 @@ from matplotlib import (
 from . import art3d, proj3d
 
 
+@_api.deprecated("3.6", alternative="Vendor the code of _move_from_center")
 def move_from_center(coord, centers, deltas, axmask=(True, True, True)):
+    """
+    For each coordinate where *axmask* is True, move *coord* away from
+    *centers* by *deltas*.
+    """
+    return _move_from_center(coord, centers, deltas, axmask=axmask)
+
+
+def _move_from_center(coord, centers, deltas, axmask=(True, True, True)):
     """
     For each coordinate where *axmask* is True, move *coord* away from
     *centers* by *deltas*.
@@ -21,7 +30,13 @@ def move_from_center(coord, centers, deltas, axmask=(True, True, True)):
     return coord + axmask * np.copysign(1, coord - centers) * deltas
 
 
+@_api.deprecated("3.6", alternative="Vendor the code of _tick_update_position")
 def tick_update_position(tick, tickxs, tickys, labelpos):
+    """Update tick line and label position and style."""
+    _tick_update_position(tick, tickxs, tickys, labelpos)
+
+
+def _tick_update_position(tick, tickxs, tickys, labelpos):
     """Update tick line and label position and style."""
 
     tick.label1.set_position(labelpos)
@@ -370,7 +385,7 @@ class Axis(maxis.XAxis):
             (self.labelpad + default_offset) * deltas_per_point * deltas)
         axmask = [True, True, True]
         axmask[index] = False
-        lxyz = move_from_center(lxyz, centers, labeldeltas, axmask)
+        lxyz = _move_from_center(lxyz, centers, labeldeltas, axmask)
         tlx, tly, tlz = proj3d.proj_transform(*lxyz, self.axes.M)
         self.label.set_position((tlx, tly))
         if self.get_rotate_label(self.label.get_text()):
@@ -391,7 +406,7 @@ class Axis(maxis.XAxis):
             outeredgep = edgep2
             outerindex = 1
 
-        pos = move_from_center(outeredgep, centers, labeldeltas, axmask)
+        pos = _move_from_center(outeredgep, centers, labeldeltas, axmask)
         olx, oly, olz = proj3d.proj_transform(*pos, self.axes.M)
         self.offsetText.set_text(self.major.formatter.get_offset())
         self.offsetText.set_position((olx, oly))
@@ -491,10 +506,10 @@ class Axis(maxis.XAxis):
             labeldeltas = (tick.get_pad() + default_label_offset) * points
 
             pos[tickdir] = edgep1_tickdir
-            pos = move_from_center(pos, centers, labeldeltas, axmask)
+            pos = _move_from_center(pos, centers, labeldeltas, axmask)
             lx, ly, lz = proj3d.proj_transform(*pos, self.axes.M)
 
-            tick_update_position(tick, (x1, x2), (y1, y2), (lx, ly))
+            _tick_update_position(tick, (x1, x2), (y1, y2), (lx, ly))
             tick.tick1line.set_linewidth(tick_lw[tick._major])
             tick.draw(renderer)
 


### PR DESCRIPTION
## PR Summary

The two functions are not in the public documentation and are helper functions which should be considered private.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
