### PR TITLE
Deprecate 'x' argument for widgets.TextBox.begin_typing

### DIFF
--- a/doc/api/next_api_changes/deprecations/24806-KS.rst
+++ b/doc/api/next_api_changes/deprecations/24806-KS.rst
@@ -1,0 +1,4 @@
+Deprecate unused parameter *x* to ``TextBox.begin_typing``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This parameter was unused in the method, but was a required argument.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -982,7 +982,7 @@ def test_TextBox(ax, toolbar):
     assert tool.text == 'x**2'
     assert text_change_event.call_count == 1
 
-    tool.begin_typing(tool.text)
+    tool.begin_typing()
     tool.stop_typing()
 
     assert submit_event.call_count == 2

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1279,7 +1279,8 @@ class TextBox(AxesWidget):
             self._observers.process('change', self.text)
             self._observers.process('submit', self.text)
 
-    def begin_typing(self, x):
+    @_api.delete_parameter("3.7", "x")
+    def begin_typing(self, x=None):
         self.capturekeystrokes = True
         # Disable keypress shortcuts, which may otherwise cause the figure to
         # be saved, closed, etc., until the user stops typing.  The way to
@@ -1326,7 +1327,7 @@ class TextBox(AxesWidget):
         if event.canvas.mouse_grabber != self.ax:
             event.canvas.grab_mouse(self.ax)
         if not self.capturekeystrokes:
-            self.begin_typing(event.x)
+            self.begin_typing()
         self.cursor_index = self.text_disp._char_index_at(event.x)
         self._rendercursor()
 


### PR DESCRIPTION
## PR Summary

This argument is a holdover from seemingly a debugging print statement
that has long since been removed.

It is not used internally, and was passed entirely different things in
the two places it was called (once in tests, once in library code).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
    - no docstring to begin with, not sure its worth adding for just an already unused argument being deprecated
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
