### PR TITLE
Doc: improve spelling and grammar

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/anchored_artists.py
+++ b/lib/mpl_toolkits/axes_grid1/anchored_artists.py
@@ -30,7 +30,7 @@ class AnchoredDrawingArea(AnchoredOffsetbox):
             Location of this artist.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
-            'lower left', 'lower center, 'lower right'.
+            'lower left', 'lower center', 'lower right'.
             For backward compatibility, numeric values are accepted as well.
             See the parameter *loc* of `.Legend` for details.
         pad : float, default: 0.4
@@ -88,7 +88,7 @@ class AnchoredAuxTransformBox(AnchoredOffsetbox):
             Location of this artist.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
-            'lower left', 'lower center, 'lower right'.
+            'lower left', 'lower center', 'lower right'.
             For backward compatibility, numeric values are accepted as well.
             See the parameter *loc* of `.Legend` for details.
         pad : float, default: 0.4
@@ -144,7 +144,7 @@ class AnchoredEllipse(AnchoredOffsetbox):
             Location of the ellipse.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
-            'lower left', 'lower center, 'lower right'.
+            'lower left', 'lower center', 'lower right'.
             For backward compatibility, numeric values are accepted as well.
             See the parameter *loc* of `.Legend` for details.
         pad : float, default: 0.1
@@ -194,7 +194,7 @@ class AnchoredSizeBar(AnchoredOffsetbox):
             Location of the size bar.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
-            'lower left', 'lower center, 'lower right'.
+            'lower left', 'lower center', 'lower right'.
             For backward compatibility, numeric values are accepted as well.
             See the parameter *loc* of `.Legend` for details.
         pad : float, default: 0.1
@@ -314,7 +314,7 @@ class AnchoredDirectionArrows(AnchoredOffsetbox):
             Location of the arrow.  Valid locations are
             'upper left', 'upper center', 'upper right',
             'center left', 'center', 'center right',
-            'lower left', 'lower center, 'lower right'.
+            'lower left', 'lower center', 'lower right'.
             For backward compatibility, numeric values are accepted as well.
             See the parameter *loc* of `.Legend` for details.
         angle : float, default: 0

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -167,10 +167,10 @@ class Divider:
         Parameters
         ----------
         nx, nx1 : int
-            Integers specifying the column-position of the
-            cell. When *nx1* is None, a single *nx*-th column is
-            specified. Otherwise location of columns spanning between *nx*
-            to *nx1* (but excluding *nx1*-th column) is specified.
+            Integers specifying the column-position of the cell. When *nx1* is
+            None, a single *nx*-th column is specified. Otherwise, the
+            location of columns spanning between *nx* to *nx1* (but excluding
+            *nx1*-th column) is specified.
         ny, ny1 : int
             Same as *nx* and *nx1*, but for row positions.
         axes
@@ -486,8 +486,8 @@ class AxesDivider(Divider):
         pad : :mod:`~mpl_toolkits.axes_grid1.axes_size` or float or str
             Padding between the axes.  float or str arguments are interpreted
             as for *size*.  Defaults to :rc:`figure.subplot.wspace` times the
-            main axes width (left or right axes) or :rc:`figure.subplot.hspace`
-            times the main axes height (bottom or top axes).
+            main Axes width (left or right axes) or :rc:`figure.subplot.hspace`
+            times the main Axes height (bottom or top axes).
         axes_class : subclass type of `~.axes.Axes`, optional
             The type of the new axes.  Defaults to the type of the main axes.
         **kwargs

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -48,7 +48,7 @@ class Grid:
     """
     A grid of Axes.
 
-    In Matplotlib, the axes location (and size) is specified in normalized
+    In Matplotlib, the Axes location (and size) is specified in normalized
     figure coordinates. This may not be ideal for images that needs to be
     displayed with a given aspect ratio; for example, it is difficult to
     display multiple images of a same size with some fixed padding between

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -1,6 +1,6 @@
 """
 Provides classes of simple units that will be used with AxesDivider
-class (or others) to determine the size of each axes. The unit
+class (or others) to determine the size of each Axes. The unit
 classes define `get_size` method that returns a tuple of two floats,
 meaning relative and absolute sizes, respectively.
 
