### PR TITLE
Expire parameter renaming and deletion and attribute privatization from 3.5

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3195,7 +3195,6 @@ class _AxesBase(martist.Artist):
         self.stale = True
 
     @_docstring.dedent_interpd
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=None, which='major', axis='both', **kwargs):
         """
         Configure the grid lines.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1553,7 +1553,6 @@ class Axis(martist.Artist):
 
         return self.minorTicks[:numticks]
 
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=None, which='major', **kwargs):
         """
         Configure the grid lines.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -449,8 +449,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         """
         return self.renderer.buffer_rgba()
 
-    @_api.delete_parameter("3.5", "args")
-    def print_raw(self, filename_or_obj, *args):
+    def print_raw(self, filename_or_obj):
         FigureCanvasAgg.draw(self)
         renderer = self.get_renderer()
         with cbook.open_file_cm(filename_or_obj, "wb") as fh:
@@ -468,8 +467,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             filename_or_obj, self.buffer_rgba(), format=fmt, origin="upper",
             dpi=self.figure.dpi, metadata=metadata, pil_kwargs=pil_kwargs)
 
-    @_api.delete_parameter("3.5", "args")
-    def print_png(self, filename_or_obj, *args,
+    def print_png(self, filename_or_obj,
                   metadata=None, pil_kwargs=None):
         """
         Write the figure to a PNG file.
@@ -529,8 +527,7 @@ class FigureCanvasAgg(FigureCanvasBase):
     # print_figure(), and the latter ensures that `self.figure.dpi` already
     # matches the dpi kwarg (if any).
 
-    @_api.delete_parameter("3.5", "args")
-    def print_jpg(self, filename_or_obj, *args, pil_kwargs=None):
+    def print_jpg(self, filename_or_obj, pil_kwargs=None):
         # savefig() has already applied savefig.facecolor; we now set it to
         # white to make imsave() blend semi-transparent figures against an
         # assumed white background.

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -828,11 +828,9 @@ class FigureCanvasPS(FigureCanvasBase):
     def get_default_filetype(self):
         return 'ps'
 
-    @_api.delete_parameter("3.5", "args")
     def _print_ps(
-            self, fmt, outfile, *args,
-            metadata=None, papertype=None, orientation='portrait',
-            **kwargs):
+            self, fmt, outfile, metadata=None, papertype=None,
+            orientation='portrait', **kwargs):
 
         dpi = self.figure.dpi
         self.figure.dpi = 72  # Override the dpi kwarg

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1314,8 +1314,7 @@ class FigureCanvasSVG(FigureCanvasBase):
 
     fixed_dpi = 72
 
-    @_api.delete_parameter("3.5", "args")
-    def print_svg(self, filename, *args, bbox_inches_restore=None,
+    def print_svg(self, filename, bbox_inches_restore=None,
                   metadata=None):
         """
         Parameters
@@ -1362,8 +1361,7 @@ class FigureCanvasSVG(FigureCanvasBase):
             self.figure.draw(renderer)
             renderer.finalize()
 
-    @_api.delete_parameter("3.5", "args")
-    def print_svgz(self, filename, *args, **kwargs):
+    def print_svgz(self, filename, **kwargs):
         with cbook.open_file_cm(filename, "wb") as fh, \
                 gzip.GzipFile(mode='w', fileobj=fh) as gzipwriter:
             return self.print_svg(gzipwriter, **kwargs)

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -197,8 +197,7 @@ class FigureCanvasTemplate(FigureCanvasBase):
     # you should add it to the class-scope filetypes dictionary as follows:
     filetypes = {**FigureCanvasBase.filetypes, 'foo': 'My magic Foo format'}
 
-    @_api.delete_parameter("3.5", "args")
-    def print_foo(self, filename, *args, **kwargs):
+    def print_foo(self, filename, **kwargs):
         """
         Write out format foo.
 

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -389,8 +389,6 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
         if name_of_method in _ALLOWED_TOOL_ITEMS
     ]
 
-    cursor = _api.deprecate_privatize_attribute("3.5")
-
     def __init__(self, canvas):
         self.message = ''
         self._cursor = None  # Remove with deprecation.

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -353,11 +353,6 @@ class Colorbar:
         for spine in self.ax.spines.values():
             spine.set_visible(False)
         self.outline = self.ax.spines['outline'] = _ColorbarSpine(self.ax)
