### PR TITLE
Make `draw_gouraud_triangle` optional and remove unused versions

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -158,7 +158,7 @@ class RendererBase:
 
     * `draw_path`
     * `draw_image`
-    * `draw_gouraud_triangle`
+    * `draw_gouraud_triangle` or `draw_gouraud_triangles`
 
     The following methods *should* be implemented in the backend for
     optimization reasons:
@@ -300,6 +300,11 @@ class RendererBase:
             RGBA colors for each point of the triangle.
         transform : `matplotlib.transforms.Transform`
             An affine transform to apply to the points.
+
+        .. note::
+            It is enough to implement one of `draw_gouraud_triangle` and
+            `draw_gouraud_triangles`. Any `Artist` must call
+            `draw_gouraud_triangles`.
         """
         raise NotImplementedError
 
@@ -316,6 +321,11 @@ class RendererBase:
             Array of *N* RGBA colors for each point of the triangles.
         transform : `matplotlib.transforms.Transform`
             An affine transform to apply to the points.
+
+        .. note::
+            It is enough to implement one of `draw_gouraud_triangle` and
+            `draw_gouraud_triangles`. Any `Artist` must call
+            `draw_gouraud_triangles`.
         """
         transform = transform.frozen()
         for tri, col in zip(triangles_array, colors_array):

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -101,7 +101,6 @@ class RendererAgg(RendererBase):
         self.__init__(state['width'], state['height'], state['dpi'])
 
     def _update_methods(self):
-        self.draw_gouraud_triangle = self._renderer.draw_gouraud_triangle
         self.draw_gouraud_triangles = self._renderer.draw_gouraud_triangles
         self.draw_image = self._renderer.draw_image
         self.draw_markers = self._renderer.draw_markers

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2153,10 +2153,6 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                 lastx, lasty = x, y
         output(Op.grestore)
 
-    def draw_gouraud_triangle(self, gc, points, colors, trans):
-        self.draw_gouraud_triangles(gc, points.reshape((1, 3, 2)),
-                                    colors.reshape((1, 3, 4)), trans)
-
     def draw_gouraud_triangles(self, gc, points, colors, trans):
         assert len(points) == len(colors)
         if len(points) == 0:

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -711,11 +711,6 @@ grestore
         self._pswriter.write("grestore\n")
 
     @_log_if_debug_on
-    def draw_gouraud_triangle(self, gc, points, colors, trans):
-        self.draw_gouraud_triangles(gc, points.reshape((1, 3, 2)),
-                                    colors.reshape((1, 3, 4)), trans)
-
-    @_log_if_debug_on
     def draw_gouraud_triangles(self, gc, points, colors, trans):
         assert len(points) == len(colors)
         assert points.ndim == 3

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2097,7 +2097,7 @@ class QuadMesh(Collection):
         """
         Convert a given mesh into a sequence of triangles, each point
         with its own color.  The result can be used to construct a call to
-        `~.RendererBase.draw_gouraud_triangle`.
+        `~.RendererBase.draw_gouraud_triangles`.
         """
         if isinstance(coordinates, np.ma.MaskedArray):
             p = coordinates.data

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -191,12 +191,6 @@ class RendererAgg
                         ColorArray &edgecolors);
 
     template <class PointArray, class ColorArray>
-    void draw_gouraud_triangle(GCAgg &gc,
-                               PointArray &points,
-                               ColorArray &colors,
-                               agg::trans_affine &trans);
-
-    template <class PointArray, class ColorArray>
     void draw_gouraud_triangles(GCAgg &gc,
                                 PointArray &points,
                                 ColorArray &colors,
@@ -1221,20 +1215,6 @@ inline void RendererAgg::_draw_gouraud_triangle(PointArray &points,
     } else {
         agg::render_scanlines_aa(theRasterizer, slineP8, rendererBase, span_alloc, span_gen);
     }
-}
-
-template <class PointArray, class ColorArray>
-inline void RendererAgg::draw_gouraud_triangle(GCAgg &gc,
-                                               PointArray &points,
-                                               ColorArray &colors,
-                                               agg::trans_affine &trans)
-{
-    theRasterizer.reset_clipping();
-    rendererBase.reset_clipping(true);
-    set_clipbox(gc.cliprect, theRasterizer);
-    bool has_clippath = render_clippath(gc.clippath.path, gc.clippath.trans, gc.snap_mode);
-
-    _draw_gouraud_triangle(points, colors, trans, has_clippath);
 }
 
 template <class PointArray, class ColorArray>

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -422,47 +422,6 @@ static PyObject *PyRendererAgg_draw_quad_mesh(PyRendererAgg *self, PyObject *arg
 }
 
 static PyObject *
