### PR TITLE
FIX: unbreak ipympl

### DIFF
--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -30,7 +30,7 @@ import tornado.websocket
 
 
 import matplotlib as mpl
-from matplotlib.backends.backend_webagg_core import (
+from matplotlib.backends.backend_webagg import (
     FigureManagerWebAgg, new_figure_manager_given_figure)
 from matplotlib.figure import Figure
 

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -427,7 +427,9 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
 
 
 class FigureManagerWebAgg(backend_bases.FigureManagerBase):
-    _toolbar2_class = ToolbarCls = NavigationToolbar2WebAgg
+    # This must be None to not break ipympl
+    _toolbar2_class = None
+    ToolbarCls = NavigationToolbar2WebAgg
 
     def __init__(self, canvas, num):
         self.web_sockets = set()

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -2,6 +2,7 @@ import subprocess
 import os
 import sys
 import pytest
+import matplotlib.backends.backend_webagg_core
 
 
 @pytest.mark.parametrize("backend", ["webagg", "nbagg"])
@@ -25,3 +26,8 @@ def test_webagg_fallback(backend):
     ret = subprocess.call([sys.executable, "-c", test_code], env=env)
 
     assert ret == 0
+
+
+def test_webagg_core_no_toolbar():
+    fm = matplotlib.backends.backend_webagg_core.FigureManagerWebAgg
+    assert fm._toolbar2_class is None


### PR DESCRIPTION

## PR Summary

We must not try to make a toolbar for the classes in backend_webaggcore because
ipympl inherits from these classes and requires its own toolbar to be used.

This also fixes the webagg embedding example without breaking ipympl.

closes #23699


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

