### PR TITLE
STY: make allowed line length 9 longer to 88 from 79

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 79
+max-line-length = 88
 select =
     # flake8 default
     C90, E, F, W,

--- a/doc/api/next_api_changes/development/24893-KS.rst
+++ b/doc/api/next_api_changes/development/24893-KS.rst
@@ -1,0 +1,15 @@
+Maximum line length increased to 88 characters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The maximum line length for new contributions has been extended from 79 characters to
+88 characters.
+This change provides an extra 9 characters to allow code which is a single idea to fit
+on fewer lines (often a single line).
+Other line lengths considered included 115 and 99, but ultimately 88 characters was the
+consensus as it is relatively conservative while still providing reasonable benefit.
+The ability to view side-by-side git diffs was a key point in choosing the smaller
+limit.
+Additionally, it is easier to increase the line length again than to decrease it if it
+was found too large.
+The chosen length is the same as `black <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length>`_.
+Their justifications influenced the discussion and provided a standard value.

--- a/doc/api/next_api_changes/development/24893-KS.rst
+++ b/doc/api/next_api_changes/development/24893-KS.rst
@@ -5,11 +5,4 @@ The maximum line length for new contributions has been extended from 79 characte
 88 characters.
 This change provides an extra 9 characters to allow code which is a single idea to fit
 on fewer lines (often a single line).
-Other line lengths considered included 115 and 99, but ultimately 88 characters was the
-consensus as it is relatively conservative while still providing reasonable benefit.
-The ability to view side-by-side git diffs was a key point in choosing the smaller
-limit.
-Additionally, it is easier to increase the line length again than to decrease it if it
-was found too large.
 The chosen length is the same as `black <https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length>`_.
-Their justifications influenced the discussion and provided a standard value.

--- a/doc/devel/MEP/MEP08.rst
+++ b/doc/devel/MEP/MEP08.rst
@@ -9,7 +9,10 @@
 Status
 ======
 
-**Completed**
+**Superseded**
+
+Current guidelines for style, including usage of pep8 are maintained
+in `our pull request guidelines <https://matplotlib.org/devdocs/devel/coding_guide.html>`_.
 
 We are currently enforcing a sub-set of pep8 on new code contributions.
 

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -157,11 +157,10 @@ Content topics:
 * Does the PR conform with the :ref:`coding_guidelines`?
 * Is the :ref:`documentation <pr-documentation>` (docstrings, examples,
   what's new, API changes) updated?
-* Is the change only reflowing code/docstrings for increased line length?
-  Generally, such changes are discouraged when not part of other non-stylistic
-  work because it obscures the git history of functional changes to the code.
-  Reflowing a method or docstring as part of a larger refactor/rewrite is
-  acceptable.
+* Is the change purely stylistic? Generally, such changes are discouraged when
+  not part of other non-stylistic work because it obscures the git history of
+  functional changes to the code. Reflowing a method or docstring as part of a
+  larger refactor/rewrite is acceptable.
 
 
 Organizational topics:

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -30,7 +30,8 @@ rules before submitting a pull request:
   for more details.
 
 * Formatting should follow the recommendations of PEP8_, as enforced by
-  flake8_.  You can check flake8 compliance from the command line with ::
+  flake8_. Matplotlib modifies PEP8 to extend the maximum line length to 88
+  characters. You can check flake8 compliance from the command line with ::
 
     python -m pip install flake8
     flake8 /path/to/module.py
@@ -156,6 +157,12 @@ Content topics:
 * Does the PR conform with the :ref:`coding_guidelines`?
 * Is the :ref:`documentation <pr-documentation>` (docstrings, examples,
   what's new, API changes) updated?
+* Is the change only reflowing code/docstrings for increased line length?
+  Generally, such changes are discouraged when not part of other non-stylistic
+  work because it obscures the git history of functional changes to the code.
+  Reflowing a method or docstring as part of a larger refactor/rewrite is
+  acceptable.
+
 
 Organizational topics:
 


### PR DESCRIPTION
As discussed on the call this week, we should consider making the style enforced line length slightly longer.

Going to 88 matches the default of black.  https://black.readthedocs.io/en/stable/the_black_code_style/current_style.html#line-length is a nice explanation of how they landed there.

Key points from the call:
 - we should keep this low enough that GH's side-by-side diff view works
 - keep this small enough 2 or 3 panels can be up next to each other in an editor
 - we can make it bigger in the future, but making it smaller would be rough

There are no plans to re-flow the entire code base, but new stuff could come in more relaxed.