### PR TITLE
fix: removed inconsistent spacing between lines

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ sys.path.append(str(Path(__file__).resolve().parent))
 import setupext
 from setupext import print_raw, print_status
 
-
 # These are the packages in the order we want to display them.
 mpl_packages = [
     setupext.Matplotlib(),
@@ -51,7 +50,6 @@ mpl_packages = [
     setupext.Tests(),
     setupext.BackendMacOSX(),
     ]
-
 
 # From https://bugs.python.org/issue26689
 def has_flag(self, flagname):
@@ -67,7 +65,6 @@ def has_flag(self, flagname):
                 raise
             return False
     return True
-
 
 class BuildExtraLibraries(setuptools.command.build_ext.build_ext):
     def finalize_options(self):
@@ -99,7 +96,6 @@ class BuildExtraLibraries(setuptools.command.build_ext.build_ext):
             return env
         enable_lto = setupext.config.getboolean('libs', 'enable_lto',
                                                 fallback=None)
-
         def prepare_flags(name, enable_lto):
             """
             Prepare *FLAGS from the environment.
@@ -197,7 +193,6 @@ class BuildExtraLibraries(setuptools.command.build_ext.build_ext):
         finally:
             self.build_temp = orig_build_temp
 
-
 def update_matplotlibrc(path):
     # If packagers want to change the default backend, insert a `#backend: ...`
     # line.  Otherwise, use the default `##backend: Agg` which has no effect
@@ -221,13 +216,11 @@ class BuildPy(setuptools.command.build_py.build_py):
             update_matplotlibrc(
                 Path(self.build_lib, "matplotlib/mpl-data/matplotlibrc"))
 
-
 class Sdist(setuptools.command.sdist.sdist):
     def make_release_tree(self, base_dir, files):
         super().make_release_tree(base_dir, files)
         update_matplotlibrc(
             Path(base_dir, "lib/matplotlib/mpl-data/matplotlibrc"))
-
 
 package_data = {}  # Will be filled below by the various components.
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
