### PR TITLE
Simplify and tighten parse_fontconfig_pattern.

### DIFF
--- a/doc/api/next_api_changes/deprecations/24220-AL.rst
+++ b/doc/api/next_api_changes/deprecations/24220-AL.rst
@@ -1,0 +1,5 @@
+``parse_fontconfig_pattern`` will no longer ignore unknown constant names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, in a fontconfig pattern like ``DejaVu Sans:foo``, the unknown
+``foo`` constant name would be silently ignored.  This now raises a warning,
+and will become an error in the future.

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -1,3 +1,5 @@
+import pytest
+
 from matplotlib.font_manager import FontProperties
 
 
@@ -60,7 +62,7 @@ def test_fontconfig_str():
         assert getattr(font, k)() == getattr(right, k)(), test + k
 
     test = "full "
-    s = ("serif:size=24:style=oblique:variant=small-caps:weight=bold"
+    s = ("serif-24:style=oblique:variant=small-caps:weight=bold"
          ":stretch=expanded")
     font = FontProperties(s)
     right = FontProperties(family="serif", size=24, weight="bold",
@@ -68,3 +70,8 @@ def test_fontconfig_str():
                            stretch="expanded")
     for k in keys:
         assert getattr(font, k)() == getattr(right, k)(), test + k
+
+
+def test_fontconfig_unknown_constant():
+    with pytest.warns(DeprecationWarning):
+        FontProperties(":unknown")


### PR DESCRIPTION
- Warn on unknown constant names, e.g. ``DejaVu Sans:unknown`` (as opposed e.g. to ``DejaVu Sans:bold``); they were previously silently ignored.

- Rewrite the parser into something much simpler, moving nearly all the logic into a single block post-processing the result of parseString, instead of splitting everything into many small parse actions.  In particular this makes the parser mostly stateless (except for the cache held by pyparsing itself), instead of having the various parts communicate through the _properties attribute.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
