### PR TITLE
Deprecate apply_theta_transforms=True to PolarTransform

### DIFF
--- a/doc/api/next_api_changes/deprecations/24834-DS.rst
+++ b/doc/api/next_api_changes/deprecations/24834-DS.rst
@@ -1,6 +1,7 @@
 Applying theta transforms in ``PolarTransform``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Applying theta transforms in `~matplotlib.projections.polar.PolarTransform`
+and `~matplotlib.projections.polar.InvertedPolarTransform`
 is deprecated. This is currently the default behaviour, so to prevent
 a warning, manually pass ``_apply_theta_transforms=False``, and
 apply any theta shift before passing points to this transform.

--- a/doc/api/next_api_changes/deprecations/24834-DS.rst
+++ b/doc/api/next_api_changes/deprecations/24834-DS.rst
@@ -1,0 +1,6 @@
+Applying theta transforms in ``PolarTransform``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Applying theta transforms in `~matplotlib.projections.polar.PolarTransform`
+is deprecated. This is currently the default behaviour, so to prevent
+a warning, manually pass ``_apply_theta_transforms=False``, and
+apply any theta shift before passing points to this transform.

--- a/doc/api/next_api_changes/deprecations/24834-DS.rst
+++ b/doc/api/next_api_changes/deprecations/24834-DS.rst
@@ -2,6 +2,15 @@ Applying theta transforms in ``PolarTransform``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Applying theta transforms in `~matplotlib.projections.polar.PolarTransform`
 and `~matplotlib.projections.polar.InvertedPolarTransform`
-is deprecated. This is currently the default behaviour, so to prevent
-a warning, manually pass ``_apply_theta_transforms=False``, and
-apply any theta shift before passing points to this transform.
+is deprecated, and will be removed in a future version of Matplotlib. This
+is currently the default behaviour when these transforms are used externally,
+but only takes affect when:
+
+- An axis is associated with the transform.
+- The axis has a non-zero theta offset or has theta values increasing in
+  a clockwise direction.
+
+To silence this warning and adopt future behaviour,
+set ``apply_theta_transforms=False``. If you need to retain the behaviour
+where theta values are transformed, chain the ``PolarTransform`` with
+another transform that performs the theta shift and/or sign shift.

--- a/doc/api/next_api_changes/deprecations/24834-DS.rst
+++ b/doc/api/next_api_changes/deprecations/24834-DS.rst
@@ -13,4 +13,5 @@ but only takes affect when:
 To silence this warning and adopt future behaviour,
 set ``apply_theta_transforms=False``. If you need to retain the behaviour
 where theta values are transformed, chain the ``PolarTransform`` with
-another transform that performs the theta shift and/or sign shift.
+a `~matplotlib.transforms.Affine2D` transform that performs the theta shift
+and/or sign shift.

