### PR TITLE
FIX: only expect FigureCanvas on backend module if using new style

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -263,7 +263,6 @@ def switch_backend(newbackend):
 
     backend_mod = importlib.import_module(
         cbook._backend_module_name(newbackend))
-    canvas_class = backend_mod.FigureCanvas
 
     required_framework = _get_required_interactive_framework(backend_mod)
     if required_framework is not None:
@@ -293,6 +292,8 @@ def switch_backend(newbackend):
     # also update backend_mod accordingly; also, per-backend customization of
     # draw_if_interactive is disabled.
     if new_figure_manager is None:
+        # only try to get the canvas class if have opted into the new scheme
+        canvas_class = backend_mod.FigureCanvas
         def new_figure_manager_given_figure(num, figure):
             return canvas_class.new_manager(figure, num)
 


### PR DESCRIPTION

## PR Summary

This is to un-break pycharm's backend_interagg

Closes #23911


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).


I'm not sure the best way to test this, I guess we need to make a minimal backend that does not have FigureCanvas and try push it through the machinery?  Is it worth the effort?