### PR TITLE
fix treatment of pan/zoom events for overlapping axes

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -513,6 +513,9 @@ Interactive
    Axes.get_navigate_mode
    Axes.set_navigate_mode
 
+   Axes.get_capture_navigation_event
+   Axes.set_capture_navigation_event
+
    Axes.start_pan
    Axes.drag_pan
    Axes.end_pan

--- a/doc/api/next_api_changes/behavior/22347-RQ.rst
+++ b/doc/api/next_api_changes/behavior/22347-RQ.rst
@@ -1,0 +1,13 @@
+Correctly treat pan/zoom events of overlapping Axes
+---------------------------------------------------
+
+The forwarding of pan/zoom events is now determined by the visibility of the
+background-patch (e.g. ``ax.patch.get_visible()``) and by the ``zorder`` of the axes.
+
+- Axes with a visible patch do not forward events to axes below.
+  Only the Axes with the highest ``zorder`` that contains the event is triggered
+  (if there are multiple Axes with the same ``zorder``, the last added Axes counts)
+- Axes with an invisible patch forward events to axes at lower or equal ``zorder``
+
+To override the default behavior and explicitly set whether an Axes
+should capture navigation events, use `.Axes.set_capture_navigation_events`.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -582,6 +582,7 @@ class _AxesBase(martist.Artist):
                  xscale=None,
                  yscale=None,
                  box_aspect=None,
+                 capture_navigation_events="auto",
                  **kwargs
                  ):
         """
@@ -615,6 +616,11 @@ class _AxesBase(martist.Artist):
         box_aspect : float, optional
             Set a fixed aspect for the Axes box, i.e. the ratio of height to
             width. See `~.axes.Axes.set_box_aspect` for details.
+
+        capture_navigation_events : bool or "auto"
+            Control whether pan/zoom events are passed through to Axes below
+            this one. See `~.axes.Axes.set_capture_navigation_events` for
+            details.
 
         **kwargs
             Other optional keyword arguments:
@@ -651,6 +657,7 @@ class _AxesBase(martist.Artist):
         self._adjustable = 'box'
         self._anchor = 'C'
         self._stale_viewlims = {name: False for name in self._axis_names}
+        self._capture_navigation_events = capture_navigation_events
         self._sharex = sharex
         self._sharey = sharey
         self.set_label(label)
@@ -4065,7 +4072,12 @@ class _AxesBase(martist.Artist):
 
         Parameters
         ----------
-        b : bool
+        b : bool or None
+
+        See Also
+        --------
+        matplotlib.axes.Axes.set_capture_navigation_events
+
         """
         self._navigate = b
 
@@ -4523,6 +4535,8 @@ class _AxesBase(martist.Artist):
                     [0, 0, 1, 1], self.transAxes))
         self.set_adjustable('datalim')
         twin.set_adjustable('datalim')
+        twin.set_zorder(self.zorder)
+
         self._twinned_axes.join(self, twin)
         return twin
 
@@ -4645,3 +4659,28 @@ class _AxesBase(martist.Artist):
             self.yaxis.set_tick_params(which="both", labelright=False)
             if self.yaxis.offsetText.get_position()[0] == 1:
                 self.yaxis.offsetText.set_visible(False)
+
+    def set_capture_navigation_events(self, capture):
+        """
+        Set how pan/zoom events are forwarded to Axes below this one.
+
+        Parameters
+        ----------
+        capture : bool or None
+            Possible values:
+
+            - True: Events are only executed on this axes.
+            - False: Forward events to other axes with lower or equal zorder
+            - "auto": Default behaviour ("True" for axes with an invisible
+              patch and False otherwise)
+
+        See Also
+        --------
+        matplotlib.axes.Axes.set_navigate
+
+        """
+        self._capture_navigation_events = capture
+
+    def get_capture_navigation_events(self):
+        """Get how pan/zoom events are forwarded to Axes below this one."""
+        return self._capture_navigation_events


### PR DESCRIPTION
❗  follow-up for  #22347

## PR Summary
This is intended to fix the treatment of pan/zoom events for overlapping axes (e.g. #22324 )

<details>
<summary> 🐍  code to generate the plot of the gif </summary>

```python
import matplotlib.pyplot as plt

def styleax(ax, bg, c, zorder, txtxy=(.5,.5)):
    # bg=False sets the patch to invisible
    # any other value keeps the patch AS IS
    
    if bg is False:
        ax.patch.set_visible(False)
        for _, s in ax.spines.items():
            s.set_edgecolor(c)
        ax.tick_params(axis='x', colors=c)
        ax.tick_params(axis='y', colors=c)

    else:
        ax.patch.set_facecolor(c)
        for _, s in ax.spines.items():
            s.set_edgecolor(c)

        ax.tick_params(axis='x', colors=c)
        ax.tick_params(axis='y', colors=c)  
        
    ax.set_zorder(zorder)
    if txtxy:
        ax.text(*txtxy, 
                f"{'NO' if bg is False else ''} patch axes \n at zorder={zorder}", 
                c=c, horizontalalignment="center", verticalalignment="center", 
                bbox=dict(facecolor='w', alpha=0.75),
                fontsize=7)

f, ax = plt.subplots()
styleax(ax, None, ".8", 0, False)
styleax(ax.twinx(), None, ".8", 0, False)  # a basic twinx

# manually added axes with background
ax = f.add_axes((.5,.5,.4,.4))
styleax(ax, None, "g", 0, (.7, .5))

# manually added axes with background and twinx
ax = f.add_axes((.5,.5,.2,.2))
styleax(ax, None, "b", 0)
styleax(ax.twinx(), None, "b", 0, False)

# manually added axes with NO background and twinx
ax = f.add_axes((.2,.25,.2,.2))
styleax(ax, False, "r", 0)
styleax(ax.twinx(), None, "r", 0, False)

# manually added axes with NO background on different zorder
ax = f.add_axes((0.05,.1,.55,.7))
styleax(ax, False, "c", 2, (.5,.7))
styleax(ax.twinx(), False, "c", 2, (.5,.7))

# manually added axes with background and twinx on different zorder
ax = f.add_axes((.5,.25,.2,.2))
styleax(ax, None, "m", 5)
styleax(ax.twinx(), None, "m", 5, False)
# a joined axes
ax2 = f.add_axes((.8,.25,.15,.15))
styleax(ax2, None, "m", 5)
ax2.get_shared_x_axes().join(ax2, ax)
```

</details>


![mpl_issue_2](https://user-images.githubusercontent.com/22773387/151589404-7e540830-3f82-414a-807f-29391c81c2c5.gif)


#### changes on pan/zoom events
- instead of triggering all axes, only the topmost ax with `ax.patch.get_visible = True` triggers pan/zoom events
- axes with with `ax.patch.get_visible = False` (at lower or equal zorder than the triggered ax) pass events to
  axes below (e.g. at lower or equal zorder)
#### other changes
- to allow a coherent treatment for twin-axes, the `zorder` property is set to the `zorder` of the parent axes.
  in `ax._make_twin_axes()`


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Tests and Styling**
- [x] Has pytest style unit tests (and `pytest` passes).
- [x] Is [Flake 8](https://flake8.pycqa.org/en/latest/) compliant (install `flake8-docstrings` and run `flake8 --docstring-convention=all`).

**Documentation**
- [x] New features are documented, with examples if plot related.
- [x] New features have an entry in `doc/users/next_whats_new/` (follow instructions in README.rst there).
- [x] API changes documented in `doc/api/next_api_changes/` (follow instructions in README.rst there).
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Do not create the PR out of main, but out of a separate branch.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
