### PR TITLE
Remove contour warning for "no-valid-levels".

### DIFF
--- a/doc/api/next_api_changes/behavior/24912-AL.rst
+++ b/doc/api/next_api_changes/behavior/24912-AL.rst
@@ -1,0 +1,4 @@
+``contour`` no longer warns if no contour lines are drawn.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This can occur if the user explicitly passes a ``levels`` array with no values
+between ``z.min()`` and ``z.max()``; or if ``z`` has the same value everywhere.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1137,18 +1137,8 @@ class ContourSet(cm.ScalarMappable, ContourLabeler):
             self.levels = self._autolev(levels_arg)
         else:
             self.levels = np.asarray(levels_arg, np.float64)
-
-        if not self.filled:
-            inside = (self.levels > self.zmin) & (self.levels < self.zmax)
-            levels_in = self.levels[inside]
-            if len(levels_in) == 0:
-                self.levels = [self.zmin]
-                _api.warn_external(
-                    "No contour levels were found within the data range.")
-
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
-
         if len(self.levels) > 1 and np.min(np.diff(self.levels)) <= 0.0:
             raise ValueError("Contour levels must be increasing")
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -62,15 +62,16 @@ def test_contour_shape_error(args, message):
         ax.contour(*args)
 
 
-def test_contour_empty_levels():
-
-    x = np.arange(9)
-    z = np.random.random((9, 9))
-
+def test_contour_no_valid_levels():
     fig, ax = plt.subplots()
-    with pytest.warns(UserWarning) as record:
-        ax.contour(x, x, z, levels=[])
-    assert len(record) == 1
+    # no warning for empty levels.
+    ax.contour(np.random.rand(9, 9), levels=[])
+    # no warning if levels is given and is not within the range of z.
+    cs = ax.contour(np.arange(81).reshape((9, 9)), levels=[100])
+    # ... and if fmt is given.
+    ax.clabel(cs, fmt={100: '%1.2f'})
+    # no warning if z is uniform.
+    ax.contour(np.ones((9, 9)))
 
 
 def test_contour_Nlevels():
@@ -82,33 +83,6 @@ def test_contour_Nlevels():
     assert len(cs1.levels) > 1
     cs2 = ax.contour(z, levels=5)
     assert (cs1.levels == cs2.levels).all()
-
-
-def test_contour_badlevel_fmt():
-    # Test edge case from https://github.com/matplotlib/matplotlib/issues/9742
-    # User supplied fmt for each level as a dictionary, but Matplotlib changed
-    # the level to the minimum data value because no contours possible.
-    # This was fixed in https://github.com/matplotlib/matplotlib/pull/9743
-    x = np.arange(9)
-    z = np.zeros((9, 9))
-
-    fig, ax = plt.subplots()
-    fmt = {1.: '%1.2f'}
-    with pytest.warns(UserWarning) as record:
-        cs = ax.contour(x, x, z, levels=[1.])
-        ax.clabel(cs, fmt=fmt)
-    assert len(record) == 1
-
-
-def test_contour_uniform_z():
-
-    x = np.arange(9)
-    z = np.ones((9, 9))
-
-    fig, ax = plt.subplots()
-    with pytest.warns(UserWarning) as record:
-        ax.contour(x, x, z)
-    assert len(record) == 1
 
 
 @image_comparison(['contour_manual_labels'], remove_text=True, style='mpl20')


### PR DESCRIPTION
If the user explicitly passes a levels array (the default is auto-determined), let's assume that they know what they are doing.  Closes #23778.

(I *could* consider keeping the warning for now in the case where the user didn't pass `levels` but `z` is uniform throughout, as that's more likely to be a "data-exploration" case.)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
