### PR TITLE
DOC: Post warnings as reviews on PRs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,6 +141,7 @@ commands:
                [ "$CIRCLE_PR_NUMBER" = "" ]; then
               export RELEASE_TAG='-t release'
             fi
+            mkdir -p logs
             make html O="-T $RELEASE_TAG -j4 -w /tmp/sphinxerrorswarnings.log"
             rm -r build/html/_sources
           working_directory: doc
@@ -154,20 +155,35 @@ commands:
       - run:
           name: Extract possible build errors and warnings
           command: |
-           (grep "WARNING\|ERROR" /tmp/sphinxerrorswarnings.log ||
-            echo "No errors or warnings")
+            (grep "WARNING\|ERROR" /tmp/sphinxerrorswarnings.log ||
+             echo "No errors or warnings")
+            # Save logs as an artifact, and convert from absolute paths to
+            # repository-relative paths.
+            sed "s~$PWD/~~" /tmp/sphinxerrorswarnings.log > \
+              doc/logs/sphinx-errors-warnings.log
           when: always
+      - store_artifacts:
+          path: doc/logs/sphinx-errors-warnings.log
 
   doc-show-deprecations:
     steps:
       - run:
           name: Extract possible deprecation warnings in examples and tutorials
           command: |
-           (grep DeprecationWarning -r -l doc/build/html/gallery ||
-            echo "No deprecation warnings in gallery")
-           (grep DeprecationWarning -r -l doc/build/html/tutorials ||
-            echo "No deprecation warnings in tutorials")
+            (grep -rl DeprecationWarning doc/build/html/gallery ||
+             echo "No deprecation warnings in gallery")
+            (grep -rl DeprecationWarning doc/build/html/plot_types ||
+             echo "No deprecation warnings in plot_types")
+            (grep -rl DeprecationWarning doc/build/html/tutorials ||
+             echo "No deprecation warnings in tutorials")
+            # Save deprecations that are from this absolute directory, and
+            # convert to repository-relative paths.
+            (grep -Ero --no-filename "$PWD/.+DeprecationWarning.+$" \
+             doc/build/html/{gallery,plot_types,tutorials} || echo) | \
+              sed "s~$PWD/~~" > doc/logs/sphinx-deprecations.log
           when: always
+      - store_artifacts:
+          path: doc/logs/sphinx-deprecations.log
 
   doc-bundle:
     steps:

--- a/.circleci/fetch_doc_logs.py
+++ b/.circleci/fetch_doc_logs.py
@@ -1,0 +1,63 @@
+"""
+Download artifacts from CircleCI for a documentation build.
+
+This is run by the :file:`.github/workflows/circleci.yml` workflow in order to
+get the warning/deprecation logs that will be posted on commits as checks. Logs
+are downloaded from the :file:`docs/logs` artifact path and placed in the
+:file:`logs` directory.
+
+Additionally, the artifact count for a build is produced as a workflow output,
+by appending to the file specified by :env:`GITHUB_OUTPUT`.
+
+If there are no logs, an "ERROR" message is printed, but this is not fatal, as
+the initial 'status' workflow runs when the build has first started, and there
+are naturally no artifacts at that point.
+
+This script should be run by passing the CircleCI build URL as its first
+argument. In the GitHub Actions workflow, this URL comes from
+``github.event.target_url``.
+"""
+import json
+import os
+from pathlib import Path
+import sys
+from urllib.parse import urlparse
+from urllib.request import urlopen
+
+
+if len(sys.argv) != 2:
+    print('USAGE: fetch_doc_results.py CircleCI-build-url')
+    sys.exit(1)
+
+target_url = urlparse(sys.argv[1])
+*_, organization, repository, build_id = target_url.path.split('/')
+print(f'Fetching artifacts from {organization}/{repository} for {build_id}')
+
+artifact_url = (
+    f'https://circleci.com/api/v2/project/gh/'
+    f'{organization}/{repository}/{build_id}/artifacts'
+)
+print(artifact_url)
+with urlopen(artifact_url) as response:
+    artifacts = json.load(response)
+artifact_count = len(artifacts['items'])
+print(f'Found {artifact_count} artifacts')
+
+with open(os.environ['GITHUB_OUTPUT'], 'w+') as fd:
+    fd.write(f'count={artifact_count}\n')
+
+logs = Path('logs')
+logs.mkdir(exist_ok=True)
+
+found = False
+for item in artifacts['items']:
+    path = item['path']
+    if path.startswith('doc/logs/'):
+        path = Path(path).name
+        print(f'Downloading {path} from {item["url"]}')
+        with urlopen(item['url']) as response:
+            (logs / path).write_bytes(response.read())
+        found = True
+
+if not found:
+    print('ERROR: Did not find any artifact logs!')

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -15,7 +15,3 @@ jobs:
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: docs-python38
           job-title: View the built docs
