### PR TITLE
Stripey `LineCollection`

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -60,6 +60,18 @@ def _get_dash_pattern(style):
     return offset, dashes
 
 
+def _get_inverse_dash_pattern(offset, dashes):
+    """Return the inverse of the given dash pattern, for filling the gaps."""
+    # Define the inverse pattern by moving the last gap to the start of the
+    # sequence.
+    gaps = dashes[-1:] + dashes[:-1]
+    # Set the offset so that this new first segment is skipped
+    # (see backend_bases.GraphicsContextBase.set_dashes for offset definition).
+    offset_gaps = offset + dashes[-1]
+
+    return offset_gaps, gaps
+
+
 def _scale_dashes(offset, dashes, lw):
     if not mpl.rcParams['lines.scale_dashes']:
         return offset, dashes
@@ -780,14 +792,8 @@ class Line2D(Artist):
                     lc_rgba = mcolors.to_rgba(self._gapcolor, self._alpha)
                     gc.set_foreground(lc_rgba, isRGBA=True)
 
-                    # Define the inverse pattern by moving the last gap to the
-                    # start of the sequence.
-                    dashes = self._dash_pattern[1]
-                    gaps = dashes[-1:] + dashes[:-1]
-                    # Set the offset so that this new first segment is skipped
-                    # (see backend_bases.GraphicsContextBase.set_dashes for
-                    # offset definition).
-                    offset_gaps = self._dash_pattern[0] + dashes[-1]
+                    offset_gaps, gaps = _get_inverse_dash_pattern(
+                        *self._dash_pattern)
 
                     gc.set_dashes(offset_gaps, gaps)
                     renderer.draw_path(gc, tpath, affine.frozen())

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import io
+import itertools
 import re
 from types import SimpleNamespace
 
@@ -1191,3 +1192,27 @@ def test_check_offsets_dtype():
     unmasked_offsets = np.column_stack([x, y])
     scat.set_offsets(unmasked_offsets)
     assert isinstance(scat.get_offsets(), type(unmasked_offsets))
+
+
+@pytest.mark.parametrize('gapcolor', ['orange', ['r', 'k']])
+@check_figures_equal(extensions=['png'])
+@mpl.rc_context({'lines.linewidth': 20})
+def test_striped_lines(fig_test, fig_ref, gapcolor):
+    ax_test = fig_test.add_subplot(111)
+    ax_ref = fig_ref.add_subplot(111)
+
+    for ax in [ax_test, ax_ref]:
+        ax.set_xlim(0, 6)
+        ax.set_ylim(0, 1)
+
+    x = range(1, 6)
+    linestyles = [':', '-', '--']
+
+    ax_test.vlines(x, 0, 1, linestyle=linestyles, gapcolor=gapcolor, alpha=0.5)
+
+    if isinstance(gapcolor, str):
+        gapcolor = [gapcolor]
+
+    for x, gcol, ls in zip(x, itertools.cycle(gapcolor),
+                           itertools.cycle(linestyles)):
+        ax_ref.axvline(x, 0, 1, linestyle=ls, gapcolor=gcol, alpha=0.5)


### PR DESCRIPTION
## PR Summary

Closes #24796.

Following #23208, which implemented the `gapcolor` property for `Line2D`, this PR implements `gapcolor` for `LineCollection`.  So we can set a colour (or list of colours) to fill the gaps in dashed lines and make a striped effect.  For example

```python
import matplotlib.pyplot as plt

_, ax = plt.subplots()
ax.vlines(range(1, 5), 0, 1, linestyle=':', linewidth=5,
          color='k', gapcolor=['r', 'b'])

plt.show()
```

![stripey_vlines](https://user-images.githubusercontent.com/10599679/216572497-c9a37208-de0a-4323-b8c4-a3104d282bba.png)

I marked this functionality as "experimental" to be consistent with `Line2D`.

My current implementation works, but I'm pretty unsure about the way I've structured it: it doesn't seem great to have the `LineCollection`-specific handling within `Collection`.  The only way I can see to avoid that is to define `LineCollection.draw`, but that would mean duplicating some code, which also wouldn't seem great.

For reference, the test images look like this:

`gapcolor='orange'`
![test_striped_lines png-orange](https://user-images.githubusercontent.com/10599679/210132558-03ec9066-5ce8-4173-ab44-f129e30ea6ad.png)

`gapcolor=['r', 'k']`
![test_striped_lines png-gapcolor1](https://user-images.githubusercontent.com/10599679/210132563-46ba0818-fdae-40cb-a087-d223ef1b35e2.png)

I'm happy to squash the commits down once we're happy with the implementation, but I suspect there will be plenty of changes before that...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
