### PR TITLE
FIX: behaviour of legend labels with leading underscores did not adhere to the API documentation

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -22,7 +22,6 @@ information.
 """
 
 import itertools
-import logging
 import time
 
 import numpy as np
@@ -1217,8 +1216,6 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
         *kwargs* with keywords handles and labels removed.
 
     """
-    log = logging.getLogger(__name__)
-
     handlers = kwargs.get('handler_map')
     extra_args = ()
 
@@ -1242,8 +1239,8 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
     elif len(args) == 0:
         handles, labels = _get_legend_handles_labels(axs, handlers)
         if not handles:
-            log.warning(
-                "No artists with labels found to put in legend.  Note that "
+            _api.warn_external(
+                "No artists with labels found to put in legend. Note that "
                 "artists whose label start with an underscore are ignored "
                 "when legend() is called with no argument.")
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -418,17 +418,6 @@ class Legend(Artist):
         self.borderaxespad = val_or_rc(borderaxespad, 'legend.borderaxespad')
         self.columnspacing = val_or_rc(columnspacing, 'legend.columnspacing')
         self.shadow = val_or_rc(shadow, 'legend.shadow')
-        # trim handles and labels if illegal label...
-        _lab, _hand = [], []
-        for label, handle in zip(labels, handles):
-            if isinstance(label, str) and label.startswith('_'):
-                _api.warn_external(f"The label {label!r} of {handle!r} starts "
-                                   "with '_'. It is thus excluded from the "
-                                   "legend.")
-            else:
-                _lab.append(label)
-                _hand.append(handle)
-        labels, handles = _lab, _hand
 
         handles = list(handles)
         if len(handles) < 2:

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -80,18 +80,30 @@ def test_various_labels():
     ax.legend(numpoints=1, loc='best')
 
 
-def test_legend_label_with_leading_underscore():
+def test_legend_label_with_leading_underscore1():
     """
     Test that artists with labels starting with an underscore are not added to
-    the legend, and that a warning is issued if one tries to add them
-    explicitly.
+    the legend when the legend method is called with no arguments, and that a
+    warning is issued if one tries to add them explicitly.
     """
     fig, ax = plt.subplots()
-    line, = ax.plot([0, 1], label='_foo')
+    ax.plot([0, 1], label='_foo')
     with pytest.warns(UserWarning,
-                      match=r"starts with '_'.*excluded from the legend."):
-        legend = ax.legend(handles=[line])
+                      match=r"artists whose label start with an underscore "
+                            "are ignored"):
+        legend = ax.legend()
     assert len(legend.legendHandles) == 0
+
+
+def test_legend_label_with_leading_underscore2():
+    """
+    Test that artists with labels starting with an underscore are added to the
+    legend when the legend method is called with the handles argument.
+    """
+    fig, ax = plt.subplots()
+    lines = ax.plot([0, 1], label='_foo')
+    legend = ax.legend(handles=lines)
+    assert len(legend.legendHandles) == 1
 
 
 @image_comparison(['legend_labels_first.png'], remove_text=True)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -524,9 +524,10 @@ def test_text_nohandler_warning():
     """Test that Text artists with labels raise a warning"""
     fig, ax = plt.subplots()
     ax.text(x=0, y=0, s="text", label="label")
-    with pytest.warns(UserWarning) as record:
+    with pytest.warns(UserWarning,
+                      match="Legend does not support handles for .+ "
+                            "instances"):
         ax.legend()
-    assert len(record) == 1
 
     # this should _not_ warn:
     f, ax = plt.subplots()
@@ -558,7 +559,7 @@ def test_legend_title_empty():
     # it comes back as an empty string, and that it is not
     # visible:
     fig, ax = plt.subplots()
-    ax.plot(range(10))
+    ax.plot(range(10), label="foo")
     leg = ax.legend()
     assert leg.get_title().get_text() == ""
     assert not leg.get_title().get_visible()
@@ -591,7 +592,7 @@ def test_window_extent_cached_renderer():
 
 def test_legend_title_fontprop_fontsize():
     # test the title_fontsize kwarg
