### PR TITLE
Start transitioning to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,48 @@
+[project]
+name = "matplotlib"
+authors = [
+  {email = "matplotlib-users@python.org"},
+  {name = "John D. Hunter, Michael Droettboom"}
+]
+description = "Python plotting package"
+readme = "README.md"
+license = { file = "LICENSE/LICENSE" }
+dynamic = ["version", "optional-dependencies"]
+classifiers=[
+    'Development Status :: 5 - Production/Stable',
+    'Framework :: Matplotlib',
+    'Intended Audience :: Science/Research',
+    'Intended Audience :: Education',
+    'License :: OSI Approved :: Python Software Foundation License',
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.9',
+    'Programming Language :: Python :: 3.10',
+    'Programming Language :: Python :: 3.11',
+    'Topic :: Scientific/Engineering :: Visualization',
+]
+
+# When updating the list of dependencies, add an api_changes/development
+# entry and also update the following places:
+# - lib/matplotlib/__init__.py (matplotlib._check_versions())
+# - requirements/testing/minver.txt
+# - doc/devel/dependencies.rst
+# - .github/workflows/tests.yml
+# - environment.yml
+dependencies = [
+    "contourpy>=1.0.1",
+    "cycler>=0.10",
+    "fonttools>=4.22.0",
+    "kiwisolver>=1.0.1",
+    "numpy>=1.21",
+    "packaging>=20.0",
+    "pillow>=6.2.0",
+    "pyparsing>=2.3.1",
+    "python-dateutil>=2.7",
+    "setuptools_scm>=7.0"
+]
+requires-python = ">=3.9"
+
 [build-system]
 build-backend = "setuptools.build_meta"
 requires = [
@@ -7,7 +52,6 @@ requires = [
     "setuptools_scm>=7",
 ]
 
-
 [tool.isort]
 known_mpltoolkits = "mpl_toolkits"
 known_pydata = "numpy, matplotlib.pyplot"
@@ -15,3 +59,38 @@ known_firstparty = "matplotlib"
 sections = "FUTURE,STDLIB,THIRDPARTY,PYDATA,FIRSTPARTY,MPLTOOLKITS,LOCALFOLDER"
 no_lines_before = "MPLTOOLKITS"
 force_sort_within_sections = true
+
+[tool.setuptools]
+platforms = ["any"]
+py-modules = ["pylab"]
+namespace-packages = ["mpl_toolkits"]
+
+[tool.setuptools.packages.find]
+where = ["lib"]
+include = ["matplotlib*", "mpl_toolkits*"]
+exclude = [
+    "matplotlib.tests*",
+    "mpl_toolkits.axes_grid1.tests*",
+    "mpl_toolkits.axisartist.tests*",
+    "mpl_toolkits.mplot3d.tests*"
+]
+namespaces = false
+
+[tool.setuptools.exclude-package-data]
+"*" = ["*.png", "*.svg"]
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
+local_scheme = "node-and-date"
+write_to = "lib/matplotlib/_version.py"
+parentdir_prefix_version = "matplotlib-"
+fallback_version = "0.0+UNKNOWN"
+
+[project.urls]
+'Homepage' = 'https://matplotlib.org'
+'Download' = 'https://matplotlib.org/stable/users/installing/index.html'
+'Documentation' = 'https://matplotlib.org'
+'Source Code' = 'https://github.com/matplotlib/matplotlib'
+'Bug Tracker' = 'https://github.com/matplotlib/matplotlib/issues'
+'Forum' = 'https://discourse.matplotlib.org/'
+'Donate' = 'https://numfocus.org/donate-to-matplotlib'

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ from pathlib import Path
 import shutil
 import subprocess
 
-from setuptools import setup, find_packages, Distribution, Extension
+from setuptools import setup, Distribution, Extension
 import setuptools.command.build_ext
 import setuptools.command.build_py
 import setuptools.command.sdist
@@ -268,82 +268,15 @@ if not (any('--' + opt in sys.argv
             package_data[key] = list(set(val + package_data[key]))
 
 setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
-    name="matplotlib",
-    description="Python plotting package",
-    author="John D. Hunter, Michael Droettboom",
-    author_email="matplotlib-users@python.org",
-    url="https://matplotlib.org",
-    download_url="https://matplotlib.org/stable/users/installing/index.html",
-    project_urls={
-        'Documentation': 'https://matplotlib.org',
-        'Source Code': 'https://github.com/matplotlib/matplotlib',
-        'Bug Tracker': 'https://github.com/matplotlib/matplotlib/issues',
-        'Forum': 'https://discourse.matplotlib.org/',
-        'Donate': 'https://numfocus.org/donate-to-matplotlib'
-    },
-    long_description=Path("README.md").read_text(encoding="utf-8"),
-    long_description_content_type="text/markdown",
-    license="PSF",
-    platforms="any",
-    classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Framework :: Matplotlib',
-        'Intended Audience :: Science/Research',
-        'Intended Audience :: Education',
-        'License :: OSI Approved :: Python Software Foundation License',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Topic :: Scientific/Engineering :: Visualization',
-    ],
-
-    package_dir={"": "lib"},
-    packages=find_packages("lib"),
-    namespace_packages=["mpl_toolkits"],
-    py_modules=["pylab"],
     # Dummy extension to trigger build_ext, which will swap it out with
     # real extensions that can depend on numpy for the build.
     ext_modules=[Extension("", [])],
     package_data=package_data,
 
-    python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
-    # When updating the list of dependencies, add an api_changes/development
-    # entry and also update the following places:
-    # - lib/matplotlib/__init__.py (matplotlib._check_versions())
-    # - requirements/testing/minver.txt
-    # - doc/devel/dependencies.rst
-    # - .github/workflows/tests.yml
-    # - environment.yml
-    install_requires=[
-        "contourpy>=1.0.1",
-        "cycler>=0.10",
-        "fonttools>=4.22.0",
-        "kiwisolver>=1.0.1",
-        "numpy>=1.21",
-        "packaging>=20.0",
-        "pillow>=6.2.0",
-        "pyparsing>=2.3.1",
-        "python-dateutil>=2.7",
-    ] + (
-        # Installing from a git checkout that is not producing a wheel.
-        ["setuptools_scm>=7"] if (
-            Path(__file__).with_name(".git").exists() and
-            os.environ.get("CIBUILDWHEEL", "0") != "1"
-        ) else []
-    ),
     extras_require={
         ':python_version<"3.10"': [
             "importlib-resources>=3.2.0",
         ],
-    },
-    use_scm_version={
-        "version_scheme": "release-branch-semver",
-        "local_scheme": "node-and-date",
-        "write_to": "lib/matplotlib/_version.py",
-        "parentdir_prefix_version": "matplotlib-",
-        "fallback_version": "0.0+UNKNOWN",
     },
     cmdclass={
         "build_ext": BuildExtraLibraries,


### PR DESCRIPTION
## PR Summary

Related to #23815

Issues: 

``` 
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpheklt6mf.build-lib/matplotlib/mpl-data/matplotlibrc'


              If you are seeing this warning it is very likely that a setuptools
              plugin or customization overrides the `build_py` command, without
              tacking into consideration how editable installs run build steps
              starting from v64.0.0.

              Plugin authors and developers relying on custom build steps are encouraged
              to update their `build_py` implementation considering the information in
              https://setuptools.pypa.io/en/latest/userguide/extension.html
              about editable installs.

              For the time being `setuptools` will silence this error and ignore
              the faulty command, but this behaviour will change in future versions.
```

~Lots of:~
```
  /tmp/pip-build-env-7a9fvqdh/overlay/lib/python3.10/site-packages/setuptools/command/build_py.py:202: SetuptoolsDeprecationWarning:     Installing 'matplotlib.tests.baseline_images.test_polar' as data is deprecated, please list it in `packages`.
      !!


      ############################
      # Package would be ignored #
      ############################
      Python recognizes 'matplotlib.tests.baseline_images.test_polar' as an importable package,
      but it is not listed in the `packages` configuration of setuptools.

      'matplotlib.tests.baseline_images.test_polar' has been automatically added to the distribution only
      because it may contain data files, but this behavior is likely to change
      in future versions of setuptools (and therefore is considered deprecated).

      Please make sure that 'matplotlib.tests.baseline_images.test_polar' is included as a package by using
      the `packages` configuration field or the proper discovery methods
      (for example by using `find_namespace_packages(...)`/`find_namespace:`
      instead of `find_packages(...)`/`find:`).

      You can read more about "package discovery" and "data files" on setuptools
      documentation page.
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
