### PR TITLE
Remove search field from sidebar

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -412,7 +412,6 @@ html_index = 'index.html'
 # Custom sidebar templates, maps page names to templates.
 html_sidebars = {
     "index": [
-        'search-field.html',
         # 'sidebar_announcement.html',
         "sidebar_versions.html",
         "cheatsheet_sidebar.html",


### PR DESCRIPTION
search is now accessible via a button in the nav bar, which opens an overlay search field.