### PR TITLE
DOC: fix deprecation warnings in examples

### DIFF
--- a/examples/mplot3d/box3d.py
+++ b/examples/mplot3d/box3d.py
@@ -67,9 +67,9 @@ ax.set(
     zticks=[0, -150, -300, -450],
 )
 
-# Set distance and angle view
+# Set zoom and angle view
 ax.view_init(40, -30, 0)
-ax.dist = 11
+ax.set_box_aspect(None, zoom=0.9)
 
 # Colorbar
 fig.colorbar(C, ax=ax, fraction=0.02, pad=0.1, label='Name [units]')

--- a/examples/shapes_and_collections/artist_reference.py
+++ b/examples/shapes_and_collections/artist_reference.py
@@ -45,7 +45,7 @@ patches.append(wedge)
 label(grid[2], "Wedge")
 
 # add a Polygon
-polygon = mpatches.RegularPolygon(grid[3], 5, 0.1)
+polygon = mpatches.RegularPolygon(grid[3], 5, radius=0.1)
 patches.append(polygon)
 label(grid[3], "Polygon")
 

--- a/examples/shapes_and_collections/patch_collection.py
+++ b/examples/shapes_and_collections/patch_collection.py
@@ -45,7 +45,7 @@ patches += [
 ]
 
 for i in range(N):
-    polygon = Polygon(np.random.rand(N, 2), True)
+    polygon = Polygon(np.random.rand(N, 2), closed=True)
     patches.append(polygon)
 
 colors = 100 * np.random.rand(len(patches))

--- a/examples/specialty_plots/leftventricle_bulleye.py
+++ b/examples/specialty_plots/leftventricle_bulleye.py
@@ -56,6 +56,9 @@ def bullseye_plot(ax, data, seg_bold=None, cmap=None, norm=None):
     theta = np.linspace(0, 2 * np.pi, 768)
     r = np.linspace(0.2, 1, 4)
 
+    # Remove grid
+    ax.grid(False)
+
     # Create the bound for the segment 17
     for i in range(r.shape[0]):
         ax.plot(theta, np.repeat(r[i], theta.shape), '-k', lw=linewidth)

--- a/examples/text_labels_and_annotations/figlegend_demo.py
+++ b/examples/text_labels_and_annotations/figlegend_demo.py
@@ -23,8 +23,8 @@ y4 = np.exp(-2 * x)
 l3, = axs[1].plot(x, y3, color='tab:green')
 l4, = axs[1].plot(x, y4, color='tab:red', marker='^')
 
-fig.legend((l1, l2), ('Line 1', 'Line 2'), 'upper left')
-fig.legend((l3, l4), ('Line 3', 'Line 4'), 'upper right')
+fig.legend((l1, l2), ('Line 1', 'Line 2'), loc='upper left')
+fig.legend((l3, l4), ('Line 3', 'Line 4'), loc='upper right')
 
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
## PR Summary

- The dist attribute was deprecated in Matplotlib 3.6 and will be removed two minor releases later.
- Passing the loc parameter of __init__() positionally is deprecated since Matplotlib 3.6; the parameter will become keyword-only two minor releases later.
- Passing the radius parameter of __init__() positionally is deprecated since Matplotlib 3.6; the parameter will become keyword-only two minor releases later.
- Passing the closed parameter of __init__() positionally is deprecated since Matplotlib 3.6; the parameter will become keyword-only two minor releases later.
- Auto-removal of grids by pcolor() and pcolormesh() is deprecated since 3.5 and will be removed two minor releases later; please call grid(False) first.

(#23855 was for the tutorials, this is for the examples, sorry - I didn't notice it first that there were deprecations in the examples too)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
