### PR TITLE
sample versioning directives, empty + description

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2648,6 +2648,9 @@ class Axes(_AxesBase):
             When *fmt* is a string and can be interpreted in both formats,
             %-style takes precedence over {}-style.
 
+            .. versionadded:: 3.7
+               Support for {}-style format string and callables.
+
         label_type : {'edge', 'center'}, default: 'edge'
             The label type. Possible values:
 
@@ -3328,6 +3331,10 @@ class Axes(_AxesBase):
         *x*, *y* define the data locations, *xerr*, *yerr* define the errorbar
         sizes. By default, this draws the data markers/lines as well the
         errorbars. Use fmt='none' to draw errorbars without any data markers.
+
+        .. versionadded:: 3.7
+           Caps and error lines are drawn in polar coordinates on polar plots.
+
 
         Parameters
         ----------

--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -106,6 +106,9 @@ class HostAxesBase:
         Despite this method's name, this should actually be thought of as an
         ``add_parasite_axes`` method.
 
+        .. versionchanged:: 3.7
+           Defaults to same base axes class as host axes.
+
         Parameters
         ----------
         tr : `~matplotlib.transforms.Transform` or None, default: None


### PR DESCRIPTION
Based on discussion on call and in #23506, trying out some versioning directives. Policy at #24161 

Haven't styled anything yet, tried w/o and w/ description cause wasn't sure what made more sense. I guess w/o is a pointer to go look up those release notes, but not sure how to document that. The issue is that these two are partially new things - polar errobars and more valid parameter values, rather than wholly new things. 

![image](https://user-images.githubusercontent.com/1300499/195741176-ae20ebcf-62fd-486a-9f4f-509fb365c08e.png)
![image](https://user-images.githubusercontent.com/1300499/195741508-ad6e3c26-d66f-418f-866c-976914e5659b.png)
![image](https://user-images.githubusercontent.com/1300499/195741602-0d8e7ff5-30ed-476a-a785-b13b982fb6dc.png)

