### PR TITLE
`Collection.set_linestyle`: remove redundant string handling

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -613,8 +613,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
             try:
                 dashes = [mlines._get_dash_pattern(x) for x in ls]
             except ValueError as err:
-                raise ValueError('Do not know how to convert {!r} to '
-                                 'dashes'.format(ls)) from err
+                emsg = f'Do not know how to convert {ls!r} to dashes'
+                raise ValueError(emsg) from err
 
         # get the list of raw 'unscaled' dash patterns
         self._us_linestyles = dashes

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -608,18 +608,13 @@ class Collection(artist.Artist, cm.ScalarMappable):
             complete description.
         """
         try:
-            if isinstance(ls, str):
-                ls = cbook.ls_mapper.get(ls, ls)
-                dashes = [mlines._get_dash_pattern(ls)]
-            else:
-                try:
-                    dashes = [mlines._get_dash_pattern(ls)]
-                except ValueError:
-                    dashes = [mlines._get_dash_pattern(x) for x in ls]
-
-        except ValueError as err:
-            raise ValueError('Do not know how to convert {!r} to '
-                             'dashes'.format(ls)) from err
+            dashes = [mlines._get_dash_pattern(ls)]
+        except ValueError:
+            try:
+                dashes = [mlines._get_dash_pattern(x) for x in ls]
+            except ValueError as err:
+                raise ValueError('Do not know how to convert {!r} to '
+                                 'dashes'.format(ls)) from err
 
         # get the list of raw 'unscaled' dash patterns
         self._us_linestyles = dashes

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -611,6 +611,12 @@ def test_lslw_bcast():
     assert (col.get_linewidths() == [1, 2, 3]).all()
 
 
+def test_set_wrong_linestyle():
+    c = Collection()
+    with pytest.raises(ValueError, match="Do not know how to convert 'fuzzy'"):
+        c.set_linestyle('fuzzy')
+
+
 @mpl.style.context('default')
 def test_capstyle():
     col = mcollections.PathCollection([], capstyle='round')


### PR DESCRIPTION
## PR Summary

The type check and mapping for strings is also done at the start of `_get_dash_pattern`:
https://github.com/matplotlib/matplotlib/blob/7c6e057148533e7a0b28154c485aeef9b6209bb5/lib/matplotlib/lines.py#L36-L37

So it's redundant here.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
