### PR TITLE
Kill FontconfigPatternParser.

### DIFF
--- a/doc/api/fontconfig_pattern_api.rst
+++ b/doc/api/fontconfig_pattern_api.rst
@@ -1,8 +1,0 @@
-*********************************
-``matplotlib.fontconfig_pattern``
-*********************************
-
-.. automodule:: matplotlib.fontconfig_pattern
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -118,7 +118,6 @@ Alphabetical list of modules:
    dviread.rst
    figure_api.rst
    font_manager_api.rst
-   fontconfig_pattern_api.rst
    ft2font.rst
    gridspec_api.rst
    hatch_api.rst

--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -18,113 +18,95 @@ from pyparsing import (
 from matplotlib import _api
 
 
-family_punc = r'\\\-:,'
-_family_unescape = partial(re.compile(r'\\(?=[%s])' % family_punc).sub, '')
-_family_escape = partial(re.compile(r'(?=[%s])' % family_punc).sub, r'\\')
-value_punc = r'\\=_:,'
-_value_unescape = partial(re.compile(r'\\(?=[%s])' % value_punc).sub, '')
-_value_escape = partial(re.compile(r'(?=[%s])' % value_punc).sub, r'\\')
-
-# Remove after module deprecation elapses (3.8); then remove underscores
-# from _{family,value}_{un,}escape.
-family_unescape = re.compile(r'\\([%s])' % family_punc).sub
-value_unescape = re.compile(r'\\([%s])' % value_punc).sub
-family_escape = re.compile(r'([%s])' % family_punc).sub
-value_escape = re.compile(r'([%s])' % value_punc).sub
+_family_punc = r'\\\-:,'
+_family_unescape = partial(re.compile(r'\\(?=[%s])' % _family_punc).sub, '')
+_family_escape = partial(re.compile(r'(?=[%s])' % _family_punc).sub, r'\\')
+_value_punc = r'\\=_:,'
+_value_unescape = partial(re.compile(r'\\(?=[%s])' % _value_punc).sub, '')
+_value_escape = partial(re.compile(r'(?=[%s])' % _value_punc).sub, r'\\')
 
 
-class FontconfigPatternParser:
-    """
-    A simple pyparsing-based parser for `fontconfig patterns`_.
+_CONSTANTS = {
+    'thin':           ('weight', 'light'),
+    'extralight':     ('weight', 'light'),
+    'ultralight':     ('weight', 'light'),
+    'light':          ('weight', 'light'),
+    'book':           ('weight', 'book'),
+    'regular':        ('weight', 'regular'),
+    'normal':         ('weight', 'normal'),
+    'medium':         ('weight', 'medium'),
+    'demibold':       ('weight', 'demibold'),
+    'semibold':       ('weight', 'semibold'),
+    'bold':           ('weight', 'bold'),
+    'extrabold':      ('weight', 'extra bold'),
+    'black':          ('weight', 'black'),
+    'heavy':          ('weight', 'heavy'),
+    'roman':          ('slant', 'normal'),
+    'italic':         ('slant', 'italic'),
+    'oblique':        ('slant', 'oblique'),
+    'ultracondensed': ('width', 'ultra-condensed'),
+    'extracondensed': ('width', 'extra-condensed'),
+    'condensed':      ('width', 'condensed'),
+    'semicondensed':  ('width', 'semi-condensed'),
+    'expanded':       ('width', 'expanded'),
+    'extraexpanded':  ('width', 'extra-expanded'),
+    'ultraexpanded':  ('width', 'ultra-expanded'),
+}
 
-    .. _fontconfig patterns:
-       https://www.freedesktop.org/software/fontconfig/fontconfig-user.html
-    """
 
-    _constants = {
-        'thin':           ('weight', 'light'),
-        'extralight':     ('weight', 'light'),
-        'ultralight':     ('weight', 'light'),
-        'light':          ('weight', 'light'),
-        'book':           ('weight', 'book'),
-        'regular':        ('weight', 'regular'),
-        'normal':         ('weight', 'normal'),
-        'medium':         ('weight', 'medium'),
-        'demibold':       ('weight', 'demibold'),
-        'semibold':       ('weight', 'semibold'),
-        'bold':           ('weight', 'bold'),
-        'extrabold':      ('weight', 'extra bold'),
-        'black':          ('weight', 'black'),
-        'heavy':          ('weight', 'heavy'),
-        'roman':          ('slant', 'normal'),
-        'italic':         ('slant', 'italic'),
-        'oblique':        ('slant', 'oblique'),
-        'ultracondensed': ('width', 'ultra-condensed'),
-        'extracondensed': ('width', 'extra-condensed'),
-        'condensed':      ('width', 'condensed'),
-        'semicondensed':  ('width', 'semi-condensed'),
-        'expanded':       ('width', 'expanded'),
-        'extraexpanded':  ('width', 'extra-expanded'),
-        'ultraexpanded':  ('width', 'ultra-expanded'),
-    }
+@lru_cache  # The parser instance is a singleton.
+def _make_fontconfig_parser():
+    def comma_separated(elem):
+        return elem + ZeroOrMore(Suppress(",") + elem)
 
-    def __init__(self):
-        def comma_separated(elem):
-            return elem + ZeroOrMore(Suppress(",") + elem)
-
-        family = Regex(r"([^%s]|(\\[%s]))*" % (family_punc, family_punc))
-        size = Regex(r"([0-9]+\.?[0-9]*|\.[0-9]+)")
-        name = Regex(r"[a-z]+")
-        value = Regex(r"([^%s]|(\\[%s]))*" % (value_punc, value_punc))
-        prop = (
-            (name + Suppress("=") + comma_separated(value))
-            | name  # replace by oneOf(self._constants) in mpl 3.9.
-        )
-        pattern = (
-            Optional(comma_separated(family)("families"))
-            + Optional("-" + comma_separated(size)("sizes"))
-            + ZeroOrMore(":" + prop("properties*"))
-            + StringEnd()
-        )
-        self._parser = pattern
-        self.ParseException = ParseException
-
-    def parse(self, pattern):
-        """
-        Parse the given fontconfig *pattern* and return a dictionary
-        of key/value pairs useful for initializing a
-        `.font_manager.FontProperties` object.
-        """
-        try:
-            parse = self._parser.parseString(pattern)
-        except ParseException as err:
-            # explain becomes a plain method on pyparsing 3 (err.explain(0)).
-            raise ValueError("\n" + ParseException.explain(err, 0)) from None
-        self._parser.resetCache()
-        props = {}
-        if "families" in parse:
-            props["family"] = [*map(_family_unescape, parse["families"])]
-        if "sizes" in parse:
-            props["size"] = [*parse["sizes"]]
-        for prop in parse.get("properties", []):
-            if len(prop) == 1:
-                if prop[0] not in self._constants:
-                    _api.warn_deprecated(
-                        "3.7", message=f"Support for unknown constants "
-                        f"({prop[0]!r}) is deprecated since %(since)s and "
-                        f"will be removed %(removal)s.")
-                    continue
-                prop = self._constants[prop[0]]
-            k, *v = prop
-            props.setdefault(k, []).extend(map(_value_unescape, v))
-        return props
+    family = Regex(r"([^%s]|(\\[%s]))*" % (_family_punc, _family_punc))
+    size = Regex(r"([0-9]+\.?[0-9]*|\.[0-9]+)")
+    name = Regex(r"[a-z]+")
+    value = Regex(r"([^%s]|(\\[%s]))*" % (_value_punc, _value_punc))
+    # replace trailing `| name` by oneOf(_CONSTANTS) in mpl 3.9.
+    prop = (name + Suppress("=") + comma_separated(value)) | name
+    return (
+        Optional(comma_separated(family)("families"))
+        + Optional("-" + comma_separated(size)("sizes"))
+        + ZeroOrMore(":" + prop("properties*"))
+        + StringEnd()
+    )
 
 
 # `parse_fontconfig_pattern` is a bottleneck during the tests because it is
 # repeatedly called when the rcParams are reset (to validate the default
 # fonts).  In practice, the cache size doesn't grow beyond a few dozen entries
 # during the test suite.
-parse_fontconfig_pattern = lru_cache()(FontconfigPatternParser().parse)
+@lru_cache
+def parse_fontconfig_pattern(pattern):
+    """
+    Parse a fontconfig *pattern* into a dict that can initialize a
+    `.font_manager.FontProperties` object.
+    """
+    parser = _make_fontconfig_parser()
+    try:
+        parse = parser.parseString(pattern)
+    except ParseException as err:
+        # explain becomes a plain method on pyparsing 3 (err.explain(0)).
+        raise ValueError("\n" + ParseException.explain(err, 0)) from None
+    parser.resetCache()
+    props = {}
+    if "families" in parse:
+        props["family"] = [*map(_family_unescape, parse["families"])]
+    if "sizes" in parse:
+        props["size"] = [*parse["sizes"]]
+    for prop in parse.get("properties", []):
+        if len(prop) == 1:
+            if prop[0] not in _CONSTANTS:
+                _api.warn_deprecated(
+                    "3.7", message=f"Support for unknown constants "
+                    f"({prop[0]!r}) is deprecated since %(since)s and "
+                    f"will be removed %(removal)s.")
+                continue
+            prop = _CONSTANTS[prop[0]]
+        k, *v = prop
+        props.setdefault(k, []).extend(map(_value_unescape, v))
+    return props
 
 
 def generate_fontconfig_pattern(d):

--- a/lib/matplotlib/fontconfig_pattern.py
+++ b/lib/matplotlib/fontconfig_pattern.py
@@ -1,3 +1,20 @@
+import re
+from pyparsing import ParseException
+
 from matplotlib._fontconfig_pattern import *  # noqa: F401, F403
+from matplotlib._fontconfig_pattern import (
+    parse_fontconfig_pattern, _family_punc, _value_punc)
 from matplotlib import _api
 _api.warn_deprecated("3.6", name=__name__, obj_type="module")
+
+
+family_unescape = re.compile(r'\\([%s])' % _family_punc).sub
+value_unescape = re.compile(r'\\([%s])' % _value_punc).sub
+family_escape = re.compile(r'([%s])' % _family_punc).sub
+value_escape = re.compile(r'([%s])' % _value_punc).sub
+
+
+class FontconfigPatternParser:
+    ParseException = ParseException
+
+    def parse(self, pattern): return parse_fontconfig_pattern(pattern)


### PR DESCRIPTION
Remove the single-method class in favor of plain functions.  The backcompat class can be moved to the deprecated public fontconfig_parser (no underscore) module, so they'll get removed at the same time.  While we're at it do the same for {family,value}_{escape,unescape}; however, despite the comment, I decided to keep the new versions of _{family,value}_{escape,unescape} still underscore-prefixed within the private module (signalling that these aren't intended to be used even from other Matplotlib modules).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
