### PR TITLE
3d plots what's new cleanups

### DIFF
--- a/doc/users/next_whats_new/3d_plot_aspects.rst
+++ b/doc/users/next_whats_new/3d_plot_aspects.rst
@@ -27,6 +27,7 @@ Users can set the aspect ratio for the X, Y, Z axes of a 3D plot to be 'equal',
     for i, ax in enumerate(axs):
         ax.set_box_aspect((3, 4, 5))
         ax.set_aspect(aspects[i])
-        ax.set_title("set_aspect('{aspects[i]}')")
+        ax.set_title(f"set_aspect('{aspects[i]}')")
 
+    fig.set_size_inches(13, 3)
     plt.show()

--- a/doc/users/next_whats_new/3d_plot_focal_length.rst
+++ b/doc/users/next_whats_new/3d_plot_focal_length.rst
@@ -19,13 +19,13 @@ The focal length can be calculated from a desired FOV via the equation:
 
     from mpl_toolkits.mplot3d import axes3d
     import matplotlib.pyplot as plt
-    fig, axs = plt.subplots(1, 3, subplot_kw={'projection': '3d'},
-                            constrained_layout=True)
+    from numpy import inf
+    fig, axs = plt.subplots(1, 3, subplot_kw={'projection': '3d'})
     X, Y, Z = axes3d.get_test_data(0.05)
-    focal_lengths = [0.25, 1, 4]
+    focal_lengths = [0.2, 1, inf]
     for ax, fl in zip(axs, focal_lengths):
         ax.plot_wireframe(X, Y, Z, rstride=10, cstride=10)
         ax.set_proj_type('persp', focal_length=fl)
         ax.set_title(f"focal_length = {fl}")
-    plt.tight_layout()
+    fig.set_size_inches(10, 4)
     plt.show()

--- a/doc/users/next_whats_new/3d_plot_roll_angle.rst
+++ b/doc/users/next_whats_new/3d_plot_roll_angle.rst
@@ -18,4 +18,5 @@ existing 3D plots.
     X, Y, Z = axes3d.get_test_data(0.05)
     ax.plot_wireframe(X, Y, Z, rstride=10, cstride=10)
     ax.view_init(elev=0, azim=0, roll=30)
+    ax.set_title('elev=0, azim=0, roll=30')
     plt.show()


### PR DESCRIPTION
## PR Summary
The previous plots were squished with overlapping titles, this cleans them up.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
