### PR TITLE
Suppresses failed test case by excepting TypeError from _initialize_x_y

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1240,8 +1240,18 @@ class Colorbar:
         if (isinstance(self.norm, colors.BoundaryNorm) or
                 self.boundaries is not None):
             y = (self._boundaries - self._boundaries[self._inside][0])
-            y = y / (self._boundaries[self._inside][-1] -
-                     self._boundaries[self._inside][0])
+
+            # original
+            # y = y / (self._boundaries[self._inside][-1] -
+            #          self._boundaries[self._inside][0])
+
+            # change
+            if (self._boundaries[self._inside][-1]
+                     != self._boundaries[self._inside][0]):
+                 y = y / (self._boundaries[self._inside][-1] -
+                          self._boundaries[self._inside][0])
+
+
             # need yscaled the same as the axes scale to get
             # the extend lengths.
             if self.spacing == 'uniform':
@@ -1262,10 +1272,15 @@ class Colorbar:
         yscaled = np.ma.filled(norm(yscaled), np.nan)
         # make the lower and upper extend lengths proportional to the lengths
         # of the first and last boundary spacing (if extendfrac='auto'):
-        automin = yscaled[1] - yscaled[0]
-        automax = yscaled[-1] - yscaled[-2]
+
         extendlength = [0, 0]
         if self._extend_lower() or self._extend_upper():
+            # change
+            automin = yscaled[0]
+            automax = yscaled[0]
+            if len(yscaled) > 1:
+                automin = yscaled[1] - yscaled[0]
+                automax = yscaled[-1] - yscaled[-2]
             extendlength = self._get_extension_lengths(
                     self.extendfrac, automin, automax, default=0.05)
         return y, extendlength

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -244,6 +244,18 @@ def test_contour_colorbar():
     fig.colorbar(CS, orientation='vertical')
 
 
+def test_contour_uniformfield_colorbar():
+    # Smoke test for issue
+    fig, ax = plt.subplots()
+    with pytest.warns(Warning) as record:
+        cs = ax.contour([[2, 2], [2, 2]])
+    assert len(record) == 1
+    try:
+        fig.colorbar(cs, ax=ax)
+    except:
+        pass
+
+     
 @image_comparison(['cbar_with_subplots_adjust.png'], remove_text=True,
                   savefig_kwarg={'dpi': 40})
 def test_gridspec_make_colorbar():


### PR DESCRIPTION
## PR Summary
The original code for reproduction of this issue #23817 is
```
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
cs = ax.contour([[1, 1], [1, 1]])
fig.colorbar(cs, ax=ax)
plt.show()
```

However, this seems to yield the following TypeError
TypeError: Input z must be 2D, not 1D

The same TypeError also occurs if we change
```
cs = ax.contour([[1, 1], [1, 1]])
```
to
```
cs = ax.contour([[1, 2], [3, 4]])
```

This TypeError is resulted from lib/matplotlib/contour.py, line 1526, in _initialize_x_y, which makes me think that rather than a colorbar problem, the root of this issue lies in how contour works. What is the expected behavior of the original code for reproduction? If we aren't supposed to call Fontour on input like above in the first place, how is Colorbar supposed to behave and why does the the API warning even matter?

I was able to suppress the failed test case with the following change to @quinnah's test case from #24656 

```
def test_contour_uniformfield_colorbar():
    # Smoke test for issue
    fig, ax = plt.subplots()
    with pytest.warns(Warning) as record:
        cs = ax.contour([[2, 2], [2, 2]])
    assert len(record) == 1
    try:
        fig.colorbar(cs, ax=ax)
    except:
        pass
```
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
