### PR TITLE
Fix example where wrong variable was used

### DIFF
--- a/examples/subplots_axes_and_figures/subplots_demo.py
+++ b/examples/subplots_axes_and_figures/subplots_demo.py
@@ -176,7 +176,7 @@ ax2.plot(x, y**2, 'tab:orange')
 ax3.plot(x + 1, -y, 'tab:green')
 ax4.plot(x + 2, -y**2, 'tab:red')
 
-for ax in axs.flat:
+for ax in fig.get_axes():
     ax.label_outer()
 
 ###############################################################################


### PR DESCRIPTION
variable `axs` was not defined in the code snippet of `Sharing x per column, y per row` figure, rather it was defined in some earlier snippets. The intended use here is applying `label_outer()` on the axes of the figure in the current snippet.

## PR Checklist

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] Fixed a bug in examples code snippets.