### PR TITLE
Add test for mutating input arrays #8990

### DIFF
--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2124,3 +2124,37 @@ def test_panecolor_rcparams():
                          'axes3d.zaxis.panecolor': 'b'}):
         fig = plt.figure(figsize=(1, 1))
         fig.add_subplot(projection='3d')
+
+
+@check_figures_equal(extensions=["png"])
+def test_mutating_input_arrays_y_and_z(fig_test, fig_ref):
+    """
+    Test to see if the `z` axis does not get mutated
+    after a call to `Axes3D.plot`
+
+    test cases came from GH#8990
+    """
+    ax1 = fig_test.add_subplot(111, projection='3d')
+    x = [1, 2, 3]
+    y = [0.0, 0.0, 0.0]
+    z = [0.0, 0.0, 0.0]
+    ax1.plot(x, y, z, 'o-')
+
+    ax1.set_ylim([0, 4])
+    ax1.set_zlim([0, 4])
+    fig_test.draw_without_rendering()
+
+    # mutate y,z to get a nontrivial line
+    y[:] = [1, 2, 3]
+    z[:] = [1, 2, 3]
+
+    # draw the same plot without mutating x and y
+    ax2 = fig_ref.add_subplot(111, projection='3d')
+    x = [1, 2, 3]
+    y = [0.0, 0.0, 0.0]
+    z = [0.0, 0.0, 0.0]
+    ax2.plot(x, y, z, 'o-')
+
+    ax2.set_ylim([0, 4])
+    ax2.set_zlim([0, 4])
+    fig_test.draw_without_rendering()

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2140,10 +2140,6 @@ def test_mutating_input_arrays_y_and_z(fig_test, fig_ref):
     z = [0.0, 0.0, 0.0]
     ax1.plot(x, y, z, 'o-')
 
-    ax1.set_ylim([0, 4])
-    ax1.set_zlim([0, 4])
-    fig_test.draw_without_rendering()
-
     # mutate y,z to get a nontrivial line
     y[:] = [1, 2, 3]
     z[:] = [1, 2, 3]
@@ -2154,7 +2150,3 @@ def test_mutating_input_arrays_y_and_z(fig_test, fig_ref):
     y = [0.0, 0.0, 0.0]
     z = [0.0, 0.0, 0.0]
     ax2.plot(x, y, z, 'o-')
-
-    ax2.set_ylim([0, 4])
-    ax2.set_zlim([0, 4])
-    fig_test.draw_without_rendering()


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
