### PR TITLE
Add parameter doc to PolarTransform

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -31,6 +31,17 @@ class PolarTransform(mtransforms.Transform):
 
     def __init__(self, axis=None, use_rmin=True,
                  _apply_theta_transforms=True):
+        """
+        Parameters
+        ----------
+        axis : `~matplotlib.axis.Axis`, optional
+            Axis associated with this transform. This is used to get the
+            minimum radial limit.
+        use_rmin : `bool`, optional
+            If ``True``, subtract the minimum radial axis limit before
+            transforming to Cartesian coordinates. *axis* must also be
+            specified for this to take effect.
+        """
         super().__init__()
         self._axis = axis
         self._use_rmin = use_rmin
@@ -171,6 +182,17 @@ class InvertedPolarTransform(mtransforms.Transform):
 
     def __init__(self, axis=None, use_rmin=True,
                  _apply_theta_transforms=True):
+        """
+        Parameters
+        ----------
+        axis : `~matplotlib.axis.Axis`, optional
+            Axis associated with this transform. This is used to get the
+            minimum radial limit.
+        use_rmin : `bool`, optional
+            If ``True`` add the minimum radial axis limit after
+            transforming from Cartesian coordinates. *axis* must also be
+            specified for this to take effect.
+        """
         super().__init__()
         self._axis = axis
         self._use_rmin = use_rmin


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
