### PR TITLE
Fix cross-compiling internal freetype

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -635,7 +635,7 @@ class FreeType(SetupPackage):
                 "--with-png=no", "--with-harfbuzz=no", "--enable-static",
                 "--disable-shared"
             ]
-            host = sysconfig.get_config_var('BUILD_GNU_TYPE')
+            host = sysconfig.get_config_var('HOST_GNU_TYPE')
             if host is not None:  # May be unset on PyPy.
                 configure.append(f"--host={host}")
             subprocess.check_call(configure, env=env, cwd=src_path)


### PR DESCRIPTION
## PR Summary
Instead of passing `BUILD_GNU_TYPE` as the host, it should be `HOST_GNU_TYPE`. This fixes cross-compilation for osx_arm64 on conda-forge. See https://github.com/conda-forge/matplotlib-feedstock/pull/329.

I wasn't able to find any quick documentation for these keys, but [this discussion post](https://discuss.python.org/t/towards-standardizing-cross-compiling/10357) is what clued me in. @QuLogic did you have something else that led you to use `BUILD_GNU_TYPE` when you added it originally?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
