### PR TITLE
Remove unnecessary np.{,as}array / astype calls.

### DIFF
--- a/examples/event_handling/path_editor.py
+++ b/examples/event_handling/path_editor.py
@@ -82,17 +82,12 @@ class PathInteractor:
         Return the index of the point closest to the event position or *None*
         if no point is within ``self.epsilon`` to the event position.
         """
-        # display coords
-        xy = np.asarray(self.pathpatch.get_path().vertices)
-        xyt = self.pathpatch.get_transform().transform(xy)
+        xy = self.pathpatch.get_path().vertices
+        xyt = self.pathpatch.get_transform().transform(xy)  # to display coords
         xt, yt = xyt[:, 0], xyt[:, 1]
         d = np.sqrt((xt - event.x)**2 + (yt - event.y)**2)
         ind = d.argmin()
-
-        if d[ind] >= self.epsilon:
-            ind = None
-
-        return ind
+        return ind if d[ind] < self.epsilon else None
 
     def on_draw(self, event):
         """Callback for draws."""

--- a/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/examples/subplots_axes_and_figures/secondary_axis.py
@@ -59,7 +59,7 @@ ax.set_title('Random spectrum')
 
 def one_over(x):
     """Vectorized 1/x, treating x==0 manually"""
-    x = np.array(x).astype(float)
+    x = np.array(x, float)
     near_zero = np.isclose(x, 0)
     x[near_zero] = np.inf
     x[~near_zero] = 1 / x[~near_zero]

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -144,7 +144,7 @@ class TaggedValue(metaclass=TaggedValueMeta):
         return object.__getattribute__(self, name)
 
     def __array__(self, dtype=object):
-        return np.asarray(self.value).astype(dtype)
+        return np.asarray(self.value, dtype)
 
     def __array_wrap__(self, array, context):
         return TaggedValue(array, self.unit)

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1464,7 +1464,7 @@ class PickEvent(Event):
             line = event.artist
             xdata, ydata = line.get_data()
             ind = event.ind
-            print('on pick line:', np.array([xdata[ind], ydata[ind]]).T)
+            print(f'on pick line: {xdata[ind]:.3f}, {ydata[ind]:.3f}')
 
         cid = fig.canvas.mpl_connect('pick_event', on_pick)
     """

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -547,8 +547,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
             offsets = offsets[None, :]
         self._offsets = np.column_stack(
-            (np.asarray(self.convert_xunits(offsets[:, 0]), 'float'),
-             np.asarray(self.convert_yunits(offsets[:, 1]), 'float')))
+            (np.asarray(self.convert_xunits(offsets[:, 0]), float),
+             np.asarray(self.convert_yunits(offsets[:, 1]), float)))
         self.stale = True
 
     def get_offsets(self):
@@ -573,7 +573,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
         if lw is None:
             lw = self._get_default_linewidth()
         # get the un-scaled/broadcast lw
-        self._us_lw = np.atleast_1d(np.asarray(lw))
+        self._us_lw = np.atleast_1d(lw)
 
         # scale all of the dash patterns.
         self._linewidths, self._linestyles = self._bcast_lwls(

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1144,7 +1144,7 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
         if isinstance(levels_arg, Integral):
             self.levels = self._autolev(levels_arg)
         else:
-            self.levels = np.asarray(levels_arg).astype(np.float64)
+            self.levels = np.asarray(levels_arg, np.float64)
 
         if not self.filled:
             inside = (self.levels > self.zmin) & (self.levels < self.zmax)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1701,7 +1701,7 @@ def _pil_png_to_float_array(pil_png):
     mode = pil_png.mode
     rawmode = pil_png.png.im_rawmode
     if rawmode == "1":  # Grayscale.
-        return np.asarray(pil_png).astype(np.float32)
+        return np.asarray(pil_png, np.float32)
     if rawmode == "L;2":  # Grayscale.
         return np.divide(pil_png, 2**2 - 1, dtype=np.float32)
     if rawmode == "L;4":  # Grayscale.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1221,9 +1221,7 @@ class Wedge(Patch):
                 arc.codes, [connector, connector, Path.CLOSEPOLY]])
 
         # Shift and scale the wedge to the final location.