--- a/galleries/examples/axisartist/demo_axis_direction.py
+++ b/galleries/examples/axisartist/demo_axis_direction.py
@@ -20,7 +20,10 @@ def setup_axes(fig, rect):
     """Polar projection, but in a rectangular box."""
     # see demo_curvelinear_grid.py for details
     grid_helper = GridHelperCurveLinear(
-        Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform(),
+        (
+            Affine2D().scale(np.pi/180., 1.) +
+            PolarAxes.PolarTransform(apply_theta_transforms=False)
+        ),
         extreme_finder=angle_helper.ExtremeFinderCycle(
             20, 20,
             lon_cycle=360, lat_cycle=None,

--- a/galleries/examples/axisartist/demo_curvelinear_grid.py
+++ b/galleries/examples/axisartist/demo_curvelinear_grid.py
@@ -55,7 +55,7 @@ def curvelinear_test2(fig):
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
     tr = Affine2D().scale(np.pi/180, 1) + PolarAxes.PolarTransform(
-        _apply_theta_transforms=False)
+        apply_theta_transforms=False)
     # Polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes
     # (min, max of the coordinate within the view).

--- a/galleries/examples/axisartist/demo_curvelinear_grid.py
+++ b/galleries/examples/axisartist/demo_curvelinear_grid.py
@@ -54,7 +54,8 @@ def curvelinear_test2(fig):
 
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
-    tr = Affine2D().scale(np.pi/180, 1) + PolarAxes.PolarTransform()
+    tr = Affine2D().scale(np.pi/180, 1) + PolarAxes.PolarTransform(
+        _apply_theta_transforms=False)
     # Polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes
     # (min, max of the coordinate within the view).

--- a/galleries/examples/axisartist/demo_floating_axes.py
+++ b/galleries/examples/axisartist/demo_floating_axes.py
@@ -54,7 +54,7 @@ def setup_axes2(fig, rect):
     With custom locator and formatter.
     Note that the extreme values are swapped.
     """
-    tr = PolarAxes.PolarTransform(_apply_theta_transforms=False)
+    tr = PolarAxes.PolarTransform(apply_theta_transforms=False)
 
     pi = np.pi
     angle_ticks = [(0, r"$0$"),
@@ -100,7 +100,7 @@ def setup_axes3(fig, rect):
     tr_scale = Affine2D().scale(np.pi/180., 1.)
 
     tr = tr_rotate + tr_scale + PolarAxes.PolarTransform(
-        _apply_theta_transforms=False)
+        apply_theta_transforms=False)
 
     grid_locator1 = angle_helper.LocatorHMS(4)
     tick_formatter1 = angle_helper.FormatterHMS()

--- a/galleries/examples/axisartist/demo_floating_axes.py
+++ b/galleries/examples/axisartist/demo_floating_axes.py
@@ -54,7 +54,7 @@ def setup_axes2(fig, rect):
     With custom locator and formatter.
     Note that the extreme values are swapped.
     """
-    tr = PolarAxes.PolarTransform()
+    tr = PolarAxes.PolarTransform(_apply_theta_transforms=False)
 
     pi = np.pi
     angle_ticks = [(0, r"$0$"),
@@ -99,7 +99,8 @@ def setup_axes3(fig, rect):
     # scale degree to radians
     tr_scale = Affine2D().scale(np.pi/180., 1.)
 
-    tr = tr_rotate + tr_scale + PolarAxes.PolarTransform()
+    tr = tr_rotate + tr_scale + PolarAxes.PolarTransform(
+        _apply_theta_transforms=False)
 
     grid_locator1 = angle_helper.LocatorHMS(4)
     tick_formatter1 = angle_helper.FormatterHMS()

--- a/galleries/examples/axisartist/demo_floating_axis.py
+++ b/galleries/examples/axisartist/demo_floating_axis.py
@@ -22,7 +22,8 @@ import mpl_toolkits.axisartist.angle_helper as angle_helper
 def curvelinear_test2(fig):
     """Polar projection, but in a rectangular box."""
     # see demo_curvelinear_grid.py for details
-    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform()
+    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform(
+        _apply_theta_transforms=False)
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20,
                                                      20,

--- a/galleries/examples/axisartist/demo_floating_axis.py
+++ b/galleries/examples/axisartist/demo_floating_axis.py
@@ -23,7 +23,7 @@ def curvelinear_test2(fig):
     """Polar projection, but in a rectangular box."""
     # see demo_curvelinear_grid.py for details
     tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform(
-        _apply_theta_transforms=False)
+        apply_theta_transforms=False)
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20,
                                                      20,

--- a/galleries/examples/axisartist/simple_axis_pad.py
+++ b/galleries/examples/axisartist/simple_axis_pad.py
@@ -21,7 +21,8 @@ def setup_axes(fig, rect):
     """Polar projection, but in a rectangular box."""
 
     # see demo_curvelinear_grid.py for details
-    tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform()
+    tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform(
+        _apply_theta_transforms=False)
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20, 20,
                                                      lon_cycle=360,

--- a/galleries/examples/axisartist/simple_axis_pad.py
+++ b/galleries/examples/axisartist/simple_axis_pad.py
@@ -22,7 +22,7 @@ def setup_axes(fig, rect):
 
     # see demo_curvelinear_grid.py for details
     tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform(
-        _apply_theta_transforms=False)
+        apply_theta_transforms=False)
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20, 20,
                                                      lon_cycle=360,

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -19,10 +19,10 @@ def _apply_theta_transforms_warn():
     _api.warn_deprecated(
                 "3.7",
                 message=(
-                    "Passing `_apply_theta_transforms=True` (the default) "
+                    "Passing `apply_theta_transforms=True` (the default) "
                     "is deprecated. Support for this will be removed in "
                     "Matplotlib %(removal)s. To prevent this warning, "
-                    "set `_apply_theta_transforms=False`, and make sure to "
+                    "set `apply_theta_transforms=False`, and make sure to "
                     "shift theta values before being passed to this transform."
                 )
             )
