### PR TITLE
[DOC] swapped params in fig_compare_error msg

### DIFF
--- a/lib/matplotlib/testing/decorators.py
+++ b/lib/matplotlib/testing/decorators.py
@@ -453,7 +453,7 @@ def check_figures_equal(*, extensions=("png", "pdf", "svg"), tol=0):
 
         if not {"fig_test", "fig_ref"}.issubset(old_sig.parameters):
             raise ValueError("The decorated function must have at least the "
-                             "parameters 'fig_ref' and 'fig_test', but your "
+                             "parameters 'fig_test' and 'fig_ref', but your "
                              f"function has the signature {old_sig}")
 
         @pytest.mark.parametrize("ext", extensions)


### PR DESCRIPTION
Swapped `fig_ref` and `fig_test` in the error message so that it'd match the order in the function signature. Technically I think order doesn't matter since it's done by signature, but I think having them in the same order slightly reduces friction. 