### PR TITLE
Fixed the positioning of cursor in Textbox: no approximation

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -339,6 +339,32 @@ def test_set_position():
         assert a + shift_val == b
 
 
+def test_char_index_at():
+    fig = plt.figure()
+    text = fig.text(0.1, 0.9, "")
+
+    text.set_text("i")
+    bbox = text.get_window_extent()
+    size_i = bbox.x1 - bbox.x0
+
+    text.set_text("m")
+    bbox = text.get_window_extent()
+    size_m = bbox.x1 - bbox.x0
+
+    text.set_text("iiiimmmm")
+    bbox = text.get_window_extent()
+    origin = bbox.x0
+
+    assert text._char_index_at(origin - size_i) == 0  # left of first char
+    assert text._char_index_at(origin) == 0
+    assert text._char_index_at(origin + 0.499*size_i) == 0
+    assert text._char_index_at(origin + 0.501*size_i) == 1
+    assert text._char_index_at(origin + size_i*3) == 3
+    assert text._char_index_at(origin + size_i*4 + size_m*3) == 7
+    assert text._char_index_at(origin + size_i*4 + size_m*4) == 8
+    assert text._char_index_at(origin + size_i*4 + size_m*10) == 8
+
+
 @pytest.mark.parametrize('text', ['', 'O'], ids=['empty', 'non-empty'])
 def test_non_default_dpi(text):
     fig, ax = plt.subplots()

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -124,6 +124,7 @@ class Text(Artist):
     """Handle storing and drawing of text in window or data coordinates."""
 
     zorder = 3
+    _charsize_cache = dict()
 
     def __repr__(self):
         return "Text(%s, %s, %s)" % (self._x, self._y, repr(self._text))
@@ -278,6 +279,38 @@ class Text(Artist):
             return self._multialignment
         else:
             return self._horizontalalignment
+
+    def _char_index_at(self, x):
+        """
+        Calculate the index closest to the coordinate x in display space.
+
+        The position of text[index] is assumed to be the sum of the widths
+        of all preceding characters text[:index].
+
+        This works only on single line texts.
+        """
+        if not self._text:
+            return 0
+
+        text = self._text
+
+        fontproperties = str(self._fontproperties)
+        if fontproperties not in Text._charsize_cache:
+            Text._charsize_cache[fontproperties] = dict()
+
+        charsize_cache = Text._charsize_cache[fontproperties]
+        for char in set(text):
+            if char not in charsize_cache:
+                self.set_text(char)
+                bb = self.get_window_extent()
+                charsize_cache[char] = bb.x1 - bb.x0
+
+        self.set_text(text)
+        bb = self.get_window_extent()
+
+        size_accum = np.cumsum([0] + [charsize_cache[x] for x in text])
+        std_x = x - bb.x0
+        return (np.abs(size_accum - std_x)).argmin()
 
     def get_rotation(self):
         """Return the text angle in degrees between 0 and 360."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1315,17 +1315,6 @@ class TextBox(AxesWidget):
             # call it once we've already done our cleanup.
             self._observers.process('submit', self.text)
 
-    def position_cursor(self, x):
-        # now, we have to figure out where the cursor goes.
-        # approximate it based on assuming all characters the same length
-        if len(self.text) == 0:
-            self.cursor_index = 0
-        else:
-            bb = self.text_disp.get_window_extent()
-            ratio = np.clip((x - bb.x0) / bb.width, 0, 1)
-            self.cursor_index = int(len(self.text) * ratio)
-        self._rendercursor()
-
     def _click(self, event):
         if self.ignore(event):
             return
@@ -1338,7 +1327,8 @@ class TextBox(AxesWidget):
             event.canvas.grab_mouse(self.ax)
         if not self.capturekeystrokes:
             self.begin_typing(event.x)
-        self.position_cursor(event.x)
+        self.cursor_index = self.text_disp._char_index_at(event.x)
+        self._rendercursor()
 
     def _resize(self, event):
         self.stop_typing()


### PR DESCRIPTION
## PR Summary

I updated the position_cursor function of Textbox so that it doesn't approximate the position of the cursor incorrectly anymore. Now, instead, to calculate the cursor's position, we accumulate the width of each character contained in the text and find the index where the distance between the click position and the accumulated sum is minimal.

I found that the approximation used in the position_cursor function before this PR was really buggy sometimes, running this code block and trying to set the cursor in different positions makes it apparent :

```
from matplotlib import pyplot as plt
from matplotlib.widgets import TextBox

fig = plt.figure(figsize=(4, 3))
        
box_input = fig.add_axes([0.1, 0.5, 0.8, 0.2])
        
text_box = TextBox(ax=box_input, initial=f'kkkkkk iiiii kkkkkk', label='')

fig.show()
```

For example, to put the cursor at the start of the second block of "k"s you needed to click one letter forward, while with the change it works as one would expect.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

