### PR TITLE
Don't pass unused xdescent to _get_packed_offsets.

### DIFF
--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -122,71 +122,69 @@ def test_expand_with_tight_layout():
     fig.tight_layout()  # where the crash used to happen
 
 
-@pytest.mark.parametrize('wd_list',
-                         ([(150, 1)], [(150, 1)]*3, [(0.1, 1)], [(0.1, 1)]*2))
+@pytest.mark.parametrize('widths',
+                         ([150], [150, 150, 150], [0.1], [0.1, 0.1]))
 @pytest.mark.parametrize('total', (250, 100, 0, -1, None))
 @pytest.mark.parametrize('sep', (250, 1, 0, -1))
 @pytest.mark.parametrize('mode', ("expand", "fixed", "equal"))
-def test_get_packed_offsets(wd_list, total, sep, mode):
+def test_get_packed_offsets(widths, total, sep, mode):
     # Check a (rather arbitrary) set of parameters due to successive similar
     # issue tickets (at least #10476 and #10784) related to corner cases
     # triggered inside this function when calling higher-level functions
     # (e.g. `Axes.legend`).
     # These are just some additional smoke tests. The output is untested.
-    _get_packed_offsets(wd_list, total, sep, mode=mode)
+    _get_packed_offsets(widths, total, sep, mode=mode)
 
 
 _Params = namedtuple('_params', 'wd_list, total, sep, expected')
 
 
-@pytest.mark.parametrize('wd_list, total, sep, expected', [
+@pytest.mark.parametrize('widths, total, sep, expected', [
     _Params(  # total=None
-        [(3, 0), (1, 0), (2, 0)], total=None, sep=1, expected=(8, [0, 4, 6])),
+        [3, 1, 2], total=None, sep=1, expected=(8, [0, 4, 6])),
     _Params(  # total larger than required
-        [(3, 0), (1, 0), (2, 0)], total=10, sep=1, expected=(10, [0, 4, 6])),
+        [3, 1, 2], total=10, sep=1, expected=(10, [0, 4, 6])),
     _Params(  # total smaller than required
-        [(3, 0), (1, 0), (2, 0)], total=5, sep=1, expected=(5, [0, 4, 6])),
+        [3, 1, 2], total=5, sep=1, expected=(5, [0, 4, 6])),
 ])
-def test_get_packed_offsets_fixed(wd_list, total, sep, expected):
-    result = _get_packed_offsets(wd_list, total, sep, mode='fixed')
+def test_get_packed_offsets_fixed(widths, total, sep, expected):
+    result = _get_packed_offsets(widths, total, sep, mode='fixed')
     assert result[0] == expected[0]
     assert_allclose(result[1], expected[1])
 
 
-@pytest.mark.parametrize('wd_list, total, sep, expected', [
+@pytest.mark.parametrize('widths, total, sep, expected', [
     _Params(  # total=None (implicit 1)
-        [(.1, 0)] * 3, total=None, sep=None, expected=(1, [0, .45, .9])),
+        [.1, .1, .1], total=None, sep=None, expected=(1, [0, .45, .9])),
     _Params(  # total larger than sum of widths
-        [(3, 0), (1, 0), (2, 0)], total=10, sep=1, expected=(10, [0, 5, 8])),
+        [3, 1, 2], total=10, sep=1, expected=(10, [0, 5, 8])),
     _Params(  # total smaller sum of widths: overlapping boxes
-        [(3, 0), (1, 0), (2, 0)], total=5, sep=1, expected=(5, [0, 2.5, 3])),
+        [3, 1, 2], total=5, sep=1, expected=(5, [0, 2.5, 3])),
 ])
-def test_get_packed_offsets_expand(wd_list, total, sep, expected):
-    result = _get_packed_offsets(wd_list, total, sep, mode='expand')
+def test_get_packed_offsets_expand(widths, total, sep, expected):
+    result = _get_packed_offsets(widths, total, sep, mode='expand')
     assert result[0] == expected[0]
     assert_allclose(result[1], expected[1])
 
 
-@pytest.mark.parametrize('wd_list, total, sep, expected', [
+@pytest.mark.parametrize('widths, total, sep, expected', [
     _Params(  # total larger than required
-        [(3, 0), (2, 0), (1, 0)], total=6, sep=None, expected=(6, [0, 2, 4])),
+        [3, 2, 1], total=6, sep=None, expected=(6, [0, 2, 4])),
     _Params(  # total smaller sum of widths: overlapping boxes
-        [(3, 0), (2, 0), (1, 0), (.5, 0)], total=2, sep=None,
-        expected=(2, [0, 0.5, 1, 1.5])),
+        [3, 2, 1, .5], total=2, sep=None, expected=(2, [0, 0.5, 1, 1.5])),
     _Params(  # total larger than required
-        [(.5, 0), (1, 0), (.2, 0)], total=None, sep=1,
-        expected=(6, [0, 2, 4])),
+        [.5, 1, .2], total=None, sep=1, expected=(6, [0, 2, 4])),
     # the case total=None, sep=None is tested separately below
 ])
-def test_get_packed_offsets_equal(wd_list, total, sep, expected):
-    result = _get_packed_offsets(wd_list, total, sep, mode='equal')
+def test_get_packed_offsets_equal(widths, total, sep, expected):
+    result = _get_packed_offsets(widths, total, sep, mode='equal')
     assert result[0] == expected[0]
     assert_allclose(result[1], expected[1])
 
 
 def test_get_packed_offsets_equal_total_none_sep_none():
     with pytest.raises(ValueError):
-        _get_packed_offsets([(1, 0)] * 3, total=None, sep=None, mode='equal')
+        _get_packed_offsets([1, 1, 1], total=None, sep=None, mode='equal')
 
 
 @pytest.mark.parametrize('child_type', ['draw', 'image', 'text'])


### PR DESCRIPTION
Instead of passing a list of (widths, xdescents) where xdescent is unused, just pass a list of widths.  This helper is private so we just need to adjust the call sites and tests with no deprecation.

This patch is preliminary work for some further cleanup on the offsetbox module (somewhat motivated by #24386).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [ ] Has pytest style unit tests (and `pytest` passes).
- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