-      - name: Check the URL
-        if: github.event.status != 'pending'
-        run: |
-          curl --fail ${{ steps.step1.outputs.url }} | grep $GITHUB_SHA

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,11 +1,12 @@
 ---
+name: "CircleCI artifact handling"
 on: [status]
-permissions:
-  statuses: write
 jobs:
   circleci_artifacts_redirector_job:
-    runs-on: ubuntu-latest
     if: "${{ github.event.context == 'ci/circleci: docs-python38' }}"
+    permissions:
+      statuses: write
+    runs-on: ubuntu-latest
     name: Run CircleCI artifacts redirector
     steps:
       - name: GitHub Action step
@@ -15,3 +16,54 @@ jobs:
           artifact-path: 0/doc/build/html/index.html
           circleci-jobs: docs-python38
           job-title: View the built docs
+
+  post_warnings_as_review:
+    if: "${{ github.event.context == 'ci/circleci: docs-python38' }}"
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
+    runs-on: ubuntu-latest
+    name: Post warnings/errors as review
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Fetch result artifacts
+        id: fetch-artifacts
+        run: |
+          python .circleci/fetch_doc_logs.py "${{ github.event.target_url }}"
+
+      - name: Set up reviewdog
+        if: "${{ steps.fetch-artifacts.outputs.count != 0 }}"
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
+
+      - name: Post review
+        if: "${{ steps.fetch-artifacts.outputs.count != 0 }}"
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REVIEWDOG_SKIP_DOGHOUSE: "true"
+          CI_COMMIT: ${{ github.event.sha }}
+          CI_REPO_OWNER: ${{ github.event.repository.owner.login }}
+          CI_REPO_NAME: ${{ github.event.repository.name }}
+        run: |
+          # The 'status' event does not contain information in the way that
+          # reviewdog expects, so we unset those so it reads from the
+          # environment variables we set above.
+          unset GITHUB_ACTIONS GITHUB_EVENT_PATH
+          cat logs/sphinx-errors-warnings.log | \
+            reviewdog \
+              -efm '%f\:%l: %tEBUG: %m' \
+              -efm '%f\:%l: %tNFO: %m' \
+              -efm '%f\:%l: %tARNING: %m' \
+              -efm '%f\:%l: %tRROR: %m' \
+              -efm '%f\:%l: %tEVERE: %m' \
+              -efm '%f\:%s: %tARNING: %m' \
+              -efm '%f\:%s: %tRROR: %m' \
+              -name=sphinx -tee -fail-on-error=false \
+              -reporter=github-check -filter-mode=nofilter
+          cat logs/sphinx-deprecations.log | \
+            reviewdog \
+              -efm '%f\:%l: %m' \
+              -name=examples -tee -reporter=github-check -filter-mode=nofilter


### PR DESCRIPTION
## PR Summary

This posts the warnings and deprecations from the doc builds as artifacts, then fetches them from the GitHub Action for CircleCI posting, and posts them as commit checks.

It also removes the URL check that I added in #24579. While it can be fixed, it would still "error" when the build initially starts (because there are no artifacts) and we've lasted without it so far, so I took it out.

Now, I've found out that the `status` event only triggers for the workflow on the default branch, so the changes here won't be directly reflected until merged (and is why the URL check thing above wasn't noticed before merging). Therefore, I have pushed this change to my fork's `main` branch, then opened a PR that breaks a reST target and a deprecation in an example. You can see this posting here: https://github.com/QuLogic/matplotlib/pull/25/files

Fixes #22176

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`