### PR TITLE
DOC: Removed matplotlib from mission statement title

### DIFF
--- a/doc/users/project/mission.rst
+++ b/doc/users/project/mission.rst
@@ -1,5 +1,5 @@
 Mission Statement
-============================
+=================
 
 The Matplotlib developer community develops, maintains, and supports Matplotlib
 and its extensions to provide data visualization tools for the Scientific

--- a/doc/users/project/mission.rst
+++ b/doc/users/project/mission.rst
@@ -1,4 +1,4 @@
-Matplotlib Mission Statement
+Mission Statement
 ============================
 
 The Matplotlib developer community develops, maintains, and supports Matplotlib


### PR DESCRIPTION
Mostly it just looks superfluous in autogenerated table of contents (xref #24493)
