### PR TITLE
[WIP] Attempted fix to colorbar bug when yscaled len = 1 as suggested in previous PR

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1249,8 +1249,11 @@ class Colorbar:
         if (isinstance(self.norm, colors.BoundaryNorm) or
                 self.boundaries is not None):
             y = (self._boundaries - self._boundaries[self._inside][0])
-            y = y / (self._boundaries[self._inside][-1] -
-                     self._boundaries[self._inside][0])
+            if (self._boundaries[self._inside][-1]
+                    != self._boundaries[self._inside][0]):
+                y = y / (self._boundaries[self._inside][-1] -
+                         self._boundaries[self._inside][0])
+
             # need yscaled the same as the axes scale to get
             # the extend lengths.
             if self.spacing == 'uniform':
@@ -1271,10 +1274,13 @@ class Colorbar:
         yscaled = np.ma.filled(norm(yscaled), np.nan)
         # make the lower and upper extend lengths proportional to the lengths
         # of the first and last boundary spacing (if extendfrac='auto'):
-        automin = yscaled[1] - yscaled[0]
-        automax = yscaled[-1] - yscaled[-2]
         extendlength = [0, 0]
         if self._extend_lower() or self._extend_upper():
+            automin = yscaled[0]
+            automax = yscaled[0]
+            if len(yscaled) > 1:
+                automin = yscaled[1] - yscaled[0]
+                automax = yscaled[-1] - yscaled[-2]
             extendlength = self._get_extension_lengths(
                     self.extendfrac, automin, automax, default=0.05)
         return y, extendlength

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -244,6 +244,15 @@ def test_contour_colorbar():
     fig.colorbar(CS, orientation='vertical')
 
 
+def test_contour_uniformfield_colorbar():
+    # Smoke test for issue
+    fig, ax = plt.subplots()
+    with pytest.warns(Warning) as record:
+        cs = ax.contour([[1, 1], [1, 1]])
+    assert len(record) == 1
+    fig.colorbar(cs, ax=ax)
+
+
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
 def test_gridspec_make_colorbar():


### PR DESCRIPTION
## PR Summary
Opening a draft PR for issue #23817, building off the work of @Andes0113 in PR #23984 and attempting to address the issues mentioned there.

When I run the test, I'm able to fix the underlying issue by using the same yscaled value for
automin and automax. However, later on in the test, I run into a warning on the `fig.colorbar(cs, ax)`:
```
$ pytest lib/matplotlib/tests/test_colorbar.py -k 'test_contour_uniformfield_colorbar'

UserWarning: Attempting to set identical low and high ylims makes transformation singular; automatically expanding.
```

When I look at the stack trace, I see the following (I omitted decorator wrapping frames):

```
lib/matplotlib/figure.py:1277: in colorbar
    cb = cbar.Colorbar(cax, mappable, **cb_kw)
lib/matplotlib/colorbar.py:420: in __init__
    self._draw_all()
lib/matplotlib/colorbar.py:566: in _draw_all
    self.ax.set_ylim(lower, upper)
```

This makes me think that the warning has to do with the axis set on the plot. Online, posts seem to suggest that this error comes up when generating plots with no spread in the y-axis. That zero-width
spread on the y-axis seems critical to the test though, so I'm not sure how to proceed.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
