### PR TITLE
Harmonize exceptions for unknown keyword arguments.

### DIFF
--- a/doc/api/next_api_changes/behavior/24889-AL.rst
+++ b/doc/api/next_api_changes/behavior/24889-AL.rst
@@ -1,0 +1,3 @@
+``AxesImage.set_extent`` now raises ``TypeError`` for unknown keyword arguments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It previously raised a `ValueError`.

--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -342,6 +342,23 @@ def nargs_error(name, takes, given):
                      f"{given} were given")
 
 
+def kwarg_error(name, kw):
+    """
+    Generate a TypeError to be raised by function calls with wrong kwarg.
+
+    Parameters
+    ----------
+    name : str
+        The name of the calling function.
+    kw : str or Iterable[str]
+        Either the invalid keyword argument name, or an iterable yielding
+        invalid keyword arguments (e.g., a ``kwargs`` dict).
+    """
+    if not isinstance(kw, str):
+        kw = next(iter(kw))
+    return TypeError(f"{name}() got an unexpected keyword argument '{kw}'")
+
+
 def recursive_subclasses(cls):
     """Yield *cls* and direct and indirect subclasses of *cls*."""
     yield cls

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7795,8 +7795,7 @@ such objects
         extent = xmin, xmax, freqs[0], freqs[-1]
 
         if 'origin' in kwargs:
-            raise TypeError("specgram() got an unexpected keyword argument "
-                            "'origin'")
+            raise _api.kwarg_error("specgram", "origin")
 
         im = self.imshow(Z, cmap, extent=extent, vmin=vmin, vmax=vmax,
                          origin='upper', **kwargs)
@@ -7894,8 +7893,7 @@ such objects
                 kwargs['cmap'] = mcolors.ListedColormap(['w', 'k'],
                                                         name='binary')
             if 'interpolation' in kwargs:
-                raise TypeError(
-                    "spy() got an unexpected keyword argument 'interpolation'")
+                raise _api.kwarg_error("spy", "interpolation")
             if 'norm' not in kwargs:
                 kwargs['norm'] = mcolors.NoNorm()
             ret = self.imshow(mask, interpolation='nearest',
@@ -7920,8 +7918,7 @@ such objects
             if markersize is None:
                 markersize = 10
             if 'linestyle' in kwargs:
-                raise TypeError(
-                    "spy() got an unexpected keyword argument 'linestyle'")
+                raise _api.kwarg_error("spy", "linestyle")
             ret = mlines.Line2D(
                 x, y, linestyle='None', marker=marker, markersize=markersize,
                 **kwargs)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -243,8 +243,7 @@ class _process_plot_var_args:
 
         for pos_only in "xy":
             if pos_only in kwargs:
-                raise TypeError("{} got an unexpected keyword argument {!r}"
-                                .format(self.command, pos_only))
+                raise _api.kwarg_error(self.command, pos_only)
 
         if not args:
             return
@@ -2188,8 +2187,7 @@ class _AxesBase(martist.Artist):
             self.set_xlim(xmin, xmax, emit=emit, auto=xauto)
             self.set_ylim(ymin, ymax, emit=emit, auto=yauto)
         if kwargs:
-            raise TypeError(f"axis() got an unexpected keyword argument "
-                            f"'{next(iter(kwargs))}'")
+            raise _api.kwarg_error("axis", kwargs)
         return (*self.get_xlim(), *self.get_ylim())
 
     def get_legend(self):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -716,8 +716,7 @@ default: %(va)s
         if 'figure' in kwargs:
             # Axes itself allows for a 'figure' kwarg, but since we want to
             # bind the created Axes to self, it is not allowed here.
-            raise TypeError(
-                "add_subplot() got an unexpected keyword argument 'figure'")
+            raise _api.kwarg_error("add_subplot", "figure")
 
         if (len(args) == 1
                 and isinstance(args[0], mpl.axes._base._AxesBase)

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -978,11 +978,8 @@ class AxesImage(_ImageBase):
             [("x", [extent[0], extent[1]]),
              ("y", [extent[2], extent[3]])],
             kwargs)
-        if len(kwargs):
-            raise ValueError(
-                "set_extent did not consume all of the kwargs passed." +
-                f"{list(kwargs)!r} were unused"
-            )
+        if kwargs:
+            raise _api.kwarg_error("set_extent", kwargs)
         xmin = self.axes._validate_converted_limits(
             xmin, self.convert_xunits)
         xmax = self.axes._validate_converted_limits(

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8244,7 +8244,7 @@ def test_automatic_legend():
 
 
 def test_plot_errors():
-    with pytest.raises(TypeError, match="plot got an unexpected keyword"):
+    with pytest.raises(TypeError, match=r"plot\(\) got an unexpected keyword"):
         plt.plot([1, 2, 3], x=1)
     with pytest.raises(ValueError, match=r"plot\(\) with multiple groups"):
         plt.plot([1, 2, 3], [1, 2, 3], [2, 3, 4], [2, 3, 4], label=['1', '2'])
@@ -8419,8 +8419,7 @@ def test_extent_units():
     axs[1, 1].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
     axs[1, 1].set(xlabel='Day of Jan 2020')
 
-    with pytest.raises(ValueError,
-                       match="set_extent did not consume all of the kwargs"):
+    with pytest.raises(TypeError, match=r"set_extent\(\) got an unexpected"):
         im.set_extent([2, 12, date_first, date_last], clip=False)
 
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2069,9 +2069,7 @@ class MaxNLocator(Locator):
         if 'integer' in kwargs:
             self._integer = kwargs.pop('integer')
         if kwargs:
-            key, _ = kwargs.popitem()
-            raise TypeError(
-                f"set_params() got an unexpected keyword argument '{key}'")
+            raise _api.kwarg_error("set_params", kwargs)
 
     def _raw_ticks(self, vmin, vmax):
         """


### PR DESCRIPTION
... via a kwarg_error helper (see nargs_error for a similar design).  In particular the type of the exception thrown by AxesImage.set_extent changed, and parentheses were added to the error thrown by _process_plot_var_args.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
