### PR TITLE
Make LogLocator only return one tick out of range

### DIFF
--- a/doc/api/next_api_changes/behavior/24436-DS.rst
+++ b/doc/api/next_api_changes/behavior/24436-DS.rst
@@ -1,0 +1,9 @@
+Improved tick location logic in ``LogLocator``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`~.LogLocator.tick_values` previously returned two ticks that were outside
+the range ``{vmin, vmax}``. This has been updated to only return all ticks
+for the decades containing ``vmin`` and ``vmax``. If ``vmin`` or ``vmax``
+are exactly on a decade this means no ticks above/below are returned.
+Otherwise a single major tick is returned above/below, and for minor ticks
+all the ticks in the decade containing ``vmin`` or ``vmax`` are returned.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6419,8 +6419,8 @@ def test_auto_numticks_log():
     fig, ax = plt.subplots()
     mpl.rcParams['axes.autolimit_mode'] = 'round_numbers'
     ax.loglog([1e-20, 1e5], [1e-16, 10])
-    assert (np.log10(ax.get_xticks()) == np.arange(-26, 18, 4)).all()
-    assert (np.log10(ax.get_yticks()) == np.arange(-20, 10, 3)).all()
+    assert_array_equal(np.log10(ax.get_xticks()), np.arange(-22, 14, 4))
+    assert_array_equal(np.log10(ax.get_yticks()), np.arange(-17, 7, 3))
 
 
 def test_broken_barh_empty():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -493,10 +493,10 @@ def test_colorbar_autotickslog():
                              orientation='vertical', shrink=0.4)
         # note only -12 to +12 are visible
         np.testing.assert_almost_equal(cbar.ax.yaxis.get_ticklocs(),
-                                       10**np.arange(-16., 16.2, 4.))
-        # note only -24 to +24 are visible
+                                       10**np.arange(-12., 12.2, 4.))
+        # note only -12 to +12 are visible
         np.testing.assert_almost_equal(cbar2.ax.yaxis.get_ticklocs(),
-                                       10**np.arange(-24., 25., 12.))
+                                       10**np.arange(-12., 13., 12.))
 
 
 def test_colorbar_get_ticks():
@@ -584,6 +584,7 @@ def test_colorbar_log_minortick_labels():
 def test_colorbar_renorm():
     x, y = np.ogrid[-4:4:31j, -4:4:31j]
     z = 120000*np.exp(-x**2 - y**2)
+    # min/max of z vals is 1.5196998658913011e-09, 120000.0
 
     fig, ax = plt.subplots()
     im = ax.imshow(z)
@@ -597,7 +598,7 @@ def test_colorbar_renorm():
     norm = LogNorm(z.min(), z.max())
     im.set_norm(norm)
     np.testing.assert_allclose(cbar.ax.yaxis.get_majorticklocs(),
-                               np.logspace(-10, 7, 18))
+                               np.logspace(-9, 6, 16))
     # note that set_norm removes the FixedLocator...
     assert np.isclose(cbar.vmin, z.min())
     cbar.set_ticks([1, 2, 3])
@@ -616,6 +617,7 @@ def test_colorbar_format(fmt):
     # make sure that format is passed properly
     x, y = np.ogrid[-4:4:31j, -4:4:31j]
     z = 120000*np.exp(-x**2 - y**2)
+    # min/max of z vals is 1.5196998658913011e-09, 120000.0
 
     fig, ax = plt.subplots()
     im = ax.imshow(z)
@@ -633,7 +635,7 @@ def test_colorbar_format(fmt):
     im.set_norm(LogNorm(vmin=0.1, vmax=10))
     fig.canvas.draw()
     assert (cbar.ax.yaxis.get_ticklabels()[0].get_text() ==
-            '$\\mathdefault{10^{-2}}$')
+            '$\\mathdefault{10^{-1}}$')
 
 
 def test_colorbar_scale_reset():

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -198,10 +198,10 @@ class TestLogLocator:
         'vmin, vmax, expected_ticks',
         (
             [1, 10, [1, 10]],
-            [0.9, 10.1, [1, 10]],
-            [0.9, 9, [1]],
-            [1.1, 11, [10]],
-            [0.5, 983, [1, 10, 100]]
+            [0.9, 10.1, [0.1, 1, 10, 100]],
+            [0.9, 9, [0.1, 1, 10]],
+            [1.1, 11, [1, 10, 100]],
+            [0.5, 983, [0.1, 1, 10, 100, 1000]]
         )
     )
     def test_tick_locs(self, vmin, vmax, expected_ticks):
@@ -210,13 +210,13 @@ class TestLogLocator:
 
     def test_basic(self):
         loc = mticker.LogLocator(numticks=5)
-        test_value = np.array([1.00000000e-05, 1.00000000e-03, 1.00000000e-01,
+        test_value = np.array([1.00000000e-03, 1.00000000e-01,
                                1.00000000e+01, 1.00000000e+03, 1.00000000e+05,
-                               1.00000000e+07, 1.000000000e+09])
-        assert_almost_equal(loc.tick_values(0.001, 1.1e5), test_value)
+                               1.00000000e+07])
+        assert_almost_equal(loc.tick_values(1e-3, 1.1e5), test_value)
 
         loc = mticker.LogLocator(base=2)
