### PR TITLE
DOC: Organize Axes3D methods into sections

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.0.0.rst
@@ -106,7 +106,7 @@ Different exception types for undocumented options
 - Passing the undocumented ``xmin`` or ``xmax`` arguments to
   :meth:`~matplotlib.axes.Axes.set_xlim` would silently override the ``left``
   and ``right`` arguments.  :meth:`~matplotlib.axes.Axes.set_ylim` and the
-  3D equivalents (e.g. `~.Axes3D.set_zlim3d`) had a
+  3D equivalents (e.g. `~.Axes3D.set_zlim`) had a
   corresponding problem.
   A ``TypeError`` will be raised if they would override the earlier
   limit arguments.  In 3.0 these were kwargs were deprecated, but in 3.1

--- a/doc/api/toolkits/mplot3d.rst
+++ b/doc/api/toolkits/mplot3d.rst
@@ -29,6 +29,7 @@ the toolbar pan and zoom buttons are not used.
 
    mplot3d/faq.rst
    mplot3d/view_angles.rst
+   mplot3d/axes3d.rst
 
 .. note::
    `.pyplot` cannot be used to add content to 3D plots, because its function
@@ -51,11 +52,8 @@ the toolbar pan and zoom buttons are not used.
    Please report any functions that do not behave as expected as a bug.
    In addition, help and patches would be greatly appreciated!
 
-.. autosummary::
-   :toctree: ../_as_gen
-   :template: autosummary.rst
 
-   axes3d.Axes3D
+`axes3d.Axes3D` (fig[, rect, elev, azim, roll, ...])    3D Axes object.
 
 
 .. module:: mpl_toolkits.mplot3d.axis3d

--- a/doc/api/toolkits/mplot3d/axes3d.rst
+++ b/doc/api/toolkits/mplot3d/axes3d.rst
@@ -1,0 +1,306 @@
+mpl\_toolkits.mplot3d.axes3d.Axes3D
+===================================
+
+
+.. currentmodule:: mpl_toolkits.mplot3d.axes3d
+
+
+.. autoclass:: Axes3D
+   :no-members:
+   :no-undoc-members:
+   :show-inheritance:
+
+
+.. currentmodule:: mpl_toolkits.mplot3d.axes3d.Axes3D
+
+
+Plotting
+--------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   plot
+   scatter
+   bar
+   bar3d
+
+   plot_surface
+   plot_wireframe
+   plot_trisurf
+
+   clabel
+   contour
+   tricontour
+   contourf
+   tricontourf
+
+   quiver
+   voxels
+   errorbar
+   stem
+
+
+Text and annotations
+--------------------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   text
+   text2D
+
+
+Clearing
+--------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   clear
+
+
+Appearance
+----------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   set_axis_off
+   set_axis_on
+   grid
+   get_frame_on
+   set_frame_on
+
+
+Axis
+----
+
+Axis limits and direction
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   get_zaxis
+   get_xlim
+   get_ylim
+   get_zlim
+   set_zlim
+   get_w_lims
+   invert_zaxis
+   zaxis_inverted
+   get_zbound
+   set_zbound
+
+
+Axis labels and title
+^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   set_zlabel
+   get_zlabel
+   set_title
+
+
+Axis scales
+^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   set_xscale
+   set_yscale
+   set_zscale
+   get_zscale
+
+
+Autoscaling and margins
+^^^^^^^^^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   set_zmargin
+   margins
+   autoscale
+   autoscale_view
+   set_autoscalez_on
+   get_autoscalez_on
+   auto_scale_xyz
+
+
+Aspect ratio
+^^^^^^^^^^^^
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   set_aspect
+   set_box_aspect
+   apply_aspect
+
+
+Ticks
+^^^^^
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   tick_params
+   set_zticks
+   get_zticks
+   set_zticklabels
+   get_zticklines
+   get_zgridlines
+   get_zminorticklabels
+   get_zmajorticklabels
+   zaxis_date
+
+
+Units
+-----
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   convert_zunits
+
+
+Adding artists
+--------------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   add_collection3d
+
+
+Sharing
+-------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   sharez
+
+
+Interactive
+-----------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   can_zoom
+   can_pan
+   disable_mouse_rotation
+   mouse_init
+   drag_pan
+   format_zdata
+   format_coord
+
+
+Projection and perspective
+--------------------------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   view_init
+   set_proj_type
+   get_proj
+   set_top_view
+
+
+Drawing
+-------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   draw
+   get_tightbbox
+
+
+Aliases and deprecated methods
+------------------------------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+    set_zlim3d
+    stem3D
+    text3D
+    tunit_cube
+    tunit_edges
+    unit_cube
+    w_xaxis
+    w_yaxis
+    w_zaxis
+
+
+Other
+-----
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   get_axis_position
+   add_contour_set
+   add_contourf_set
+   update_datalim
+
+
+.. currentmodule:: mpl_toolkits.mplot3d
+
+Sample 3D data
+--------------
+
+.. autosummary::
+   :toctree: ../../_as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   axes3d.get_test_data
+
+
+.. minigallery:: mpl_toolkits.mplot3d.axes3d.Axes3D
+   :add-heading:

