### PR TITLE
removed casting handles to list in legend

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -448,7 +448,6 @@ class Legend(Artist):
             labels.reverse()
             handles.reverse()
 
-        handles = list(handles)
         if len(handles) < 2:
             ncols = 1
         self._ncols = ncols if ncols != 1 else ncol


### PR DESCRIPTION
removed line casting handles to legend b/c  in the line above, the handles are set to a list that was created right before the loop. 

Please merge after #24759 so it won't need to be rebased. 