### PR TITLE
Plot directive: delegate file handling to Sphinx

### DIFF
--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -18,6 +18,7 @@ def test_tinypages(tmp_path):
     shutil.copytree(Path(__file__).parent / 'tinypages', tmp_path,
                     dirs_exist_ok=True)
     html_dir = tmp_path / '_build' / 'html'
+    img_dir = html_dir / '_images'
     doctree_dir = tmp_path / 'doctrees'
     # Build the pages with warnings turned into errors
     cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
@@ -35,7 +36,7 @@ def test_tinypages(tmp_path):
     build_sphinx_html(tmp_path, doctree_dir, html_dir)
 
     def plot_file(num):
-        return html_dir / f'some_plots-{num}.png'
+        return img_dir / f'some_plots-{num}.png'
 
     def plot_directive_file(num):
         # This is always next to the doctree dir.
@@ -58,8 +59,8 @@ def test_tinypages(tmp_path):
 
     assert b'# Only a comment' in html_contents
     # check plot defined in external file.
-    assert filecmp.cmp(range_4, html_dir / 'range4.png')
-    assert filecmp.cmp(range_6, html_dir / 'range6.png')
+    assert filecmp.cmp(range_4, img_dir / 'range4.png')
+    assert filecmp.cmp(range_6, img_dir / 'range6.png')
     # check if figure caption made it into html file
     assert b'This is the caption for plot 15.' in html_contents
     # check if figure caption using :caption: made it into html file
@@ -111,13 +112,13 @@ def test_plot_html_show_source_link(tmp_path):
     # Make sure source scripts are created by default
     html_dir1 = tmp_path / '_build' / 'html1'
     build_sphinx_html(tmp_path, doctree_dir, html_dir1)
-    assert "index-1.py" in [p.name for p in html_dir1.iterdir()]
+    assert len(list(html_dir1.glob("**/index-1.py"))) == 1
     # Make sure source scripts are NOT created when
     # plot_html_show_source_link` is False
     html_dir2 = tmp_path / '_build' / 'html2'
     build_sphinx_html(tmp_path, doctree_dir, html_dir2,
                       extra_args=['-D', 'plot_html_show_source_link=0'])
-    assert "index-1.py" not in [p.name for p in html_dir2.iterdir()]
+    assert len(list(html_dir2.glob("**/index-1.py"))) == 0
 
 
 @pytest.mark.parametrize('plot_html_show_source_link', [0, 1])
@@ -137,7 +138,7 @@ def test_show_source_link_true(tmp_path, plot_html_show_source_link):
     html_dir = tmp_path / '_build' / 'html'
     build_sphinx_html(tmp_path, doctree_dir, html_dir, extra_args=[
         '-D', f'plot_html_show_source_link={plot_html_show_source_link}'])
-    assert "index-1.py" in [p.name for p in html_dir.iterdir()]
+    assert len(list(html_dir.glob("**/index-1.py"))) == 1
 
 
 @pytest.mark.parametrize('plot_html_show_source_link', [0, 1])
@@ -157,7 +158,7 @@ def test_show_source_link_false(tmp_path, plot_html_show_source_link):
     html_dir = tmp_path / '_build' / 'html'
     build_sphinx_html(tmp_path, doctree_dir, html_dir, extra_args=[
         '-D', f'plot_html_show_source_link={plot_html_show_source_link}'])
-    assert "index-1.py" not in [p.name for p in html_dir.iterdir()]
+    assert len(list(html_dir.glob("**/index-1.py"))) == 0
 
 
 def build_sphinx_html(tmp_path, doctree_dir, html_dir, extra_args=None):


### PR DESCRIPTION
## PR Summary
This PR solves multiple problems with file handling in `matplotlib.sphinxext.plot_directive` described in issue #24005 (and #13858) by delegating all files copying and links generation to the Sphinx `:download:` role instead of trying to do so explicitly (which apparently cannot be done properly with the current approach).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [N/A] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
