### PR TITLE
Don't require FigureCanvas on backend module more

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -182,7 +182,8 @@ def findobj(o=None, match=None, include_self=True):
 
 
 def _get_required_interactive_framework(backend_mod):
-    if not hasattr(backend_mod.FigureCanvas, "required_interactive_framework"):
+    if not hasattr(getattr(backend_mod, "FigureCanvas", None),
+                   "required_interactive_framework"):
         _api.warn_deprecated(
             "3.6", name="Support for FigureCanvases without a "
             "required_interactive_framework attribute")


### PR DESCRIPTION
## PR Summary

A slightly modified version of the check proposed by @TLCFEM.

Fixes #23911.

## PR Checklist

**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).