### PR TITLE
DOC: Make animation continuous

### DIFF
--- a/examples/animation/dynamic_image.py
+++ b/examples/animation/dynamic_image.py
@@ -23,8 +23,8 @@ y = np.linspace(0, 2 * np.pi, 100).reshape(-1, 1)
 # each frame
 ims = []
 for i in range(60):
-    x += np.pi / 15.
-    y += np.pi / 20.
+    x += np.pi / 15
+    y += np.pi / 30
     im = ax.imshow(f(x, y), animated=True)
     if i == 0:
         ax.imshow(f(x, y))  # show an initial one first


### PR DESCRIPTION
This changes the phase such that the start and end images are the same. This is a bit nicer for the animation thumbnails https://matplotlib.org/devdocs/gallery/index.html#animation. They are shown in an endless loop and if start and end images are different, we get a discontiguous jump when the animation is repeated. With this changes, the animation flow is contiguous.

