### PR TITLE
Deprecate axes_divider.AxesLocator.

### DIFF
--- a/doc/api/next_api_changes/deprecations/24312-AL.rst
+++ b/doc/api/next_api_changes/deprecations/24312-AL.rst
@@ -1,0 +1,9 @@
+``axes_grid1.axes_divider`` API changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``AxesLocator`` class is deprecated.  The ``new_locator`` method of divider
+instances now instead returns an opaque callable (which can still be passed to
+``ax.set_axes_locator``).
+
+``Divider.locate`` is deprecated; use ``Divider.new_locator(...)(ax, renderer)``
+instead.

--- a/galleries/users_explain/toolkits/axes_grid.py
+++ b/galleries/users_explain/toolkits/axes_grid.py
@@ -302,7 +302,7 @@ We use these constraints to initialize a `.Divider` object::
     horiz = [...]  # Some other horizontal constraints.
     divider = Divider(fig, rect, horiz, vert)
 
-then use `.Divider.new_locator` to create an `.AxesLocator` instance for a
+then use `.Divider.new_locator` to create an axes locator callable for a
 given grid entry::
 
     locator = divider.new_locator(nx=0, ny=1)  # Grid entry (1, 0).
@@ -311,7 +311,7 @@ and make it responsible for locating the axes::
 
     ax.set_axes_locator(locator)
 
-The `.AxesLocator` is a callable object that returns the location and size of
+The axes locator callable returns the location and size of
 the cell at the first column and the second row.
 
 Locators that spans over multiple cells can be created with, e.g.::

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -608,9 +608,14 @@ def test_grid_axes_position(direction):
     fig = plt.figure()
     grid = Grid(fig, 111, (2, 2), direction=direction)
     loc = [ax.get_axes_locator() for ax in np.ravel(grid.axes_row)]
-    assert loc[1]._nx > loc[0]._nx and loc[2]._ny < loc[0]._ny
-    assert loc[0]._nx == loc[2]._nx and loc[0]._ny == loc[1]._ny
-    assert loc[3]._nx == loc[1]._nx and loc[3]._ny == loc[2]._ny
+    # Test nx.
+    assert loc[1].args[0] > loc[0].args[0]
+    assert loc[0].args[0] == loc[2].args[0]
+    assert loc[3].args[0] == loc[1].args[0]
+    # Test ny.
+    assert loc[2].args[1] < loc[0].args[1]
+    assert loc[0].args[1] == loc[1].args[1]
+    assert loc[3].args[1] == loc[2].args[1]
 
 
 @pytest.mark.parametrize('rect, ngrids, error, message', (


### PR DESCRIPTION
The axes_divider module creates axes locator objects, allowing the following pattern.
```
divider = Divider(<divider-args>)  # or a subclass of Divider
locator = divider.new_locator(<locator-args>)
ax.set_axes_locator(locator)  # will call locator(ax, renderer) at draw time
```
`locator` is actually an AxesLocator instance, which gets passed `divider` and `<locator-args>`; `locator(ax, renderer)` then simply calls (something like) `divider.locate(<locator-args>, ax, renderer)`, i.e. the AxesLocator instance simply exists to hold arguments for calling back into a divider method.

One issue of this approach is that all the communication between the Divider and the AxesLocator class becomes public API (e.g., the locate method), even though these are essentially internal implementation details.  This makes e.g. tightening of the locate API need to go through deprecation cycles (6eeb9ba).

Instead, this PR completely gets rid of the AxesLocator class, and lets new_locator return an essentially opaque callable object (a functools.partial over a private method of AxesLocator), for which the only documented API is "this can be used as an axes locator callable, i.e. passed to ax.set_axes.locator".  ~~For simplicity, this PR also cancels the deprecations put in by 6eeb9ba, because these only target APIs that will ultimately get removed anyways~~; it also clarifies the role of _xrefindex and _yrefindex and consolidates all their handling into append_size, letting new_horizontal and new_vertical call that method instead of manipulating these indices themselves.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
