### PR TITLE
Fix PolygonSelector.clear()

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1690,46 +1690,23 @@ def test_polygon_selector_clear_method(ax):
     onselect = mock.Mock(spec=noop, return_value=None)
     tool = widgets.PolygonSelector(ax, onselect)
 
-    event_sequence = [
-        *polygon_place_vertex(50, 50),
-        *polygon_place_vertex(150, 50),
-        *polygon_place_vertex(50, 150),
-        *polygon_place_vertex(50, 50),
-    ]
-    expected_result = [(50, 50), (150, 50), (50, 150), (50, 50)]
+    for result in ([(50, 50), (150, 50), (50, 150), (50, 50)],
+                   [(50, 50), (100, 50), (50, 150), (50, 50)]):
+        for x, y in result:
+            for etype, event_args in polygon_place_vertex(x, y):
+                do_event(tool, etype, **event_args)
 
-    for (etype, event_args) in event_sequence:
-        do_event(tool, etype, **event_args)
+        artist = tool._selection_artist
 
-    artist = tool._selection_artist
+        assert tool._selection_completed
+        assert tool.get_visible()
+        assert artist.get_visible()
+        np.testing.assert_equal(artist.get_xydata(), result)
+        assert onselect.call_args == ((result[:-1],), {})
 
-    assert tool._selection_completed
-    assert tool.get_visible()
-    assert artist.get_visible()
-    np.testing.assert_equal(artist.get_xydata(), expected_result)
-    assert onselect.call_args == ((expected_result[:-1],), {})
-
-    tool.clear()
-    assert not tool._selection_completed
-    np.testing.assert_equal(artist.get_xydata(), [(0, 0)])
-
-    # Do another cycle of events to make sure we can
-    event_sequence = [
-        *polygon_place_vertex(50, 50),
-        *polygon_place_vertex(100, 50),
-        *polygon_place_vertex(50, 150),
-        *polygon_place_vertex(50, 50),
-    ]
-    expected_result2 = [(50, 50), (100, 50), (50, 150), (50, 50)]
-
-    for (etype, event_args) in event_sequence:
-        do_event(tool, etype, **event_args)
-
-    assert tool._selection_completed
-    assert tool.get_visible()
-    assert artist.get_visible()
-    np.testing.assert_equal(artist.get_xydata(), expected_result2)
-    assert onselect.call_args == ((expected_result2[:-1],), {})
+        tool.clear()
+        assert not tool._selection_completed
+        np.testing.assert_equal(artist.get_xydata(), [(0, 0)])
 
 
 @pytest.mark.parametrize("horizOn", [False, True])

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4141,8 +4141,9 @@ class PolygonSelector(_SelectorWidget):
             self._remove_box()
             self.set_visible(True)
 
-    def _draw_polygon(self):
-        """Redraw the polygon based on the new vertex positions."""
+    def _draw_polygon_without_update(self):
+        """Redraw the polygon based on the new vertex positions, no update().
+        """
         xs, ys = zip(*self._xys) if self._xys else ([], [])
         self._selection_artist.set_data(xs, ys)
         self._update_box()
@@ -4155,6 +4156,10 @@ class PolygonSelector(_SelectorWidget):
             self._polygon_handles.set_data(xs[:-1], ys[:-1])
         else:
             self._polygon_handles.set_data(xs, ys)
+
+    def _draw_polygon(self):
+        """Redraw the polygon based on the new vertex positions."""
+        self._draw_polygon_without_update()
         self.update()
 
     @property
@@ -4177,11 +4182,10 @@ class PolygonSelector(_SelectorWidget):
             self._add_box()
         self._draw_polygon()
 
-    def clear(self):
-        super().clear()
+    def _clear_without_update(self):
+        self._selection_completed = False
         self._xys = [(0, 0)]
-        self.set_visible(True)
-        self._draw_polygon()
+        self._draw_polygon_without_update()
 
 
 class Lasso(AxesWidget):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4142,8 +4142,7 @@ class PolygonSelector(_SelectorWidget):
             self.set_visible(True)
 
     def _draw_polygon_without_update(self):
-        """Redraw the polygon based on the new vertex positions, no update().
-        """
+        """Redraw the polygon based on new vertex positions, no update()."""
         xs, ys = zip(*self._xys) if self._xys else ([], [])
         self._selection_artist.set_data(xs, ys)
         self._update_box()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4177,6 +4177,12 @@ class PolygonSelector(_SelectorWidget):
             self._add_box()
         self._draw_polygon()
 
+    def clear(self):
+        super().clear()
+        self._xys = [(0, 0)]
+        self.set_visible(True)
+        self._draw_polygon()
+
 
 class Lasso(AxesWidget):
     """


### PR DESCRIPTION
## PR Summary

This PR implements PolygonSelector.clear() to delete all vertices and enable visibility.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).