### PR TITLE
TST: set style in mpl_toolkits to ease later transition

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -59,7 +59,9 @@ def test_divider_append_axes():
     assert bboxes["top"].x1 == bboxes["main"].x1 == bboxes["bottom"].x1
 
 
-@image_comparison(['twin_axes_empty_and_removed'], extensions=["png"], tol=1)
+# Update style when regenerating the test image
+@image_comparison(['twin_axes_empty_and_removed'], extensions=["png"], tol=1,
+                  style=('classic', '_classic_test_patch'))
 def test_twin_axes_empty_and_removed():
     # Purely cosmetic font changes (avoid overlap)
     mpl.rcParams.update(
@@ -321,7 +323,9 @@ def test_fill_facecolor():
     mark_inset(ax[3], axins, loc1=2, loc2=4, fc="g", ec="0.5", fill=False)
 
 
-@image_comparison(['zoomed_axes.png', 'inverted_zoomed_axes.png'])
+# Update style when regenerating the test image
+@image_comparison(['zoomed_axes.png', 'inverted_zoomed_axes.png'],
+                  style=('classic', '_classic_test_patch'))
 def test_zooming_with_inverted_axes():
     fig, ax = plt.subplots()
     ax.plot([1, 2, 3], [1, 2, 3])
@@ -336,8 +340,10 @@ def test_zooming_with_inverted_axes():
     inset_ax.axis([1.4, 1.1, 1.4, 1.1])
 
 
+# Update style when regenerating the test image
 @image_comparison(['anchored_direction_arrows.png'],
-                  tol=0 if platform.machine() == 'x86_64' else 0.01)
+                  tol=0 if platform.machine() == 'x86_64' else 0.01,
+                  style=('classic', '_classic_test_patch'))
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((10, 10)), interpolation='nearest')
@@ -346,7 +352,9 @@ def test_anchored_direction_arrows():
     ax.add_artist(simple_arrow)
 
 
-@image_comparison(['anchored_direction_arrows_many_args.png'])
+# Update style when regenerating the test image
+@image_comparison(['anchored_direction_arrows_many_args.png'],
+                  style=('classic', '_classic_test_patch'))
 def test_anchored_direction_arrows_many_args():
     fig, ax = plt.subplots()
     ax.imshow(np.ones((10, 10)))
@@ -618,7 +626,9 @@ def test_auto_adjustable():
     assert tbb.y1 == pytest.approx(fig.bbox.height - pad * fig.dpi)
 
 
-@image_comparison(['rgb_axes.png'], remove_text=True)
+# Update style when regenerating the test image
+@image_comparison(['rgb_axes.png'], remove_text=True,
+                  style=('classic', '_classic_test_patch'))
 def test_rgb_axes():
     fig = plt.figure()
     ax = RGBAxes(fig, (0.1, 0.1, 0.8, 0.8), pad=0.1)
@@ -629,7 +639,9 @@ def test_rgb_axes():
     ax.imshow_rgb(r, g, b, interpolation='none')
 
 
-@image_comparison(['insetposition.png'], remove_text=True)
+# Update style when regenerating the test image
+@image_comparison(['insetposition.png'], remove_text=True,
+                  style=('classic', '_classic_test_patch'))
 def test_insetposition():
     fig, ax = plt.subplots(figsize=(2, 2))
     ax_ins = plt.axes([0, 0, 1, 1])

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1799,8 +1799,9 @@ def test_subfigure_simple():
     ax = sf[1].add_subplot(1, 1, 1, projection='3d', label='other')
 
 
+# Update style when regenerating the test image
 @image_comparison(baseline_images=['computed_zorder'], remove_text=True,
-                  extensions=['png'])
+                  extensions=['png'], style=('classic', '_classic_test_patch'))
 def test_computed_zorder():
     fig = plt.figure()
     ax1 = fig.add_subplot(221, projection='3d')

--- a/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
@@ -7,7 +7,9 @@ import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import art3d
 
 
-@image_comparison(['legend_plot.png'], remove_text=True)
+# Update style when regenerating the test image
+@image_comparison(['legend_plot.png'], remove_text=True,
+                  style=('classic', '_classic_test_patch'))
 def test_legend_plot():
     fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
     x = np.arange(10)
@@ -16,7 +18,9 @@ def test_legend_plot():
     ax.legend()
 
 
-@image_comparison(['legend_bar.png'], remove_text=True)
+# Update style when regenerating the test image
+@image_comparison(['legend_bar.png'], remove_text=True,
+                  style=('classic', '_classic_test_patch'))
 def test_legend_bar():
     fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
     x = np.arange(10)
@@ -25,7 +29,9 @@ def test_legend_bar():
     ax.legend([b1[0], b2[0]], ['up', 'down'])
 
 
-@image_comparison(['fancy.png'], remove_text=True)
+# Update style when regenerating the test image
+@image_comparison(['fancy.png'], remove_text=True,
+                  style=('classic', '_classic_test_patch'))
 def test_fancy():
     fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
     ax.plot(np.arange(10), np.full(10, 5), np.full(10, 5), 'o--', label='line')


### PR DESCRIPTION
## PR Summary

The long term plan is that all test images should use `style='mpl20'` (= `style='default'). To be able to change the default of `image_comparison` to this, it makes sense to change all tests that doesn't explicitly specify style to use the current default.

This PR handles mpl_toolkits.

The comment isn't that explicit as I expect that once the default is changed, one can simply reword it to drop the style. (I do not expect many regenerated images before that happens...)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
