### PR TITLE
TST: convert nose-style tests

### DIFF
--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -51,7 +51,7 @@ class Test_delete_masked_points:
 
 
 class Test_boxplot_stats:
-    def setup(self):
+    def setup_method(self):
         np.random.seed(937)
         self.nrows = 37
         self.ncols = 4
@@ -177,7 +177,7 @@ class Test_boxplot_stats:
 
 
 class Test_callback_registry:
-    def setup(self):
+    def setup_method(self):
         self.signal = 'test'
         self.callbacks = cbook.CallbackRegistry()
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -97,7 +97,7 @@ def test_window():
 
 
 class TestDetrend:
-    def setup(self):
+    def setup_method(self):
         np.random.seed(0)
         n = 1000
         x = np.linspace(0., 100, n)


### PR DESCRIPTION
## PR Summary

A minimal change to resolve #24148.  Replaced Nose's `setup` with pytest's [`setup_method`](https://docs.pytest.org/en/7.1.x/how-to/xunit_setup.html?highlight=setup_method#method-and-function-level-setup-teardown).  I note that there is already an instance of `setup_method` within [test_transforms.py](https://github.com/matplotlib/matplotlib/blob/c744161bdaf8b2a40bf96dcc0ebcd37ea0444319/lib/matplotlib/tests/test_transforms.py#L229).  I installed `pytest` with

`pip install git+https://github.com/pytest-dev/pytest.git@main`

and verified that

* With a clean branch, I reproduce the errors shown at #24148.
* With the change, these test modules pass.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
