### PR TITLE
DOC: fix strip_chart example with numpy 1.24

### DIFF
--- a/examples/animation/strip_chart.py
+++ b/examples/animation/strip_chart.py
@@ -37,7 +37,7 @@ class Scope:
         t = self.tdata[0] + len(self.tdata) * self.dt
 
         self.tdata.append(t)
-        self.ydata.append(y)
+        self.ydata.append(float(y))
         self.line.set_data(self.tdata, self.ydata)
         return self.line,
 


### PR DESCRIPTION
## PR Summary

With numpy 1.24 we are ending up with the y-data being passed to the line that looked like

```
[0, 0.0, 0.0, 0.0, 0.0, array([0.75523994])]
```

which was then causing issues when we went to convert that list to an array.  I did not track down if this is a change in the behavior of `np.random.rand` or in how picky the list->array casting logic is.

For reasons that are very unclear to me this also unbreaks the unchained example when building the docs which suggests to me that the examples are not as isolated as we think (I could not get the unchained demo to fail outside of the docs build which also suggests some state leakage between them).