### PR TITLE
Raises ValueError on unequal lengths of labels and handles input

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1261,7 +1261,7 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
         handles, labels = args[:2]
         extra_args = args[2:]
     
-    #Check length of handles and labels is consistent
+    # Check length of handles and labels is consistent
     elif len(handles) != len(labels):
         raise ValueError("Number of handles not equal to number of labels.")
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1264,7 +1264,7 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
     # Check length of handles and labels is consistent
     elif len(handles) != len(labels):
         raise ValueError("Number of handles not equal "
-                        "to number of labels.")
+                         "to number of labels.")
     else:
         raise TypeError('Invalid arguments to legend.')
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1263,7 +1263,8 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
 
     # Check length of handles and labels is consistent
     elif len(handles) != len(labels):
-        raise ValueError("Number of handles not equal to number of labels.")
+        raise ValueError("Number of handles not equal "
+                        "to number of labels.")
     else:
         raise TypeError('Invalid arguments to legend.')
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1260,6 +1260,10 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
     elif len(args) >= 2:
         handles, labels = args[:2]
         extra_args = args[2:]
+    
+    #Check length of handles and labels is consistent
+    elif len(handles) != len(labels):
+        raise ValueError("Number of handles not equal to number of labels.")
 
     else:
         raise TypeError('Invalid arguments to legend.')

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1260,11 +1260,10 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
     elif len(args) >= 2:
         handles, labels = args[:2]
         extra_args = args[2:]
-    
+
     # Check length of handles and labels is consistent
     elif len(handles) != len(labels):
         raise ValueError("Number of handles not equal to number of labels.")
-
     else:
         raise TypeError('Invalid arguments to legend.')
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -976,5 +976,5 @@ def test_handles_labels_length(self):
     l1 = plt.plot(range(10))
     l2 = plt.plot(range(11))
     with pytest.raises(ValueError, match="Number of handles not equal "
-                                        "to number of labels."):
+                                         "to number of labels."):
         plt.legend([l1, l2], ['l1', 'l2', 'l3'])

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -970,3 +970,11 @@ def test_ncol_ncols(fig_test, fig_ref):
     ncols = 3
     fig_test.legend(strings, ncol=ncols)
     fig_ref.legend(strings, ncols=ncols)
+
+
+def test_handles_labels_length(self):
+    l1 = plt.plot(range(10))
+    l2 = plt.plot(range(11))
+    with pytest.raises(ValueError, match="Number of handles not equal "
+                                        "to number of labels."):
+        plt.legend([l1, l2], ['l1', 'l2', 'l3'])


### PR DESCRIPTION
…_args

## PR Summary
Verifying that the inputs are of a consistent length in _parse_legend_args.
Number of elements in handles and labels should be equal, addressing the issue #24050 .

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
