### PR TITLE
Small TransformWrapper cleanups.

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -722,3 +722,11 @@ def test_deepcopy():
     b1.translate(3, 4)
     assert not s._invalid
     assert (s.get_matrix() == a.get_matrix()).all()
+
+
+def test_transformwrapper():
+    t = mtransforms.TransformWrapper(mtransforms.Affine2D())
+    with pytest.raises(ValueError, match=(
+            r"The input and output dims of the new child \(1, 1\) "
+            r"do not match those of current child \(2, 2\)")):
+        t.set(scale.LogTransform(10))


### PR DESCRIPTION
Move _init() and _set() into set().

_init was split out in 5478183 to improve the pickling of TransformWrappers but was made unnecessary in 08387d8 following improvements in pickling in recent Pythons.  _set and set can also easily be combined.

Make input_dims, output_dims straight properties similarly to is_affine & friends; and improve the error message for mismatched dimensions (to indicate the wrong values).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
