### PR TITLE
Fix key reporting in pick events

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2445,10 +2445,6 @@ class Figure(FigureBase):
         # pickling.
         self._canvas_callbacks = cbook.CallbackRegistry(
             signals=FigureCanvasBase.events)
-        self._button_pick_id = self._canvas_callbacks._connect_picklable(
-            'button_press_event', self.pick)
-        self._scroll_pick_id = self._canvas_callbacks._connect_picklable(
-            'scroll_event', self.pick)
         connect = self._canvas_callbacks._connect_picklable
         self._mouse_key_ids = [
             connect('key_press_event', backend_bases._key_handler),
@@ -2459,6 +2455,8 @@ class Figure(FigureBase):
             connect('scroll_event', backend_bases._mouse_handler),
             connect('motion_notify_event', backend_bases._mouse_handler),
         ]
+        self._button_pick_id = connect('button_press_event', self.pick)
+        self._scroll_pick_id = connect('scroll_event', self.pick)
 
         if figsize is None:
             figsize = mpl.rcParams['figure.figsize']

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -2,7 +2,7 @@ import re
 
 from matplotlib import path, transforms
 from matplotlib.backend_bases import (
-    FigureCanvasBase, LocationEvent, MouseButton, MouseEvent,
+    FigureCanvasBase, KeyEvent, LocationEvent, MouseButton, MouseEvent,
     NavigationToolbar2, RendererBase)
 from matplotlib.backend_tools import RubberbandBase
 from matplotlib.figure import Figure
@@ -124,12 +124,18 @@ def test_pick():
     fig = plt.figure()
     fig.text(.5, .5, "hello", ha="center", va="center", picker=True)
     fig.canvas.draw()
+
     picks = []
-    fig.canvas.mpl_connect("pick_event", lambda event: picks.append(event))
-    start_event = MouseEvent(
-        "button_press_event", fig.canvas, *fig.transFigure.transform((.5, .5)),
-        MouseButton.LEFT)
-    fig.canvas.callbacks.process(start_event.name, start_event)
+    def handle_pick(event):
+        assert event.mouseevent.key == "a"
+        picks.append(event)
+    fig.canvas.mpl_connect("pick_event", handle_pick)
+
+    KeyEvent("key_press_event", fig.canvas, "a")._process()
+    MouseEvent("button_press_event", fig.canvas,
+               *fig.transFigure.transform((.5, .5)),
+               MouseButton.LEFT)._process()
+    KeyEvent("key_release_event", fig.canvas, "a")._process()
     assert len(picks) == 1
 
 


### PR DESCRIPTION
## PR Summary

Fixes #24199

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).