### PR TITLE
consistent notation for minor/patch branches

### DIFF
--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -134,13 +134,13 @@ Milestones
 * Set the milestone according to these rules:
 
   * *New features and API changes* are milestoned for the next minor release
-    ``v3.X.0``.
+    ``v3.N.0``.
 
   * *Bugfixes and docstring changes* are milestoned for the next patch
-    release ``v3.X.Y``
+    release ``v3.N.M``
 
   * *Documentation changes* (all .rst files and examples) are milestoned
-    ``v3.X-doc``
+    ``v3.N-doc``
 
   If multiple rules apply, choose the first matching from the above list.
 


### PR DESCRIPTION
before, the milestone section used V3.X.Y notation while the backport section used V3.N.M and it tripped me up, so teeny change for them both to use N.M notation based on this discussion https://gitter.im/matplotlib/matplotlib?at=63276b4a11a6a83d04bf3626