### PR TITLE
added random colormap option to cm.py (lines 705-740ish)

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -704,6 +704,14 @@ vmin, vmax : float, optional
 )
 
 
+def get_random_cmap():
+    """ 
+    Returns a colormap at random from _colormaps
+
+    """
+    return _get_cmap(np.random.choice(_colormaps))
+
+
 def _ensure_cmap(cmap):
     """
     Ensure that we have a `.Colormap` object.
@@ -715,6 +723,7 @@ def _ensure_cmap(cmap):
     cmap : None, str, Colormap
 
         - if a `Colormap`, return it
+        - if "random", return a random Colormap with get_random_cmap()
         - if a string, look it up in mpl.colormaps
         - if None, look up the default color map in mpl.colormaps
 
@@ -725,6 +734,8 @@ def _ensure_cmap(cmap):
     """
     if isinstance(cmap, colors.Colormap):
         return cmap
+    if cmap == "random":
+        return get_random_cmap()
     cmap_name = cmap if cmap is not None else mpl.rcParams["image.cmap"]
     # use check_in_list to ensure type stability of the exception raised by
     # the internal usage of this (ValueError vs KeyError)


### PR DESCRIPTION
## PR Summary

Original PR #24340
Matplotlib has a huge number of colormaps and no way to quickly sample them! The above PR's comments contain spirited debate and a video of the proposed functionality - passing the argument 'cmap = "random"'

This PR adds a few lines to cm.py to allow coders everywhere to sample matplotlib's many colormaps on any plot they like, anytime they like.

Two things are changed in cm.py:
    1) added one-liner function get_random_cmap() which returns a Colormap at random from _colormaps
    2) added if statement to _ensure_cmap so that when a user passes "random" as a colormap, _ensure_cmap returns get_random_cmap()

And that's it.

The workflow was:
    - Edit cmp.y and test functionality in venv
    - Ensure flake8
    - Run pytest - 1 depreciation warning when pickling
    - Edit docstrings - went with precedent of other similarly short functions in cm.py
        - Did not edit whats_new_next as feature is small 


Attached is an example dataset (credit to Kaggle) as well as a script called random_colormap_test.py, which showcases the changes proposed.

[melbourne.csv](https://github.com/matplotlib/matplotlib/files/9956554/melbourne.csv)
[random_colormap_test.txt](https://github.com/matplotlib/matplotlib/files/9956569/random_colormap_test.txt)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [✓] Has pytest style unit tests (and `pytest` passes).
- [✓] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [NA] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`



- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
