### PR TITLE
space in version added for reverse in legend

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -213,7 +213,7 @@ reverse : bool, default: False
     If *True*, the legend labels are displayed in reverse order from the input.
     If *False*, the legend labels are displayed in the same order as the input.
 
-    ..versionadded:: 3.7
+    .. versionadded:: 3.7
 
 frameon : bool, default: :rc:`legend.frameon`
     Whether the legend should be drawn on a patch (frame).


### PR DESCRIPTION
missed that version added was missing a space in #24759 so it's not rendering right currently