### PR TITLE
Add explicit permissions to GitHub Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,4 +229,6 @@ workflows:
   version: 2
   build:
     jobs:
+      # NOTE: If you rename this job, then you must update the `if` condition
+      # and `circleci-jobs` option in `.github/workflows/circleci.yml`.
       - docs-python38

--- a/.github/workflows/cibuildsdist.yml
+++ b/.github/workflows/cibuildsdist.yml
@@ -1,3 +1,4 @@
+---
 name: Build CI sdist and wheel
 
 on:
@@ -16,6 +17,9 @@ on:
       - synchronize
       - reopened
       - labeled
+
+permissions:
+  contents: read
 
 jobs:
   build_sdist:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,3 +1,4 @@
+---
 name: Build CI wheels
 
 on:
@@ -16,6 +17,9 @@ on:
       - synchronize
       - reopened
       - labeled
+
+permissions:
+  contents: read
 
 jobs:
   build_wheels:

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,7 +1,11 @@
+---
 on: [status]
+permissions:
+  statuses: write
 jobs:
   circleci_artifacts_redirector_job:
     runs-on: ubuntu-latest
+    if: "${{ github.event.context == 'ci/circleci: docs-python38' }}"
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
@@ -11,3 +15,7 @@ jobs:
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: docs-python38
           job-title: View the built docs
+      - name: Check the URL
+        if: github.event.status != 'pending'
+        run: |
+          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA

--- a/.github/workflows/clean_pr.yml
+++ b/.github/workflows/clean_pr.yml
@@ -1,5 +1,9 @@
+---
 name: PR cleanliness
 on: [pull_request]
+
+permissions:
+  contents: read
 
 jobs:
   pr_clean:

--- a/.github/workflows/conflictcheck.yml
+++ b/.github/workflows/conflictcheck.yml
@@ -1,3 +1,4 @@
+---
 name: "Maintenance"
 on:
   # So that PRs touching the same files as the push are updated
@@ -7,6 +8,9 @@ on:
   # In `pull_request` we wouldn't be able to change labels of fork PRs
   pull_request_target:
     types: [synchronize]
+
+permissions:
+  pull-requests: write
 
 jobs:
   main:

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -7,6 +7,9 @@ on:
   # Run on demand with workflow dispatch
   workflow_dispatch:
 
+permissions:
+  actions: read
+
 jobs:
   upload_nightly_wheels:
     name: Upload nightly wheels to Anaconda Cloud

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -1,6 +1,10 @@
+---
 name: PR Greetings
 
 on: [pull_request_target]
+
+permissions:
+  pull-requests: write
 
 jobs:
   greeting:

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,5 +1,11 @@
+---
 name: Linting
 on: [pull_request]
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
 
 jobs:
   flake8:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,4 @@
+---
 name: Tests
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.number }}-${{ github.event.ref }}
@@ -25,6 +26,8 @@ env:
 jobs:
   test:
     if: "github.event_name == 'workflow_dispatch' || github.repository == 'matplotlib/matplotlib' && !contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, '[skip github]')"
+    permissions:
+      contents: read
     name: "Python ${{ matrix.python-version }} on ${{ matrix.os }} ${{ matrix.name-suffix }}"
     runs-on: ${{ matrix.os }}
 
@@ -285,9 +288,11 @@ jobs:
 
   # Separate dependent job to only upload one issue from the matrix of jobs
   create-issue:
-    runs-on: ubuntu-latest
-    needs: [test]
     if: ${{ failure() && github.event_name == 'schedule' }}
+    needs: [test]
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
     name: "Create issue on failure"
 
     steps:


### PR DESCRIPTION
## PR Summary

While everything we do is basically public, there's no reason to give the tokens on these jobs full permissions. (Note, once a single item is added, all other permissions are disabled.)

Also update the CircleCI check to the action's latest recommended jobs.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`