### PR TITLE
DOC: align contour parameter doc with implementation

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1600,7 +1600,7 @@ levels : int or array-like, optional
 
     If an int *n*, use `~matplotlib.ticker.MaxNLocator`, which tries
     to automatically choose no more than *n+1* "nice" contour levels
-    between *vmin* and *vmax*.
+    between minimum and maximum numeric values of *Z*.
 
     If array-like, draw contour lines at the specified levels.
     The values must be in increasing order.

--- a/lib/matplotlib/tri/tricontour.py
+++ b/lib/matplotlib/tri/tricontour.py
@@ -114,7 +114,7 @@ levels : int or array-like, optional
 
     If an int *n*, use `~matplotlib.ticker.MaxNLocator`, which tries to
     automatically choose no more than *n+1* "nice" contour levels between
-    *vmin* and *vmax*.
+    between minimum and maximum numeric values of *Z*.
 
     If array-like, draw contour lines at the specified levels.  The values must
     be in increasing order.


### PR DESCRIPTION
## PR Summary
Issue #24121.

The docstrings implied a functionality that does not exist and never has, this PR updates to what actually happens.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

