### PR TITLE
WIP: Fix remove methods

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -409,13 +409,13 @@ def remove_methods(methods, cls=None):
     if cls is None:  # Return the actual class decorator.
         return functools.partial(remove_methods, methods)
 
-    def make_wrapper(name):
+    def make_wrapper(method_name):
         msg = (
             f"`{method_name}` is removed on " +
             f"`{cls.__module__}.{cls.__qualname__}`."
         )
         def method(self, *args, **kwargs):
-            raise Exception(msg)
+            raise NotImplementedError(msg)
 
         method.__doc__ = msg
         method.__name__ = method_name

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -739,7 +739,6 @@ def reposition_colorbar(layoutgrids, cbax, renderer, *, offset=None):
             pbcb = pbcb.translated(0, dy)
 
     pbcb = trans_fig_to_subfig.transform_bbox(pbcb)
-    cbax.set_transform(fig.transSubfigure)
     cbax._set_position(pbcb)
     cbax.set_anchor(anchor)
     if location in ['bottom', 'top']:

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1524,9 +1524,12 @@ class ArtistInspector:
             if not name.startswith('set_'):
                 continue
             func = getattr(self.o, name)
-            if (not callable(func)
-                    or self.number_of_parameters(func) < 2
-                    or self.is_alias(func)):
+            if (
+                not callable(func)
+                or self.number_of_parameters(func) < 2
+                or self.is_alias(func)
+                or getattr(func, 'is_removed', False)
+            ):
                 continue
             setters.append(name[4:])
         return setters

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -544,6 +544,7 @@ class _process_plot_var_args:
             return [l[0] for l in result]
 
 
+@_api.remove_methods(['set_transform', 'get_transform'])
 @_api.define_aliases({"facecolor": ["fc"]})
 class _AxesBase(martist.Artist):
     name = "rectilinear"

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -166,6 +166,7 @@ class SubplotParams:
             self.hspace = hspace
 
 
+@_api.remove_methods(['set_transform', 'get_transform'])
 class FigureBase(Artist):
     """
     Base class for `.Figure` and `.SubFigure` containing the methods that add


### PR DESCRIPTION
## PR Summary

We have a number of sub-classes which inherit redundant methods from their
parents (including the Axes and Figure families).

This adds an API helper to replace those methods with versions that raise (it
is better to explode on the user than to silently drop input on the floor) and
removes the keywords for those setters from the built docs.

Closes #24225

Leaving this as WIP until we agree that we want to do this sort of thing.  This intersects with something I think @timhoffm was working on to edit the auto-generated kwdoc tables?

This caught one usage of `ax.set_transform` in the constrained layout code, but I think it had no effect

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] New features are documented, with examples if plot related.
- [ ] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [ ] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
