### PR TITLE
[DOC] removed flake8 from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,11 +3,9 @@
 ## PR Checklist
 
 <!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
-**Tests and Styling**
-- [ ] Has pytest style unit tests (and `pytest` passes).
-- [ ] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).
 
-**Documentation**
+**Documentation and Tests**
+- [ ] Has pytest style unit tests (and `pytest` passes)
 - [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
 - [ ] New plotting related features are documented with examples.
 


### PR DESCRIPTION
Since flake is now a part of the CI test and recommended as part of the pre-commit hooks, figured it can be dropped from the checklist and then the template can be condensed a drop. 
