### PR TITLE
DOC: Fix example for what's new imshow so it isn't cut off or crowded.

### DIFF
--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -8,7 +8,7 @@ can now be expressed with units.
 
     import matplotlib.pyplot as plt
     import numpy as np
-    from matplotlib.dates import HourLocator, DateFormatter
+    from matplotlib.dates import HourLocator, ConciseDateFormatter
     from matplotlib.ticker import AutoMinorLocator
 
     fig, ax = plt.subplots(layout='constrained')
@@ -19,8 +19,14 @@ can now be expressed with units.
 
     ax.imshow(arr, origin='lower', extent=[1, 11, date_first, date_last])
 
-    ax.yaxis.set_major_formatter(DateFormatter('%d/%m/%y:- %H00hours'))
-    ax.yaxis.set_major_locator(HourLocator(byhour=[0, 12, 24]))
+    locator = HourLocator(byhour=[0, 12, 24])
+    ax.yaxis.set_major_formatter(
+        ConciseDateFormatter(
+            locator, show_offset=False,
+            zero_formats=['', '%Y', '%b', '%b-%d %H:%M', '%H:%M', '%H:%M']
+        )
+    )
+    ax.yaxis.set_major_locator(locator)
     ax.yaxis.set_minor_locator(AutoMinorLocator())
 
     plt.show()

--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -11,7 +11,7 @@ can now be expressed with units.
     from matplotlib.dates import HourLocator, DateFormatter
     from matplotlib.ticker import AutoMinorLocator
 
-    fig, ax = plt.subplots(figsize=(6, 6))
+    fig, ax = plt.subplots(figsize=(6, 4))
     date_first = np.datetime64('2020-01-01', 'D')
     date_last = np.datetime64('2020-01-11', 'D')
 

--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -11,7 +11,7 @@ can now be expressed with units.
     from matplotlib.dates import HourLocator, DateFormatter
     from matplotlib.ticker import AutoMinorLocator
 
-    fig, ax = plt.subplots()
+    fig, ax = plt.subplots(figsize=(6, 6))
     date_first = np.datetime64('2020-01-01', 'D')
     date_last = np.datetime64('2020-01-11', 'D')
 
@@ -20,7 +20,9 @@ can now be expressed with units.
     ax.imshow(arr, origin='lower', extent=[1, 11, date_first, date_last])
 
     ax.yaxis.set_major_formatter(DateFormatter('%d/%m/%y:- %H00hours'))
-    ax.yaxis.set_major_locator(HourLocator(byhour=[0, 6, 12, 18, 24]))
+    ax.yaxis.set_major_locator(HourLocator(byhour=[0, 12, 24]))
     ax.yaxis.set_minor_locator(AutoMinorLocator())
+
+    fig.tight_layout()
 
     plt.show()

--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -8,7 +8,6 @@ can now be expressed with units.
 
     import matplotlib.pyplot as plt
     import numpy as np
-    from matplotlib.dates import DateFormatter
 
     fig, ax = plt.subplots(layout='constrained')
     date_first = np.datetime64('2020-01-01', 'D')
@@ -16,8 +15,6 @@ can now be expressed with units.
 
     arr = [[i+j for i in range(10)] for j in range(10)]
 
-    ax.imshow(arr, origin='lower', extent=[1, 11, date_first, date_last])
-
-    ax.yaxis.set_major_formatter(DateFormatter('%d/%m/%y'))
+    ax.imshow(arr, origin='lower', extent=[0, 10, date_first, date_last])
 
     plt.show()

--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -11,7 +11,7 @@ can now be expressed with units.
     from matplotlib.dates import HourLocator, DateFormatter
     from matplotlib.ticker import AutoMinorLocator
 
-    fig, ax = plt.subplots(figsize=(6, 4))
+    fig, ax = plt.subplots(layout='constrained')
     date_first = np.datetime64('2020-01-01', 'D')
     date_last = np.datetime64('2020-01-11', 'D')
 
@@ -22,7 +22,5 @@ can now be expressed with units.
     ax.yaxis.set_major_formatter(DateFormatter('%d/%m/%y:- %H00hours'))
     ax.yaxis.set_major_locator(HourLocator(byhour=[0, 12, 24]))
     ax.yaxis.set_minor_locator(AutoMinorLocator())
-
-    fig.tight_layout()
 
     plt.show()

--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -8,8 +8,7 @@ can now be expressed with units.
 
     import matplotlib.pyplot as plt
     import numpy as np
-    from matplotlib.dates import HourLocator, ConciseDateFormatter
-    from matplotlib.ticker import AutoMinorLocator
+    from matplotlib.dates import DateFormatter
 
     fig, ax = plt.subplots(layout='constrained')
     date_first = np.datetime64('2020-01-01', 'D')
@@ -19,15 +18,6 @@ can now be expressed with units.
 
     ax.imshow(arr, origin='lower', extent=[1, 11, date_first, date_last])
 
-    # customize tick locations and labels
-    locator = HourLocator(byhour=[0, 12])
-    ax.yaxis.set_major_formatter(
-        ConciseDateFormatter(
-            locator, show_offset=False,
-            zero_formats=['', '%Y', '%b', '%b-%d %H:%M', '%H:%M', '%H:%M']
-        )
-    )
-    ax.yaxis.set_major_locator(locator)
-    ax.yaxis.set_minor_locator(AutoMinorLocator())
+    ax.yaxis.set_major_formatter(DateFormatter('%d/%m/%y'))
 
     plt.show()

--- a/doc/users/next_whats_new/imshow_extent_units.rst
+++ b/doc/users/next_whats_new/imshow_extent_units.rst
@@ -19,7 +19,8 @@ can now be expressed with units.
 
     ax.imshow(arr, origin='lower', extent=[1, 11, date_first, date_last])
 
-    locator = HourLocator(byhour=[0, 12, 24])
+    # customize tick locations and labels
+    locator = HourLocator(byhour=[0, 12])
     ax.yaxis.set_major_formatter(
         ConciseDateFormatter(
             locator, show_offset=False,


### PR DESCRIPTION
## PR Summary
The example for the What's new entry on the `extent` parameter to `imshow` currently has a very crowded y-axis and the labels are being cut off:
<img width="840" alt="Screen Shot 2022-11-12 at 1 45 55 PM" src="https://user-images.githubusercontent.com/24376333/201489885-49891672-1b05-4be0-b6f4-27811ea89c57.png">

I reduced the number of major ticks and adjusted the figure size in addition to calling `tight_layout()` to fix this. It now looks like the below in the [built docs](https://output.circle-artifacts.com/output/job/0e4b2611-e306-4e93-9804-442b8365b5a9/artifacts/0/doc/build/html/users/next_whats_new/imshow_extent_units.html).
<img width="873" alt="Screen Shot 2022-11-12 at 2 21 16 PM" src="https://user-images.githubusercontent.com/24376333/201491135-c8c857c0-eea6-4f7b-ac88-e89e6cd6efab.png">


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [N/A] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