-        v *= self.r
-        v += np.asarray(self.center)
-        self._path = Path(v, c)
+        self._path = Path(v * self.r + self.center, c)
 
     def set_center(self, center):
         self._path = None

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -434,10 +434,7 @@ class Sankey:
         Sankey.finish
         """
         # Check and preprocess the arguments.
-        if flows is None:
-            flows = np.array([1.0, -1.0])
-        else:
-            flows = np.array(flows)
+        flows = np.array([1.0, -1.0]) if flows is None else np.array(flows)
         n = flows.shape[0]  # Number of flows
         if rotation is None:
             rotation = 0

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -500,8 +500,8 @@ def save_diff_image(expected, actual, output):
     actual_image = _load_image(actual)
     actual_image, expected_image = crop_to_same(
         actual, actual_image, expected, expected_image)
-    expected_image = np.array(expected_image).astype(float)
-    actual_image = np.array(actual_image).astype(float)
+    expected_image = np.array(expected_image, float)
+    actual_image = np.array(actual_image, float)
     if expected_image.shape != actual_image.shape:
         raise ImageComparisonFailure(
             "Image sizes do not match expected size: {} "

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1499,7 +1499,7 @@ def test_arc_ellipse():
         [np.cos(rtheta), -np.sin(rtheta)],
         [np.sin(rtheta), np.cos(rtheta)]])
 
-    x, y = np.dot(R, np.array([x, y]))
+    x, y = np.dot(R, [x, y])
     x += xcenter
     y += ycenter
 
@@ -2097,7 +2097,7 @@ def test_hist_datetime_datasets():
 @pytest.mark.parametrize("bins_preprocess",
                          [mpl.dates.date2num,
                           lambda bins: bins,
-                          lambda bins: np.asarray(bins).astype('datetime64')],
+                          lambda bins: np.asarray(bins, 'datetime64')],
                          ids=['date2num', 'datetime.datetime',
                               'np.datetime64'])
 def test_hist_datetime_datasets_bins(bins_preprocess):
@@ -6409,7 +6409,7 @@ def test_pandas_pcolormesh(pd):
 
 def test_pandas_indexing_dates(pd):
     dates = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
-    values = np.sin(np.array(range(len(dates))))
+    values = np.sin(range(len(dates)))
     df = pd.DataFrame({'dates': dates, 'values': values})
 
     ax = plt.gca()

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -696,7 +696,7 @@ def test_pathcollection_legend_elements():
 
     h, l = sc.legend_elements(fmt="{x:g}")
     assert len(h) == 5
-    assert_array_equal(np.array(l).astype(float), np.arange(5))
+    assert l == ["0", "1", "2", "3", "4"]
     colors = np.array([line.get_color() for line in h])
     colors2 = sc.cmap(np.arange(5)/4)
     assert_array_equal(colors, colors2)
@@ -707,16 +707,14 @@ def test_pathcollection_legend_elements():
     l2 = ax.legend(h2, lab2, loc=2)
 
     h, l = sc.legend_elements(prop="sizes", alpha=0.5, color="red")
-    alpha = np.array([line.get_alpha() for line in h])
-    assert_array_equal(alpha, 0.5)
-    color = np.array([line.get_markerfacecolor() for line in h])
-    assert_array_equal(color, "red")
+    assert all(line.get_alpha() == 0.5 for line in h)
+    assert all(line.get_markerfacecolor() == "red" for line in h)
     l3 = ax.legend(h, l, loc=4)
 
     h, l = sc.legend_elements(prop="sizes", num=4, fmt="{x:.2f}",
                               func=lambda x: 2*x)
     actsizes = [line.get_markersize() for line in h]
-    labeledsizes = np.sqrt(np.array(l).astype(float)/2)
+    labeledsizes = np.sqrt(np.array(l, float) / 2)
     assert_array_almost_equal(actsizes, labeledsizes)
     l4 = ax.legend(h, l, loc=3)
 
@@ -727,7 +725,7 @@ def test_pathcollection_legend_elements():
 
     levels = [-1, 0, 55.4, 260]
     h6, lab6 = sc.legend_elements(num=levels, prop="sizes", fmt="{x:g}")
-    assert_array_equal(np.array(lab6).astype(float), levels[2:])
+    assert [float(l) for l in lab6] == levels[2:]
 
     for l in [l1, l2, l3, l4]:
         ax.add_artist(l)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -243,7 +243,7 @@ def test_colormap_invalid():
     # Test scalar representations
     assert_array_equal(cmap(-np.inf), cmap(0))
     assert_array_equal(cmap(np.inf), cmap(1.0))
-    assert_array_equal(cmap(np.nan), np.array([0., 0., 0., 0.]))
+    assert_array_equal(cmap(np.nan), [0., 0., 0., 0.])
 
 
 def test_colormap_return_types():
@@ -574,7 +574,7 @@ def test_Normalize():
     # i.e. 127-(-128) here).
     vals = np.array([-128, 127], dtype=np.int8)
     norm = mcolors.Normalize(vals.min(), vals.max())
-    assert_array_equal(np.asarray(norm(vals)), [0, 1])
+    assert_array_equal(norm(vals), [0, 1])
 
     # Don't lose precision on longdoubles (float128 on Linux):
     # for array inputs...

--- a/lib/matplotlib/tests/test_sankey.py
+++ b/lib/matplotlib/tests/test_sankey.py
@@ -1,5 +1,5 @@
 import pytest
-import numpy as np
+from numpy.testing import assert_allclose, assert_array_equal
 
 from matplotlib.sankey import Sankey
 from matplotlib.testing.decorators import check_figures_equal
@@ -67,28 +67,28 @@ def test_sankey2():
     s = Sankey(flows=[0.25, -0.25, 0.5, -0.5], labels=['Foo'],
                orientations=[-1], unit='Bar')
     sf = s.finish()
-    assert np.all(np.equal(np.array((0.25, -0.25, 0.5, -0.5)), sf[0].flows))
+    assert_array_equal(sf[0].flows, [0.25, -0.25, 0.5, -0.5])
     assert sf[0].angles == [1, 3, 1, 3]
     assert all([text.get_text()[0:3] == 'Foo' for text in sf[0].texts])
     assert all([text.get_text()[-3:] == 'Bar' for text in sf[0].texts])
     assert sf[0].text.get_text() == ''
-    assert np.allclose(np.array(((-1.375, -0.52011255),
-                                 (1.375, -0.75506044),
-                                 (-0.75, -0.41522509),
-                                 (0.75, -0.8599479))),
-                       sf[0].tips)
+    assert_allclose(sf[0].tips,
+                    [(-1.375, -0.52011255),
+                     (1.375, -0.75506044),
+                     (-0.75, -0.41522509),
+                     (0.75, -0.8599479)])
 
     s = Sankey(flows=[0.25, -0.25, 0, 0.5, -0.5], labels=['Foo'],
                orientations=[-1], unit='Bar')
     sf = s.finish()
-    assert np.all(np.equal(np.array((0.25, -0.25, 0, 0.5, -0.5)), sf[0].flows))
+    assert_array_equal(sf[0].flows, [0.25, -0.25, 0, 0.5, -0.5])
     assert sf[0].angles == [1, 3, None, 1, 3]
-    assert np.allclose(np.array(((-1.375, -0.52011255),
-                                 (1.375, -0.75506044),
-                                 (0, 0),
-                                 (-0.75, -0.41522509),
-                                 (0.75, -0.8599479))),
-                       sf[0].tips)
+    assert_allclose(sf[0].tips,
+                    [(-1.375, -0.52011255),
+                     (1.375, -0.75506044),
+                     (0, 0),
+                     (-0.75, -0.41522509),
+                     (0.75, -0.8599479)])
 
 
 @check_figures_equal(extensions=['png'])

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -422,7 +422,7 @@ class TestTransformPlotInterface:
         ax = plt.axes()
         offset = mtransforms.Affine2D().translate(10, 10)
         na_offset = NonAffineForTest(mtransforms.Affine2D().translate(10, 10))
-        pth = Path(np.array([[0, 0], [0, 10], [10, 10], [10, 0]]))
+        pth = Path([[0, 0], [0, 10], [10, 10], [10, 0]])
         patch = mpatches.PathPatch(pth,
                                    transform=offset + na_offset + ax.transData)
         ax.add_patch(patch)
@@ -432,7 +432,7 @@ class TestTransformPlotInterface:
     def test_pathc_extents_affine(self):
         ax = plt.axes()
         offset = mtransforms.Affine2D().translate(10, 10)
-        pth = Path(np.array([[0, 0], [0, 10], [10, 10], [10, 0]]))
+        pth = Path([[0, 0], [0, 10], [10, 10], [10, 0]])
         patch = mpatches.PathPatch(pth, transform=offset + ax.transData)
         ax.add_patch(patch)
         expected_data_lim = np.array([[0., 0.], [10.,  10.]]) + 10

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -944,8 +944,7 @@ def test_tritools():
     mask = np.array([False, False, True], dtype=bool)
     triang = mtri.Triangulation(x, y, triangles, mask=mask)
     analyser = mtri.TriAnalyzer(triang)
-    assert_array_almost_equal(analyser.scale_factors,
-                              np.array([1., 1./(1.+0.5*np.sqrt(3.))]))
+    assert_array_almost_equal(analyser.scale_factors, [1, 1/(1+3**.5/2)])
     assert_array_almost_equal(
         analyser.circle_ratios(rescale=False),
         np.ma.masked_array([0.5, 1./(1.+np.sqrt(2.)), np.nan], mask))

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -925,7 +925,7 @@ class Bbox(BboxBase):
            - When ``False``, include the existing bounds of the `Bbox`.
            - When ``None``, use the last value passed to :meth:`ignore`.
         """
