### PR TITLE
Fix deprecation messages for vendoring unused things

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -436,7 +436,7 @@ def _get_executable_info(name):
         raise ValueError("Unknown executable: {!r}".format(name))
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of this function")
 def checkdep_usetex(s):
     if not s:
         return False

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -92,7 +92,7 @@ _log = logging.getLogger(__name__)
 # * draw_quad_mesh
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of _fill")
 def fill(strings, linelen=75):
     return _fill(strings, linelen=linelen)
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -87,7 +87,7 @@ def _nums_to_str(*args):
     return " ".join(f"{arg:1.3f}".rstrip("0").rstrip(".") for arg in args)
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of this function")
 def quote_ps_string(s):
     """
     Quote dangerous characters of S for use in a PostScript string constant.

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -66,7 +66,7 @@ backend_version = mpl.__version__
 # --------------------------------------------------------------------
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of _escape_cdata")
 def escape_cdata(s):
     return _escape_cdata(s)
 
@@ -81,7 +81,7 @@ def _escape_cdata(s):
 _escape_xml_comment = re.compile(r'-(?=-)')
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of _escape_comment")
 def escape_comment(s):
     return _escape_comment.sub(s)
 
@@ -91,7 +91,7 @@ def _escape_comment(s):
     return _escape_xml_comment.sub('- ', s)
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of _escape_attrib")
 def escape_attrib(s):
     return _escape_attrib(s)
 
@@ -111,7 +111,7 @@ def _quote_escape_attrib(s):
             '"' + _escape_attrib(s) + '"')
 
 
-@_api.deprecated("3.6", alternative="Vendor the code")
+@_api.deprecated("3.6", alternative="a vendored copy of _short_float_fmt")
 def short_float_fmt(x):
     return _short_float_fmt(x)
 

--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -32,8 +32,8 @@ def _cleanup_cm():
         plt.close("all")
 
 
-@_api.deprecated("3.6", alternative="Vendor the existing code, "
-                 "including the private function _cleanup_cm.")
+@_api.deprecated("3.6", alternative="a vendored copy of the existing code, "
+                 "including the private function _cleanup_cm")
 class CleanupTestCase(unittest.TestCase):
     """A wrapper for unittest.TestCase that includes cleanup operations."""
     @classmethod
@@ -45,8 +45,8 @@ class CleanupTestCase(unittest.TestCase):
         cls._cm.__exit__(None, None, None)
 
 
-@_api.deprecated("3.6", alternative="Vendor the existing code, "
-                 "including the private function _cleanup_cm.")
+@_api.deprecated("3.6", alternative="a vendored copy of the existing code, "
+                 "including the private function _cleanup_cm")
 def cleanup(style=None):
     """
     A decorator to ensure that any global state is reset before
@@ -88,8 +88,8 @@ def cleanup(style=None):
         return make_cleanup
 
 
-@_api.deprecated("3.6", alternative="Vendor the existing code "
-                 "of _check_freetype_version.")
+@_api.deprecated("3.6", alternative="a vendored copy of the existing code "
+                 "of _check_freetype_version")
 def check_freetype_version(ver):
     return _check_freetype_version(ver)
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -13,7 +13,7 @@ from matplotlib import (
 from . import art3d, proj3d
 
 
-@_api.deprecated("3.6", alternative="Vendor the code of _move_from_center")
+@_api.deprecated("3.6", alternative="a vendored copy of _move_from_center")
 def move_from_center(coord, centers, deltas, axmask=(True, True, True)):
     """
     For each coordinate where *axmask* is True, move *coord* away from
@@ -31,7 +31,7 @@ def _move_from_center(coord, centers, deltas, axmask=(True, True, True)):
     return coord + axmask * np.copysign(1, coord - centers) * deltas
 
 
-@_api.deprecated("3.6", alternative="Vendor the code of _tick_update_position")
+@_api.deprecated("3.6", alternative="a vendored copy of _tick_update_position")
 def tick_update_position(tick, tickxs, tickys, labelpos):
     """Update tick line and label position and style."""
     _tick_update_position(tick, tickxs, tickys, labelpos)


### PR DESCRIPTION
## PR Summary

Formerly, the deprecation message would say "Use Vendor the code instead"; now they say "Use a vendored copy of the code instead", etc.

This weird grammar can cause some confusion, cf #23244

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).