### PR TITLE
Update lasso_demo.py

### DIFF
--- a/examples/event_handling/lasso_demo.py
+++ b/examples/event_handling/lasso_demo.py
@@ -10,6 +10,10 @@ selected points
 This is currently a proof-of-concept implementation (though it is
 usable as is).  There will be some refinement of the API.
 
+.. Error:: When only clicking (without drawing a lasso line), the program hangs!
+
+.. fixed:: Using new bool variable callback_has_been_called
+
 .. note::
     This example exercises the interactive capabilities of Matplotlib, and this
     will not appear in the static documentation. Please run this code on your
@@ -45,6 +49,8 @@ class LassoManager:
         self.canvas = ax.figure.canvas
         self.data = data
 
+        self.callback_has_been_called = False
+
         self.Nxy = len(data)
 
         facecolors = [d.color for d in data]
@@ -72,18 +78,20 @@ class LassoManager:
         self.canvas.draw_idle()
         self.canvas.widgetlock.release(self.lasso)
         del self.lasso
+        self.callback_has_been_called = True
 
     def on_press(self, event):
         if self.canvas.widgetlock.locked():
             return
         if event.inaxes is None:
             return
+        self.callback_has_been_called = False
         self.lasso = Lasso(event.inaxes,
                            (event.xdata, event.ydata),
                            self.callback)
         # acquire a lock on the widget drawing
-        self.canvas.widgetlock(self.lasso)
-
+        if self.callback_has_been_called:
+            self.canvas.widgetlock(self.lasso)
 
 if __name__ == '__main__':
 
@@ -96,3 +104,4 @@ if __name__ == '__main__':
     lman = LassoManager(ax, data)
 
     plt.show()
+


### PR DESCRIPTION
fixed error: hang up when clicking without drawing a lasso line

## PR Summary
I added a bool variable to control the call of  self.canvas.widgetlock(self.lasso).

## PR Checklist
Now the widgetlock is not called, if no line has been drawn. 

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
