### PR TITLE
made explict that install link is install docs in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,13 +54,12 @@ formats and interactive environments across platforms. Matplotlib can be used
 in Python scripts, Python/IPython shells, web application servers, and
 various graphical user interface toolkits.
 
-
 Install
 =======
 
-For installation instructions and requirements, see the `install documentation
-<https://matplotlib.org/stable/users/installing/index.html>`_ or
-`installing.rst <doc/users/installing/index.rst>`_ in the source.
+See the `install documentation
+<https://matplotlib.org/stable/users/installing/index.html>`_, which is
+generated from ``/doc/users/installing/index.rst``
 
 Contribute
 ==========


### PR DESCRIPTION
I think it's confusing to tell people read the install docs or install.rst (I totally didn't even parse that they were the same doc at first) and we link to the docs in other sections of the readme.