### PR TITLE
[FIX]: Make inset axes transparent on savefig(..., transparent=True)

### DIFF
--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -539,6 +539,29 @@ def test_savefig_preserve_layout_engine(tmp_path):
     assert fig.get_layout_engine()._compress
 
 
+@mpl.rc_context({"savefig.transparent": True})
+@check_figures_equal(extensions=["png"])
+def test_savefig_transparent(fig_test, fig_ref):
+    # create two transparent subfigures with corresponding transparent inset
+    # axes. the entire background of the image should be transparent.
+    gs1 = fig_test.add_gridspec(3, 3, left=0.05, wspace=0.05)
+    f1 = fig_test.add_subfigure(gs1[:, :])
+    f2 = f1.add_subfigure(gs1[0, 0])
+
+    ax12 = f2.add_subplot(gs1[:, :])
+
+    ax1 = f1.add_subplot(gs1[:-1, :])
+    iax1 = ax1.inset_axes([.1, .2, .3, .4])
+    iax2 = iax1.inset_axes([.1, .2, .3, .4])
+
+    ax2 = fig_test.add_subplot(gs1[-1, :-1])
+    ax3 = fig_test.add_subplot(gs1[-1, -1])
+
+    for ax in [ax12, ax1, iax1, iax2, ax2, ax3]:
+        ax.set(xticks=[], yticks=[])
+        ax.spines[:].set_visible(False)
+
+
 def test_figure_repr():
     fig = plt.figure(figsize=(10, 20), dpi=10)
     assert repr(fig) == "<Figure size 100x200 with 0 Axes>"


### PR DESCRIPTION
## PR Summary
This is a continuation on #22816 to make sure `savefig(..., transparent=True)` handles nested figures and axes. Also updates the test figure to include doubly-nested cases to test against.

Closes issue #22674  
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
