### PR TITLE
Use `repr` in error message Addresses #21959

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4416,7 +4416,7 @@ class Axes(_AxesBase):
                     # severe failure => one may appreciate a verbose feedback.
                     raise ValueError(
                         f"'c' argument must be a color, a sequence of colors, "
-                        f"or a sequence of numbers, not {c}") from err
+                        f"or a sequence of numbers, not {c!r}") from err
             else:
                 if len(colors) not in (0, 1, xsize):
                     # NB: remember that a single color is also acceptable.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8297,12 +8297,11 @@ def test_repr_error_message():
     def get_next_color():
         return 'blue'  # currently unused
     import re
-    err = re.escape(
-        ("'c' argument must be a color, a sequence of colors"
-         ", or a sequence of numbers, not 'red\\n'")
-    )
-    with pytest.raises(ValueError,
-                       match=(err)):
+    msg = re.escape(
+            "'c' argument must be a color, a sequence of colors"
+            ", or a sequence of numbers, not 'red\\n'"
+        )
+    with pytest.raises(ValueError, match=msg):
         c = 'red\n'
         mpl.axes.Axes._parse_scatter_color_args(
             c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8295,7 +8295,7 @@ def test_extent_units():
 def test_repr_error_message():
 
     def get_next_color():
-        return 'blue'  # currently unused
+        return 'blue'  # pragma: no cover
     import re
     msg = re.escape(
             "'c' argument must be a color, a sequence of colors"

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8292,14 +8292,13 @@ def test_extent_units():
         im.set_extent([2, 12, date_first, date_last], clip=False)
 
 
-def test_repr_error_message():
+def test_scatter_color_repr_error():
 
     def get_next_color():
         return 'blue'  # pragma: no cover
-    import re
-    msg = re.escape(
-            "'c' argument must be a color, a sequence of colors"
-            ", or a sequence of numbers, not 'red\\n'"
+    msg = (
+            r"'c' argument must be a color, a sequence of colors"
+            r", or a sequence of numbers, not 'red\\n'"
         )
     with pytest.raises(ValueError, match=msg):
         c = 'red\n'

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8291,12 +8291,18 @@ def test_extent_units():
                        match="set_extent did not consume all of the kwargs"):
         im.set_extent([2, 12, date_first, date_last], clip=False)
 
+
 def test_repr_error_message():
+
     def get_next_color():
         return 'blue'  # currently unused
     import re
+    err = re.escape(
+        ("'c' argument must be a color, a sequence of colors"
+         ", or a sequence of numbers, not 'red\\n'")
+    )
     with pytest.raises(ValueError,
-                       match=(re.escape("'c' argument must be a color, a sequence of colors, or a sequence of numbers, not 'red\\n'"))):
+                       match=(err)):
         c = 'red\n'
         mpl.axes.Axes._parse_scatter_color_args(
             c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8290,3 +8290,13 @@ def test_extent_units():
     with pytest.raises(ValueError,
                        match="set_extent did not consume all of the kwargs"):
         im.set_extent([2, 12, date_first, date_last], clip=False)
+
+def test_repr_error_message():
+    def get_next_color():
+        return 'blue'  # currently unused
+    import re
+    with pytest.raises(ValueError,
+                       match=(re.escape("'c' argument must be a color, a sequence of colors, or a sequence of numbers, not 'red\\n'"))):
+        c = 'red\n'
+        mpl.axes.Axes._parse_scatter_color_args(
+            c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)


### PR DESCRIPTION
Implements the proposed solution in issue #21959. Error message now outputs the user’s input via `repr`.

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
