### PR TITLE
Add tests for ToolManager

### DIFF
--- a/lib/matplotlib/backend_managers.py
+++ b/lib/matplotlib/backend_managers.py
@@ -185,7 +185,7 @@ class ToolManager:
             Keys to associate with the tool.
         """
         if name not in self._tools:
-            raise KeyError(f'{name} not in Tools')
+            raise KeyError(f'{name!r} not in Tools')
         self._remove_keys(name)
         if isinstance(key, str):
             key = [key]
@@ -404,6 +404,7 @@ class ToolManager:
             return name
         if name not in self._tools:
             if warn:
-                _api.warn_external(f"ToolManager does not control tool {name}")
+                _api.warn_external(
+                    f"ToolManager does not control tool {name!r}")
             return None
         return self._tools[name]

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -4,12 +4,19 @@ from matplotlib import path, transforms
 from matplotlib.backend_bases import (
     FigureCanvasBase, LocationEvent, MouseButton, MouseEvent,
     NavigationToolbar2, RendererBase)
+from matplotlib.backend_tools import RubberbandBase
 from matplotlib.figure import Figure
 from matplotlib.testing._markers import needs_pgf_xelatex
 import matplotlib.pyplot as plt
 
 import numpy as np
 import pytest
+
+
+_EXPECTED_WARNING_TOOLMANAGER = (
+    r"Treat the new Tool classes introduced in "
+    r"v[0-9]*.[0-9]* as experimental for now; "
+    "the API and rcParam may change in future versions.")
 
 
 def test_uses_per_path():
@@ -247,11 +254,7 @@ def test_interactive_colorbar(plot_func, orientation, tool, button, expected):
 
 
 def test_toolbar_zoompan():
-    expected_warning_regex = (
-        r"Treat the new Tool classes introduced in "
-        r"v[0-9]*.[0-9]* as experimental for now; "
-        "the API and rcParam may change in future versions.")
-    with pytest.warns(UserWarning, match=expected_warning_regex):
+    with pytest.warns(UserWarning, match=_EXPECTED_WARNING_TOOLMANAGER):
         plt.rcParams['toolbar'] = 'toolmanager'
     ax = plt.gca()
     assert ax.get_navigate_mode() is None
@@ -349,3 +352,44 @@ def test_interactive_pan(key, mouseend, expectedxlim, expectedylim):
     # Should be close, but won't be exact due to screen integer resolution
     assert tuple(ax.get_xlim()) == pytest.approx(expectedxlim, abs=0.02)
     assert tuple(ax.get_ylim()) == pytest.approx(expectedylim, abs=0.02)
+
+
+def test_toolmanager_remove():
+    with pytest.warns(UserWarning, match=_EXPECTED_WARNING_TOOLMANAGER):
+        plt.rcParams['toolbar'] = 'toolmanager'
+    fig = plt.gcf()
+    initial_len = len(fig.canvas.manager.toolmanager.tools)
+    assert 'forward' in fig.canvas.manager.toolmanager.tools
+    fig.canvas.manager.toolmanager.remove_tool('forward')
+    assert len(fig.canvas.manager.toolmanager.tools) == initial_len - 1
+    assert 'forward' not in fig.canvas.manager.toolmanager.tools
+
+
+def test_toolmanager_get_tool():
+    with pytest.warns(UserWarning, match=_EXPECTED_WARNING_TOOLMANAGER):
+        plt.rcParams['toolbar'] = 'toolmanager'
+    fig = plt.gcf()
+    rubberband = fig.canvas.manager.toolmanager.get_tool('rubberband')
+    assert isinstance(rubberband, RubberbandBase)
+    assert fig.canvas.manager.toolmanager.get_tool(rubberband) is rubberband
+    with pytest.warns(UserWarning,
+                      match="ToolManager does not control tool 'foo'"):
+        assert fig.canvas.manager.toolmanager.get_tool('foo') is None
+    assert fig.canvas.manager.toolmanager.get_tool('foo', warn=False) is None
+
+    with pytest.warns(UserWarning,
+                      match="ToolManager does not control tool 'foo'"):
+        assert fig.canvas.manager.toolmanager.trigger_tool('foo') is None
+
+
+def test_toolmanager_update_keymap():
+    with pytest.warns(UserWarning, match=_EXPECTED_WARNING_TOOLMANAGER):
+        plt.rcParams['toolbar'] = 'toolmanager'
+    fig = plt.gcf()
+    assert 'v' in fig.canvas.manager.toolmanager.get_tool_keymap('forward')
+    with pytest.warns(UserWarning,
+                      match="Key c changed from back to forward"):
+        fig.canvas.manager.toolmanager.update_keymap('forward', 'c')
+    assert fig.canvas.manager.toolmanager.get_tool_keymap('forward') == ['c']
+    with pytest.raises(KeyError, match="'foo' not in Tools"):
+        fig.canvas.manager.toolmanager.update_keymap('foo', 'c')


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
