### PR TITLE
Add new-style string formatting option and callable option to `fmt` in `Axes.bar_label()`.

### DIFF
--- a/doc/users/next_whats_new/bar_label_formatting.rst
+++ b/doc/users/next_whats_new/bar_label_formatting.rst
@@ -8,7 +8,7 @@ The ``fmt`` argument of `~matplotlib.axes.Axes.bar_label` now accepts
 
     import matplotlib.pyplot as plt
 
-    fruit_names = ["Coffee", "Salted Caramel", "Pistachio"]
+    fruit_names = ['Coffee', 'Salted Caramel', 'Pistachio']
     fruit_counts = [4000, 2000, 7000]
 
     fig, ax = plt.subplots()
@@ -20,7 +20,7 @@ It also accepts callables:
 
 .. code-block:: python
 
-    animal_names = ["Lion", "Gazelle", "Cheetah"]
+    animal_names = ['Lion', 'Gazelle', 'Cheetah']
     mph_speed = [50, 60, 75]
 
     fig, ax = plt.subplots()

--- a/doc/users/next_whats_new/bar_label_formatting.rst
+++ b/doc/users/next_whats_new/bar_label_formatting.rst
@@ -1,0 +1,31 @@
+Additional format string options in `~matplotlib.axes.Axes.bar_label`
+---------------------------------------------------------------------
+
+The ``fmt`` argument of `~matplotlib.axes.Axes.bar_label` now accepts
+{}-style format strings:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+
+    fruit_names = ["Coffee", "Salted Caramel", "Pistachio"]
+    fruit_counts = [4000, 2000, 7000]
+
+    fig, ax = plt.subplots()
+    bar_container = ax.bar(fruit_names, fruit_counts)
+    ax.set(ylabel='pints sold', title='Gelato sales by flavor', ylim=(0, 8000))
+    ax.bar_label(bar_container, fmt='{:,.0f}')
+
+It also accepts callables:
+
+.. code-block:: python
+
+    animal_names = ["Lion", "Gazelle", "Cheetah"]
+    mph_speed = [50, 60, 75]
+
+    fig, ax = plt.subplots()
+    bar_container = ax.bar(animal_names, mph_speed)
+    ax.set(ylabel='speed in MPH', title='Running speeds', ylim=(0, 80))
+    ax.bar_label(
+        bar_container, fmt=lambda x: '{:.1f} km/h'.format(x * 1.61)
+    )

--- a/examples/lines_bars_and_markers/bar_label_demo.py
+++ b/examples/lines_bars_and_markers/bar_label_demo.py
@@ -94,6 +94,30 @@ ax.set_xlim(right=16)
 
 plt.show()
 
+###############################################################################
+# Bar labels using {}-style format string
+
+fruit_names = ['Coffee', 'Salted Caramel', 'Pistachio']
+fruit_counts = [4000, 2000, 7000]
+
+fig, ax = plt.subplots()
+bar_container = ax.bar(fruit_names, fruit_counts)
+ax.set(ylabel='pints sold', title='Gelato sales by flavor', ylim=(0, 8000))
+ax.bar_label(bar_container, fmt='{:,.0f}')
+
+###############################################################################
+# Bar labels using a callable
+
+animal_names = ['Lion', 'Gazelle', 'Cheetah']
+mph_speed = [50, 60, 75]
+
+fig, ax = plt.subplots()
+bar_container = ax.bar(animal_names, mph_speed)
+ax.set(ylabel='speed in MPH', title='Running speeds', ylim=(0, 80))
+ax.bar_label(
+    bar_container, fmt=lambda x: '{:.1f} km/h'.format(x * 1.61)
+)
+
 #############################################################################
 #
 # .. admonition:: References

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2625,7 +2625,8 @@ class Axes(_AxesBase):
         fmt : str or callable, default: '%g'
             An unnamed %-style or {}-style format string for the label or a
             function to call with the value as the first argument.
