### PR TITLE
removed single word in documenting doc

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -94,7 +94,7 @@ You can use the ``O`` variable to set additional options:
 * ``make O=-Dplot_formats=png:100 html`` saves figures in low resolution.
 * ``make O=-Dplot_gallery=0 html`` skips the gallery build.
 
-Multiple options can be combined using e.g. ``make O='-j4 -Dplot_gallery=0'
+Multiple options can be combined, e.g. ``make O='-j4 -Dplot_gallery=0'
 html``.
 
 On Windows, either put the arguments at the end of the statement or set the options as environment variables, e.g.:


### PR DESCRIPTION
is basically a typo type thing, removed a `using` that I think stuck around from an old construction.
