### PR TITLE
[DOC]: adding a grid to the style sheet reference.

### DIFF
--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -69,7 +69,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     ax.grid(visible=True)
 
     # Add title for enabling grid
-    plt.title('ax.grid(True)', family='monospace', fonstize='small')
+    plt.title('ax.grid(True)', family='monospace', fontsize='small')
 
     ax.set_xlim([-4, 8])
     ax.set_ylim([-5, 6])

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -66,14 +66,12 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     for sty_dict, j in zip(plt.rcParams['axes.prop_cycle'], range(nb_samples)):
         ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
                                 radius=1.0, color=sty_dict['color']))
-    
     ax.grid(visible=True)
     # Add annotation for enabling grid
     ax.annotate('ax.grid(True)', xy=(1, 1),
                 xytext=(5, 8),
                 va="top", ha="right",
                 )
-    
     # Force the limits to be the same across the styles (because different
     # styles may have different numbers of available colors).
     ax.set_xlim([-4, 8])
@@ -100,6 +98,7 @@ def plot_histograms(ax, prng, nb_samples=10000):
         values = prng.beta(a, b, size=nb_samples)
         ax.hist(values, histtype="stepfilled", bins=30,
                 alpha=0.8, density=True)
+
     # Add a small annotation.
     ax.annotate('Annotation', xy=(0.25, 4.25),
                 xytext=(0.9, 0.9), textcoords=ax.transAxes,
@@ -140,14 +139,10 @@ def plot_figure(style_label=""):
     plot_colored_circles(axs[5], prng)
 
     # add divider
-    rec = Rectangle(
-                    (1 + 0.025, -2), 
-                    0.05, 16, 
-                    clip_on=False, 
-                    color='gray')
-                    
-    axs[4].add_artist(rec)
+    rec = Rectangle((1 + 0.025, -2), 0.05, 16,
+                    clip_on=False, color='gray')
 
+    axs[4].add_artist(rec)
 
 if __name__ == "__main__":
 

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -12,6 +12,7 @@ line plot and histogram,
 import numpy as np
 import matplotlib.pyplot as plt
 import matplotlib.colors as mcolors
+from matplotlib.patches import Rectangle
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)
@@ -65,6 +66,14 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     for sty_dict, j in zip(plt.rcParams['axes.prop_cycle'], range(nb_samples)):
         ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
                                 radius=1.0, color=sty_dict['color']))
+    
+    ax.grid(visible=True)
+    # Add annotation for enabling grid
+    ax.annotate('ax.grid(True)', xy=(1, 1),
+                xytext=(5, 8),
+                va="top", ha="right",
+                )
+    
     # Force the limits to be the same across the styles (because different
     # styles may have different numbers of available colors).
     ax.set_xlim([-4, 8])
@@ -110,7 +119,7 @@ def plot_figure(style_label=""):
     prng = np.random.RandomState(96917002)
 
     fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
-                            figsize=(14.8, 2.7), constrained_layout=True)
+                            figsize=(14.8, 2.8), constrained_layout=True)
 
     # make a suptitle, in the same style for all subfigures,
     # except those with dark backgrounds, which get a lighter color:
@@ -126,9 +135,18 @@ def plot_figure(style_label=""):
     plot_scatter(axs[0], prng)
     plot_image_and_patch(axs[1], prng)
     plot_bar_graphs(axs[2], prng)
-    plot_colored_circles(axs[3], prng)
-    plot_colored_lines(axs[4])
-    plot_histograms(axs[5], prng)
+    plot_colored_lines(axs[3])
+    plot_histograms(axs[4], prng)
+    plot_colored_circles(axs[5], prng)
+
+    # add divider
+    rec = Rectangle(
+                    (1 + 0.025, -2), 
+                    0.05, 16, 
+                    clip_on=False, 
+                    color='gray')
+                    
+    axs[4].add_artist(rec)
 
 
 if __name__ == "__main__":

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -69,7 +69,7 @@ def plot_colored_circles(ax, prng, nb_samples=15):
     ax.grid(visible=True)
 
     # Add title for enabling grid
-    plt.title('ax.grid(True)', family='monospace', y=1.075)
+    plt.title('ax.grid(True)', family='monospace', fonstize='small')
 
     ax.set_xlim([-4, 8])
     ax.set_ylim([-5, 6])

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -67,13 +67,10 @@ def plot_colored_circles(ax, prng, nb_samples=15):
         ax.add_patch(plt.Circle(prng.normal(scale=3, size=2),
                                 radius=1.0, color=sty_dict['color']))
     ax.grid(visible=True)
-    # Add annotation for enabling grid
-    ax.annotate('ax.grid(True)', xy=(1, 1),
-                xytext=(5, 8),
-                va="top", ha="right",
-                )
-    # Force the limits to be the same across the styles (because different
-    # styles may have different numbers of available colors).
+
+    # Add title for enabling grid
+    plt.title('ax.grid(True)', family='monospace', y=1.075)
+
     ax.set_xlim([-4, 8])
     ax.set_ylim([-5, 6])
     ax.set_aspect('equal', adjustable='box')  # to plot circles as circles


### PR DESCRIPTION
## PR Summary
This PR adds gridlines to the last plot in the stylesheets example and adds an annotation `ax.grid(True)` as well as a divider to clearly distinguish between subplots. This addresses https://github.com/matplotlib/matplotlib/issues/23601
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
