### PR TITLE
Add test and example for VBoxDivider

### DIFF
--- a/examples/axes_grid1/demo_axes_vbox_divider.py
+++ b/examples/axes_grid1/demo_axes_vbox_divider.py
@@ -1,0 +1,43 @@
+"""
+===================
+`.VBoxDivider` demo
+===================
+
+Using an `.VBoxDivider` to arrange subplots.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+from mpl_toolkits.axes_grid1.axes_divider import VBoxDivider
+import mpl_toolkits.axes_grid1.axes_size as Size
+
+
+def make_widths_equal(fig, rect, ax1, ax2, pad):
+    # pad in inches
+    divider = VBoxDivider(
+        fig, rect,
+        horizontal=[Size.AxesX(ax1), Size.Scaled(1), Size.AxesX(ax2)],
+        vertical=[Size.AxesY(ax1), Size.Fixed(pad), Size.AxesY(ax2)])
+    ax1.set_axes_locator(divider.new_locator(0))
+    ax2.set_axes_locator(divider.new_locator(2))
+
+
+if __name__ == "__main__":
+
+    arr1 = np.arange(20).reshape((4, 5))
+    arr2 = np.arange(20).reshape((5, 4))
+
+    fig, (ax1, ax2) = plt.subplots(2, 1)
+    ax1.imshow(arr1)
+    ax2.imshow(arr2)
+
+    make_widths_equal(fig, 111, ax1, ax2, pad=0.5)
+
+    fig.text(.5, .5,
+             "Both axes' location are adjusted\n"
+             "so that they have equal widths\n"
+             "while maintaining their aspect ratios",
+             va="center", ha="center", rotation=90,
+             bbox=dict(boxstyle="round, pad=1", facecolor="w"))
+
+    plt.show()

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -17,7 +17,7 @@ from mpl_toolkits.axes_grid1 import (
 from mpl_toolkits.axes_grid1.anchored_artists import (
     AnchoredSizeBar, AnchoredDirectionArrows)
 from mpl_toolkits.axes_grid1.axes_divider import (
-    Divider, HBoxDivider, make_axes_area_auto_adjustable)
+    Divider, HBoxDivider, make_axes_area_auto_adjustable, VBoxDivider)
 from mpl_toolkits.axes_grid1.axes_rgb import RGBAxes
 from mpl_toolkits.axes_grid1.inset_locator import (
     zoomed_inset_axes, mark_inset, inset_axes, BboxConnectorPatch)
@@ -476,6 +476,29 @@ def test_hbox_divider():
     p2 = ax2.get_position()
     assert p1.height == p2.height
     assert p2.width / p1.width == pytest.approx((4 / 5) ** 2)
+
+
+def test_vbox_divider():
+    arr1 = np.arange(20).reshape((4, 5))
+    arr2 = np.arange(20).reshape((5, 4))
+
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+    ax1.imshow(arr1)
+    ax2.imshow(arr2)
+
+    pad = 0.5  # inches.
+    divider = VBoxDivider(
+        fig, 111,  # Position of combined axes.
+        horizontal=[Size.AxesX(ax1), Size.Scaled(1), Size.AxesX(ax2)],
+        vertical=[Size.AxesY(ax1), Size.Fixed(pad), Size.AxesY(ax2)])
+    ax1.set_axes_locator(divider.new_locator(0))
+    ax2.set_axes_locator(divider.new_locator(2))
+
+    fig.canvas.draw()
+    p1 = ax1.get_position()
+    p2 = ax2.get_position()
+    assert p1.width == p2.width
+    assert p1.height / p2.height == pytest.approx((4 / 5) ** 2)
 
 
 def test_axes_class_tuple():


### PR DESCRIPTION
## PR Summary

VBoxDivider was not tested earlier.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
