### PR TITLE
When comparing eps images, run ghostscript with -dEPSCrop.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -146,10 +146,10 @@ jobs:
             ~/.cache/matplotlib
             !~/.cache/matplotlib/tex.cache
             !~/.cache/matplotlib/test_cache
-          key: 1-${{ runner.os }}-py${{ matrix.python-version }}-mpl-${{ github.ref }}-${{ github.sha }}
+          key: 2-${{ runner.os }}-py${{ matrix.python-version }}-mpl-${{ github.ref }}-${{ github.sha }}
           restore-keys: |
-            1-${{ runner.os }}-py${{ matrix.python-version }}-mpl-${{ github.ref }}-
-            1-${{ runner.os }}-py${{ matrix.python-version }}-mpl-
+            2-${{ runner.os }}-py${{ matrix.python-version }}-mpl-${{ github.ref }}-
+            2-${{ runner.os }}-py${{ matrix.python-version }}-mpl-
 
       - name: Install Python dependencies
         run: |

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -103,7 +103,7 @@ class _GSConverter(_Converter):
         if not self._proc:
             self._proc = subprocess.Popen(
                 [mpl._get_executable_info("gs").executable,
-                 "-dNOSAFER", "-dNOPAUSE", "-sDEVICE=png16m"],
+                 "-dNOSAFER", "-dNOPAUSE", "-dEPSCrop", "-sDEVICE=png16m"],
                 # As far as I can see, ghostscript never outputs to stderr.
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE)
             try:


### PR DESCRIPTION
Currently, the ps backend positions eps images into an imaginary page (the smallest standard page size which can contain the figure size, which happens to be lettersized for the default figure size), setting the %%BoundingBox based on that positioning.  But the eps file format doesn't actually record the full page size (that's not the intent of the eps format anyways), just the position of the drawing relative to an origin.

GhostScript is then used to rasterize the eps images during testing; it implicitly assumes a default page size of "letter" (https://ghostscript.readthedocs.io/en/latest/Use.html#choosing-paper-size) which just happens to match the page size selected above.  So things are OK... except if the test figure is nondefault and actually *bigger* than lettersized; in that case ghostscript will just crop out whatever is out of the lettersized paper.  Note that such an image comparison test won't *fail*; it will just fail to compare anything that's outside of the lettersize paper.

Instead, pass -dEPSCrop to GhostScript
(https://ghostscript.readthedocs.io/en/latest/Use.html#depscrop) which readjusts the papersize to match the eps bounding box.

Test e.g. with
```python
import subprocess
from matplotlib.figure import Figure
for fs in [5, 10, 15, 20]:
    Figure(figsize=(fs, fs)).add_subplot().figure.savefig(f"test-{fs}.eps")
    subprocess.run([
        "gs", "-dNOSAFER", "-dNOPAUSE", "-dEPSCrop",
        "-o", f"test-{fs}.png", "-sDEVICE=png16m", f"test-{fs}.eps"])
```

(Noted while troubleshooting failed tests on mplcairo, which does not perform the centering -- but there were so few tests using eps that the difference in behavior was entirely hidden by the general mplcairo test tolerance, until some more tests were added in matplotlib 3.6.)

Not really a regression, but would still be nice to have this in 3.6.1 to make testing of mplcairo simpler (otherwise I'll just xfail some more tests in mplcairo...).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
