### PR TITLE
Improve argument checking for set_xticks().

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -162,6 +162,8 @@ def check_shape(_shape, **kwargs):
                                     if n is not None
                                     else next(dim_labels)
                                     for n in target_shape))
+            if len(target_shape) == 1:
+                text_shape += ","
 
             raise ValueError(
                 f"{k!r} must be {len(target_shape)}D "

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2046,6 +2046,7 @@ class Axis(martist.Artist):
 
         # XXX if the user changes units, the information will be lost here
         ticks = self.convert_units(ticks)
+        locator = mticker.FixedLocator(ticks)  # validate ticks early.
         for name, axis in self.axes._axis_map.items():
             if self is axis:
                 shared = [
@@ -2061,10 +2062,10 @@ class Axis(martist.Artist):
                 axis.set_view_interval(min(ticks), max(ticks))
         self.axes.stale = True
         if minor:
-            self.set_minor_locator(mticker.FixedLocator(ticks))
+            self.set_minor_locator(locator)
             return self.get_minor_ticks(len(ticks))
         else:
-            self.set_major_locator(mticker.FixedLocator(ticks))
+            self.set_major_locator(locator)
             return self.get_major_ticks(len(ticks))
 
     def set_ticks(self, ticks, labels=None, *, minor=False, **kwargs):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5788,13 +5788,18 @@ def test_set_ticks_with_labels(fig_test, fig_ref):
     ax.set_yticks([2, 4], ['A', 'B'], minor=True)
 
 
-def test_set_noniterable_ticklabels():
-    # Ensure a useful TypeError message is raised
-    # when given a non-iterable ticklabels argument
-    # Pull request #22710
+def test_xticks_bad_args():
+    ax = plt.figure().add_subplot()
     with pytest.raises(TypeError, match='must be a sequence'):
-        fig, ax = plt.subplots(2)
-        ax[1].set_xticks([2, 9], 3.1)
+        ax.set_xticks([2, 9], 3.1)
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((-1, 1)))
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((1, -1)))
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((-1, 1)), labels=range(4))
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((1, -1)), labels=range(4))
 
 
 def test_subsampled_ticklabels():

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1718,6 +1718,7 @@ class FixedLocator(Locator):
 
     def __init__(self, locs, nbins=None):
         self.locs = np.asarray(locs)
+        _api.check_shape((None,), locs=self.locs)
         self.nbins = max(nbins, 2) if nbins is not None else None
 
     def set_params(self, nbins=None):


### PR DESCRIPTION
## PR Summary

Most addresses #24480, although @timhoffm's point about documentation (https://github.com/matplotlib/matplotlib/issues/24480#issuecomment-1319264238) remains.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
