### PR TITLE
DOC: Suppress IPython output in examples and tutorials where not needed

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -199,6 +199,7 @@ sphinx_gallery_conf = {
     'subsection_order': gallery_order.sectionorder,
     'thumbnail_size': (320, 224),
     'within_subsection_order': gallery_order.subsectionorder,
+    'capture_repr': (),
 }
 
 if 'plot_gallery=0' in sys.argv:

--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -115,6 +115,7 @@ drawing of the ticks, tick labels and axis labels.
 
 Try creating the figure below.
 """
+# sphinx_gallery_capture_repr = ('__repr__',)
 
 import numpy as np
 import matplotlib.pyplot as plt

--- a/tutorials/intermediate/autoscale.py
+++ b/tutorials/intermediate/autoscale.py
@@ -26,7 +26,7 @@ ax.plot(x, y)
 # -------
 # The default margin around the data limits is 5%:
 
-ax.margins()
+print(ax.margins())
 
 ###############################################################################
 # The margins can be made larger using `~matplotlib.axes.Axes.margins`:


### PR DESCRIPTION
## PR Summary

By default, sphinx-gallery captures the last output of each code block and shows it in the generated html in yellow boxes. Especially in tutorials with frequently interleaving code and text blocks this may appear confusing and reduces readability. In some cases, however, the output is desired (although it could always be replaced by printing).

The global configuration is now changed to "capture nothing", for one tutorial with multiple desired outputs this is overridden in the file to show the output and in other cases with just one desired output it's converted to a call to print().

(I went through all the examples and tutorials by searching the generated rst files for `.. rst-class:: sphx-glr-script-out` to see if we need the generated output, hopefully I didn't overlook some desired output)

This PR addresses this https://github.com/matplotlib/matplotlib/pull/21794#issuecomment-981711155:

> I won't object if someone has a way to suppress these via configuration. However, note that some of our examples want the output to show up, so it can't be global.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
