### PR TITLE
Triplot duplicated label

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1299,3 +1299,14 @@ def test_triplot_with_ls(fig_test, fig_ref):
     data = [[0, 1, 2]]
     fig_test.subplots().triplot(x, y, data, ls='--')
     fig_ref.subplots().triplot(x, y, data, linestyle='--')
+    
+    
+@check_figures_equal()
+def test_triplot_label(fig_test, fig_ref):
+    x = [0, 2, 1]
+    y = [0, 0, 1]
+    data = [[0, 1, 2]]
+    fig_test.subplots().triplot(x, y, data, label='label')
+    fig_test.axes[0].legend()
+    fig_ref.subplots().triplot(x, y, data)
+    fig_ref.axes[0].legend(['label'])

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1299,8 +1299,8 @@ def test_triplot_with_ls(fig_test, fig_ref):
     data = [[0, 1, 2]]
     fig_test.subplots().triplot(x, y, data, ls='--')
     fig_ref.subplots().triplot(x, y, data, linestyle='--')
-    
-    
+
+
 @check_figures_equal()
 def test_triplot_label(fig_test, fig_ref):
     x = [0, 2, 1]
@@ -1310,4 +1310,3 @@ def test_triplot_label(fig_test, fig_ref):
     fig_test.axes[0].legend()
     fig_ref.subplots().triplot(x, y, data)
     fig_ref.axes[0].legend(['label'])
-    

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1310,3 +1310,4 @@ def test_triplot_label(fig_test, fig_ref):
     fig_test.axes[0].legend()
     fig_ref.subplots().triplot(x, y, data)
     fig_ref.axes[0].legend(['label'])
+    

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1301,12 +1301,13 @@ def test_triplot_with_ls(fig_test, fig_ref):
     fig_ref.subplots().triplot(x, y, data, linestyle='--')
 
 
-@check_figures_equal()
-def test_triplot_label(fig_test, fig_ref):
+def test_triplot_label():
     x = [0, 2, 1]
     y = [0, 0, 1]
     data = [[0, 1, 2]]
-    fig_test.subplots().triplot(x, y, data, label='label')
-    fig_test.axes[0].legend()
-    fig_ref.subplots().triplot(x, y, data)
-    fig_ref.axes[0].legend(['label'])
+    fig, ax = plt.subplots()
+    lines, markers = ax.triplot(x, y, data, label='label')
+    handles, labels = ax.get_legend_handles_labels()
+    assert labels == ['label']
+    assert len(handles) == 1
+    assert handles[0] is lines

--- a/lib/matplotlib/tri/triplot.py
+++ b/lib/matplotlib/tri/triplot.py
@@ -77,6 +77,7 @@ def triplot(ax, *args, **kwargs):
         **kw,
         'linestyle': 'None',  # No line to draw.
     }
+    kw_markers.pop('label',None)
     if marker not in [None, 'None', '', ' ']:
         tri_markers = ax.plot(x, y, **kw_markers)
     else:

--- a/lib/matplotlib/tri/triplot.py
+++ b/lib/matplotlib/tri/triplot.py
@@ -77,7 +77,7 @@ def triplot(ax, *args, **kwargs):
         **kw,
         'linestyle': 'None',  # No line to draw.
     }
-    kw_markers.pop('label',None)
+    kw_markers.pop('label', None)
     if marker not in [None, 'None', '', ' ']:
         tri_markers = ax.plot(x, y, **kw_markers)
     else:


### PR DESCRIPTION
## PR Summary
This is a fix for bug https://github.com/matplotlib/matplotlib/issues/22965. It pops `label` from `kw` to avoid duplicated labels on `triplot`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
