### PR TITLE
Fix cmap deprecations

### DIFF
--- a/doc/api/next_api_changes/behavior/23710-ES.rst
+++ b/doc/api/next_api_changes/behavior/23710-ES.rst
@@ -1,0 +1,7 @@
+``plt.get_cmap`` and ``matplotlib.cm.get_cmap`` return a copy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Formerly, `~.pyplot.get_cmap` and `.cm.get_cmap` returned a global version of a
+`.Colormap`. This was prone to errors as modification of the colormap would
+propagate from one location to another without warning. Now, a new copy of the
+colormap is returned.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -204,7 +204,7 @@ globals().update(_colormaps)
 @_api.deprecated(
     '3.6',
     pending=True,
-    alternative="``matplotlib.colormaps.register_cmap(name)``"
+    alternative="``matplotlib.colormaps.register(name)``"
 )
 def register_cmap(name=None, cmap=None, *, override_builtin=False):
     """
@@ -288,7 +288,7 @@ get_cmap = _api.deprecated(
 @_api.deprecated(
     '3.6',
     pending=True,
-    alternative="``matplotlib.colormaps.unregister_cmap(name)``"
+    alternative="``matplotlib.colormaps.unregister(name)``"
 )
 def unregister_cmap(name):
     """

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -280,7 +280,8 @@ def _get_cmap(name=None, lut=None):
 # do it in two steps like this so we can have an un-deprecated version in
 # pyplot.
 get_cmap = _api.deprecated(
-    '3.6', pending=True, alternative="``matplotlib.colormaps[name]``"
+    '3.6',
+    name='get_cmap', pending=True, alternative="``matplotlib.colormaps[name]``"
 )(_get_cmap)
 
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -69,7 +69,7 @@ def test_register_cmap():
     target = "viridis2"
     with pytest.warns(
             PendingDeprecationWarning,
-            match=r"matplotlib\.colormaps\.register_cmap\(name\)"
+            match=r"matplotlib\.colormaps\.register\(name\)"
     ):
         cm.register_cmap(target, new_cm)
     assert mpl.colormaps[target] == new_cm
@@ -78,13 +78,13 @@ def test_register_cmap():
                        match="Arguments must include a name or a Colormap"):
         with pytest.warns(
             PendingDeprecationWarning,
-            match=r"matplotlib\.colormaps\.register_cmap\(name\)"
+            match=r"matplotlib\.colormaps\.register\(name\)"
         ):
             cm.register_cmap()
 
     with pytest.warns(
             PendingDeprecationWarning,
-            match=r"matplotlib\.colormaps\.unregister_cmap\(name\)"
+            match=r"matplotlib\.colormaps\.unregister\(name\)"
     ):
         cm.unregister_cmap(target)
     with pytest.raises(ValueError,
@@ -96,7 +96,7 @@ def test_register_cmap():
             cm.get_cmap(target)
     with pytest.warns(
             PendingDeprecationWarning,
-            match=r"matplotlib\.colormaps\.unregister_cmap\(name\)"
+            match=r"matplotlib\.colormaps\.unregister\(name\)"
     ):
         # test that second time is error free
         cm.unregister_cmap(target)
@@ -104,7 +104,7 @@ def test_register_cmap():
     with pytest.raises(TypeError, match="'cmap' must be"):
         with pytest.warns(
             PendingDeprecationWarning,
-            match=r"matplotlib\.colormaps\.register_cmap\(name\)"
+            match=r"matplotlib\.colormaps\.register\(name\)"
         ):
             cm.register_cmap('nome', cmap='not a cmap')
 


### PR DESCRIPTION
## PR Summary

Some names in the deprecation messages were incorrect, and the `get_cmap` copying did not have an API note.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).