### PR TITLE
DOC: restore SHA to footer

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -315,6 +315,11 @@ try:
 except (subprocess.CalledProcessError, FileNotFoundError):
     SHA = matplotlib.__version__
 
+
+html_context = {
+    "doc_version": SHA,
+}
+
 project = 'Matplotlib'
 copyright = (
     '2002–2012 John Hunter, Darren Dale, Eric Firing, Michael Droettboom '
@@ -449,6 +454,7 @@ html_theme_options = {
              "image_dark": "images/logo_dark.svg"},
     "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"],
     "secondary_sidebar_items": "page-toc.html",
+     "footer_items": ["copyright", "sphinx-version", "doc_version"],
 }
 include_analytics = is_release_build
 if include_analytics:

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -14,7 +14,7 @@ ipywidgets
 numpydoc>=1.0
 packaging>=20
 pydata-sphinx-theme>=0.12.0
-mpl-sphinx-theme
+mpl-sphinx-theme>=3.7.0
 pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10


### PR DESCRIPTION
## PR Summary

Depends on https://github.com/matplotlib/mpl-sphinx-theme/pull/54 being merged.

We used to include the exact commit used to build the docs in the footer (see https://matplotlib.org/3.4.3/index.html) however that got lost as part of the move to mpl-sphinx-theme. This adds the option to put this in the footer again.