### PR TITLE
Add exception class to pytest.warns calls

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -491,13 +491,15 @@ def test_subclass_clear_cla():
     # Note, we cannot use mocking here as we want to be sure that the
     # superclass fallback does not recurse.
 
-    with pytest.warns(match='Overriding `Axes.cla`'):
+    with pytest.warns(PendingDeprecationWarning,
+                      match='Overriding `Axes.cla`'):
         class ClaAxes(Axes):
             def cla(self):
                 nonlocal called
                 called = True
 
-    with pytest.warns(match='Overriding `Axes.cla`'):
+    with pytest.warns(PendingDeprecationWarning,
+                      match='Overriding `Axes.cla`'):
         class ClaSuperAxes(Axes):
             def cla(self):
                 nonlocal called

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -117,7 +117,7 @@ def test_double_register_builtin_cmap():
             mpl.colormaps[name], name=name, force=True
         )
     with pytest.raises(ValueError, match='A colormap named "viridis"'):
-        with pytest.warns():
+        with pytest.warns(PendingDeprecationWarning):
             cm.register_cmap(name, mpl.colormaps[name])
     with pytest.warns(UserWarning):
         # TODO is warning more than once!
@@ -128,7 +128,7 @@ def test_unregister_builtin_cmap():
     name = "viridis"
     match = f'cannot unregister {name!r} which is a builtin colormap.'
     with pytest.raises(ValueError, match=match):
-        with pytest.warns():
+        with pytest.warns(PendingDeprecationWarning):
             cm.unregister_cmap(name)
 
 


### PR DESCRIPTION
## PR Summary

This is failing on current pytest.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).