### PR TITLE
[Doc] Document legend_handles and legend_handlers

### DIFF
--- a/doc/api/next_api_changes/deprecations/24538-OG.rst
+++ b/doc/api/next_api_changes/deprecations/24538-OG.rst
@@ -1,5 +1,4 @@
 ``legend.legendHandles``
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-... was undocumented and has been renamed to ``legend_handles``. Using the
-old name is deprecated.
+... was undocumented and has been renamed to ``legend_handles``. Using ``legendHandles`` is deprecated.

--- a/doc/api/next_api_changes/deprecations/24538-OG.rst
+++ b/doc/api/next_api_changes/deprecations/24538-OG.rst
@@ -1,0 +1,5 @@
+``legend.legendHandles``
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+... was undocumented and has been renamed to ``legend_handles``. Using the
+old name is deprecated.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -369,7 +369,7 @@ class Legend(Artist):
         Attributes
         ----------
         legend_handles
-            List of `.Artists` added as legend entries. 
+            List of `.Artist` objects added as legend entries.
 
             .. versionadded:: 3.7
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -360,7 +360,7 @@ class Legend(Artist):
         labels : list of str
             A list of labels to show next to the artists. The length of handles
             and labels should be the same. If they are not, they are truncated
-            to the shortest of both lengths.
+            to the length of the shorter list.
 
         Other Parameters
         ----------------
@@ -369,7 +369,7 @@ class Legend(Artist):
         Attributes
         ----------
         legend_handles
-            A list of legend handles used by the legend.
+            List of `.Artists` added as legend entries. 
 
             .. versionadded:: 3.7
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -360,11 +360,18 @@ class Legend(Artist):
         labels : list of str
             A list of labels to show next to the artists. The length of handles
             and labels should be the same. If they are not, they are truncated
-            to the smaller of both lengths.
+            to the shortest of both lengths.
 
         Other Parameters
         ----------------
         %(_legend_kw_doc)s
+
+        Attributes
+        ----------
+        legend_handles
+            A list of legend handles used by the legend.
+
+            .. versionadded:: 3.7
 
         Notes
         -----
@@ -397,7 +404,7 @@ class Legend(Artist):
         self._fontsize = self.prop.get_size_in_points()
 
         self.texts = []
-        self.legendHandles = []
+        self.legend_handles = []
         self._legend_title_box = None
 
         #: A dictionary with the extra handler mappings for this Legend
@@ -561,7 +568,7 @@ class Legend(Artist):
                 labelcolor = mpl.rcParams['text.color']
         if isinstance(labelcolor, str) and labelcolor in color_getters:
             getter_names = color_getters[labelcolor]
-            for handle, text in zip(self.legendHandles, self.texts):
+            for handle, text in zip(self.legend_handles, self.texts):
                 try:
                     if handle.get_array() is not None:
                         continue
@@ -593,6 +600,9 @@ class Legend(Artist):
                 text.set_color(color)
         else:
             raise ValueError(f"Invalid labelcolor: {labelcolor!r}")
+
+    legendHandles = _api.deprecated('3.7', alternative="legend_handles")(
+        property(lambda self: self.legend_handles))
 
     def _set_artist_props(self, a):
         """
@@ -838,7 +848,7 @@ class Legend(Artist):
         self._legend_box.set_figure(self.figure)
         self._legend_box.axes = self.axes
         self.texts = text_list
-        self.legendHandles = handle_list
+        self.legend_handles = handle_list
 
     def _auto_legend_data(self):
         """
@@ -885,12 +895,12 @@ class Legend(Artist):
 
     def get_lines(self):
         r"""Return the list of `~.lines.Line2D`\s in the legend."""
