### PR TITLE
DOC: Lowercase some parameter names

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -243,7 +243,7 @@ def test_tripcolor_color():
     fig, ax = plt.subplots()
     with pytest.raises(TypeError, match=r"tripcolor\(\) missing 1 required "):
         ax.tripcolor(x, y)
-    with pytest.raises(ValueError, match="The length of C must match either"):
+    with pytest.raises(ValueError, match="The length of c must match either"):
         ax.tripcolor(x, y, [1, 2, 3])
     with pytest.raises(ValueError,
                        match="length of facecolors must match .* triangles"):
@@ -255,7 +255,7 @@ def test_tripcolor_color():
                        match="'gouraud' .* at the points.* not at the faces"):
         ax.tripcolor(x, y, [1, 2], shading='gouraud')  # faces
     with pytest.raises(TypeError,
-                       match="positional.*'C'.*keyword-only.*'facecolors'"):
+                       match="positional.*'c'.*keyword-only.*'facecolors'"):
         ax.tripcolor(x, y, C=[1, 2, 3, 4])
 
     # smoke test for valid color specifications (via C or facecolors)
@@ -278,16 +278,16 @@ def test_tripcolor_clim():
 def test_tripcolor_warnings():
     x = [-1, 0, 1, 0]
     y = [0, -1, 0, 1]
-    C = [0.4, 0.5]
+    c = [0.4, 0.5]
     fig, ax = plt.subplots()
     # additional parameters
     with pytest.warns(DeprecationWarning, match="Additional positional param"):
-        ax.tripcolor(x, y, C, 'unused_positional')
-    # facecolors takes precedence over C
-    with pytest.warns(UserWarning, match="Positional parameter C .*no effect"):
-        ax.tripcolor(x, y, C, facecolors=C)
-    with pytest.warns(UserWarning, match="Positional parameter C .*no effect"):
-        ax.tripcolor(x, y, 'interpreted as C', facecolors=C)
+        ax.tripcolor(x, y, c, 'unused_positional')
+    # facecolors takes precedence over c
+    with pytest.warns(UserWarning, match="Positional parameter c .*no effect"):
+        ax.tripcolor(x, y, c, facecolors=c)
+    with pytest.warns(UserWarning, match="Positional parameter c .*no effect"):
+        ax.tripcolor(x, y, 'interpreted as c', facecolors=c)
 
 
 def test_no_modify():

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -83,8 +83,8 @@ Draw contour %%(type)s on an unstructured triangular grid.
 
 Call signatures::
 
-    %%(func)s(triangulation, Z, [levels], ...)
-    %%(func)s(x, y, Z, [levels], *, [triangles=triangles], [mask=mask], ...)
+    %%(func)s(triangulation, z, [levels], ...)
+    %%(func)s(x, y, z, [levels], *, [triangles=triangles], [mask=mask], ...)
 
 The triangular grid can be specified either by passing a `.Triangulation`
 object as the first parameter, or by passing the points *x*, *y* and
@@ -93,7 +93,7 @@ explanation of these parameters. If neither of *triangulation* or
 *triangles* are given, the triangulation is calculated on the fly.
 
 It is possible to pass *triangles* positionally, i.e.
-``%%(func)s(x, y, triangles, Z, ...)``. However, this is discouraged. For more
+``%%(func)s(x, y, triangles, z, ...)``. However, this is discouraged. For more
 clarity, pass *triangles* via keyword argument.
 
 Parameters
@@ -105,7 +105,7 @@ x, y, triangles, mask
     Parameters defining the triangular grid. See `.Triangulation`.
     This is mutually exclusive with specifying *triangulation*.
 
-Z : array-like
+z : array-like
     The height values over which the contour is drawn.  Color-mapping is
     controlled by *cmap*, *norm*, *vmin*, and *vmax*.
 
@@ -157,20 +157,20 @@ alpha : float, default: 1
     This parameter is ignored if *colors* is set.
 
 origin : {*None*, 'upper', 'lower', 'image'}, default: None
-    Determines the orientation and exact position of *Z* by specifying the
-    position of ``Z[0, 0]``.  This is only relevant, if *X*, *Y* are not given.
+    Determines the orientation and exact position of *z* by specifying the
+    position of ``z[0, 0]``.  This is only relevant, if *X*, *Y* are not given.
 
-    - *None*: ``Z[0, 0]`` is at X=0, Y=0 in the lower left corner.
-    - 'lower': ``Z[0, 0]`` is at X=0.5, Y=0.5 in the lower left corner.
-    - 'upper': ``Z[0, 0]`` is at X=N+0.5, Y=0.5 in the upper left corner.
+    - *None*: ``z[0, 0]`` is at X=0, Y=0 in the lower left corner.
+    - 'lower': ``z[0, 0]`` is at X=0.5, Y=0.5 in the lower left corner.
+    - 'upper': ``z[0, 0]`` is at X=N+0.5, Y=0.5 in the upper left corner.
     - 'image': Use the value from :rc:`image.origin`.
 
 extent : (x0, x1, y0, y1), optional
     If *origin* is not *None*, then *extent* is interpreted as in `.imshow`: it
-    gives the outer pixel boundaries. In this case, the position of Z[0, 0] is
+    gives the outer pixel boundaries. In this case, the position of z[0, 0] is
     the center of the pixel, not a corner. If *origin* is *None*, then
