### PR TITLE
Move geo/polar projections to their own pages

### DIFF
--- a/doc/api/projections/geo.rst
+++ b/doc/api/projections/geo.rst
@@ -1,0 +1,7 @@
+******************************
+``matplotlib.projections.geo``
+******************************
+
+.. automodule:: matplotlib.projections.geo
+   :members:
+   :show-inheritance:

--- a/doc/api/projections/polar.rst
+++ b/doc/api/projections/polar.rst
@@ -1,0 +1,7 @@
+********************************
+``matplotlib.projections.polar``
+********************************
+
+.. automodule:: matplotlib.projections.polar
+   :members:
+   :show-inheritance:

--- a/doc/api/projections_api.rst
+++ b/doc/api/projections_api.rst
@@ -6,16 +6,13 @@
    :members:
    :show-inheritance:
 
-``matplotlib.projections.polar``
-================================
+Built in projections
+====================
+Matplotlib has built in support for polar and some geographic projections.
+See the following pages for more information:
 
-.. automodule:: matplotlib.projections.polar
-   :members:
-   :show-inheritance:
+.. toctree::
+   :maxdepth: 1
 
-``matplotlib.projections.geo``
-==============================
-
-.. automodule:: matplotlib.projections.geo
-   :members:
-   :show-inheritance:
+   projections/polar
+   projections/geo

--- a/doc/api/projections_api.rst
+++ b/doc/api/projections_api.rst
@@ -6,9 +6,9 @@
    :members:
    :show-inheritance:
 
-Built in projections
+Built-in projections
 ====================
-Matplotlib has built in support for polar and some geographic projections.
+Matplotlib has built-in support for polar and some geographic projections.
 See the following pages for more information:
 
 .. toctree::


### PR DESCRIPTION
## PR Summary
Instead of having all the API reference crowded on the Projections page, create new pages for polar/geo projection API.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
