### PR TITLE
[DOC] Fix some documentation typos

### DIFF
--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -45,7 +45,7 @@ When making a PR, pay attention to:
   on GitHub.
 * When updating your PR, instead of adding new commits to fix something, please
   consider amending your initial commit(s) to keep the history clean.
-  You can achieve this using
+  You can achieve this by using
 
   .. code-block:: bash
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -222,7 +222,7 @@ rules before submitting a pull request:
 
   or your editor may provide integration with it.  Note that Matplotlib
   intentionally does not use the black_ auto-formatter (1__), in particular due
-  to its unability to understand the semantics of mathematical expressions
+  to its inability to understand the semantics of mathematical expressions
   (2__, 3__).
 
   .. _PEP8: https://www.python.org/dev/peps/pep-0008/


### PR DESCRIPTION
## PR Summary
Hi, I just started with open source and this is my first PR. Noticed some types in the documentation and fixed them.