### PR TITLE
added a reversing section to colormap reference

### DIFF
--- a/examples/color/colormap_reference.py
+++ b/examples/color/colormap_reference.py
@@ -6,15 +6,16 @@ Colormap reference
 Reference for colormaps included with Matplotlib.
 
 A reversed version of each of these colormaps is available by appending
-``_r`` to the name, e.g., ``viridis_r``.
+``_r`` to the name, as shown in :ref:`reverse-cmap`.
 
 See :doc:`/tutorials/colors/colormaps` for an in-depth discussion about
-colormaps, including colorblind-friendliness.
+colormaps, including colorblind-friendliness, and
+:doc:`/tutorials/colors/colormap-manipulation` for a guide to creating
+colormaps.
 """
 
 import numpy as np
 import matplotlib.pyplot as plt
-
 
 cmaps = [('Perceptually Uniform Sequential', [
             'viridis', 'plasma', 'inferno', 'magma', 'cividis']),
@@ -40,7 +41,6 @@ cmaps = [('Perceptually Uniform Sequential', [
             'gist_rainbow', 'rainbow', 'jet', 'turbo', 'nipy_spectral',
             'gist_ncar'])]
 
-
 gradient = np.linspace(0, 1, 256)
 gradient = np.vstack((gradient, gradient))
 
@@ -52,7 +52,7 @@ def plot_color_gradients(cmap_category, cmap_list):
     fig, axs = plt.subplots(nrows=nrows, figsize=(6.4, figh))
     fig.subplots_adjust(top=1-.35/figh, bottom=.15/figh, left=0.2, right=0.99)
 
-    axs[0].set_title(cmap_category + ' colormaps', fontsize=14)
+    axs[0].set_title(f"{cmap_category} colormaps", fontsize=14)
 
     for ax, cmap_name in zip(axs, cmap_list):
         ax.imshow(gradient, aspect='auto', cmap=cmap_name)
@@ -67,7 +67,21 @@ def plot_color_gradients(cmap_category, cmap_list):
 for cmap_category, cmap_list in cmaps:
     plot_color_gradients(cmap_category, cmap_list)
 
-plt.show()
+
+###############################################################################
+# .. _reverse-cmap:
+#
+# Reversed colormaps
+# ------------------
+#
+# Append ``_r`` to the name of any built-in colormap to get the reversed
+# version:
+
+plot_color_gradients("Original and reversed ", ['viridis', 'viridis_r'])
+
+# %%
+# The built-in reversed colormaps are generated using `.Colormap.reversed`.
+# For an example, see :ref:`reversing-colormap`
 
 #############################################################################
 #

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -870,13 +870,13 @@ class Colormap:
         """
         Return a reversed instance of the Colormap.
 
-        .. note:: This function is not implemented for base class.
+        .. note:: This function is not implemented for the base class.
 
         Parameters
         ----------
         name : str, optional
-            The name for the reversed colormap. If it's None the
-            name will be the name of the parent colormap + "_r".
+            The name for the reversed colormap. If None, the
+            name is set to ``self.name + "_r"``.
 
         See Also
         --------
@@ -1079,8 +1079,8 @@ class LinearSegmentedColormap(Colormap):
         Parameters
         ----------
         name : str, optional
-            The name for the reversed colormap. If it's None the
-            name will be the name of the parent colormap + "_r".
+            The name for the reversed colormap. If None, the
+            name is set to ``self.name + "_r"``.
 
         Returns
         -------
@@ -1179,8 +1179,8 @@ class ListedColormap(Colormap):
         Parameters
         ----------
         name : str, optional
-            The name for the reversed colormap. If it's None the
-            name will be the name of the parent colormap + "_r".
+            The name for the reversed colormap. If None, the
+            name is set to ``self.name + "_r"``.
 
         Returns
         -------

--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -256,6 +256,48 @@ cmap2 = LinearSegmentedColormap.from_list("mycmap", list(zip(nodes, colors)))
 plot_examples([cmap1, cmap2])
 
 #############################################################################
+# .. _reversing-colormap:
+#
+# Reversing a colormap
+# ====================
+#
+# `.Colormap.reversed` creates a new colormap that is a reversed version of
+# the original colormap.
+
+colors = ["#ffffcc", "#a1dab4", "#41b6c4", "#2c7fb8", "#253494"]
+my_cmap = ListedColormap(colors, name="my_cmap")
+
+my_cmap_r = my_cmap.reversed()
+
+plot_examples([my_cmap, my_cmap_r])
+# %%
+# If no name is passed in, ``.reversed`` also names the copy by
+# :ref:`appending '_r' <registering-colormap>` to the original colormap's
+# name.
+
+##############################################################################
+# .. _registering-colormap:
+#
+# Registering a colormap
+# ======================
+#
+# Colormaps can be added to the `matplotlib.colormaps` list of named colormaps.
+# This allows the colormaps to be accessed by name in plotting functions:
+
+# my_cmap, my_cmap_r from reversing a colormap
+mpl.colormaps.register(cmap=my_cmap)
+mpl.colormaps.register(cmap=my_cmap_r)
+
+data = [[1, 2, 3, 4, 5]]
+
+fig, (ax1, ax2) = plt.subplots(nrows=2)
+
+ax1.imshow(data, cmap='my_cmap')
+ax2.imshow(data, cmap='my_cmap_r')
+
+plt.show()
+
+#############################################################################
 #
 # .. admonition:: References
 #


### PR DESCRIPTION
## PR Summary
changed the note about reversing a colormap into a section of the colormap reference 'cause it was kind of buried in the preamble

![image](https://user-images.githubusercontent.com/1300499/190524474-6b24f606-d9ea-4a03-971c-ab8bf4c964d5.png)

## PR Checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
