### PR TITLE
DOC: Don't import doctest because we're not using it

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -57,7 +57,6 @@ warnings.filterwarnings('error', append=True)
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
-    'sphinx.ext.doctest',
     'sphinx.ext.inheritance_diagram',
     'sphinx.ext.intersphinx',
     'sphinx.ext.ifconfig',


### PR DESCRIPTION
AFAICS we're not using it, so don't need to import it in conf.py

