### PR TITLE
MNT: make orphaned colorbar deprecate versus raise

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1253,11 +1253,13 @@ default: %(va)s
         # Store the value of gca so that we can set it back later on.
         if cax is None:
             if ax is None:
-                raise ValueError(
+                _api.warn_deprecated("3.6", message=(
                     'Unable to determine Axes to steal space for Colorbar. '
+                    'Using gca(), but will raise in the future. '
                     'Either provide the *cax* argument to use as the Axes for '
                     'the Colorbar, provide the *ax* argument to steal space '
-                    'from it, or add *mappable* to an Axes.')
+                    'from it, or add *mappable* to an Axes.'))
+                ax = self.gca()
             current_ax = self.gca()
             userax = False
             if (use_gridspec and isinstance(ax, SubplotBase)):

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1,9 +1,11 @@
 import numpy as np
 import pytest
 
+from matplotlib import _api
 from matplotlib import cm
 import matplotlib.colors as mcolors
 import matplotlib as mpl
+
 
 from matplotlib import rc_context
 from matplotlib.testing.decorators import image_comparison
@@ -319,7 +321,8 @@ def test_parentless_mappable():
     pc = mpl.collections.PatchCollection([], cmap=plt.get_cmap('viridis'))
     pc.set_array([])
 
-    with pytest.raises(ValueError, match='Unable to determine Axes to steal'):
+    with pytest.warns(_api.MatplotlibDeprecationWarning,
+                      match='Unable to determine Axes to steal'):
         plt.colorbar(pc)
 
 


### PR DESCRIPTION
## PR Summary

Closes #23973 where we, without warning, started raising if a colorbar's mappable had no axes.  This adds a deprecation, and otherwise restores the previous behaviour.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
