### PR TITLE
Offsetbox default arguments

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -369,7 +369,7 @@ class OffsetBox(martist.Artist):
 
 
 class PackerBase(OffsetBox):
-    def __init__(self, pad=0, sep=0, width=None, height=None,
+    def __init__(self, pad=0., sep=0., width=None, height=None,
                  align="baseline", mode="fixed", children=None):
         """
         Parameters

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -369,7 +369,7 @@ class OffsetBox(martist.Artist):
 
 
 class PackerBase(OffsetBox):
-    def __init__(self, pad=0., sep=0., width=None, height=None,
+    def __init__(self, pad=0, sep=0, width=None, height=None,
                  align="baseline", mode="fixed", children=None):
         """
         Parameters
@@ -502,7 +502,7 @@ class PaddedBox(OffsetBox):
     """
 
     @_api.make_keyword_only("3.6", name="draw_frame")
-    def __init__(self, child, pad=0., draw_frame=False, patch_attrs=None):
+    def __init__(self, child, pad=0, draw_frame=False, patch_attrs=None):
         """
         Parameters
         ----------
@@ -530,17 +530,6 @@ class PaddedBox(OffsetBox):
         )
         if patch_attrs is not None:
             self.patch.update(patch_attrs)
-
-    def get_offset(self, width, height, xdescent, ydescent, renderer):
-        # docstring inherited
-        bbox = Bbox.from_bounds(0, 0, width, height)
-        pad = (self._children[0].pad
-               * renderer.points_to_pixels(
-                self._children[0].prop.get_size_in_points()))
-        bbox_to_anchor = self._children[0].get_bbox_to_anchor()
-        x0, y0 = _get_anchored_bbox(
-            self._children[0].loc, bbox, bbox_to_anchor, pad)
-        return x0 + xdescent, y0 + ydescent
 
     def get_extent_offsets(self, renderer):
         # docstring inherited.
@@ -1253,13 +1242,13 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
             The position *(x, y)* to place the text at. The coordinate system
             is determined by *boxcoords*.
 
-        xycoords : str or `.Artist` or `.Transform` or callable or \
-(float, float), default: 'data'
+        xycoords : single or two-tuple of str or `.Artist` or `.Transform` or \
+callable, default: 'data'
             The coordinate system that *xy* is given in. See the parameter
             *xycoords* in `.Annotation` for a detailed description.
 
-        boxcoords : str or `.Artist` or `.Transform` or callable or \
-(float, float), default: value of *xycoords*
+        boxcoords : single or two-tuple of str or `.Artist` or `.Transform` \
+or callable, default: value of *xycoords*
             The coordinate system that *xybox* is given in. See the parameter
             *textcoords* in `.Annotation` for a detailed description.
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -535,9 +535,11 @@ class PaddedBox(OffsetBox):
         # docstring inherited
         bbox = Bbox.from_bounds(0, 0, width, height)
         pad = (self._children[0].pad
-               * renderer.points_to_pixels(self._children[0].prop.get_size_in_points()))
+               * renderer.points_to_pixels(
+                self._children[0].prop.get_size_in_points()))
         bbox_to_anchor = self._children[0].get_bbox_to_anchor()
-        x0, y0 = _get_anchored_bbox(self._children[0].loc, bbox, bbox_to_anchor, pad)
+        x0, y0 = _get_anchored_bbox(
+            self._children[0].loc, bbox, bbox_to_anchor, pad)
         return x0 + xdescent, y0 + ydescent
 
     def get_extent_offsets(self, renderer):

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -369,12 +369,12 @@ class OffsetBox(martist.Artist):
 
 
 class PackerBase(OffsetBox):
-    def __init__(self, pad=0., sep=None, width=None, height=None,
+    def __init__(self, pad=0., sep=0., width=None, height=None,
                  align="baseline", mode="fixed", children=None):
         """
         Parameters
         ----------
-        pad : float, required
+        pad : float, optional
             The boundary padding in points.
 
         sep : float, optional

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -369,12 +369,12 @@ class OffsetBox(martist.Artist):
 
 
 class PackerBase(OffsetBox):
-    def __init__(self, pad=None, sep=None, width=None, height=None,
+    def __init__(self, pad=0., sep=None, width=None, height=None,
                  align="baseline", mode="fixed", children=None):
         """
         Parameters
         ----------
-        pad : float, optional
+        pad : float, required
             The boundary padding in points.
 
         sep : float, optional
@@ -502,7 +502,7 @@ class PaddedBox(OffsetBox):
     """
 
     @_api.make_keyword_only("3.6", name="draw_frame")
-    def __init__(self, child, pad=None, draw_frame=False, patch_attrs=None):
+    def __init__(self, child, pad=0., draw_frame=False, patch_attrs=None):
         """
         Parameters
         ----------
@@ -530,6 +530,15 @@ class PaddedBox(OffsetBox):
         )
         if patch_attrs is not None:
             self.patch.update(patch_attrs)
