### PR TITLE
Updated Angles on Bracket arrow styles example to make angles clear #23176

### DIFF
--- a/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
+++ b/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
@@ -51,7 +51,7 @@ for i, style in enumerate(["]-[", "|-|"]):
             kw = dict(connectionstyle=f"arc3,rad={dir * 0.5}",
                       arrowstyle=arrowstyle, color="C0")
             ax.add_patch(FancyArrowPatch(vline, patch_top, **kw))
-            ax.text(vline[0] - dir * 0.15, y + 0.3, angle, ha="center",
+            ax.text(vline[0] - dir * 0.15, y + 0.3, f'{angle}°', ha="center",
                     va="center")
 
 #############################################################################

--- a/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
+++ b/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
@@ -7,7 +7,7 @@ This example shows how to add angle annotations to bracket arrow styles
 created using `.FancyArrowPatch`. *angleA* and *angleB* are measured from a
 vertical line as positive (to the left) or negative (to the right). Blue
 `.FancyArrowPatch` arrows indicate the directions of *angleA* and *angleB*
- from the vertical and axes text annotate the angle sizes.
+from the vertical and axes text annotate the angle sizes.
 """
 
 import matplotlib.pyplot as plt

--- a/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
+++ b/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
@@ -1,0 +1,64 @@
+"""
+===================================
+Angle annotations on bracket arrows
+===================================
+
+This example shows how to add angle annotations to bracket arrow styles
+created using `.FancyArrowPatch`. *angleA* and *angleB* are measured from a
+vertical line as positive (to the left) or negative (to the right). Blue
+`.FancyArrowPatch` arrows indicate the directions of *angleA* and *angleB*
+ from the vertical and axes text annotate the angle sizes.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+from matplotlib.patches import FancyArrowPatch
+
+
+def get_point_of_rotated_vertical(origin, line_length, degrees):
+    """Return xy coordinates of the vertical line end rotated by degrees."""
+    rad = np.deg2rad(-degrees)
+    return [origin[0] + line_length * np.sin(rad),
+            origin[1] + line_length * np.cos(rad)]
+
+
+fig, ax = plt.subplots(figsize=(8, 7))
+ax.set(xlim=(0, 6), ylim=(-1, 4))
+ax.set_title("Orientation of the bracket arrows relative to angleA and angleB")
+
+for i, style in enumerate(["]-[", "|-|"]):
+    for j, angle in enumerate([-40, 60]):
+        y = 2*i + j
+        arrow_centers = ((1, y), (5, y))
+        vlines = ((1, y + 0.5), (5, y + 0.5))
+        anglesAB = (angle, -angle)
+        bracketstyle = f"{style}, angleA={anglesAB[0]}, angleB={anglesAB[1]}"
+        bracket = FancyArrowPatch(*arrow_centers, arrowstyle=bracketstyle,
+                                  mutation_scale=42)
+        ax.add_patch(bracket)
+        ax.text(3, y + 0.05, bracketstyle, ha="center", va="bottom")
+        ax.vlines([i[0] for i in vlines], [y, y], [i[1] for i in vlines],
+                  linestyles="--", color="C0")
+        # Get the top coordinates for the drawn patches at A and B
+        patch_tops = [get_point_of_rotated_vertical(center, 0.5, angle)
+                      for center, angle in zip(arrow_centers, anglesAB)]
+        # Define the connection directions for the annotation arrows
+        connection_dirs = (1, -1) if angle > 0 else (-1, 1)
+        # Add arrows and annotation text
+        arrowstyle = "Simple, tail_width=0.5, head_width=4, head_length=8"
+        for vline, dir, patch_top, angle in zip(vlines, connection_dirs,
+                                                patch_tops, anglesAB):
+            kw = dict(connectionstyle=f"arc3,rad={dir * 0.5}",
+                      arrowstyle=arrowstyle, color="C0")
+            ax.add_patch(FancyArrowPatch(vline, patch_top, **kw))
+            ax.text(vline[0] - dir * 0.15, y + 0.3, angle, ha="center",
+                    va="center")
+
+#############################################################################
+#
+# .. admonition:: References
+#
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.patches.ArrowStyle`

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3119,6 +3119,14 @@ class ArrowStyle(_Style):
     stroked. This is meant to be used to correct the location of the
     head so that it does not overshoot the destination point, but not all
     classes support it.
+
+    Notes
+    -----
+    *angleA* and *angleB* specify the orientation of the bracket, as either a
+    clockwise or counterclockwise angle depending on the arrow type. 0 degrees
+    means perpendicular to the line connecting the arrow's head and tail.
+
+    .. plot:: gallery/text_labels_and_annotations/angles_on_bracket_arrows.py
     """
 
     _style_list = {}


### PR DESCRIPTION
## PR Summary

PR relates to this [issue](https://github.com/matplotlib/matplotlib/issues/23176). Added `AngleAnnotation` patches to mark the angles and included `FancyArrowPatch` arrows to show the directions of AngleA and AngleB.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
