### PR TITLE
Fixed issue #23171 where axes vlines() / hlines() doesn't autoscale correctly with blended transform.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1095,7 +1095,8 @@ class Axes(_AxesBase):
             maxy = np.nanmax(masked_verts[..., 1])
             corners = (minx, miny), (maxx, maxy)
             self.update_datalim(corners)
-            self._request_autoscale_view()
+            update_axis = "y" if ("transform" in kwargs) else "all"
+            self._request_autoscale_view(axis=update_axis)
 
         return lines
 
@@ -1174,9 +1175,9 @@ class Axes(_AxesBase):
             miny = np.nanmin(masked_verts[..., 1])
             maxy = np.nanmax(masked_verts[..., 1])
             corners = (minx, miny), (maxx, maxy)
+            update_axis = "x" if ("transform" in kwargs) else "all"
             self.update_datalim(corners)
-            self._request_autoscale_view()
-
+            self._request_autoscale_view(axis=update_axis)
         return lines
 
     @_preprocess_data(replace_names=["positions", "lineoffsets",


### PR DESCRIPTION
## PR Summary
Changed vlines() and hlines() of axes to not autoscale on the horizontal/vertical axis given a transform argument. This is so that it doesn't autoscale incorrectly, treating the minimum argument as a data coordinate, as mentioned in issue #23171

## PR Checklist


**Documentation and Tests**
- [ Yes] Has pytest style unit tests (and `pytest` passes)
- [ N/A ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ N/A ] New plotting related features are documented with examples.

**Release Notes**
- [N/A ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`