### PR TITLE
FIX: do not replace the Axes._children list object

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/parasite_axes.py
+++ b/lib/mpl_toolkits/axes_grid1/parasite_axes.py
@@ -136,7 +136,7 @@ class HostAxesBase:
             self._children.extend(ax.get_children())
 
         super().draw(renderer)
-        self._children = self._children[:orig_children_len]
+        del self._children[orig_children_len:]
 
     def clear(self):
         super().clear()

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -684,3 +684,14 @@ def test_imagegrid():
     im = ax.imshow([[1, 2]], norm=mpl.colors.LogNorm())
     cb = ax.cax.colorbar(im)
     assert isinstance(cb.locator, mticker.LogLocator)
+
+
+def test_removal():
+    import matplotlib.pyplot as plt
+    import mpl_toolkits.axisartist as AA
+    fig = plt.figure()
+    ax = host_subplot(111, axes_class=AA.Axes, figure=fig)
+    col = ax.fill_between(range(5), 0, range(5))
+    fig.canvas.draw()
+    col.remove()
+    fig.canvas.draw()


### PR DESCRIPTION
## PR Summary

Each Artist keeps a reference to `Axes._children.remove` as `art._remove_method`.  If we replace the `_children` instance on the Axes with a different list instance the Artists will not be updated and their remove method will refer to the wrong list.  This will cause subsequent failures on the next draw because on remove we reset the `art.axes` and `art.figure` to None.

xref https://discourse.matplotlib.org/t/host-subplot-and-artist-remove/23374



## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
