### PR TITLE
Simplify some patches path definitions.

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1040,7 +1040,6 @@ class Path:
         If *inside* is `True`, clip to the inside of the box, otherwise
         to the outside of the box.
         """
-        # Use make_compound_path_from_polys
         verts = _path.clip_path_to_rect(self, bbox, inside)
         paths = [Path(poly) for poly in verts]
         return self.make_compound_path(*paths)


### PR DESCRIPTION
- When a Path ends with a CLOSEPOLY, it is not necessary to put a LINETO to the closing position before it (in fact that can result in an incorrect line join at that position), and the xy position associated with the CLOSEPOLY can just be (0, 0), as it is irrelevant.
- For defining the codes arrays, for short paths (such as the patch shapes here), one can just use list unpacking for shorter definitions.
- Rename the _path and _fillable lists in ArrowStyle to plural names.
- Rely on the default tolerance of
  split_bezier_intersecting_with_closedpath (which is 0.01) rather than
  re-specifying the same magic value everywhere.
- Remove inapplicable comment re: make_compound_path_from_polys (which
  only applies to polygons all of with the same number of sides, which
  is not the case when clipping to a bbox).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
