### PR TITLE
Fix get_window_extent for collections

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -251,7 +251,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
         transform = self.get_transform()
         offset_trf = self.get_offset_transform()
         if not (isinstance(offset_trf, transforms.IdentityTransform)
-                or offset_trf.contains_branch(transData)):
+                or offset_trf.contains_branch(transData)
+                or isinstance(transData, transforms.IdentityTransform)):
             # if the offsets are in some coords other than data,
             # then don't use them for autoscaling.
             return transforms.Bbox.null()
@@ -269,7 +270,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
             # transforms.get_affine().contains_branch(transData).  But later,
             # be careful to only apply the affine part that remains.
 
-        if any(transform.contains_branch_seperately(transData)):
+        # if any(transform.contains_branch_seperately(transData)):
+        if (any(transform.contains_branch_seperately(transData)) or
+            isinstance(transData, transforms.IdentityTransform)):
             # collections that are just in data units (like quiver)
             # can properly have the axes limits set by their shape +
             # offset.  LineCollections that have no offsets can
@@ -973,6 +976,10 @@ class _CollectionWithSizes(Collection):
     def draw(self, renderer):
         self.set_sizes(self._sizes, self.figure.dpi)
         super().draw(renderer)
+
+    def get_window_extent(self, renderer=None):
+        self.set_sizes(self._sizes, self.figure.dpi)
+        return super().get_window_extent(renderer)
 
 
 class PathCollection(_CollectionWithSizes):


### PR DESCRIPTION
## PR Summary

Calling `get_window_extent` for (some of) collections returns indefinite extent.

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
sc = ax.scatter([0, 1], [0, 1], s=100)
bbox = sc.get_window_extent()
print(bbox)

fill = ax.fill_between([0, 1], [0, 1])
bbox = fill.get_window_extent()
print(bbox)
```

With current main branch, above code prints 

```
Bbox(x0=inf, y0=inf, x1=-inf, y1=-inf)
Bbox(x0=inf, y0=inf, x1=-inf, y1=-inf)
```

The PR is my naive attempt to fix this, which seem to work although my tests are limited.
It would be good if any expert can take a look into this

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
