### PR TITLE
Use HTML5 for webagg files

### DIFF
--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -52,16 +52,15 @@ def create_figure():
 # The following is the content of the web page.  You would normally
 # generate this using some sort of template facility in your web
 # framework, but here we just use Python string formatting.
-html_content = """
-<html>
+html_content = """<!DOCTYPE html>
+<html lang="en">
   <head>
     <!-- TODO: There should be a way to include all of the required javascript
                and CSS so matplotlib can add to the set in the future if it
                needs to. -->
     <link rel="stylesheet" href="_static/css/page.css" type="text/css">
-    <link rel="stylesheet" href="_static/css/boilerplate.css"
-          type="text/css" />
-    <link rel="stylesheet" href="_static/css/fbm.css" type="text/css" />
+    <link rel="stylesheet" href="_static/css/boilerplate.css" type="text/css">
+    <link rel="stylesheet" href="_static/css/fbm.css" type="text/css">
     <link rel="stylesheet" href="_static/css/mpl.css" type="text/css">
     <script src="mpl.js"></script>
 

--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -1,8 +1,9 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <link rel="stylesheet" href="{{ prefix }}/_static/css/page.css" type="text/css">
-    <link rel="stylesheet" href="{{ prefix }}/_static/css/boilerplate.css" type="text/css" />
-    <link rel="stylesheet" href="{{ prefix }}/_static/css/fbm.css" type="text/css" />
+    <link rel="stylesheet" href="{{ prefix }}/_static/css/boilerplate.css" type="text/css">
+    <link rel="stylesheet" href="{{ prefix }}/_static/css/fbm.css" type="text/css">
     <link rel="stylesheet" href="{{ prefix }}/_static/css/mpl.css" type="text/css">
     <script src="{{ prefix }}/_static/js/mpl_tornado.js"></script>
     <script src="{{ prefix }}/js/mpl.js"></script>

--- a/lib/matplotlib/backends/web_backend/single_figure.html
+++ b/lib/matplotlib/backends/web_backend/single_figure.html
@@ -1,8 +1,9 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
     <link rel="stylesheet" href="{{ prefix }}/_static/css/page.css" type="text/css">
-    <link rel="stylesheet" href="{{ prefix }}/_static/css/boilerplate.css" type="text/css" />
-    <link rel="stylesheet" href="{{ prefix }}/_static/css/fbm.css" type="text/css" />
+    <link rel="stylesheet" href="{{ prefix }}/_static/css/boilerplate.css" type="text/css">
+    <link rel="stylesheet" href="{{ prefix }}/_static/css/fbm.css" type="text/css">
     <link rel="stylesheet" href="{{ prefix }}/_static/css/mpl.css" type="text/css">
     <script src="{{ prefix }}/_static/js/mpl_tornado.js"></script>
     <script src="{{ prefix }}/js/mpl.js"></script>


### PR DESCRIPTION
## PR Summary

Without the doctype, the file is loaded in quirks mode, which is probably unwanted.

## PR Checklist

**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`