### PR TITLE
DOC: Don't try to link paths that are on a different drive

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -682,7 +682,10 @@ if link_github:
                     if lineno else "")
 
         startdir = Path(matplotlib.__file__).parent.parent
-        fn = os.path.relpath(fn, start=startdir).replace(os.path.sep, '/')
+        try:
+            fn = os.path.relpath(fn, start=startdir).replace(os.path.sep, '/')
+        except ValueError:
+            return None
 
         if not fn.startswith(('matplotlib/', 'mpl_toolkits/')):
             return None


### PR DESCRIPTION
## PR Summary

This may happen if Python is installed on C: and Matplotlib is installed on some other drive. As the point of this extension is to create GitHub links for Matplotlib *only*, we should ignore all paths that cannot be relativized to it.

Fixes #24574

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`