-        # Only kept for backcompat; remove after deprecation of .patch elapses.
-        self._patch = mpatches.Polygon(
-            np.empty((0, 2)),
-            color=mpl.rcParams['axes.facecolor'], linewidth=0.01, zorder=-1)
-        ax.add_artist(self._patch)
 
         self.dividers = collections.LineCollection(
             [],
@@ -465,9 +460,6 @@ class Colorbar:
         # We now restore the old cla() back and can call it directly
         del self.ax.cla
         self.ax.cla()
-
-    # Also remove ._patch after deprecation elapses.
-    patch = _api.deprecate_privatize_attribute("3.5", alternative="ax")
 
     filled = _api.deprecate_privatize_attribute("3.6")
 
@@ -849,8 +841,7 @@ class Colorbar:
         self._minorlocator = minorlocator
         _log.debug('locator: %r', locator)
 
-    @_api.delete_parameter("3.5", "update_ticks")
-    def set_ticks(self, ticks, update_ticks=True, labels=None, *,
+    def set_ticks(self, ticks, labels=None, *,
                   minor=False, **kwargs):
         """
         Set tick locations.
@@ -890,8 +881,7 @@ class Colorbar:
         else:
             return self._long_axis().get_majorticklocs()
 
-    @_api.delete_parameter("3.5", "update_ticks")
-    def set_ticklabels(self, ticklabels, update_ticks=True, *, minor=False,
+    def set_ticklabels(self, ticklabels, *, minor=False,
                        **kwargs):
         """
         [*Discouraged*] Set tick labels.

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1028,8 +1028,7 @@ class _LuatexKpsewhich:
 
 
 @lru_cache()
-@_api.delete_parameter("3.5", "format")
-def _find_tex_file(filename, format=None):
+def _find_tex_file(filename):
     """
     Find a file in the texmf tree using kpathsea_.
 
@@ -1057,15 +1056,13 @@ def _find_tex_file(filename, format=None):
     # out of caution
     if isinstance(filename, bytes):
         filename = filename.decode('utf-8', errors='replace')
-    if isinstance(format, bytes):
-        format = format.decode('utf-8', errors='replace')
 
     try:
         lk = _LuatexKpsewhich()
     except FileNotFoundError:
         lk = None  # Fallback to directly calling kpsewhich, as below.
 
-    if lk and format is None:
+    if lk:
         path = lk.search(filename)
 
     else:
@@ -1079,10 +1076,7 @@ def _find_tex_file(filename, format=None):
             kwargs = {'encoding': sys.getfilesystemencoding(),
                       'errors': 'surrogateescape'}
 
-        cmd = ['kpsewhich']
-        if format is not None:
-            cmd += ['--format=' + format]
-        cmd += [filename]
+        cmd = ['kpsewhich', filename]
         try:
             path = (cbook._check_and_log_subprocess(cmd, _log, **kwargs)
                     .rstrip('\n'))
@@ -1099,11 +1093,9 @@ def _find_tex_file(filename, format=None):
 
 # After the deprecation period elapses, delete this shim and rename
 # _find_tex_file to find_tex_file everywhere.
-@_api.delete_parameter("3.5", "format")
-def find_tex_file(filename, format=None):
+def find_tex_file(filename):
     try:
-        return (_find_tex_file(filename, format) if format is not None else
-                _find_tex_file(filename))
+        return _find_tex_file(filename)
     except FileNotFoundError as exc:
         _api.warn_deprecated(
             "3.6", message=f"{exc.args[0]}; in the future, this will raise a "

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -121,26 +121,21 @@ class SubplotParams:
             The height of the padding between subplots,
             as a fraction of the average Axes height.
         """
-        self._validate = True
         for key in ["left", "bottom", "right", "top", "wspace", "hspace"]:
             setattr(self, key, mpl.rcParams[f"figure.subplot.{key}"])
         self.update(left, bottom, right, top, wspace, hspace)
-
-    # Also remove _validate after deprecation elapses.
-    validate = _api.deprecate_privatize_attribute("3.5")
 
     def update(self, left=None, bottom=None, right=None, top=None,
                wspace=None, hspace=None):
         """
         Update the dimensions of the passed parameters. *None* means unchanged.
         """
-        if self._validate:
-            if ((left if left is not None else self.left)
-                    >= (right if right is not None else self.right)):
-                raise ValueError('left cannot be >= right')
-            if ((bottom if bottom is not None else self.bottom)
-                    >= (top if top is not None else self.top)):
-                raise ValueError('bottom cannot be >= top')
+        if ((left if left is not None else self.left)
+                >= (right if right is not None else self.right)):
+            raise ValueError('left cannot be >= right')
+        if ((bottom if bottom is not None else self.bottom)
+                >= (top if top is not None else self.top)):
+            raise ValueError('bottom cannot be >= top')
         if left is not None:
             self.left = left
         if right is not None:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3853,11 +3853,8 @@ class FancyBboxPatch(Patch):
 
     @_docstring.dedent_interpd
     @_api.make_keyword_only("3.6", name="mutation_scale")
-    @_api.delete_parameter("3.4", "bbox_transmuter", alternative="boxstyle")
-    def __init__(self, xy, width, height,
-                 boxstyle="round", bbox_transmuter=None,
-                 mutation_scale=1, mutation_aspect=1,
-                 **kwargs):
+    def __init__(self, xy, width, height, boxstyle="round", mutation_scale=1,
+                 mutation_aspect=1, **kwargs):
         """
         Parameters
         ----------
@@ -3905,17 +3902,7 @@ class FancyBboxPatch(Patch):
         self._width = width
         self._height = height
 
-        if boxstyle == "custom":
-            _api.warn_deprecated(
-                "3.4", message="Support for boxstyle='custom' is deprecated "
-                "since %(since)s and will be removed %(removal)s; directly "
-                "pass a boxstyle instance as the boxstyle parameter instead.")
-            if bbox_transmuter is None:
-                raise ValueError("bbox_transmuter argument is needed with "
-                                 "custom boxstyle")
-            self._bbox_transmuter = bbox_transmuter
-        else:
-            self.set_boxstyle(boxstyle)
+        self.set_boxstyle(boxstyle)
 
         self._mutation_scale = mutation_scale
         self._mutation_aspect = mutation_aspect
@@ -4435,10 +4422,6 @@ default: 'arc3'
             self.get_mutation_aspect())
 
         return _path, fillable
-
-    get_path_in_displaycoord = _api.deprecate_privatize_attribute(
-        "3.5",
-        alternative="self.get_transform().transform_path(self.get_path())")
 
     def draw(self, renderer):
         if not self.get_visible():

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -100,11 +100,6 @@ class TexManager:
         'computer modern typewriter': 'monospace',
     }
 
-    grey_arrayd = _api.deprecate_privatize_attribute("3.5")
-    font_family = _api.deprecate_privatize_attribute("3.5")
-    font_families = _api.deprecate_privatize_attribute("3.5")
-    font_info = _api.deprecate_privatize_attribute("3.5")
-
     @functools.lru_cache()  # Always return the same instance.
     def __new__(cls):
         Path(cls.texcache).mkdir(parents=True, exist_ok=True)

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -492,8 +492,7 @@ class AxesDivider(Divider):
         ax.set_axes_locator(locator)
         return ax
 
-    @_api.delete_parameter("3.5", "add_to_figure", alternative="ax.remove()")
-    def append_axes(self, position, size, pad=None, add_to_figure=True, *,
+    def append_axes(self, position, size, pad=None, *,
                     axes_class=None, **kwargs):
         """
         Add a new axes on a given side of the main axes.
@@ -524,8 +523,6 @@ class AxesDivider(Divider):
         }, position=position)
         ax = create_axes(
             size, pad, pack_start=pack_start, axes_class=axes_class, **kwargs)
