### PR TITLE
Adding new feature

### DIFF
--- a/plot_types/basic/scatter_plot.py
+++ b/plot_types/basic/scatter_plot.py
@@ -8,22 +8,25 @@ See `~matplotlib.axes.Axes.scatter`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-plt.style.use('_mpl-gallery')
+
 
 # make the data
 np.random.seed(3)
 x = 4 + np.random.normal(0, 2, 24)
 y = 4 + np.random.normal(0, 2, len(x))
 # size and color:
-sizes = np.random.uniform(15, 80, len(x))
+sizes = 5*np.random.uniform(15, 80, len(x))
+
 colors = np.random.uniform(15, 80, len(x))
 
 # plot
 fig, ax = plt.subplots()
 
-ax.scatter(x, y, s=sizes, c=colors, vmin=0, vmax=100)
+ax.scatter(x, y, s=sizes,alpha=0.5, cmap='nipy_spectral', c=colors, vmin=0, vmax=100,marker='+')
 
-ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
-       ylim=(0, 8), yticks=np.arange(1, 8))
+plt.xlabel('X-axis')
+plt.ylabel('Y-axis')
 
+
+plt.grid(color = 'green', linestyle = '--', linewidth = 0.5)
 plt.show()


### PR DESCRIPTION
Looking amazing and easy to visualize

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
