### PR TITLE
Show errors and warnings in doc CI after build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,13 +141,31 @@ commands:
                [ "$CIRCLE_PR_NUMBER" = "" ]; then
               export RELEASE_TAG='-t release'
             fi
-            make html O="-T $RELEASE_TAG -j4"
+            make html O="-T $RELEASE_TAG -j4 -w /tmp/sphinxerrorswarnings.log"
             rm -r build/html/_sources
           working_directory: doc
       - save_cache:
           key: sphinx-env-v1-{{ .BuildNum }}-{{ .Environment.CIRCLE_JOB }}
           paths:
             - doc/build/doctrees
+
+  doc-show-errors-warnings:
+    steps:
+      - run:
+          name: Extract possible build errors and warnings
+          command: |
+           (grep "WARNING\|ERROR" /tmp/sphinxerrorswarnings.log ||
+            echo "No errors or warnings")
+
+  doc-show-deprecations:
+    steps:
+      - run:
+          name: Extract possible deprecation warnings in examples and tutorials
+          command: |
+           (grep DeprecationWarning -r -l doc/build/html/gallery ||
+            echo "No deprecation warnings in gallery")
+           (grep DeprecationWarning -r -l doc/build/html/tutorials ||
+            echo "No deprecation warnings in tutorials")
 
   doc-bundle:
     steps:
@@ -186,6 +204,8 @@ jobs:
       - doc-deps-install
 
       - doc-build
+      - doc-show-errors-warnings
+      - doc-show-deprecations
 
       - doc-bundle
 

--- a/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -54,11 +54,10 @@ _annotate(ax, x, y, "shading='flat'")
 # -----------------------------
 #
 # Often, however, data is provided where *X* and *Y* match the shape of *Z*.
-# While this makes sense for other ``shading`` types, it is no longer permitted
-# when ``shading='flat'`` (and will raise a MatplotlibDeprecationWarning as of
-# Matplotlib v3.3). Historically, Matplotlib silently dropped the last row and
-# column of *Z* in this case, to match Matlab's behavior. If this behavior is
-# still desired, simply drop the last row and column manually:
+# While this makes sense for other ``shading`` types, it is not permitted
+# when ``shading='flat'``. Historically, Matplotlib silently dropped the last
+# row and column of *Z* in this case, to match Matlab's behavior. If this
+# behavior is still desired, simply drop the last row and column manually:
 
 x = np.arange(ncols)  # note *not* ncols + 1 as before
 y = np.arange(nrows)

--- a/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -52,9 +52,8 @@ ax.pcolormesh(X, Y, Z)
 # Often a user wants to pass *X* and *Y* with the same sizes as *Z* to
 # `.axes.Axes.pcolormesh`. This is also allowed if ``shading='auto'`` is
 # passed (default set by :rc:`pcolor.shading`). Pre Matplotlib 3.3,
-# ``shading='flat'`` would drop the last column and row of *Z*; while that
-# is still allowed for back compatibility purposes, a DeprecationWarning is
-# raised. If this is really what you want, then simply drop the last row and
+# ``shading='flat'`` would drop the last column and row of *Z*, but now gives
+# an error. If this is really what you want, then simply drop the last row and
 # column of Z manually:
 
 x = np.arange(10)  # len = 10


### PR DESCRIPTION
## PR Summary

Adds a separate step that summarized the warnings and errors during documentation build.

Adds a step which checks for deprecation warnings in examples and tutorials.

I'm quite sure that there is an issue for that which I cannot find, but ideally this should be fed back to GitHub as a comment so it will still not be closed.

Anyway, this should help a bit as it is easier than scrolling back in the very long log (and some messages may have disappeared...).

Helps with #23866 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
