### PR TITLE
CenteredNorm changes

### DIFF
--- a/doc/api/next_api_changes/behavior/24132-GL.rst
+++ b/doc/api/next_api_changes/behavior/24132-GL.rst
@@ -1,0 +1,29 @@
+``CenteredNorm`` halfrange is not modified when vcenter changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, the **halfrange** would expand in proportion to the
+amount that **vcenter** was moved away from either **vmin** or **vmax**.
+Now, the halfrange remains fixed when vcenter is changed, and **vmin** and
+**vmax** are updated based on the **vcenter** and **halfrange** values.
+
+For example, this is what the values were when changing vcenter previously.
+
+.. code-block::
+
+    norm = CenteredNorm(vcenter=0, halfrange=1)
+    # Move vcenter up by one
+    norm.vcenter = 1
+    # updates halfrange and vmax (vmin stays the same)
+    # norm.halfrange == 2, vmin == -1, vmax == 3
+
+and now, with that same example
+
+.. code-block::
+
+    norm = CenteredNorm(vcenter=0, halfrange=1)
+    norm.vcenter = 1
+    # updates vmin and vmax (halfrange stays the same)
+    # norm.halfrange == 1, vmin == 0, vmax == 2
+
+The **halfrange** can be set manually or ``norm.autoscale()``
+can be used to automatically set the limits after setting **vcenter**.

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1060,6 +1060,17 @@ def test_negative_boundarynorm():
     np.testing.assert_allclose(cb.ax.get_yticks(), clevs)
 
 
+def test_centerednorm():
+    # Test default centered norm gets expanded with non-singular limits
+    # when plot data is all equal (autoscale halfrange == 0)
+    fig, ax = plt.subplots(figsize=(1, 3))
+
+    norm = mcolors.CenteredNorm()
+    mappable = ax.pcolormesh(np.zeros((3, 3)), norm=norm)
+    fig.colorbar(mappable)
+    assert (norm.vmin, norm.vmax) == (-0.1, 0.1)
+
+
 @image_comparison(['nonorm_colorbars.svg'], style='mpl20')
 def test_nonorm():
     plt.rcParams['svg.fonttype'] = 'none'

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -485,11 +485,25 @@ def test_CenteredNorm():
     norm(np.linspace(-1.0, 0.0, 10))
     assert norm.vmax == 1.0
     assert norm.halfrange == 1.0
-    # set vcenter to 1, which should double halfrange
+    # set vcenter to 1, which should move the center but leave the
+    # halfrange unchanged
     norm.vcenter = 1
-    assert norm.vmin == -1.0
-    assert norm.vmax == 3.0
-    assert norm.halfrange == 2.0
+    assert norm.vmin == 0
+    assert norm.vmax == 2
+    assert norm.halfrange == 1
+
+    # Check setting vmin directly updates the halfrange and vmax, but
+    # leaves vcenter alone
+    norm.vmin = -1
+    assert norm.halfrange == 2
+    assert norm.vmax == 3
+    assert norm.vcenter == 1
+
+    # also check vmax updates
+    norm.vmax = 2
+    assert norm.halfrange == 1
+    assert norm.vmin == 0
+    assert norm.vcenter == 1
 
 
 @pytest.mark.parametrize("vmin,vmax", [[-1, 2], [3, 1]])


### PR DESCRIPTION
## PR Summary

This updates `CenteredNorm` to be consistent between all setting/getting of `vcenter`, `halfrange`, `vmin`, and `vmax`. The norm is defined by `vcenter` and `halfrange`, and `vmin`/`vmax` are adjusted accordingly.

Currently, if we change the center of the norm, the halfrange also gets updated based on the distance away from the previous `vmin`/`vmax` values. This "feature" is hard to maintain in this refactor, so I'm going to propose that this should be changed to not modify `halfrange` (i.e. if I update `vcenter` I just pan the center limit and keep the linear scaling out from the center fixed). I'm not sure how easy it would be to deprecate, so I think this needs some discussion and should not be backported to 3.6.

Additionally, now setting `vmin` or `vmax` is equivalent to updating the `halfrange` from either `vcenter - vmin` or `vmax - vcenter`.

xref: #24093

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
