### PR TITLE
FIX: add missing method to ColormapRegistry

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.6.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.6.0/deprecations.rst
@@ -52,7 +52,13 @@ In Matplotlib 3.6 we have marked those top level functions as pending
 deprecation with the intention of deprecation in Matplotlib 3.7. The following
 functions have been marked for pending deprecation:
 
-- ``matplotlib.cm.get_cmap``; use ``matplotlib.colormaps[name]`` instead
+- ``matplotlib.cm.get_cmap``; use ``matplotlib.colormaps[name]`` instead if you
+  have a `str`.
+
+  **Added 3.6.1** Use `matplotlib.cm.ColormapRegistry.get_cmap` if you
+  have a string, `None` or a `matplotlib.colors.Colormap` object that you want
+  to convert to a `matplotlib.colors.Colormap` instance.  Raises `KeyError`
+  rather than `ValueError` for missing strings.
 - ``matplotlib.cm.register_cmap``; use `matplotlib.colormaps.register
   <.ColormapRegistry.register>` instead
 - ``matplotlib.cm.unregister_cmap``; use `matplotlib.colormaps.unregister
@@ -305,7 +311,7 @@ Backend-specific deprecations
   private functions if you rely on it.
 - ``backend_svg.generate_transform`` and ``backend_svg.generate_css``
 - ``backend_tk.NavigationToolbar2Tk.lastrect`` and
-  ``backend_tk.RubberbandTk.lastrect`` 
+  ``backend_tk.RubberbandTk.lastrect``
 - ``backend_tk.NavigationToolbar2Tk.window``; use ``toolbar.master`` instead.
 - ``backend_tools.ToolBase.destroy``; To run code upon tool removal, connect to
   the ``tool_removed_event`` event.

--- a/doc/api/prev_api_changes/api_changes_3.6.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.6.0/deprecations.rst
@@ -57,8 +57,7 @@ functions have been marked for pending deprecation:
 
   **Added 3.6.1** Use `matplotlib.cm.ColormapRegistry.get_cmap` if you
   have a string, `None` or a `matplotlib.colors.Colormap` object that you want
-  to convert to a `matplotlib.colors.Colormap` instance.  Raises `KeyError`
-  rather than `ValueError` for missing strings.
+  to convert to a `matplotlib.colors.Colormap` instance.
 - ``matplotlib.cm.register_cmap``; use `matplotlib.colormaps.register
   <.ColormapRegistry.register>` instead
 - ``matplotlib.cm.unregister_cmap``; use `matplotlib.colormaps.unregister

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -202,10 +202,6 @@ class ColormapRegistry(Mapping):
         Returns
         -------
         Colormap
-
-        Raises
-        ------
-        KeyError
         """
         # get the default color map
         if cmap is None:
@@ -214,9 +210,14 @@ class ColormapRegistry(Mapping):
         # if the user passed in a Colormap, simply return it
         if isinstance(cmap, colors.Colormap):
             return cmap
-
-        # otherwise, it must be a string so look it up
-        return self[cmap]
+        if isinstance(cmap, str):
+            _api.check_in_list(sorted(_colormaps), cmap=cmap)
+            # otherwise, it must be a string so look it up
+            return self[cmap]
+        raise TypeError(
+            'get_cmap expects None or an instance of a str or Colormap . ' +
+            f'you passed {cmap!r} of type {type(cmap)}'
+        )
 
 
 # public access to the colormaps should be via `matplotlib.colormaps`. For now,

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -193,6 +193,39 @@ class ColormapRegistry(Mapping):
                              "colormap.")
         self._cmaps.pop(name, None)
 
+    def get_cmap(self, cmap):
+        """
+        Ensure that at given object is a converted to a color map.
+
+        If *cmap* in `None`, returns the Colormap named by :rc:`image.cmap`.
+
+        Parameters
+        ----------
+        cmap : str, Colormap, None
+
+            - if a `~matplotlib.colors.Colormap`, return it
+            - if a string, look it up in mpl.colormaps
+            - if None, look up the default color map in mpl.colormaps
+
+        Returns
+        -------
+        Colormap
+
+        Raises
+        ------
+        KeyError
+        """
+        # get the default color map
+        if cmap is None:
+            return self[mpl.rcParams["image.cmap"]]
+
+        # if the user passed in a Colormap, simply return it
+        if isinstance(cmap, colors.Colormap):
+            return cmap
+
+        # otherwise, it must be a string so look it up
+        return self[cmap]
+
 
 # public access to the colormaps should be via `matplotlib.colormaps`. For now,
 # we still create the registry here, but that should stay an implementation
@@ -281,7 +314,12 @@ def _get_cmap(name=None, lut=None):
 # pyplot.
 get_cmap = _api.deprecated(
     '3.6',
-    name='get_cmap', pending=True, alternative="``matplotlib.colormaps[name]``"
+    name='get_cmap',
+    pending=True,
+    alternative=(
+        "``matplotlib.colormaps[name]`` " +
+        "or ``matplotlib.colormaps.get_cmap(obj)``"
+    )
 )(_get_cmap)
 
 
@@ -687,6 +725,8 @@ def _ensure_cmap(cmap):
     """
     Ensure that we have a `.Colormap` object.
 
