### PR TITLE
FIX: use process_event in dpi changes on macosx backend

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1352,7 +1352,8 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     }
     if (PyObject_IsTrue(change)) {
         // Notify that there was a resize_event that took place
-        gil_call_method(canvas, "resize_event");
+        PROCESS_EVENT("ResizeEvent", "sO", "resize_event", canvas);
+        gil_call_method(canvas, "draw_idle");
         [self setNeedsDisplay: YES];
     }
 


### PR DESCRIPTION
## PR Summary

Avoids `resize_event()` deprecation notices that stem from switching dpis or starting with HiDPI. Likely missed while rebasing PR https://github.com/matplotlib/matplotlib/pull/16931, I tried looking for other potentially deprecated `*_event()`s hidden in the macos code and I didn't find any at a cursory glance.

closes #23921

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
