### PR TITLE
DOC: Display "dev" instead of "devdocs" in the version switcher

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -6,7 +6,7 @@
     },
     {
         "name": "3.7 (dev)",
-        "version": "devdocs",
+        "version": "dev",
         "url": "https://matplotlib.org/devdocs/"
     },
     {


### PR DESCRIPTION
This changes ![image](https://user-images.githubusercontent.com/2836374/191008193-9ec7111b-05e0-40ad-af28-2ed624f1eb25.png) to only show "dev".

While the url is devdocs historically, and I'm not going to change this, the displayed names should be "stable" and "dev". This has the added advantage that dev takes a little less space in the menubar, and thus wrapping occurs slightly later.
