### PR TITLE
DOC: clarify rc_context resets all rcParams changes

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1080,6 +1080,9 @@ def rc_context(rc=None, fname=None):
 
     The :rc:`backend` will not be reset by the context manager.
 
+    rcParams changed both through the context manager invocation and
+    in the body of the context will be reset on context exit.
+
     Parameters
     ----------
     rc : dict
@@ -1106,6 +1109,13 @@ def rc_context(rc=None, fname=None):
 
          with mpl.rc_context(fname='print.rc'):
              plt.plot(x, y)  # uses 'print.rc'
+
+    Setting in the context body::
+
+        with mpl.rc_context():
+            # will be reset
+            mpl.rcParams['lines.linewidth'] = 5
+            plt.plot(x, y)
 
     """
     orig = dict(rcParams.copy())


### PR DESCRIPTION
## PR Summary

Inspired by #24351

Reading the docstring of `rc_context` it was very unclear that all rcparams set in the body will be reset not just those set in the context invocation.  This has been the behavior back to 2012 when we added this to the code base in 2045bdbd2c00cb71fbce3c03c066b06213aa1567 .