### PR TITLE
DOC: Fix What's New entry for bar_label() formatting.

### DIFF
--- a/doc/users/next_whats_new/bar_label_formatting.rst
+++ b/doc/users/next_whats_new/bar_label_formatting.rst
@@ -4,7 +4,8 @@ Additional format string options in `~matplotlib.axes.Axes.bar_label`
 The ``fmt`` argument of `~matplotlib.axes.Axes.bar_label` now accepts
 {}-style format strings:
 
-.. code-block:: python
+.. plot::
+    :include-source: true
 
     import matplotlib.pyplot as plt
 
@@ -18,7 +19,8 @@ The ``fmt`` argument of `~matplotlib.axes.Axes.bar_label` now accepts
 
 It also accepts callables:
 
-.. code-block:: python
+.. plot::
+    :include-source: true
 
     animal_names = ['Lion', 'Gazelle', 'Cheetah']
     mph_speed = [50, 60, 75]


### PR DESCRIPTION
## PR Summary
I noticed that a what's new entry I submitted as part of a [previous PR](https://github.com/matplotlib/matplotlib/pull/23690) is not rendering the plots. I switched to render the plot and the source code like the other examples.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
