### PR TITLE
BUG: Warn when an existing layout manager changes to tight layout

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3430,8 +3430,12 @@ class Figure(FigureBase):
         engine = TightLayoutEngine(pad=pad, h_pad=h_pad, w_pad=w_pad,
                                    rect=rect)
         try:
+            previous_engine = self.get_layout_engine()
             self.set_layout_engine(engine)
             engine.execute(self)
+            if not isinstance(previous_engine, TightLayoutEngine) \
+                    and previous_engine is not None:
+                _api.warn_external('The figure layout has changed to tight')
         finally:
             self.set_layout_engine(None)
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -598,6 +598,17 @@ def test_invalid_layouts():
         fig.set_layout_engine("constrained")
 
 
+@pytest.mark.parametrize('layout', ['constrained', 'compressed'])
+def test_layout_change_warning(layout):
+    """
+    Raise a warning when a previously assigned layout changes to tight using
+    plt.tight_layout().
+    """
+    fig, ax = plt.subplots(layout=layout)
+    with pytest.warns(UserWarning, match='The figure layout has changed to'):
+        plt.tight_layout()
+
+
 @check_figures_equal(extensions=["png", "pdf"])
 def test_add_artist(fig_test, fig_ref):
     fig_test.dpi = 100


### PR DESCRIPTION
## PR Summary
Warn the user with a `UserWarning` when a figure's layout changes from 'constrained' or 'compressed' to 'tight.'

Addresses #24387 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
