### PR TITLE
Correctly handle Axes subclasses that override cla

### DIFF
--- a/doc/api/next_api_changes/deprecations/23735-ES.rst
+++ b/doc/api/next_api_changes/deprecations/23735-ES.rst
@@ -1,0 +1,13 @@
+``AXes`` subclasses should override ``clear`` instead of ``cla``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For clarity, `.axes.Axes.clear` is now preferred over `.Axes.cla`. However, for
+backwards compatibility, the latter will remain as an alias for the former.
+
+For additional compatibility with third-party libraries, Matplotlib will
+continue to call the ``cla`` method of any `~.axes.Axes` subclasses if they
+define it. In the future, this will no longer occur, and Matplotlib will only
+call the ``clear`` method in `~.axes.Axes` subclasses.
+
+It is recommended to define only the ``clear`` method when on Matplotlib 3.6,
+and only ``cla`` for older versions.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -709,7 +709,7 @@ class _AxesBase(martist.Artist):
                 pending=True,
                 message=f'Overriding `Axes.cla` in {cls.__qualname__} is '
                 'pending deprecation in %(since)s and will be fully '
-                'deprecated for `Axes.clear` in the future. Please report '
+                'deprecated in favor of `Axes.clear` in the future. Please report '
                 f'this to the {cls.__module__!r} author.')
         cls._subclass_uses_cla = 'cla' in cls.__dict__ or parent_uses_cla
         super().__init_subclass__(**kwargs)
@@ -1216,7 +1216,11 @@ class _AxesBase(martist.Artist):
 
     def _clear(self):
         """Clear the Axes."""
-        # Note: this is called by Axes.__init__()
+        # The actual implementation of clear() as long as clear() has to be
+        # an adapter delegating to the correct implementation.
+        # The implementation can move back into clear() when the
+        # deprecation on cla() subclassing expires.
+        
 
         # stash the current visibility state
         if hasattr(self, 'patch'):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -709,7 +709,8 @@ class _AxesBase(martist.Artist):
                 pending=True,
                 message=f'Overriding `Axes.cla` in {cls.__qualname__} is '
                 'pending deprecation in %(since)s and will be fully '
-                'deprecated in favor of `Axes.clear` in the future. Please report '
+                'deprecated in favor of `Axes.clear` in the future. '
+                'Please report '
                 f'this to the {cls.__module__!r} author.')
         cls._subclass_uses_cla = 'cla' in cls.__dict__ or parent_uses_cla
         super().__init_subclass__(**kwargs)
@@ -1214,13 +1215,12 @@ class _AxesBase(martist.Artist):
         self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
         self.yaxis._scale = other.yaxis._scale
 
-    def _clear(self):
+    def __clear(self):
         """Clear the Axes."""
         # The actual implementation of clear() as long as clear() has to be
         # an adapter delegating to the correct implementation.
         # The implementation can move back into clear() when the
         # deprecation on cla() subclassing expires.
-        
 
         # stash the current visibility state
         if hasattr(self, 'patch'):
@@ -1344,14 +1344,14 @@ class _AxesBase(martist.Artist):
         if self._subclass_uses_cla:
             self.cla()
         else:
-            self._clear()
+            self.__clear()
 
     def cla(self):
         """Clear the Axes."""
         # Act as an alias, or as the superclass implementation depending on the
         # subclass implementation.
         if self._subclass_uses_cla:
-            self._clear()
+            self.__clear()
         else:
             self.clear()
 


### PR DESCRIPTION
## PR Summary

In #22802, `Axes.clear` was made the primary interface over `Axes.cla`. However, while this can be enforced internally, that can't be said for third-party subclasses. I'm pretty sure we did not intend to remove or deprecate `Axes.cla` given its wide use, though I'm not sure if we wanted to discourage it (by undocumenting or just putting that in the docstring.)

This fixes, e.g., Cartopy, but probably most other third-party packages that will subclass `Axes`.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).