### PR TITLE
Make Path3DCollection store indexed offset, and only apply z-ordered offset during draw

### DIFF
--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -1,0 +1,38 @@
+import matplotlib.pyplot as plt
+
+from matplotlib.backend_bases import MouseEvent
+
+
+def test_scatter_3d_projection_conservation():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    # fix axes3d projection
+    ax.roll = 0
+    ax.elev = 0
+    ax.azim = -45
+    ax.stale = True
+
+    x = [0, 1, 2, 3, 4]
+    scatter_collection = ax.scatter(x, x, x)
+    fig.canvas.draw_idle()
+
+    # Get scatter location on canvas and freeze the data
+    scatter_offset = scatter_collection.get_offsets()
+    scatter_location = ax.transData.transform(scatter_offset)
+
+    # Yaw -44 and -46 are enough to produce two set of scatter
+    # with opposite z-order without moving points too far
+    for azim in (-44, -46):
+        ax.azim = azim
+        ax.stale = True
+        fig.canvas.draw_idle()
+
+        for i in range(5):
+            # Create a mouse event used to locate and to get index
+            # from each dots
+            event = MouseEvent("button_press_event", fig.canvas,
+                               *scatter_location[i, :])
+            contains, ind = scatter_collection.contains(event)
+            assert contains is True
+            assert len(ind["ind"]) == 1
+            assert ind["ind"][0] == i


### PR DESCRIPTION
## PR Summary

This PR is targeted to resolve issue [#23155](https://github.com/matplotlib/matplotlib/issues/23155) by maintain offset order for indexing purpose. And z-ordered offset will only be applied during rendering peroid.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
