### PR TITLE
Ignore 'CFMessagePort: bootstrap_register' messages

### DIFF
--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -53,11 +53,14 @@ def _isolated_tk_test(success_count, func=None):
                         + str(e.stderr))
         else:
             # macOS may actually emit irrelevant errors about Accelerated
-            # OpenGL vs. software OpenGL, so suppress them.
+            # OpenGL vs. software OpenGL, or some permission error on Azure, so
+            # suppress them.
             # Asserting stderr first (and printing it on failure) should be
             # more helpful for debugging that printing a failed success count.
+            ignored_lines = ["OpenGL", "CFMessagePort: bootstrap_register",
+                             "/usr/include/servers/bootstrap_defs.h"]
             assert not [line for line in proc.stderr.splitlines()
-                        if "OpenGL" not in line]
+                        if all(msg not in line for msg in ignored_lines)]
             assert proc.stdout.count("success") == success_count
 
     return test_func


### PR DESCRIPTION
## PR Summary

This should fix macOS errors on Azure (or I'm hoping it will.)

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).