-PyRendererAgg_draw_gouraud_triangle(PyRendererAgg *self, PyObject *args)
-{
-    GCAgg gc;
-    numpy::array_view<const double, 2> points;
-    numpy::array_view<const double, 2> colors;
-    agg::trans_affine trans;
-
-    if (!PyArg_ParseTuple(args,
-                          "O&O&O&O&|O:draw_gouraud_triangle",
-                          &convert_gcagg,
-                          &gc,
-                          &points.converter,
-                          &points,
-                          &colors.converter,
-                          &colors,
-                          &convert_trans_affine,
-                          &trans)) {
-        return NULL;
-    }
-
-    if (points.dim(0) != 3 || points.dim(1) != 2) {
-        PyErr_Format(PyExc_ValueError,
-                     "points must be a 3x2 array, got %" NPY_INTP_FMT "x%" NPY_INTP_FMT,
-                     points.dim(0), points.dim(1));
-        return NULL;
-    }
-
-    if (colors.dim(0) != 3 || colors.dim(1) != 4) {
-        PyErr_Format(PyExc_ValueError,
-                     "colors must be a 3x4 array, got %" NPY_INTP_FMT "x%" NPY_INTP_FMT,
-                     colors.dim(0), colors.dim(1));
-        return NULL;
-    }
-
-
-    CALL_CPP("draw_gouraud_triangle", (self->x->draw_gouraud_triangle(gc, points, colors, trans)));
-
-    Py_RETURN_NONE;
-}
-
-static PyObject *
 PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
@@ -594,7 +553,6 @@ static PyTypeObject *PyRendererAgg_init_type()
         {"draw_image", (PyCFunction)PyRendererAgg_draw_image, METH_VARARGS, NULL},
         {"draw_path_collection", (PyCFunction)PyRendererAgg_draw_path_collection, METH_VARARGS, NULL},
         {"draw_quad_mesh", (PyCFunction)PyRendererAgg_draw_quad_mesh, METH_VARARGS, NULL},
-        {"draw_gouraud_triangle", (PyCFunction)PyRendererAgg_draw_gouraud_triangle, METH_VARARGS, NULL},
         {"draw_gouraud_triangles", (PyCFunction)PyRendererAgg_draw_gouraud_triangles, METH_VARARGS, NULL},
 
         {"clear", (PyCFunction)PyRendererAgg_clear, METH_NOARGS, NULL},


### PR DESCRIPTION
## PR Summary

Closes #23819

Clarify that it is enough to implement one of `draw_gouraud_triangle` and `draw_gouraud_triangles` in a backend and that any `Artist` should call the latter.

Remove unused versions of `draw_gouraud_triangle`.

I assume that there should be some sort of note here clarifying the changed behaviour (in practice that any custom artists should call `draw_gouraud_triangles`). Including the example code:
``` python
    def draw_gouraud_triangle(self, gc, points, colors, trans):
        self.draw_gouraud_triangles(gc, points.reshape((1, 3, 2)),
                                    colors.reshape((1, 3, 4)), trans)
```

I do not really see a way to deprecate this, without really deprecating `draw_gouraud_triangle` completely (and instead introduce something like `_draw_gouraud_triangle` which wouldn't really fit well with the general structure). It would be possible to deprecate the now removed versions though. A quick search show that https://github.com/ArduPilot/MAVProxy uses a copy of the backend_agg.py-file which has it included, but that is the only thing I could find which may cause anyone some problem.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
