### PR TITLE
changed contribute docs link to writing docs

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -45,7 +45,7 @@ process or how to fix something feel free to ask on `gitter
 
 .. rst-class:: sd-d-inline-block
 
-    .. button-ref:: contributing_documentation
+    .. button-ref:: documenting-matplotlib
         :class: sd-fs-6
         :color: primary
 


### PR DESCRIPTION
Changed the link for the "write documentation" button on 
![image](https://user-images.githubusercontent.com/1300499/210913573-be3f3089-b952-46e2-8f4c-648f50d3498f.png)

from https://matplotlib.org/devdocs/devel/contributing.html#contributing-documentation to https://matplotlib.org/devdocs/devel/documenting_mpl.html  because the way I use this button is to find the "writing documentation" section (which did not notice it was in the sidebar 'til now). 
Was considering moving the "contributing-documentation" section of the guide to the "writing docs" guide as a preamble, but I also get why it may be worth having in the contributing documentation page for folks skimming it so might be worth writing up a similar overview for the "writing docs" page, possibly once we sort out guidelines https://github.com/matplotlib/matplotlib/issues/24746#issuecomment-1356499911

Alternatively since that page is so "coding contribution heavy", it may make more sense to pull "coding guidlines" out into it's page too and make both of those buttons link out. It is kind of weird that these are all top level & then there's coding guidelines, but I also think some of this is gonna go as part of doc reshuffle. attn: @melissawm 
![image](https://user-images.githubusercontent.com/1300499/210915113-dca7a1cc-079d-4291-812f-71f8041d7e76.png)
