### PR TITLE
Minor redundancy cleanup of code which sets 3D aspect 3D

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -324,9 +324,6 @@ class Axes3D(Axes):
         """
         _api.check_in_list(('auto', 'equal', 'equalxy', 'equalyz', 'equalxz'),
                            aspect=aspect)
-        if adjustable is None:
-            adjustable = self._adjustable
-        _api.check_in_list(('box', 'datalim'), adjustable=adjustable)
         super().set_aspect(
             aspect='auto', adjustable=adjustable, anchor=anchor, share=share)
         self._aspect = aspect
@@ -338,7 +335,7 @@ class Axes3D(Axes):
                                        self.yaxis.get_view_interval(),
                                        self.zaxis.get_view_interval()])
             ptp = np.ptp(view_intervals, axis=1)
-            if adjustable == 'datalim':
+            if self._adjustable == 'datalim':
                 mean = np.mean(view_intervals, axis=1)
                 delta = max(ptp[ax_indices])
                 scale = self._box_aspect[ptp == delta][0]


### PR DESCRIPTION
## PR Summary
On line 330 of
https://github.com/matplotlib/matplotlib/blob/d8bb1a52316c38434e526412c27d9c4b01960084/lib/mpl_toolkits/mplot3d/axes3d.py#L327-L332
`super().set_aspect` calls `self.set_adjustable`
https://github.com/matplotlib/matplotlib/blob/d8bb1a52316c38434e526412c27d9c4b01960084/lib/matplotlib/axes/_base.py#L1744-L1746
which in turn calls `_api.check_in_list` and sets `self._adjustable`.
https://github.com/matplotlib/matplotlib/blob/d8bb1a52316c38434e526412c27d9c4b01960084/lib/matplotlib/axes/_base.py#L1796-L1811
It ought to be safe to remove the extra validation code.

## PR Checklist

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

