### PR TITLE
Fix toggling layout engines

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2760,9 +2760,9 @@ class Figure(FigureBase):
         """
         if tight is None:
             tight = mpl.rcParams['figure.autolayout']
+        _tight = 'tight' if bool(tight) else 'none'
         _tight_parameters = tight if isinstance(tight, dict) else {}
-        if bool(tight):
-            self.set_layout_engine(TightLayoutEngine(**_tight_parameters))
+        self.set_layout_engine(_tight, **_tight_parameters)
         self.stale = True
 
     def get_constrained_layout(self):
@@ -2797,10 +2797,9 @@ class Figure(FigureBase):
         """
         if constrained is None:
             constrained = mpl.rcParams['figure.constrained_layout.use']
-        _constrained = bool(constrained)
+        _constrained = 'constrained' if bool(constrained) else 'none'
         _parameters = constrained if isinstance(constrained, dict) else {}
-        if _constrained:
-            self.set_layout_engine(ConstrainedLayoutEngine(**_parameters))
+        self.set_layout_engine(_constrained, **_parameters)
         self.stale = True
 
     @_api.deprecated(

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -667,3 +667,14 @@ def test_compressed1():
 def test_set_constrained_layout(arg, state):
     fig, ax = plt.subplots(constrained_layout=arg)
     assert fig.get_constrained_layout() is state
+
+
+def test_constrained_toggle():
+    fig, ax = plt.subplots()
+    with pytest.warns(PendingDeprecationWarning):
+        fig.set_constrained_layout(True)
+        assert fig.get_constrained_layout()
+        fig.set_constrained_layout(False)
+        assert not fig.get_constrained_layout()
+        fig.set_constrained_layout(True)
+        assert fig.get_constrained_layout()

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -380,3 +380,14 @@ def test_tight_pads():
 def test_tight_kwargs():
     fig, ax = plt.subplots(tight_layout={'pad': 0.15})
     fig.draw_without_rendering()
+
+
+def test_tight_toggle():
+    fig, ax = plt.subplots()
+    with pytest.warns(PendingDeprecationWarning):
+        fig.set_tight_layout(True)
+        assert fig.get_tight_layout()
+        fig.set_tight_layout(False)
+        assert not fig.get_tight_layout()
+        fig.set_tight_layout(True)
+        assert fig.get_tight_layout()


### PR DESCRIPTION
## PR Summary

Re-uses the tests from #22849, but also tests that going _back_ on works as well.

Fixes #22847

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`