### PR TITLE
DOC: Move Quick Start Tutorial to first position

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -50,9 +50,9 @@ class MplExplicitOrder(ExplicitOrder):
 list_all = [
     #  **Tutorials**
     #  introductory
-    "usage", "pyplot", "sample_plots", "images", "lifecycle", "customizing",
+    "quick_start", "pyplot", "images", "lifecycle", "customizing",
     #  intermediate
-    "artists", "legend_guide", "color_cycle", "gridspec",
+    "artists", "legend_guide", "color_cycle",
     "constrainedlayout_guide", "tight_layout_guide",
     #  advanced
     #  text


### PR DESCRIPTION
## PR Summary
Move the _Quick Start Tutorial_ to first position in _Introductory Tutorials_ and remove some non-existing tutorial names in `gallery_order.py`.

(the _Usage Tutorial_ was renamed into `Quick Start Tutorial` in 2f65ecade and thus moved to the very end of the `Introductory Tutorials` list)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
