### PR TITLE
Fix: restore make_axes to accept a tuple of axes

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -11,6 +11,7 @@ In Matplotlib they are drawn into a dedicated `~.axes.Axes`.
    End-users most likely won't need to directly use this module's API.
 """
 
+import collections.abc as collections_abc
 import logging
 
 import numpy as np
@@ -1403,7 +1404,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
 
     Parameters
     ----------
-    parents : `~.axes.Axes` or list or `numpy.ndarray` of `~.axes.Axes`
+    parents : `~.axes.Axes` or sequence or `numpy.ndarray` of `~.axes.Axes`
         The Axes to use as parents for placing the colorbar.
     %(_make_axes_kw_doc)s
 
@@ -1429,7 +1430,7 @@ def make_axes(parents, location=None, orientation=None, fraction=0.15,
     # reuse them, leading to a memory leak
     if isinstance(parents, np.ndarray):
         parents = list(parents.flat)
-    elif not isinstance(parents, list):
+    elif not isinstance(parents, collections_abc.Sequence):
         parents = [parents]
     fig = parents[0].get_figure()
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1191,7 +1191,7 @@ default: %(va)s
         cax : `~matplotlib.axes.Axes`, optional
             Axes into which the colorbar will be drawn.
 
-        ax : `~.axes.Axes` or list or `numpy.ndarray` of Axes, optional
+        ax : `~.axes.Axes` or sequence or `numpy.ndarray` of Axes, optional
             One or more parent axes from which space for a new colorbar axes
             will be stolen, if *cax* is None.  This has no effect if *cax* is
             set.

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1188,3 +1188,14 @@ def test_colorbar_errors(kwargs, error, message):
         kwargs['cax'] = ax.inset_axes([0, 1.05, 1, 0.05])
     with pytest.raises(error, match=message):
         fig.colorbar(im, **kwargs)
+
+
+def test_colorbar_axes_parmeters():
+    fig, ax = plt.subplots(2)
+    im = ax[0].imshow([[0, 1], [2, 3]])
+    # colorbar should accept any form of axes sequence:
+    fig.colorbar(im, ax=ax)
+    fig.colorbar(im, ax=ax[0])
+    fig.colorbar(im, ax=[_ax for _ax in ax])
+    fig.colorbar(im, ax=(ax[0], ax[1]))
+    fig.draw_without_rendering()


### PR DESCRIPTION
## PR Summary

Allow to pass a tuple of axes as "ax" parameter of make_axes function.
It restores functionality available in this function, before memory leak fix
(in PR: https://github.com/matplotlib/matplotlib/pull/22089 ).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
