### PR TITLE
Deprecate AxisArtistHelpers with inconsistent loc/nth_coord.

### DIFF
--- a/doc/api/next_api_changes/deprecations/24904-AL.rst
+++ b/doc/api/next_api_changes/deprecations/24904-AL.rst
@@ -1,0 +1,4 @@
+Passing inconsistent ``loc`` and ``nth_coord`` to axisartist helpers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Trying to construct for example a "top y-axis" or a "left x-axis" is now
+deprecated.

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -126,12 +126,17 @@ class AxisArtistHelper:
 
         def __init__(self, loc, nth_coord=None):
             """``nth_coord = 0``: x-axis; ``nth_coord = 1``: y-axis."""
-            _api.check_in_list(["left", "right", "bottom", "top"], loc=loc)
-            self._loc = loc
-            self._pos = {"bottom": 0, "top": 1, "left": 0, "right": 1}[loc]
             self.nth_coord = (
                 nth_coord if nth_coord is not None else
-                {"bottom": 0, "top": 0, "left": 1, "right": 1}[loc])
+                _api.check_getitem(
+                    {"bottom": 0, "top": 0, "left": 1, "right": 1}, loc=loc))
+            if (nth_coord == 0 and loc not in ["left", "right"]
+                    or nth_coord == 1 and loc not in ["bottom", "top"]):
+                _api.warn_deprecated(
+                    "3.7", message=f"{loc=!r} is incompatible with "
+                    "{nth_coord=}; support is deprecated since %(since)s")
+            self._loc = loc
+            self._pos = {"bottom": 0, "top": 1, "left": 0, "right": 1}[loc]
             super().__init__()
             # axis line in transAxes
             self._path = Path(self._to_xy((0, 1), const=self._pos))


### PR DESCRIPTION
A "top y-axis" or a "left x-axis" doesn't make sense.

See https://github.com/matplotlib/matplotlib/pull/22314#issuecomment-1374427550.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
