### PR TITLE
Simplify implementation of _is_sorted.

### DIFF
--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -807,54 +807,29 @@ static PyObject *Py_is_sorted(PyObject *self, PyObject *obj)
 
     /* Handle just the most common types here, otherwise coerce to
     double */
-    switch(PyArray_TYPE(array)) {
+    switch (PyArray_TYPE(array)) {
     case NPY_INT:
-        {
-            _is_sorted_int<npy_int> is_sorted;
-            result = is_sorted(array);
-        }
+        result = is_sorted<npy_int>(array);
         break;
-
     case NPY_LONG:
-        {
-            _is_sorted_int<npy_long> is_sorted;
-            result = is_sorted(array);
-        }
+        result = is_sorted<npy_long>(array);
         break;
-
     case NPY_LONGLONG:
-        {
-            _is_sorted_int<npy_longlong> is_sorted;
-            result = is_sorted(array);
-        }
+        result = is_sorted<npy_longlong>(array);
         break;
-
     case NPY_FLOAT:
-        {
-            _is_sorted<npy_float> is_sorted;
-            result = is_sorted(array);
-        }
+        result = is_sorted<npy_float>(array);
         break;
-
     case NPY_DOUBLE:
-        {
-            _is_sorted<npy_double> is_sorted;
-            result = is_sorted(array);
-        }
+        result = is_sorted<npy_double>(array);
         break;
-
     default:
-        {
-            Py_DECREF(array);
-            array = (PyArrayObject *)PyArray_FromObject(obj, NPY_DOUBLE, 1, 1);
-
-            if (array == NULL) {
-                return NULL;
-            }
-
-            _is_sorted<npy_double> is_sorted;
-            result = is_sorted(array);
+        Py_DECREF(array);
+        array = (PyArrayObject *)PyArray_FromObject(obj, NPY_DOUBLE, 1, 1);
+        if (array == NULL) {
+            return NULL;
         }
+        result = is_sorted<npy_double>(array);
     }
 
     Py_DECREF(array);


### PR DESCRIPTION
We don't need a separate specialization for ints (we can rely on the compiler to inline isnan<int> as always false), and having a separate loop to find the first non-nan value isn't necessary either.

One change in behavior this causes (in this private function) is that a fully nan input is considered as being sorted, but this is consistent with empty inputs being considered sorted too, and also OK with the actual use of the function (determine whether to go through a fast path in drawing lines -- fully nan lines are not drawn anyways).

followup to #24575, which I unfortunately have to slightly revert (going back to `x != x`) due to the lack of `isnan(IntegralValue)` on MSVC (https://stackoverflow.com/questions/61646166/how-to-resolve-fpclassify-ambiguous-call-to-overloaded-function), even though cppreference declares that it should exist (https://en.cppreference.com/w/cpp/numeric/math/isnan)...

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