-            When *fmt* is a string, %-style takes precedence over {}-style.
+            When *fmt* is a string and can be interpreted in both formats,
+            %-style takes precedence over {}-style.
 
         label_type : {'edge', 'center'}, default: 'edge'
             The label type. Possible values:
@@ -2748,10 +2749,12 @@ class Axes(_AxesBase):
                 lbl = ''
 
             if lbl is None:
-                try:
-                    lbl = fmt(value)
-                except TypeError:
+                if isinstance(fmt, str):
                     lbl = cbook._auto_format_str(fmt, value)
+                elif callable(fmt):
+                    lbl = fmt(value)
+                else:
+                    raise TypeError("fmt must be a str or callable")
             annotation = self.annotate(lbl,
                                        xy, xytext, textcoords="offset points",
                                        ha=ha, va=va, **kwargs)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2622,8 +2622,9 @@ class Axes(_AxesBase):
             A list of label texts, that should be displayed. If not given, the
             label texts will be the data values formatted with *fmt*.
 
-        fmt : str, default: '%g'
-            A format string for the label.
+        fmt : str or callable, default: '%g'
+            A format string for the label or a function to call with the value
+            as the first argument.
 
         label_type : {'edge', 'center'}, default: 'edge'
             The label type. Possible values:
@@ -2746,9 +2747,18 @@ class Axes(_AxesBase):
                 lbl = ''
 
             if lbl is None:
