### PR TITLE
Remove custom polar behaviour in LogLocator

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -208,6 +208,15 @@ class TestLogLocator:
         test_value = np.array([0.5, 1., 2., 4., 8., 16., 32., 64., 128., 256.])
         assert_almost_equal(loc.tick_values(1, 100), test_value)
 
+    def test_polar_axes(self):
+        """
+        Polar axes have a different ticking logic.
+        """
+        fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+        ax.set_yscale('log')
+        ax.set_ylim(1, 100)
+        assert_array_equal(ax.get_yticks(), [10, 100, 1000])
+
     def test_switch_to_autolocator(self):
         loc = mticker.LogLocator(subs="all")
         assert_array_equal(loc.tick_values(0.45, 0.55),

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2352,14 +2352,6 @@ class LogLocator(Locator):
             numticks = self.numticks
 
         b = self._base
-        # dummy axis has no axes attribute
-        if hasattr(self.axis, 'axes') and self.axis.axes.name == 'polar':
-            vmax = math.ceil(math.log(vmax) / math.log(b))
-            decades = np.arange(vmax - self.numdecs, vmax)
-            ticklocs = b ** decades
-
-            return ticklocs
-
         if vmin <= 0.0:
             if self.axis is not None:
                 vmin = self.axis.get_minpos()
@@ -2443,10 +2435,6 @@ class LogLocator(Locator):
         b = self._base
 
         vmin, vmax = self.nonsingular(vmin, vmax)
-
-        if self.axis.axes.name == 'polar':
-            vmax = math.ceil(math.log(vmax) / math.log(b))
-            vmin = b ** (vmax - self.numdecs)
 
         if mpl.rcParams['axes.autolimit_mode'] == 'round_numbers':
             vmin = _decade_less_equal(vmin, self._base)


### PR DESCRIPTION
## PR Summary
As part of investigating https://github.com/matplotlib/matplotlib/issues/24383, I noticed that `LogLocator` has custom behaviour for polar Axes. This dates back 13 years (!!) to https://github.com/matplotlib/matplotlib/commit/1fdd5a8af97df3443d9a26a902b9f3513f33fe92. Since log-scaled polar Axes are broken anyway, I thought I would remove this logic and see if any existing tests break.

I've also added a new test to check the y-ticks on a log-scaled polar plot. Prior to this PR the ticks were given at `[ 0.01  0.1   1.   10.  ]`, not including the max limit of `100`, showing that the custom polar logic in `LogLocator` was wrong anyway.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
