### PR TITLE
Enable interactive figure resizing for webagg and nbagg backends

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -612,8 +612,8 @@ mpl.figure.prototype.mouse_event = function (event, name) {
             && canvas_pos.y >= this.rubberband_canvas.height - this.resize_handle_size) {
             this.resizing = true;
             this.resizing_pad = {
-                x: this.rubberband_canvas.width-canvas_pos.x,
-                y: this.rubberband_canvas.height-canvas_pos.y
+                x: this.rubberband_canvas.width - canvas_pos.x,
+                y: this.rubberband_canvas.height - canvas_pos.y
             };
             return; 
         } else {
@@ -649,11 +649,11 @@ mpl.figure.prototype.resize_event = function (event) {
     if (this.resizing) {
         var boundingRect = this.rubberband_canvas.getBoundingClientRect();
         this._resize_canvas(event.clientX - boundingRect.left + this.resizing_pad.x,
-                            event.clientY - boundingRect.top + this.resizing_pad.y, 1);
+            event.clientY - boundingRect.top + this.resizing_pad.y, 1);
     }
 }
 
-mpl.figure.prototype.stop_resize_event = function (event) {
+mpl.figure.prototype.stop_resize_event = function () {
     this.resizing = false;
 }
 

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -54,6 +54,14 @@ mpl.figure = function (figure_id, websocket, ondownload, parent_element) {
     this._init_header(this);
     this._init_canvas(this);
     this._init_toolbar(this);
+    
+    this.resizing = false;
+    this.resize_handle_size = 20;
+    this._resize_event = this.resize_event.bind(this);
+    this._stop_resize_event = this.stop_resize_event.bind(this);
+    
+    window.addEventListener('mousemove', this._resize_event);
+    window.addEventListener('mouseup', this._stop_resize_event);
 
     var fig = this;
 
@@ -82,6 +90,7 @@ mpl.figure = function (figure_id, websocket, ondownload, parent_element) {
 
     this.imageObj.onunload = function () {
         fig.ws.close();
+        fig.remove();
     };
 
     this.ws.onmessage = this._make_on_message_function(this);
@@ -599,8 +608,22 @@ mpl.figure.prototype.mouse_event = function (event, name) {
     var canvas_pos = mpl.findpos(event);
 
     if (name === 'button_press') {
-        this.canvas.focus();
-        this.canvas_div.focus();
+        if (canvas_pos.x >= this.rubberband_canvas.width - this.resize_handle_size 
+            && canvas_pos.y >= this.rubberband_canvas.height - this.resize_handle_size) {
+            this.resizing = true;
+            this.resizing_pad = {
+                x: this.rubberband_canvas.width-canvas_pos.x,
+                y: this.rubberband_canvas.height-canvas_pos.y
+            };
+            return; 
+        } else {
+            this.canvas.focus();
+            this.canvas_div.focus();
+        }
+    }
+    
+    if (this.resizing) {
+        return;
     }
 
     var x = canvas_pos.x * this.ratio;
@@ -621,6 +644,23 @@ mpl.figure.prototype.mouse_event = function (event, name) {
     event.preventDefault();
     return false;
 };
+
+mpl.figure.prototype.resize_event = function (event) {
+    if (this.resizing) {
+        var boundingRect = this.rubberband_canvas.getBoundingClientRect();
+        this._resize_canvas(event.clientX - boundingRect.left + this.resizing_pad.x,
+                            event.clientY - boundingRect.top + this.resizing_pad.y, 1);
+    }
+}
+
+mpl.figure.prototype.stop_resize_event = function (event) {
+    this.resizing = false;
+}
+
+mpl.figure.prototype.remove = function() {
+    window.removeEventListener('mousemove', this._resize_event);
+    window.removeEventListener('mouseup', this._stop_resize_event);
+}
 
 mpl.figure.prototype._key_event_extra = function (_event, _name) {
     // Handle any extra behaviour associated with a key event

--- a/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/nbagg_mpl.js
@@ -91,6 +91,7 @@ mpl.figure.prototype.handle_close = function (fig, msg) {
     fig.parent_element.innerHTML =
         '<img src="' + dataURL + '" width="' + width + '">';
     fig.close_ws(fig, msg);
+    fig.remove();
 };
 
 mpl.figure.prototype.close_ws = function (fig, msg) {
@@ -206,6 +207,7 @@ mpl.figure.prototype._remove_fig_handler = function (event) {
         return;
     }
     fig.close_ws(fig, {});
+    fig.remove();
 };
 
 mpl.figure.prototype._root_extra_style = function (el) {


### PR DESCRIPTION
## PR Summary
This PR adds support for interactively resizing figures when using WebAgg or NbAgg backends. It essentially backports the logic used in ipympl which supports the same manner of resizing (i.e. dragging the bottom right corner).

Note the same logic applies to both webagg and nbagg (via mpl.js).

Fixes #24075

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->

https://user-images.githubusercontent.com/114848324/193519952-9edecc74-f06a-43cb-bb3b-7e111a80521d.mov


https://user-images.githubusercontent.com/114848324/193519979-0d2c0346-77ca-4589-9b6d-03aa5927b667.mov

