### PR TITLE
Improve rubberband rendering in wx and tk

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -212,7 +212,8 @@ class FigureCanvasTk(FigureCanvasBase):
 
         self._tkcanvas.focus_set()
 
-        self._rubberband_rect = None
+        self._rubberband_rect_black = None
+        self._rubberband_rect_white = None
 
     def _update_device_pixel_ratio(self, event=None):
         # Tk gives scaling with respect to 72 DPI, but Windows screens are
@@ -667,21 +668,30 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         # Block copied from remove_rubberband for backend_tools convenience.
-        if self.canvas._rubberband_rect:
-            self.canvas._tkcanvas.delete(self.canvas._rubberband_rect)
+        if self.canvas._rubberband_rect_white:
+            self.canvas._tkcanvas.delete(self.canvas._rubberband_rect_white)
+        if self.canvas._rubberband_rect_black:
+            self.canvas._tkcanvas.delete(self.canvas._rubberband_rect_black)
         height = self.canvas.figure.bbox.height
         y0 = height - y0
         y1 = height - y1
-        self.canvas._rubberband_rect = self.canvas._tkcanvas.create_rectangle(
-            x0, y0, x1, y1)
+        self.canvas._rubberband_rect_black = (
+            self.canvas._tkcanvas.create_rectangle(
+                x0, y0, x1, y1))
+        self.canvas._rubberband_rect_white = (
+            self.canvas._tkcanvas.create_rectangle(
+                x0, y0, x1, y1, outline='white', dash=(3, 3)))
 
     def remove_rubberband(self):
-        if self.canvas._rubberband_rect:
-            self.canvas._tkcanvas.delete(self.canvas._rubberband_rect)
-            self.canvas._rubberband_rect = None
+        if self.canvas._rubberband_rect_white:
+            self.canvas._tkcanvas.delete(self.canvas._rubberband_rect_white)
+            self.canvas._rubberband_rect_white = None
+        if self.canvas._rubberband_rect_black:
+            self.canvas._tkcanvas.delete(self.canvas._rubberband_rect_black)
+            self.canvas._rubberband_rect_black = None
 
     lastrect = _api.deprecated("3.6")(
-        property(lambda self: self.canvas._rubberband_rect))
+        property(lambda self: self.canvas._rubberband_rect_black))
 
     def _set_image_for_button(self, button):
         """
@@ -907,7 +917,7 @@ class RubberbandTk(backend_tools.RubberbandBase):
             self._make_classic_style_pseudo_toolbar())
 
     lastrect = _api.deprecated("3.6")(
-        property(lambda self: self.figure.canvas._rubberband_rect))
+        property(lambda self: self.figure.canvas._rubberband_rect_black))
 
 
 @_api.deprecated("3.5", alternative="ToolSetCursor")

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -508,6 +508,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         _log.debug("%s - __init__() - bitmap w:%d h:%d", type(self), w, h)
         self._isDrawn = False
         self._rubberband_rect = None
+        self._rubberband_pen_black = wx.Pen('BLACK', 1, wx.PENSTYLE_SHORT_DASH)
+        self._rubberband_pen_white = wx.Pen('WHITE', 1, wx.PENSTYLE_SOLID)
 
         self.Bind(wx.EVT_SIZE, self._on_size)
         self.Bind(wx.EVT_PAINT, self._on_paint)
@@ -626,10 +628,10 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         if self._rubberband_rect is not None:
             # Some versions of wx+python don't support numpy.float64 here.
             x0, y0, x1, y1 = map(int, self._rubberband_rect)
-            drawDC.DrawLineList(
-                [(x0, y0, x1, y0), (x1, y0, x1, y1),
-                 (x0, y0, x0, y1), (x0, y1, x1, y1)],
-                wx.Pen('BLACK', 1, wx.PENSTYLE_SHORT_DASH))
+            rect = [(x0, y0, x1, y0), (x1, y0, x1, y1),
+                    (x0, y0, x0, y1), (x0, y1, x1, y1)]
+            drawDC.DrawLineList(rect, self._rubberband_pen_white)
+            drawDC.DrawLineList(rect, self._rubberband_pen_black)
 
     filetypes = {
         **FigureCanvasBase.filetypes,

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -627,7 +627,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         drawDC.DrawBitmap(bmp, 0, 0)
         if self._rubberband_rect is not None:
             # Some versions of wx+python don't support numpy.float64 here.
-            x0, y0, x1, y1 = map(int, self._rubberband_rect)
+            x0, y0, x1, y1 = map(round, self._rubberband_rect)
             rect = [(x0, y0, x1, y0), (x1, y0, x1, y1),
                     (x0, y0, x0, y1), (x0, y1, x1, y1)]
             drawDC.DrawLineList(rect, self._rubberband_pen_white)


### PR DESCRIPTION
## PR Summary

Closes #23969 (as there is a separate OSX issue #23777)

Draw a solid white rectangle and then add a dashed black rectangle so that it works on both light and dark backgrounds. For the tk backend it messes up the deprecated `lastrect` as bit since it only can contain one of the two rectangles. Not sure what `lastrect` is used for. If it is only to get the position it should be OK, but if it is to possibly modify the rectangle it may not work.

No obvious way to test it in the CI.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
