### PR TITLE
GOV: change security reporting to use tidelift

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,15 +17,12 @@ versions.
 
 ## Reporting a Vulnerability
 
+
+To report a security vulnerability, please use the [Tidelift security
+contact](https://tidelift.com/security).  Tidelift will coordinate the fix and
+disclosure.
+
 If you have found a security vulnerability, in order to keep it confidential,
 please do not report an issue on GitHub.
-
-Please email us details of the vulnerability at matplotlib-steering-council@numfocus.org;
-include a description and proof-of-concept that is [short and
-self-contained](http://www.sscce.org/).
-
-You should expect a response within a week of your email. Depending on the
-severity of the issue, this may require some time to draft an immediate bugfix
-release. Less severe issues may be held until the next release.
 
 We do not award bounties for security vulnerabilities.


### PR DESCRIPTION
## PR Summary

I have checked with the numpy and scipy maintainers who have been happy with using tidelift to manage security vulnerability in both the case of valid and invalid reports.

matplotlib-steering-council@numfocus.org is still the email address that tidelift has to contact when they get a report.

The contract does not open us to any additional liability.