### PR TITLE
MNT: Issue a warning instead of logging if RGB(A) passed to scatter(..., c)

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4394,7 +4394,7 @@ class Axes(_AxesBase):
                     c_is_mapped = True
                 else:  # Wrong size; it must not be intended for mapping.
                     if c.shape in ((3,), (4,)):
-                        _log.warning(
+                        _api.warn_external(
                             "*c* argument looks like a single numeric RGB or "
                             "RGBA sequence, which should be avoided as value-"
                             "mapping will have precedence in case its length "


### PR DESCRIPTION
When to use what:

- warnings.warn() in library code if the issue is avoidable and the client application should be modified to eliminate the warning
- logging.warning() if there is nothing the client application can do about the situation, but the event should still be noted

There are unambiguous ways for the user to specify the color (see the message). Here, the user should take action and switch from using *c* to using *color*. Thus warnings.warn() is the way to go.

Closes half of #23422.

