### PR TITLE
DOC: AnnotationBbox keyword descriptions

### DIFF
--- a/examples/text_labels_and_annotations/demo_annotation_box.py
+++ b/examples/text_labels_and_annotations/demo_annotation_box.py
@@ -31,7 +31,8 @@ ab = AnnotationBbox(offsetbox, xy,
                     xybox=(-20, 40),
                     xycoords='data',
                     boxcoords="offset points",
-                    arrowprops=dict(arrowstyle="->"))
+                    arrowprops=dict(arrowstyle="->"),
+                    bboxprops=dict(boxstyle="sawtooth"))
 ax.add_artist(ab)
 
 # Annotate the 1st position with another text box ('Test')
@@ -54,11 +55,12 @@ p = Circle((10, 10), 10)
 da.add_artist(p)
 
 ab = AnnotationBbox(da, xy,
-                    xybox=(1.02, xy[1]),
+                    xybox=(1., xy[1]),
                     xycoords='data',
                     boxcoords=("axes fraction", "data"),
-                    box_alignment=(0., 0.5),
-                    arrowprops=dict(arrowstyle="->"))
+                    box_alignment=(0.2, 0.5),
+                    arrowprops=dict(arrowstyle="->"),
+                    bboxprops=dict(alpha=0.5))
 
 ax.add_artist(ab)
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1262,6 +1262,16 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             (accessible as the ``patch`` attribute of the `.AnnotationBbox`).
             If *frameon* is set to False, this patch is made invisible.
 
+        annotation_clip: bool or None, default: None
+            Whether to clip (i.e. not draw) the annotation when the annotation
+            point *xy* is outside the axes area.
+
+            - If *True*, the annotation will be clipped when *xy* is outside
+              the axes.
+            - If *False*, the annotation will always be drawn.
+            - If *None*, the annotation will be clipped when *xy* is outside
+              the axes and *xycoords* is 'data'.
+
         pad : float, default: 0.4
             Padding around the offsetbox.
 
@@ -1270,8 +1280,25 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             the offset box w.r.t. the *boxcoords*.
             The lower-left corner is (0, 0) and upper-right corner is (1, 1).
 
+        bboxprops : dict, optional
+            A dictionary of properties to set for the annotation bounding box,
+            for example *boxstyle* and *alpha*.  See `.FancyBboxPatch` for
+            details.
+
+        arrowprops: dict, optional
+            Arrow properties, see `.Annotation` for description.
+
+        fontsize: float or str, optional
+            Translated to points and passed as *mutation_scale* into
+            `.FancyBboxPatch` to scale attributes of the box style (e.g. pad
+            or rounding_size).  The name is chosen in analogy to `.Text` where
+            *fontsize* defines the mutation scale as well.  If not given,
+            :rc:`legend.fontsize` is used.  See `.Text.set_fontsize` for valid
+            values.
+
         **kwargs
-            Other parameters are identical to `.Annotation`.
+            Other `AnnotationBbox` properties.  See `.AnnotationBbox.set` for
+            a list.
         """
 
         martist.Artist.__init__(self)


### PR DESCRIPTION
## PR Summary

Closes #24390.

* Add a description of the `bboxprops` keyword for `AnnotationBbox` instantiation.  At https://github.com/matplotlib/matplotlib/issues/24390#issuecomment-1307083940 @oscargus noted that `arrowprops` and `fontsize` are also missing from the docstring, but possibly they are covered by "Other parameters are identical to Annotation"?  I note that the `arrowprops` description in [Annotation](https://matplotlib.org/stable/api/text_api.html#matplotlib.text.Annotation) is quite extensive, so am not sure of the wisdom of copying it across to related docstrings.
* Modify the AnnotationBbox demo to include some examples using the `bboxprops` keyword.  ~While I was in there I also changed all double quotes to single quotes, as there is currently a mixture and I think it should be consistent within the example.~

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [N/A] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
