### PR TITLE
Improve matplotlib.axes documentation

### DIFF
--- a/doc/_templates/autosummary_class_only.rst
+++ b/doc/_templates/autosummary_class_only.rst
@@ -1,0 +1,11 @@
+{{ fullname | escape | underline }}
+
+
+.. currentmodule:: {{ module }}
+
+
+{% if objtype in ['class'] %}
+.. auto{{ objtype }}:: {{ objname }}
+    :no-members:
+
+{% endif %}

--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -2,6 +2,10 @@
 ``matplotlib.axes``
 *******************
 
+The `~.axes.Axes` class represents one (sub-)plot in a figure. It contains the
+plotted data, axis ticks, labels, title, legend, etc. Its methods are the main
+interface for manipulating the plot.
+
 .. currentmodule:: matplotlib.axes
 
 .. contents:: Table of Contents
@@ -14,18 +18,15 @@
    :no-members:
    :no-undoc-members:
 
-Inheritance
-===========
-.. inheritance-diagram:: matplotlib.axes.Axes
-   :private-bases:
-
 The Axes class
 ==============
 
-.. autoclass:: Axes
-   :no-members:
-   :no-undoc-members:
-   :show-inheritance:
+.. autosummary::
+   :toctree: _as_gen
+   :template: autosummary_class_only.rst
+   :nosignatures:
+
+   Axes
 
 Plotting
 ========

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -46,9 +46,14 @@ _log = logging.getLogger(__name__)
 @_docstring.interpd
 class Axes(_AxesBase):
     """
-    The `Axes` contains most of the figure elements: `~.axis.Axis`,
+    An Axes object encapsulates all the elements of an individual (sub-)plot in
+    a figure.
+
+    It contains most of the (sub-)plot elements: `~.axis.Axis`,
     `~.axis.Tick`, `~.lines.Line2D`, `~.text.Text`, `~.patches.Polygon`, etc.,
     and sets the coordinate system.
+
+    Like all visible elements in a figure, Axes is an `.Artist` subclass.
 
     The `Axes` instance supports callbacks through a callbacks attribute which
     is a `~.cbook.CallbackRegistry` instance.  The events you can connect to


### PR DESCRIPTION
- Move the Axes class documentation to a sub-page. The constructor is quite lengthy and not needed by most users.
- Add an introductory sentence to set the context for the subsequent listing and structure of the Axes methods.

Note: I've removed the inheritance diagram, because it does not contain much relevant information.
The inheritance from `_AxesBase` is shown in the class docstring as well (and is not of much use since the private `_AxesBase` does not have generated documentation. The only additional information is that it originally inherits from `Artist`, which I've now included as a sentence in the docstring.
