### PR TITLE
Labels for PatchCollection do not show #23998 

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -665,6 +665,8 @@ class Legend(Artist):
         ErrorbarContainer: legend_handler.HandlerErrorbar(),
         Line2D: legend_handler.HandlerLine2D(),
         Patch: legend_handler.HandlerPatch(),
+        #I added this (emma mastro)
+        PathCollection: legend_handler.HandlerPatchCollection(),
         StepPatch: legend_handler.HandlerStepPatch(),
         LineCollection: legend_handler.HandlerLineCollection(),
         RegularPolyCollection: legend_handler.HandlerRegularPolyCollection(),

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -665,7 +665,6 @@ class Legend(Artist):
         ErrorbarContainer: legend_handler.HandlerErrorbar(),
         Line2D: legend_handler.HandlerLine2D(),
         Patch: legend_handler.HandlerPatch(),
-        #I added this (emma mastro)
         PathCollection: legend_handler.HandlerPatchCollection(),
         StepPatch: legend_handler.HandlerStepPatch(),
         LineCollection: legend_handler.HandlerLineCollection(),

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -347,7 +347,7 @@ class HandlerPatch(HandlerBase):
         self.update_prop(p, orig_handle, legend)
         p.set_transform(trans)
         return [p]
-#I added this (emmamastro)
+
 class HandlerPatchCollection(HandlerBase):
     """
     Handler for Collection of `.Patch` instances.

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -328,6 +328,38 @@ class HandlerPatch(HandlerBase):
         super().__init__(**kwargs)
         self._patch_func = patch_func
 
+
+    def _create_patch(self, legend, orig_handle,
+                      xdescent, ydescent, width, height, fontsize):
+        if self._patch_func is None:
+            p = Rectangle(xy=(-xdescent, -ydescent),
+                          width=width, height=height)
+        else:
+            p = self._patch_func(legend=legend, orig_handle=orig_handle,
+                                 xdescent=xdescent, ydescent=ydescent,
+                                 width=width, height=height, fontsize=fontsize)
+        return p
+
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize, trans):
+        p = self._create_patch(legend, orig_handle,
+                               xdescent, ydescent, width, height, fontsize)
+        self.update_prop(p, orig_handle, legend)
+        p.set_transform(trans)
+        return [p]
+#I added this (emmamastro)
+class HandlerPatchCollection(HandlerBase):
+    """
+    Handler for Collection of `.Patch` instances.
+    """
+    def _default_update_prop(self, legend_handle, orig_handle):
+            lw = orig_handle.get_linewidths()[0]
+            dashes = orig_handle._us_linestyles[0]
+            color = orig_handle.get_colors()[0]
+            legend_handle.set_color(color)
+            legend_handle.set_linestyle(dashes)
+            legend_handle.set_linewidth(lw)
+
     def _create_patch(self, legend, orig_handle,
                       xdescent, ydescent, width, height, fontsize):
         if self._patch_func is None:


### PR DESCRIPTION
## PR Summary
This is in response to Labels for PatchCollection Issue #23998. I added both the Handler for Patch collection class and the patch collection handler to the default_handler_map.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A ] Has pytest style unit tests (and `pytest` passes).
- [N/A ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ N/A] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
