### PR TITLE
Expire unused positional parameters in canvas subclasses

### DIFF
--- a/doc/api/next_api_changes/removals/24355-OG.rst
+++ b/doc/api/next_api_changes/removals/24355-OG.rst
@@ -1,0 +1,6 @@
+Unused positional parameters to ``print_<fmt>`` methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+None of the ``print_<fmt>`` methods implemented by canvas subclasses used
+positional arguments other that the first (the output filename or file-like),
+so these extra parameters are removed.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -441,8 +441,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         """
         return self.renderer.buffer_rgba()
 
-    @_api.delete_parameter("3.5", "args")
-    def print_raw(self, filename_or_obj, *args):
+    def print_raw(self, filename_or_obj):
         FigureCanvasAgg.draw(self)
         renderer = self.get_renderer()
         with cbook.open_file_cm(filename_or_obj, "wb") as fh:
@@ -460,9 +459,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             filename_or_obj, self.buffer_rgba(), format=fmt, origin="upper",
             dpi=self.figure.dpi, metadata=metadata, pil_kwargs=pil_kwargs)
 
-    @_api.delete_parameter("3.5", "args")
-    def print_png(self, filename_or_obj, *args,
-                  metadata=None, pil_kwargs=None):
+    def print_png(self, filename_or_obj, *, metadata=None, pil_kwargs=None):
         """
         Write the figure to a PNG file.
 
@@ -521,8 +518,7 @@ class FigureCanvasAgg(FigureCanvasBase):
     # print_figure(), and the latter ensures that `self.figure.dpi` already
     # matches the dpi kwarg (if any).
 
-    @_api.delete_parameter("3.5", "args")
-    def print_jpg(self, filename_or_obj, *args, pil_kwargs=None):
+    def print_jpg(self, filename_or_obj, *, pil_kwargs=None):
         # savefig() has already applied savefig.facecolor; we now set it to
         # white to make imsave() blend semi-transparent figures against an
         # assumed white background.

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -822,9 +822,8 @@ class FigureCanvasPS(FigureCanvasBase):
     def get_default_filetype(self):
         return 'ps'
 
-    @_api.delete_parameter("3.5", "args")
     def _print_ps(
-            self, fmt, outfile, *args,
+            self, fmt, outfile, *,
             metadata=None, papertype=None, orientation='portrait',
             **kwargs):
 

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1334,9 +1334,7 @@ class FigureCanvasSVG(FigureCanvasBase):
 
     fixed_dpi = 72
 
-    @_api.delete_parameter("3.5", "args")
-    def print_svg(self, filename, *args, bbox_inches_restore=None,
-                  metadata=None):
+    def print_svg(self, filename, *, bbox_inches_restore=None, metadata=None):
         """
         Parameters
         ----------
@@ -1382,8 +1380,7 @@ class FigureCanvasSVG(FigureCanvasBase):
             self.figure.draw(renderer)
             renderer.finalize()
 
-    @_api.delete_parameter("3.5", "args")
-    def print_svgz(self, filename, *args, **kwargs):
+    def print_svgz(self, filename, **kwargs):
         with cbook.open_file_cm(filename, "wb") as fh, \
                 gzip.GzipFile(mode='w', fileobj=fh) as gzipwriter:
             return self.print_svg(gzipwriter, **kwargs)

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -197,8 +197,7 @@ class FigureCanvasTemplate(FigureCanvasBase):
     # you should add it to the class-scope filetypes dictionary as follows:
     filetypes = {**FigureCanvasBase.filetypes, 'foo': 'My magic Foo format'}
 
-    @_api.delete_parameter("3.5", "args")
-    def print_foo(self, filename, *args, **kwargs):
+    def print_foo(self, filename, **kwargs):
         """
         Write out format foo.
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
