### PR TITLE
Revert "Refactor handling of tick and ticklabel visiblity in Axis.clear"

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -846,36 +846,14 @@ class Axis(martist.Artist):
         return [self.label, self.offsetText,
                 *self.get_major_ticks(), *self.get_minor_ticks()]
 
-    def _reset_major_tick_kw(self, keep_tick_and_label_visibility=False):
-        """
-        Reset major tick params to defaults.
-
-        Shared subplots pre-configure tick and label visibility. To keep this
-        beyond an Axis.clear() operation, we may
-        *keep_tick_and_label_visibility*.
-        """
-        backup = {name: value for name, value in self._major_tick_kw.items()
-                  if name in ['tick1On', 'tick2On', 'label1On', 'label2On']}
+    def _reset_major_tick_kw(self):
         self._major_tick_kw.clear()
-        if keep_tick_and_label_visibility:
-            self._major_tick_kw.update(backup)
         self._major_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'major'))
 
-    def _reset_minor_tick_kw(self, keep_tick_and_label_visibility=False):
-        """
-        Reset minor tick params to defaults.
-
-        Shared subplots pre-configure tick and label visibility. To keep this
-        beyond an Axis.clear() operation, we may
-        *keep_tick_and_label_visibility*.
-        """
-        backup = {name: value for name, value in self._minor_tick_kw.items()
-                  if name in ['tick1On', 'tick2On', 'label1On', 'label2On']}
+    def _reset_minor_tick_kw(self):
         self._minor_tick_kw.clear()
-        if keep_tick_and_label_visibility:
-            self._minor_tick_kw.update(backup)
         self._minor_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
@@ -892,8 +870,6 @@ class Axis(martist.Artist):
         - major and minor grid
         - units
         - registered callbacks
-
-        This does not reset tick and tick label visibility.
         """
         self.label._reset_visual_defaults()
         self.offsetText._reset_visual_defaults()
@@ -908,8 +884,12 @@ class Axis(martist.Artist):
             signals=["units", "units finalize"])
 
         # whether the grids are on
-        self._reset_major_tick_kw(keep_tick_and_label_visibility=True)
-        self._reset_minor_tick_kw(keep_tick_and_label_visibility=True)
+        self._major_tick_kw['gridOn'] = (
+                mpl.rcParams['axes.grid'] and
+                mpl.rcParams['axes.grid.which'] in ('both', 'major'))
+        self._minor_tick_kw['gridOn'] = (
+                mpl.rcParams['axes.grid'] and
+                mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
         self.reset_ticks()
 
         self.converter = None


### PR DESCRIPTION
## PR Summary
This reverts commit 2357c92d87d96d519c8470776e76180e71663d0b. (#22587)

Reversal due to a regression #23808.

Decision on the dev call: We revert this change so that the exact code from 3.5 is still used in 3.6.
We plan to have a full discussion on what `clear()` should do for 3.7.