+    For internal use to preserve type stability of errors.
+
     Parameters
     ----------
     cmap : None, str, Colormap
@@ -698,6 +738,7 @@ def _ensure_cmap(cmap):
     Returns
     -------
     Colormap
+
     """
     if isinstance(cmap, colors.Colormap):
         return cmap

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -61,12 +61,6 @@ class ColormapRegistry(Mapping):
     r"""
     Container for colormaps that are known to Matplotlib by name.
 
-    .. admonition:: Experimental
-
-       While we expect the API to be final, we formally mark it as
-       experimental for 3.5 because we want to keep the option to still adapt
-       the API for 3.6 should the need arise.
-
     The universal registry instance is `matplotlib.colormaps`. There should be
     no need for users to instantiate `.ColormapRegistry` themselves.
 

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -189,17 +189,15 @@ class ColormapRegistry(Mapping):
 
     def get_cmap(self, cmap):
         """
-        Ensure that at given object is a converted to a color map.
-
-        If *cmap* in `None`, returns the Colormap named by :rc:`image.cmap`.
+        Return a color map specified through *cmap*.
 
         Parameters
         ----------
-        cmap : str, Colormap, None
+        cmap : str or `~matplotlib.colors.Colormap` or None
 
-            - if a `~matplotlib.colors.Colormap`, return it
-            - if a string, look it up in mpl.colormaps
-            - if None, look up the default color map in mpl.colormaps
+            - if a `.Colormap`, return it
+            - if a string, look it up in ``mpl.colormaps``
+            - if None, return the Colormap defined in :rc:`image.cmap`
 
         Returns
         -------

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -109,7 +109,7 @@ def test_register_cmap():
             cm.register_cmap('nome', cmap='not a cmap')
 
 
-def test_ensure_cmap():
+def test_colormaps_get_cmap():
     cr = mpl.colormaps
     new_cm = mcolors.ListedColormap(cr["viridis"].colors, name='v2')
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -111,17 +111,22 @@ def test_register_cmap():
 
 def test_colormaps_get_cmap():
     cr = mpl.colormaps
-    new_cm = mcolors.ListedColormap(cr["viridis"].colors, name='v2')
 
-    # check None, str, and Colormap pass
+    # check str, and Colormap pass
     assert cr.get_cmap('plasma') == cr["plasma"]
     assert cr.get_cmap(cr["magma"]) == cr["magma"]
 
-    # check default default
+    # check default
     assert cr.get_cmap(None) == cr[mpl.rcParams['image.cmap']]
+
+    # check ValueError on bad name
     bad_cmap = 'AardvarksAreAwkward'
-    with pytest.raises(KeyError, match=bad_cmap):
+    with pytest.raises(ValueError, match=bad_cmap):
         cr.get_cmap(bad_cmap)
+
+    # check TypeError on bad type
+    with pytest.raises(TypeError, match='object'):
+        cr.get_cmap(object())
 
 
 def test_double_register_builtin_cmap():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -109,6 +109,21 @@ def test_register_cmap():
             cm.register_cmap('nome', cmap='not a cmap')
 
 
+def test_ensure_cmap():
+    cr = mpl.colormaps
+    new_cm = mcolors.ListedColormap(cr["viridis"].colors, name='v2')
+
+    # check None, str, and Colormap pass
+    assert cr.get_cmap('plasma') == cr["plasma"]
+    assert cr.get_cmap(cr["magma"]) == cr["magma"]
+
+    # check default default
+    assert cr.get_cmap(None) == cr[mpl.rcParams['image.cmap']]
+    bad_cmap = 'AardvarksAreAwkward'
+    with pytest.raises(KeyError, match=bad_cmap):
+        cr.get_cmap(bad_cmap)
+
+
 def test_double_register_builtin_cmap():
     name = "viridis"
     match = f"Re-registering the builtin cmap {name!r}."


### PR DESCRIPTION
## PR Summary

After putting pending deprecations on `cm.get_cmap` we discovered that downstream libraries (pandas) were using the deprecated method to normalize between `None` (to get the default colormap), strings, and Colormap instances. This adds a method to `ColormapRegistry` to do this normalization.

This can not replace our internal helper due to variations in what exceptions are raised.

Closes #23981

I opted to edit the existing deprecation message as this seemed like the lest-bad option.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
