### PR TITLE
Expire deprecations in dates and ticker

### DIFF
--- a/doc/api/next_api_changes/removals/24128-OG.rst
+++ b/doc/api/next_api_changes/removals/24128-OG.rst
@@ -1,0 +1,17 @@
+``epoch2num`` and ``num2epoch`` are removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These methods convert from unix timestamps to matplotlib floats, but are not
+used internally to Matplotlib, and should not be needed by end users. To
+convert a unix timestamp to datetime, simply use
+`datetime.datetime.utcfromtimestamp`, or to use NumPy `~numpy.datetime64`
+``dt = np.datetime64(e*1e6, 'us')``.
+
+
+Locator and Formatter wrapper methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``set_view_interval``, ``set_data_interval`` and ``set_bounds`` methods of
+`.Locator`\s and `.Formatter`\s (and their common base class, TickHelper) are
+removed. Directly manipulate the view and data intervals on the underlying
+axis instead.

--- a/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
@@ -545,8 +545,8 @@ experimental and may change in the future.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ... is deprecated.
 
-`.epoch2num` and `.num2epoch` are deprecated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``epoch2num`` and ``num2epoch`` are deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These are unused and can be easily reproduced by other date tools.
 `.get_epoch` will return Matplotlib's epoch.
 

--- a/doc/api/prev_api_changes/api_changes_3.3.1.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.1.rst
@@ -15,7 +15,7 @@ reverts the deprecation.
 Functions ``epoch2num`` and ``dates.julian2num`` use ``date.epoch`` rcParam
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Now `~.dates.epoch2num` and (undocumented) ``julian2num`` return floating point
+Now ``epoch2num`` and (undocumented) ``julian2num`` return floating point
 days since `~.dates.get_epoch` as set by :rc:`date.epoch`, instead of
 floating point days since the old epoch of "0000-12-31T00:00:00".  If
 needed, you can translate from the new to old values as

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -187,10 +187,9 @@ import matplotlib as mpl
 from matplotlib import _api, cbook, ticker, units
 
 __all__ = ('datestr2num', 'date2num', 'num2date', 'num2timedelta', 'drange',
-           'epoch2num', 'num2epoch', 'set_epoch', 'get_epoch', 'DateFormatter',
-           'ConciseDateFormatter', 'AutoDateFormatter',
-           'DateLocator', 'RRuleLocator', 'AutoDateLocator', 'YearLocator',
-           'MonthLocator', 'WeekdayLocator',
+           'set_epoch', 'get_epoch', 'DateFormatter', 'ConciseDateFormatter',
+           'AutoDateFormatter', 'DateLocator', 'RRuleLocator',
+           'AutoDateLocator', 'YearLocator', 'MonthLocator', 'WeekdayLocator',
            'DayLocator', 'HourLocator', 'MinuteLocator',
            'SecondLocator', 'MicrosecondLocator',
            'rrule', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA', 'SU',
@@ -1737,16 +1736,6 @@ class MicrosecondLocator(DateLocator):
         self._wrapped_locator.set_axis(axis)
         return super().set_axis(axis)
 
-    @_api.deprecated("3.5", alternative="`.Axis.set_view_interval`")
-    def set_view_interval(self, vmin, vmax):
-        self._wrapped_locator.set_view_interval(vmin, vmax)
-        return super().set_view_interval(vmin, vmax)
-
-    @_api.deprecated("3.5", alternative="`.Axis.set_data_interval`")
-    def set_data_interval(self, vmin, vmax):
-        self._wrapped_locator.set_data_interval(vmin, vmax)
-        return super().set_data_interval(vmin, vmax)
-
     def __call__(self):
         # if no data have been set, this will tank with a ValueError
         try:
@@ -1776,52 +1765,6 @@ class MicrosecondLocator(DateLocator):
     def _get_interval(self):
         # docstring inherited
         return self._interval
-
-
-@_api.deprecated(
-    "3.5",
-    alternative="``[date2num(datetime.utcfromtimestamp(t)) for t in e]`` or "
-                "numpy.datetime64 types")
-def epoch2num(e):
-    """
-    Convert UNIX time to days since Matplotlib epoch.
-
-    Parameters
-    ----------
-    e : list of floats
-        Time in seconds since 1970-01-01.
-
-    Returns
-    -------
-    `numpy.array`
-        Time in days since Matplotlib epoch (see `~.dates.get_epoch()`).
-    """
-
-    dt = (np.datetime64('1970-01-01T00:00:00', 's') -
-          np.datetime64(get_epoch(), 's')).astype(float)
-
-    return (dt + np.asarray(e)) / SEC_PER_DAY
-
-
-@_api.deprecated("3.5", alternative="`num2date(e).timestamp()<.num2date>`")
-def num2epoch(d):
-    """
-    Convert days since Matplotlib epoch to UNIX time.
-
-    Parameters
-    ----------
-    d : list of floats
-        Time in days since Matplotlib epoch (see `~.dates.get_epoch()`).
-
-    Returns
-    -------
-    `numpy.array`
-        Time in seconds since 1970-01-01.
-    """
-    dt = (np.datetime64('1970-01-01T00:00:00', 's') -
-          np.datetime64(get_epoch(), 's')).astype(float)
-
-    return np.asarray(d) * SEC_PER_DAY - dt
 
 
 @_api.deprecated("3.6", alternative="`AutoDateLocator` and `AutoDateFormatter`"

--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -16,8 +16,7 @@ from matplotlib.cbook import flatten, silent_list
 import matplotlib as mpl
 
 from matplotlib.dates import (
-    date2num, num2date, datestr2num, drange, epoch2num,
-    num2epoch, DateFormatter, DateLocator,
+    date2num, num2date, datestr2num, drange, DateFormatter, DateLocator,
     RRuleLocator, YearLocator, MonthLocator, WeekdayLocator, DayLocator,
     HourLocator, MinuteLocator, SecondLocator, rrule, MO, TU, WE, TH, FR,
     SA, SU, YEARLY, MONTHLY, WEEKLY, DAILY, HOURLY, MINUTELY, SECONDLY,

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1240,19 +1240,6 @@ def test_change_interval_multiples():
     assert ax.get_xticklabels()[1].get_text() == 'Feb 01 2020'
 
 
-def test_epoch2num():
-    with _api.suppress_matplotlib_deprecation_warning():
-        mdates._reset_epoch_test_example()
-        mdates.set_epoch('0000-12-31')
-        assert mdates.epoch2num(86400) == 719164.0
-        assert mdates.num2epoch(719165.0) == 86400 * 2
-        # set back to the default
-        mdates._reset_epoch_test_example()
-        mdates.set_epoch('1970-01-01T00:00:00')
-        assert mdates.epoch2num(86400) == 1.0
-        assert mdates.num2epoch(2.0) == 86400 * 2
-
-
 def test_julian2num():
     mdates._reset_epoch_test_example()
     mdates.set_epoch('0000-12-31')

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -196,21 +196,6 @@ class TickHelper:
         if self.axis is None:
             self.axis = _DummyAxis(**kwargs)
 
-    @_api.deprecated("3.5", alternative="`.Axis.set_view_interval`")
-    def set_view_interval(self, vmin, vmax):
-        self.axis.set_view_interval(vmin, vmax)
-
-    @_api.deprecated("3.5", alternative="`.Axis.set_data_interval`")
-    def set_data_interval(self, vmin, vmax):
-        self.axis.set_data_interval(vmin, vmax)
-
-    @_api.deprecated(
-        "3.5",
-        alternative="`.Axis.set_view_interval` and `.Axis.set_data_interval`")
-    def set_bounds(self, vmin, vmax):
-        self.set_view_interval(vmin, vmax)
-        self.set_data_interval(vmin, vmax)
-
 
 class Formatter(TickHelper):
     """


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
