### PR TITLE
DOC: Fix title formats in backend api docs

### DIFF
--- a/doc/api/backend_agg_api.rst
+++ b/doc/api/backend_agg_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_agg`
-===================
+***********************************
+``matplotlib.backends.backend_agg``
+***********************************
 
 .. automodule:: matplotlib.backends.backend_agg
    :members:

--- a/doc/api/backend_bases_api.rst
+++ b/doc/api/backend_bases_api.rst
@@ -1,6 +1,6 @@
-
-:mod:`matplotlib.backend_bases`
-================================
+****************************
+``matplotlib.backend_bases``
+****************************
 
 .. automodule:: matplotlib.backend_bases
    :members:

--- a/doc/api/backend_cairo_api.rst
+++ b/doc/api/backend_cairo_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_cairo`
-=====================
+*************************************
+``matplotlib.backends.backend_cairo``
+*************************************
 
 .. automodule:: matplotlib.backends.backend_cairo
    :members:

--- a/doc/api/backend_gtk3_api.rst
+++ b/doc/api/backend_gtk3_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_gtk3agg`, :mod:`.backend_gtk3cairo`
-==================================================
+**********************************************************************************
+``matplotlib.backends.backend_gtk3agg``, ``matplotlib.backends.backend_gtk3cairo``
+**********************************************************************************
 
 **NOTE** These backends are not documented here, to avoid adding a dependency
 to building the docs.

--- a/doc/api/backend_gtk4_api.rst
+++ b/doc/api/backend_gtk4_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_gtk4agg`, :mod:`.backend_gtk4cairo`
-==================================================
+**********************************************************************************
+``matplotlib.backends.backend_gtk4agg``, ``matplotlib.backends.backend_gtk4cairo``
+**********************************************************************************
 
 **NOTE** These backends are not documented here, to avoid adding a dependency
 to building the docs.

--- a/doc/api/backend_managers_api.rst
+++ b/doc/api/backend_managers_api.rst
@@ -1,6 +1,6 @@
-
-:mod:`matplotlib.backend_managers`
-==================================
+*******************************
+``matplotlib.backend_managers``
+*******************************
 
 .. automodule:: matplotlib.backend_managers
    :members:

--- a/doc/api/backend_mixed_api.rst
+++ b/doc/api/backend_mixed_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_mixed`
-=====================
+*************************************
+``matplotlib.backends.backend_mixed``
+*************************************
 
 .. automodule:: matplotlib.backends.backend_mixed
    :members:

--- a/doc/api/backend_nbagg_api.rst
+++ b/doc/api/backend_nbagg_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_nbagg`
-=====================
+*************************************
+``matplotlib.backends.backend_nbagg``
+*************************************
 
 .. automodule:: matplotlib.backends.backend_nbagg
    :members:

--- a/doc/api/backend_pdf_api.rst
+++ b/doc/api/backend_pdf_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_pdf`
-===================
+***********************************
+``matplotlib.backends.backend_pdf``
+***********************************
 
 .. automodule:: matplotlib.backends.backend_pdf
    :members:

--- a/doc/api/backend_pgf_api.rst
+++ b/doc/api/backend_pgf_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_pgf`
-===================
+***********************************
+``matplotlib.backends.backend_pgf``
+***********************************
 
 .. automodule:: matplotlib.backends.backend_pgf
    :members:

--- a/doc/api/backend_ps_api.rst
+++ b/doc/api/backend_ps_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_ps`
-==================
+**********************************
+``matplotlib.backends.backend_ps``
+**********************************
 
 .. automodule:: matplotlib.backends.backend_ps
    :members:

--- a/doc/api/backend_qt_api.rst
+++ b/doc/api/backend_qt_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_qtagg`, :mod:`.backend_qtcairo`
-==============================================
+******************************************************************************
+``matplotlib.backends.backend_qtagg``, ``matplotlib.backends.backend_qtcairo``
+******************************************************************************
 
 **NOTE** These backends are not (auto) documented here, to avoid adding a
 dependency to building the docs.

--- a/doc/api/backend_svg_api.rst
+++ b/doc/api/backend_svg_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_svg`
-===================
+***********************************
+``matplotlib.backends.backend_svg``
+***********************************
 
 .. automodule:: matplotlib.backends.backend_svg
    :members:

--- a/doc/api/backend_template_api.rst
+++ b/doc/api/backend_template_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_template`
-========================
+****************************************
+``matplotlib.backends.backend_template``
+****************************************
 
 .. automodule:: matplotlib.backends.backend_template
    :members:

--- a/doc/api/backend_tk_api.rst
+++ b/doc/api/backend_tk_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_tkagg`, :mod:`.backend_tkcairo`
-==============================================
+******************************************************************************
+``matplotlib.backends.backend_tkagg``, ``matplotlib.backends.backend_tkcairo``
+******************************************************************************
 
 .. automodule:: matplotlib.backends.backend_tkagg
    :members:

--- a/doc/api/backend_tools_api.rst
+++ b/doc/api/backend_tools_api.rst
@@ -1,6 +1,6 @@
-
-:mod:`matplotlib.backend_tools`
-===============================
+****************************
+``matplotlib.backend_tools``
+****************************
 
 .. automodule:: matplotlib.backend_tools
    :members:

--- a/doc/api/backend_webagg_api.rst
+++ b/doc/api/backend_webagg_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_webagg`
-======================
+**************************************
+``matplotlib.backends.backend_webagg``
+**************************************
 
 .. automodule:: matplotlib.backends.backend_webagg
    :members:

--- a/doc/api/backend_wx_api.rst
+++ b/doc/api/backend_wx_api.rst
@@ -1,5 +1,6 @@
-:mod:`.backend_wxagg`, :mod:`.backend_wxcairo`
-==============================================
+******************************************************************************
+``matplotlib.backends.backend_wxagg``, ``matplotlib.backends.backend_wxcairo``
+******************************************************************************
 
 **NOTE** These backends are not documented here, to avoid adding a dependency
 to building the docs.


### PR DESCRIPTION
## PR Summary

We don't use links in titles.

Fixes part of #24398.

