### PR TITLE
DOC: fix deprecation warnings

### DIFF
--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -164,7 +164,7 @@ print(ax.margins())
 
 fig, ax = plt.subplots()
 collection = mpl.collections.StarPolygonCollection(
-    5, 0, [250, ],  # five point star, zero angle, size 250px
+    5, rotation=0, sizes=(250,),  # five point star, zero angle, size 250px
     offsets=np.column_stack([x, y]),  # Set the positions
     offset_transform=ax.transData,  # Propagate transformations of the Axes
 )

--- a/tutorials/introductory/images.py
+++ b/tutorials/introductory/images.py
@@ -245,7 +245,7 @@ plt.colorbar(ticks=[0.1, 0.3, 0.5, 0.7], orientation='horizontal')
 from PIL import Image
 
 img = Image.open('../../doc/_static/stinkbug.png')
-img.thumbnail((64, 64), Image.ANTIALIAS)  # resizes image in-place
+img.thumbnail((64, 64), Image.Resampling.LANCZOS)  # resizes image in-place
 imgplot = plt.imshow(img)
 
 ###############################################################################


### PR DESCRIPTION
## PR Summary

- ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
- Passing the rotation parameter of __init__() positionally is deprecated since Matplotlib 3.6; the parameter will become keyword-only two minor releases later.



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
