### PR TITLE
Fix _FigureManagerGTK.resize on GTK4

### DIFF
--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -233,8 +233,8 @@ class _FigureManagerGTK(FigureManagerBase):
         width = int(width / self.canvas.device_pixel_ratio)
         height = int(height / self.canvas.device_pixel_ratio)
         if self.toolbar:
-            toolbar_size = self.toolbar.size_request()
-            height += toolbar_size.height
+            min_size, nat_size = self.toolbar.get_preferred_size()
+            height += nat_size.height
         canvas_size = self.canvas.get_allocation()
         if self._gtk_ver >= 4 or canvas_size.width == canvas_size.height == 1:
             # A canvas size of (1, 1) cannot exist in most cases, because


### PR DESCRIPTION
## PR Summary

Using the [same method as `__init__`](https://github.com/matplotlib/matplotlib/blob/a283d20f9d682543e40a3d5acb63f299aee92aa4/lib/matplotlib/backends/_backend_gtk.py#L174-L175) to avoid the deprecated-in-GTK3 and removed-in-GTK4 API.

Closes #24015

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).