### PR TITLE
Fix random generation of single floats

### DIFF
--- a/examples/animation/bayes_update.py
+++ b/examples/animation/bayes_update.py
@@ -47,7 +47,7 @@ class UpdateDist:
             return self.line,
 
         # Choose success based on exceed a threshold with a uniform pick
-        if np.random.rand(1,) < self.prob:
+        if np.random.rand() < self.prob:
             self.success += 1
         y = beta_pdf(self.x, self.success + 1, (i - self.success) + 1)
         self.line.set_data(self.x, y)

--- a/examples/animation/strip_chart.py
+++ b/examples/animation/strip_chart.py
@@ -37,7 +37,7 @@ class Scope:
         t = self.tdata[0] + len(self.tdata) * self.dt
 
         self.tdata.append(t)
-        self.ydata.append(float(y))
+        self.ydata.append(y)
         self.line.set_data(self.tdata, self.ydata)
         return self.line,
 
@@ -45,11 +45,11 @@ class Scope:
 def emitter(p=0.1):
     """Return a random value in [0, 1) with probability p, else 0."""
     while True:
-        v = np.random.rand(1)
+        v = np.random.rand()
         if v > p:
             yield 0.
         else:
-            yield np.random.rand(1)
+            yield np.random.rand()
 
 
 # Fixing random state for reproducibility


### PR DESCRIPTION
## PR Summary

Passing 1 means we get a 1D array with a single element, but passing nothing means a 0D array, aka a single float.

Also reverts #24774 as it should be unnecessary.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`