### PR TITLE
Add QuadContourSet.remove.

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -11,13 +11,13 @@ from numpy import ma
 import matplotlib as mpl
 from matplotlib import _api, _docstring
 from matplotlib.backend_bases import MouseButton
+from matplotlib.text import Text
 import matplotlib.path as mpath
 import matplotlib.ticker as ticker
 import matplotlib.cm as cm
 import matplotlib.colors as mcolors
 import matplotlib.collections as mcoll
 import matplotlib.font_manager as font_manager
-import matplotlib.text as text
 import matplotlib.cbook as cbook
 import matplotlib.patches as mpatches
 import matplotlib.transforms as mtransforms
@@ -31,7 +31,7 @@ import matplotlib.transforms as mtransforms
 # per level.
 
 
-class ClabelText(text.Text):
+class ClabelText(Text):
     """
     Unlike the ordinary text, the get_rotation returns an updated
     angle in the pixel coordinate assuming that the input rotation is
@@ -253,11 +253,10 @@ class ContourLabeler:
         fig = self.axes.figure
         renderer = fig._get_renderer()
         return (
-            text.Text(0, 0,
-                      self.get_text(self.labelLevelList[nth], self.labelFmt),
-                      figure=fig,
-                      size=self.labelFontSizeList[nth],
-                      fontproperties=self.labelFontProps)
+            Text(0, 0, self.get_text(self.labelLevelList[nth], self.labelFmt),
+                 figure=fig,
+                 size=self.labelFontSizeList[nth],
+                 fontproperties=self.labelFontProps)
             .get_window_extent(renderer).width)
 
     @_api.deprecated("3.5")
@@ -267,8 +266,8 @@ class ContourLabeler:
             lev = self.get_text(lev, fmt)
         fig = self.axes.figure
         renderer = fig._get_renderer()
-        width = (text.Text(0, 0, lev, figure=fig,
-                           size=fsize, fontproperties=self.labelFontProps)
+        width = (Text(0, 0, lev, figure=fig,
+                      size=fsize, fontproperties=self.labelFontProps)
                  .get_window_extent(renderer).width)
         width *= 72 / fig.dpi
         return width
@@ -419,10 +418,9 @@ class ContourLabeler:
 
     def _get_label_text(self, x, y, rotation):
         dx, dy = self.axes.transData.inverted().transform((x, y))
-        t = text.Text(dx, dy, rotation=rotation,
-                      horizontalalignment='center',
-                      verticalalignment='center', zorder=self._clabel_zorder)
-        return t
+        return Text(dx, dy, rotation=rotation,
+                    horizontalalignment='center',
+                    verticalalignment='center', zorder=self._clabel_zorder)
 
     def _get_label_clabeltext(self, x, y, rotation):
         # x, y, rotation is given in pixel coordinate. Convert them to
@@ -584,6 +582,10 @@ class ContourLabeler:
             # by new ones if inlining.
             if inline:
                 paths[:] = additions
+
+    def remove(self):
+        for text in self.labelTexts:
+            text.remove()
 
 
 def _is_closed_polygon(X):
@@ -1388,6 +1390,11 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
                     ymin = xc[1]
 
         return (conmin, segmin, imin, xmin, ymin, d2min)
+
+    def remove(self):
+        super().remove()
+        for coll in self.collections:
+            coll.remove()
 
 
 @_docstring.dedent_interpd

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -682,3 +682,13 @@ def test_negative_linestyles(style):
     ax4.clabel(CS4, fontsize=9, inline=True)
     ax4.set_title(f'Single color - negative contours {style}')
     assert CS4.negative_linestyles == style
+
+
+def test_contour_remove():
+    ax = plt.figure().add_subplot()
+    orig_children = ax.get_children()
+    cs = ax.contour(np.arange(16).reshape((4, 4)))
+    cs.clabel()
+    assert ax.get_children() != orig_children
+    cs.remove()
+    assert ax.get_children() == orig_children


### PR DESCRIPTION
## PR Summary

Closes https://github.com/matplotlib/matplotlib/issues/5332.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
