### PR TITLE
AxisArtist to use standard tick directions and have an option for tick orientation

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -944,10 +944,10 @@ class AxisArtist(martist.Artist):
         multiplier = (
             self.major_ticks.get_visible()
             * {"out": 1, "inout": .5, "in": 0}[self.major_ticks._tickdir])
-        self.major_ticklabels._set_external_pad(
-            multiplier * self.major_ticks._ticksize * dpi_cor)
-        self.minor_ticklabels._set_external_pad(
-            multiplier * self.major_ticks._ticksize * dpi_cor)
+        self.major_ticklabels._external_pad = \
+            multiplier * self.major_ticks._ticksize * dpi_cor
+        self.minor_ticklabels._external_pad = \
+            multiplier * self.major_ticks._ticksize * dpi_cor
 
         majortick_iter, minortick_iter = \
             self._axis_artist_helper.get_tick_iterators(self.axes)

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -1021,15 +1021,27 @@ class AxisArtist(martist.Artist):
         if not self.label.get_visible():
             return
 
+        # We calculate the pad size for the axislabel.
         if self._ticklabel_add_angle != self._axislabel_add_angle:
-            if ((self.major_ticks.get_visible()  # ???
-                 and not self.major_ticks.get_tick_out())
-                or (self.minor_ticks.get_visible()
-                    and not self.major_ticks.get_tick_out())):
-                axislabel_pad = self.major_ticks._ticksize
-            else:
-                axislabel_pad = 0
+            # If ticklabels and axislabel are on differenct side, we only
+            # conside the padding for the ticks only.
+
+            ticksizes = []
+            # ticksize of the major_ticks
+            ticksizes.append(
+                self.major_ticks.get_visible()
+                * {"out": 1, "inout": .5, "in": 0}[self.major_ticks._tickdir]
+                * self.major_ticks._ticksize
+            )
+            ticksizes.append(
+                self.minor_ticks.get_visible()
+                * {"out": 1, "inout": .5, "in": 0}[self.minor_ticks._tickdir]
+                * self.minor_ticks._ticksize
+            )
+            axislabel_pad = max(ticksizes)
         else:
+            # If ticklabels and axislabel are on the same side, we use values
+            # from the the ticklabels.
             axislabel_pad = max(self.major_ticklabels._axislabel_pad,
                                 self.minor_ticklabels._axislabel_pad)
 

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -313,6 +313,10 @@ class GridHelperCurveLinear(GridHelperBase):
         # axisline.major_ticklabels.set_visible(True)
         # axisline.minor_ticklabels.set_visible(False)
 
+        # For floating axis, we force the tick_orientation of "parallel".
+        axisline.major_ticks.set_tick_orientation("parallel")
+        axisline.minor_ticks.set_tick_orientation("parallel")
+
         return axisline
 
     def _update_grid(self, x1, y1, x2, y2):

--- a/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
@@ -78,8 +78,9 @@ def test_ticklabels():
 
 @image_comparison(['axis_artist.png'], style='default')
 def test_axis_artist():
-    # Remove this line when this test image is regenerated.
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     fig, ax = plt.subplots()
 

--- a/lib/mpl_toolkits/axisartist/tests/test_axislines.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_axislines.py
@@ -9,8 +9,9 @@ from mpl_toolkits.axisartist import Axes, SubplotHost
 
 @image_comparison(['SubplotZero.png'], style='default')
 def test_SubplotZero():
-    # Remove this line when this test image is regenerated.
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     fig = plt.figure()
 
@@ -30,8 +31,9 @@ def test_SubplotZero():
 
 @image_comparison(['Subplot.png'], style='default')
 def test_Subplot():
-    # Remove this line when this test image is regenerated.
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     fig = plt.figure()
 
@@ -59,9 +61,10 @@ def test_Axes():
 
 @image_comparison(['ParasiteAxesAuxTrans_meshplot.png'],
                   remove_text=True, style='default', tol=0.075)
-def test_ParasiteAxesAuxTrans():
-    # Remove this line when this test image is regenerated.
+def test_ParasiteAxesAuxTrans(parasite_cls):
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     data = np.ones((6, 6))
     data[2, 2] = 2

--- a/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
@@ -21,6 +21,9 @@ def test_subplot():
 # remove when image is regenerated.
 @image_comparison(['curvelinear3.png'], style='default', tol=5)
 def test_curvelinear3():
+    # Remove this lines when this test image is regenerated.
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
+
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
@@ -67,8 +70,9 @@ def test_curvelinear3():
 # remove when image is regenerated.
 @image_comparison(['curvelinear4.png'], style='default', tol=0.9)
 def test_curvelinear4():
-    # Remove this line when this test image is regenerated.
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     fig = plt.figure(figsize=(5, 5))
 

--- a/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
@@ -16,6 +16,9 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import \
 
 @image_comparison(['custom_transform.png'], style='default', tol=0.2)
 def test_custom_transform():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
+
     class MyTransform(Transform):
         input_dims = output_dims = 2
 
@@ -77,8 +80,9 @@ def test_custom_transform():
 
 @image_comparison(['polar_box.png'], style='default', tol=0.04)
 def test_polar_box():
-    # Remove this line when this test image is regenerated.
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     fig = plt.figure(figsize=(5, 5))
 
@@ -139,8 +143,9 @@ def test_polar_box():
 
 @image_comparison(['axis_direction.png'], style='default', tol=0.071)
 def test_axis_direction():
-    # Remove this line when this test image is regenerated.
+    # Remove these lines when this test image is regenerated.
     plt.rcParams['text.kerning_factor'] = 6
+    plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "in"})
 
     fig = plt.figure(figsize=(5, 5))
 


### PR DESCRIPTION
## PR Summary
This is a rebased version of PR #19102 that addresses issue #19101. It also add an option to change the orientation of ticks. The ticks in AxisArtist were drawn along the gridlines and may not be perpendicular to spines. This PR introduce an option of `tick_orientation` that controls this behavior so that it can be normal to spines (see the discussion in #19102).

* It will respect "xtick.direction" and "ytick.direction" in rcParams.
* The `tick.orientation` can be one of  "parallel", "normal" and "auto". Defaut is "auto".
    - 'parallel' - ticks along the grid lines
    - 'normal' - ticks normal to axis line.
    -  'auto' - 'normal' if tickdir is 'out' else 'parallel'

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
