### PR TITLE
MNT: Get rcParams from mpl

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -18,6 +18,7 @@ import textwrap
 
 import numpy as np
 
+import matplotlib as mpl
 from matplotlib import _api, cbook, _docstring, _preprocess_data
 import matplotlib.artist as martist
 import matplotlib.axes as maxes
@@ -28,7 +29,7 @@ import matplotlib.lines as mlines
 import matplotlib.patches as mpatches
 import matplotlib.container as mcontainer
 import matplotlib.transforms as mtransforms
-from matplotlib.axes import Axes, rcParams
+from matplotlib.axes import Axes
 from matplotlib.axes._base import _axis_method_wrapper, _process_plot_format
 from matplotlib.transforms import Bbox
 from matplotlib.tri.triangulation import Triangulation
@@ -964,10 +965,10 @@ class Axes3D(Axes):
         # docstring inherited.
         super().clear()
         if self._focal_length == np.inf:
-            self._zmargin = rcParams['axes.zmargin']
+            self._zmargin = mpl.rcParams['axes.zmargin']
         else:
             self._zmargin = 0.
-        self.grid(rcParams['axes3d.grid'])
+        self.grid(mpl.rcParams['axes3d.grid'])
 
     def _button_press(self, event):
         if event.inaxes == self:
@@ -1394,7 +1395,7 @@ class Axes3D(Axes):
         rcount = kwargs.pop('rcount', 50)
         ccount = kwargs.pop('ccount', 50)
 
-        if rcParams['_internal.classic_mode']:
+        if mpl.rcParams['_internal.classic_mode']:
             # Strides have priority over counts in classic mode.
             # So, only compute strides from counts
             # if counts were explicitly given
@@ -1640,7 +1641,7 @@ class Axes3D(Axes):
         rcount = kwargs.pop('rcount', 50)
         ccount = kwargs.pop('ccount', 50)
 
-        if rcParams['_internal.classic_mode']:
+        if mpl.rcParams['_internal.classic_mode']:
             # Strides have priority over counts in classic mode.
             # So, only compute strides from counts
             # if counts were explicitly given
@@ -2965,7 +2966,7 @@ pivot='tail', normalize=False, **kwargs)
         # Make the style dict for caps (the "hats").
         eb_cap_style = {**base_style, 'linestyle': 'None'}
         if capsize is None:
-            capsize = rcParams["errorbar.capsize"]
+            capsize = mpl.rcParams["errorbar.capsize"]
         if capsize > 0:
             eb_cap_style['markersize'] = 2. * capsize
         if capthick is not None:
@@ -3006,7 +3007,7 @@ pivot='tail', normalize=False, **kwargs)
         # scene is rotated, they are given a standard size based on viewing
         # them directly in planar form.
         quiversize = eb_cap_style.get('markersize',
-                                      rcParams['lines.markersize']) ** 2
+                                      mpl.rcParams['lines.markersize']) ** 2
         quiversize *= self.figure.dpi / 72
         quiversize = self.transAxes.inverted().transform([
             (0, 0), (quiversize, quiversize)])
@@ -3221,7 +3222,7 @@ pivot='tail', normalize=False, **kwargs)
         # Determine style for stem lines.
         linestyle, linemarker, linecolor = _process_plot_format(linefmt)
         if linestyle is None:
-            linestyle = rcParams['lines.linestyle']
+            linestyle = mpl.rcParams['lines.linestyle']
 
         # Plot everything in required order.
         baseline, = self.plot(basex, basey, basefmt, zs=bottom,

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -6,9 +6,10 @@ import inspect
 
 import numpy as np
 
+import matplotlib as mpl
 from matplotlib import (
     _api, artist, lines as mlines, axis as maxis, patches as mpatches,
-    transforms as mtransforms, rcParams, colors as mcolors)
+    transforms as mtransforms, colors as mcolors)
 from . import art3d, proj3d
 
 
@@ -81,15 +82,15 @@ class Axis(maxis.XAxis):
         # This is a temporary member variable.
         # Do not depend on this existing in future releases!
         self._axinfo = self._AXINFO[name].copy()
-        if rcParams['_internal.classic_mode']:
+        if mpl.rcParams['_internal.classic_mode']:
             self._axinfo.update({
                 'label': {'va': 'center', 'ha': 'center'},
                 'tick': {
                     'inward_factor': 0.2,
                     'outward_factor': 0.1,
                     'linewidth': {
-                        True: rcParams['lines.linewidth'],  # major
-                        False: rcParams['lines.linewidth'],  # minor
+                        True: mpl.rcParams['lines.linewidth'],  # major
+                        False: mpl.rcParams['lines.linewidth'],  # minor
                     }
                 },
                 'axisline': {'linewidth': 0.75, 'color': (0, 0, 0, 1)},
@@ -107,21 +108,21 @@ class Axis(maxis.XAxis):
                     'outward_factor': 0.1,
                     'linewidth': {
                         True: (  # major
-                            rcParams['xtick.major.width'] if name in 'xz' else
-                            rcParams['ytick.major.width']),
+                            mpl.rcParams['xtick.major.width'] if name in 'xz'
+                            else mpl.rcParams['ytick.major.width']),
                         False: (  # minor
-                            rcParams['xtick.minor.width'] if name in 'xz' else
-                            rcParams['ytick.minor.width']),
+                            mpl.rcParams['xtick.minor.width'] if name in 'xz'
+                            else mpl.rcParams['ytick.minor.width']),
                     }
                 },
                 'axisline': {
-                    'linewidth': rcParams['axes.linewidth'],
-                    'color': rcParams['axes.edgecolor'],
+                    'linewidth': mpl.rcParams['axes.linewidth'],
+                    'color': mpl.rcParams['axes.edgecolor'],
                 },
                 'grid': {
-                    'color': rcParams['grid.color'],
-                    'linewidth': rcParams['grid.linewidth'],
-                    'linestyle': rcParams['grid.linestyle'],
+                    'color': mpl.rcParams['grid.color'],
+                    'linewidth': mpl.rcParams['grid.linewidth'],
+                    'linestyle': mpl.rcParams['grid.linestyle'],
                 },
             })
 


### PR DESCRIPTION
## PR Summary

I seem to recall that one should use `mpl.rcParams` (and in any way not import it from `Axes`).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
