### PR TITLE
DOC: Replace .format by f-strings in examples

### DIFF
--- a/examples/event_handling/resample.py
+++ b/examples/event_handling/resample.py
@@ -45,7 +45,7 @@ class DataDisplayDownsampler:
         xdata = xdata[::ratio]
         ydata = ydata[::ratio]
 
-        print("using {} of {} visible points".format(len(ydata), np.sum(mask)))
+        print(f"using {len(ydata)} of {np.sum(mask)} visible points")
 
         return xdata, ydata
 

--- a/examples/images_contours_and_fields/contour_corner_mask.py
+++ b/examples/images_contours_and_fields/contour_corner_mask.py
@@ -27,7 +27,7 @@ fig, axs = plt.subplots(ncols=2)
 for ax, corner_mask in zip(axs, corner_masks):
     cs = ax.contourf(x, y, z, corner_mask=corner_mask)
     ax.contour(cs, colors='k')
-    ax.set_title('corner_mask = {0}'.format(corner_mask))
+    ax.set_title(f'{corner_mask=}')
 
     # Plot grid.
     ax.grid(c='k', ls='-', alpha=0.3)

--- a/examples/images_contours_and_fields/image_annotated_heatmap.py
+++ b/examples/images_contours_and_fields/image_annotated_heatmap.py
@@ -252,8 +252,8 @@ annotate_heatmap(im, valfmt="{x:.1f}", size=7)
 # use an integer format on the annotations and provide some colors.
 
 data = np.random.randint(2, 100, size=(7, 7))
