### PR TITLE
Fixed colorbar bug when yscaled length is 1

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1243,10 +1243,13 @@ class Colorbar:
         yscaled = np.ma.filled(norm(yscaled), np.nan)
         # make the lower and upper extend lengths proportional to the lengths
         # of the first and last boundary spacing (if extendfrac='auto'):
-        automin = yscaled[1] - yscaled[0]
-        automax = yscaled[-1] - yscaled[-2]
         extendlength = [0, 0]
         if self._extend_lower() or self._extend_upper():
+            automin = yscaled[0]
+            automax = yscaled[0]
+            if len(yscaled) > 1:
+                automin = yscaled[1] - yscaled[0]
+                automax = yscaled[-1] - yscaled[-2]
             extendlength = self._get_extension_lengths(
                     self.extendfrac, automin, automax, default=0.05)
         return y, extendlength

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1221,8 +1221,10 @@ class Colorbar:
         if (isinstance(self.norm, colors.BoundaryNorm) or
                 self.boundaries is not None):
             y = (self._boundaries - self._boundaries[self._inside][0])
-            y = y / (self._boundaries[self._inside][-1] -
-                     self._boundaries[self._inside][0])
+            if (self._boundaries[self._inside][-1]
+                    != self._boundaries[self._inside][0]):
+                y = y / (self._boundaries[self._inside][-1] -
+                         self._boundaries[self._inside][0])
             # need yscaled the same as the axes scale to get
             # the extend lengths.
             if self.spacing == 'uniform':

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -241,10 +241,12 @@ def test_contour_colorbar():
     fig.colorbar(CS, orientation='horizontal', extend='both')
     fig.colorbar(CS, orientation='vertical')
 
+
 def test_contour_uniformfield_colorbar():
     fig, ax = plt.subplots()
     cs = ax.contour([[1, 1], [1, 1]])
     fig.colorbar(cs, ax=ax)
+
 
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -241,6 +241,10 @@ def test_contour_colorbar():
     fig.colorbar(CS, orientation='horizontal', extend='both')
     fig.colorbar(CS, orientation='vertical')
 
+def test_contour_uniformfield_colorbar():
+    fig, ax = plt.subplots()
+    cs = ax.contour([[1, 1], [1, 1]])
+    fig.colorbar(cs, ax=ax)
 
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -243,11 +243,10 @@ def test_contour_colorbar():
 
 
 def test_contour_uniformfield_colorbar():
-	# Smoke test for gh#23817
+    # Smoke test for gh#23817
     fig, ax = plt.subplots()
     with pytest.warns(Warning) as record:
         cs = ax.contour([[1, 1], [1, 1]])
-        fig.colorbar(cs, ax=ax)
     assert len(record) == 1
 
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -243,9 +243,12 @@ def test_contour_colorbar():
 
 
 def test_contour_uniformfield_colorbar():
+	# Smoke test for gh#23817
     fig, ax = plt.subplots()
-    cs = ax.contour([[1, 1], [1, 1]])
-    fig.colorbar(cs, ax=ax)
+    with pytest.warns(Warning) as record:
+        cs = ax.contour([[1, 1], [1, 1]])
+        fig.colorbar(cs, ax=ax)
+    assert len(record) == 1
 
 
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -248,6 +248,7 @@ def test_contour_uniformfield_colorbar():
     with pytest.warns(Warning) as record:
         cs = ax.contour([[1, 1], [1, 1]])
     assert len(record) == 1
+    fig.colorbar(cs, ax=ax)
 
 
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,


### PR DESCRIPTION
## PR Summary
This pull request aims to solve issue #23817  in which an error would be thrown in the event that yscaled's length was 1. To fix this, I added a check to see if yscaled's length was 1, and if so, to set automin and automax to yscaled's only value. I also moved the declaration of automin and automax inside the if statement where extendlength is declared as suggested by @oscargus , since they are unused otherwise. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).