### PR TITLE
DOC: fix versions in v3.6.x doc switcher

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -2,31 +2,31 @@
     {
         "name": "3.6 (stable)",
         "version": "stable",
-        "url": "https://matplotlib.org/stable"
+        "url": "https://matplotlib.org/stable/"
     },
     {
         "name": "3.7 (dev)",
         "version": "devdocs",
-        "url": "https://matplotlib.org/devdocs"
+        "url": "https://matplotlib.org/devdocs/"
     },
     {
         "name": "3.5",
         "version": "3.5.3",
-        "url": "https://matplotlib.org/3.5.3"
+        "url": "https://matplotlib.org/3.5.3/"
     },
     {
         "name": "3.4",
         "version": "3.4.3",
-        "url": "https://matplotlib.org/3.4.3"
+        "url": "https://matplotlib.org/3.4.3/"
     },
     {
         "name": "3.3",
         "version": "3.3.4",
-        "url": "https://matplotlib.org/3.3.4"
+        "url": "https://matplotlib.org/3.3.4/"
     },
     {
         "name": "2.2",
         "version": "2.2.4",
-        "url": "https://matplotlib.org/2.2.4"
+        "url": "https://matplotlib.org/2.2.4/"
     }
 ]

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -15,11 +15,6 @@
         "url": "https://matplotlib.org/3.5.3"
     },
     {
-        "name": "3.5",
-        "version": "3.5.3",
-        "url": "https://matplotlib.org/3.5.3/"
-    },
-    {
         "name": "3.4",
         "version": "3.4.3",
         "url": "https://matplotlib.org/3.4.3"

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -6,7 +6,7 @@
     },
     {
         "name": "3.7 (dev)",
-        "version": "devdocs",
+        "version": "dev",
         "url": "https://matplotlib.org/devdocs/"
     },
     {


### PR DESCRIPTION
Reverts matplotlib/matplotlib#23936

Duplication that does not need a backport. Likely we got trapped somewhere with asynchronous updates on both branches.