### PR TITLE
Fixed color tuple's precision

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -391,7 +391,7 @@ def _to_rgba_no_colorcycle(c, alpha=None):
         alpha = 1
     if alpha is not None:
         c = c[:3] + (alpha,)
-    if any(round(elem,7) < 0 or round(elem,7) > 1 for elem in c):
+    if any(round(elem, 7) < 0 or round(elem, 7) > 1 for elem in c):
         raise ValueError("RGBA values should be within 0-1 range")
     return c
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -391,7 +391,7 @@ def _to_rgba_no_colorcycle(c, alpha=None):
         alpha = 1
     if alpha is not None:
         c = c[:3] + (alpha,)
-    if any(elem < 0 or elem > 1 for elem in c):
+    if any(float(int(elem*1e+7))/1e+7 < 0 or float(int(elem*1e+7))/1e+7 > 1 for elem in c):
         raise ValueError("RGBA values should be within 0-1 range")
     return c
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -391,7 +391,7 @@ def _to_rgba_no_colorcycle(c, alpha=None):
         alpha = 1
     if alpha is not None:
         c = c[:3] + (alpha,)
-    if any(float(int(elem*1e+7))/1e+7 < 0 or float(int(elem*1e+7))/1e+7 > 1 for elem in c):
+    if any(round(elem,7) < 0 or round(elem,7) > 1 for elem in c):
         raise ValueError("RGBA values should be within 0-1 range")
     return c
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
