### PR TITLE
Add textcolor to legend based on labelcolor string

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -563,7 +563,7 @@ class Legend(Artist):
             getter_names = color_getters[labelcolor]
             for handle, text in zip(self.legendHandles, self.texts):
                 try:
-                    if isinstance(handle.cmap, colors.LinearSegmentedColormap):
+                    if handle.get_array() is not None:
                         continue
                 except AttributeError:
                     pass

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -562,10 +562,24 @@ class Legend(Artist):
         if isinstance(labelcolor, str) and labelcolor in color_getters:
             getter_names = color_getters[labelcolor]
             for handle, text in zip(self.legendHandles, self.texts):
+                try:
+                    if isinstance(handle.cmap, colors.LinearSegmentedColormap):
+                        continue
+                except AttributeError:
+                    pass
                 for getter_name in getter_names:
                     try:
                         color = getattr(handle, getter_name)()
-                        text.set_color(color)
+                        if isinstance(color, np.ndarray):
+                            if (
+                                    color.shape[0] == 1
+                                    or np.isclose(color, color[0]).all()
+                            ):
+                                text.set_color(color[0])
+                            else:
+                                pass
+                        else:
+                            text.set_color(color)
                         break
                     except AttributeError:
                         pass

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -671,6 +671,47 @@ def test_legend_labelcolor_linecolor():
         assert mpl.colors.same_color(text.get_color(), color)
 
 
