### PR TITLE
Adjust docstrings of legend for typos, font size

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -172,7 +172,7 @@ prop : None or `matplotlib.font_manager.FontProperties` or dict
     The font properties of the legend. If None (default), the current
     :data:`matplotlib.rcParams` will be used.
 
-fontsize : int or {'xx-small', 'x-small', 'small', 'medium', 'large', \
+fontsize : float or {'xx-small', 'x-small', 'small', 'medium', 'large', \
 'x-large', 'xx-large'}
     The font size of the legend. If the value is numeric the size will be the
     absolute font size in points. String values are relative to the current
@@ -250,7 +250,7 @@ title_fontproperties : None or `matplotlib.font_manager.FontProperties` or dict
     *title_fontsize* argument will be used if present; if *title_fontsize* is
     also None, the current :rc:`legend.title_fontsize` will be used.
 
-title_fontsize : int or {'xx-small', 'x-small', 'small', 'medium', 'large', \
+title_fontsize : float or {'xx-small', 'x-small', 'small', 'medium', 'large', \
 'x-large', 'xx-large'}, default: :rc:`legend.title_fontsize`
     The font size of the legend's title.
     Note: This cannot be combined with *title_fontproperties*. If you want
@@ -728,7 +728,7 @@ class Legend(Artist):
     def get_legend_handler(legend_handler_map, orig_handle):
         """
         Return a legend handler from *legend_handler_map* that
-        corresponds to *orig_handler*.
+        corresponds to *orig_handle*.
 
         *legend_handler_map* should be a dictionary object (that is
         returned by the get_legend_handler_map method).

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -114,7 +114,7 @@ class HandlerBase:
             The legend for which these legend artists are being created.
         orig_handle : :class:`matplotlib.artist.Artist` or similar
             The object for which these legend artists are being created.
-        fontsize : int
+        fontsize : float
             The fontsize in pixels. The artists being created should
             be scaled according to the given fontsize.
         handlebox : `matplotlib.offsetbox.OffsetBox`
@@ -157,7 +157,7 @@ class HandlerBase:
         xdescent, ydescent, width, height : int
             The rectangle (*xdescent*, *ydescent*, *width*, *height*) that the
             legend artists being created should fit within.
-        fontsize : int
+        fontsize : float
             The fontsize in pixels. The legend artists being created should
             be scaled according to the given fontsize.
         trans :  `~matplotlib.transforms.Transform`


### PR DESCRIPTION
## PR Summary

As far as I can tell, fontsize is a floating point value in points that
is passed directly to legend_handler... which makes me skeptical about
the documentation that says it is an integer number of pixels.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
