### PR TITLE
TST: Increase fp tolerance on more tests for new NumPy

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -4,7 +4,8 @@ import re
 
 import contourpy
 import numpy as np
-from numpy.testing import assert_array_almost_equal
+from numpy.testing import (
+    assert_array_almost_equal, assert_array_almost_equal_nulp)
 import matplotlib as mpl
 from matplotlib.testing.decorators import image_comparison
 from matplotlib import pyplot as plt, rc_context
@@ -313,7 +314,7 @@ def test_contourf_log_extension():
     cb = plt.colorbar(c1, ax=ax1)
     assert cb.ax.get_ylim() == (1e-8, 1e10)
     cb = plt.colorbar(c2, ax=ax2)
-    assert cb.ax.get_ylim() == (1e-4, 1e6)
+    assert_array_almost_equal_nulp(cb.ax.get_ylim(), np.array((1e-4, 1e6)))
     cb = plt.colorbar(c3, ax=ax3)
 
 

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -34,7 +34,8 @@ def test_startpoints():
     plt.plot(start_x, start_y, 'ok')
 
 
-@image_comparison(['streamplot_colormap'], remove_text=True, style='mpl20')
+@image_comparison(['streamplot_colormap'], remove_text=True, style='mpl20',
+                  tol=0.022)
 def test_colormap():
     X, Y, U, V = velocity_field()
     plt.streamplot(X, Y, U, V, color=U, density=0.6, linewidth=2,


### PR DESCRIPTION
## PR Summary

This is similar to #22132 in that NumPy has added more code paths that now take advantage of AVX512 optimizations and causes slight variations in results.

Fixes #24060

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] New features are documented, with examples if plot related.
- [n/a] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [n/a] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).