### PR TITLE
Emit "axes not compatible with tight_layout" in a single place.

### DIFF
--- a/lib/matplotlib/_tight_layout.py
+++ b/lib/matplotlib/_tight_layout.py
@@ -226,7 +226,10 @@ def get_tight_layout_figure(fig, axes_list, subplotspec_list, renderer,
     ss_to_subplots = {ss: [] for ss in subplotspec_list}
     for ax, ss in zip(axes_list, subplotspec_list):
         ss_to_subplots[ss].append(ax)
-    ss_to_subplots.pop(None, None)  # Skip subplotspec == None.
+    if ss_to_subplots.pop(None, None):
+        _api.warn_external(
+            "This figure includes Axes that are not compatible with "
+            "tight_layout, so results might be incorrect.")
     if not ss_to_subplots:
         return {}
     subplot_list = list(ss_to_subplots.values())

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3424,12 +3424,6 @@ class Figure(FigureBase):
         .Figure.set_layout_engine
         .pyplot.tight_layout
         """
-        from ._tight_layout import get_subplotspec_list
-        subplotspec_list = get_subplotspec_list(self.axes)
-        if None in subplotspec_list:
-            _api.warn_external("This figure includes Axes that are not "
-                               "compatible with tight_layout, so results "
-                               "might be incorrect.")
         # note that here we do not permanently set the figures engine to
         # tight_layout but rather just perform the layout in place and remove
         # any previous engines.

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -467,20 +467,12 @@ class GridSpec(GridSpecBase):
             coordinates that the whole subplots area (including labels) will
             fit into. Default (None) is the whole figure.
         """
-
-        subplotspec_list = _tight_layout.get_subplotspec_list(
-            figure.axes, grid_spec=self)
-        if None in subplotspec_list:
-            _api.warn_external("This figure includes Axes that are not "
-                               "compatible with tight_layout, so results "
-                               "might be incorrect.")
-
         if renderer is None:
             renderer = figure._get_renderer()
-
         kwargs = _tight_layout.get_tight_layout_figure(
-            figure, figure.axes, subplotspec_list, renderer,
-            pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)
+            figure, figure.axes,
+            _tight_layout.get_subplotspec_list(figure.axes, grid_spec=self),
+            renderer, pad=pad, h_pad=h_pad, w_pad=w_pad, rect=rect)
         if kwargs:
             self.update(**kwargs)
 

--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -17,7 +17,6 @@ by subclassing `.LayoutEngine`.
 from contextlib import nullcontext
 
 import matplotlib as mpl
-import matplotlib._api as _api
 
 from matplotlib._constrained_layout import do_constrained_layout
 from matplotlib._tight_layout import (get_subplotspec_list,
@@ -170,15 +169,10 @@ class TightLayoutEngine(LayoutEngine):
         See also: `.figure.Figure.tight_layout` and `.pyplot.tight_layout`.
         """
         info = self._params
-        subplotspec_list = get_subplotspec_list(fig.axes)
-        if None in subplotspec_list:
-            _api.warn_external("This figure includes Axes that are not "
-                               "compatible with tight_layout, so results "
-                               "might be incorrect.")
         renderer = fig._get_renderer()
         with getattr(renderer, "_draw_disabled", nullcontext)():
             kwargs = get_tight_layout_figure(
-                fig, fig.axes, subplotspec_list, renderer,
+                fig, fig.axes, get_subplotspec_list(fig.axes), renderer,
                 pad=info['pad'], h_pad=info['h_pad'], w_pad=info['w_pad'],
                 rect=info['rect'])
         if kwargs:


### PR DESCRIPTION
... instead of triplicating it on the caller side.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
