### PR TITLE
Improve matplotlib.pyplot importtime by caching ArtistInspector

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -895,8 +895,11 @@ class Axis(martist.Artist):
 
         This does not reset tick and tick label visibility.
         """
+        self.label._reset_visual_defaults()
+        self.offsetText._reset_visual_defaults()
+        self.labelpad = mpl.rcParams['axes.labelpad']
 
-        self.label.set_text('')  # self.set_label_text would change isDefault_
+        self._init()
 
         self._set_scale('linear')
 
@@ -2193,6 +2196,13 @@ class XAxis(Axis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._init()
+
+    def _init(self):
+        """
+        Initialize the label and offsetText instance values and
+        `label_position` / `offset_text_position`.
+        """
         # x in axes coords, y in display coords (to be updated at draw time by
         # _update_label_positions and _update_offset_text_position).
         self.label.set(
@@ -2202,6 +2212,7 @@ class XAxis(Axis):
                 self.axes.transAxes, mtransforms.IdentityTransform()),
         )
         self.label_position = 'bottom'
+
         self.offsetText.set(
             x=1, y=0,
             verticalalignment='top', horizontalalignment='right',
@@ -2444,6 +2455,13 @@ class YAxis(Axis):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self._init()
+
+    def _init(self):
+        """
+        Initialize the label and offsetText instance values and
+        `label_position` / `offset_text_position`.
+        """
         # x in display coords, y in axes coords (to be updated at draw time by
         # _update_label_positions and _update_offset_text_position).
         self.label.set(

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -164,6 +164,39 @@ class Text(Artist):
         super().__init__()
         self._x, self._y = x, y
         self._text = ''
+        self._reset_visual_defaults(
+            text=text,
+            color=color,
+            fontproperties=fontproperties,
+            usetex=usetex,
+            parse_math=parse_math,
+            wrap=wrap,
+            verticalalignment=verticalalignment,
+            horizontalalignment=horizontalalignment,
+            multialignment=multialignment,
+            rotation=rotation,
+            transform_rotates_text=transform_rotates_text,
+            linespacing=linespacing,
+            rotation_mode=rotation_mode,
+        )
+        self.update(kwargs)
+
+    def _reset_visual_defaults(
+        self,
+        text='',
+        color=None,
+        fontproperties=None,
+        usetex=None,
+        parse_math=None,
+        wrap=False,
+        verticalalignment='baseline',
+        horizontalalignment='left',
+        multialignment=None,
+        rotation=None,
+        transform_rotates_text=False,
+        linespacing=None,
+        rotation_mode=None,
+    ):
         self.set_text(text)
         self.set_color(
             color if color is not None else mpl.rcParams["text.color"])
@@ -183,7 +216,6 @@ class Text(Artist):
             linespacing = 1.2  # Maybe use rcParam later.
         self.set_linespacing(linespacing)
         self.set_rotation_mode(rotation_mode)
-        self.update(kwargs)
 
     def update(self, kwargs):
         # docstring inherited


### PR DESCRIPTION
## PR Summary

During import of matplotlib.pyplot the `ArtistInspector` performs actions for objects of type `Artist`. Several actions are performed twice and can be avoided by caching the result.

This PR improves the import time from by 1149 ms to 808 ms (the numbers are system dependent, quoted numbers are on Windows with python 3.10).

The PR consists of 3 elements:

* Adding a `lru_cache` to `ArtistInspector.is_alias`.
* Creating a cached method `ArtistInspector.number_of_parameters(` for `len(inspect.signature(func).parameters)`
* Creating a method `getdoc_pure` that is equal to `inspect.getdoc`, but without an expensive call to `inspect.cleandoc`.

Notes:

This part of the code was identified by using https://github.com/asottile/importtime-waterfall and https://jiffyclub.github.io/snakeviz/. Analysis of the data shows there are several other places where the import time can be improved, but that is for another PR.

The usage of caching adds some memory overhead, but not a lot. This can be inspected for this PR by
```
import matplotlib.artist
c=matplotlib.artist.ArtistInspector.is_alias
c.cache_info()
```
Timings are obtained using `python -c "import time; t0=time.perf_counter(); import matplotlib.pyplot; dt=time.perf_counter()-t0; print(f'{1e3*dt:.2f} ms')"`

The method `ArtistInspector.get_valid_values` is still a quite expensive method that is called during startup. The full docstring is used there, so it could not easily be refactored.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there). *No new feature*

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
