### PR TITLE
BLD: be more cautious about checking editable mode

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,7 @@ def update_matplotlibrc(path):
 class BuildPy(setuptools.command.build_py.build_py):
     def run(self):
         super().run()
-        if not self.editable_mode:
+        if not getattr(self, 'editable_mode', False):
             update_matplotlibrc(
                 Path(self.build_lib, "matplotlib/mpl-data/matplotlibrc"))
 


### PR DESCRIPTION
## PR Summary

It can be missing rather than false when invoke as

$ pip install --no-build-isolation .

