### PR TITLE
Fix some minor docstring typos

### DIFF
--- a/lib/matplotlib/cbook/__init__.py
+++ b/lib/matplotlib/cbook/__init__.py
@@ -132,9 +132,9 @@ class CallbackRegistry:
     for a set of signals and callbacks:
 
         >>> def oneat(x):
-        ...    print('eat', x)
+        ...     print('eat', x)
         >>> def ondrink(x):
-        ...    print('drink', x)
+        ...     print('drink', x)
 
         >>> from matplotlib.cbook import CallbackRegistry
         >>> callbacks = CallbackRegistry()
@@ -1905,7 +1905,7 @@ def _array_perimeter(arr):
 
     Examples
     --------
-    >>> i, j = np.ogrid[:3,:4]
+    >>> i, j = np.ogrid[:3, :4]
     >>> a = i*10 + j
     >>> a
     array([[ 0,  1,  2,  3],
@@ -1949,7 +1949,7 @@ def _unfold(arr, axis, size, step):
 
     Examples
     --------
-    >>> i, j = np.ogrid[:3,:7]
+    >>> i, j = np.ogrid[:3, :7]
     >>> a = i*10 + j
     >>> a
     array([[ 0,  1,  2,  3,  4,  5,  6],

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2908,10 +2908,9 @@ class RectangleSelector(_SelectorWidget):
     ...     print(erelease.xdata, erelease.ydata)
     >>> props = dict(facecolor='blue', alpha=0.5)
     >>> rect = mwidgets.RectangleSelector(ax, onselect, interactive=True,
-                                          props=props)
+    ...                                   props=props)
     >>> fig.show()
-
-    >>> selector.add_state('square')
+    >>> rect.add_state('square')
 
     See also: :doc:`/gallery/widgets/rectangle_selector`
     """


### PR DESCRIPTION
## PR Summary

Found while testing out `flake8-rst` (for which there are unfortunately a few too many false positives.)

## PR Checklist

**Tests and Styling**
- [n/a] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`