### PR TITLE
Expire cursor-related deprecations

### DIFF
--- a/doc/api/next_api_changes/removals/24129-OG.rst
+++ b/doc/api/next_api_changes/removals/24129-OG.rst
@@ -1,0 +1,33 @@
+Interactive cursor details
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting a mouse cursor on a window has been moved from the toolbar to the
+canvas. Consequently, several implementation details on toolbars and within
+backends have been removed.
+
+``NavigationToolbar2.set_cursor`` and ``backend_tools.SetCursorBase.set_cursor``
+................................................................................
+
+Instead, use the `.FigureCanvasBase.set_cursor` method on the canvas (available
+as the ``canvas`` attribute on the toolbar or the Figure.)
+
+``backend_tools.SetCursorBase`` and subclasses
+..............................................
+
+``backend_tools.SetCursorBase`` was subclassed to provide backend-specific
+implementations of ``set_cursor``. As that is now removed, the subclassing
+is no longer necessary. Consequently, the following subclasses are also
+removed:
+
+- ``matplotlib.backends.backend_gtk3.SetCursorGTK3``
+- ``matplotlib.backends.backend_qt5.SetCursorQt``
+- ``matplotlib.backends._backend_tk.SetCursorTk``
+- ``matplotlib.backends.backend_wx.SetCursorWx``
+
+Instead, use the `.backend_tools.ToolSetCursor` class.
+
+``cursord`` in GTK and wx backends
+..................................
+
+The ``backend_gtk3.cursord`` and ``backend_wx.cursord`` dictionaries are
+removed. This makes the GTK module importable on headless environments.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3296,18 +3296,6 @@ class NavigationToolbar2:
         """Save the current figure."""
         raise NotImplementedError
 
-    @_api.deprecated("3.5", alternative="`.FigureCanvasBase.set_cursor`")
-    def set_cursor(self, cursor):
-        """
-        Set the current cursor to one of the :class:`Cursors` enums values.
-
-        If required by the backend, this method should trigger an update in
-        the backend event loop after the cursor is set, as this method may be
-        called e.g. before a long-running task during which the GUI is not
-        updated.
-        """
-        self.canvas.set_cursor(cursor)
-
     def update(self):
         """Reset the Axes stack."""
         self._nav_stack.clear()

--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -257,16 +257,6 @@ class ToolManager:
                                'exists, not added')
             return self._tools[name]
 
-        if name == 'cursor' and tool_cls != backend_tools.SetCursorBase:
-            _api.warn_deprecated("3.5",
-                                 message="Overriding ToolSetCursor with "
-                                 f"{tool_cls.__qualname__} was only "
-                                 "necessary to provide the .set_cursor() "
-                                 "method, which is deprecated since "
-                                 "%(since)s and will be removed "
-                                 "%(removal)s. Please report this to the "
-                                 f"{tool_cls.__module__} author.")
-
         tool_obj = tool_cls(self, name, *args, **kwargs)
         self._tools[name] = tool_obj
 

--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -252,12 +252,12 @@ class ToolToggleBase(ToolBase):
                 self._toggled = True
 
 
-class SetCursorBase(ToolBase):
+class ToolSetCursor(ToolBase):
     """
     Change to the current cursor while inaxes.
 
-    This tool, keeps track of all `ToolToggleBase` derived tools, and calls
-    `set_cursor` when a tool gets triggered.
+    This tool, keeps track of all `ToolToggleBase` derived tools, and updates
+    the cursor when a tool gets triggered.
     """
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -309,18 +309,6 @@ class SetCursorBase(ToolBase):
         elif self._last_cursor != self._default_cursor:
             self.canvas.set_cursor(self._default_cursor)
             self._last_cursor = self._default_cursor
-
-    @_api.deprecated("3.5", alternative="`.FigureCanvasBase.set_cursor`")
-    def set_cursor(self, cursor):
-        """
-        Set the cursor.
-        """
-        self.canvas.set_cursor(cursor)
-
-
-# This exists solely for deprecation warnings; remove with
-# SetCursorBase.set_cursor.
-ToolSetCursor = SetCursorBase
 
 
 class ToolCursorPosition(ToolBase):
@@ -979,7 +967,7 @@ default_tools = {'home': ToolHome, 'back': ToolBack, 'forward': ToolForward,
                  'yscale': ToolYScale,
                  'position': ToolCursorPosition,
                  _views_positions: ToolViewsPositions,
-                 'cursor': SetCursorBase,
+                 'cursor': ToolSetCursor,
                  'rubberband': RubberbandBase,
                  'help': ToolHelpBase,
                  'copy': ToolCopyToClipboardBase,

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -910,13 +910,6 @@ class RubberbandTk(backend_tools.RubberbandBase):
         property(lambda self: self.figure.canvas._rubberband_rect))
 
 
