### PR TITLE
BUG: Fix bug with mutable input modification

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1653,6 +1653,9 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
             rgba = sm.to_rgba(arr, bytes=True)
         if pil_kwargs is None:
             pil_kwargs = {}
+        else:
+            # we modify this below, so make a copy (don't modify caller's dict)
+            pil_kwargs = pil_kwargs.copy()
         pil_shape = (rgba.shape[1], rgba.shape[0])
         image = PIL.Image.frombuffer(
             "RGBA", pil_shape, rgba, "raw", "RGBA", 0, 1)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -254,9 +254,11 @@ def test_pil_kwargs_webp():
     buf_small = io.BytesIO()
     pil_kwargs_low = {"quality": 1}
     plt.savefig(buf_small, format="webp", pil_kwargs=pil_kwargs_low)
+    assert len(pil_kwargs_low) == 1
     buf_large = io.BytesIO()
     pil_kwargs_high = {"quality": 100}
     plt.savefig(buf_large, format="webp", pil_kwargs=pil_kwargs_high)
+    assert len(pil_kwargs_high) == 1
     assert buf_large.getbuffer().nbytes > buf_small.getbuffer().nbytes
 
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -249,6 +249,7 @@ def test_imsave_pil_kwargs_tiff():
     buf = io.BytesIO()
     pil_kwargs = {"description": "test image"}
     plt.imsave(buf, [[0, 1], [2, 3]], format="tiff", pil_kwargs=pil_kwargs)
+    assert len(pil_kwargs) == 1
     im = Image.open(buf)
     tags = {TAGS[k].name: v for k, v in im.tag_v2.items()}
     assert tags["ImageDescription"] == "test image"


### PR DESCRIPTION
## PR Summary

On `main`, `imsave` (and thus `fig.savefig`) modifies the mutable `pil_kwargs` without making a copy. The modified tests fail on `main` but pass on this PR.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`