### PR TITLE
Fix building on MINGW

### DIFF
--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -231,13 +231,13 @@ bool load_tcl_tk(T lib)
 {
     // Try to fill Tcl/Tk global vars with function pointers.  Return whether
     // all of them have been filled.
-    if (void* ptr = dlsym(lib, "Tcl_SetVar")) {
+    if (auto ptr = dlsym(lib, "Tcl_SetVar")) {
         TCL_SETVAR = (Tcl_SetVar_t)ptr;
     }
-    if (void* ptr = dlsym(lib, "Tk_FindPhoto")) {
+    if (auto ptr = dlsym(lib, "Tk_FindPhoto")) {
         TK_FIND_PHOTO = (Tk_FindPhoto_t)ptr;
     }
-    if (void* ptr = dlsym(lib, "Tk_PhotoPutBlock")) {
+    if (auto* ptr = dlsym(lib, "Tk_PhotoPutBlock")) {
         TK_PHOTO_PUT_BLOCK = (Tk_PhotoPutBlock_t)ptr;
     }
     return TCL_SETVAR && TK_FIND_PHOTO && TK_PHOTO_PUT_BLOCK;

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -237,7 +237,7 @@ bool load_tcl_tk(T lib)
     if (auto ptr = dlsym(lib, "Tk_FindPhoto")) {
         TK_FIND_PHOTO = (Tk_FindPhoto_t)ptr;
     }
-    if (auto* ptr = dlsym(lib, "Tk_PhotoPutBlock")) {
+    if (auto ptr = dlsym(lib, "Tk_PhotoPutBlock")) {
         TK_PHOTO_PUT_BLOCK = (Tk_PhotoPutBlock_t)ptr;
     }
     return TCL_SETVAR && TK_FIND_PHOTO && TK_PHOTO_PUT_BLOCK;


### PR DESCRIPTION
## PR Summary

Fix building matplotlib on MINGW. Recent changes in https://github.com/matplotlib/matplotlib/commit/e1fcc90c13b037da1501aa53b3491d27081598ca broke it.

Fixes #23943

## PR Checklist

**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
