### PR TITLE
Modernize a bit floating_axes tests.

### DIFF
--- a/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
@@ -6,8 +6,7 @@ import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import image_comparison
 from mpl_toolkits.axisartist.axislines import Subplot
 from mpl_toolkits.axisartist.floating_axes import (
-    FloatingSubplot,
-    GridHelperCurveLinear)
+    FloatingAxes, GridHelperCurveLinear)
 from mpl_toolkits.axisartist.grid_finder import FixedLocator
 from mpl_toolkits.axisartist import angle_helper
 
@@ -26,37 +25,27 @@ def test_curvelinear3():
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
           mprojections.PolarAxes.PolarTransform())
-
-    grid_locator1 = angle_helper.LocatorDMS(15)
-    tick_formatter1 = angle_helper.FormatterDMS()
-
-    grid_locator2 = FixedLocator([2, 4, 6, 8, 10])
-
-    grid_helper = GridHelperCurveLinear(tr,
-                                        extremes=(0, 360, 10, 3),
-                                        grid_locator1=grid_locator1,
-                                        grid_locator2=grid_locator2,
-                                        tick_formatter1=tick_formatter1,
-                                        tick_formatter2=None)
-
-    ax1 = FloatingSubplot(fig, 111, grid_helper=grid_helper)
-    fig.add_subplot(ax1)
+    grid_helper = GridHelperCurveLinear(
+        tr,
+        extremes=(0, 360, 10, 3),
+        grid_locator1=angle_helper.LocatorDMS(15),
+        grid_locator2=FixedLocator([2, 4, 6, 8, 10]),
+        tick_formatter1=angle_helper.FormatterDMS(),
+        tick_formatter2=None)
+    ax1 = fig.add_subplot(axes_class=FloatingAxes, grid_helper=grid_helper)
 
     r_scale = 10
     tr2 = mtransforms.Affine2D().scale(1, 1 / r_scale) + tr
-    grid_locator2 = FixedLocator([30, 60, 90])
-    grid_helper2 = GridHelperCurveLinear(tr2,
-                                         extremes=(0, 360,
-                                                   10 * r_scale, 3 * r_scale),
-                                         grid_locator2=grid_locator2)
+    grid_helper2 = GridHelperCurveLinear(
+        tr2,
+        extremes=(0, 360, 10 * r_scale, 3 * r_scale),
+        grid_locator2=FixedLocator([30, 60, 90]))
 
     ax1.axis["right"] = axis = grid_helper2.new_fixed_axis("right", axes=ax1)
 
     ax1.axis["left"].label.set_text("Test 1")
     ax1.axis["right"].label.set_text("Test 2")
-
-    for an in ["left", "right"]:
-        ax1.axis[an].set_visible(False)
+    ax1.axis["left", "right"].set_visible(False)
 
     axis = grid_helper.new_floating_axis(1, 7, axes=ax1,
                                          axis_direction="bottom")
@@ -85,27 +74,18 @@ def test_curvelinear4():
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
           mprojections.PolarAxes.PolarTransform())
-
-    grid_locator1 = angle_helper.LocatorDMS(5)
-    tick_formatter1 = angle_helper.FormatterDMS()
-
-    grid_locator2 = FixedLocator([2, 4, 6, 8, 10])
-
-    grid_helper = GridHelperCurveLinear(tr,
-                                        extremes=(120, 30, 10, 0),
-                                        grid_locator1=grid_locator1,
-                                        grid_locator2=grid_locator2,
-                                        tick_formatter1=tick_formatter1,
-                                        tick_formatter2=None)
-
-    ax1 = FloatingSubplot(fig, 111, grid_helper=grid_helper)
-    fig.add_subplot(ax1)
+    grid_helper = GridHelperCurveLinear(
+        tr,
+        extremes=(120, 30, 10, 0),
+        grid_locator1=angle_helper.LocatorDMS(5),
+        grid_locator2=FixedLocator([2, 4, 6, 8, 10]),
+        tick_formatter1=angle_helper.FormatterDMS(),
+        tick_formatter2=None)
+    ax1 = fig.add_subplot(axes_class=FloatingAxes, grid_helper=grid_helper)
 
     ax1.axis["left"].label.set_text("Test 1")
     ax1.axis["right"].label.set_text("Test 2")
-
-    for an in ["top"]:
-        ax1.axis[an].set_visible(False)
+    ax1.axis["top"].set_visible(False)
 
     axis = grid_helper.new_floating_axis(1, 70, axes=ax1,
                                          axis_direction="bottom")


### PR DESCRIPTION
Subplot has been subsumed into Axes; use add_subplot(axes_class=...) instead of manually adding axes to figures; inline some variables; rely on the ability to index multiple axises at once.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
