### PR TITLE
Factor out & improve accuracy of derivatives calculations in axisartist.

### DIFF
--- a/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
@@ -75,9 +75,9 @@ def test_custom_transform():
     ax1.grid(True)
 
 
-@image_comparison(['polar_box.png'], style='default', tol=0.04)
+# Remove tol & kerning_factor when this test image is regenerated.
+@image_comparison(['polar_box.png'], style='default', tol=0.27)
 def test_polar_box():
-    # Remove this line when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
 
     fig = plt.figure(figsize=(5, 5))
@@ -137,9 +137,9 @@ def test_polar_box():
     ax1.grid(True)
 
 
-@image_comparison(['axis_direction.png'], style='default', tol=0.071)
+# Remove tol & kerning_factor when this test image is regenerated.
+@image_comparison(['axis_direction.png'], style='default', tol=0.12)
 def test_axis_direction():
-    # Remove this line when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
 
     fig = plt.figure(figsize=(5, 5))


### PR DESCRIPTION
grid_helper_curvelinear and floating_axes, which can both draw axes that are neither horizontal nor vertical, need to compute the derivatives of the data-coords-to-screen-coords transform (actually, of data-coords-to-data-coords-of-intermediate-horizontal/vertical-axes) to get the angles at which to draw the axes labels, ticks and ticklabels.

Factor out this calculation into a _value_and_jacobian helper.  Instead of selecting the step size as some fraction of
lat_factor/lon_factor/delta_extremes, use the square root of machine precision epsilon, which is standard and (approximately) optimal for non-centered numerical differentiation (see e.g.
scipy.optimize.approx_fprime, or the Wikipedia article on numerical differentiation) -- and also happens to avoid introducing an extra paremeter into _value_and_jacobian.

Also lift some calculations out of get_tick_iterators (it doesn't really matter whether they are done inside or outside of get_tick_iterators, but dedenting the block is always nice).

The increases in tolerances arise because the calculations of the derivatives actually become *more* precise; for example, printing the angle returned by get_axislabel_pos_angle and running test_polar_box shows that previously the axes labels were drawn at angles of (45+1e-11) and 45.135 degrees, whereas they are now drawn at exactly 45 degrees.  These tolerances (0.27/0.12) are actually still very small; e.g. removing the text.kerning_factor backcompat setting would require bumping the tolerance to more than 5.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
