### PR TITLE
Avoid extra copy initializing empty Affine2D

### DIFF
--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1890,7 +1890,7 @@ class Affine2D(Affine2DBase):
         super().__init__(**kwargs)
         if matrix is None:
             # A bit faster than np.identity(3).
-            matrix = IdentityTransform._mtx.copy()
+            matrix = IdentityTransform._mtx
         self._mtx = matrix.copy()
         self._invalid = 0
 


### PR DESCRIPTION
## PR Summary

The `matrix` is copied on the next line, so no need to copy it. This saves a small amount of time each:
```
In [1]: from matplotlib.transforms import Affine2D
In [2]: %timeit Affine2D()
1.42 µs ± 6.17 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
```
vs
```
In [1]: from matplotlib.transforms import Affine2D
In [2]: %timeit Affine2D()
1.1 µs ± 13 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)
In [3]: 1.1/1.42
Out[3]: 0.7746478873239437
```

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`