### PR TITLE
Simplify generate_fontconfig_pattern.

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -12,7 +12,6 @@ A module for parsing and generating `fontconfig patterns`_.
 from functools import lru_cache, partial
 import re
 
-import numpy as np
 from pyparsing import (
     Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore)
 
@@ -21,16 +20,17 @@ from matplotlib import _api
 
 family_punc = r'\\\-:,'
 _family_unescape = partial(re.compile(r'\\(?=[%s])' % family_punc).sub, '')
-family_escape = re.compile(r'([%s])' % family_punc).sub
-
+_family_escape = partial(re.compile(r'(?=[%s])' % family_punc).sub, r'\\')
 value_punc = r'\\=_:,'
 _value_unescape = partial(re.compile(r'\\(?=[%s])' % value_punc).sub, '')
-value_escape = re.compile(r'([%s])' % value_punc).sub
+_value_escape = partial(re.compile(r'(?=[%s])' % value_punc).sub, r'\\')
 
 # Remove after module deprecation elapses (3.8); then remove underscores
-# from _family_unescape and _value_unescape.
+# from _{family,value}_{un,}escape.
 family_unescape = re.compile(r'\\([%s])' % family_punc).sub
 value_unescape = re.compile(r'\\([%s])' % value_punc).sub
+family_escape = re.compile(r'([%s])' % family_punc).sub
+value_escape = re.compile(r'([%s])' % value_punc).sub
 
 
 class FontconfigPatternParser:
@@ -127,36 +127,12 @@ class FontconfigPatternParser:
 parse_fontconfig_pattern = lru_cache()(FontconfigPatternParser().parse)
 
 
-def _escape_val(val, escape_func):
-    """
-    Given a string value or a list of string values, run each value through
-    the input escape function to make the values into legal font config
-    strings.  The result is returned as a string.
-    """
-    if not np.iterable(val) or isinstance(val, str):
-        val = [val]
-
-    return ','.join(escape_func(r'\\\1', str(x)) for x in val
-                    if x is not None)
-
-
 def generate_fontconfig_pattern(d):
-    """
-    Given a dictionary of key/value pairs, generates a fontconfig
-    pattern string.
-    """
-    props = []
-
-    # Family is added first w/o a keyword
-    family = d.get_family()
-    if family is not None and family != []:
-        props.append(_escape_val(family, family_escape))
-
-    # The other keys are added as key=value
-    for key in ['style', 'variant', 'weight', 'stretch', 'file', 'size']:
-        val = getattr(d, 'get_' + key)()
-        # Don't use 'if not val' because 0 is a valid input.
-        if val is not None and val != []:
-            props.append(":%s=%s" % (key, _escape_val(val, value_escape)))
-
-    return ''.join(props)
+    """Convert a `.FontProperties` to a fontconfig pattern string."""
+    kvs = [(k, getattr(d, f"get_{k}")())
+           for k in ["style", "variant", "weight", "stretch", "file", "size"]]
+    # Families is given first without a leading keyword.  Other entries (which
+    # are necessarily scalar) are given as key=value, skipping Nones.
+    return (",".join(_family_escape(f) for f in d.get_family())
+            + "".join(f":{k}={_value_escape(str(v))}"
+                      for k, v in kvs if v is not None))


### PR DESCRIPTION
- Switch _family_escape, _value_escape to be more similar to _family_unescape, _value_unescape.
- generate_fontconfig_pattern doesn't need to go through the generic escape_val, but instead rely on the fact that prop.get_family() always returns a list whereas the other getters always return a scalar value, and directly do the escaping and joining as needed.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
