### PR TITLE
add new & improved doc notices to what's new

### DIFF
--- a/doc/users/next_whats_new/documentation.rst
+++ b/doc/users/next_whats_new/documentation.rst
@@ -1,0 +1,6 @@
+New & Improved Narrative Documentation
+======================================
+* Brand new :doc:`Animations </tutorials/introductory/animation_tutorial>` tutorial.
+* New grouped and stacked `bar chart <../../gallery/index.html#lines_bars_and_markers>`_ examples.
+* New section for new contributors and reorganized git instructions in the :ref:`contributing guide<contributing>`.
+* Restructured :doc:`/tutorials/text/annotations` tutorial.


### PR DESCRIPTION
As [discussed on gitter](https://gitter.im/matplotlib/matplotlib?at=6397a6b30c89e71a3377677c), added a what's new entry for large documentation contributions. Very likely missed some so please add! 