### PR TITLE
CI: prefer (older) binaries over (newer) sdists

### DIFF
--- a/requirements/testing/extra.txt
+++ b/requirements/testing/extra.txt
@@ -1,5 +1,6 @@
 # Extra pip requirements for the Python 3.8+ builds
 
+--prefer-binary
 ipykernel
 nbconvert[execute]!=6.0.0,!=6.0.1
 nbformat!=5.0.0,!=5.0.1


### PR DESCRIPTION
## PR Summary
Try to fix installing test deps on windows + mac