### PR TITLE
Fix: Gracefully fail the string validator for tuple inputs

### DIFF
--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -68,7 +68,7 @@ class ValidateInStrings:
             name, = (k for k, v in globals().items() if v is self)
             _api.warn_deprecated(
                 self._deprecated_since, name=name, obj_type="function")
-        if self.ignorecase:
+        if self.ignorecase and isinstance(s, str):
             s = s.lower()
         if s in self.valid:
             return self.valid[s]

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -1,6 +1,7 @@
 import copy
 import os
 from pathlib import Path
+import re
 import subprocess
 import sys
 from unittest import mock
@@ -591,3 +592,10 @@ def test_deprecation(monkeypatch):
     # Note that the warning suppression actually arises from the
     # iteration over the updater rcParams being protected by
     # suppress_matplotlib_deprecation_warning, rather than any explicit check.
+
+
+def test_rcparams_legend_loc():
+    value = (0.9, .7)
+    match_str = f"{value} is not a valid value for legend.loc;"
+    with pytest.raises(ValueError, match=re.escape(match_str)):
+        mpl.RcParams({'legend.loc': value})


### PR DESCRIPTION
Partially closes - #22338

## PR Summary
Gracefully fail the string validator when tuple values are provided to rcParams. Addresses the first part of the issue.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