+
+    def get_offset(self, width, height, xdescent, ydescent, renderer):
+        # docstring inherited
+        bbox = Bbox.from_bounds(0, 0, width, height)
+        pad = (self._children[0].pad
+               * renderer.points_to_pixels(self._children[0].prop.get_size_in_points()))
+        bbox_to_anchor = self._children[0].get_bbox_to_anchor()
+        x0, y0 = _get_anchored_bbox(self._children[0].loc, bbox, bbox_to_anchor, pad)
+        return x0 + xdescent, y0 + ydescent
 
     def get_extent_offsets(self, renderer):
         # docstring inherited.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -374,10 +374,10 @@ class PackerBase(OffsetBox):
         """
         Parameters
         ----------
-        pad : float, optional
+        pad : float, default: 0.0
             The boundary padding in points.
 
-        sep : float, optional
+        sep : float, default: 0.0
             The spacing between items in points.
 
         width, height : float, optional
@@ -508,7 +508,7 @@ class PaddedBox(OffsetBox):
         ----------
         child : `~matplotlib.artist.Artist`
             The contained `.Artist`.
-        pad : float
+        pad : float, default: 0.0
             The padding in points. This will be scaled with the renderer dpi.
             In contrast, *width* and *height* are in *pixels* and thus not
             scaled.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -502,7 +502,7 @@ class PaddedBox(OffsetBox):
     """
 
     @_api.make_keyword_only("3.6", name="draw_frame")
