### PR TITLE
DOC: Minor cleanup in "Writing documentation"

### DIFF
--- a/doc/devel/documenting_mpl.rst
+++ b/doc/devel/documenting_mpl.rst
@@ -91,14 +91,14 @@ You can use the ``O`` variable to set additional options:
 * ``make O=-j4 html`` runs a parallel build with 4 processes.
 * ``make O=-Dplot_formats=png:100 html`` saves figures in low resolution.
 
-Multiple options can be combined, e.g. ``make O='-j4 -Dplot_gallery=0'
+Multiple options can be combined, e.g. ``make O='-j4 -Dplot_formats=png:100'
 html``.
 
 On Windows, set the options as environment variables, e.g.:
 
 .. code-block:: bat
 
-   set SPHINXOPTS= & set O=-j4 -Dplot_gallery=0 & make html
+   set SPHINXOPTS= & set O=-j4 -Dplot_formats=png:100 & make html
 
 Showing locally built docs
 --------------------------


### PR DESCRIPTION
The make option `-Dplot_gallery=0` is superseeded by `make html-noplot`. While we have removed it from the simple calls (#23870), it was still present in examples with multiple options.
Remove it in the example calls and replace it by a still used option.