-        y = np.array(y).ravel()
+        y = np.ravel(y)
         self.update_from_data_xy(np.column_stack([np.ones(y.size), y]),
                                  ignore=ignore, updatex=False)
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3207,7 +3207,7 @@ pivot='tail', normalize=False, **kwargs)
             invM = np.linalg.inv(self.get_proj())
         # elev=azim=roll=0 produces the Y-Z plane, so quiversize in 2D 'x' is
         # 'y' in 3D, hence the 1 index.
-        quiversize = np.dot(invM, np.array([quiversize, 0, 0, 0]))[1]
+        quiversize = np.dot(invM, [quiversize, 0, 0, 0])[1]
         # Quivers use a fixed 15-degree arrow head, so scale up the length so
         # that the size corresponds to the base. In other words, this constant
         # corresponds to the equation tan(15) = (base / 2) / (arrow length).

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -164,8 +164,7 @@ class Axis(maxis.XAxis):
             antialiased=True)
 
         # Store dummy data in Polygon object
-        self.pane = mpatches.Polygon(
-            np.array([[0, 0], [0, 1]]), closed=False)
+        self.pane = mpatches.Polygon([[0, 0], [0, 1]], closed=False)
         self.set_pane_color(self._axinfo['color'])
 
         self.axes._set_artist_props(self.line)

