### PR TITLE
DOC: Rearrange navbar-end elements

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -381,7 +381,7 @@ html_theme_options = {
     "logo": {"link": "index",
              "image_light": "images/logo2.svg",
              "image_dark": "images/logo_dark.svg"},
-    "navbar_end": ["version-switcher", "mpl_icon_links", "theme-switcher"]
+    "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"]
 }
 include_analytics = is_release_build
 if include_analytics:


### PR DESCRIPTION
- mpl_icon_links to the very right, as in the base mpl_sphinx-theme
- I would have liked the version-switcher to be on the very left, but somehow the search button is magically added there (note that we have not listed "search-button", but it still shows up). Since I don't have time to dig into that magic now, the minimal-effort reasonable- result change is the order

  > [search] [theme] [version-dropdown] [links]

