### PR TITLE
Backport PR #24003 on branch v3.6.2-doc: Fix wording and links lifecycle tutorial

### DIFF
--- a/tutorials/introductory/lifecycle.py
+++ b/tutorials/introductory/lifecycle.py
@@ -26,7 +26,7 @@ explicit and implicit interfaces see :ref:`api_interfaces`.
 In the explicit object-oriented (OO) interface we directly utilize instances of
 :class:`axes.Axes` to build up the visualization in an instance of
 :class:`figure.Figure`.  In the implicit interface, inspired by and modeled on
-MATLAB, uses an global state-based interface which is is encapsulated in the
+MATLAB, we use a global state-based interface which is encapsulated in the
 :mod:`.pyplot` module to plot to the "current Axes".  See the :doc:`pyplot
 tutorials </tutorials/introductory/pyplot>` for a more in-depth look at the
 pyplot interface.
@@ -34,16 +34,16 @@ pyplot interface.
 Most of the terms are straightforward but the main thing to remember
 is that:
 
-* The Figure is the final image that may contain 1 or more Axes.
-* The Axes represent an individual plot (don't confuse this with the word
-  "axis", which refers to the x/y axis of a plot).
+* The `.Figure` is the final image, and may contain one or more `~.axes.Axes`.
+* The `~.axes.Axes` represents an individual plot (not to be confused with
+   `~.axis.Axis`, which refers to the x/y axis of a plot).
 
 We call methods that do the plotting directly from the Axes, which gives
 us much more flexibility and power in customizing our plot.
 
 .. note::
 
-   In general prefer the explicit interface over the implicit pyplot interface
+   In general, use the explicit interface over the implicit pyplot interface
    for plotting.
 
 Our data


### PR DESCRIPTION
Backport of #24003

Manual backport due to conflict from one-line change in this file at #23974.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