-    plt.plot(range(10))
+    plt.plot(range(10), label="foo")
     with pytest.raises(ValueError):
         plt.legend(title='Aardvark', title_fontsize=22,
                    title_fontproperties={'family': 'serif', 'size': 22})
@@ -602,27 +603,27 @@ def test_legend_title_fontprop_fontsize():
 
     fig, axes = plt.subplots(2, 3, figsize=(10, 6))
     axes = axes.flat
-    axes[0].plot(range(10))
+    axes[0].plot(range(10), label="foo")
     leg0 = axes[0].legend(title='Aardvark', title_fontsize=22)
     assert leg0.get_title().get_fontsize() == 22
-    axes[1].plot(range(10))
+    axes[1].plot(range(10), label="foo")
     leg1 = axes[1].legend(title='Aardvark',
                           title_fontproperties={'family': 'serif', 'size': 22})
     assert leg1.get_title().get_fontsize() == 22
-    axes[2].plot(range(10))
+    axes[2].plot(range(10), label="foo")
     mpl.rcParams['legend.title_fontsize'] = None
     leg2 = axes[2].legend(title='Aardvark',
                           title_fontproperties={'family': 'serif'})
     assert leg2.get_title().get_fontsize() == mpl.rcParams['font.size']
-    axes[3].plot(range(10))
+    axes[3].plot(range(10), label="foo")
     leg3 = axes[3].legend(title='Aardvark')
     assert leg3.get_title().get_fontsize() == mpl.rcParams['font.size']
-    axes[4].plot(range(10))
+    axes[4].plot(range(10), label="foo")
     mpl.rcParams['legend.title_fontsize'] = 20
     leg4 = axes[4].legend(title='Aardvark',
                           title_fontproperties={'family': 'serif'})
     assert leg4.get_title().get_fontsize() == 20
-    axes[5].plot(range(10))
+    axes[5].plot(range(10), label="foo")
     leg5 = axes[5].legend(title='Aardvark')
     assert leg5.get_title().get_fontsize() == 20
 
@@ -907,7 +908,7 @@ def test_legend_labelcolor_rcparam_markerfacecolor_short():
 
 
 def test_get_set_draggable():
-    legend = plt.legend()
+    legend = plt.legend("foo")
     assert not legend.get_draggable()
     legend.set_draggable(True)
     assert legend.get_draggable()

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -98,11 +98,19 @@ def test_legend_label_with_leading_underscore1():
 def test_legend_label_with_leading_underscore2():
     """
     Test that artists with labels starting with an underscore are added to the
-    legend when the legend method is called with the handles argument.
+    legend when the legend method is called with arguments.
     """
     fig, ax = plt.subplots()
     lines = ax.plot([0, 1], label='_foo')
     legend = ax.legend(handles=lines)
+    assert len(legend.legendHandles) == 1
+    legend = ax.legend(handles=lines, labels=["_foo"])
+    assert len(legend.legendHandles) == 1
+    legend = ax.legend(labels=["_foo"])
+    assert len(legend.legendHandles) == 1
+    legend = ax.legend(["_foo"])
+    assert len(legend.legendHandles) == 1
+    legend = ax.legend(lines, ["_foo"])
     assert len(legend.legendHandles) == 1
 
 


### PR DESCRIPTION
## PR Summary
This PR fixes an inconsistency between API documentation and actual behaviour. As per the documentation, when matplotlib.axes.Axes.legend or matplotlib.figure.Figure.legend is called without any arguments, artists whose labels begin with an underscore are not included in the legend. This is stated for the first of four ways to invoke the method, however, it currently applies to all four.

This fix changes the current behaviour of legend-related API to adhere to the documentation, only filtering labels with leading underscores when using the first way of invoking the method (Automatic detection of elements to be shown in the legend), allowing the user to include labels with leading underscores by passing them to the legend method explicitly - using one of the remaining three options (note that in two of these, the user passes an iterable of labels, and in the remaining one, the user only explicitly passes the artist handles, not the labels).

Furthermore, this feature (exclusion of labels with leading underscores) is only documented in the two methods mentioned above, not in the matplotlib.legend.Legend class itself, where it was partly implemented prior to this PR (probably an artefact due to earlier developments).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
