### PR TITLE
[mplot3d] Add custom values for determining colors in trisurf

### DIFF
--- a/doc/users/next_whats_new/colored_trisurf.rst
+++ b/doc/users/next_whats_new/colored_trisurf.rst
@@ -1,0 +1,35 @@
+3D Trisurf plots can now have colors and allow color-maps
+---------------------------------------------------------
+
+We can now show custom properties on triangle surface in 3D color coded.
+You can provide an array of one value per vertex OR one value per face.
+The faces will then be painted based on a color map. If one value per vertex
+is specified (this is probably the default case, as we usually know data only on
+the vertices) the vertex values will be averaged over the face an then color-mapped.
+
+Now also shading of colored trisurfs is added. Before it was only possible for uniformly
+colored meshes. This might not be what you want on colormaps, so the default is off.
+
+.. plot::
+    :include-source: true
+
+    import numpy as np
+    import matplotlib.tri as mtri
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+
+    # Create a parametric sphere
+    r = np.linspace(0, np.pi, 50)
+    phi = np.linspace(-np.pi, np.pi, 50)
+    r, phi = np.meshgrid(r, phi)
+    r, phi = r.flatten(), phi.flatten()
+    tri = mtri.Triangulation(r, phi)
+
+    x = np.sin(r)*np.cos(phi)
+    y = np.sin(r)*np.sin(phi)
+    z = np.cos(r)
+
+    ax = fig.add_subplot(projection='3d')
+    ax.plot_trisurf(x, y, z, triangles=tri.triangles, c=phi, cmap=plt.cm.get_cmap('terrain'))
+    plt.show()

--- a/doc/users/next_whats_new/colored_trisurf.rst
+++ b/doc/users/next_whats_new/colored_trisurf.rst
@@ -31,5 +31,5 @@ colored meshes. This might not be what you want on colormaps, so the default is 
     z = np.cos(r)
 
     ax = fig.add_subplot(projection='3d')
-    ax.plot_trisurf(x, y, z, triangles=tri.triangles, c=phi, cmap=plt.cm.get_cmap('terrain'))
+    ax.plot_trisurf(x, y, z, triangles=tri.triangles, C=phi, cmap=plt.cm.get_cmap('terrain'))
     plt.show()

--- a/examples/mplot3d/trisurf3d_3.py
+++ b/examples/mplot3d/trisurf3d_3.py
@@ -28,7 +28,7 @@ ax = fig.add_subplot(projection='3d')
 ax.plot_trisurf(x, y, z,
                 triangles=tri.triangles,
                 cmap=plt.colormaps['terrain'],
-                c=np.sin(2*phi)*(r - np.pi/2),
+                C=np.sin(2*phi)*(r - np.pi/2),
                 shade=True)
 
 fig.tight_layout()

--- a/examples/mplot3d/trisurf3d_3.py
+++ b/examples/mplot3d/trisurf3d_3.py
@@ -1,0 +1,35 @@
+"""
+===========================
+Colored triangular 3D surfaces
+===========================
+
+This shows how to do colored trisurf plots.
+
+"""
+
+import numpy as np
+import matplotlib.tri as mtri
+import matplotlib.pyplot as plt
+
+fig = plt.figure()
+
+# Create a parametric sphere
+r = np.linspace(0, np.pi, 50)
+phi = np.linspace(-np.pi, np.pi, 50)
+r, phi = np.meshgrid(r, phi)
+r, phi = r.flatten(), phi.flatten()
+tri = mtri.Triangulation(r, phi)
+
+x = np.sin(r)*np.cos(phi)
+y = np.sin(r)*np.sin(phi)
+z = np.cos(r)
+
+ax = fig.add_subplot(projection='3d')
+ax.plot_trisurf(x, y, z,
+                triangles=tri.triangles,
+                cmap=plt.colormaps['terrain'],
+                c=np.sin(2*phi)*(r - np.pi/2),
+                shade=True)
+
+fig.tight_layout()
+plt.show()

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -45,7 +45,7 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
         number of points and triangles in the triangulation it is assumed that
         color values are defined at points; to force the use of color values at
         triangles use the keyword argument ``facecolors=C`` instead of just
