### PR TITLE
Change default rotation mode for 3D labels to 'anchor'

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -96,7 +96,8 @@ class Axis(maxis.XAxis):
         self._axinfo = self._AXINFO[name].copy()
         # Common parts
         self._axinfo.update({
-            'label': {'va': 'center', 'ha': 'center'},
+            'label': {'va': 'center', 'ha': 'center',
+                      'rotation_mode': 'anchor'},
             'color': mpl.rcParams[f'axes3d.{name}axis.panecolor'],
             'tick': {
                 'inward_factor': 0.2,
@@ -403,6 +404,7 @@ class Axis(maxis.XAxis):
             self.label.set_rotation(angle)
         self.label.set_va(info['label']['va'])
         self.label.set_ha(info['label']['ha'])
+        self.label.set_rotation_mode(info['label']['rotation_mode'])
         self.label.draw(renderer)
 
         # Draw Offset text


### PR DESCRIPTION
## PR Summary

Closes #21878

As I understand it, it is primarily a bonus when editing the svg file later. Doesn't seem to break anything (in local tests, hence running all tests here now).

A bit unclear how to actually test it and if any release note is required.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
