### PR TITLE
Clarify error for colorbar with unparented mappable

### DIFF
--- a/doc/api/next_api_changes/removals/22081-AL.rst
+++ b/doc/api/next_api_changes/removals/22081-AL.rst
@@ -1,7 +1,10 @@
 colorbar defaults to stealing space from the mappable's axes rather than the current axes
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pass ``ax=plt.gca()`` to restore the previous behavior.
+If the mappable does not have an Axes, then an error will be raised.
+
+Pass the *cax* or *ax* argument to be explicit about where the colorbar will be
+placed. Passing ``ax=plt.gca()`` will restore the previous behavior.
 
 Removal of deprecated ``colorbar`` APIs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1245,13 +1245,19 @@ default: %(va)s
         """
 
         if ax is None:
-            ax = getattr(mappable, "axes", self.gca())
+            ax = getattr(mappable, "axes", None)
 
         if (self.get_layout_engine() is not None and
                 not self.get_layout_engine().colorbar_gridspec):
             use_gridspec = False
         # Store the value of gca so that we can set it back later on.
         if cax is None:
+            if ax is None:
+                raise ValueError(
+                    'Unable to determine Axes to steal space for Colorbar. '
+                    'Either provide the *cax* argument to use as the Axes for '
+                    'the Colorbar, provide the *ax* argument to steal space '
+                    'from it, or add *mappable* to an Axes.')
             current_ax = self.gca()
             userax = False
             if (use_gridspec and isinstance(ax, SubplotBase)):

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -315,6 +315,14 @@ def test_colorbarbase():
     Colorbar(ax, cmap=plt.cm.bone)
 
 
+def test_parentless_mappable():
+    pc = mpl.collections.PatchCollection([], cmap=plt.get_cmap('viridis'))
+    pc.set_array([])
+
+    with pytest.raises(ValueError, match='Unable to determine Axes to steal'):
+        plt.colorbar(pc)
+
+
 @image_comparison(['colorbar_closed_patch.png'], remove_text=True)
 def test_colorbar_closed_patch():
     # Remove this line when this test image is regenerated.
@@ -675,7 +683,7 @@ def test_colorbar_inverted_ticks():
 def test_mappable_no_alpha():
     fig, ax = plt.subplots()
     sm = cm.ScalarMappable(norm=mcolors.Normalize(), cmap='viridis')
-    fig.colorbar(sm)
+    fig.colorbar(sm, ax=ax)
     sm.set_cmap('plasma')
     plt.draw()
 


### PR DESCRIPTION
## PR Summary

Fixes #23709

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).