### PR TITLE
TST: Use article class when checking for pgf

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -91,7 +91,7 @@ def _check_for_pgf(texsystem):
     with TemporaryDirectory() as tmpdir:
         tex_path = Path(tmpdir, "test.tex")
         tex_path.write_text(r"""
-            \documentclass{minimal}
+            \documentclass{article}
             \usepackage{pgf}
             \begin{document}
             \typeout{pgfversion=\pgfversion}


### PR DESCRIPTION
## PR Summary

This follows from #23443 where pgf started using `article` instead of `minimal`, but the testing check was not updated for it.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).