### PR TITLE
MNT: Remove auto-flattening of input data to pcolormesh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6220,9 +6220,6 @@ default: :rc:`scatter.edgecolors`
         X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
                                             shading=shading, kwargs=kwargs)
         coords = np.stack([X, Y], axis=-1)
-        # convert to one dimensional array, except for 3D RGB(A) arrays
-        if C.ndim != 3:
-            C = C.ravel()
 
         kwargs.setdefault('snap', mpl.rcParams['pcolormesh.snap'])
 


### PR DESCRIPTION
## PR Summary

Opening this as a draft for discussion.

If someone passes in a 2-D array to `.pcolormesh()` should we automatically call `.ravel()` on it? See question from @jklymak here: https://github.com/matplotlib/matplotlib/pull/24619#discussion_r1039818371 Flattening is what historically has been done, but we've been moving towards QuadMesh being a primary 2-D collection lately and could get rid of this restriction on flattening input.

The updates here are all primarily surrounding what shapes the returned arrays are from the function calls and how to compare them, so drawing hasn't changed. Also note that this would introduce a deviation between `pcolor(z2d).get_facecolors() == colors1d` which returns the flattened array, while `pcolormesh(z2d).get_facecolors() == colors2d` returns the original shape of the array passed in.

`Collection` classes have a lot of "1D list of objects" method handling in them, but in `QuadMesh` there is additional handling for the known 2-D structure of the arrays (mesh in the name). `pcolor()` returns a `PolyCollection` which is a 1D list of Polygons, and if there are masked elements it will actually shrink the list and not add that Polygon, so it would require more book-keeping (maybe adding a new `PolyMeshCollection` just for pcolor) to get the 2-D logic right.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