-@_api.deprecated("3.5", alternative="ToolSetCursor")
-class SetCursorTk(backend_tools.SetCursorBase):
-    def set_cursor(self, cursor):
-        NavigationToolbar2Tk.set_cursor(
-            self._make_classic_style_pseudo_toolbar(), cursor)
-
-
 class ToolbarTk(ToolContainerBase, tk.Frame):
     def __init__(self, toolmanager, window=None):
         ToolContainerBase.__init__(self, toolmanager)

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -9,7 +9,6 @@ from matplotlib import _api, backend_tools, cbook
 from matplotlib.backend_bases import (
     FigureCanvasBase, ToolContainerBase,
     CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
-from matplotlib.backend_tools import Cursors
 
 try:
     import gi
@@ -39,22 +38,6 @@ _log = logging.getLogger(__name__)
 
 @_api.caching_module_getattr  # module-level deprecations
 class __getattr__:
-    @_api.deprecated("3.5", obj_type="")
-    @property
-    def cursord(self):
-        try:
-            new_cursor = functools.partial(
-                Gdk.Cursor.new_from_name, Gdk.Display.get_default())
-            return {
-                Cursors.MOVE:          new_cursor("move"),
-                Cursors.HAND:          new_cursor("pointer"),
-                Cursors.POINTER:       new_cursor("default"),
-                Cursors.SELECT_REGION: new_cursor("crosshair"),
-                Cursors.WAIT:          new_cursor("wait"),
-            }
-        except TypeError:
-            return {}
-
     icon_filename = _api.deprecated("3.6", obj_type="")(property(
         lambda self:
         "matplotlib.png" if sys.platform == "win32" else "matplotlib.svg"))
@@ -491,13 +474,6 @@ class SaveFigureGTK3(backend_tools.SaveFigureBase):
     def trigger(self, *args, **kwargs):
         NavigationToolbar2GTK3.save_figure(
             self._make_classic_style_pseudo_toolbar())
-
-
-@_api.deprecated("3.5", alternative="ToolSetCursor")
-class SetCursorGTK3(backend_tools.SetCursorBase):
-    def set_cursor(self, cursor):
-        NavigationToolbar2GTK3.set_cursor(
-            self._make_classic_style_pseudo_toolbar(), cursor)
 
 
 @backend_tools._register_tool_class(FigureCanvasGTK3)

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -976,13 +976,6 @@ class SaveFigureQt(backend_tools.SaveFigureBase):
             self._make_classic_style_pseudo_toolbar())
 
 
-@_api.deprecated("3.5", alternative="ToolSetCursor")
-class SetCursorQt(backend_tools.SetCursorBase):
-    def set_cursor(self, cursor):
-        NavigationToolbar2QT.set_cursor(
-            self._make_classic_style_pseudo_toolbar(), cursor)
-
-
 @backend_tools._register_tool_class(FigureCanvasQT)
 class RubberbandQt(backend_tools.RubberbandBase):
     def draw_rubberband(self, x0, y0, x1, y1):

--- a/lib/matplotlib/backends/backend_qt5.py
+++ b/lib/matplotlib/backends/backend_qt5.py
@@ -8,7 +8,7 @@ from .backend_qt import (  # noqa
     # Public API
     cursord, _create_qApp, _BackendQT, TimerQT, MainWindow, FigureCanvasQT,
     FigureManagerQT, ToolbarQt, NavigationToolbar2QT, SubplotToolQt,
-    SaveFigureQt, ConfigureSubplotsQt, SetCursorQt, RubberbandQt,
+    SaveFigureQt, ConfigureSubplotsQt, RubberbandQt,
     HelpQt, ToolCopyToClipboardQT,
     # internal re-exports
     FigureCanvasBase,  FigureManagerBase, MouseButton, NavigationToolbar2,

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -39,19 +39,6 @@ _log = logging.getLogger(__name__)
 PIXELS_PER_INCH = 75
 
 
-@_api.caching_module_getattr  # module-level deprecations
-class __getattr__:
-    cursord = _api.deprecated("3.5", obj_type="")(property(lambda self: {
-        cursors.MOVE: wx.CURSOR_HAND,
-        cursors.HAND: wx.CURSOR_HAND,
-        cursors.POINTER: wx.CURSOR_ARROW,
-        cursors.SELECT_REGION: wx.CURSOR_CROSS,
-        cursors.WAIT: wx.CURSOR_WAIT,
-        cursors.RESIZE_HORIZONTAL: wx.CURSOR_SIZEWE,
-        cursors.RESIZE_VERTICAL: wx.CURSOR_SIZENS,
-    }))
-
-
 @_api.deprecated("3.6")
 def error_msg_wx(msg, parent=None):
     """Signal an error condition with a popup error dialog."""
@@ -1290,13 +1277,6 @@ class SaveFigureWx(backend_tools.SaveFigureBase):
     def trigger(self, *args):
         NavigationToolbar2Wx.save_figure(
             self._make_classic_style_pseudo_toolbar())
-
-
-@_api.deprecated("3.5", alternative="ToolSetCursor")
-class SetCursorWx(backend_tools.SetCursorBase):
-    def set_cursor(self, cursor):
-        NavigationToolbar2Wx.set_cursor(
-            self._make_classic_style_pseudo_toolbar(), cursor)
 
 
 @backend_tools._register_tool_class(_FigureCanvasWxBase)


### PR DESCRIPTION
## PR Summary

It didn't look like `cursord` was deprecated in Qt, despite https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#cursord-in-gtk-qt-and-wx-backends

https://github.com/matplotlib/matplotlib/blob/924e2107069c8fe9b8d7683a0b5ec0055c7c3647/lib/matplotlib/backends/backend_qt.py#L82-L92

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