-        return [h for h in self.legendHandles if isinstance(h, Line2D)]
+        return [h for h in self.legend_handles if isinstance(h, Line2D)]
 
     def get_patches(self):
         r"""Return the list of `~.patches.Patch`\s in the legend."""
         return silent_list('Patch',
-                           [h for h in self.legendHandles
+                           [h for h in self.legend_handles
                             if isinstance(h, Patch)])
 
     def get_texts(self):

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -18,7 +18,7 @@ plot, *fontsize* is the fontsize in pixels, and *handlebox* is an
 `.OffsetBox` instance. Within the call, you should create relevant
 artists (using relevant properties from the *legend* and/or
 *orig_handle*) and add them into the *handlebox*. The artists need to
-be scaled according to the *fontsize* (note that the size is in pixel,
+be scaled according to the *fontsize* (note that the size is in pixels,
 i.e., this is dpi-scaled value).
 
 This module includes definition of several legend handler classes
@@ -161,7 +161,8 @@ class HandlerBase:
             The fontsize in pixels. The legend artists being created should
             be scaled according to the given fontsize.
         trans :  `~matplotlib.transforms.Transform`
-            The transform that is applied to the legend artists being created.
+            The transform that is applied to the legend artists being created.  Typically 
+            from unit coordinates in the handler box to screen coordinates.
         """
         raise NotImplementedError('Derived must override')
 
@@ -247,7 +248,7 @@ class HandlerLine2DCompound(HandlerNpoints):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-        # Doc-string inherited
+        # docstring inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -161,8 +161,9 @@ class HandlerBase:
             The fontsize in pixels. The legend artists being created should
             be scaled according to the given fontsize.
         trans :  `~matplotlib.transforms.Transform`
-            The transform that is applied to the legend artists being created.  Typically 
-            from unit coordinates in the handler box to screen coordinates.
+            The transform that is applied to the legend artists being created.
+            Typically from unit coordinates in the handler box to screen
+            coordinates.
         """
         raise NotImplementedError('Derived must override')
 
@@ -307,7 +308,7 @@ class HandlerLine2D(HandlerNpoints):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-        # Doc-string inherited
+        # docstring inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
@@ -372,7 +373,7 @@ class HandlerPatch(HandlerBase):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
-        # Doc-string inherited
+        # docstring inherited
         p = self._create_patch(legend, orig_handle,
                                xdescent, ydescent, width, height, fontsize)
         self.update_prop(p, orig_handle, legend)
@@ -406,7 +407,7 @@ class HandlerStepPatch(HandlerBase):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
-        # Doc-string inherited
+        # docstring inherited
         if orig_handle.get_fill() or (orig_handle.get_hatch() is not None):
             p = self._create_patch(orig_handle, xdescent, ydescent, width,
                                    height)
@@ -437,7 +438,7 @@ class HandlerLineCollection(HandlerLine2D):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
-        # Doc-string inherited
+        # docstring inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
         ydata = np.full_like(xdata, (height - ydescent) / 2)
@@ -504,7 +505,7 @@ class HandlerRegularPolyCollection(HandlerNpointsYoffsets):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-        # Doc-string inherited
+        # docstring inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
@@ -568,7 +569,7 @@ class HandlerErrorbar(HandlerLine2D):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-        # Doc-string inherited
+        # docstring inherited
         plotlines, caplines, barlinecols = orig_handle
 
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
@@ -687,7 +688,7 @@ class HandlerStem(HandlerNpointsYoffsets):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-        # Doc-string inherited
+        # docstring inherited
         markerline, stemlines, baseline = orig_handle
         # Check to see if the stemcontainer is storing lines as a list or a
         # LineCollection. Eventually using a list will be removed, and this
@@ -765,7 +766,7 @@ class HandlerTuple(HandlerBase):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-        # Doc-string inherited
+        # docstring inherited
         handler_map = legend.get_legend_handler_map()
 
         if self._ndivide is None:
@@ -832,7 +833,7 @@ class HandlerPolyCollection(HandlerBase):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
-        # Doc-string inherited
+        # docstring inherited
         p = Rectangle(xy=(-xdescent, -ydescent),
                       width=width, height=height)
         self.update_prop(p, orig_handle, legend)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -9,16 +9,16 @@ Default legend handlers.
     </tutorials/intermediate/legend_guide>` before reading this documentation.
 
 Legend handlers are expected to be a callable object with a following
-signature. ::
+signature::
 
     legend_handler(legend, orig_handle, fontsize, handlebox)
 
 Where *legend* is the legend itself, *orig_handle* is the original
-plot, *fontsize* is the fontsize in pixels, and *handlebox* is a
-OffsetBox instance. Within the call, you should create relevant
+plot, *fontsize* is the fontsize in pixels, and *handlebox* is an
+`.OffsetBox` instance. Within the call, you should create relevant
 artists (using relevant properties from the *legend* and/or
-*orig_handle*) and add them into the handlebox. The artists need to
-be scaled according to the fontsize (note that the size is in pixel,
+*orig_handle*) and add them into the *handlebox*. The artists need to
+be scaled according to the *fontsize* (note that the size is in pixel,
 i.e., this is dpi-scaled value).
 
 This module includes definition of several legend handler classes
@@ -49,7 +49,7 @@ class HandlerBase:
     A base class for default legend handlers.
 
     The derived classes are meant to override *create_artists* method, which
-    has a following signature.::
+    has the following signature::
 
       def create_artists(self, legend, orig_handle,
                          xdescent, ydescent, width, height, fontsize,
@@ -61,6 +61,18 @@ class HandlerBase:
 
     """
     def __init__(self, xpad=0., ypad=0., update_func=None):
+        """
+        Parameters
+        ----------
+
+        xpad : float, optional
+            Padding in x-direction.
+        ypad : float, optional
+            Padding in y-direction.
+        update_func : callable, optional
+            Function for updating the legend handler properties from another
+            legend handler, used by `~HandlerBase.update_prop`.
+        """
         self._xpad, self._ypad = xpad, ypad
         self._update_prop_func = update_func
 
@@ -133,6 +145,24 @@ class HandlerBase:
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
+        """
+        Return the legend artists generated.
+
+        Parameters
+        ----------
+        legend : `~matplotlib.legend.Legend`
+            The legend for which these legend artists are being created.
+        orig_handle : `~matplotlib.artist.Artist` or similar
+            The object for which these legend artists are being created.
+        xdescent, ydescent, width, height : int
+            The rectangle (*xdescent*, *ydescent*, *width*, *height*) that the
+            legend artists being created should fit within.
+        fontsize : int
+            The fontsize in pixels. The legend artists being created should
+            be scaled according to the given fontsize.
+        trans :  `~matplotlib.transforms.Transform`
+            The transform that is applied to the legend artists being created.
+        """
         raise NotImplementedError('Derived must override')
 
 
@@ -217,7 +247,7 @@ class HandlerLine2DCompound(HandlerNpoints):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-
+        # Doc-string inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
@@ -276,7 +306,7 @@ class HandlerLine2D(HandlerNpoints):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-
+        # Doc-string inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
@@ -341,6 +371,7 @@ class HandlerPatch(HandlerBase):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
+        # Doc-string inherited
         p = self._create_patch(legend, orig_handle,
                                xdescent, ydescent, width, height, fontsize)
         self.update_prop(p, orig_handle, legend)
@@ -374,6 +405,7 @@ class HandlerStepPatch(HandlerBase):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
+        # Doc-string inherited
         if orig_handle.get_fill() or (orig_handle.get_hatch() is not None):
             p = self._create_patch(orig_handle, xdescent, ydescent, width,
                                    height)
@@ -404,7 +436,7 @@ class HandlerLineCollection(HandlerLine2D):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
-
+        # Doc-string inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
         ydata = np.full_like(xdata, (height - ydescent) / 2)
@@ -471,6 +503,7 @@ class HandlerRegularPolyCollection(HandlerNpointsYoffsets):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
+        # Doc-string inherited
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
                                              width, height, fontsize)
 
@@ -534,7 +567,7 @@ class HandlerErrorbar(HandlerLine2D):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-
+        # Doc-string inherited
         plotlines, caplines, barlinecols = orig_handle
 
         xdata, xdata_marker = self.get_xdata(legend, xdescent, ydescent,
@@ -653,6 +686,7 @@ class HandlerStem(HandlerNpointsYoffsets):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
+        # Doc-string inherited
         markerline, stemlines, baseline = orig_handle
         # Check to see if the stemcontainer is storing lines as a list or a
         # LineCollection. Eventually using a list will be removed, and this
@@ -730,7 +764,7 @@ class HandlerTuple(HandlerBase):
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize,
                        trans):
-
+        # Doc-string inherited
         handler_map = legend.get_legend_handler_map()
 
         if self._ndivide is None:
@@ -797,6 +831,7 @@ class HandlerPolyCollection(HandlerBase):
 
     def create_artists(self, legend, orig_handle,
                        xdescent, ydescent, width, height, fontsize, trans):
+        # Doc-string inherited
         p = Rectangle(xy=(-xdescent, -ydescent),
                       width=width, height=height)
         self.update_prop(p, orig_handle, legend)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3331,7 +3331,7 @@ class ArrowStyle(_Style):
             return vertices_arrow, codes_arrow
 
         def transmute(self, path, mutation_size, linewidth):
-            # Doc-string inherited
+            # docstring inherited
             if self._beginarrow_head or self._endarrow_head:
                 head_length = self.head_length * mutation_size
                 head_width = self.head_width * mutation_size
@@ -3598,7 +3598,7 @@ class ArrowStyle(_Style):
             super().__init__()
 
         def transmute(self, path, mutation_size, linewidth):
-            # Doc-string inherited
+            # docstring inherited
             x0, y0, x1, y1, x2, y2 = self.ensure_quadratic_bezier(path)
 
             # divide the path into a head and a tail
@@ -3677,7 +3677,7 @@ class ArrowStyle(_Style):
             super().__init__()
 
         def transmute(self, path, mutation_size, linewidth):
-            # Doc-string inherited
+            # docstring inherited
             x0, y0, x1, y1, x2, y2 = self.ensure_quadratic_bezier(path)
 
             # divide the path into a head and a tail
@@ -3766,7 +3766,7 @@ class ArrowStyle(_Style):
             super().__init__()
 
         def transmute(self, path, mutation_size, linewidth):
-            # Doc-string inherited
+            # docstring inherited
             x0, y0, x1, y1, x2, y2 = self.ensure_quadratic_bezier(path)
 
             arrow_path = [(x0, y0), (x1, y1), (x2, y2)]

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -147,7 +147,7 @@ def test_legend_label_with_leading_underscore():
     with pytest.warns(UserWarning,
                       match=r"starts with '_'.*excluded from the legend."):
         legend = ax.legend(handles=[line])
-    assert len(legend.legendHandles) == 0
+    assert len(legend.legend_handles) == 0
 
 
 @image_comparison(['legend_labels_first.png'], remove_text=True)
@@ -550,7 +550,7 @@ def test_linecollection_scaled_dashes():
     ax.add_collection(lc3)
 
     leg = ax.legend([lc1, lc2, lc3], ["line1", "line2", 'line 3'])
-    h1, h2, h3 = leg.legendHandles
+    h1, h2, h3 = leg.legend_handles
 
     for oh, lh in zip((lc1, lc2, lc3), (h1, h2, h3)):
         assert oh.get_linestyles()[0] == lh._dash_pattern
@@ -970,7 +970,7 @@ def test_legend_draggable(draggable):
 def test_alpha_handles():
     x, n, hh = plt.hist([1, 2, 3], alpha=0.25, label='data', color='red')
     legend = plt.legend()
-    for lh in legend.legendHandles:
+    for lh in legend.legend_handles:
         lh.set_alpha(1.0)
     assert lh.get_facecolor()[:-1] == hh[1].get_facecolor()[:-1]
     assert lh.get_edgecolor()[:-1] == hh[1].get_edgecolor()[:-1]
@@ -1102,7 +1102,7 @@ def test_handlerline2d():
     ax.scatter([0, 1], [0, 1], marker="v")
     handles = [mlines.Line2D([0], [0], marker="v")]
     leg = ax.legend(handles, ["Aardvark"], numpoints=1)
-    assert handles[0].get_marker() == leg.legendHandles[0].get_marker()
+    assert handles[0].get_marker() == leg.legend_handles[0].get_marker()
 
 
 def test_subfigure_legend():

--- a/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
@@ -55,7 +55,7 @@ def test_linecollection_scaled_dashes():
     ax.add_collection(lc3)
 
     leg = ax.legend([lc1, lc2, lc3], ['line1', 'line2', 'line 3'])
-    h1, h2, h3 = leg.legendHandles
+    h1, h2, h3 = leg.legend_handles
 
     for oh, lh in zip((lc1, lc2, lc3), (h1, h2, h3)):
         assert oh.get_linestyles()[0] == lh._dash_pattern
@@ -67,7 +67,7 @@ def test_handlerline3d():
     ax.scatter([0, 1], [0, 1], marker="v")
     handles = [art3d.Line3D([0], [0], [0], marker="v")]
     leg = ax.legend(handles, ["Aardvark"], numpoints=1)
-    assert handles[0].get_marker() == leg.legendHandles[0].get_marker()
+    assert handles[0].get_marker() == leg.legend_handles[0].get_marker()
 
 
 def test_contour_legend_elements():


### PR DESCRIPTION
## PR Summary

Closes #20639

I'm not 100% sure about the documented arguments in `legend_handlers`, so please check those carefully.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
