### PR TITLE
Correct and improve documentation for anchored artists

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -23,9 +23,9 @@ class AnchoredDrawingArea(AnchoredOffsetbox):
         Parameters
         ----------
         width, height : float
-            width and height of the container, in pixels.
+            Width and height of the container, in pixels.
         xdescent, ydescent : float
-            descent of the container in the x- and y- direction, in pixels.
+            Descent of the container in the x- and y- direction, in pixels.
         loc : str
             Location of this artist.  Valid locations are
             'upper left', 'upper center', 'upper right',
@@ -141,7 +141,7 @@ class AnchoredEllipse(AnchoredOffsetbox):
         angle : float
             Rotation of the ellipse, in degrees, anti-clockwise.
         loc : str
-            Location of this ellipse.  Valid locations are
+            Location of the ellipse.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
             'lower left', 'lower center, 'lower right'.
@@ -191,7 +191,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
         label : str
             Label to display.
         loc : str
-            Location of this ellipse.  Valid locations are
+            Location of the size bar.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
             'lower left', 'lower center, 'lower right'.
@@ -216,7 +216,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
         fontproperties : `matplotlib.font_manager.FontProperties`, optional
             Font properties for the label text.
         fill_bar : bool, optional
-            If True and if size_vertical is nonzero, the size bar will
+            If True and if *size_vertical* is nonzero, the size bar will
             be filled in with the color specified by the size bar.
             Defaults to True if *size_vertical* is greater than
             zero and False otherwise.
@@ -311,7 +311,7 @@ class AnchoredDirectionArrows(AnchoredOffsetbox):
         fontsize : float, default: 0.08
             Size of label strings, given in coordinates of *transform*.
         loc : str, default: 'upper left'
-            Location of this ellipse.  Valid locations are
+            Location of the arrow.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
             'lower left', 'lower center, 'lower right'.

--- a/tutorials/text/annotations.py
+++ b/tutorials/text/annotations.py
@@ -304,10 +304,10 @@ ax.add_artist(at)
 # artists) is known in pixel size during the time of creation. For
 # example, If you want to draw a circle with fixed size of 20 pixel x 20
 # pixel (radius = 10 pixel), you can utilize
-# ``AnchoredDrawingArea``. The instance is created with a size of the
-# drawing area (in pixels), and arbitrary artists can added to the
-# drawing area. Note that the extents of the artists that are added to
-# the drawing area are not related to the placement of the drawing
+# `~mpl_toolkits.axes_grid1.anchored_artists.AnchoredDrawingArea`. The instance
+# is created with a size of the drawing area (in pixels), and arbitrary artists
+# can added to the drawing area. Note that the extents of the artists that are
+# added to the drawing area are not related to the placement of the drawing
 # area itself. Only the initial size matters.
 #
 # The artists that are added to the drawing area should not have a
@@ -330,9 +330,11 @@ ax.add_artist(ada)
 ###############################################################################
 # Sometimes, you want your artists to scale with the data coordinate (or
 # coordinates other than canvas pixels). You can use
-# ``AnchoredAuxTransformBox`` class. This is similar to
-# ``AnchoredDrawingArea`` except that the extent of the artist is
-# determined during the drawing time respecting the specified transform.
+# `~mpl_toolkits.axes_grid1.anchored_artists.AnchoredAuxTransformBox` class.
+# This is similar to
+# `~mpl_toolkits.axes_grid1.anchored_artists.AnchoredDrawingArea` except that
+# the extent of the artist is determined during the drawing time respecting the
+# specified transform.
 #
 # The ellipse in the example below will have width and height
 # corresponding to 0.1 and 0.4 in data coordinates and will be
@@ -441,7 +443,7 @@ ax.add_artist(box)
 # ~~~~~~~~~~~~~~~~~~~~~
 #
 # `.ConnectionPatch` is like an annotation without text. While `~.Axes.annotate`
-# is sufficient in most situations, ``ConnectionPatch`` is useful when you want to
+# is sufficient in most situations, `.ConnectionPatch` is useful when you want to
 # connect points in different axes. ::
 #
 #   from matplotlib.patches import ConnectionPatch
@@ -457,7 +459,7 @@ ax.add_artist(box)
 #    :target: ../../gallery/userdemo/connect_simple01.html
 #    :align: center
 #
-# Here, we added the ``ConnectionPatch`` to the *figure* (with `~.Figure.add_artist`)
+# Here, we added the `.ConnectionPatch` to the *figure* (with `~.Figure.add_artist`)
 # rather than to either axes: this ensures that it is drawn on top of both axes,
 # and is also necessary if using :doc:`constrained_layout
 # </tutorials/intermediate/constrainedlayout_guide>` for positioning the axes.
@@ -468,7 +470,7 @@ ax.add_artist(box)
 # Zoom effect between Axes
 # ~~~~~~~~~~~~~~~~~~~~~~~~
 #
-# ``mpl_toolkits.axes_grid1.inset_locator`` defines some patch classes useful for
+# `mpl_toolkits.axes_grid1.inset_locator` defines some patch classes useful for
 # interconnecting two axes. Understanding the code requires some knowledge of
 # Matplotlib's transform system.
 #


### PR DESCRIPTION
## PR Summary

Correct doc-strings and add links in tutorial.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
