### PR TITLE
FIX: record original dpi when dpi set

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2176,7 +2176,7 @@ class SubFigure(FigureBase):
         ----------
         val : float
         """
-        self._parent.dpi = val
+        self._parent.set_dpi(val)
         self.stale = True
 
     def _get_renderer(self):
@@ -3002,6 +3002,8 @@ class Figure(FigureBase):
         val : float
         """
         self.dpi = val
+        if hasattr(self, '_original_dpi'):
+            self._original_dpi = val
         self.stale = True
 
     def set_figwidth(self, val, forward=True):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1165,6 +1165,15 @@ def test_subfigure_dpi():
     assert fig.get_dpi() == 200
 
 
+def test_set_dpi_save(tmp_path):
+    fig = plt.figure(figsize=(1, 2), dpi=100)
+    fig.set_dpi(63)
+    outname = tmp_path / 'dpi_test.png'
+    fig.savefig(outname, dpi='figure')
+    im = np.array(Image.open(outname))
+    assert np.shape(im) == (126, 63, 4)
+
+
 @image_comparison(['test_subfigure_ss.png'], style='mpl20',
                   savefig_kwarg={'facecolor': 'teal'}, tol=0.02)
 def test_subfigure_ss():


### PR DESCRIPTION
## PR Summary

Closes #24644 or at least some of it?

The `figure._original_dpi` is used when we want to print using `dpi='figure'`.  However, if we manually set the dpi via `figure.set_dpi` this doesn't get set and the figure is saved at the origin figure dpi.

### Example

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
fig.set_dpi(150)
ax.plot([1, 2], [1, 2])
plt.show()
fig.savefig('Boo.png', dpi='figure')
```

On main, `Boo.png` has 100 dpi, whereas after this change it has 150 dpi.

### Caveat.

This doesn't completely fix `set_dpi`, which doesn't respect deviceRatio when it is called, so hiDPI screens don't double the size and resolution of the figure.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
