### PR TITLE
set_loglevel documenation and escape hatch 

### DIFF
--- a/doc/users/next_whats_new/loggers.rst
+++ b/doc/users/next_whats_new/loggers.rst
@@ -1,0 +1,10 @@
+``set_loglevel`` can opt-out of manipulating logging handlers
+-------------------------------------------------------------
+
+It is now possible to configure the logging level of the Matplotilb standard
+library logger without also implicitly installing a handler via both
+`matplotlib.set_loglevel` and `matplotlib.pyplot.set_loglevel` ::
+
+  mpl.set_loglevel('debug', ensure_handler=False)
+  # or
+  plt.set_loglevel('debug', ensure_handler=False)

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -230,7 +230,7 @@ def _ensure_handler():
     return handler
 
 
-def set_loglevel(level):
+def set_loglevel(level, *, ensure_handler=True):
     """
     Configure Matplotlib's logging levels.
 
@@ -238,7 +238,7 @@ def set_loglevel(level):
     logger 'matplotlib'.  This is a helper function to:
 
     - set Matplotlib's root logger level
-    - set the root logger handler's level, creating the handler
+    - optionally set the root logger handler's level, creating the handler
       if it does not exist yet
 
     Typically, one should call ``set_loglevel("info")`` or
@@ -253,6 +253,10 @@ def set_loglevel(level):
     level : {"notset", "debug", "info", "warning", "error", "critical"}
         The log level of the handler.
 
+    ensure_handler : bool
+        If True will ensure that there is a `logging.StreamHandler` added to
+        the matplotlib root logger and that its level matches the logger level.
+
     Notes
     -----
     The first time this function is called, an additional handler is attached
@@ -261,7 +265,8 @@ def set_loglevel(level):
 
     """
     _log.setLevel(level.upper())
-    _ensure_handler().setLevel(level.upper())
+    if ensure_handler:
+        _ensure_handler().setLevel(level.upper())
 
 
 def _logged_cached(fmt, func=None):

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -232,11 +232,21 @@ def _ensure_handler():
 
 def set_loglevel(level):
     """
-    Set Matplotlib's root logger and root logger handler level, creating
-    the handler if it does not exist yet.
+    Configure Matplotlib's logging levels.
+
+    Matplotlib uses the standard library `logging` framework under the root
+    logger 'matplotlib'.  This is a helper function to:
+
+    - set Matplotlib's root logger level
+    - set the root logger handler's level, creating the handler
+      if it does not exist yet
 
     Typically, one should call ``set_loglevel("info")`` or
     ``set_loglevel("debug")`` to get additional debugging information.
+
+    Users or applications that are installing their own logging handlers
+    may want to directly manipulate ``logging.getLogger('matplotlib')`` rather
+    than use this function.
 
     Parameters
     ----------
@@ -248,6 +258,7 @@ def set_loglevel(level):
     The first time this function is called, an additional handler is attached
     to Matplotlib's root handler; this handler is reused every time and this
     function simply manipulates the logger and handler's level.
+
     """
     _log.setLevel(level.upper())
     _ensure_handler().setLevel(level.upper())


### PR DESCRIPTION
## PR Summary

closes #23646 

If we want this new flag I'll add a test.  I am of two minds on it, we might only want the doc updates.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
