### PR TITLE
Fix TexManager's support for `openin_any = p`

### DIFF
--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,5 +1,8 @@
+import os
 from pathlib import Path
 import re
+import subprocess
+import sys
 
 import matplotlib.pyplot as plt
 from matplotlib.texmanager import TexManager
@@ -57,3 +60,15 @@ def test_unicode_characters():
     with pytest.raises(RuntimeError):
         ax.set_title('\N{SNOWMAN}')
         fig.canvas.draw()
+
+
+@needs_usetex
+def test_openin_any_paranoid():
+    completed = subprocess.run(
+        [sys.executable, "-c",
+         'import matplotlib.pyplot as plt;'
+         'plt.rcParams.update({"text.usetex": True});'
+         'plt.title("paranoid");'
+         'plt.show(block=False);'],
+        env={**os.environ, 'openin_any': 'p'}, check=True, capture_output=True)
+    assert completed.stderr == b""

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -291,12 +291,16 @@ class TexManager:
             # and thus replace() works atomically.  It also allows referring to
             # the texfile with a relative path (for pathological MPLCONFIGDIRs,
             # the absolute path may contain characters (e.g. ~) that TeX does
-            # not support.)
-            with TemporaryDirectory(dir=Path(dvifile).parent) as tmpdir:
+            # not support; n.b. relative paths cannot traverse parents, or it
+            # will be blocked when `openin_any = p` in texmf.cnf).
+            cwd = Path(dvifile).parent
+            with TemporaryDirectory(dir=cwd) as tmpdir:
+                tmppath = Path(tmpdir)
                 cls._run_checked_subprocess(
                     ["latex", "-interaction=nonstopmode", "--halt-on-error",
-                     f"../{texfile.name}"], tex, cwd=tmpdir)
-                (Path(tmpdir) / Path(dvifile).name).replace(dvifile)
+                     f"--output-directory={tmppath.name}",
+                     f"{texfile.name}"], tex, cwd=cwd)
+                (tmppath / Path(dvifile).name).replace(dvifile)
         return dvifile
 
     @classmethod


### PR DESCRIPTION
## PR Summary

Because of the security implications of being able to read/write arbitrary files, even with user permissions, TeX's path resolution system [kpathsea restricts file access](https://www.tug.org/texinfohtml/kpathsea.html#Calling-sequence) by default. While most configs overwrite this with more permissive options, a secure setup (particularly in settings where TeX is being supplied from untrusted inputs) should have `openin_any = p` in the system's `texmf.cnf` or equivalent. This setting disallows, among other things, traversal to parent directories.

PR #21414 worked around a problem with paths that contain `~` by traversing through the parent: https://github.com/matplotlib/matplotlib/blob/25b39d41d3528329b3e5164bbf71feb0d556af80/lib/matplotlib/texmanager.py#L298

That code makes it impossible to use TeX with the default settings, even if the `TEXMFOUTPUT` and `MPLCONFIGDIR` environment variables are set appropriately to allow it. This PR reorganizes access to the same directory structure to use only child directories, which are allowed.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
