### PR TITLE
DOC: `subplot_mosaic` tutorial - clarify ratios keywords used directly

### DIFF
--- a/tutorials/provisional/mosaic.py
+++ b/tutorials/provisional/mosaic.py
@@ -210,7 +210,9 @@ identify_axes(axd)
 # (the same as `.Figure.subplots`).
 #
 # In this case we want to use the input to specify the arrangement,
-# but set the relative widths of the rows / columns via *gridspec_kw*.
+# but set the relative widths of the rows / columns.  For convenience,
+# `.gridspec.GridSpec`'s *height_ratios* and *width_ratios* are exposed in the
+# `.Figure.subplot_mosaic` calling sequence.
 
 
 axd = plt.figure(constrained_layout=True).subplot_mosaic(
@@ -227,9 +229,10 @@ axd = plt.figure(constrained_layout=True).subplot_mosaic(
 identify_axes(axd)
 
 ###############################################################################
-# Or use the {*left*, *right*, *bottom*, *top*} keyword arguments to
+# Other `.gridspec.GridSpec` keywords can be passed via *gridspec_kw*.  For
+# example, use the {*left*, *right*, *bottom*, *top*} keyword arguments to
 # position the overall mosaic to put multiple versions of the same
-# mosaic in a figure
+# mosaic in a figure.
 
 mosaic = """AA
             BC"""


### PR DESCRIPTION
## PR Summary
A small tweak to the text of the `subplot_mosaic` tutorial, as the `height_ratios`/`width_ratios` example no longer (since #23191) uses the `gridspec_kw` keyword.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
