### PR TITLE
Fix deprecations of *Cursor widget event handlers

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1616,7 +1616,7 @@ class Cursor(AxesWidget):
         self.background = None
         self.needclear = False
 
-    @_api.deprecated('3.5')
+    @_api.deprecated('3.7')
     def clear(self, event):
         """Internal event handler to clear the cursor."""
         self._clear(event)
@@ -1632,7 +1632,7 @@ class Cursor(AxesWidget):
         if self.useblit:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
 
-    onmove = _api.deprecate_privatize_attribute('3.5')
+    onmove = _api.deprecate_privatize_attribute('3.7')
 
     def _onmove(self, event):
         """Internal event handler to draw the cursor when the mouse moves."""
@@ -1769,7 +1769,7 @@ class MultiCursor(Widget):
                 canvas.mpl_disconnect(cid)
             info["cids"].clear()
 
-    @_api.deprecated('3.5')
+    @_api.deprecated('3.7')
     def clear(self, event):
         """Clear the cursor."""
         if self.ignore(event):
@@ -1786,7 +1786,7 @@ class MultiCursor(Widget):
             for canvas, info in self._canvas_infos.items():
                 info["background"] = canvas.copy_from_bbox(canvas.figure.bbox)
 
-    onmove = _api.deprecate_privatize_attribute('3.5')
+    onmove = _api.deprecate_privatize_attribute('3.7')
 
     def _onmove(self, event):
         if (self.ignore(event)


### PR DESCRIPTION
## PR Summary

These were added in #19763.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`