### PR TITLE
BUG: fix a regression where tick direction wasn't conserved by Axis.clear()

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -846,6 +846,13 @@ class Axis(martist.Artist):
         return [self.label, self.offsetText,
                 *self.get_major_ticks(), *self.get_minor_ticks()]
 
+    # style parameters that should be preserved by reset operations
+    _style_tick_params = [
+        'tick1On', 'tick2On', 'tickdir',
+        'label1On', 'label2On', 'labelsize', 'labelcolor', 'labelrotation',
+        'size', 'width', 'color', 'pad'
+    ]
+
     def _reset_major_tick_kw(self, keep_tick_and_label_visibility=False):
         """
         Reset major tick params to defaults.
@@ -855,8 +862,7 @@ class Axis(martist.Artist):
         *keep_tick_and_label_visibility*.
         """
         backup = {name: value for name, value in self._major_tick_kw.items()
-                  if name in ['tick1On', 'tick2On', 'tickdir',
-                              'label1On', 'label2On']}
+                  if name in self.__class__._style_tick_params}
         self._major_tick_kw.clear()
         if keep_tick_and_label_visibility:
             self._major_tick_kw.update(backup)
@@ -873,7 +879,7 @@ class Axis(martist.Artist):
         *keep_tick_and_label_visibility*.
         """
         backup = {name: value for name, value in self._minor_tick_kw.items()
-                  if name in ['tick1On', 'tick2On', 'label1On', 'label2On']}
+                  if name in self.__class__._style_tick_params}
         self._minor_tick_kw.clear()
         if keep_tick_and_label_visibility:
             self._minor_tick_kw.update(backup)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -855,7 +855,8 @@ class Axis(martist.Artist):
         *keep_tick_and_label_visibility*.
         """
         backup = {name: value for name, value in self._major_tick_kw.items()
-                  if name in ['tick1On', 'tick2On', 'label1On', 'label2On']}
+                  if name in ['tick1On', 'tick2On', 'tickdir',
+                              'label1On', 'label2On']}
         self._major_tick_kw.clear()
         if keep_tick_and_label_visibility:
             self._major_tick_kw.update(backup)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7666,17 +7666,16 @@ def test_2dcolor_plot(fig_test, fig_ref):
 
 
 @pytest.mark.parametrize(
-    # separate colliding parameters into 2 sets
+    # separate tested parameters into two collision-free sets
+    # (e.g. avoid supplying *color*  and *colors* at the same time)
     'params',
     [
         dict(
-            which='both', axis='both',
             direction='in', length=2, width=5, color="red", pad=0.4,
             bottom=False, top=True, left=False, right=True,
             labelrotation=90, labelsize=20,
         ),
         dict(
-            which='both', axis='both',
             colors="red",
             bottom=True, top=True, left=True, right=True,
             labelbottom=False, labeltop=True, labelleft=False, labelright=True,
@@ -7686,17 +7685,12 @@ def test_2dcolor_plot(fig_test, fig_ref):
 @check_figures_equal(extensions=['png'])
 def test_persistent_style_axes_clear(fig_test, fig_ref, params):
     # see https://github.com/matplotlib/matplotlib/issues/23806
-    prng = np.random.RandomState(0)
-    img = prng.random_sample((8, 8))
-
     ax = fig_ref.subplots(1, 1)
-    ax.tick_params(**params)
-    ax.imshow(img)
+    ax.tick_params(which='both', axis='both', **params)
 
     ax = fig_test.subplots(1, 1)
-    ax.tick_params(**params)
+    ax.tick_params(which='both', axis='both', **params)
     ax.clear()
-    ax.imshow(img)
 
 
 @check_figures_equal(extensions=['png'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7665,15 +7665,38 @@ def test_2dcolor_plot(fig_test, fig_ref):
     axs[4].bar(np.arange(10), np.arange(10), color=color.reshape((1, -1)))
 
 
+@pytest.mark.parametrize(
+    # separate colliding parameters into 2 sets
+    'params',
+    [
+        dict(
+            which='both', axis='both',
+            direction='in', length=2, width=5, color="red", pad=0.4,
+            bottom=False, top=True, left=False, right=True,
+            labelrotation=90, labelsize=20,
+        ),
+        dict(
+            which='both', axis='both',
+            colors="red",
+            bottom=True, top=True, left=True, right=True,
+            labelbottom=False, labeltop=True, labelleft=False, labelright=True,
+        )
+    ]
+)
 @check_figures_equal(extensions=['png'])
-def test_tickdir_axes_clear(fig_test, fig_ref):
+def test_persistent_style_axes_clear(fig_test, fig_ref, params):
     # see https://github.com/matplotlib/matplotlib/issues/23806
+    prng = np.random.RandomState(0)
+    img = prng.random_sample((8, 8))
+
     ax = fig_ref.subplots(1, 1)
-    ax.tick_params(which='both', axis='both', direction='in')
+    ax.tick_params(**params)
+    ax.imshow(img)
 
     ax = fig_test.subplots(1, 1)
-    ax.tick_params(which='both', axis='both', direction='in')
+    ax.tick_params(**params)
     ax.clear()
+    ax.imshow(img)
 
 
 @check_figures_equal(extensions=['png'])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7666,6 +7666,17 @@ def test_2dcolor_plot(fig_test, fig_ref):
 
 
 @check_figures_equal(extensions=['png'])
+def test_tickdir_axes_clear(fig_test, fig_ref):
+    # see https://github.com/matplotlib/matplotlib/issues/23806
+    ax = fig_ref.subplots(1, 1)
+    ax.tick_params(which='both', axis='both', direction='in')
+
+    ax = fig_test.subplots(1, 1)
+    ax.tick_params(which='both', axis='both', direction='in')
+    ax.clear()
+
+
+@check_figures_equal(extensions=['png'])
 def test_shared_axes_clear(fig_test, fig_ref):
     x = np.arange(0.0, 2*np.pi, 0.01)
     y = np.sin(x)


### PR DESCRIPTION
## PR Summary

This is a quick fix for  #23806, assuming the change in behaviour I reported there wasn't intentional

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