@@ -47,8 +47,8 @@ class PolarTransform(mtransforms.Transform):
 
     input_dims = output_dims = 2
 
-    def __init__(self, axis=None, use_rmin=True,
-                 _apply_theta_transforms=True, *, scale_transform=None):
+    def __init__(self, axis=None, use_rmin=True, *,
+                 apply_theta_transforms=True, scale_transform=None):
         """
         Parameters
         ----------
@@ -63,15 +63,15 @@ class PolarTransform(mtransforms.Transform):
         super().__init__()
         self._axis = axis
         self._use_rmin = use_rmin
-        self._apply_theta_transforms = _apply_theta_transforms
+        self._apply_theta_transforms = apply_theta_transforms
         self._scale_transform = scale_transform
-        if _apply_theta_transforms:
+        if apply_theta_transforms:
             _apply_theta_transforms_warn()
 
     __str__ = mtransforms._make_str_method(
         "_axis",
         use_rmin="_use_rmin",
-        _apply_theta_transforms="_apply_theta_transforms")
+        apply_theta_transforms="_apply_theta_transforms")
 
     def _get_rorigin(self):
         # Get lower r limit after being scaled by the radial scale transform
@@ -148,8 +148,10 @@ class PolarTransform(mtransforms.Transform):
 
     def inverted(self):
         # docstring inherited
-        return PolarAxes.InvertedPolarTransform(self._axis, self._use_rmin,
-                                                self._apply_theta_transforms)
+        return PolarAxes.InvertedPolarTransform(
+            self._axis, self._use_rmin,
+            apply_theta_transforms=self._apply_theta_transforms
+        )
 
 
 class PolarAffine(mtransforms.Affine2DBase):
@@ -208,7 +210,7 @@ class InvertedPolarTransform(mtransforms.Transform):
     input_dims = output_dims = 2
 
     def __init__(self, axis=None, use_rmin=True,
-                 _apply_theta_transforms=True):
+                 *, apply_theta_transforms=True):
         """
         Parameters
         ----------
@@ -223,14 +225,14 @@ class InvertedPolarTransform(mtransforms.Transform):
         super().__init__()
         self._axis = axis
         self._use_rmin = use_rmin
-        self._apply_theta_transforms = _apply_theta_transforms
-        if _apply_theta_transforms:
+        self._apply_theta_transforms = apply_theta_transforms
+        if apply_theta_transforms:
             _apply_theta_transforms_warn()
 
     __str__ = mtransforms._make_str_method(
         "_axis",
         use_rmin="_use_rmin",
-        _apply_theta_transforms="_apply_theta_transforms")
+        apply_theta_transforms="_apply_theta_transforms")
 
     @_api.rename_parameter("3.8", "xy", "values")
     def transform_non_affine(self, values):
@@ -251,8 +253,10 @@ class InvertedPolarTransform(mtransforms.Transform):
 
     def inverted(self):
         # docstring inherited
-        return PolarAxes.PolarTransform(self._axis, self._use_rmin,
-                                        self._apply_theta_transforms)
+        return PolarAxes.PolarTransform(
+            self._axis, self._use_rmin,
+            apply_theta_transforms=self._apply_theta_transforms
+        )
 
 
 class ThetaFormatter(mticker.Formatter):