-    def __init__(self, child, pad=0, draw_frame=False, patch_attrs=None):
+    def __init__(self, child, pad=0., draw_frame=False, patch_attrs=None):
         """
         Parameters
         ----------

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -381,10 +381,7 @@ def test_packers(align):
 
 
 def test_paddedbox():
+    # smoke test for correct default value though
     fig, ax = plt.subplots()
-
     at = AnchoredText("foo",  'upper left')
-    try:
-        pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)
-    except:
-        raise Exception("incorrect default value")
+    pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -350,7 +350,7 @@ def test_packers(align):
     hpacker = HPacker(children=[r1, r2], pad=0, sep=0, align=align)
     vpacker = VPacker(children=[r1, r2], pad=0, sep=0, align=align)
 
-    #smoke testing default values
+    # smoke testing default values
     hpacker = HPacker(children=[r1, r2], align=align)
     vpacker = VPacker(children=[r1, r2], align=align)
 

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -13,7 +13,7 @@ from matplotlib.backend_bases import MouseButton, MouseEvent
 
 from matplotlib.offsetbox import (
     AnchoredOffsetbox, AnnotationBbox, AnchoredText, DrawingArea, OffsetBox,
-    OffsetImage, TextArea, _get_packed_offsets, HPacker, VPacker)
+    OffsetImage, PaddedBox, TextArea, _get_packed_offsets, HPacker, VPacker)
 
 
 @image_comparison(['offsetbox_clipping'], remove_text=True)
@@ -378,3 +378,13 @@ def test_packers(align):
         x_height = (x2 - x1) / 2
     # x-offsets, y-offsets
     assert_allclose([(x_height, 0), (0, -y2)], offset_pairs)
+
+
+def test_paddedbox():
+    fig, ax = plt.subplots()
+
+    at = AnchoredText("foo",  'upper left')
+    try:
+        pb = PaddedBox(at, patch_attrs={'facecolor' : 'r'}, draw_frame=True)
+    except:
+        raise Exception("incorrect default value")

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -385,6 +385,6 @@ def test_paddedbox():
 
     at = AnchoredText("foo",  'upper left')
     try:
-        pb = PaddedBox(at, patch_attrs={'facecolor' : 'r'}, draw_frame=True)
+        pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)
     except:
         raise Exception("incorrect default value")

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -381,7 +381,7 @@ def test_packers(align):
 
 
 def test_paddedbox():
-    # smoke test for correct default value though
+    # smoke test for correct default value
     fig, ax = plt.subplots()
     at = AnchoredText("foo",  'upper left')
     pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -364,7 +364,7 @@ def test_packers(align):
         y_height = (y2 - y1) / 2
     # x-offsets, y-offsets
     assert_allclose([(0, y_height), (x1, 0)], offset_pairs)
-    
+
     # VPacker
     *extents, offset_pairs = vpacker.get_extent_offsets(renderer)
     # width, height, xdescent, ydescent
@@ -378,6 +378,7 @@ def test_packers(align):
         x_height = (x2 - x1) / 2
     # x-offsets, y-offsets
     assert_allclose([(x_height, 0), (0, -y2)], offset_pairs)
+
 
 @pytest.mark.parametrize("align", ["baseline", "bottom", "top",
                                    "left", "right", "center"])

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -347,10 +347,6 @@ def test_packers(align):
     r1 = DrawingArea(x1, y1)
     r2 = DrawingArea(x2, y2)
 
-    hpacker = HPacker(children=[r1, r2], pad=0, sep=0, align=align)
-    vpacker = VPacker(children=[r1, r2], pad=0, sep=0, align=align)
-
-    # smoke testing default values
     hpacker = HPacker(children=[r1, r2], align=align)
     vpacker = VPacker(children=[r1, r2], align=align)
 

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -349,6 +349,11 @@ def test_packers(align):
 
     hpacker = HPacker(children=[r1, r2], pad=0, sep=0, align=align)
     vpacker = VPacker(children=[r1, r2], pad=0, sep=0, align=align)
+
+    #smoke testing default values
+    hpacker = HPacker(children=[r1, r2], align=align)
+    vpacker = VPacker(children=[r1, r2], align=align)
+
     renderer = fig.canvas.get_renderer()
 
     # HPacker
@@ -380,22 +385,10 @@ def test_packers(align):
     assert_allclose([(x_height, 0), (0, -y2)], offset_pairs)
 
 
-@pytest.mark.parametrize("align", ["baseline", "bottom", "top",
-                                   "left", "right", "center"])
-def test_paddedbox_packer(align):
-    # smoke test for correct default value
+def test_paddedbox():
+    # smoke test paddedbox for correct default value
     fig, ax = plt.subplots()
     at = AnchoredText("foo",  'upper left')
     pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)
     ax.add_artist(pb)
     fig.draw_without_rendering()
-
-    fig = plt.figure(dpi=72)
-    x1, y1 = 10, 30
-    x2, y2 = 20, 60
-    r1 = DrawingArea(x1, y1)
-    r2 = DrawingArea(x2, y2)
-
-    hpacker = HPacker(children=[r1, r2], align=align)
-    vpacker = VPacker(children=[r1, r2], align=align)
-    renderer = fig.canvas.get_renderer()

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -364,7 +364,7 @@ def test_packers(align):
         y_height = (y2 - y1) / 2
     # x-offsets, y-offsets
     assert_allclose([(0, y_height), (x1, 0)], offset_pairs)
-
+    
     # VPacker
     *extents, offset_pairs = vpacker.get_extent_offsets(renderer)
     # width, height, xdescent, ydescent
@@ -379,15 +379,16 @@ def test_packers(align):
     # x-offsets, y-offsets
     assert_allclose([(x_height, 0), (0, -y2)], offset_pairs)
 
-
-def test_paddedbox_packer():
+@pytest.mark.parametrize("align", ["baseline", "bottom", "top",
+                                   "left", "right", "center"])
+def test_paddedbox_packer(align):
     # smoke test for correct default value
     fig, ax = plt.subplots()
     at = AnchoredText("foo",  'upper left')
     pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)
     ax.add_artist(pb)
     fig.draw_without_rendering()
-    
+
     fig = plt.figure(dpi=72)
     x1, y1 = 10, 30
     x2, y2 = 20, 60
@@ -397,4 +398,3 @@ def test_paddedbox_packer():
     hpacker = HPacker(children=[r1, r2], align=align)
     vpacker = VPacker(children=[r1, r2], align=align)
     renderer = fig.canvas.get_renderer()
-    

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -380,8 +380,21 @@ def test_packers(align):
     assert_allclose([(x_height, 0), (0, -y2)], offset_pairs)
 
 
-def test_paddedbox():
+def test_paddedbox_packer():
     # smoke test for correct default value
     fig, ax = plt.subplots()
     at = AnchoredText("foo",  'upper left')
     pb = PaddedBox(at, patch_attrs={'facecolor': 'r'}, draw_frame=True)
+    ax.add_artist(pb)
+    fig.draw_without_rendering()
+    
+    fig = plt.figure(dpi=72)
+    x1, y1 = 10, 30
+    x2, y2 = 20, 60
+    r1 = DrawingArea(x1, y1)
+    r2 = DrawingArea(x2, y2)
+
+    hpacker = HPacker(children=[r1, r2], align=align)
+    vpacker = VPacker(children=[r1, r2], align=align)
+    renderer = fig.canvas.get_renderer()
+    


### PR DESCRIPTION
## PR Summary
Closes #24623

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
