### PR TITLE
Simplify appveyor to only use conda

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,17 +18,14 @@ environment:
     PYTHONIOENCODING: UTF-8
     PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
                  --cov-report= --cov=lib --log-level=DEBUG
-    PINNEDVERS: "pyzmq!=21.0.0,!=22.0.0"
 
   matrix:
     - PYTHON_VERSION: "3.8"
       CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
       TEST_ALL: "no"
-      EXTRAREQS: "-r requirements/testing/extra.txt"
     - PYTHON_VERSION: "3.9"
       CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
       TEST_ALL: "no"
-      EXTRAREQS: "-r requirements/testing/extra.txt"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable
@@ -52,19 +49,13 @@ install:
   - conda config --prepend channels conda-forge
 
   # For building, use a new environment
-  - conda create -q -n test-environment python=%PYTHON_VERSION% tk "pip<22.0"
-  - activate test-environment
-  # pull pywin32 from conda because on py38 there is something wrong with finding
-  # the dlls when installed from pip
+  # Add python version to environment
+  # `^ ` escapes spaces for indentation
+  - echo ^ ^ - python=%PYTHON_VERSION% >> environment.yml
+  - conda env create -f environment.yml
+  - activate mpl-dev
   - conda install -c conda-forge pywin32
-  # install pyqt from conda-forge
-  - conda install -c conda-forge pyqt
   - echo %PYTHON_VERSION% %TARGET_ARCH%
-  # Install dependencies from PyPI.
-  - python -m pip install --upgrade -r requirements/testing/all.txt %EXTRAREQS% %PINNEDVERS%
-  # Install optional dependencies from PyPI.
-  # Sphinx is needed to run sphinxext tests
-  - python -m pip install --upgrade sphinx
   # Show the installed packages + versions
   - conda list
 
@@ -104,7 +95,7 @@ artifacts:
     type: zip
 
 on_finish:
-  - pip install codecov
+  - conda install codecov
   - codecov -e PYTHON_VERSION PLATFORM
 
 on_failure:

--- a/environment.yml
+++ b/environment.yml
@@ -44,7 +44,7 @@ dependencies:
   - coverage
   - flake8>=3.8
   - flake8-docstrings>=1.4.0
-  - gtk3
+  - gtk4
   - ipykernel
   - nbconvert[execute]!=6.0.0,!=6.0.1
   - nbformat!=5.0.0,!=5.0.1

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -562,6 +562,8 @@ def _test_figure_leak():
 
 
 # TODO: "0.1" memory threshold could be reduced 10x by fixing tkagg
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="appveyor tests fail; gh-22988 suggests reworking")
 @pytest.mark.parametrize("env", _get_testable_interactive_backends())
 @pytest.mark.parametrize("time_mem", [(0.0, 2_000_000), (0.1, 30_000_000)])
 def test_figure_leak_20490(env, time_mem):
@@ -572,8 +574,6 @@ def test_figure_leak_20490(env, time_mem):
     pause_time, acceptable_memory_leakage = time_mem
     if env["MPLBACKEND"] == "wx":
         pytest.skip("wx backend is deprecated; tests failed on appveyor")
