### PR TITLE
Deprecate Bbox.anchored() with no container.

### DIFF
--- a/doc/api/next_api_changes/deprecations/24913-AL.rst
+++ b/doc/api/next_api_changes/deprecations/24913-AL.rst
@@ -1,0 +1,3 @@
+``bbox.anchored()`` with no explicit container
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Not passing a *container* argument to `.BboxBase.anchored` is now deprecated.

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -501,21 +501,21 @@ class BboxBase(TransformNode):
             bottom, 1 is right or top), 'C' (center), or a cardinal direction
             ('SW', southwest, is bottom left, etc.).
         container : `Bbox`, optional
-            The box within which the `Bbox` is positioned; it defaults
-            to the initial `Bbox`.
+            The box within which the `Bbox` is positioned.
 
         See Also
         --------
         .Axes.set_anchor
         """
         if container is None:
+            _api.warn_deprecated(
+                "3.8", message="Calling anchored() with no container bbox "
+                "returns a frozen copy of the original bbox and is deprecated "
+                "since %(since)s.")
             container = self
         l, b, w, h = container.bounds
-        if isinstance(c, str):
-            cx, cy = self.coefs[c]
-        else:
-            cx, cy = c
         L, B, W, H = self.bounds
+        cx, cy = self.coefs[c] if isinstance(c, str) else c
         return Bbox(self._points +
                     [(l + cx * (w - W)) - L,
                      (b + cy * (h - H)) - B])


### PR DESCRIPTION
This previously returned a copy of the bbox itself, and was completely unused; let's deprecate this for clarity ("anchoring a bbox to itself" doesn't make much sense anyways).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
