### PR TITLE
ENH: Add warning for SymLogScale when values in linear scale range

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -389,6 +389,11 @@ class InvertedSymmetricalLogTransform(Transform):
 
     def transform_non_affine(self, a):
         abs_a = np.abs(a)
+        if (abs_a < self.linthresh).all():
+            _api.warn_external(
+                "All values for SymLogScale are below linthresh, making "
+                "it effectively linear. You likely should lower the value "
+                "of linthresh. ")
         with np.errstate(divide="ignore", invalid="ignore"):
             out = np.sign(a) * self.linthresh * (
                 np.power(self.base,

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -14,6 +14,8 @@ from numpy.testing import assert_allclose
 import io
 import pytest
 
+import random
+
 
 @check_figures_equal()
 def test_log_scales(fig_test, fig_ref):
@@ -53,6 +55,25 @@ def test_symlog_mask_nan():
     out = slti.transform_non_affine(slt.transform_non_affine(x))
     assert_allclose(out, x)
     assert type(out) == type(x)
+
+
+def test_symlog_linthresh():
+    fig, ax = plt.subplots()
+
+    n_samples = 100
+
+    upper_bound = 1.0
+
+    x = [random.uniform(0.0, upper_bound) for _ in range(n_samples)]
+    y = [random.uniform(0.0, upper_bound) for _ in range(n_samples)]
+
+    with pytest.warns(UserWarning) as record:
+        plt.plot(x, y, 'o')
+        ax.set_xscale('symlog')
+        ax.set_yscale('symlog')
+        plt.show()
+
+    assert len(record) == 1
 
 
 @image_comparison(['logit_scales.png'], remove_text=True)


### PR DESCRIPTION
## PR Summary

The pull request addresses a need for generating a warning when a SymLogScale receives values that are all in the linear regime. The PR includes a baseline implementation as discussed in #24550. Some optional enhancements are in consideration. 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`