### PR TITLE
Cleanup image_zcoord example.

### DIFF
--- a/examples/images_contours_and_fields/image_zcoord.py
+++ b/examples/images_contours_and_fields/image_zcoord.py
@@ -3,12 +3,11 @@
 Modifying the coordinate formatter
 ==================================
 
-Modify the coordinate formatter to report the image "z"
-value of the nearest pixel given x and y.
-This functionality is built in by default, but it
-is still useful to show how to customize the
-`~.axes.Axes.format_coord` function.
+Modify the coordinate formatter to report the image "z" value of the nearest
+pixel given x and y.  This functionality is built in by default; this example
+just showcases how to customize the `~.axes.Axes.format_coord` function.
 """
+
 import numpy as np
 import matplotlib.pyplot as plt
 
@@ -21,17 +20,17 @@ X = 10*np.random.rand(5, 3)
 fig, ax = plt.subplots()
 ax.imshow(X)
 
-numrows, numcols = X.shape
-
 
 def format_coord(x, y):
-    col = int(x + 0.5)
-    row = int(y + 0.5)
-    if 0 <= col < numcols and 0 <= row < numrows:
+    col = round(x)
+    row = round(y)
+    nrows, ncols = X.shape
+    if 0 <= col < ncols and 0 <= row < nrows:
         z = X[row, col]
-        return 'x=%1.4f, y=%1.4f, z=%1.4f' % (x, y, z)
+        return f'x={x:1.4f}, y={y:1.4f}, z={z:1.4f}'
     else:
-        return 'x=%1.4f, y=%1.4f' % (x, y)
+        return f'x={x:1.4f}, y={y:1.4f}'
+
 
 ax.format_coord = format_coord
 plt.show()


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
