### PR TITLE
Add shading of Poly3DCollection

### DIFF
--- a/doc/users/next_whats_new/shade_poly3dcollection.rst
+++ b/doc/users/next_whats_new/shade_poly3dcollection.rst
@@ -1,0 +1,33 @@
+``Poly3DCollection`` supports shading
+-------------------------------------
+
+It is now possible to shade a `.Poly3DCollection`. This is useful if the
+polygons are obtained from e.g. a 3D model.
+
+.. plot::
+    :include-source: true
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from mpl_toolkits.mplot3d.art3d import Poly3DCollection
+
+    # Define 3D shape
+    block = np.array([
+        [[1, 1, 0],
+         [1, 0, 0],
+         [0, 1, 0]],
+        [[1, 1, 0],
+         [1, 1, 1],
+         [1, 0, 0]],
+        [[1, 1, 0],
+         [1, 1, 1],
+         [0, 1, 0]],
+        [[1, 0, 0],
+         [1, 1, 1],
+         [0, 1, 0]]
+    ])
+
+    ax = plt.subplot(projection='3d')
+    pc = Poly3DCollection(block, facecolors='b', shade=True)
+    ax.add_collection(pc)
+    plt.show()


### PR DESCRIPTION
## PR Summary

Fixes #19509.

Refactors shading of Poly3DCollection and moves it to the constructor of the collection rather than in every individual plotting method, Can still be done anywhere though.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
