### PR TITLE
DOC: Fix toc structure in explain/interactive

### DIFF
--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -137,7 +137,7 @@ Milestones
     ``v3.N.0``.
 
   * *Bugfixes, tests for released code, and docstring changes* are milestoned
-  for the next patch release ``v3.N.M``.
+    for the next patch release ``v3.N.M``.
 
   * *Documentation changes* (all .rst files and examples) are milestoned
     ``v3.N-doc``.

--- a/doc/users/explain/interactive.rst
+++ b/doc/users/explain/interactive.rst
@@ -8,9 +8,6 @@
 Interactive figures
 ===================
 
-.. toctree::
-
-
 When working with data, interactivity can be invaluable. The pan/zoom and
 mouse-location tools built into the Matplotlib GUI windows are often sufficient, but
 you can also use the event system to build customized data exploration tools.


### PR DESCRIPTION
## PR Summary

Closes #22905. Not sure why we had the `.. toctree::` entry there or what sphinx is doing with it. But it's not needed and without it the page becomes a structure leaf like it's sibling pages.