-    (*x0*, *y0*) is the position of Z[0, 0], and (*x1*, *y1*) is the position
-    of Z[-1, -1].
+    (*x0*, *y0*) is the position of z[0, 0], and (*x1*, *y1*) is the position
+    of z[-1, -1].
 
     This argument is ignored if *X* and *Y* are specified in the call to
     contour.

--- a/lib/matplotlib/tri/tripcolor.py
+++ b/lib/matplotlib/tri/tripcolor.py
@@ -13,8 +13,8 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
 
     Call signatures::
 
-      tripcolor(triangulation, C, *, ...)
-      tripcolor(x, y, C, *, [triangles=triangles], [mask=mask], ...)
+      tripcolor(triangulation, c, *, ...)
+      tripcolor(x, y, c, *, [triangles=triangles], [mask=mask], ...)
 
     The triangular grid can be specified either by passing a `.Triangulation`
     object as the first parameter, or by passing the points *x*, *y* and
@@ -22,12 +22,12 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
     explanation of these parameters.
 
     It is possible to pass the triangles positionally, i.e.
-    ``tripcolor(x, y, triangles, C, ...)``. However, this is discouraged.
+    ``tripcolor(x, y, triangles, c, ...)``. However, this is discouraged.
     For more clarity, pass *triangles* via keyword argument.
 
     If neither of *triangulation* or *triangles* are given, the triangulation
     is calculated on the fly. In this case, it does not make sense to provide
-    colors at the triangle faces via *C* or *facecolors* because there are
+    colors at the triangle faces via *c* or *facecolors* because there are
     multiple possible triangulations for a group of points and you don't know
     which triangles will be constructed.
 
@@ -38,21 +38,21 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
     x, y, triangles, mask
         Parameters defining the triangular grid. See `.Triangulation`.
         This is mutually exclusive with specifying *triangulation*.
-    C : array-like
+    c : array-like
         The color values, either for the points or for the triangles. Which one
-        is automatically inferred from the length of *C*, i.e. does it match
+        is automatically inferred from the length of *c*, i.e. does it match
         the number of points or the number of triangles. If there are the same
         number of points and triangles in the triangulation it is assumed that
         color values are defined at points; to force the use of color values at
-        triangles use the keyword argument ``facecolors=C`` instead of just
-        ``C``.
+        triangles use the keyword argument ``facecolors=c`` instead of just
+        ``c``.
         This parameter is position-only.
     facecolors : array-like, optional
-        Can be used alternatively to *C* to specify colors at the triangle
-        faces. This parameter takes precedence over *C*.
+        Can be used alternatively to *c* to specify colors at the triangle
+        faces. This parameter takes precedence over *c*.
     shading : {'flat', 'gouraud'}, default: 'flat'
-        If  'flat' and the color values *C* are defined at points, the color
-        values used for each triangle are from the mean C of the triangle's
+        If  'flat' and the color values *c* are defined at points, the color
+        values used for each triangle are from the mean c of the triangle's
         three points. If *shading* is 'gouraud' then color values must be
         defined at points.
     other_parameters
@@ -68,34 +68,34 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
     if facecolors is not None:
         if args:
             _api.warn_external(
-                "Positional parameter C has no effect when the keyword "
+                "Positional parameter c has no effect when the keyword "
                 "facecolors is given")
         point_colors = None
         if len(facecolors) != len(tri.triangles):
             raise ValueError("The length of facecolors must match the number "
                              "of triangles")
     else:
-        # Color from positional parameter C
+        # Color from positional parameter c
         if not args:
             raise TypeError(
-                "tripcolor() missing 1 required positional argument: 'C'; or "
+                "tripcolor() missing 1 required positional argument: 'c'; or "
                 "1 required keyword-only argument: 'facecolors'")
         elif len(args) > 1:
             _api.warn_deprecated(
                 "3.6", message=f"Additional positional parameters "
                 f"{args[1:]!r} are ignored; support for them is deprecated "
                 f"since %(since)s and will be removed %(removal)s")
-        C = np.asarray(args[0])
-        if len(C) == len(tri.x):
+        c = np.asarray(args[0])
+        if len(c) == len(tri.x):
             # having this before the len(tri.triangles) comparison gives
             # precedence to nodes if there are as many nodes as triangles
-            point_colors = C
+            point_colors = c
             facecolors = None
-        elif len(C) == len(tri.triangles):
+        elif len(c) == len(tri.triangles):
             point_colors = None
-            facecolors = C
+            facecolors = c
         else:
-            raise ValueError('The length of C must match either the number '
+            raise ValueError('The length of c must match either the number '
                              'of points or the number of triangles')
 
     # Handling of linewidths, shading, edgecolors and antialiased as


### PR DESCRIPTION
Changes:

- `tricontour(x, y, Z, ...)` --> `trcontour(x, y, z, ...)` (and same for `tricontourf()`
- `tripcolor(x, y, C, ...)` --> `tricpcolor(x, y, c, ...)`

There is no reason here for uppercase C or Z, the preceding parameters x, y are also not uppercase.

Note that this is not an API change since these parameters are positional-only (created from *args). Thus, we can change the names without a deprecation.
