### PR TITLE
Plots first and last minor ticks #22331

### DIFF
--- a/doc/api/next_api_changes/behavior/24661-AAMW.rst
+++ b/doc/api/next_api_changes/behavior/24661-AAMW.rst
@@ -1,0 +1,6 @@
+Placing of maximum and minimum minor ticks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Calculation of minor tick locations has been corrected to make the maximum and
+minimum minor ticks more consistent.  In some cases this results in an extra
+minor tick on an Axis.

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -396,8 +396,8 @@ def test_colorbar_minorticks_on_off():
         cbar.minorticks_on()
         np.testing.assert_almost_equal(
             cbar.ax.yaxis.get_minorticklocs(),
-            [-1.1, -0.9, -0.8, -0.7, -0.6, -0.4, -0.3, -0.2, -0.1,
-             0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.1, 1.2, 1.3])
+            [-1.2, -1.1, -0.9, -0.8, -0.7, -0.6, -0.4, -0.3, -0.2, -0.1,
+             0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.1, 1.2])
 
     # tests for github issue #13257 and PR #13265
     data = np.random.uniform(low=1, high=10, size=(20, 20))

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -106,6 +106,25 @@ class TestAutoMinorLocator:
         (1, 0)   # a single major tick => no minor tick
     ]
 
+    def test_first_and_last_minorticks(self):
+        """
+        Test that first and last minor tick appear as expected.
+        """
+        # This test is related to issue #22331
+        fig, ax = plt.subplots()
+        ax.set_xlim(-1.9, 1.9)
+        ax.xaxis.set_minor_locator(mticker.AutoMinorLocator())
+        test_value = np.array([-1.9, -1.8, -1.7, -1.6, -1.4, -1.3, -1.2, -1.1,
+                               -0.9, -0.8, -0.7, -0.6, -0.4, -0.3, -0.2, -0.1,
+                               0.1, 0.2, 0.3, 0.4, 0.6, 0.7, 0.8, 0.9, 1.1,
+                               1.2, 1.3, 1.4, 1.6, 1.7, 1.8, 1.9])
+        assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), test_value)
+
+        ax.set_xlim(-5, 5)
+        test_value = np.array([-5.0, -4.5, -3.5, -3.0, -2.5, -1.5, -1.0, -0.5,
+                               0.5, 1.0, 1.5, 2.5, 3.0, 3.5, 4.5, 5.0])
+        assert_almost_equal(ax.xaxis.get_ticklocs(minor=True), test_value)
+
     @pytest.mark.parametrize('nb_majorticks, expected_nb_minorticks', params)
     def test_low_number_of_majorticks(
             self, nb_majorticks, expected_nb_minorticks):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2908,9 +2908,9 @@ class AutoMinorLocator(Locator):
             vmin, vmax = vmax, vmin
 
         t0 = majorlocs[0]
-        tmin = ((vmin - t0) // minorstep + 1) * minorstep
-        tmax = ((vmax - t0) // minorstep + 1) * minorstep
-        locs = np.arange(tmin, tmax, minorstep) + t0
+        tmin = round((vmin - t0) / minorstep)
+        tmax = round((vmax - t0) / minorstep) + 1
+        locs = (np.arange(tmin, tmax) * minorstep) + t0
 
         return self.raise_if_exceeds(locs)
 


### PR DESCRIPTION
## PR Summary
Resolves issue where first and last minor ticks do not appear, as mentioned in issue #22331
## PR Checklist

**Documentation and Tests**
- [ Yes ] Has pytest style unit tests (and `pytest` passes)
- [ N/A ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ N/A ] New plotting related features are documented with examples.

**Release Notes**
- [ N/A ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ N/A ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ N/A ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`
