### PR TITLE
Fix Qt with PySide6 6.4.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,9 @@ jobs:
             python-version: 3.8
             extra-requirements: '-c requirements/testing/minver.txt'
             pyqt5-ver: '==5.11.2 sip==5.0.0'  # oldest versions with a Py3.8 wheel.
+            pyqt6-ver: '==6.1.0 PyQt6-Qt6==6.1.0'
+            pyside2-ver: '==5.14.0'  # oldest version with working Py3.8 wheel.
+            pyside6-ver: '==6.0.0'
             delete-font-cache: true
           - os: ubuntu-20.04
             python-version: 3.8
@@ -189,17 +192,17 @@ jobs:
             echo 'PyQt5 is available' ||
             echo 'PyQt5 is not available'
           if [[ "${{ runner.os }}" != 'macOS' ]]; then
-            python -mpip install --upgrade pyside2 &&
+            python -mpip install --upgrade pyside2${{ matrix.pyside2-ver }} &&
               python -c 'import PySide2.QtCore' &&
               echo 'PySide2 is available' ||
               echo 'PySide2 is not available'
           fi
           if [[ "${{ matrix.os }}" = ubuntu-20.04 ]]; then
-            python -mpip install --upgrade pyqt6 &&
+            python -mpip install --upgrade pyqt6${{ matrix.pyqt6-ver }} &&
               python -c 'import PyQt6.QtCore' &&
               echo 'PyQt6 is available' ||
               echo 'PyQt6 is not available'
-            python -mpip install --upgrade pyside6 &&
+            python -mpip install --upgrade pyside6${{ matrix.pyside6-ver }} &&
               python -c 'import PySide6.QtCore' &&
               echo 'PySide6 is available' ||
               echo 'PySide6 is not available'

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -92,7 +92,10 @@ def _setup_pyqt5plus():
         _isdeleted = sip.isdeleted
     elif QT_API == QT_API_PYSIDE2:
         from PySide2 import QtCore, QtGui, QtWidgets, __version__
-        import shiboken2
+        try:
+            from PySide2 import shiboken2
+        except ImportError:
+            import shiboken2
         def _isdeleted(obj):
             return not shiboken2.isValid(obj)
     else:

--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -69,7 +69,8 @@ else:
 
 
 def _setup_pyqt5plus():
-    global QtCore, QtGui, QtWidgets, __version__, _isdeleted, _getSaveFileName
+    global QtCore, QtGui, QtWidgets, __version__
+    global _getSaveFileName, _isdeleted, _to_int
 
     if QT_API == QT_API_PYQT6:
         from PyQt6 import QtCore, QtGui, QtWidgets, sip
@@ -78,10 +79,15 @@ def _setup_pyqt5plus():
         QtCore.Slot = QtCore.pyqtSlot
         QtCore.Property = QtCore.pyqtProperty
         _isdeleted = sip.isdeleted
+        _to_int = operator.attrgetter('value')
     elif QT_API == QT_API_PYSIDE6:
         from PySide6 import QtCore, QtGui, QtWidgets, __version__
         import shiboken6
         def _isdeleted(obj): return not shiboken6.isValid(obj)
+        if parse_version(__version__) >= parse_version('6.4'):
+            _to_int = operator.attrgetter('value')
+        else:
+            _to_int = int
     elif QT_API == QT_API_PYQT5:
         from PyQt5 import QtCore, QtGui, QtWidgets
         import sip
@@ -90,6 +96,7 @@ def _setup_pyqt5plus():
         QtCore.Slot = QtCore.pyqtSlot
         QtCore.Property = QtCore.pyqtProperty
         _isdeleted = sip.isdeleted
+        _to_int = int
     elif QT_API == QT_API_PYSIDE2:
         from PySide2 import QtCore, QtGui, QtWidgets, __version__
         try:
@@ -98,6 +105,7 @@ def _setup_pyqt5plus():
             import shiboken2
         def _isdeleted(obj):
             return not shiboken2.isValid(obj)
+        _to_int = int
     else:
         raise AssertionError(f"Unexpected QT_API: {QT_API}")
     _getSaveFileName = QtWidgets.QFileDialog.getSaveFileName
@@ -142,9 +150,6 @@ if (sys.platform == 'darwin' and
 
 
 # PyQt6 enum compat helpers.
-
-
-_to_int = operator.attrgetter("value") if QT_API == "PyQt6" else int
 
 
 @functools.lru_cache(None)


### PR DESCRIPTION
## PR Summary

I also set the "Minimum versions" job to test the minimum supported versions of all the Qt bindings. Due to [bugs in PySide2](https://bugreports.qt.io/browse/PYSIDE-1140), I had to set its minimum to 5.14 instead of 5.11.2 like PyQt5.

Fixes #24155.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).