-                formatted_value = (
-                    fmt.format(value) if fmt.startswith('{') else fmt % value
-                )
+                if callable(fmt):
+                    formatted_value = fmt(value)
+                elif isinstance(fmt, str):
+                    if fmt.count('{:') == fmt.count('}') == 1:
+                        formatted_value = fmt.format(value)
+                    else:
+                        formatted_value = fmt % value
+                else:
+                    raise ValueError(
+                        'fmt expected to be a callable or a format string. '
+                        f'Got "{fmt}".'
+                    )
             else:
                 formatted_value = lbl
             annotation = self.annotate(formatted_value,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2745,7 +2745,13 @@ class Axes(_AxesBase):
             if np.isnan(dat):
                 lbl = ''
 
-            annotation = self.annotate(fmt % value if lbl is None else lbl,
+            if lbl is None:
+                formatted_value = (
+                    fmt.format(value) if fmt.startswith('{') else fmt % value
+                )
+            else:
+                formatted_value = lbl
+            annotation = self.annotate(formatted_value,
                                        xy, xytext, textcoords="offset points",
                                        ha=ha, va=va, **kwargs)
             annotations.append(annotation)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2623,8 +2623,9 @@ class Axes(_AxesBase):
             label texts will be the data values formatted with *fmt*.
 
         fmt : str or callable, default: '%g'
-            A format string for the label or a function to call with the value
-            as the first argument.
+            An unnamed %-style or {}-style format string for the label or a
+            function to call with the value as the first argument.
+            When *fmt* is a string, %-style takes precedence over {}-style.
 
         label_type : {'edge', 'center'}, default: 'edge'
             The label type. Possible values:
@@ -2747,21 +2748,11 @@ class Axes(_AxesBase):
                 lbl = ''
 
             if lbl is None:
-                if callable(fmt):
-                    formatted_value = fmt(value)
-                elif isinstance(fmt, str):
-                    if fmt.count('{:') == fmt.count('}') == 1:
-                        formatted_value = fmt.format(value)
-                    else:
-                        formatted_value = fmt % value
-                else:
-                    raise ValueError(
-                        'fmt expected to be a callable or a format string. '
-                        f'Got "{fmt}".'
-                    )
-            else:
-                formatted_value = lbl
-            annotation = self.annotate(formatted_value,
+                try:
+                    lbl = fmt(value)
+                except TypeError:
+                    lbl = cbook._auto_format_str(fmt, value)
+            annotation = self.annotate(lbl,
                                        xy, xytext, textcoords="offset points",
                                        ha=ha, va=va, **kwargs)
             annotations.append(annotation)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2312,3 +2312,35 @@ def _unpack_to_numpy(x):
         if isinstance(xtmp, np.ndarray):
             return xtmp
     return x
+
+
+def _auto_format_str(fmt, value):
+    """
+    Apply *value* to the format string *fmt*.
+
+    This works both with unnamed %-style formatting and
+    unnamed {}-style formatting. %-style formatting has priority.
+    If *fmt* is %-style formattable that will be used. Otherwise,
+    {}-formatting is applied. Strings without formatting placeholders
+    are passed through as is.
+
+    Examples
+    --------
+    >>> _auto_format_str('%.2f m', 0.2)
+    '0.20 m'
+    >>> _auto_format_str('{} m', 0.2)
+    '0.2 m'
+    >>> _auto_format_str('const', 0.2)
+    'const'
+    >>> _auto_format_str('%d or {}', 0.2)
+    '0 or {}'
+    """
+    try:
+        lbl = fmt % value
+        # when used in `Axes.bar_label()`` this doesn't always raise an error
+        # when the {}-style formatting should be used instead of %-style
+        if lbl == fmt:
+            raise TypeError
+        return lbl
+    except (TypeError, ValueError):
+        return fmt.format(value)

--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -2336,11 +2336,6 @@ def _auto_format_str(fmt, value):
     '0 or {}'
     """
     try:
-        lbl = fmt % value
-        # when used in `Axes.bar_label()`` this doesn't always raise an error
-        # when the {}-style formatting should be used instead of %-style
-        if lbl == fmt:
-            raise TypeError
-        return lbl
+        return fmt % (value,)
     except (TypeError, ValueError):
         return fmt.format(value)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7773,6 +7773,13 @@ def test_bar_label_fmt(fmt):
     assert labels[1].get_text() == '-4.00'
 
 
+def test_bar_label_fmt_error():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [3, -4])
+    with pytest.raises(TypeError, match='str or callable'):
+        _ = ax.bar_label(rects, fmt=10)
+
+
 def test_bar_label_labels():
     ax = plt.gca()
     rects = ax.bar([1, 2], [3, -4])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7762,10 +7762,13 @@ def test_bar_label_location_errorbars():
     assert labels[1].get_va() == 'top'
 
 
-def test_bar_label_fmt():
+@pytest.mark.parametrize('fmt', [
+    '%.2f', '{:.2f}', '{:.2f}'.format
+])
+def test_bar_label_fmt(fmt):
     ax = plt.gca()
     rects = ax.bar([1, 2], [3, -4])
-    labels = ax.bar_label(rects, fmt='%.2f')
+    labels = ax.bar_label(rects, fmt=fmt)
     assert labels[0].get_text() == '3.00'
     assert labels[1].get_text() == '-4.00'
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -895,3 +895,18 @@ def test_safe_first_element_with_none():
     datetime_lst[0] = None
     actual = cbook._safe_first_non_none(datetime_lst)
     assert actual is not None and actual == datetime_lst[1]
+
+
+@pytest.mark.parametrize('fmt, value, result', [
+    ('%.2f m', 0.2, '0.20 m'),
+    ('{:.2f} m', 0.2, '0.20 m'),
+    ('{} m', 0.2, '0.2 m'),
+    ('const', 0.2, 'const'),
+    ('%d or {}', 0.2, '0 or {}'),
+    ('{{{:,.0f}}}', 2e5, '{200,000}'),
+    ('{:.2%}', 2/3, '66.67%'),
+    ('$%g', 2.54, '$2.54'),
+])
+def test_auto_format_str(fmt, value, result):
+    """Apply *value* to the format string *fmt*."""
+    assert cbook._auto_format_str(fmt, value) == result

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -910,3 +910,4 @@ def test_safe_first_element_with_none():
 def test_auto_format_str(fmt, value, result):
     """Apply *value* to the format string *fmt*."""
     assert cbook._auto_format_str(fmt, value) == result
+    assert cbook._auto_format_str(fmt, np.float64(value)) == result


### PR DESCRIPTION
## PR Summary
Addresses #23689

Enhancement to `Axes.bar_label()` to make it possible to format values with f-strings.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