-        ``C``.
+        ``C``. The values in C will be color-mapped.
         This parameter is position-only.
     facecolors : array-like, optional
         Can be used alternatively to *C* to specify colors at the triangle

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1733,7 +1733,7 @@ class Axes3D(Axes):
         return linec
 
     def plot_trisurf(self, *args, color=None, norm=None, vmin=None, vmax=None,
-                     lightsource=None, **kwargs):
+                     values=None, lightsource=None, **kwargs):
         """
         Plot a triangulated surface.
 
@@ -1770,6 +1770,9 @@ class Axes3D(Axes):
             An instance of Normalize to map values to colors.
         vmin, vmax : float, default: None
             Minimum and maximum value to map.
+        values : array-like, default: None
+            Values used to determine the colors via the colormap. Only works
+            if cmap is specified. Defaults to z-positions of the vertices.
         shade : bool, default: True
             Whether to shade the facecolors.  Shading is always disabled when
             *cmap* is specified.
@@ -1813,9 +1816,16 @@ class Axes3D(Axes):
         polyc = art3d.Poly3DCollection(verts, *args, **kwargs)
 
         if cmap:
-            # average over the three points of each triangle
-            avg_z = verts[:, :, 2].mean(axis=1)
-            polyc.set_array(avg_z)
+            if values is None: # Use z-pos as default
+                # average over the three points of each triangle
+                avg_z = verts[:, :, 2].mean(axis=1)
+                polyc.set_array(avg_z)
+            else:
+                values = np.asarray(values)
+                if values.shape[0] != z.shape[0]:
+                    raise ValueError("You must provide one value per vertex")
+                values_tri = values[triangles]
+                polyc.set_array(values_tri.mean(axis=1))
             if vmin is not None or vmax is not None:
                 polyc.set_clim(vmin, vmax)
             if norm is not None:

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1816,7 +1816,7 @@ class Axes3D(Axes):
         polyc = art3d.Poly3DCollection(verts, *args, **kwargs)
 
         if cmap:
-            if values is None: # Use z-pos as default
+            if values is None:  # Use z-pos as default
                 # average over the three points of each triangle
                 avg_z = verts[:, :, 2].mean(axis=1)
                 polyc.set_array(avg_z)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1733,7 +1733,7 @@ class Axes3D(Axes):
         return linec
 
     def plot_trisurf(self, *args, color=None, norm=None, vmin=None, vmax=None,
-                     c=None, facecolors=None, lightsource=None, **kwargs):
+                     C=None, facecolors=None, lightsource=None, **kwargs):
         """
         Plot a triangulated surface.
 
@@ -1771,19 +1771,17 @@ class Axes3D(Axes):
             An instance of Normalize to map values to colors.
         vmin, vmax : float, default: None
             Minimum and maximum value to map.
-        c : array-like, default: None
+        C : array-like, default: None
             Values or colors used to determine face colors. If cmap is
             specified the values will be color-mapped before the faces are
             painted. If there is one value/color per vertex, these will be
             averaged over each triangle to determine face colors. Defaults to
             the z-coordinate of vertices. This keyword argument resembles the
