### PR TITLE
Allow using masked in `set_offsets`

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -545,14 +545,11 @@ class Collection(artist.Artist, cm.ScalarMappable):
         offsets = np.asanyarray(offsets)
         if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
             offsets = offsets[None, :]
-        if isinstance(offsets, np.ma.MaskedArray):
-            self._offsets = np.ma.column_stack(
-                (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
-                 np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
-        else:
-            self._offsets = np.column_stack(
-                (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
-                 np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
+        cstack = (np.ma.column_stack if isinstance(offsets, np.ma.MaskedArray)
+                  else np.column_stack)
+        self._offsets = cstack(
+            (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
+                np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
         self.stale = True
 
     def get_offsets(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -549,7 +549,7 @@ class Collection(artist.Artist, cm.ScalarMappable):
                   else np.column_stack)
         self._offsets = cstack(
             (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
-                np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
+             np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
         self.stale = True
 
     def get_offsets(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -545,9 +545,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         offsets = np.asanyarray(offsets)
         if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
             offsets = offsets[None, :]
-        self._offsets = np.column_stack(
-            (np.asarray(self.convert_xunits(offsets[:, 0]), float),
-             np.asarray(self.convert_yunits(offsets[:, 1]), float)))
+        self._offsets = np.ma.column_stack(
+            (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
+             np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
         self.stale = True
 
     def get_offsets(self):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -545,9 +545,14 @@ class Collection(artist.Artist, cm.ScalarMappable):
         offsets = np.asanyarray(offsets)
         if offsets.shape == (2,):  # Broadcast (2,) -> (1, 2) but nothing else.
             offsets = offsets[None, :]
-        self._offsets = np.ma.column_stack(
-            (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
-             np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
+        if isinstance(offsets, np.ma.MaskedArray):
+            self._offsets = np.ma.column_stack(
+                (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
+                 np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
+        else:
+            self._offsets = np.column_stack(
+                (np.asanyarray(self.convert_xunits(offsets[:, 0]), float),
+                 np.asanyarray(self.convert_yunits(offsets[:, 1]), float)))
         self.stale = True
 
     def get_offsets(self):

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1161,15 +1161,11 @@ def test_masked_set_offsets(fig_ref, fig_test):
     scat.set_offsets(np.ma.column_stack([x, y]))
     ax_test.set_xticks([])
     ax_test.set_yticks([])
-    ax_test.set_xlim(0, 7)
-    ax_test.set_ylim(0, 6)
 
     ax_ref = fig_ref.add_subplot()
     ax_ref.scatter([1, 2, 5], [1, 2, 5])
     ax_ref.set_xticks([])
     ax_ref.set_yticks([])
-    ax_ref.set_xlim(0, 7)
-    ax_ref.set_ylim(0, 6)
 
 
 def test_check_offsets_dtype():

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1158,7 +1158,6 @@ def test_masked_set_offsets(fig_ref, fig_test):
 
     ax_test = fig_test.add_subplot()
     scat = ax_test.scatter(x, y)
-    x += 1
     scat.set_offsets(np.ma.column_stack([x, y]))
     ax_test.set_xticks([])
     ax_test.set_yticks([])
@@ -1166,7 +1165,7 @@ def test_masked_set_offsets(fig_ref, fig_test):
     ax_test.set_ylim(0, 6)
 
     ax_ref = fig_ref.add_subplot()
-    ax_ref.scatter([2, 3, 6], [1, 2, 5])
+    ax_ref.scatter([1, 2, 5], [1, 2, 5])
     ax_ref.set_xticks([])
     ax_ref.set_yticks([])
     ax_ref.set_xlim(0, 7)
@@ -1180,7 +1179,6 @@ def test_check_offsets_dtype():
 
     fig, ax = plt.subplots()
     scat = ax.scatter(x, y)
-    x += 1
     masked_offsets = np.ma.column_stack([x, y])
     scat.set_offsets(masked_offsets)
     assert isinstance(scat.get_offsets(), type(masked_offsets))

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1151,12 +1151,40 @@ def test_check_masked_offsets():
     ax.scatter(unmasked_x, masked_y)
 
 
-def test_masked_set_offsets():
+@check_figures_equal(extensions=["png"])
+def test_masked_set_offsets(fig_ref, fig_test):
+    x = np.ma.array([1, 2, 3, 4, 5], mask=[0, 0, 1, 1, 0])
+    y = np.arange(1, 6)
+
+    ax_test = fig_test.add_subplot()
+    scat = ax_test.scatter(x, y)
+    x += 1
+    scat.set_offsets(np.ma.column_stack([x, y]))
+    ax_test.set_xticks([])
+    ax_test.set_yticks([])
+    ax_test.set_xlim(0, 7)
+    ax_test.set_ylim(0, 6)
+
+    ax_ref = fig_ref.add_subplot()
+    ax_ref.scatter([2, 3, 6], [1, 2, 5])
+    ax_ref.set_xticks([])
+    ax_ref.set_yticks([])
+    ax_ref.set_xlim(0, 7)
+    ax_ref.set_ylim(0, 6)
+
+
+def test_check_offsets_dtype():
+    # Check that setting offsets doesn't change dtype
     x = np.ma.array([1, 2, 3, 4, 5], mask=[0, 0, 1, 1, 0])
     y = np.arange(1, 6)
 
     fig, ax = plt.subplots()
     scat = ax.scatter(x, y)
     x += 1
-    scat.set_offsets(np.ma.column_stack([x, y]))
-    assert np.ma.is_masked(scat.get_offsets())
+    masked_offsets = np.ma.column_stack([x, y])
+    scat.set_offsets(masked_offsets)
+    assert isinstance(scat.get_offsets(), type(masked_offsets))
+
+    unmasked_offsets = np.column_stack([x, y])
+    scat.set_offsets(unmasked_offsets)
+    assert isinstance(scat.get_offsets(), type(unmasked_offsets))

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1149,3 +1149,14 @@ def test_check_masked_offsets():
 
     fig, ax = plt.subplots()
     ax.scatter(unmasked_x, masked_y)
+
+
+def test_masked_set_offsets():
+    x = np.ma.array([1, 2, 3, 4, 5], mask=[0, 0, 1, 1, 0])
+    y = np.arange(1, 6)
+
+    fig, ax = plt.subplots()
+    scat = ax.scatter(x, y)
+    x += 1
+    scat.set_offsets(np.ma.column_stack([x, y]))
+    assert np.ma.is_masked(scat.get_offsets())


### PR DESCRIPTION
## PR Summary
`scatter` allows using masked arrays as data and it also respects it by not plotting the masked points (#24545 , #24732 , #24733). But, if the offsets are updated using `set_offsets` and the input data is a masked array, the mask information is lost in `set_offsets` and the new plot contains all the points. A quick example:

```python
import numpy as np
import matplotlib.pyplot as plt

x = np.ma.array([1, 2, 3, 4, 5], mask=[0, 0, 1, 1, 0])
y = np.arange(1, 6)

fig, ax = plt.subplots()
scat = ax.scatter(x, y)

x = x/ 2
scat.set_offsets(np.ma.column_stack([x, y]))
ax.set_xlim(0, 6)
plt.show()
```

Current behaviour:
![image](https://user-images.githubusercontent.com/29800965/208238994-0751ba8b-76fa-4591-9e17-89e3b80708fe.png)

Proposed behaviour:
![image](https://user-images.githubusercontent.com/29800965/208239015-b62c34e7-cd9b-42c7-af5b-6581f0923298.png)

This is a small effort in lines with #24733 .

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
