### PR TITLE
Run delvewheel on Windows for wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -37,6 +37,11 @@ jobs:
     env:
       CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
       MACOSX_DEPLOYMENT_TARGET: "10.12"
+      CIBW_BEFORE_BUILD_WINDOWS: >-
+        pip install certifi delvewheel oldest-supported-numpy &&
+        git clean -fxd build
+      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
+        delvewheel repair -w {dest_dir} {wheel}
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-latest, macos-11]

--- a/doc/api/next_api_changes/development/24724-ES.rst
+++ b/doc/api/next_api_changes/development/24724-ES.rst
@@ -1,0 +1,5 @@
+Windows wheel runtime bundling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Wheels built for Windows now bundle the MSVC runtime DLL ``msvcp140.dll``. This
+enables importing Matplotlib on systems that do not have the runtime installed.


### PR DESCRIPTION
## PR Summary

This causes the MSVC runtime to be bundled, which enables importing Matplotlib on systems that do not have it installed.

Fixes #24704.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`