### PR TITLE
FIX: be more forgiving in default draw wrapper

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -29,14 +29,14 @@ def _prevent_rasterization(draw):
     # (e.g., change in dpi).
 
     @wraps(draw)
-    def draw_wrapper(artist, renderer):
+    def draw_wrapper(artist, renderer, *args, **kwargs):
         if renderer._raster_depth == 0 and renderer._rasterizing:
             # Only stop when we are not in a rasterized parent
             # and something has been rasterized since last stop.
             renderer.stop_rasterizing()
             renderer._rasterizing = False
 
-        return draw(artist, renderer)
+        return draw(artist, renderer, *args, **kwargs)
 
     draw_wrapper._supports_rasterization = False
     return draw_wrapper

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -13,6 +13,7 @@ import matplotlib.path as mpath
 import matplotlib.transforms as mtransforms
 import matplotlib.collections as mcollections
 import matplotlib.artist as martist
+import matplotlib.backend_bases as mbackend_bases
 import matplotlib as mpl
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
@@ -549,3 +550,15 @@ def test_auto_no_rasterize():
 
     assert 'draw' not in Gen2.__dict__
     assert Gen2.draw is Gen1.draw
+
+
+def test_draw_wraper_forward_input():
+    class TestKlass(martist.Artist):
+        def draw(self, renderer, extra):
+            return extra
+
+    art = TestKlass()
+    renderer = mbackend_bases.RendererBase()
+
+    assert 'aardvark' == art.draw(renderer, 'aardvark')
+    assert 'aardvark' == art.draw(renderer, extra='aardvark')


### PR DESCRIPTION

## PR Summary

This un-breaks astropy which added additional inputs to custom draw methods.  Suspect that they are not the only ones.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
