### PR TITLE
Improve error message for gridspec when the index is not an integer. 

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -599,12 +599,11 @@ class SubplotSpec:
                 )
             i, j = num
         else:
-            if not isinstance(num, Integral):
+            if not isinstance(num, Integral) or num < 1 or num > rows*cols:
                 raise ValueError(
-                    f"Subplot specifier must be an integer, not {num!r}")
-            if num < 1 or num > rows*cols:
-                raise ValueError(
-                    f"num must be 1 <= num <= {rows*cols}, not {num!r}")
+                    f"num must be an integer with 1 <= num <= {rows*cols}, "
+                    f"not {num!r}"
+                )
             i = j = num
         return gs[i-1:j]
 

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -599,7 +599,10 @@ class SubplotSpec:
                 )
             i, j = num
         else:
-            if not isinstance(num, Integral) or num < 1 or num > rows*cols:
+            if not isinstance(num, Integral):
+                raise ValueError(
+                    f"Subplot specifier must be an integer, not {num!r}")
+            if num < 1 or num > rows*cols:
                 raise ValueError(
                     f"num must be 1 <= num <= {rows*cols}, not {num!r}")
             i = j = num

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -236,10 +236,15 @@ def test_add_subplot_invalid():
     with pytest.raises(ValueError,
                        match='Number of rows must be a positive integer'):
         fig.add_subplot(0, 2, 1)
-    with pytest.raises(ValueError, match='num must be 1 <= num <= 4'):
+    with pytest.raises(ValueError, match='num must be an integer with '
+                                         '1 <= num <= 4'):
         fig.add_subplot(2, 2, 0)
-    with pytest.raises(ValueError, match='num must be 1 <= num <= 4'):
+    with pytest.raises(ValueError, match='num must be an integer with '
+                                         '1 <= num <= 4'):
         fig.add_subplot(2, 2, 5)
+    with pytest.raises(ValueError, match='num must be an integer with '
+                                         '1 <= num <= 4'):
+        fig.add_subplot(2, 2, 0.5)
 
     with pytest.raises(ValueError, match='must be a three-digit integer'):
         fig.add_subplot(42)


### PR DESCRIPTION
## PR Summary

`plt.subplot(1, 2, 0.5)` raises `ValueError: num must be 1 <= num <= 2, not 0.5`, which is not so useful. 

This PR changes it to report `Subplot specifier must be an integer, not 0.5`

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
