### PR TITLE
Add information about environment variables in matplotlib.__doc__

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -77,6 +77,24 @@ The base matplotlib namespace includes:
         figure is created, because it is not possible to switch between
         different GUI backends after that.
 
+The following environment variables can be used to customize the behavior::
+
+    .. envvar:: MPLBACKEND
+
+      This optional variable can be set to choose the Matplotlib backend. See
+      :ref:`what-is-a-backend`.
+
+    .. envvar:: MPLCONFIGDIR
+
+      This is the directory used to store user customizations to
+      Matplotlib, as well as some caches to improve performance. If
+      :envvar:`MPLCONFIGDIR` is not defined, :file:`{HOME}/.config/matplotlib`
+      and :file:`{HOME}/.cache/matplotlib` are used on Linux, and
+      :file:`{HOME}/.matplotlib` on other platforms, if they are
+      writable. Otherwise, the Python standard library's `tempfile.gettempdir`
+      is used to find a base directory in which the :file:`matplotlib`
+      subdirectory is created.
+
 Matplotlib was initially written by John D. Hunter (1968-2012) and is now
 developed and maintained by a host of others.
 


### PR DESCRIPTION
## PR Summary

Closes #6893

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
