### PR TITLE
Deprecate unit_cube-related methods in Axes3D

### DIFF
--- a/doc/api/next_api_changes/deprecations/24240-OG.rst
+++ b/doc/api/next_api_changes/deprecations/24240-OG.rst
@@ -1,0 +1,6 @@
+``unit_cube``, ``tunit_cube``, and ``tunit_edges``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... of `.Axes3D` are deprecated without replacements. If you rely on them,
+please copy the code of the corresponding private function (name starting
+with ``_``).

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -236,7 +236,11 @@ class Axes3D(Axes):
     w_zaxis = _api.deprecated("3.1", alternative="zaxis", removal="3.8")(
         property(lambda self: self.zaxis))
 
+    @_api.deprecated("3.7")
     def unit_cube(self, vals=None):
+        return self._unit_cube(vals)
+
+    def _unit_cube(self, vals=None):
         minx, maxx, miny, maxy, minz, maxz = vals or self.get_w_lims()
         return [(minx, miny, minz),
                 (maxx, miny, minz),
@@ -247,15 +251,23 @@ class Axes3D(Axes):
                 (maxx, maxy, maxz),
                 (minx, maxy, maxz)]
 
+    @_api.deprecated("3.7")
     def tunit_cube(self, vals=None, M=None):
+        return self._tunit_cube(vals, M)
+
+    def _tunit_cube(self, vals=None, M=None):
         if M is None:
             M = self.M
-        xyzs = self.unit_cube(vals)
+        xyzs = self._unit_cube(vals)
         tcube = proj3d.proj_points(xyzs, M)
         return tcube
 
+    @_api.deprecated("3.7")
     def tunit_edges(self, vals=None, M=None):
-        tc = self.tunit_cube(vals, M)
+        return self._tunit_edges(vals, M)
+
+    def _tunit_edges(self, vals=None, M=None):
+        tc = self._tunit_cube(vals, M)
         edges = [(tc[0], tc[1]),
                  (tc[1], tc[2]),
                  (tc[2], tc[3]),
@@ -496,7 +508,7 @@ class Axes3D(Axes):
 
     def get_axis_position(self):
         vals = self.get_w_lims()
-        tc = self.tunit_cube(vals, self.M)
+        tc = self._tunit_cube(vals, self.M)
         xhigh = tc[1][2] > tc[2][2]
         yhigh = tc[3][2] > tc[2][2]
         zhigh = tc[0][2] > tc[2][2]
@@ -1063,7 +1075,7 @@ class Axes3D(Axes):
                     ).replace("-", "\N{MINUS SIGN}")
 
         # nearest edge
-        p0, p1 = min(self.tunit_edges(),
+        p0, p1 = min(self._tunit_edges(),
                      key=lambda edge: proj3d._line2d_seg_dist(
                          edge[0], edge[1], (xd, yd)))
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -257,7 +257,7 @@ class Axis(maxis.XAxis):
 
         # Project the bounds along the current position of the cube:
         bounds = mins[0], maxs[0], mins[1], maxs[1], mins[2], maxs[2]
-        bounds_proj = self.axes.tunit_cube(bounds, self.axes.M)
+        bounds_proj = self.axes._tunit_cube(bounds, self.axes.M)
 
         # Determine which one of the parallel planes are higher up:
         means_z0 = np.zeros(3)


### PR DESCRIPTION
## PR Summary

I cannot see that there is any valid public use for these. No doc-string either.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] New features are documented, with examples if plot related.
- [N/A] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
