### PR TITLE
made f2tfont error message explicit that it needs path to file

### DIFF
--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -146,7 +146,7 @@ def test_find_invalid(tmpdir):
 
     # Not really public, but get_font doesn't expose non-filename constructor.
     from matplotlib.ft2font import FT2Font
-    with pytest.raises(TypeError, match='font file or binary-mode file'):
+    with pytest.raises(TypeError, match='font file or a binary-mode file'):
         FT2Font(StringIO())
 
 

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -146,7 +146,7 @@ def test_find_invalid(tmpdir):
 
     # Not really public, but get_font doesn't expose non-filename constructor.
     from matplotlib.ft2font import FT2Font
-    with pytest.raises(TypeError, match='path or binary-mode file'):
+    with pytest.raises(TypeError, match='font file or binary-mode file'):
         FT2Font(StringIO())
 
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -433,7 +433,7 @@ static int PyFT2Font_init(PyFT2Font *self, PyObject *args, PyObject *kwds)
                || !(data = PyObject_CallMethod(filename, "read", "i", 0))
                || !PyBytes_Check(data)) {
         PyErr_SetString(PyExc_TypeError,
-                        "First argument must be a path or binary-mode file object");
+                        "First argument must be a path to a font file or a binary-mode file object");
         Py_CLEAR(data);
         goto exit;
     } else {


### PR DESCRIPTION
Per [conversation on gitter](https://gitter.im/matplotlib/matplotlib?at=636c7bc50513b562e8a30787), I was trying to add fonts and thought I could pass in the path to the folder of fonts cause the docs say path, so I wanted to make it a bit clearer that path means path to file. 