### PR TITLE
In usetex, remove vertical space inserted by TeX after displaymath.

### DIFF
--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -8,6 +8,7 @@ from matplotlib import dviread
 from matplotlib.testing import _has_tex_package
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 from matplotlib.testing._markers import needs_usetex
+from matplotlib.texmanager import TexManager
 import matplotlib.pyplot as plt
 
 
@@ -138,3 +139,10 @@ def test_missing_psfont(fmt, monkeypatch):
     ax.text(0.5, 0.5, 'hello')
     with TemporaryFile() as tmpfile, pytest.raises(ValueError):
         fig.savefig(tmpfile, format=fmt)
+
+
+def test_ends_with_displaymath():
+    # Check that we do not include extra vspace after displaymath.
+    text = r'\begin{eqnarray*} foo \\ bar \end{eqnarray*}'
+    w, h, d = TexManager().get_text_width_height_descent(text, 12)
+    assert d == 0  # no extra descent on the last line.

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -231,7 +231,7 @@ class TexManager:
             rf"\fontsize{{{fontsize}}}{{{baselineskip}}}%",
             r"\ifdefined\psfrag\else\hbox{}\fi%",
             rf"{{\obeylines{fontcmd} {tex}}}%",
-            r"\special{matplotlibbaselinemarker}%",
+            r"\vskip-\lastskip\special{matplotlibbaselinemarker}%",
             r"\end{document}",
         ])
 


### PR DESCRIPTION
## PR Summary

Closes #23977.  One can also check with the simpler example given at https://github.com/matplotlib/matplotlib/issues/23977#issuecomment-1255990339.

Actually in the specific case of the eqnarray given in #23977 there would still seem to be an extra blank line at the bottom, but this is due to the extra `\\` at the end of the eqnarray, which is now taken into account (... but not by dvipng apparently (\*)); removing it (as shown in documented eqnarray examples, e.g. http://latexref.xyz/eqnarray.html, https://texfaq.org/FAQ-eqnarray) handles that.

(\*) but hopefully we'll get rid of dvipng anyways in favor of directly rendering the glyphs ourselves; see e.g. https://github.com/matplotlib/matplotlib/issues/22459#issuecomment-1038449575.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
