### PR TITLE
Support masked dates

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -444,7 +444,10 @@ def date2num(d):
     if not iterable:
         d = [d]
 
+    masked = np.ma.is_masked(d)
+    mask = np.ma.getmask(d)
     d = np.asarray(d)
+
     # convert to datetime64 arrays, if not already:
     if not np.issubdtype(d.dtype, np.datetime64):
         # datetime arrays
@@ -458,6 +461,7 @@ def date2num(d):
             d = np.asarray(d)
         d = d.astype('datetime64[us]')
 
+    d = np.ma.masked_array(d, mask=mask) if masked else d
     d = _dt64_to_ordinalf(d)
 
     return d if iterable else d[0]

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -69,6 +69,26 @@ def test_date2num_NaT_scalar(units):
     assert np.isnan(tmpl)
 
 
+def test_date2num_masked():
+    # Without tzinfo
+    base = datetime.datetime(2022, 12, 15)
+    dates = np.ma.array([base + datetime.timedelta(days=(2 * i))
+                         for i in range(7)], mask=[0, 1, 1, 0, 0, 0, 1])
+    npdates = mdates.date2num(dates)
+    np.testing.assert_array_equal(np.ma.getmask(npdates),
+                                  (False, True, True, False, False, False,
+                                   True))
+
+    # With tzinfo
+    base = datetime.datetime(2022, 12, 15, tzinfo=mdates.UTC)
+    dates = np.ma.array([base + datetime.timedelta(days=(2 * i))
+                         for i in range(7)], mask=[0, 1, 1, 0, 0, 0, 1])
+    npdates = mdates.date2num(dates)
+    np.testing.assert_array_equal(np.ma.getmask(npdates),
+                                  (False, True, True, False, False, False,
+                                   True))
+
+
 def test_date_empty():
     # make sure we do the right thing when told to plot dates even
     # if no date data has been presented, cf


### PR DESCRIPTION
## PR Summary

Related to https://github.com/matplotlib/matplotlib/pull/24732#issuecomment-1352981155

Now, `date2num` does not strip any mask information.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
