### PR TITLE
Re-cache Line2D path when transform changed

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -422,6 +422,7 @@ class Line2D(Artist):
         self._xy = None
         self._path = None
         self._transformed_path = None
+        self._transform_when_path_transformed = None
         self._subslice = False
         self._x_filled = None  # used in subslicing; only x is needed
 
@@ -729,6 +730,7 @@ class Line2D(Artist):
                          _interpolation_steps=self._path._interpolation_steps)
         else:
             _path = self._path
+        self._transform_when_path_transformed = self.get_transform().frozen()
         self._transformed_path = TransformedPath(_path, self.get_transform())
 
     def _get_transformed_path(self):
@@ -750,7 +752,7 @@ class Line2D(Artist):
         if not self.get_visible():
             return
 
-        if self._invalidy or self._invalidx:
+        if self._invalidy or self._invalidx or self.get_transform() != self._transform_when_path_transformed:
             self.recache()
         self.ind_offset = 0  # Needed for contains() method.
         if self._subslice and self.axes:

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -588,3 +588,27 @@ def test_radial_locator_wrapping():
     assert ax.yaxis.isDefault_majloc
     assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
     assert isinstance(ax.yaxis.get_major_locator().base, mticker.LogLocator)
+
+
+@check_figures_equal(extensions=["png"])
+def test_polar_lim_draw(fig_test, fig_ref):
+    """
+    Check that lines on polar axes are correctly transformed after
+    a draw and an axes limit change.
+
+    """
+    # A quarter arc at r=5
+    theta = np.linspace(0, np.pi/2, 90)
+    r = np.full(90, 5)
+
+    ax_ref = fig_ref.add_subplot(projection='polar')
+    ax_ref.set_ylim(0, 10)
+    ax_ref.plot(theta, r)
+
+    ax_test = fig_test.add_subplot(projection='polar')
+    ax_test.set_ylim(4, 10)
+
+    ax_test.plot(theta, r)
+    fig_test.canvas.draw()
+
+    ax_test.set_ylim(0, 10)


### PR DESCRIPTION
## PR Summary
When the transform of a `Line2D` is changed, re-calculate the transformed path. This is needed in the case of polar plots where a line is drawn, and the radial limits on the axes changed. This changes the transform of the line, which requires recomputation of its path. Because only the non-affine part of the transform is cached in `Line2D`, this does not show up for normal cartesian axes, because changing the y-limits does not change the non-affine part of the transform.

Fixes https://github.com/matplotlib/matplotlib/issues/24790

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
