### PR TITLE
Small animation docs/style fixes.

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -840,7 +840,8 @@ class Animation:
         system notifications.
 
     blit : bool, default: False
-        Whether blitting is used to optimize drawing.
+        Whether blitting is used to optimize drawing.  If the backend does not
+        support blitting, then this parameter has no effect.
 
     See Also
     --------
@@ -956,7 +957,7 @@ class Animation:
         extra_anim : list, default: []
             Additional `Animation` objects that should be included
             in the saved movie file. These need to be from the same
-            `matplotlib.figure.Figure` instance. Also, animation frames will
+            `.Figure` instance. Also, animation frames will
             just be simply combined, so there should be a 1:1 correspondence
             between the frames from the different animations.
 
@@ -977,8 +978,7 @@ class Animation:
 
             Example code to write the progress to stdout::
 
-                progress_callback =\
-                    lambda i, n: print(f'Saving frame {i} of {n}')
+                progress_callback = lambda i, n: print(f'Saving frame {i}/{n}')
 
         Notes
         -----
@@ -1025,9 +1025,8 @@ class Animation:
 
         all_anim = [self]
         if extra_anim is not None:
-            all_anim.extend(anim
-                            for anim
-                            in extra_anim if anim._fig is self._fig)
+            all_anim.extend(anim for anim in extra_anim
+                            if anim._fig is self._fig)
 
         # If we have the name of a writer, instantiate an instance of the
         # registered class.


### PR DESCRIPTION
Clarify that it is OK to pass blit=True even if the backend does not support it.  Tweak the progress_callback example to avoid a backslash escape.  Small additional doc/style fixes.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
