### PR TITLE
Fix incorrect window_extent of AxesImage

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -935,7 +935,7 @@ class AxesImage(_ImageBase):
     def get_window_extent(self, renderer=None):
         x0, x1, y0, y1 = self._extent
         bbox = Bbox.from_extents([x0, y0, x1, y1])
-        return bbox.transformed(self.axes.transData)
+        return bbox.transformed(self.get_transform())
 
     def make_image(self, renderer, magnification=1.0, unsampled=False):
         # docstring inherited

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -589,6 +589,20 @@ def test_get_window_extent_for_AxisImage():
 
     assert_array_equal(im_bbox.get_points(), [[400, 200], [700, 900]])
 
+    fig, ax = plt.subplots(figsize=(10, 10), dpi=100)
+    ax.set_position([0, 0, 1, 1])
+    ax.set_xlim(1, 2)
+    ax.set_ylim(0, 1)
+    im_obj = ax.imshow(
+        im, extent=[0.4, 0.7, 0.2, 0.9], interpolation='nearest',
+        transform=ax.transAxes)
+
+    fig.canvas.draw()
+    renderer = fig.canvas.renderer
+    im_bbox = im_obj.get_window_extent(renderer)
+
+    assert_array_equal(im_bbox.get_points(), [[400, 200], [700, 900]])
+
 
 @image_comparison(['zoom_and_clip_upper_origin.png'],
                   remove_text=True, style='mpl20')


### PR DESCRIPTION
## PR Summary

`AxesImage` can take a transform parameter. However,  `AxesImage.get_window_extent` does not respect its value and simply use the hardcoded value of `transData` (the `draw` method does respect the transform parameter).
The PR makes the `get_window_extent` method to use the return value of `get_transfrom`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
