### PR TITLE
Set figure options dynamically

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -49,21 +49,20 @@ def figure_edit(axes, parent=None):
     general = [
         ('Title', axes.get_title()),
         sep,
+        *chain.from_iterable([
+            (
+                (None, f"<b>{name.upper()}-Axis</b>"),
+                ('Min', axis_limits[name][0]),
+                ('Max', axis_limits[name][1]),
+                ('Label', axis.get_label().get_text()),
+                ('Scale', [axis.get_scale(),
+                           'linear', 'log', 'symlog', 'logit']),
+                sep,
+            )
+            for name, axis in axis_map.items()
+        ]),
+        ('(Re-)Generate automatic legend', False),
     ]
-    axes_info = [
-        (
-            (None, f"<b>{name.upper()}-Axis</b>"),
-            ('Min', axis_limits[name][0]),
-            ('Max', axis_limits[name][1]),
-            ('Label', axis.get_label().get_text()),
-            ('Scale', [axis.get_scale(),
-                       'linear', 'log', 'symlog', 'logit']),
-            sep,
-        )
-        for name, axis in axis_map.items()
-    ]
-    general.extend(chain.from_iterable(axes_info))
-    general.append(('(Re-)Generate automatic legend', False))
 
     # Save the unit data
     axis_units = {
@@ -175,7 +174,7 @@ def figure_edit(axes, parent=None):
         """A callback to apply changes."""
         orig_limits = {
             name: getattr(axes, f"get_{name}lim")()
-            for name in axis_map.keys()
+            for name in axis_map
         }
 
         general = data.pop(0)

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -51,7 +51,7 @@ def figure_edit(axes, parent=None):
         sep,
         *chain.from_iterable([
             (
-                (None, f"<b>{name.upper()}-Axis</b>"),
+                (None, f"<b>{name.title()}-Axis</b>"),
                 ('Min', axis_limits[name][0]),
                 ('Max', axis_limits[name][1]),
                 ('Label', axis.get_label().get_text()),

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -41,10 +41,10 @@ def figure_edit(axes, parent=None):
 
     axis_map = axes._axis_map
     axis_limits = {
-        axname: tuple(convert_limits(
-            getattr(axes, f'get_{axname}lim')(), axis.converter
+        name: tuple(convert_limits(
+            getattr(axes, f'get_{name}lim')(), axis.converter
         ))
-        for axname, axis in axis_map.items()
+        for name, axis in axis_map.items()
     }
     general = [
         ('Title', axes.get_title()),
@@ -52,23 +52,23 @@ def figure_edit(axes, parent=None):
     ]
     axes_info = [
         (
-            (None, f"<b>{axis.upper()}-Axis</b>"),
-            ('Min', axis_limits[axis][0]),
-            ('Max', axis_limits[axis][1]),
-            ('Label', getattr(axes, f"get_{axis}label")()),
-            ('Scale', [getattr(axes, f"get_{axis}scale")(),
+            (None, f"<b>{name.upper()}-Axis</b>"),
+            ('Min', axis_limits[name][0]),
+            ('Max', axis_limits[name][1]),
+            ('Label', axis.get_label().get_text()),
+            ('Scale', [axis.get_scale(),
                        'linear', 'log', 'symlog', 'logit']),
             sep,
         )
-        for axis in axis_map.keys()
+        for name, axis in axis_map.items()
     ]
     general.extend(chain.from_iterable(axes_info))
     general.append(('(Re-)Generate automatic legend', False))
 
     # Save the unit data
     axis_units = {
-        axis: getattr(getattr(axes, f"{axis}axis"), "get_units")()
-        for axis in axis_map.keys()
+        name: axis.get_units()
+        for name, axis in axis_map.items()
     }
 
     # Get / Curves
@@ -174,8 +174,8 @@ def figure_edit(axes, parent=None):
     def apply_callback(data):
         """A callback to apply changes."""
         orig_limits = {
-            axis: getattr(axes, f"get_{axis}lim")()
-            for axis in axis_map.keys()
+            name: getattr(axes, f"get_{name}lim")()
+            for name in axis_map.keys()
         }
 
         general = data.pop(0)
@@ -188,19 +188,19 @@ def figure_edit(axes, parent=None):
         axes.set_title(title)
         generate_legend = general.pop()
 
-        for i, (axname, ax) in enumerate(axis_map.items()):
-            axmin = general[4*i]
-            axmax = general[4*i + 1]
-            axlabel = general[4*i + 2]
-            axscale = general[4*i + 3]
-            if getattr(axes, f"get_{axname}scale")() != axscale:
-                getattr(axes, f"set_{axname}scale")(axscale)
+        for i, (name, axis) in enumerate(axis_map.items()):
+            axis_min = general[4*i]
+            axis_max = general[4*i + 1]
+            axis_label = general[4*i + 2]
+            axis_scale = general[4*i + 3]
+            if getattr(axes, f"get_{name}scale")() != axis_scale:
+                getattr(axes, f"set_{name}scale")(axis_scale)
 
-            getattr(axes, f"set_{axname}lim")(axmin, axmax)
-            getattr(axes, f"set_{axname}label")(axlabel)
-            setattr(ax, 'converter', ax.converter)
-            getattr(ax, 'set_units')(axis_units[axname])
-            ax._update_axisinfo()
+            getattr(axes, f"set_{name}lim")(axis_min, axis_max)
+            axis.set_label_text(axis_label)
+            setattr(axis, 'converter', axis.converter)
+            axis.set_units(axis_units[name])
+            axis._update_axisinfo()
 
         # Set / Curves
         for index, curve in enumerate(curves):
@@ -247,8 +247,8 @@ def figure_edit(axes, parent=None):
         # Redraw
         figure = axes.get_figure()
         figure.canvas.draw()
-        for axis in axis_map.keys():
-            if getattr(axes, f"get_{axis}lim")() != orig_limits[axis]:
+        for name in axis_map.keys():
+            if getattr(axes, f"get_{name}lim")() != orig_limits[name]:
                 figure.canvas.toolbar.push_current()
                 break
 

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -40,6 +40,10 @@ def figure_edit(axes, parent=None):
         return map(float, lim)
 
     axis_map = axes._axis_map
+    axis_converter = {
+        name: axis.converter
+        for name, axis in axis_map.items()
+    }
     axis_limits = {
         name: tuple(convert_limits(
             getattr(axes, f'get_{name}lim')(), axis.converter
@@ -197,7 +201,7 @@ def figure_edit(axes, parent=None):
 
             getattr(axes, f"set_{name}lim")(axis_min, axis_max)
             axis.set_label_text(axis_label)
-            setattr(axis, 'converter', axis.converter)
+            axis.converter = axis_converter[name]
             axis.set_units(axis_units[name])
             axis._update_axisinfo()
 
@@ -246,7 +250,7 @@ def figure_edit(axes, parent=None):
         # Redraw
         figure = axes.get_figure()
         figure.canvas.draw()
-        for name in axis_map.keys():
+        for name in axis_map:
             if getattr(axes, f"get_{name}lim")() != orig_limits[name]:
                 figure.canvas.toolbar.push_current()
                 break

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -40,15 +40,11 @@ def figure_edit(axes, parent=None):
         return map(float, lim)
 
     axis_map = axes._axis_map
-    axis_converter = {
-        axis: getattr(getattr(axes, f'{axis}axis'), 'converter')
-        for axis in axis_map.keys()
-    }
     axis_limits = {
-        axis: tuple(convert_limits(
-            getattr(axes, f'get_{axis}lim')(), axis_converter[axis]
+        axname: tuple(convert_limits(
+            getattr(axes, f'get_{axname}lim')(), axis.converter
         ))
-        for axis in axis_map.keys()
+        for axname, axis in axis_map.items()
     }
     general = [
         ('Title', axes.get_title()),
@@ -192,19 +188,18 @@ def figure_edit(axes, parent=None):
         axes.set_title(title)
         generate_legend = general.pop()
 
-        for i, axis in enumerate(axis_map.keys()):
-            ax = getattr(axes, f"{axis}axis")
+        for i, (axname, ax) in enumerate(axis_map.items()):
             axmin = general[4*i]
             axmax = general[4*i + 1]
             axlabel = general[4*i + 2]
             axscale = general[4*i + 3]
-            if getattr(axes, f"get_{axis}scale")() != axscale:
-                getattr(axes, f"set_{axis}scale")(axscale)
+            if getattr(axes, f"get_{axname}scale")() != axscale:
+                getattr(axes, f"set_{axname}scale")(axscale)
 
-            getattr(axes, f"set_{axis}lim")(axmin, axmax)
-            getattr(axes, f"set_{axis}label")(axlabel)
-            setattr(ax, 'converter', axis_converter[axis])
-            getattr(ax, 'set_units')(axis_units[axis])
+            getattr(axes, f"set_{axname}lim")(axmin, axmax)
+            getattr(axes, f"set_{axname}label")(axlabel)
+            setattr(ax, 'converter', ax.converter)
+            getattr(ax, 'set_units')(axis_units[axname])
             ax._update_axisinfo()
 
         # Set / Curves

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -199,7 +199,7 @@ def figure_edit(axes, parent=None):
             if axis.get_scale() != axis_scale:
                 getattr(axes, f"set_{name}scale")(axis_scale)
 
-            getattr(axes, f"set_{name}lim")(axis_min, axis_max)
+            axis._set_lim(axis_min, axis_max, auto=False)
             axis.set_label_text(axis_label)
 
             # Restore the unit data

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -205,7 +205,6 @@ def figure_edit(axes, parent=None):
             # Restore the unit data
             axis.converter = axis_converter[name]
             axis.set_units(axis_units[name])
-            axis._update_axisinfo()
 
         # Set / Curves
         for index, curve in enumerate(curves):

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -40,10 +40,6 @@ def figure_edit(axes, parent=None):
         return map(float, lim)
 
     axis_map = axes._axis_map
-    axis_converter = {
-        name: axis.converter
-        for name, axis in axis_map.items()
-    }
     axis_limits = {
         name: tuple(convert_limits(
             getattr(axes, f'get_{name}lim')(), axis.converter
@@ -68,7 +64,11 @@ def figure_edit(axes, parent=None):
         ('(Re-)Generate automatic legend', False),
     ]
 
-    # Save the unit data
+    # Save the converter and unit data
+    axis_converter = {
+        name: axis.converter
+        for name, axis in axis_map.items()
+    }
     axis_units = {
         name: axis.get_units()
         for name, axis in axis_map.items()
@@ -196,11 +196,13 @@ def figure_edit(axes, parent=None):
             axis_max = general[4*i + 1]
             axis_label = general[4*i + 2]
             axis_scale = general[4*i + 3]
-            if getattr(axes, f"get_{name}scale")() != axis_scale:
+            if axis.get_scale() != axis_scale:
                 getattr(axes, f"set_{name}scale")(axis_scale)
 
             getattr(axes, f"set_{name}lim")(axis_min, axis_max)
             axis.set_label_text(axis_label)
+
+            # Restore the unit data
             axis.converter = axis_converter[name]
             axis.set_units(axis_units[name])
             axis._update_axisinfo()


### PR DESCRIPTION
As mentioned in #23566 , for the figure options, things were hard coded for the X and Y axes but were not implemented for the Z axis. With this commit, all the options in the Figure options dialogue box are generated dynamically based on the axes present in the figure. This removes all the hard coded part and should make it more modular to make further changes.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
