### PR TITLE
ci: Stop building wheels on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -79,17 +79,7 @@ test_script:
   - echo The following args are passed to pytest %PYTEST_ARGS%
   - pytest %PYTEST_ARGS%
 
-after_test:
-  # After the tests were a success, build wheels.
-  # Hide the output, the copied files really clutter the build log...
-  - 'python setup.py bdist_wheel > NUL:'
-  - dir dist\
-  - echo finished...
-
 artifacts:
-  - path: dist\*
-    name: packages
-
   - path: result_images\*
     name: result_images
     type: zip


### PR DESCRIPTION
## PR Summary

We rarely need them, and if so, then there's the cibuildwheel job on GitHub Actions that can be enabled _where necessary_ (and matches what actually goes on PyPI.) We also create nightly wheel snapshots from there already, so there's even less use for the AppVeyor wheels.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`