### PR TITLE
Allow polar scales where zero is not in valid interval

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -422,14 +422,25 @@ class RadialLocator(mticker.Locator):
                     return [tick for tick in self.base() if tick > rorigin]
         return self.base()
 
+    def _zero_in_bounds(self):
+        """
+        Return True if zero is within the valid values for the
+        scale of the radial axis.
+        """
+        vmin, vmax = self._axes.yaxis._scale.limit_range_for_scale(0, 1, 1e-5)
+        return vmin == 0
+
     def nonsingular(self, vmin, vmax):
         # docstring inherited
-        return ((0, 1) if (vmin, vmax) == (-np.inf, np.inf)  # Init. limits.
-                else self.base.nonsingular(vmin, vmax))
+        if self._zero_in_bounds() and (vmin, vmax) == (-np.inf, np.inf):
+            # Initial view limits
+            return (0, 1)
+        else:
+            return self.base.nonsingular(vmin, vmax)
 
     def view_limits(self, vmin, vmax):
         vmin, vmax = self.base.view_limits(vmin, vmax)
-        if vmax > vmin:
+        if self._zero_in_bounds() and vmax > vmin:
             # this allows inverted r/y-lims
             vmin = min(0, vmin)
         return mtransforms.nonsingular(vmin, vmax)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -291,6 +291,13 @@ def test_polar_no_data():
     assert ax.get_rmin() == 0 and ax.get_rmax() == 1
 
 
+def test_polar_default_log_lims():
+    plt.subplot(projection='polar')
+    ax = plt.gca()
+    ax.set_rscale('log')
+    assert ax.get_rmin() > 0
+
+
 def test_polar_not_datalim_adjustable():
     ax = plt.figure().add_subplot(projection="polar")
     with pytest.raises(ValueError):


### PR DESCRIPTION
## PR Summary
This allows scales to be set on polar Axes where 0 is not in the valid scale limits (e.g. a log scale falls into this category). Because there is some special casing in polar radial view limits that tries to include zero all the time, I didn't want to break this, so instead I've gone for the most general check of running the interval [0, 1] through the scale's `limit_range_for_scale` method, and checking if a 0 comes out. If it doesn't, the deafult behaviour of the locator is used to set the view limits and nonsingular values.

Goes part way to fixing https://github.com/matplotlib/matplotlib/issues/24383


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
