### PR TITLE
Deprecate draw_gouraud_triangle

### DIFF
--- a/doc/api/next_api_changes/deprecations/23824-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23824-OG.rst
@@ -1,7 +1,7 @@
 ``draw_gouraud_triangle``
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
-... is deprecated as this in most backends is a redundant call. Use
+... is deprecated as in most backends this is a redundant call. Use
 `~.RendererBase.draw_gouraud_triangles` instead. A ``draw_gouraud_triangle``
 call in a custom `~matplotlib.artist.Artist` can readily be replaced as::
 

--- a/doc/api/next_api_changes/deprecations/23824-OG.rst
+++ b/doc/api/next_api_changes/deprecations/23824-OG.rst
@@ -1,0 +1,16 @@
+``draw_gouraud_triangle``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... is deprecated as this in most backends is a redundant call. Use
+`~.RendererBase.draw_gouraud_triangles` instead. A ``draw_gouraud_triangle``
+call in a custom `~matplotlib.artist.Artist` can readily be replaced as::
+
+    self.draw_gouraud_triangles(gc, points.reshape((1, 3, 2)),
+                                colors.reshape((1, 3, 4)), trans)
+
+A `~.RendererBase.draw_gouraud_triangles` method can be implemented from an
+existing ``draw_gouraud_triangle`` method as::
+
+    transform = transform.frozen()
+    for tri, col in zip(triangles_array, colors_array):
+        self.draw_gouraud_triangle(gc, tri, col, transform)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -158,7 +158,7 @@ class RendererBase:
 
     * `draw_path`
     * `draw_image`
-    * `draw_gouraud_triangle`
+    * `draw_gouraud_triangles`
 
     The following methods *should* be implemented in the backend for
     optimization reasons:
@@ -286,6 +286,7 @@ class RendererBase:
             gc, master_transform, paths, [], offsets, offsetTrans, facecolors,
             edgecolors, linewidths, [], [antialiased], [None], 'screen')
 
+    @_api.deprecated("3.7", alternative="draw_gouraud_triangles")
     def draw_gouraud_triangle(self, gc, points, colors, transform):
         """
         Draw a Gouraud-shaded triangle.
@@ -317,9 +318,7 @@ class RendererBase:
         transform : `matplotlib.transforms.Transform`
             An affine transform to apply to the points.
         """
-        transform = transform.frozen()
-        for tri, col in zip(triangles_array, colors_array):
-            self.draw_gouraud_triangle(gc, tri, col, transform)
+        raise NotImplementedError
 
     def _iter_collection_raw_paths(self, master_transform, paths,
                                    all_transforms):

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -801,7 +801,9 @@ class RendererSVG(RendererBase):
 
     def draw_gouraud_triangle(self, gc, points, colors, trans):
         # docstring inherited
+        self._draw_gouraud_triangle(gc, points, colors, trans)
 
+    def _draw_gouraud_triangle(self, gc, points, colors, trans):
         # This uses a method described here:
         #
         #   http://www.svgopen.org/2005/papers/Converting3DFaceToSVG/index.html
@@ -936,7 +938,7 @@ class RendererSVG(RendererBase):
         self.writer.start('g', **self._get_clip_attrs(gc))
         transform = transform.frozen()
         for tri, col in zip(triangles_array, colors_array):
-            self.draw_gouraud_triangle(gc, tri, col, transform)
+            self._draw_gouraud_triangle(gc, tri, col, transform)
         self.writer.end('g')
 
     def option_scale_image(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2097,7 +2097,7 @@ class QuadMesh(Collection):
         """
         Convert a given mesh into a sequence of triangles, each point
         with its own color.  The result can be used to construct a call to
-        `~.RendererBase.draw_gouraud_triangle`.
+        `~.RendererBase.draw_gouraud_triangles`.
         """
         if isinstance(coordinates, np.ma.MaskedArray):
             p = coordinates.data


### PR DESCRIPTION
## PR Summary

Closes #23820 #23819

Main benefit, see more above, is that we can remove code which is now effectively dead.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
