### PR TITLE
Fix rcParams documentation

### DIFF
--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -43,7 +43,7 @@ def depart_query_reference_node(self, node):
 def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     # Generate a pending cross-reference so that Sphinx will ensure this link
     # isn't broken at some point in the future.
-    title = f'rcParam["{text}"]'
+    title = f'rcParams["{text}"]'
     target = 'matplotlibrc-sample'
     ref_nodes, messages = inliner.interpreted(title, f'{title} <{target}>',
                                               'ref', lineno)

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -5,10 +5,7 @@
 ## This is a sample Matplotlib configuration file - you can find a copy
 ## of it on your system in site-packages/matplotlib/mpl-data/matplotlibrc
 ## (relative to your Python installation location).
-##
-## You should find a copy of it on your system at
-## site-packages/matplotlib/mpl-data/matplotlibrc (relative to your Python
-## installation location).  DO NOT EDIT IT!
+## DO NOT EDIT IT!
 ##
 ## If you wish to change your default style, copy this file to one of the
 ## following locations:


### PR DESCRIPTION
## PR Summary

The `rcParam` typo was accidentally introduced by me in #23641.

Fixes #23745

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).