### PR TITLE
Transform ParasiteAxesBase._update_viewlim into standard callback.

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.6.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.6.0/removals.rst
@@ -152,7 +152,7 @@ The following class methods have been removed:
   ``RendererAgg.tostring_rgba_minimized()``
 - ``NavigationToolbar2Wx.get_canvas()``
 
-- ``ParasiteAxesBase.update_viewlim()``; use `.ParasiteAxesBase.apply_aspect`
+- ``ParasiteAxesBase.update_viewlim()``; use ``ParasiteAxesBase.apply_aspect``
   instead.
 - ``Subplot.get_geometry()``; use ``SubplotBase.get_subplotspec`` instead.
 - ``Subplot.change_geometry()``; use ``SubplotBase.set_subplotspec`` instead.


### PR DESCRIPTION
update_viewlim as an independent method was deprecated in da2f77a and
has since then been removed.  We could just inline _update_viewlim into
apply_aspect, but transforming it into a callback on
xlim_changed/ylim_changed helps moving towards the removal of
ParasiteAxes as a separate class and its replacement by standard (child)
axes with some extra attributes/callbacks set.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
