### PR TITLE
[DOC]: Add grid to style sheets 

### DIFF
--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -39,6 +39,7 @@ def plot_colored_lines(ax):
     amplitudes = np.linspace(1, 1.5, nb_colors)
     for t0, a in zip(shifts, amplitudes):
         ax.plot(t, a * sigmoid(t, t0), '-')
+    ax.grid(linewidth=1)
     ax.set_xlim(-10, 10)
     return ax
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -39,7 +39,7 @@ def plot_colored_lines(ax):
     amplitudes = np.linspace(1, 1.5, nb_colors)
     for t0, a in zip(shifts, amplitudes):
         ax.plot(t, a * sigmoid(t, t0), '-')
-    ax.grid(linewidth=1)
+    ax.grid(visible=True)
     ax.set_xlim(-10, 10)
     return ax
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -40,6 +40,12 @@ def plot_colored_lines(ax):
     for t0, a in zip(shifts, amplitudes):
         ax.plot(t, a * sigmoid(t, t0), '-')
     ax.grid(visible=True)
+    # Add annotation for enabling grid
+    ax.annotate('ax.grid(True)', xy=(-5.0, 0.5),
+                xytext=(1.4, 1.4),
+                va="top", ha="right",
+                bbox=dict(boxstyle="round", alpha=0.2),
+                )
     ax.set_xlim(-10, 10)
     return ax
 


### PR DESCRIPTION
## PR Summary

This PR adds gridlines for all available style sheets to help visualise the default colour of the grid in each style sheet. 
Addresses #23601 

## PR Checklist

**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).



