### PR TITLE
DOC: Fix duplicate redirect

### DIFF
--- a/tutorials/intermediate/artists.py
+++ b/tutorials/intermediate/artists.py
@@ -717,5 +717,5 @@ plt.show()
 #
 #
 # .. include:: ../../gallery/ticks/dollar_ticks.rst
-#    :start-after: y-axis labels.
+#    :start-after: .. redirect-from:: /gallery/pyplots/dollar_ticks
 #    :end-before: .. admonition:: References


### PR DESCRIPTION
The example /gallery/pyplots/dollar_ticks is included into the artists tutorial. #24054 Moved that example and added a `.. redirect-from::` directive. This was then duplicated by the include.

This PR fixes the issue by moving the include start point after the redirect.

Closes #24058.