### PR TITLE
Replace getmask with getmaskarray

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1302,9 +1302,8 @@ class Normalize:
             dtype = np.promote_types(dtype, np.float32)
         # ensure data passed in as an ndarray subclass are interpreted as
         # an ndarray. See issue #6622.
-        mask = np.ma.getmask(value)
-        data = np.asarray(value)
-        result = np.ma.array(data, mask=mask, dtype=dtype, copy=True)
+        result = np.ma.array(np.asarray(value), mask=np.ma.getmaskarray(value),
+                             dtype=dtype, copy=True)
         return result, is_scalar
 
     def __call__(self, value, clip=None):
@@ -1341,9 +1340,8 @@ class Normalize:
             raise ValueError("minvalue must be less than or equal to maxvalue")
         else:
             if clip:
-                mask = np.ma.getmask(result)
                 result = np.ma.array(np.clip(result.filled(vmax), vmin, vmax),
-                                     mask=mask)
+                                     mask=np.ma.getmaskarray(result))
             # ma division is very slow; we can take a shortcut
             resdat = result.data
             resdat -= vmin
@@ -1459,7 +1457,7 @@ class TwoSlopeNorm(Normalize):
         result = np.ma.masked_array(
             np.interp(result, [self.vmin, self.vcenter, self.vmax],
                       [0, 0.5, 1], left=-np.inf, right=np.inf),
-            mask=np.ma.getmask(result))
+            mask=np.ma.getmaskarray(result))
         if is_scalar:
             result = np.atleast_1d(result)[0]
         return result
@@ -1873,9 +1871,8 @@ class PowerNorm(Normalize):
             result.fill(0)
         else:
             if clip:
-                mask = np.ma.getmask(result)
                 result = np.ma.array(np.clip(result.filled(vmax), vmin, vmax),
-                                     mask=mask)
+                                     mask=np.ma.getmaskarray(result))
             resdat = result.data
             resdat -= vmin
             resdat[resdat < 0] = 0

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1849,7 +1849,7 @@ class Affine2DBase(AffineBase):
         mtx = self.get_matrix()
         if isinstance(points, np.ma.MaskedArray):
             tpoints = affine_transform(points.data, mtx)
-            return np.ma.MaskedArray(tpoints, mask=np.ma.getmask(points))
+            return np.ma.MaskedArray(tpoints, mask=np.ma.getmaskarray(points))
         return affine_transform(points, mtx)
 
     if DEBUG:


### PR DESCRIPTION
## PR Summary

Related to #24115

There seems to be a change in numpy 1.24 where sometimes `getmask` does not return an array. By using `getmaskarray` an array is guaranteed to be returned.

This PR is a bit speculative. It should not break anything, but may not really help as it may be that this change is never triggered (with current test data). On the other hand, it may help for certain input data (not clear which).

Will be interesting to see test coverage for the changes as experience shows that not all the masked stuff is tested everyhwhere.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