--- a/lib/mpl_toolkits/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/tests/test_axes_grid1.py
@@ -208,23 +208,22 @@ def test_inset_axes_complete():
     ins = inset_axes(ax, width=2., height=2., borderpad=0)
     fig.canvas.draw()
     assert_array_almost_equal(
-            ins.get_position().extents,
-            np.array(((0.9*figsize[0]-2.)/figsize[0],
-                      (0.9*figsize[1]-2.)/figsize[1], 0.9, 0.9)))
+        ins.get_position().extents,
+        [(0.9*figsize[0]-2.)/figsize[0], (0.9*figsize[1]-2.)/figsize[1],
+         0.9, 0.9])
 
     ins = inset_axes(ax, width="40%", height="30%", borderpad=0)
     fig.canvas.draw()
     assert_array_almost_equal(
-            ins.get_position().extents,
-            np.array((.9-.8*.4, .9-.8*.3, 0.9, 0.9)))
+        ins.get_position().extents, [.9-.8*.4, .9-.8*.3, 0.9, 0.9])
 
     ins = inset_axes(ax, width=1., height=1.2, bbox_to_anchor=(200, 100),
                      loc=3, borderpad=0)
     fig.canvas.draw()
     assert_array_almost_equal(
-            ins.get_position().extents,
-            np.array((200./dpi/figsize[0], 100./dpi/figsize[1],
-                     (200./dpi+1)/figsize[0], (100./dpi+1.2)/figsize[1])))
+        ins.get_position().extents,
+        [200/dpi/figsize[0], 100/dpi/figsize[1],
+         (200/dpi+1)/figsize[0], (100/dpi+1.2)/figsize[1]])
 
     ins1 = inset_axes(ax, width="35%", height="60%", loc=3, borderpad=1)
     ins2 = inset_axes(ax, width="100%", height="100%",


### PR DESCRIPTION
Quite often numpy will call asarray for us, saving us the need to call asarray explicitly.

When we do call asarray (or array) ourselves, a dtype can directly be passed in, rather than immediately calling astype immediately after. Passing the dtype makes it unnecessary for asarray to infer the dtype of the passed-in container, and can also save an extra array allocation if asarray first has to allocate an array of a type and astype immediately has to allocate an array of another type.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
