### PR TITLE
Improve handling of degenerate jacobians in non-rectilinear grids.

### DIFF
--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -71,25 +71,19 @@ class FixedAxisArtistHelper(grid_helper_curvelinear.FloatingAxisArtistHelper):
 
         if self.nth_coord == 0:
             mask = (ymin <= yy0) & (yy0 <= ymax)
-            (xx1, yy1), (dxx1, dyy1), (dxx2, dyy2) = \
-                grid_helper_curvelinear._value_and_jacobian(
+            (xx1, yy1), angle_normal, angle_tangent = \
+                grid_helper_curvelinear._value_and_jac_angle(
                     trf_xy, self.value, yy0[mask], (xmin, xmax), (ymin, ymax))
             labels = self._grid_info["lat_labels"]
 
         elif self.nth_coord == 1:
             mask = (xmin <= xx0) & (xx0 <= xmax)
-            (xx1, yy1), (dxx2, dyy2), (dxx1, dyy1) = \
-                grid_helper_curvelinear._value_and_jacobian(
+            (xx1, yy1), angle_tangent, angle_normal = \
+                grid_helper_curvelinear._value_and_jac_angle(
                     trf_xy, xx0[mask], self.value, (xmin, xmax), (ymin, ymax))
             labels = self._grid_info["lon_labels"]
 
         labels = [l for l, m in zip(labels, mask) if m]
-
-        angle_normal = np.arctan2(dyy1, dxx1)
-        angle_tangent = np.arctan2(dyy2, dxx2)
-        mm = (dyy1 == 0) & (dxx1 == 0)  # points with degenerate normal
-        angle_normal[mm] = angle_tangent[mm] + np.pi / 2
-
         tick_to_axes = self.get_tick_transform(axes) - axes.transAxes
         in_01 = functools.partial(
             mpl.transforms._interval_contains_close, (0, 1))


### PR DESCRIPTION
grid_helper_curvelinear and floating_axes have code to specifically handle the case where the transform from rectlinear to non-rectilinear axes has null derivatives in one of the directions, inferring the angle of the jacobian from the derivative in the other direction.  (This angle defines the rotation applied to axis labels, ticks, and tick labels.)

This approach, however, is insufficient if the derivatives in both directions are zero.  A classical example is e.g. the ``exp(-1/x**2)`` transform, for which all derivatives are zero.  To handle this case more robustly (and also to better encapsulate the angle calculation, which is currently repeated at a few places), instead, one can increase the step size of the numerical differentiation until the gradient becomes nonzero.  This amounts to moving along the corresponding gridline until one actually leaves the position of the tick, and thus is indeed a justifiable approach to compute the tick rotation.

Full example:

    import matplotlib.pyplot as plt
    import mpl_toolkits.axisartist.floating_axes as floating_axes
    import numpy as np

    # def tr(x, y): return x - y, x + y
    # def inv_tr(u, v): return (u + v) / 2, (v - u) / 2

    @np.errstate(divide="ignore")  # at x=0, exp(-1/x**2)=0; div-by-zero can be ignored.
    def tr(x, y):
        return np.exp(-x**-2) - np.exp(-y**-2), np.exp(-x**-2) + np.exp(-y**-2)
    def inv_tr(u, v):
        return (-np.log((u+v)/2))**(1/2), (-np.log((v-u)/2))**(1/2)

    ax1 = plt.figure().add_subplot(
        axes_class=floating_axes.FloatingAxes,
        grid_helper=floating_axes.GridHelperCurveLinear(
            (tr, inv_tr), extremes=(0, 10, 0, 10)))

    plt.show()

np.broadcast_shapes requires numpy 1.20, which is allowed per NEP29.

before:
![old](https://user-images.githubusercontent.com/1322974/207392781-dfcfaca9-3e9b-494f-9f3c-a90166b1089d.png)
after:
![new](https://user-images.githubusercontent.com/1322974/207392801-ba83a4e5-b9fc-4bab-887b-836b036fb1b3.png)
(note the orientation of the ticks at (0, 0)).

Followup to #24509.

----

Edit: Currently fails because this doesn't support a tick at r=0 on an r axis in a polar plot anymore, although I guess the old approach wasn't really robust anyways (e.g. it would probably fail on an r axis with a "sheared" theta...).  To be further investigated...  For the record, a case where the *old* approach also failed:
```python
import numpy as np
from matplotlib import pyplot as plt
from matplotlib.projections.polar import PolarTransform
from matplotlib.transforms import Affine2D
from mpl_toolkits.axisartist import (
    angle_helper, GridHelperCurveLinear, HostAxes)


ax1 = plt.figure().add_subplot(
    axes_class=HostAxes,
    grid_helper=GridHelperCurveLinear(
        Affine2D().scale(np.pi / 180, 1)
        + PolarTransform()
        + Affine2D().scale(2, 1),
        extreme_finder=angle_helper.ExtremeFinderCycle(
            20, 20,
            lon_cycle=360, lat_cycle=None,
            lon_minmax=None, lat_minmax=(0, np.inf),
        ),
        grid_locator1=angle_helper.LocatorDMS(12),
        tick_formatter1=angle_helper.FormatterDMS(),
    ),
    aspect=1, xlim=(-5, 12), ylim=(-5, 10))
ax1.axis["lat"] = axis = ax1.new_floating_axis(0, 40)
axis.label.set_text(r"$\theta = 40^{\circ}$")
axis.label.set_visible(True)
ax1.grid(True)

plt.show()
```
![test](https://user-images.githubusercontent.com/1322974/208249985-67388170-a30c-457a-8e6b-44ae97c484bc.png)
Note that the tick at r=0 on the theta=40° axis is not parallel with the other ticks on the same axis, because locally there's no gridline that can be followed and so the old code just falls back to drawing the tick locally perpendicular to the axis.  I *guess* the right approach I would like to try is to see whether one can instead also slightly move along the r axis and take the limit as r->0 of the tick angle (because that tick angle is actually constant for all r!=0, so taking the limit will give the right answer.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
