### PR TITLE
Simplest pyproject.toml containing build-system only

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           # Upgrade pip and setuptools and wheel to get as clean an install as
           # possible.
-          python -m pip install --upgrade pip setuptools wheel
+          python -m pip install --upgrade pip 'setuptools<64' wheel
 
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -224,8 +224,9 @@ jobs:
           git describe
 
           # Set flag in a delayed manner to avoid issues with installing other
-          # packages
-          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+          # packages. Only enabling coverage on minimum versions run as both
+          # need building using --no-build-isolation.
+          if [[ "${{ matrix.name-suffix }}" == '(Minimum Versions)' ]]; then
             if [[ "$(lsb_release -r -s)" == "20.04" ]]; then
               export CPPFLAGS='--coverage -fprofile-abs-path'
             else
@@ -242,9 +243,13 @@ jobs:
 
           # All dependencies must have been pre-installed, so that the minver
           # constraints are held.
-          python -m pip install --no-deps -ve .
+          if [[ "${{ matrix.name-suffix }}" == '(Minimum Versions)' ]]; then
+            python -m pip install --no-deps --no-build-isolation -ve .
+          else
+            python -m pip install --no-deps -ve .
+          fi
 
-          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+          if [[ "${{ matrix.name-suffix }}" == '(Minimum Versions)' ]]; then
             unset CPPFLAGS
           fi
 
@@ -266,7 +271,7 @@ jobs:
             --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
           lcov --list coverage.info
           find . -name '*.gc*' -delete
-        if: ${{ runner.os != 'macOS' }}
+        if: ${{ matrix.name-suffix == '(Minimum Versions)' }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,7 +155,7 @@ jobs:
         run: |
           # Upgrade pip and setuptools and wheel to get as clean an install as
           # possible.
-          python -m pip install --upgrade pip 'setuptools<64' wheel
+          python -m pip install --upgrade pip setuptools wheel
 
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \
@@ -224,9 +224,8 @@ jobs:
           git describe
 
           # Set flag in a delayed manner to avoid issues with installing other
-          # packages. Only enabling coverage on minimum versions run as both
-          # need building using --no-build-isolation.
-          if [[ "${{ matrix.name-suffix }}" == '(Minimum Versions)' ]]; then
+          # packages
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
             if [[ "$(lsb_release -r -s)" == "20.04" ]]; then
               export CPPFLAGS='--coverage -fprofile-abs-path'
             else
@@ -241,15 +240,15 @@ jobs:
 
           cat mplsetup.cfg
 
-          # All dependencies must have been pre-installed, so that the minver
-          # constraints are held.
           if [[ "${{ matrix.name-suffix }}" == '(Minimum Versions)' ]]; then
+            # Minimum versions run does not use build isolation so that it
+            # builds against the pre-installed minver dependencies.
             python -m pip install --no-deps --no-build-isolation -ve .
           else
             python -m pip install --no-deps -ve .
           fi
 
-          if [[ "${{ matrix.name-suffix }}" == '(Minimum Versions)' ]]; then
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
             unset CPPFLAGS
           fi
 
@@ -271,7 +270,7 @@ jobs:
             --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
           lcov --list coverage.info
           find . -name '*.gc*' -delete
-        if: ${{ matrix.name-suffix == '(Minimum Versions)' }}
+        if: ${{ runner.os != 'macOS' }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = [
+    "certifi>=2020.06.20",
+    "numpy>=1.19",
+    "setuptools_scm>=7",
+]

--- a/setup.py
+++ b/setup.py
@@ -216,8 +216,9 @@ def update_matplotlibrc(path):
 class BuildPy(setuptools.command.build_py.build_py):
     def run(self):
         super().run()
+        base_dir = "lib" if self.editable_mode else self.build_lib
         update_matplotlibrc(
-            Path(self.build_lib, "matplotlib/mpl-data/matplotlibrc"))
+            Path(base_dir, "matplotlib/mpl-data/matplotlibrc"))
 
 
 class Sdist(setuptools.command.sdist.sdist):

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ import setuptools.command.build_ext
 import setuptools.command.build_py
 import setuptools.command.sdist
 
+# sys.path modified to find setupext.py during pyproject.toml builds.
 sys.path.append(str(Path(__file__).resolve().parent))
 
 import setupext
@@ -71,7 +72,7 @@ def has_flag(self, flagname):
 class BuildExtraLibraries(setuptools.command.build_ext.build_ext):
     def finalize_options(self):
         # If coverage is enabled then need to keep the .o and .gcno files in a
-        # non-temporary directory otherwise coverage info is not collected.
+        # non-temporary directory otherwise coverage info not collected.
         cppflags = os.getenv('CPPFLAGS')
         if cppflags and '--coverage' in cppflags:
             self.build_temp = 'build'

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,8 @@ import setuptools.command.build_ext
 import setuptools.command.build_py
 import setuptools.command.sdist
 
+sys.path.append(str(Path(__file__).resolve().parent))
+
 import setupext
 from setupext import print_raw, print_status
 
@@ -300,11 +302,6 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
     package_data=package_data,
 
     python_requires='>={}'.format('.'.join(str(n) for n in py_min_version)),
-    setup_requires=[
-        "certifi>=2020.06.20",
-        "numpy>=1.19",
-        "setuptools_scm>=7",
-    ],
     install_requires=[
         "contourpy>=1.0.1",
         "cycler>=0.10",

--- a/setup.py
+++ b/setup.py
@@ -216,9 +216,9 @@ def update_matplotlibrc(path):
 class BuildPy(setuptools.command.build_py.build_py):
     def run(self):
         super().run()
-        base_dir = "lib" if self.editable_mode else self.build_lib
-        update_matplotlibrc(
-            Path(base_dir, "matplotlib/mpl-data/matplotlibrc"))
+        if not self.editable_mode:
+            update_matplotlibrc(
+                Path(self.build_lib, "matplotlib/mpl-data/matplotlibrc"))
 
 
 class Sdist(setuptools.command.sdist.sdist):

--- a/setup.py
+++ b/setup.py
@@ -70,6 +70,12 @@ def has_flag(self, flagname):
 
 class BuildExtraLibraries(setuptools.command.build_ext.build_ext):
     def finalize_options(self):
+        # If coverage is enabled then need to keep the .o and .gcno files in a
+        # non-temporary directory otherwise coverage info is not collected.
+        cppflags = os.getenv('CPPFLAGS')
+        if cppflags and '--coverage' in cppflags:
+            self.build_temp = 'build'
+
         self.distribution.ext_modules[:] = [
             ext
             for package in good_packages


### PR DESCRIPTION
This is the start of a transition to a `pyproject.toml` build system (issue #23815) and is a alternative to (or precursor to) PR #23829.

This is the only part of the `pyproject.toml` transition that is required for the `pybind11` progress to continue. So after this is merged work can continue on both `pyproject.toml` and `pybind11` independently.