### PR TITLE
TST: force test with shared test image to run in serial

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -894,18 +894,14 @@ def test_hexbin_extent():
     ax.hexbin("x", "y", extent=[.1, .3, .6, .7], data=data)
 
 
-@image_comparison(['hexbin_empty.png'], remove_text=True)
+@image_comparison(['hexbin_empty.png', 'hexbin_empty.png'], remove_text=True)
 def test_hexbin_empty():
     # From #3886: creating hexbin from empty dataset raises ValueError
-    ax = plt.gca()
+    fig, ax = plt.subplots()
     ax.hexbin([], [])
-
-
-@image_comparison(['hexbin_empty.png'], remove_text=True)
-def test_hexbin_log_empty():
+    fig, ax = plt.subplots()
     # From #23922: creating hexbin with log scaling from empty
     # dataset raises ValueError
-    ax = plt.gca()
     ax.hexbin([], [], bins='log')
 
 


### PR DESCRIPTION
## PR Summary

The tests test_hexbin_empty and test_hexbin_log_empty use the same target image, however if they the tests ended up being run in different workers when running the tests in parallel they will step on each other if one of the test starts writing the output file while the other is trying to read the test image.

By putting them in the same test they will save and evaluate in order.

I verified I could break both tests.

The other option here is to make a copy of the file (which should be free at the git level due to content based addressing).  I am happy to switch to that if the consensus that is a better approach happy to switch (I was very much on the fence).

This should fix the current rash of transient failures.  We are running `-n 2` on CI so we need to get unlucky that the tests go to different workers and that they run close enough in time to matter which is why we only see in 1-2 jobs per CI run and re-running seems to reliably fix it. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