-        test_value = np.array([0.5, 1., 2., 4., 8., 16., 32., 64., 128., 256.])
+        test_value = np.array([1., 2., 4., 8., 16., 32., 64., 128.])
         assert_almost_equal(loc.tick_values(1, 100), test_value)
 
     def test_invalid_lim_error(self):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -194,6 +194,20 @@ class TestAutoMinorLocator:
 
 
 class TestLogLocator:
+    @pytest.mark.parametrize(
+        'vmin, vmax, expected_ticks',
+        (
+            [1, 10, [1, 10]],
+            [0.9, 10.1, [1, 10]],
+            [0.9, 9, [1]],
+            [1.1, 11, [10]],
+            [0.5, 983, [1, 10, 100]]
+        )
+    )
+    def test_tick_locs(self, vmin, vmax, expected_ticks):
+        ll = mticker.LogLocator(base=10.0, subs=(1.0,))
+        np.testing.assert_equal(ll.tick_values(vmin, vmax), expected_ticks)
+
     def test_basic(self):
         loc = mticker.LogLocator(numticks=5)
         test_value = np.array([1.00000000e-05, 1.00000000e-03, 1.00000000e-01,

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -196,9 +196,6 @@ class TestAutoMinorLocator:
 class TestLogLocator:
     def test_basic(self):
         loc = mticker.LogLocator(numticks=5)
-        with pytest.raises(ValueError):
-            loc.tick_values(0, 1000)
-
         test_value = np.array([1.00000000e-05, 1.00000000e-03, 1.00000000e-01,
                                1.00000000e+01, 1.00000000e+03, 1.00000000e+05,
                                1.00000000e+07, 1.000000000e+09])
@@ -207,6 +204,15 @@ class TestLogLocator:
         loc = mticker.LogLocator(base=2)
         test_value = np.array([0.5, 1., 2., 4., 8., 16., 32., 64., 128., 256.])
         assert_almost_equal(loc.tick_values(1, 100), test_value)
+
+    def test_invalid_lim_error(self):
+        loc = mticker.LogLocator()
+        with pytest.raises(
+                ValueError,
+                match='Data has no positive values, '
+                'and therefore can not be log-scaled.'
+        ):
+            loc.tick_values(0, 1000)
 
     def test_polar_axes(self):
         """

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -223,7 +223,7 @@ class TestLogLocator:
         loc = mticker.LogLocator()
         with pytest.raises(
                 ValueError,
-                match='Data has no positive values, '
+                match='Data has non-positive values, '
                 'and therefore can not be log-scaled.'
         ):
             loc.tick_values(0, 1000)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -235,7 +235,7 @@ class TestLogLocator:
         fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
         ax.set_yscale('log')
         ax.set_ylim(1, 100)
-        assert_array_equal(ax.get_yticks(), [10, 100, 1000])
+        assert_array_equal(ax.get_yticks(), [10, 100])
 
     def test_switch_to_autolocator(self):
         loc = mticker.LogLocator(subs="all")

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2344,6 +2344,15 @@ class LogLocator(Locator):
         return self.tick_values(vmin, vmax)
 
     def tick_values(self, vmin, vmax):
+        """
+        Return the values of the located ticks given **vmin** and **vmax**.
+
+        Notes
+        -----
+        The tick values returned include all ticks for the decades containing
+        ``vmin`` and ``vmax``, which can result in some tick values below
+        ``vmin`` and above ``vmax``.
+        """
         if self.numticks == 'auto':
             if self.axis is not None:
                 numticks = np.clip(self.axis.get_tick_space(), 2, 9)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2408,8 +2408,10 @@ class LogLocator(Locator):
         # whether we're a major or a minor locator.
         have_subs = len(subs) > 1 or (len(subs) == 1 and subs[0] != 1.0)
 
-        decades = np.arange(math.floor(log_vmin) - stride,
-                            math.ceil(log_vmax) + 2 * stride, stride)
+        # Return one tick below (or equal to) vmin,
+        # and one tick above (or equal to) vmax
+        decades = np.arange(math.floor(log_vmin),
+                            math.ceil(log_vmax) + stride, stride)
 
         if hasattr(self, '_transform'):
             ticklocs = self._transform.inverted().transform(decades)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2368,7 +2368,7 @@ class LogLocator(Locator):
 
             if vmin <= 0.0 or not np.isfinite(vmin):
                 raise ValueError(
-                    "Data has no positive values, and therefore can not be "
+                    "Data has non-positive values, and therefore can not be "
                     "log-scaled.")
 
         _log.debug('vmin %s vmax %s', vmin, vmax)
@@ -2461,7 +2461,7 @@ class LogLocator(Locator):
             vmin, vmax = 1, 10  # Initial range, no data plotted yet.
         elif vmax <= 0:
             _api.warn_external(
-                "Data has no positive values, and therefore cannot be "
+                "Data has non-positive values, and therefore cannot be "
                 "log-scaled.")
             vmin, vmax = 1, 10
         else:


### PR DESCRIPTION
## PR Summary
I'm working on thoroughly testing `LogLocator`, and this PR is a start. There is a new parametrized test that checks the tick locations for a given vmin, vmax.

I have also changed the logic for geting the tick locations slightly. Before the locator was returning two ticks below `vmin`, and two ticks above `vmax`. Looking through the commit history I cannot find any reason to do this, so to make the logic clear I have changed this to returning one tick below `vmin`/one ablove `vmax` (as is needed for clipping and potentially autoscaling). I've then documented this logic in the docstring.

The changed tests are just removing the extra tick at each end - because there is still a single "out of bounds" tick returned at each end no figures should change with this PR.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
