### PR TITLE
Backport of PR#24488 (Update for pydata-sphinx-theme 0.12.0)

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -383,7 +383,7 @@ html_theme_options = {
              "image_light": "images/logo2.svg",
              "image_dark": "images/logo_dark.svg"},
     "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"],
-    "page_sidebar_items": "page-toc.html",
+    "secondary_sidebar_items": "page-toc.html",
 }
 include_analytics = is_release_build
 if include_analytics:

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -13,7 +13,7 @@ ipython
 ipywidgets
 numpydoc>=1.0
 packaging>=20
-pydata-sphinx-theme>=0.9.0
+pydata-sphinx-theme>=0.12.0
 mpl-sphinx-theme~=3.6.0
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10


### PR DESCRIPTION
## PR Summary

`pydata-sphinx-theme` updated, renaming some configuration names. (only one of which we actually configure)
While they are just warnings for now, we are configured to error on warning so CircleCI is indicating failure.

This does the 'easy' route of just changing to the new name and expecting the version in which it is implemented.

If desired, I could do a larger change to accomodate both by checking the version, but I'm also not _too_ worried about more tightly pinning already relatively tight requirements.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`