### PR TITLE
Test scroll zoom bbox update

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7118,6 +7118,42 @@ def test_spines_properbbox_after_zoom():
     np.testing.assert_allclose(bb.get_points(), bb2.get_points(), rtol=1e-6)
 
 
+def test_limits_after_scroll_zoom():
+    fig, ax = plt.subplots()
+    #
+    xlim = (-0.5, 0.5)
+    ylim = (-1, 2)
+    ax.set_xlim(xlim)
+    ax.set_ylim(ymin=ylim[0], ymax=ylim[1])
+    # This is what scroll zoom calls:
+    # Zoom with factor 1, small numerical change
+    ax._set_view_from_bbox((200, 200, 1.))
+    np.testing.assert_allclose(xlim, ax.get_xlim(), atol=1e-16)
+    np.testing.assert_allclose(ylim, ax.get_ylim(), atol=1e-16)
+
+    # Zoom in
+    ax._set_view_from_bbox((200, 200, 2.))
+    # Hard-coded values
+    new_xlim = (-0.3790322580645161, 0.12096774193548387)
+    new_ylim = (-0.40625, 1.09375)
+
+    res_xlim = ax.get_xlim()
+    res_ylim = ax.get_ylim()
+    np.testing.assert_allclose(res_xlim[1] - res_xlim[0], 0.5)
+    np.testing.assert_allclose(res_ylim[1] - res_ylim[0], 1.5)
+    np.testing.assert_allclose(new_xlim, res_xlim, atol=1e-16)
+    np.testing.assert_allclose(new_ylim, res_ylim)
+
+    # Zoom out, should be same as before, except for numerical issues
+    ax._set_view_from_bbox((200, 200, 0.5))
+    res_xlim = ax.get_xlim()
+    res_ylim = ax.get_ylim()
+    np.testing.assert_allclose(res_xlim[1] - res_xlim[0], 1)
+    np.testing.assert_allclose(res_ylim[1] - res_ylim[0], 3)
+    np.testing.assert_allclose(xlim, res_xlim, atol=1e-16)
+    np.testing.assert_allclose(ylim, res_ylim, atol=1e-16)
+
+
 def test_gettightbbox_ignore_nan():
     fig, ax = plt.subplots()
     remove_ticks_and_titles(fig)


### PR DESCRIPTION
## PR Summary

Until we have proper GUI tests, this is the only way to test it (AFAIK).

Edit: rebased to get better coverage report.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
