### PR TITLE
Do not distill and embed fonts if no text

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1063,6 +1063,13 @@ showpage
 """,
                 encoding="latin-1")
 
+            if len(ps_renderer.psfrag) == 0:
+                # No text, so no need to distill
+                if is_eps:
+                    pstoeps(str(tmppath))
+                _move_path_to_path_or_stream(tmppath, outfile)
+                return
+
             if orientation is _Orientation.landscape:  # now, ready to rotate
                 width, height = height, width
                 bbox = (lly, llx, ury, urx)

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -254,6 +254,22 @@ def test_linedash():
     assert buf.tell() > 0
 
 
+def test_noembed_fonts():
+    """Test that fonts are not embedded when no text is used"""
+    mpl.rcParams["text.usetex"] = True
+    fig, ax = plt.subplots()
+    ax.set_axis_off()
+
+    # About 160k with embedded fonts
+    buf = io.BytesIO()
+    fig.savefig(buf, format="ps")
+    assert buf.getbuffer().nbytes < 1000
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="eps")
+    assert buf.getbuffer().nbytes < 1000
+
+
 def test_no_duplicate_definition():
 
     fig = Figure()


### PR DESCRIPTION
## PR Summary

Closes #23253

With this, there is no distill to embed psfrags, if there are no psfrags. So smaller files, for the example in #23253 reduced from 161k to 800 bytes. This will primarily only make a difference when usetex=True, e.g. from a style-file, but there is no text in the plot.

I do not really know how to test this properly, but all current tests pass if nothing else.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