-        if add_to_figure:
-            self._fig.add_axes(ax)
         return ax
 
     def get_aspect(self):

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -513,7 +513,6 @@ class Axes(maxes.Axes):
     def get_grid_helper(self):
         return self._grid_helper
 
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=None, which='major', axis="both", **kwargs):
         """
         Toggle the gridlines, and optionally set the properties of the lines.

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -66,8 +66,6 @@ class FixedAxisArtistHelper(AxisArtistHelper.Fixed):
 
 
 class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
-    grid_info = _api.deprecate_privatize_attribute("3.5")
-
     def __init__(self, grid_helper, nth_coord, value, axis_direction=None):
         """
         nth_coord = along which coordinate value varies.
@@ -252,8 +250,6 @@ class FloatingAxisArtistHelper(AxisArtistHelper.Floating):
 
 
 class GridHelperCurveLinear(GridHelperBase):
-    grid_info = _api.deprecate_privatize_attribute("3.5")
-
     def __init__(self, aux_trans,
                  extreme_finder=None,
                  grid_locator1=None,

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1187,7 +1187,6 @@ class Axes3D(Axes):
         self._frameon = bool(b)
         self.stale = True
 
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=True, **kwargs):
         """
         Set / unset 3D grid.


### PR DESCRIPTION
## PR Summary

Will add a (quite long) release note.

Skipped widgets.py as it was a bit confusing at stages. But apart from that all renaming, deletion and privatization should be gone.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
