### PR TITLE
Remove unused dicts from backend_cairo.

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -72,35 +72,6 @@ def _cairo_font_args_from_font_prop(prop):
     return name, slant, weight
 
 
-# Mappings used for deprecated properties in RendererCairo, see below.
-_f_weights = {
-    100:          cairo.FONT_WEIGHT_NORMAL,
-    200:          cairo.FONT_WEIGHT_NORMAL,
-    300:          cairo.FONT_WEIGHT_NORMAL,
-    400:          cairo.FONT_WEIGHT_NORMAL,
-    500:          cairo.FONT_WEIGHT_NORMAL,
-    600:          cairo.FONT_WEIGHT_BOLD,
-    700:          cairo.FONT_WEIGHT_BOLD,
-    800:          cairo.FONT_WEIGHT_BOLD,
-    900:          cairo.FONT_WEIGHT_BOLD,
-    'ultralight': cairo.FONT_WEIGHT_NORMAL,
-    'light':      cairo.FONT_WEIGHT_NORMAL,
-    'normal':     cairo.FONT_WEIGHT_NORMAL,
-    'medium':     cairo.FONT_WEIGHT_NORMAL,
-    'regular':    cairo.FONT_WEIGHT_NORMAL,
-    'semibold':   cairo.FONT_WEIGHT_BOLD,
-    'bold':       cairo.FONT_WEIGHT_BOLD,
-    'heavy':      cairo.FONT_WEIGHT_BOLD,
-    'ultrabold':  cairo.FONT_WEIGHT_BOLD,
-    'black':      cairo.FONT_WEIGHT_BOLD,
-}
-_f_angles = {
-    'italic':  cairo.FONT_SLANT_ITALIC,
-    'normal':  cairo.FONT_SLANT_NORMAL,
-    'oblique': cairo.FONT_SLANT_OBLIQUE,
-}
-
-
 class RendererCairo(RendererBase):
     def __init__(self, dpi):
         self.dpi = dpi


### PR DESCRIPTION
They are unused since 15c39a3.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
