### PR TITLE
DOC: Fix colorbar what's new entry so it isn't cut off.

### DIFF
--- a/doc/users/next_whats_new/colorbar_has_location_argument.rst
+++ b/doc/users/next_whats_new/colorbar_has_location_argument.rst
@@ -23,3 +23,4 @@ An example is:
     im = ax.imshow(imdata)
     fig.colorbar(im, cax=ax.inset_axes([0, 1.05, 1, 0.05]),
                  location='top')
+    fig.tight_layout()

--- a/doc/users/next_whats_new/colorbar_has_location_argument.rst
+++ b/doc/users/next_whats_new/colorbar_has_location_argument.rst
@@ -19,8 +19,7 @@ An example is:
     import numpy as np
     rng = np.random.default_rng(19680801)
     imdata = rng.random((10, 10))
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(layout='constrained')
     im = ax.imshow(imdata)
     fig.colorbar(im, cax=ax.inset_axes([0, 1.05, 1, 0.05]),
                  location='top')
-    fig.tight_layout()


### PR DESCRIPTION
## PR Summary
The example for the What's new entry on colorbar location is currently being cut off. I added a call to `tight_layout()` to fix this:
<img width="856" alt="Screen Shot 2022-11-12 at 1 33 41 PM" src="https://user-images.githubusercontent.com/24376333/201489457-32144f65-bba9-45cf-9747-cc03a79878ab.png">

After the change, it looks like this ([link to this in the built docs](https://output.circle-artifacts.com/output/job/7c7b133c-59ff-4536-8681-342778427566/artifacts/0/doc/build/html/users/next_whats_new/colorbar_has_location_argument.html)):
<img width="864" alt="Screen Shot 2022-11-12 at 2 02 57 PM" src="https://user-images.githubusercontent.com/24376333/201490491-398dbbf7-158d-46e8-8e2f-369809e4539a.png">


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