--- a/doc/users/prev_whats_new/whats_new_3.4.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.4.0.rst
@@ -866,7 +866,7 @@ Stem plots in 3D Axes
 ---------------------
 
 Stem plots are now supported on 3D Axes. Much like 2D stems,
-`~.axes3d.Axes3D.stem3D` supports plotting the stems in various orientations:
+`~.axes3d.Axes3D.stem` supports plotting the stems in various orientations:
 
 .. plot::
 

--- a/examples/mplot3d/stem3d_demo.py
+++ b/examples/mplot3d/stem3d_demo.py
@@ -26,7 +26,7 @@ plt.show()
 # *linefmt*, *markerfmt*, and *basefmt* control basic format properties of the
 # plot. However, in contrast to `~.axes3d.Axes3D.plot` not all properties are
 # configurable via keyword arguments. For more advanced control adapt the line
-# objects returned by `.stem3D`.
+# objects returned by `~mpl_toolkits.mplot3d.axes3d.Axes3D.stem`.
 
 fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
 markerline, stemlines, baseline = ax.stem(

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -499,6 +499,9 @@ class Axes3D(Axes):
         return xhigh, yhigh, zhigh
 
     def update_datalim(self, xys, **kwargs):
+        """
+        Not implemented in `~mpl_toolkits.mplot3d.axes3d.Axes3D`.
+        """
         pass
 
     get_autoscalez_on = _axis_method_wrapper("zaxis", "_get_autoscale_on")


### PR DESCRIPTION
## PR Summary
Organize [Axes3D doc](https://matplotlib.org/devdocs/api/_as_gen/mpl_toolkits.mplot3d.axes3d.Axes3D.html) with sections and tables, similar to the [Axes doc](https://matplotlib.org/devdocs/api/axes_api.html?highlight=axes#plotting). Adds a new file, doc/api/toolkits/mplot3d/axes3d.rst.

For Issue #23901.

Further improvements for this PR:

 1. ~~Exclude or add docstrings to undocumented `axes3d.Axes3D` public methods.~~
    
    ~~a. Should deprecated methods be excluded? (`Axes3D.unit_cube()`, `Axes3D.tunit_cube()`, and `Axes3D.tunit_edges()`)~~
    ~~b. `Axes3D.update_datalim()` is an empty method that only contains `pass`. The docstring seems to be inherited from matplotlib/axes/_base.py. Should the `Axes3D.update_datalim()` docstring be changed to something like "Not implemented in Axes3D."?~~
    ~~c. For `Axes3D.add_contour_set()` and `Axes3D.add_contourf_set()`, would a docstring like "Supporting method for Axes3D.contour()" be useful?~~
2. Adjust initial organization of methods?
    - The four unsorted methods are now in the "Other" section at the bottom of the Axes3D page.
4. Maintain current appearance of the axes3d section of [api/toolkits/mplot3d.html](https://matplotlib.org/stable/api/toolkits/mplot3d.html#module-mpl_toolkits.mplot3d.axes3d).
    - The new text has lost most of its whitespace. [reST line blocks](https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#line-blocks) did not preserve whitespace in local doc builds.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
