### PR TITLE
Remove `Axes.cla` from examples

### DIFF
--- a/examples/animation/animation_demo.py
+++ b/examples/animation/animation_demo.py
@@ -20,9 +20,9 @@ data = np.random.random((50, 50, 50))
 
 fig, ax = plt.subplots()
 
-for i in range(len(data)):
-    ax.cla()
-    ax.imshow(data[i])
-    ax.set_title("frame {}".format(i))
+for i, img in enumerate(data):
+    ax.clear()
+    ax.imshow(img)
+    ax.set_title(f"frame {i}")
     # Note that using time.sleep does *not* work here!
     plt.pause(0.1)

--- a/examples/event_handling/data_browser.py
+++ b/examples/event_handling/data_browser.py
@@ -75,7 +75,7 @@ class PointBrowser:
 
         dataind = self.lastind
 
-        ax2.cla()
+        ax2.clear()
         ax2.plot(X[dataind])
 
         ax2.text(0.05, 0.9, f'mu={xs[dataind]:1.3f}\nsigma={ys[dataind]:1.3f}',


### PR DESCRIPTION
## PR Summary

Also, minor improvement to animation demo.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).