### PR TITLE
windows doc build parity

### DIFF
--- a/doc/make.bat
+++ b/doc/make.bat
@@ -28,12 +28,32 @@ if errorlevel 9009 (
 )
 
 if "%1" == "" goto help
+if "%1" == "html-noplot" goto html-noplot
+if "%1" == "show" goto show
 
 %SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+if "%1" == "clean" (
+	REM workaround because sphinx does not completely clean up (#11139)
+	rmdir /s /q "%SOURCEDIR%\build"
+	rmdir /s /q "%SOURCEDIR%\api\_as_gen"
+	rmdir /s /q "%SOURCEDIR%\gallery"
+	rmdir /s /q "%SOURCEDIR%\plot_types"
+	rmdir /s /q "%SOURCEDIR%\tutorials"
+	rmdir /s /q "%SOURCEDIR%\savefig"
+	rmdir /s /q "%SOURCEDIR%\sphinxext\__pycache__"
+)
 goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:html-noplot
+%SPHINXBUILD% -M html %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O% -D plot_gallery=0
+goto end
+
+:show
+python -m webbrowser -t "%~dp0\build\html\index.html"
 
 :end
 popd


### PR DESCRIPTION
added `html-noplot` and `show` targets to make.bat  so that it supports all the [documented build options](https://matplotlib.org/stable/devel/documenting_mpl.html#setting-up-the-doc-build) and updated the clean to fully clean (#11319)
