### PR TITLE
FIX: error in formatting in error string in redirect extension

### DIFF
--- a/doc/sphinxext/redirect_from.py
+++ b/doc/sphinxext/redirect_from.py
@@ -83,7 +83,7 @@ class RedirectFromDomain(Domain):
             elif self.redirects[src] != dst:
                 raise ValueError(
                     f"Inconsistent redirections from {src} to "
-                    F"{self.redirects[src]} and {otherdata.redirects[src]}")
+                    f"{self.redirects[src]} and {otherdata['redirects'][src]}")
 
 
 class RedirectFrom(Directive):


### PR DESCRIPTION
`otherdata` is a dict

## PR Summary

Given that this is a helper sphinx extension that we do not ship, I do no think we need a test (but this error existing made debugging a build issues easy!).