### PR TITLE
Backport PR #24606: FIX: do not use deprecated API in gtk4 backend

### DIFF
--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -6,7 +6,8 @@ import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
 from matplotlib.backend_bases import (
     FigureCanvasBase, ToolContainerBase,
-    KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
+    KeyEvent, LocationEvent, MouseEvent, ResizeEvent,
+    CloseEvent)
 
 try:
     import gi
@@ -81,7 +82,7 @@ class FigureCanvasGTK4(FigureCanvasBase, Gtk.DrawingArea):
         style_ctx.add_class("matplotlib-canvas")
 
     def destroy(self):
-        self.close_event()
+        CloseEvent("close_event", self)._process()
 
     def set_cursor(self, cursor):
         # docstring inherited


### PR DESCRIPTION
Merge pull request #24606 from tacaswell/fix_gtk_closevent

FIX: do not use deprecated API in gtk4 backend
(cherry picked from commit 0aac9f17b9373f66c709f436149568bda69595b3)

