### PR TITLE
Small cleanups to axislines docs.

### DIFF
--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -52,48 +52,35 @@ from .axis_artist import AxisArtist, GridlinesCollection
 
 class AxisArtistHelper:
     """
-    AxisArtistHelper should define
-    following method with given APIs. Note that the first axes argument
-    will be axes attribute of the caller artist.::
+    Axis helpers should define the methods listed below.  The *axes* argument
+    will be the axes attribute of the caller artist.
 
+    ::
 
-        # LINE (spinal line?)
-
-        def get_line(self, axes):
-            # path : Path
-            return path
+        # Construct the spine.
 
         def get_line_transform(self, axes):
-            # ...
-            # trans : transform
-            return trans
+            return transform
 
-        # LABEL
+        def get_line(self, axes):
+            return path
 
-        def get_label_pos(self, axes):
-            # x, y : position
-            return (x, y), trans
+        # Construct the label.
 
+        def get_axislabel_transform(self, axes):
+            return transform
 
-        def get_label_offset_transform(self,
-                axes,
-                pad_points, fontprops, renderer,
-                bboxes,
-                ):
-            # va : vertical alignment
-            # ha : horizontal alignment
-            # a : angle
-            return trans, va, ha, a
+        def get_axislabel_pos_angle(self, axes):
+            return (x, y), angle
 
-        # TICK
+        # Construct the ticks.
 
         def get_tick_transform(self, axes):
-            return trans
+            return transform
 
         def get_tick_iterators(self, axes):
-            # iter : iterable object that yields (c, angle, l) where
-            # c, angle, l is position, tick angle, and label
-
+            # A pair of iterables (one for major ticks, one for minor ticks)
+            # that yield (tick_position, tick_angle, tick_label).
             return iter_major, iter_minor
     """
 
@@ -117,10 +104,7 @@ class AxisArtistHelper:
                                     top=(0, 1))
 
         def __init__(self, loc, nth_coord=None):
-            """
-            nth_coord = along which coordinate value varies
-            in 2D, nth_coord = 0 ->  x axis, nth_coord = 1 -> y axis
-            """
+            """``nth_coord = 0``: x-axis; ``nth_coord = 1``: y-axis."""
             _api.check_in_list(["left", "right", "bottom", "top"], loc=loc)
             self._loc = loc
 


### PR DESCRIPTION
## PR Summary

Note that get_label_{offset_transform,pos} only ever existed in very old
versions of axisartist; get_axislabel_{transform,pos_angle} are what's
been used ever since then.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
