### PR TITLE
Changed the return type of streamplot to a container object

### DIFF
--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -1,3 +1,5 @@
+import collections
+
 from matplotlib import cbook
 from matplotlib.artist import Artist
 
@@ -15,7 +17,12 @@ class Container(tuple):
                 .format(type(self).__name__, len(self)))
 
     def __new__(cls, *args, **kwargs):
-        return tuple.__new__(cls, args[0])
+        if isinstance(args[0], collections.abc.Iterable):
+            iterable_of_artists = args[0]
+        else:
+            iterable_of_artists = (a for a in args if isinstance(a, Artist))
+
+        return tuple.__new__(cls, iterable_of_artists)
 
     def __init__(self, kl, label=None):
         self._callbacks = cbook.CallbackRegistry(signals=["pchanged"])

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -230,51 +230,29 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
         axes.add_patch(p)
 
     axes.autoscale_view()
-    stream_container = StreamplotContainer((lc, ac))
-    return stream_container
+    return StreamplotSet(lc, ac)
 
 
-@_api.deprecated("major.minor", alternative="streamplot.StreamplotContainer")
-class StreamplotSet:
-    def __init__(self, lines, arrows):
-        self.lines = lines
-        self.arrows = arrows
-
-
-class StreamplotContainer(Container):
+class StreamplotSet(Container):
     """
     `~.Container` object for artists created in an `~.Axes.streamplot` plot.
 
     It can be treated like a namedtuple with fields ``(lines, arrows)``
 
-    .. versionadded major.minor ::
+    .. versionchanged major.minor ::
 
     Attributes
     ----------
     lines: `~.LineCollection`
-`       The collection of `.Line2d` segments that make up the streamlines
+`       collection of `.Line2d` segments that make up the streamlines
     arrows: `~.PatchCollection`
-        The collection of `.FancyArrow` arrows half-way along each streamline
-
-    .. note::
-        This container will probably change in the future to allow changes
-        to the colormap, alpha, etc. for both lines and arrows, but these
-        changes should be backward compatible.
+        collection of `.FancyArrow` arrows half-way along each streamline
     """
 
-    def __init__(self, lines_arrows, **kwargs):
-        """
-        Parameters
-        ----------
-        lines_arrows : tuple
-            Tuple of (lines, arrows)
-            ``lines``: `.LineCollection` of streamlines.
-            ``arrows``: `.PatchCollection` of `.FancyArrowPatch` arrows
-        """
-        lines, arrows = lines_arrows
+    def __init__(self, lines, arrows, **kwargs):
         self.lines = lines
         self.arrows = arrows
-        super().__init__(lines_arrows, **kwargs)
+        super().__init__(lines, arrows, **kwargs)
 
 
 # Coordinate definitions


### PR DESCRIPTION
The idea of using a container object for streamplots was discussed in #803, but they settled on basically a lightweight datatype object. My reasoning for switching to a container was a combo of container providing a nicer `repl` (kind of) and so that there would be more uniformity around artist return types cause the docs can all point to [`.Container`](https://matplotlib.org/devdocs/api/container_api.html#matplotlib.container.Container)

I'm sort of concerned that no tests seem to fail given the discussion in the original PR is that containers don't play well with scalar mappables, but that could be due to changes in how container was implemented? 

This came up cause of the discussion in #24274 around good examples for `ArtistAnimation` being the artists that return containers or contourset. Looking at contourset, that seemed very specialized and like it made more sense to think of this like the containers and maybe build out to support some of the other things mentioned in the note for this method. 

The actual change is super lightweight since it's switching one named tuple for the other, which means anyone currently relying on a StreamplotSet object  doesn't lose the `lines` or `arrows` attribute. 

It seemed easiest to weave this in is by 
1) deprecating `StreamplotSet`
2) adding `StreamplotContainer`

I didn't write up a whats new or api_change 'cause I know this needs to be discussed first. 

Eta: @efiring what sorta information did you want this container to hold? 