### PR TITLE
FIX: ensure type stability for missing cmaps in `set_cmap`

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -701,6 +701,6 @@ def _ensure_cmap(cmap):
     """
     if isinstance(cmap, colors.Colormap):
         return cmap
-    return mpl.colormaps[
-        cmap if cmap is not None else mpl.rcParams['image.cmap']
-    ]
+    cmap_name = cmap if cmap is not None else mpl.rcParams["image.cmap"]
+    _api.check_in_list(sorted(_colormaps), cmap=cmap_name)
+    return mpl.colormaps[cmap_name]

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -702,5 +702,7 @@ def _ensure_cmap(cmap):
     if isinstance(cmap, colors.Colormap):
         return cmap
     cmap_name = cmap if cmap is not None else mpl.rcParams["image.cmap"]
+    # use check_in_list to ensure type stability of the exception raised by
+    # the internal usage of this (ValueError vs KeyError)
     _api.check_in_list(sorted(_colormaps), cmap=cmap_name)
     return mpl.colormaps[cmap_name]

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1543,3 +1543,11 @@ def test_color_sequences():
     plt.color_sequences.unregister('rgb')  # multiple unregisters are ok
     with pytest.raises(ValueError, match="Cannot unregister builtin"):
         plt.color_sequences.unregister('tab10')
+
+
+def test_cm_set_cmap_error():
+    sm = cm.ScalarMappable()
+    # Pick a name we are pretty sure will never be a colormap name
+    bad_cmap = 'AardvarksAreAwkward'
+    with pytest.raises(ValueError, match=bad_cmap):
+        sm.set_cmap(bad_cmap)


### PR DESCRIPTION
## PR Summary

Previously this would raise a `ValueError`, the refactor caused it to raise
`KeyError`.   This inadvertently located a bad test in x-array, but restoring
the old behavior.

https://github.com/pydata/xarray/runs/8104117777?check_suite_focus=true#step:8:673


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
