### PR TITLE
Do not pass width_ratios or height_ratios to inner layouts in subplot_mosaic

### DIFF
--- a/doc/api/next_api_changes/behavior/24188-JB.rst
+++ b/doc/api/next_api_changes/behavior/24188-JB.rst
@@ -1,0 +1,9 @@
+`fig.subplot_mosaic` no longer passes the `width_ratios` or `height_ratios` args to the nested gridspecs.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, the entirety of the `gridspec_kw` dictionary was passed to
+the nested gridspecs. This caused an error if the inner layout was
+incompatible with one of these ratios. A new dictionary is now made,
+`nested_gs_kw`, where the `"width_ratios"` and `"height_ratios"` keys
+have been removed, which is passed to any nested gridspecs. This
+prevents such errors.

--- a/doc/api/next_api_changes/behavior/24188-JB.rst
+++ b/doc/api/next_api_changes/behavior/24188-JB.rst
@@ -1,9 +1,9 @@
-`fig.subplot_mosaic` no longer passes the `width_ratios` or `height_ratios` args to the nested gridspecs.
+``fig.subplot_mosaic`` no longer passes the ``width_ratios`` or ``height_ratios`` args to the nested gridspecs.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Previously, the entirety of the `gridspec_kw` dictionary was passed to
-the nested gridspecs. This caused an error if the inner layout was
+Previously, the entirety of the ``gridspec_kw`` dictionary was passed
+to the nested gridspecs. This caused an error if the inner layout was
 incompatible with one of these ratios. A new dictionary is now made,
-`nested_gs_kw`, where the `"width_ratios"` and `"height_ratios"` keys
-have been removed, which is passed to any nested gridspecs. This
+``nested_gs_kw``, where the ``"width_ratios"`` and ``"height_ratios"``
+keys have been removed, which is passed to any nested gridspecs. This
 prevents such errors.

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -932,6 +932,16 @@ class TestSubplotMosaic:
         assert axd["A"].get_gridspec().get_width_ratios() == width_ratios
         assert axd["B"].get_gridspec().get_width_ratios() != width_ratios
 
+    def test_nested_height_ratios(self):
+        x = [["A", [["B"],
+                    ["C"]]], ["D", "D"]]
+        height_ratios = [1, 2]
+
+        fig, axd = plt.subplot_mosaic(x, height_ratios=height_ratios)
+
+        assert axd["D"].get_gridspec().get_height_ratios() == height_ratios
+        assert axd["B"].get_gridspec().get_height_ratios() != height_ratios
+
     @check_figures_equal(extensions=["png"])
     @pytest.mark.parametrize(
         "x, empty_sentinel",

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -922,6 +922,16 @@ class TestSubplotMosaic:
         fig_ref.subplot_mosaic([["F"], [x]])
         fig_test.subplot_mosaic([["F"], [xt]])
 
+    def test_nested_width_ratios(self):
+        x = [["A", [["B"],
+                    ["C"]]]]
+        width_ratios = [2, 1]
+
+        fig, axd = plt.subplot_mosaic(x, width_ratios=width_ratios)
+
+        assert axd["A"].get_gridspec().get_width_ratios() == width_ratios
+        assert axd["B"].get_gridspec().get_width_ratios() != width_ratios
+
     @check_figures_equal(extensions=["png"])
     @pytest.mark.parametrize(
         "x, empty_sentinel",


### PR DESCRIPTION
## PR Summary

Fixes #24099 

Constructs a new `gridspec_kw` dictionary with the `"width_ratios"` and `"height_ratios"` removed, which is passed to the inner layouts instead of the original. This prevents an error from occurring when one of the inner layouts is not compatible with one of the specified ratios.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [X] Has pytest style unit tests (and `pytest` passes).
- [X] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
