### PR TITLE
Improve documentation for ticker

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1707,10 +1707,10 @@ class IndexLocator(Locator):
 
 class FixedLocator(Locator):
     """
-    Tick locations are fixed.  If nbins is not None,
-    the array of possible positions will be subsampled to
-    keep the number of ticks <= nbins +1.
-    The subsampling will be done so as to include the smallest
+    Tick locations are fixed at *locs*.  If *nbins* is not None,
+    the array *locs* of possible positions will be subsampled to
+    keep the number of ticks <= *nbins* +1.
+    The subsampling will be done to include the smallest
     absolute value; for example, if zero is included in the
     array of possibilities, then it is guaranteed to be one of
     the chosen ticks.
@@ -1774,14 +1774,21 @@ class LinearLocator(Locator):
     Determine the tick locations
 
     The first time this function is called it will try to set the
-    number of ticks to make a nice tick partitioning.  Thereafter the
+    number of ticks to make a nice tick partitioning.  Thereafter, the
     number of ticks will be fixed so that interactive navigation will
     be nice
 
     """
     def __init__(self, numticks=None, presets=None):
         """
-        Use presets to set locs based on lom.  A dict mapping vmin, vmax->locs
+        Parameters
+        ----------
+        numticks : int or None, default None
+            Number of ticks. If None, *numticks* = 11.
+        presets : dict or None, default: None
+            Dictionary mapping ``(vmin, vmax)`` to an array of locations.
+            Overrides *numticks* if there is an entry for the current
+            ``(vmin, vmax)``.
         """
         self.numticks = numticks
         if presets is None:
@@ -1847,7 +1854,8 @@ class LinearLocator(Locator):
 
 class MultipleLocator(Locator):
     """
-    Set a tick on each integer multiple of a base within the view interval.
+    Set a tick on each integer multiple of the *base* within the view
+    interval.
     """
 
     def __init__(self, base=1.0):
@@ -1874,7 +1882,7 @@ class MultipleLocator(Locator):
 
     def view_limits(self, dmin, dmax):
         """
-        Set the view limits to the nearest multiples of base that
+        Set the view limits to the nearest multiples of *base* that
         contain the data.
         """
         if mpl.rcParams['axes.autolimit_mode'] == 'round_numbers':
@@ -1903,16 +1911,20 @@ def scale_range(vmin, vmax, n=1, threshold=100):
 
 class _Edge_integer:
     """
-    Helper for MaxNLocator, MultipleLocator, etc.
+    Helper for `.MaxNLocator`, `.MultipleLocator`, etc.
 
-    Take floating point precision limitations into account when calculating
+    Take floating-point precision limitations into account when calculating
     tick locations as integer multiples of a step.
     """
     def __init__(self, step, offset):
         """
-        *step* is a positive floating-point interval between ticks.
-        *offset* is the offset subtracted from the data limits
-        prior to calculating tick locations.
+        Parameters
+        ----------
+        step : float > 0
+            Interval between ticks.
+        offset : float
+            Offset subtracted from the data limits prior to calculating tick
+            locations.
         """
         if step <= 0:
             raise ValueError("'step' must be positive")
@@ -1946,8 +1958,8 @@ class _Edge_integer:
 
 class MaxNLocator(Locator):
     """
-    Find nice tick locations with no more than N being within the view limits.
-    Locations beyond the limits are added to support autoscaling.
+    Find nice tick locations with no more than *nbins* + 1 being within the
+    view limits. Locations beyond the limits are added to support autoscaling.
     """
     default_params = dict(nbins=10,
                           steps=None,

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1708,7 +1708,7 @@ class IndexLocator(Locator):
 class FixedLocator(Locator):
     """
     Tick locations are fixed at *locs*.  If *nbins* is not None,
-    the array *locs* of possible positions will be subsampled to
+    the *locs* array of possible positions will be subsampled to
     keep the number of ticks <= *nbins* +1.
     The subsampling will be done to include the smallest
     absolute value; for example, if zero is included in the


### PR DESCRIPTION
## PR Summary

Closes #5908

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
