### PR TITLE
Use user-selected format in Tk savefig, rather than inferring it from the filename

### DIFF
--- a/doc/api/next_api_changes/behavior/24531-DOS.rst
+++ b/doc/api/next_api_changes/behavior/24531-DOS.rst
@@ -1,0 +1,8 @@
+Tk backend respects file format selection when saving figures
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When saving a figure from a Tkinter GUI to a filename without an
+extension, the file format is now selected based on the value of
+the dropdown menu, rather than defaulting to PNG. When the filename
+contains an extension, or the OS automatically appends one, the
+behavior remains unchanged.

--- a/doc/api/next_api_changes/development/24531-DOS.rst
+++ b/doc/api/next_api_changes/development/24531-DOS.rst
@@ -1,0 +1,13 @@
+Increase to minimum supported optional dependencies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For Matplotlib 3.8, the :ref:`minimum supported versions of optional dependencies
+<optional_dependencies>` are being bumped:
+
++------------+-----------------+---------------+
+| Dependency |  min in mpl3.7  | min in mpl3.8 |
++============+=================+===============+
+|   Tk       |      8.4        |     8.5       |
++------------+-----------------+---------------+
+
+This is consistent with our :ref:`min_deps_policy`

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -46,7 +46,7 @@ Matplotlib figures can be rendered to various user interfaces. See
 :ref:`what-is-a-backend` for more details on the optional Matplotlib backends
 and the capabilities they provide.
 
-* Tk_ (>= 8.4, != 8.6.0 or 8.6.1): for the Tk-based backends. Tk is part of
+* Tk_ (>= 8.5, != 8.6.0 or 8.6.1): for the Tk-based backends. Tk is part of
   most standard Python installations, but it's not part of Python itself and
   thus may not be present in rare cases.
 * PyQt6_ (>= 6.1), PySide6_, PyQt5_, or PySide2_: for the Qt-based backends.


### PR DESCRIPTION
## PR Summary
This also allows us to sort all extensions in alphabetical order, in line with the other backends, rather than having to put the default option first.

This change required raising the minimum supported version of Tk to 8.5, as discussed in #24450. I also removed a try statement around `iconphoto`, which should only have failed on Tk < 8.5 - it didn't feel big enough to deserve its own PR, but happy to separate it out if anyone disagrees.

Closes #24450.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [X] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [X] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
