### PR TITLE
DEV: add flake8-force plugin

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -113,3 +113,4 @@ per-file-ignores =
     examples/user_interfaces/pylab_with_gtk4_sgskip.py: E402
     examples/user_interfaces/toolmanager_sgskip.py: E402
     examples/userdemo/pgf_preamble_sgskip.py: E402
+force-check = True

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
-        additional_dependencies: [pydocstyle>5.1.0, flake8-docstrings>1.4.0]
+        additional_dependencies: [pydocstyle>5.1.0, flake8-docstrings>1.4.0, flake8-force]
         args: ["--docstring-convention=all"]
   - repo: https://github.com/codespell-project/codespell
     rev: v2.1.0

--- a/requirements/testing/flake8.txt
+++ b/requirements/testing/flake8.txt
@@ -5,3 +5,5 @@ flake8>=3.8
 pydocstyle>=5.1.0
 # 1.4.0 adds docstring-convention=all
 flake8-docstrings>=1.4.0
+# fix bug where flake8 aborts checking on syntax error
+flake8-force


### PR DESCRIPTION
## PR Summary

Add plugin to fix flake8's behavior to run all checks even if there is a syntax
error.

Despite upstream's view that they "fixed" a bug, there was a regression in functionality in flake8 v4 that suppresses all other warnings if there is a syntax error.   https://github.com/kmaehashi/flake8-force is a flake8 plugin that lets you opt back into the previous behavior.