-            functionality of ``C`` in  `matplotlib.axes.Axes.tripcolor`, but
-            adds the feature that values are first color-mapped if ``cmap`` is
-            specified, like the ``c`` in `matplotlib.pyplot.scatter`.
+            functionality of ``C`` in  `matplotlib.axes.Axes.tripcolor`.
         facecolors: array-like, shape (n, 3/4), default None
             Individual face colors. Must be of shape *(#faces, 3)* for
             RBG or *(#faces, 4)* for RGBA with the colors in the rows.
-            Overrides everything from the ``c`` keyword argument.
+            Overrides everything from the ``C`` keyword argument.
             This works like the ``facecolors`` keyword argument in
             '~matplotlib.axes.Axes.tripcolor'.
         shade : bool, default: True
@@ -1826,28 +1824,28 @@ class Axes3D(Axes):
 
         if facecolors is None:
             if cmap:
-                if c is None:
-                    c = z
+                if C is None:
+                    C = z
 
                 if vmin is not None or vmax is not None:
                     polyc.set_clim(vmin, vmax)
                 if norm is not None:
                     polyc.set_norm(norm)
 
-                if c.shape[0] == z.shape[0]:
-                    face_values = c[triangles].mean(axis=1)
-                elif c.shape[0] == triangles.shape[0]:
-                    face_values = c
+                if C.shape[0] == z.shape[0]:
+                    face_values = C[triangles].mean(axis=1)
+                elif C.shape[0] == triangles.shape[0]:
+                    face_values = C
                 else:
                     raise ValueError("c needs either one value per vertex or "
                                      "per face")
 
                 facecolors = polyc.to_rgba(face_values)
-            elif c is not None:
-                if c.shape[0] == z.shape[0]:
-                    facecolors = c[triangles].mean(axis=1)
-                elif c.shape[0] == triangles.shape[0]:
-                    facecolors = c
+            elif C is not None:
+                if C.shape[0] == z.shape[0]:
+                    facecolors = C[triangles].mean(axis=1)
+                elif C.shape[0] == triangles.shape[0]:
+                    facecolors = C
                 else:
                     raise ValueError("c needs either one color per vertex or "
                                      "per face")

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1733,7 +1733,7 @@ class Axes3D(Axes):
         return linec
 
     def plot_trisurf(self, *args, color=None, norm=None, vmin=None, vmax=None,
-                     values=None, lightsource=None, **kwargs):
+                     C=None, lightsource=None, **kwargs):
         """
         Plot a triangulated surface.
 
@@ -1770,7 +1770,7 @@ class Axes3D(Axes):
             An instance of Normalize to map values to colors.
         vmin, vmax : float, default: None
             Minimum and maximum value to map.
-        values : array-like, default: None
+        C : array-like, default: None
             Values used to determine the colors via the colormap. Only works
             if cmap is specified. Defaults to z-positions of the vertices.
         shade : bool, default: True
@@ -1816,12 +1816,12 @@ class Axes3D(Axes):
         polyc = art3d.Poly3DCollection(verts, *args, **kwargs)
 
         if cmap:
-            if values is None:  # Use z-pos as default
+            if C is None:  # Use z-pos as default
                 # average over the three points of each triangle
                 avg_z = verts[:, :, 2].mean(axis=1)
                 polyc.set_array(avg_z)
             else:
-                values = np.asarray(values)
+                values = np.asarray(C)
                 if values.shape[0] != z.shape[0]:
                     raise ValueError("You must provide one value per vertex")
                 values_tri = values[triangles]

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -14,6 +14,7 @@ from matplotlib.collections import LineCollection, PolyCollection
 from matplotlib.patches import Circle, PathPatch
 from matplotlib.path import Path
 from matplotlib.text import Text
+from matplotlib.tri import Triangulation
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -667,6 +668,34 @@ def test_trisurf3d():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     ax.plot_trisurf(x, y, z, cmap=cm.jet, linewidth=0.2)
+
+
+@check_figures_equal(extensions=['png'])
+def test_colorcoded_trisurf3d(fig_ref, fig_test):
+    ax = fig_ref.add_subplot(projection='3d')
+    ax_test = fig_test.add_subplot(projection='3d')
+
+    # Create a parametric unit sphere
+    r = np.linspace(0, np.pi, 20)
+    phi = np.linspace(-np.pi, np.pi, 20)
+    r, phi = np.meshgrid(r, phi)
+    r, phi = r.flatten(), phi.flatten()
+    tri = Triangulation(r, phi)
+
+    x = np.sin(r)*np.cos(phi)
+    y = np.sin(r)*np.sin(phi)
+    z = np.cos(r)
+
+    # Old implementation uses z-coordinates for color code
+    ax.plot_trisurf(x, y, z,
+                    triangles=tri.triangles,
+                    cmap=cm.Spectral)
+
+    # Manually specify z-value as custom color-source
+    ax_test.plot_trisurf(x, y, z,
+                         triangles=tri.triangles,
+                         cmap=cm.Spectral,
+                         C=z)
 
 
 @mpl3d_image_comparison(['trisurf3d_shaded.png'], tol=0.03)

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -695,7 +695,7 @@ def test_colorcoded_trisurf3d(fig_ref, fig_test):
     ax_test.plot_trisurf(x, y, z,
                          triangles=tri.triangles,
                          cmap=cm.Spectral,
-                         c=z)
+                         C=z)
 
 
 @check_figures_equal(extensions=['png'])
@@ -723,7 +723,7 @@ def test_value_per_vertex_vs_value_per_face(fig_ref, fig_test):
 
     ax_test.plot_trisurf(x, y, z,
                          triangles=tri.triangles,
-                         c=phi,
+                         C=phi,
                          cmap=cmap,
                          norm=norm)
 

--- a/lib/mpl_toolkits/tests/test_mplot3d.py
+++ b/lib/mpl_toolkits/tests/test_mplot3d.py
@@ -695,7 +695,37 @@ def test_colorcoded_trisurf3d(fig_ref, fig_test):
     ax_test.plot_trisurf(x, y, z,
                          triangles=tri.triangles,
                          cmap=cm.Spectral,
-                         C=z)
+                         c=z)
+
+
+@check_figures_equal(extensions=['png'])
+def test_value_per_vertex_vs_value_per_face(fig_ref, fig_test):
+    ax = fig_ref.add_subplot(projection='3d')
+    ax_test = fig_test.add_subplot(projection='3d')
+
+    # Create a parametric unit sphere
+    r = np.linspace(0, np.pi, 20)
+    phi = np.linspace(-np.pi, np.pi, 20)
+    r, phi = np.meshgrid(r, phi)
+    r, phi = r.flatten(), phi.flatten()
+    tri = Triangulation(r, phi)
+
+    x = np.sin(r)*np.cos(phi)
+    y = np.sin(r)*np.sin(phi)
+    z = np.cos(r)
+
+    norm = plt.Normalize(vmin=phi.min(), vmax=phi.max())
+    cmap = plt.colormaps['jet']
+    expected_facecolors = cmap(norm(phi[tri.triangles].mean(axis=1)))
+    ax.plot_trisurf(x, y, z,
+                    triangles=tri.triangles,
+                    facecolors=expected_facecolors)
+
+    ax_test.plot_trisurf(x, y, z,
+                         triangles=tri.triangles,
+                         c=phi,
+                         cmap=cmap,
+                         norm=norm)
 
 
 @mpl3d_image_comparison(['trisurf3d_shaded.png'], tol=0.03)


### PR DESCRIPTION
## PR Summary

This PR adds the possibility to color faces individually in `plot_trisurf`. Before one could only use one color for all faces, or use a colormap encoding the mean z-coordinate of the vertices at each triangle for the triangle's surface. In this PR the function get a new keyword argument called `c`, defaulting to None. One can now specify a value for each vertex via `c`. Then these values are used to determine face-colors via the colormap, not the mere z-coordinates.

### Example

```python
import matplotlib.tri as mtri
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.add_subplot(projection='3d')

r = np.linspace(0, np.pi, 50)
phi = np.linspace(-np.pi, np.pi, 50)
r, phi = np.meshgrid(r, phi)
r, phi = r.flatten(), phi.flatten()
tri = mtri.Triangulation(r, phi)

x = np.sin(r)*np.cos(phi)
y = np.sin(r)*np.sin(phi)
z = np.cos(r)

ax.plot_trisurf(x, y, z, triangles=tri.triangles, c=phi, cmap=plt.cm.Spectral)
```
![image](https://user-images.githubusercontent.com/30664255/189688849-2ab443f7-eb59-4911-ac87-8d799bbe0063.png)

Plots like this were not possible, even not with the `color` keyword argument - this only allowed for a single color.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
