### PR TITLE
Deprecate offsetbox.bbox_artist

### DIFF
--- a/doc/api/next_api_changes/deprecations/24664-OG.rst
+++ b/doc/api/next_api_changes/deprecations/24664-OG.rst
@@ -1,0 +1,5 @@
+``offsetbox.bbox_artist``
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... is deprecated. This is just a wrapper to call `.patches.bbox_artist` if a
+flag is set in the file, so use that directly if you need the behavior.

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -40,8 +40,14 @@ from matplotlib.transforms import Bbox, BboxBase, TransformedBbox
 DEBUG = False
 
 
-# for debugging use
+@_api.deprecated("3.7", alternative='patches.bbox_artist')
 def bbox_artist(*args, **kwargs):
+    if DEBUG:
+        mbbox_artist(*args, **kwargs)
+
+
+# for debugging use
+def _bbox_artist(*args, **kwargs):
     if DEBUG:
         mbbox_artist(*args, **kwargs)
 
@@ -364,7 +370,7 @@ class OffsetBox(martist.Artist):
         for c, (ox, oy) in zip(self.get_visible_children(), offsets):
             c.set_offset((px + ox, py + oy))
             c.draw(renderer)
-        bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
+        _bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
         self.stale = False
 
 
@@ -672,7 +678,7 @@ class DrawingArea(OffsetBox):
                 c.set_clip_path(tpath)
             c.draw(renderer)
 
-        bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
+        _bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
         self.stale = False
 
 
@@ -794,7 +800,7 @@ class TextArea(OffsetBox):
     def draw(self, renderer):
         # docstring inherited
         self._text.draw(renderer)
-        bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
+        _bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
         self.stale = False
 
 
@@ -877,7 +883,7 @@ class AuxTransformBox(OffsetBox):
         # docstring inherited
         for c in self._children:
             c.draw(renderer)
-        bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
+        _bbox_artist(self, renderer, fill=False, props=dict(pad=0.))
         self.stale = False
 
 


### PR DESCRIPTION
## PR Summary

This shows up in the documentation (although not documented). Shouldn't really need to be there.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
