### PR TITLE
Improve PolarAffine docstring

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -124,9 +124,9 @@ class PolarAffine(mtransforms.Affine2DBase):
 
     .. math::
 
-        x_{1} = 0.5 \left [ \frac{x_{0}}{(r_{max} - r_{min})} + 1 \right ]
+        x_{1} = 0.5 \left [ \frac{x_{0}}{(r_{\max} - r_{\min})} + 1 \right ]
 
-    :math:`r_{min}, r_{max}` are the minimum and maximum radial limits after
+    :math:`r_{\min}, r_{\max}` are the minimum and maximum radial limits after
     any scaling (e.g. log scaling) has been removed.
     """
     def __init__(self, scale_transform, limits):

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -115,15 +115,30 @@ class PolarTransform(mtransforms.Transform):
 
 
 class PolarAffine(mtransforms.Affine2DBase):
-    """
-    The affine part of the polar projection.  Scales the output so
-    that maximum radius rests on the edge of the axes circle.
+    r"""
+    The affine part of the polar projection.
+
+    Scales the output so that maximum radius rests on the edge of the axes
+    circle and the origin is mapped to (0.5, 0.5). The transform applied is
+    the same to x and y components and given by:
+
+    .. math::
+
+        x_{1} = 0.5 \left [ \frac{x_{0}}{(r_{max} - r_{min})} + 1 \right ]
+
+    :math:`r_{min}, r_{max}` are the minimum and maximum radial limits after
+    any scaling (e.g. log scaling) has been removed.
     """
     def __init__(self, scale_transform, limits):
         """
-        *limits* is the view limit of the data.  The only part of
-        its bounds that is used is the y limits (for the radius limits).
-        The theta range is handled by the non-affine transform.
+        Parameters
+        ----------
+        scale_transform : `~matplotlib.transforms.Transform`
+            Scaling transform for the data. This is used to remove any scaling
+            from the radial view limits.
+        limits : `~matplotlib.transforms.BboxBase`
+            View limits of the data. The only part of its bounds that is used
+            is the y limits (for the radius limits).
         """
         super().__init__()
         self._scale_transform = scale_transform


### PR DESCRIPTION
## PR Summary
This adds a bit more context and information to the `PolarAffine` docstring.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