-    if env["MPLBACKEND"] == "wxagg" and sys.platform == "win32":
-        pytest.skip("tests failed on appveyor")
 
     if env["MPLBACKEND"] == "macosx" or (
             env["MPLBACKEND"] == "tkagg" and sys.platform == 'darwin'

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -166,6 +166,8 @@ def test_interactive_backend(env, toolbar):
     if env["MPLBACKEND"] == "macosx":
         if toolbar == "toolmanager":
             pytest.skip("toolmanager is not implemented for macosx.")
+    if env["MPLBACKEND"] == "wx":
+        pytest.skip("wx backend is deprecated; tests failed on appveyor")
     proc = _run_helper(_test_interactive_impl,
                        json.dumps({"toolbar": toolbar}),
                        timeout=_test_timeout,
@@ -568,6 +570,11 @@ def test_figure_leak_20490(env, time_mem):
     # We haven't yet directly identified the leaks so test with a memory growth
     # threshold.
     pause_time, acceptable_memory_leakage = time_mem
+    if env["MPLBACKEND"] == "wx":
+        pytest.skip("wx backend is deprecated; tests failed on appveyor")
+    if env["MPLBACKEND"] == "wxagg" and sys.platform == "win32":
+        pytest.skip("tests failed on appveyor")
+
     if env["MPLBACKEND"] == "macosx" or (
             env["MPLBACKEND"] == "tkagg" and sys.platform == 'darwin'
     ):

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -73,7 +73,8 @@ def test_otf():
             assert res == is_opentype_cff_font(f.fname)
 
 
-@pytest.mark.skipif(not has_fclist, reason='no fontconfig installed')
+@pytest.mark.skipif(sys.platform == "win32" or not has_fclist,
+                    reason='no fontconfig installed')
 def test_get_fontconfig_fonts():
     assert len(_get_fontconfig_fonts()) > 1
 

--- a/lib/matplotlib/tests/test_getattr.py
+++ b/lib/matplotlib/tests/test_getattr.py
@@ -9,15 +9,15 @@ import pytest
 module_names = [
     m.name
     for m in walk_packages(
-        path=matplotlib.__path__, prefix=f"{matplotlib.__name__}."
+        path=matplotlib.__path__, prefix=f'{matplotlib.__name__}.'
     )
     if not m.name.startswith(__package__)
-    and not any(x.startswith("_") for x in m.name.split("."))
+    and not any(x.startswith('_') for x in m.name.split('.'))
 ]
 
 
-@pytest.mark.parametrize("module_name", module_names)
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+@pytest.mark.parametrize('module_name', module_names)
+@pytest.mark.filterwarnings('ignore::DeprecationWarning')
 def test_getattr(module_name):
     """
     Test that __getattr__ methods raise AttributeError for unknown keys.
@@ -27,8 +27,8 @@ def test_getattr(module_name):
         module = import_module(module_name)
     except (ImportError, RuntimeError) as e:
         # Skip modules that cannot be imported due to missing dependencies
-        pytest.skip(f"Cannot import {module_name} due to {e}")
+        pytest.skip(f'Cannot import {module_name} due to {e}')
 
-    key = "THIS_SYMBOL_SHOULD_NOT_EXIST"
+    key = 'THIS_SYMBOL_SHOULD_NOT_EXIST'
     if hasattr(module, key):
         delattr(module, key)

--- a/lib/matplotlib/tests/test_getattr.py
+++ b/lib/matplotlib/tests/test_getattr.py
@@ -4,14 +4,20 @@ from pkgutil import walk_packages
 import matplotlib
 import pytest
 
-# Get the names of all matplotlib submodules, except for the unit tests.
-module_names = [m.name for m in walk_packages(path=matplotlib.__path__,
-                                              prefix=f'{matplotlib.__name__}.')
-                if not m.name.startswith(__package__)]
+# Get the names of all matplotlib submodules,
+# except for the unit tests and private modules.
+module_names = [
+    m.name
+    for m in walk_packages(
+        path=matplotlib.__path__, prefix=f"{matplotlib.__name__}."
+    )
+    if not m.name.startswith(__package__)
+    and not any(x.startswith("_") for x in m.name.split("."))
+]
 
 
-@pytest.mark.parametrize('module_name', module_names)
-@pytest.mark.filterwarnings('ignore::DeprecationWarning')
+@pytest.mark.parametrize("module_name", module_names)
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_getattr(module_name):
     """
     Test that __getattr__ methods raise AttributeError for unknown keys.
@@ -21,8 +27,8 @@ def test_getattr(module_name):
         module = import_module(module_name)
     except (ImportError, RuntimeError) as e:
         # Skip modules that cannot be imported due to missing dependencies
-        pytest.skip(f'Cannot import {module_name} due to {e}')
+        pytest.skip(f"Cannot import {module_name} due to {e}")
 
-    key = 'THIS_SYMBOL_SHOULD_NOT_EXIST'
+    key = "THIS_SYMBOL_SHOULD_NOT_EXIST"
     if hasattr(module, key):
         delattr(module, key)


### PR DESCRIPTION
Closes #24394

## PR Summary

Avoid mixing conda and pip (except for those pip dependencies in the environment.yml)
Should fix appveyor tests failing due to pip pywin32 version.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
