### PR TITLE
Expire deprecation of grid argument name

### DIFF
--- a/doc/api/next_api_changes/removals/24253-OG.rst
+++ b/doc/api/next_api_changes/removals/24253-OG.rst
@@ -1,0 +1,5 @@
+The first parameter of ``Axes.grid`` and ``Axis.grid`` has been renamed to *visible*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The parameter was previously named *b*. This name change only matters if that
+parameter was passed using a keyword argument, e.g. ``grid(b=False)``.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3240,7 +3240,6 @@ class _AxesBase(martist.Artist):
         self.stale = True
 
     @_docstring.dedent_interpd
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=None, which='major', axis='both', **kwargs):
         """
         Configure the grid lines.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1553,7 +1553,6 @@ class Axis(martist.Artist):
 
         return self.minorTicks[:numticks]
 
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=None, which='major', **kwargs):
         """
         Configure the grid lines.

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -503,7 +503,6 @@ class Axes(maxes.Axes):
     def get_grid_helper(self):
         return self._grid_helper
 
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=None, which='major', axis="both", **kwargs):
         """
         Toggle the gridlines, and optionally set the properties of the lines.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1350,7 +1350,6 @@ class Axes3D(Axes):
         self._frameon = bool(b)
         self.stale = True
 
-    @_api.rename_parameter("3.5", "b", "visible")
     def grid(self, visible=True, **kwargs):
         """
         Set / unset 3D grid.


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
