### PR TITLE
Fix that font files never pass the test on Win

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -189,7 +189,7 @@ def list_fonts(directory, extensions):
     if sys.platform == 'win32' and directory == win32FontDirectory():
         return [os.path.join(directory, filename)
                 for filename in os.listdir(directory)
-                if os.path.isfile(filename)]
+                if os.path.isfile(os.path.join(directory, filename))]
     else:
         return [os.path.join(dirpath, filename)
                 # os.walk ignores access errors, unlike Path.glob.


### PR DESCRIPTION
Hi! 👋 

I am gratefully making use of MPL's font management code for our text rendering in [PyGfx](https://github.com/pygfx/pygfx). While I was examining the code, I found what I think is a bug. 

The `isfile()` test is applied on the relative pathname and will thus always fail. This PR should fix that. I would expect that it should also test for the extension, but I'm not 100% sure so I did not add this yet.

Diving a bit deeper, this bug has likely gone unnoticed because the code to detect fonts follows two paths on Windows:
* It checks the registry for known installed fonts in a small set of predefined directories.
* It detects font files *in these same directories* using `os.listdir` or `os.walk`.

Why are these two paths followed? I can see how the second route can find fonts that are present but not known in the registry, but why check the registry at all then?