@@ -207,7 +207,7 @@ class Fraction(_Base):
 @_api.deprecated("3.6", alternative="size + pad")
 class Padded(_Base):
     """
-    Return a instance where the absolute part of *size* is
+    Return an instance where the absolute part of *size* is
     increase by the amount of *pad*.
     """
 

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -342,7 +342,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
         Location to place the inset axes.  Valid locations are
         'upper left', 'upper center', 'upper right',
         'center left', 'center', 'center right',
-        'lower left', 'lower center, 'lower right'.
+        'lower left', 'lower center', 'lower right'.
         For backward compatibility, numeric values are accepted as well.
         See the parameter *loc* of `.Legend` for details.
 
@@ -450,7 +450,7 @@ def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
         Location to place the inset axes.  Valid locations are
         'upper left', 'upper center', 'upper right',
         'center left', 'center', 'center right',
-        'lower left', 'lower center, 'lower right'.
+        'lower left', 'lower center', 'lower right'.
         For backward compatibility, numeric values are accepted as well.
         See the parameter *loc* of `.Legend` for details.
 

--- a/lib/mpl_toolkits/axisartist/axisline_style.py
+++ b/lib/mpl_toolkits/axisartist/axisline_style.py
@@ -75,7 +75,7 @@ class AxislineStyle(_Style):
     """
     A container class which defines style classes for AxisArtists.
 
-    An instance of any axisline style class is an callable object,
+    An instance of any axisline style class is a callable object,
     whose call signature is ::
 
        __call__(self, axis_artist, path, transform)

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -130,7 +130,7 @@ class GridFinder:
                  tick_formatter2=None):
         """
         transform : transform from the image coordinate (which will be
-        the transData of the axes to the world coordinate.
+        the transData of the axes to the world coordinate).
 
         or transform = (transform_xy, inv_transform_xy)
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -514,10 +514,9 @@ class Patch3DCollection(PatchCollection):
         :class:`~matplotlib.collections.PatchCollection`. In addition,
         keywords *zs=0* and *zdir='z'* are available.
 
-        Also, the keyword argument *depthshade* is available to
-        indicate whether or not to shade the patches in order to
-        give the appearance of depth (default is *True*).
-        This is typically desired in scatter plots.
+        Also, the keyword argument *depthshade* is available to indicate
+        whether to shade the patches in order to give the appearance of depth
+        (default is *True*). This is typically desired in scatter plots.
         """
         self._depthshade = depthshade
         super().__init__(*args, **kwargs)
@@ -622,10 +621,9 @@ class Path3DCollection(PathCollection):
         :class:`~matplotlib.collections.PathCollection`. In addition,
         keywords *zs=0* and *zdir='z'* are available.
 
-        Also, the keyword argument *depthshade* is available to
-        indicate whether or not to shade the patches in order to
-        give the appearance of depth (default is *True*).
-        This is typically desired in scatter plots.
+        Also, the keyword argument *depthshade* is available to indicate
+        whether to shade the patches in order to give the appearance of depth
+        (default is *True*). This is typically desired in scatter plots.
         """
         self._depthshade = depthshade
         self._in_draw = False

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2349,7 +2349,7 @@ class Axes3D(Axes):
         """
         Generate a 3D barplot.
 
-        This method creates three dimensional barplot where the width,
+        This method creates three-dimensional barplot where the width,
         depth, height, and color of the bars can all be uniquely set.
 
         Parameters
@@ -2402,8 +2402,7 @@ class Axes3D(Axes):
         Returns
         -------
         collection : `~.art3d.Poly3DCollection`
-            A collection of three dimensional polygons representing
-            the bars.
+            A collection of three-dimensional polygons representing the bars.
         """
 
         had_data = self.has_data()
@@ -2908,7 +2907,7 @@ pivot='tail', normalize=False, **kwargs)
             The format for the data points / data lines. See `.plot` for
             details.
 
-            Use 'none' (case insensitive) to plot errorbars without any data
+            Use 'none' (case-insensitive) to plot errorbars without any data
             markers.
 
         ecolor : color, default: None


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
