### PR TITLE
Add draggable as param to Legend init

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -342,7 +342,8 @@ class Legend(Artist):
         title_fontproperties=None,  # properties for the legend title
         alignment="center",       # control the alignment within the legend box
         *,
-        ncol=1  # synonym for ncols (backward compatibility)
+        ncol=1,  # synonym for ncols (backward compatibility)
+        draggable=None  # whether the legend can be dragged with the mouse
     ):
         """
         Parameters
@@ -537,7 +538,9 @@ class Legend(Artist):
             title_prop_fp.set_size(title_fontsize)
 
         self.set_title(title, prop=title_prop_fp)
+
         self._draggable = None
+        self.set_draggable(state=draggable)
 
         # set the text color
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -286,6 +286,9 @@ handler_map : dict or None
     The custom dictionary mapping instances or types to a legend
     handler. This *handler_map* updates the default handler map
     found at `matplotlib.legend.Legend.get_legend_handler_map`.
+
+draggable : bool or None
+    Whether the legend can be dragged with the mouse.
 """)
 
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -287,7 +287,7 @@ handler_map : dict or None
     handler. This *handler_map* updates the default handler map
     found at `matplotlib.legend.Legend.get_legend_handler_map`.
 
-draggable : bool or None
+draggable : bool, default: False
     Whether the legend can be dragged with the mouse.
 """)
 
@@ -346,7 +346,7 @@ class Legend(Artist):
         alignment="center",       # control the alignment within the legend box
         *,
         ncol=1,  # synonym for ncols (backward compatibility)
-        draggable=None  # whether the legend can be dragged with the mouse
+        draggable=False  # whether the legend can be dragged with the mouse
     ):
         """
         Parameters

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -788,7 +788,7 @@ def test_legend_draggable(draggable):
     fig, ax = plt.subplots()
     ax.plot(range(10), label='shabnams')
     leg = ax.legend(draggable=draggable)
-    assert leg.get_draggable() == draggable
+    assert leg.get_draggable() is draggable
 
 
 def test_alpha_handles():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -783,6 +783,14 @@ def test_get_set_draggable():
     assert not legend.get_draggable()
 
 
+@pytest.mark.parametrize('draggable', (True, False))
+def test_legend_draggable(draggable):
+    fig, ax = plt.subplots()
+    ax.plot(range(10), label='shabnams')
+    leg = ax.legend(draggable=draggable)
+    assert leg.get_draggable() == draggable
+
+
 def test_alpha_handles():
     x, n, hh = plt.hist([1, 2, 3], alpha=0.25, label='data', color='red')
     legend = plt.legend()


### PR DESCRIPTION
## PR Summary
Closes #9181
FYI @tacaswell 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