+def test_legend_pathcollection_labelcolor_linecolor():
+    # test the labelcolor for labelcolor='linecolor' on PathCollection
+    fig, ax = plt.subplots()
+    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', c='r')
+    ax.scatter(np.arange(10), np.arange(10)*2, label='#2', c='g')
+    ax.scatter(np.arange(10), np.arange(10)*3, label='#3', c='b')
+
+    leg = ax.legend(labelcolor='linecolor')
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_linecolor_iterable():
+    # test the labelcolor for labelcolor='linecolor' on PathCollection
+    # with iterable colors
+    fig, ax = plt.subplots()
+    colors = np.random.default_rng().choice(['r', 'g', 'b'], 10)
+    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', c=colors)
+
+    leg = ax.legend(labelcolor='linecolor')
+    for text, color in zip(leg.get_texts(), ['k']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_linecolor_cmap():
+    # test the labelcolor for labelcolor='linecolor' on PathCollection
+    # with a colormap
+    fig, ax = plt.subplots()
+    ax.scatter(
+        np.arange(10),
+        np.arange(10),
+        label='#1',
+        c=np.arange(10),
+        cmap="Reds"
+    )
+
+    leg = ax.legend(labelcolor='linecolor')
+    for text, color in zip(leg.get_texts(), ['k']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
 def test_legend_labelcolor_markeredgecolor():
     # test the labelcolor for labelcolor='markeredgecolor'
     fig, ax = plt.subplots()
@@ -683,6 +724,49 @@ def test_legend_labelcolor_markeredgecolor():
         assert mpl.colors.same_color(text.get_color(), color)
 
 
+def test_legend_pathcollection_labelcolor_markeredgecolor():
+    # test the labelcolor for labelcolor='markeredgecolor' on PathCollection
+    fig, ax = plt.subplots()
+    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', edgecolor='r')
+    ax.scatter(np.arange(10), np.arange(10)*2, label='#2', edgecolor='g')
+    ax.scatter(np.arange(10), np.arange(10)*3, label='#3', edgecolor='b')
+
+    leg = ax.legend(labelcolor='markeredgecolor')
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_markeredgecolor_iterable():
+    # test the labelcolor for labelcolor='markeredgecolor' on PathCollection
+    # with iterable colors
+    fig, ax = plt.subplots()
+    colors = np.random.default_rng().choice(['r', 'g', 'b'], 10)
+    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', edgecolor=colors)
+
+    leg = ax.legend(labelcolor='markeredgecolor')
+    for text, color in zip(leg.get_texts(), ['k']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_markeredgecolor_cmap():
+    # test the labelcolor for labelcolor='markeredgecolor' on PathCollection
+    # with a colormap
+    fig, ax = plt.subplots()
+    edgecolors = mpl.cm.viridis(np.random.rand(10))
+    ax.scatter(
+        np.arange(10),
+        np.arange(10),
+        label='#1',
+        c=np.arange(10),
+        edgecolor=edgecolors,
+        cmap="Reds"
+    )
+
+    leg = ax.legend(labelcolor='markeredgecolor')
+    for text, color in zip(leg.get_texts(), ['k']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
 def test_legend_labelcolor_markerfacecolor():
     # test the labelcolor for labelcolor='markerfacecolor'
     fig, ax = plt.subplots()
@@ -692,6 +776,48 @@ def test_legend_labelcolor_markerfacecolor():
 
     leg = ax.legend(labelcolor='markerfacecolor')
     for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_markerfacecolor():
+    # test the labelcolor for labelcolor='markerfacecolor' on PathCollection
+    fig, ax = plt.subplots()
+    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', facecolor='r')
+    ax.scatter(np.arange(10), np.arange(10)*2, label='#2', facecolor='g')
+    ax.scatter(np.arange(10), np.arange(10)*3, label='#3', facecolor='b')
+
+    leg = ax.legend(labelcolor='markerfacecolor')
+    for text, color in zip(leg.get_texts(), ['r', 'g', 'b']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_markerfacecolor_iterable():
+    # test the labelcolor for labelcolor='markerfacecolor' on PathCollection
+    # with iterable colors
+    fig, ax = plt.subplots()
+    colors = np.random.default_rng().choice(['r', 'g', 'b'], 10)
+    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', facecolor=colors)
+
+    leg = ax.legend(labelcolor='markerfacecolor')
+    for text, color in zip(leg.get_texts(), ['k']):
+        assert mpl.colors.same_color(text.get_color(), color)
+
+
+def test_legend_pathcollection_labelcolor_markfacecolor_cmap():
+    # test the labelcolor for labelcolor='markerfacecolor' on PathCollection
+    # with colormaps
+    fig, ax = plt.subplots()
+    facecolors = mpl.cm.viridis(np.random.rand(10))
+    ax.scatter(
+        np.arange(10),
+        np.arange(10),
+        label='#1',
+        c=np.arange(10),
+        facecolor=facecolors
+    )
+
+    leg = ax.legend(labelcolor='markerfacecolor')
+    for text, color in zip(leg.get_texts(), ['k']):
         assert mpl.colors.same_color(text.get_color(), color)
 
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -692,7 +692,7 @@ def test_legend_pathcollection_labelcolor_linecolor_iterable():
 
     leg = ax.legend(labelcolor='linecolor')
     text, = leg.get_texts()
-    assert mpl.colors.same_color(text, 'black')
+    assert mpl.colors.same_color(text.get_text(), 'black')
 
 
 def test_legend_pathcollection_labelcolor_linecolor_cmap():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -691,25 +691,19 @@ def test_legend_pathcollection_labelcolor_linecolor_iterable():
     ax.scatter(np.arange(10), np.arange(10)*1, label='#1', c=colors)
 
     leg = ax.legend(labelcolor='linecolor')
-    for text, color in zip(leg.get_texts(), ['k']):
-        assert mpl.colors.same_color(text.get_color(), color)
+    text, = leg.get_texts()
+    assert mpl.colors.same_color(text, 'black')
 
 
 def test_legend_pathcollection_labelcolor_linecolor_cmap():
     # test the labelcolor for labelcolor='linecolor' on PathCollection
     # with a colormap
     fig, ax = plt.subplots()
-    ax.scatter(
-        np.arange(10),
-        np.arange(10),
-        label='#1',
-        c=np.arange(10),
-        cmap="Reds"
-    )
+    ax.scatter(np.arange(10), np.arange(10), c=np.arange(10), label='#1')
 
     leg = ax.legend(labelcolor='linecolor')
-    for text, color in zip(leg.get_texts(), ['k']):
-        assert mpl.colors.same_color(text.get_color(), color)
+    text, = leg.get_texts()
+    assert mpl.colors.same_color(text, 'black')
 
 
 def test_legend_labelcolor_markeredgecolor():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -692,7 +692,7 @@ def test_legend_pathcollection_labelcolor_linecolor_iterable():
 
     leg = ax.legend(labelcolor='linecolor')
     text, = leg.get_texts()
-    assert mpl.colors.same_color(text.get_text(), 'black')
+    assert mpl.colors.same_color(text.get_color(), 'black')
 
 
 def test_legend_pathcollection_labelcolor_linecolor_cmap():
@@ -703,7 +703,7 @@ def test_legend_pathcollection_labelcolor_linecolor_cmap():
 
     leg = ax.legend(labelcolor='linecolor')
     text, = leg.get_texts()
-    assert mpl.colors.same_color(text.get_text(), 'black')
+    assert mpl.colors.same_color(text.get_color(), 'black')
 
 
 def test_legend_labelcolor_markeredgecolor():

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -703,7 +703,7 @@ def test_legend_pathcollection_labelcolor_linecolor_cmap():
 
     leg = ax.legend(labelcolor='linecolor')
     text, = leg.get_texts()
-    assert mpl.colors.same_color(text, 'black')
+    assert mpl.colors.same_color(text.get_text(), 'black')
 
 
 def test_legend_labelcolor_markeredgecolor():


### PR DESCRIPTION
## PR Summary

As raised by #20577, setting `labelcolor` to any of the string options did not work with a scatter plot as it is a PathCollection with possible multiple color values. This commit fixes that. Now, if there is a colormap or a scatter plot with multiple values, then, the legend text color is not changed, but otherwise, the text color is changed to the color of the scatter markers.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