-y = ["Book {}".format(i) for i in range(1, 8)]
-x = ["Store {}".format(i) for i in list("ABCDEFG")]
+y = [f"Book {i}" for i in range(1, 8)]
+x = [f"Store {i}" for i in list("ABCDEFG")]
 im, _ = heatmap(data, y, x, ax=ax2, vmin=0,
                 cmap="magma_r", cbarlabel="weekly sold copies")
 annotate_heatmap(im, valfmt="{x:d}", size=7, threshold=20,
@@ -265,8 +265,8 @@ annotate_heatmap(im, valfmt="{x:d}", size=7, threshold=20,
 # labels from an array of classes.
 
 data = np.random.randn(6, 6)
-y = ["Prod. {}".format(i) for i in range(10, 70, 10)]
-x = ["Cycle {}".format(i) for i in range(1, 7)]
+y = [f"Prod. {i}" for i in range(10, 70, 10)]
+x = [f"Cycle {i}" for i in range(1, 7)]
 
 qrates = list("ABCDEFG")
 norm = matplotlib.colors.BoundaryNorm(np.linspace(-3.5, 3.5, 8), 7)
@@ -292,7 +292,7 @@ im, _ = heatmap(corr_matrix, vegetables, vegetables, ax=ax4,
 
 
 def func(x, pos):
-    return "{:.2f}".format(x).replace("0.", ".").replace("1.00", "")
+    return f"{x:.2f}".replace("0.", ".").replace("1.00", "")
 
 annotate_heatmap(im, valfmt=matplotlib.ticker.FuncFormatter(func), size=7)
 

--- a/examples/lines_bars_and_markers/eventplot_demo.py
+++ b/examples/lines_bars_and_markers/eventplot_demo.py
@@ -20,7 +20,7 @@ np.random.seed(19680801)
 data1 = np.random.random([6, 50])
 
 # set different colors for each set of positions
-colors1 = ['C{}'.format(i) for i in range(6)]
+colors1 = [f'C{i}' for i in range(6)]
 
 # set different line properties for each set of positions
 # note that some overlap

--- a/examples/lines_bars_and_markers/filled_step.py
+++ b/examples/lines_bars_and_markers/filled_step.py
@@ -49,17 +49,16 @@ def filled_hist(ax, edges, values, bottoms=None, orientation='v',
     """
     print(orientation)
     if orientation not in 'hv':
-        raise ValueError("orientation must be in {{'h', 'v'}} "
-                         "not {o}".format(o=orientation))
+        raise ValueError(f"orientation must be in {{'h', 'v'}} "
+                         f"not {orientation}")
 
     kwargs.setdefault('step', 'post')
     kwargs.setdefault('alpha', 0.7)
     edges = np.asarray(edges)
     values = np.asarray(values)
     if len(edges) - 1 != len(values):
-        raise ValueError('Must provide one more bin edge than value not: '
-                         'len(edges): {lb} len(values): {lv}'.format(
-                             lb=len(edges), lv=len(values)))
+        raise ValueError(f'Must provide one more bin edge than value not: '
+                         f'{len(edges)=} {len(values)=}')
 
     if bottoms is None:
         bottoms = 0
@@ -159,7 +158,7 @@ def stack_hist(ax, stacked_data, sty_cycle, bottoms=None,
     arts = {}
     for j, (data, label, sty) in loop_iter:
         if label is None:
-            label = 'dflt set {n}'.format(n=j)
+            label = f'dflt set {j}'
         label = sty.pop('label', label)
         vals, edges = hist_func(data)
         if bottoms is None:
@@ -182,7 +181,7 @@ hist_func = partial(np.histogram, bins=edges)
 
 # set up style cycles
 color_cycle = cycler(facecolor=plt.rcParams['axes.prop_cycle'][:4])
-label_cycle = cycler(label=['set {n}'.format(n=n) for n in range(4)])
+label_cycle = cycler(label=[f'set {n}' for n in range(4)])
 hatch_cycle = cycler(hatch=['/', '*', '+', '|'])
 
 # Fixing random state for reproducibility

--- a/examples/misc/table_demo.py
+++ b/examples/misc/table_demo.py
@@ -51,7 +51,7 @@ the_table = plt.table(cellText=cell_text,
 # Adjust layout to make room for the table:
 plt.subplots_adjust(left=0.2, bottom=0.2)
 
-plt.ylabel("Loss in ${0}'s".format(value_increment))
+plt.ylabel(f"Loss in ${value_increment}'s")
 plt.yticks(values * value_increment, ['%d' % val for val in values])
 plt.xticks([])
 plt.title('Loss by Disaster')

--- a/examples/pie_and_polar_charts/pie_and_donut_labels.py
+++ b/examples/pie_and_polar_charts/pie_and_donut_labels.py
@@ -44,7 +44,7 @@ ingredients = [x.split()[-1] for x in recipe]
 
 def func(pct, allvals):
     absolute = int(np.round(pct/100.*np.sum(allvals)))
-    return "{:.1f}%\n({:d} g)".format(pct, absolute)
+    return f"{pct:.1f}%\n({absolute:d} g)"
 
 
 wedges, texts, autotexts = ax.pie(data, autopct=lambda pct: func(pct, data),
@@ -108,7 +108,7 @@ for i, p in enumerate(wedges):
     y = np.sin(np.deg2rad(ang))
     x = np.cos(np.deg2rad(ang))
     horizontalalignment = {-1: "right", 1: "left"}[int(np.sign(x))]
-    connectionstyle = "angle,angleA=0,angleB={}".format(ang)
+    connectionstyle = f"angle,angleA=0,angleB={ang}"
     kw["arrowprops"].update({"connectionstyle": connectionstyle})
     ax.annotate(recipe[i], xy=(x, y), xytext=(1.35*np.sign(x), 1.4*y),
                 horizontalalignment=horizontalalignment, **kw)

--- a/examples/scales/asinh_demo.py
+++ b/examples/scales/asinh_demo.py
@@ -68,7 +68,7 @@ ax1.set_title('asinh')
 fig2 = plt.figure(constrained_layout=True)
 axs = fig2.subplots(1, 3, sharex=True)
 for ax, (a0, base) in zip(axs, ((0.2, 2), (1.0, 0), (5.0, 10))):
-    ax.set_title('linear_width={:.3g}'.format(a0))
+    ax.set_title(f'linear_width={a0:.3g}')
     ax.plot(x, x, label='y=x')
     ax.plot(x, 10*x, label='y=10x')
     ax.plot(x, 100*x, label='y=100x')

--- a/examples/specialty_plots/topographic_hillshading.py
+++ b/examples/specialty_plots/topographic_hillshading.py
@@ -58,7 +58,7 @@ for col, ve in zip(axs.T, [0.1, 1, 10]):
 
 # Label rows and columns
 for ax, ve in zip(axs[0], [0.1, 1, 10]):
-    ax.set_title('{0}'.format(ve), size=18)
+    ax.set_title(f'{ve}', size=18)
 for ax, mode in zip(axs[:, 0], ['Hillshade', 'hsv', 'overlay', 'soft']):
     ax.set_ylabel(mode, size=18)
 

--- a/examples/subplots_axes_and_figures/axes_margins.py
+++ b/examples/subplots_axes_and_figures/axes_margins.py
@@ -69,7 +69,7 @@ for ax, status in zip((ax1, ax2), ('Is', 'Is Not')):
     )  # not sticky
     ax.margins(x=0.1, y=0.05)
     ax.set_aspect('equal')
-    ax.set_title('{} Sticky'.format(status))
+    ax.set_title(f'{status} Sticky')
 
 plt.show()
 

--- a/examples/text_labels_and_annotations/font_table.py
+++ b/examples/text_labels_and_annotations/font_table.py
@@ -75,8 +75,8 @@ def draw_font_table(path):
     # we have indeed selected a Unicode charmap.
     codes = font.get_charmap().items()
 
-    labelc = ["{:X}".format(i) for i in range(16)]
-    labelr = ["{:02X}".format(16 * i) for i in range(16)]
+    labelc = [f"{i:X}" for i in range(16)]
+    labelr = [f"{i:02X}" for i in range(0, 16*16, 16)]
     chars = [["" for c in range(16)] for r in range(16)]
 
     for char_code, glyph_index in codes:

--- a/examples/text_labels_and_annotations/legend_demo.py
+++ b/examples/text_labels_and_annotations/legend_demo.py
@@ -45,7 +45,7 @@ fig, (ax0, ax1) = plt.subplots(2, 1)
 
 # Plot the lines y=x**n for n=1..4.
 for n in range(1, 5):
-    ax0.plot(x, x**n, label="n={0}".format(n))
+    ax0.plot(x, x**n, label=f"{n=}")
 leg = ax0.legend(loc="upper left", bbox_to_anchor=[0, 1],
                  ncol=2, shadow=True, title="Legend", fancybox=True)
 leg.get_title().set_color("red")

--- a/examples/ticks/custom_ticker1.py
+++ b/examples/ticks/custom_ticker1.py
@@ -15,7 +15,7 @@ import matplotlib.pyplot as plt
 
 def millions(x, pos):
     """The two arguments are the value and tick position."""
-    return '${:1.1f}M'.format(x*1e-6)
+    return f'${x*1e-6:1.1f}M'
 
 
 fig, ax = plt.subplots()

--- a/examples/units/basic_units.py
+++ b/examples/units/basic_units.py
@@ -150,7 +150,7 @@ class TaggedValue(metaclass=TaggedValueMeta):
         return TaggedValue(array, self.unit)
 
     def __repr__(self):
-        return 'TaggedValue({!r}, {!r})'.format(self.value, self.unit)
+        return f'TaggedValue({self.value!r}, {self.unit!r})'
 
     def __str__(self):
         return f"{self.value} in {self.unit}"

--- a/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -122,7 +122,7 @@ class MyApplication(tornado.web.Application):
 
         def get(self):
             manager = self.application.manager
-            ws_uri = "ws://{req.host}/".format(req=self.request)
+            ws_uri = f"ws://{self.request.host}/"
             content = html_content % {
                 "ws_uri": ws_uri, "fig_id": manager.num}
             self.write(content)
@@ -206,8 +206,8 @@ class MyApplication(tornado.web.Application):
             if self.supports_binary:
                 self.write_message(blob, binary=True)
             else:
-                data_uri = "data:image/png;base64,{0}".format(
-                    blob.encode('base64').replace('\n', ''))
+                data_uri = ("data:image/png;base64," +
+                            blob.encode('base64').replace('\n', ''))
                 self.write_message(data_uri)
 
     def __init__(self, figure):

--- a/examples/user_interfaces/fourier_demo_wx_sgskip.py
+++ b/examples/user_interfaces/fourier_demo_wx_sgskip.py
@@ -98,7 +98,7 @@ class SliderGroup(Knob):
         self.param.set(value)
 
     def setKnob(self, value):
-        self.sliderText.SetValue('%g' % value)
+        self.sliderText.SetValue(f'{value:g}')
         self.slider.SetValue(int(value * 1000))
 
 

--- a/examples/user_interfaces/svg_histogram_sgskip.py
+++ b/examples/user_interfaces/svg_histogram_sgskip.py
@@ -66,18 +66,18 @@ plt.title("From a web browser, click on the legend\n"
 
 hist_patches = {}
 for ic, c in enumerate(containers):
-    hist_patches['hist_%d' % ic] = []
+    hist_patches[f'hist_{ic}'] = []
     for il, element in enumerate(c):
-        element.set_gid('hist_%d_patch_%d' % (ic, il))
-        hist_patches['hist_%d' % ic].append('hist_%d_patch_%d' % (ic, il))
+        element.set_gid(f'hist_{ic}_patch_{il}')
+        hist_patches[f'hist_{ic}'].append(f'hist_{ic}_patch_{il}')
 
 # Set ids for the legend patches
 for i, t in enumerate(leg.get_patches()):
-    t.set_gid('leg_patch_%d' % i)
+    t.set_gid(f'leg_patch_{i}')
 
 # Set ids for the text patches
 for i, t in enumerate(leg.get_texts()):
-    t.set_gid('leg_text_%d' % i)
+    t.set_gid(f'leg_text_{i}')
 
 # Save SVG in a fake file object.
 f = BytesIO()
@@ -91,13 +91,13 @@ tree, xmlid = ET.XMLID(f.getvalue())
 
 # Add attributes to the patch objects.
 for i, t in enumerate(leg.get_patches()):
-    el = xmlid['leg_patch_%d' % i]
+    el = xmlid[f'leg_patch_{i}']
     el.set('cursor', 'pointer')
     el.set('onclick', "toggle_hist(this)")
 
 # Add attributes to the text objects.
 for i, t in enumerate(leg.get_texts()):
-    el = xmlid['leg_text_%d' % i]
+    el = xmlid[f'leg_text_{i}']
     el.set('cursor', 'pointer')
     el.set('onclick', "toggle_hist(this)")
 

--- a/examples/user_interfaces/svg_tooltip_sgskip.py
+++ b/examples/user_interfaces/svg_tooltip_sgskip.py
@@ -48,8 +48,8 @@ for i, (item, label) in enumerate(zip(shapes, labels)):
                                                  zorder=1))
 
     ax.add_patch(patch)
-    patch.set_gid('mypatch_{:03d}'.format(i))
-    annotate.set_gid('mytooltip_{:03d}'.format(i))
+    patch.set_gid(f'mypatch_{i:03d}')
+    annotate.set_gid(f'mytooltip_{i:03d}')
 
 # Save the figure in a fake file object
 ax.set_xlim(-30, 30)
@@ -69,10 +69,10 @@ for i in shapes:
     # Get the index of the shape
     index = shapes.index(i)
     # Hide the tooltips
-    tooltip = xmlid['mytooltip_{:03d}'.format(index)]
+    tooltip = xmlid[f'mytooltip_{index:03d}']
     tooltip.set('visibility', 'hidden')
     # Assign onmouseover and onmouseout callbacks to patches.
-    mypatch = xmlid['mypatch_{:03d}'.format(index)]
+    mypatch = xmlid[f'mypatch_{index:03d}']
     mypatch.set('onmouseover', "ShowTooltip(this)")
     mypatch.set('onmouseout', "HideTooltip(this)")
 

--- a/examples/user_interfaces/wxcursor_demo_sgskip.py
+++ b/examples/user_interfaces/wxcursor_demo_sgskip.py
@@ -50,8 +50,7 @@ class CanvasFrame(wx.Frame):
 
     def UpdateStatusBar(self, event):
         if event.inaxes:
-            self.statusBar.SetStatusText(
-                "x={}  y={}".format(event.xdata, event.ydata))
+            self.statusBar.SetStatusText(f"x={event.xdata}  y={event.ydata}")
 
 
 class App(wx.App):


### PR DESCRIPTION
## PR Summary

Just some minor modernization.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`