### PR TITLE
DOC: Mark SubplotBase removals in code style

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.6.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.6.0/removals.rst
@@ -154,8 +154,8 @@ The following class methods have been removed:
 
 - ``ParasiteAxesBase.update_viewlim()``; use `.ParasiteAxesBase.apply_aspect`
   instead.
-- ``Subplot.get_geometry()``; use `.SubplotBase.get_subplotspec` instead.
-- ``Subplot.change_geometry()``; use `.SubplotBase.set_subplotspec` instead.
+- ``Subplot.get_geometry()``; use ``SubplotBase.get_subplotspec`` instead.
+- ``Subplot.change_geometry()``; use ``SubplotBase.set_subplotspec`` instead.
 - ``Subplot.update_params()``; this method did nothing.
 - ``Subplot.is_first_row()``; use ``ax.get_subplotspec().is_first_row``
   instead.


### PR DESCRIPTION
## PR Summary

This fixes the doc build.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).