### PR TITLE
MNT: Remove redundant int after round

### DIFF
--- a/examples/statistics/time_series_histogram.py
+++ b/examples/statistics/time_series_histogram.py
@@ -41,7 +41,7 @@ x = np.linspace(0, 4 * np.pi, num_points)
 # Generate unbiased Gaussian random walks
 Y = np.cumsum(np.random.randn(num_series, num_points), axis=-1)
 # Generate sinusoidal signals
-num_signal = int(round(SNR * num_series))
+num_signal = round(SNR * num_series)
 phi = (np.pi / 8) * np.random.randn(num_signal, 1)  # small random offset
 Y[-num_signal:] = (
     np.sqrt(np.arange(num_points))[None, :]  # random walk RMS scaling factor

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -515,7 +515,7 @@ def to_hex(c, keep_alpha=False):
     c = to_rgba(c)
     if not keep_alpha:
         c = c[:3]
-    return "#" + "".join(format(int(round(val * 255)), "02x") for val in c)
+    return "#" + "".join(format(round(val * 255), "02x") for val in c)
 
 
 ### Backwards-compatible color-conversion API

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1244,8 +1244,8 @@ class PcolorImage(AxesImage):
         l, b, r, t = self.axes.bbox.extents
         width = (round(r) + 0.5) - (round(l) - 0.5)
         height = (round(t) + 0.5) - (round(b) - 0.5)
-        width = int(round(width * magnification))
-        height = int(round(height * magnification))
+        width = round(width * magnification)
+        height = round(height * magnification)
         vl = self.axes.viewLim
 
         x_pix = np.linspace(vl.x0, vl.x1, width)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2568,9 +2568,9 @@ class BoxStyle(_Style):
 
             # the sizes of the vertical and horizontal sawtooth are
             # separately adjusted to fit the given box size.
-            dsx_n = int(round((width - tooth_size) / (tooth_size * 2))) * 2
+            dsx_n = round((width - tooth_size) / (tooth_size * 2)) * 2
             dsx = (width - tooth_size) / dsx_n
-            dsy_n = int(round((height - tooth_size) / (tooth_size * 2))) * 2
+            dsy_n = round((height - tooth_size) / (tooth_size * 2)) * 2
             dsy = (height - tooth_size) / dsy_n
 
             x0, y0 = x0 - pad + tooth_size2, y0 - pad + tooth_size2

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2021,9 +2021,9 @@ class Axes3D(Axes):
                     continue
 
             stepsize = (len(topverts[0]) - 1) / (nsteps - 1)
-            for i in range(int(round(nsteps)) - 1):
-                i1 = int(round(i * stepsize))
-                i2 = int(round((i + 1) * stepsize))
+            for i in range(round(nsteps) - 1):
+                i1 = round(i * stepsize)
+                i2 = round((i + 1) * stepsize)
                 polyverts.append([topverts[0][i1],
                                   topverts[0][i2],
                                   botverts[0][i2],


### PR DESCRIPTION
## PR Summary

`round` does return an `int` (at least in Python 3).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
