### PR TITLE
Fix errorbar crash on nan values

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3498,28 +3498,32 @@ class Axes(_AxesBase):
 
             Otherwise, fallback to casting to an object array.
             """
-
-            if (
-                    # make sure it is not a scalar
-                    np.iterable(err) and
-                    # and it is not empty
-                    len(err) > 0 and
-                    # and the first element is an array sub-class use
-                    # safe_first_element because getitem is index-first not
-                    # location first on pandas objects so err[0] almost always
-                    # fails.
-                    isinstance(cbook._safe_first_finite(err), np.ndarray)
-            ):
-                # Get the type of the first element
-                atype = type(cbook._safe_first_finite(err))
-                # Promote the outer container to match the inner container
-                if atype is np.ndarray:
-                    # Converts using np.asarray, because data cannot
-                    # be directly passed to init of np.ndarray
-                    return np.asarray(err, dtype=object)
-                # If atype is not np.ndarray, directly pass data to init.
-                # This works for types such as unyts and astropy units
-                return atype(err)
+            try:
+                if (
+                        # make sure it is not a scalar
+                        np.iterable(err) and
+                        # and it is not empty
+                        len(err) > 0 and
+                        # and the first element is an array sub-class use
+                        # safe_first_element because getitem is index-first not
+                        # location first on pandas objects so err[0] almost
+                        # always fails.
+                        isinstance(cbook._safe_first_finite(err), np.ndarray)
+                ):
+                    # Get the type of the first element
+                    atype = type(cbook._safe_first_finite(err))
+                    # Promote the outer container to match the inner container
+                    if atype is np.ndarray:
+                        # Converts using np.asarray, because data cannot
+                        # be directly passed to init of np.ndarray
+                        return np.asarray(err, dtype=object)
+                    # If atype is not np.ndarray, directly pass data to init.
+                    # This works for types such as unyts and astropy units
+                    return atype(err)
+            except StopIteration:
+                # this means we found no finite element, fall back to default
+                # case.
+                pass
             # Otherwise wrap it in an object array
             return np.asarray(err, dtype=object)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3981,6 +3981,12 @@ def test_errorbar_nan(fig_test, fig_ref):
     ax.errorbar([4], [3], [6], fmt="C0")
 
 
+def test_errorbar_allnan_error():
+    fig, ax = plt.subplots()
+    with pytest.warns(RuntimeWarning, match="All-NaN axis encountered"):
+        ax.errorbar([0], [0], [np.nan])
+
+
 @image_comparison(['hist_stacked_stepfilled', 'hist_stacked_stepfilled'])
 def test_hist_stacked_stepfilled():
     # make some data


### PR DESCRIPTION
## PR Summary

Fixes issue #24818 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
