### PR TITLE
Use oldest-supported-numpy for build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,6 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "certifi>=2020.06.20",
-    "numpy>=1.19",
+    "oldest-supported-numpy",
     "setuptools_scm>=7",
 ]


### PR DESCRIPTION
## PR Summary

Otherwise, a new version will be installed in the isolated build environment, and Matplotlib will fail to import in an existing environment with older NumPy.

According to its docs, this _should_ be okay even though we target a newer version at runtime, and this linkage may possibly go away if we move to pybind11 anyway.

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`