### PR TITLE
Document "." as a filled marker.

### DIFF
--- a/examples/lines_bars_and_markers/marker_reference.py
+++ b/examples/lines_bars_and_markers/marker_reference.py
@@ -60,9 +60,6 @@ for ax, markers in zip(axs, split_list(unfilled_markers)):
         ax.plot([y] * 3, marker=marker, **marker_style)
     format_axes(ax)
 
-plt.show()
-
-
 ###############################################################################
 # Filled markers
 # ==============
@@ -74,8 +71,6 @@ for ax, markers in zip(axs, split_list(Line2D.filled_markers)):
         ax.text(-0.5, y, repr(marker), **text_style)
         ax.plot([y] * 3, marker=marker, **marker_style)
     format_axes(ax)
-
-plt.show()
 
 ###############################################################################
 # .. _marker_fill_styles:
@@ -102,9 +97,6 @@ for y, fill_style in enumerate(Line2D.fillStyles):
     ax.plot([y] * 3, fillstyle=fill_style, **filled_marker_style)
 format_axes(ax)
 
-plt.show()
-
-
 ###############################################################################
 # Markers created from TeX symbols
 # ================================
@@ -127,9 +119,6 @@ for y, marker in enumerate(markers):
     ax.text(-0.5, y, repr(marker).replace("$", r"\$"), **text_style)
     ax.plot([y] * 3, marker=marker, **marker_style)
 format_axes(ax)
-
-plt.show()
-
 
 ###############################################################################
 # Markers created from Paths
@@ -159,8 +148,6 @@ for y, (name, marker) in enumerate(markers.items()):
     ax.text(-0.5, y, name, **text_style)
     ax.plot([y] * 3, marker=marker, **marker_style)
 format_axes(ax)
-
-plt.show()
 
 ###############################################################################
 # Advanced marker modifications with transform
@@ -197,7 +184,6 @@ for x, theta in enumerate(angles):
 format_axes(ax)
 
 fig.tight_layout()
-plt.show()
 
 ###############################################################################
 # Setting marker cap style and join style
@@ -235,7 +221,6 @@ for y, cap_style in enumerate(CapStyle):
         ax.plot(x, y, marker=m, **marker_outer)
         ax.text(x, len(CapStyle) - .5, f'{theta}°', ha='center')
 format_axes(ax)
-plt.show()
 
 ###############################################################################
 # Modifying the join style:

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -217,7 +217,7 @@ class MarkerStyle:
     # Just used for informational purposes.  is_filled()
     # is calculated in the _set_* functions.
     filled_markers = (
-        'o', 'v', '^', '<', '>', '8', 's', 'p', '*', 'h', 'H', 'D', 'd',
+        '.', 'o', 'v', '^', '<', '>', '8', 's', 'p', '*', 'h', 'H', 'D', 'd',
         'P', 'X')
 
     fillstyles = ('full', 'left', 'right', 'bottom', 'top', 'none')

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -195,7 +195,11 @@ def test_marker_fill_styles():
     x = np.array([0, 9])
     fig, ax = plt.subplots()
 
-    for j, marker in enumerate(mlines.Line2D.filled_markers):
+    # This hard-coded list of markers correspond to an earlier iteration of
+    # MarkerStyle.filled_markers; the value of that attribute has changed but
+    # we kept the old value here to not regenerate the baseline image.
+    # Replace with mlines.Line2D.filled_markers when the image is regenerated.
+    for j, marker in enumerate("ov^<>8sp*hHDdPX"):
         for i, fs in enumerate(mlines.Line2D.fillStyles):
             color = next(colors)
             ax.plot(j * 10 + x, y + i + .5 * (j % 2),


### PR DESCRIPTION
... which it really is.  Closes #23849.

Also remove a bunch of unnecessary plt.show() from the marker reference example, to make it more convenient to run from the command line.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