@@ -896,7 +900,7 @@ class PolarAxes(Axes):
         # data.  This one is aware of rmin
         self.transProjection = self.PolarTransform(
             self,
-            _apply_theta_transforms=False,
+            apply_theta_transforms=False,
             scale_transform=self.transScale
         )
         # Add dependency on rorigin.

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -17,13 +17,14 @@ from matplotlib.spines import Spine
 
 def _apply_theta_transforms_warn():
     _api.warn_deprecated(
-                "3.7",
+                "3.9",
                 message=(
                     "Passing `apply_theta_transforms=True` (the default) "
-                    "is deprecated. Support for this will be removed in "
-                    "Matplotlib %(removal)s. To prevent this warning, "
-                    "set `apply_theta_transforms=False`, and make sure to "
-                    "shift theta values before being passed to this transform."
+                    "is deprecated since Matplotlib %(since)s. "
+                    "Support for this will be removed in Matplotlib %(removal)s. "
+                    "To prevent this warning, set `apply_theta_transforms=False`, "
+                    "and make sure to shift theta values before being passed to "
+                    "this transform."
                 )
             )
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -15,6 +15,19 @@ import matplotlib.transforms as mtransforms
 from matplotlib.spines import Spine
 
 
+def _apply_theta_transforms_warn():
+    _api.warn_deprecated(
+                "3.7",
+                message=(
+                    "Passing `_apply_theta_transforms=True` (the default) "
+                    "is deprecated. Support for this will be removed in "
+                    "Matplotlib %(removal)s. To prevent this warning, "
+                    "set `_apply_theta_transforms=False`, and make sure to "
+                    "shift theta values before being passed to this transform."
+                )
+            )
+
+
 class PolarTransform(mtransforms.Transform):
     r"""
     The base polar transform.
@@ -53,16 +66,7 @@ class PolarTransform(mtransforms.Transform):
         self._apply_theta_transforms = _apply_theta_transforms
         self._scale_transform = scale_transform
         if _apply_theta_transforms:
-            _api.warn_deprecated(
-                "3.7",
-                message=(
-                    "Passing `_apply_theta_transforms=True` (the default) "
-                    "is deprecated. Support for this will be removed in "
-                    "Matplotlib %(removal)s. To prevent this warning, "
-                    "set `_apply_theta_transforms=False`, and make sure to "
-                    "shift theta values before being passed to this transform."
-                )
-            )
+            _apply_theta_transforms_warn()
 
     __str__ = mtransforms._make_str_method(
         "_axis",
@@ -220,6 +224,8 @@ class InvertedPolarTransform(mtransforms.Transform):
         self._axis = axis
         self._use_rmin = use_rmin
         self._apply_theta_transforms = _apply_theta_transforms
+        if _apply_theta_transforms:
+            _apply_theta_transforms_warn()
 
     __str__ = mtransforms._make_str_method(
         "_axis",

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -52,6 +52,17 @@ class PolarTransform(mtransforms.Transform):
         self._use_rmin = use_rmin
         self._apply_theta_transforms = _apply_theta_transforms
         self._scale_transform = scale_transform
+        if _apply_theta_transforms:
+            _api.warn_deprecated(
+                "3.7",
+                message=(
+                    "Passing `_apply_theta_transforms=True` (the default) "
+                    "is deprecated. Support for this will be removed in "
+                    "Matplotlib %(removal)s. To prevent this warning, "
+                    "set `_apply_theta_transforms=False`, and make sure to "
+                    "shift theta values before being passed to this transform."
+                )
+            )
 
     __str__ = mtransforms._make_str_method(
         "_axis",

--- a/lib/matplotlib/projections/polar.pyi
+++ b/lib/matplotlib/projections/polar.pyi
@@ -17,8 +17,8 @@ class PolarTransform(mtransforms.Transform):
         self,
         axis: PolarAxes | None = ...,
         use_rmin: bool = ...,
-        _apply_theta_transforms: bool = ...,
         *,
+        apply_theta_transforms: bool = ...,
         scale_transform: mtransforms.Transform | None = ...,
     ) -> None: ...
     def inverted(self) -> InvertedPolarTransform: ...
@@ -35,7 +35,8 @@ class InvertedPolarTransform(mtransforms.Transform):
         self,
         axis: PolarAxes | None = ...,
         use_rmin: bool = ...,
-        _apply_theta_transforms: bool = ...,
+        *,
+        apply_theta_transforms: bool = ...,
     ) -> None: ...
     def inverted(self) -> PolarTransform: ...
 

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -859,7 +859,7 @@ CompositeGenericTransform(
         PolarTransform(
             PolarAxes(0.125,0.1;0.775x0.8),
             use_rmin=True,
-            _apply_theta_transforms=False)),
+            apply_theta_transforms=False)),
     CompositeGenericTransform(
         CompositeGenericTransform(
             PolarAffine(

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1497,7 +1497,7 @@ class _AnnotationBase:
             return self.axes.transData
         elif coords == 'polar':
             from matplotlib.projections import PolarAxes
-            tr = PolarAxes.PolarTransform()
+            tr = PolarAxes.PolarTransform(_apply_theta_transforms=False)
             trans = tr + self.axes.transData
             return trans
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1497,7 +1497,7 @@ class _AnnotationBase:
             return self.axes.transData
         elif coords == 'polar':
             from matplotlib.projections import PolarAxes
-            tr = PolarAxes.PolarTransform(_apply_theta_transforms=False)
+            tr = PolarAxes.PolarTransform(apply_theta_transforms=False)
             trans = tr + self.axes.transData
             return trans
 

--- a/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
@@ -24,7 +24,7 @@ def test_curvelinear3():
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
-          mprojections.PolarAxes.PolarTransform(_apply_theta_transforms=False))
+          mprojections.PolarAxes.PolarTransform(apply_theta_transforms=False))
     grid_helper = GridHelperCurveLinear(
         tr,
         extremes=(0, 360, 10, 3),
@@ -73,7 +73,7 @@ def test_curvelinear4():
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
-          mprojections.PolarAxes.PolarTransform(_apply_theta_transforms=False))
+          mprojections.PolarAxes.PolarTransform(apply_theta_transforms=False))
     grid_helper = GridHelperCurveLinear(
         tr,
         extremes=(120, 30, 10, 0),

--- a/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
@@ -24,7 +24,7 @@ def test_curvelinear3():
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
-          mprojections.PolarAxes.PolarTransform())
+          mprojections.PolarAxes.PolarTransform(_apply_theta_transforms=False))
     grid_helper = GridHelperCurveLinear(
         tr,
         extremes=(0, 360, 10, 3),
@@ -73,7 +73,7 @@ def test_curvelinear4():
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
-          mprojections.PolarAxes.PolarTransform())
+          mprojections.PolarAxes.PolarTransform(_apply_theta_transforms=False))
     grid_helper = GridHelperCurveLinear(
         tr,
         extremes=(120, 30, 10, 0),

--- a/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
@@ -83,7 +83,7 @@ def test_polar_box():
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
     tr = (Affine2D().scale(np.pi / 180., 1.) +
-          PolarAxes.PolarTransform(_apply_theta_transforms=False))
+          PolarAxes.PolarTransform(apply_theta_transforms=False))
 
     # polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes
@@ -146,7 +146,7 @@ def test_axis_direction():
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
     tr = (Affine2D().scale(np.pi / 180., 1.) +
-          PolarAxes.PolarTransform(_apply_theta_transforms=False))
+          PolarAxes.PolarTransform(apply_theta_transforms=False))
 
     # polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes

--- a/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
@@ -82,7 +82,8 @@ def test_polar_box():
 
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
-    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform()
+    tr = (Affine2D().scale(np.pi / 180., 1.) +
+          PolarAxes.PolarTransform(_apply_theta_transforms=False))
 
     # polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes
@@ -144,7 +145,8 @@ def test_axis_direction():
 
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
-    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform()
+    tr = (Affine2D().scale(np.pi / 180., 1.) +
+          PolarAxes.PolarTransform(_apply_theta_transforms=False))
 
     # polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes


### PR DESCRIPTION
## PR Summary
This parameter was introduced in https://github.com/matplotlib/matplotlib/pull/4699 for backwards compatabilty reasons, when shifting theta values was refactored out of `PolarTransform`.

- It think it's reasonable to **not** expect `PolarTransform` to do a theta shift first
- We do not currently test the case `_apply_theta_transforms = True`
- Removing this will simplify the polar transform code slightly

So I think it's worth deprecating and eventually removing this.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
