### PR TITLE
DOC: Change event handling table into a tab set

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -109,3 +109,15 @@ div.graphviz {
 img.graphviz.inheritance {
     max-width: none;
 }
+
+/* Make tables in notes horizontally scrollable if too large. */
+div.wide-table {
+    overflow-x: auto;
+}
+
+div.wide-table table th.stub {
+    background-color: var(--pst-color-background);
+    background-clip: padding-box;
+    left: 0;
+    position: sticky;
+}

--- a/doc/users/explain/event_handling.rst
+++ b/doc/users/explain/event_handling.rst
@@ -85,25 +85,124 @@ Event name             Class            Description
    what you may expect to receive as key(s) (using a QWERTY keyboard layout)
    from the different user interface toolkits, where a comma separates different keys:
 
-   ================ ============================= ============================== ============================== ============================== ============================== ===================================
-   Key(s) Pressed   WxPython                      Qt                             WebAgg                         Gtk                            Tkinter                        macosx
-   ================ ============================= ============================== ============================== ============================== ============================== ===================================
-   Shift+2          shift, shift+2                shift, @                       shift, @                       shift, @                       shift, @                       shift, @
-   Shift+F1         shift, shift+f1               shift, shift+f1                shift, shift+f1                shift, shift+f1                shift, shift+f1                shift, shift+f1
-   Shift            shift                         shift                          shift                          shift                          shift                          shift
-   Control          control                       control                        control                        control                        control                        control
-   Alt              alt                           alt                            alt                            alt                            alt                            alt
-   AltGr            Nothing                       Nothing                        alt                            iso_level3_shift               iso_level3_shift
-   CapsLock         caps_lock                     caps_lock                      caps_lock                      caps_lock                      caps_lock                      caps_lock
-   CapsLock+a       caps_lock, a                  caps_lock, a                   caps_lock, A                   caps_lock, A                   caps_lock, A                   caps_lock, a
-   a                a                             a                              a                              a                              a                              a
-   Shift+a          shift, A                      shift, A                       shift, A                       shift, A                       shift, A                       shift, A
-   CapsLock+Shift+a caps_lock, shift, A           caps_lock, shift, A            caps_lock, shift, a            caps_lock, shift, a            caps_lock, shift, a            caps_lock, shift, A
-   Ctrl+Shift+Alt   control, ctrl+shift, ctrl+alt control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+meta control, ctrl+shift, ctrl+alt+shift
-   Ctrl+Shift+a     control, ctrl+shift, ctrl+A   control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+A    control, ctrl+shift, ctrl+a    control, ctrl+shift, ctrl+A
-   F1               f1                            f1                             f1                             f1                             f1                             f1
-   Ctrl+F1          control, ctrl+f1              control, ctrl+f1               control, ctrl+f1               control, ctrl+f1               control, ctrl+f1               control, Nothing
-   ================ ============================= ============================== ============================== ============================== ============================== ===================================
+   .. container:: wide-table
+
+      .. list-table::
+         :header-rows: 1
+         :stub-columns: 1
+
+         * - Key(s) Pressed
+           - Tkinter
+           - Qt
+           - macosx
+           - WebAgg
+           - GTK
+           - WxPython
+         * - :kbd:`Shift+2`
+           - shift, @
+           - shift, @
+           - shift, @
+           - shift, @
+           - shift, @
+           - shift, shift+2
+         * - :kbd:`Shift+F1`
+           - shift, shift+f1
+           - shift, shift+f1
+           - shift, shift+f1
+           - shift, shift+f1
+           - shift, shift+f1
+           - shift, shift+f1
+         * - :kbd:`Shift`
+           - shift
+           - shift
+           - shift
+           - shift
+           - shift
+           - shift
+         * - :kbd:`Control`
+           - control
+           - control
+           - control
+           - control
+           - control
+           - control
+         * - :kbd:`Alt`
+           - alt
+           - alt
+           - alt
+           - alt
+           - alt
+           - alt
+         * - :kbd:`AltGr`
+           - iso_level3_shift
+           - *nothing*
+           -
+           - alt
+           - iso_level3_shift
+           - *nothing*
+         * - :kbd:`CapsLock`
+           - caps_lock
+           - caps_lock
+           - caps_lock
+           - caps_lock
+           - caps_lock
+           - caps_lock
+         * - :kbd:`CapsLock+a`
+           - caps_lock, A
+           - caps_lock, a
+           - caps_lock, a
+           - caps_lock, A
+           - caps_lock, A
+           - caps_lock, a
+         * - :kbd:`a`
+           - a
+           - a
+           - a
+           - a
+           - a
+           - a
+         * - :kbd:`Shift+a`
+           - shift, A
+           - shift, A
+           - shift, A
+           - shift, A
+           - shift, A
+           - shift, A
+         * - :kbd:`CapsLock+Shift+a`
+           - caps_lock, shift, a
+           - caps_lock, shift, A
+           - caps_lock, shift, A
+           - caps_lock, shift, a
+           - caps_lock, shift, a
+           - caps_lock, shift, A
+         * - :kbd:`Ctrl+Shift+Alt`
+           - control, ctrl+shift, ctrl+meta
+           - control, ctrl+shift, ctrl+meta
+           - control, ctrl+shift, ctrl+alt+shift
+           - control, ctrl+shift, ctrl+meta
+           - control, ctrl+shift, ctrl+meta
+           - control, ctrl+shift, ctrl+alt
+         * - :kbd:`Ctrl+Shift+a`
+           - control, ctrl+shift, ctrl+a
+           - control, ctrl+shift, ctrl+A
+           - control, ctrl+shift, ctrl+A
+           - control, ctrl+shift, ctrl+A
+           - control, ctrl+shift, ctrl+A
+           - control, ctrl+shift, ctrl+A
+         * - :kbd:`F1`
+           - f1
+           - f1
+           - f1
+           - f1
+           - f1
+           - f1
+         * - :kbd:`Ctrl+F1`
+           - control, ctrl+f1
+           - control, ctrl+f1
+           - control, *nothing*
+           - control, ctrl+f1
+           - control, ctrl+f1
+           - control, ctrl+f1
 
 Matplotlib attaches some keypress callbacks by default for interactivity; they
 are documented in the :ref:`key-event-handling` section.


### PR DESCRIPTION
## PR Summary

The existing table is too wide, and overflow is clipped, so that not all toolkits are visible.

Fixes (partially?) #24741

I also changed `Nothing` to `*nothing*` to make it clearer and added a `*nothing*` to the macosx table for <kbd>AltGr</kbd>.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`