### PR TITLE
Removed 'above' wording from Input hook integration docs (#24632)

### DIFF
--- a/doc/users/explain/interactive_guide.rst
+++ b/doc/users/explain/interactive_guide.rst
@@ -166,7 +166,7 @@ takes over again.
 This time-share technique only allows the event loop to run while
 python is otherwise idle and waiting for user input.  If you want the
 GUI to be responsive during long running code it is necessary to
-periodically flush the GUI event queue as described :ref:`spin_event_loop`.
+periodically flush the GUI event queue as described in :ref:`spin_event_loop`.
 In this case it is your code, not the REPL, which
 is blocking the process so you need to handle the "time-share" manually.
 Conversely, a very slow figure draw will block the prompt until it

--- a/doc/users/explain/interactive_guide.rst
+++ b/doc/users/explain/interactive_guide.rst
@@ -166,8 +166,8 @@ takes over again.
 This time-share technique only allows the event loop to run while
 python is otherwise idle and waiting for user input.  If you want the
 GUI to be responsive during long running code it is necessary to
-periodically flush the GUI event queue as described :ref:`above
-<spin_event_loop>`.  In this case it is your code, not the REPL, which
+periodically flush the GUI event queue as described :ref:`spin_event_loop`.
+In this case it is your code, not the REPL, which
 is blocking the process so you need to handle the "time-share" manually.
 Conversely, a very slow figure draw will block the prompt until it
 finishes drawing.


### PR DESCRIPTION
## PR Summary

Addresses https://github.com/matplotlib/matplotlib/issues/24632 by removing "above" wording from the docs.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
