### PR TITLE
Swap ipython directives for code-block directives

### DIFF
--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -20,14 +20,12 @@ is :func:`matplotlib.colors.Normalize`.
 Artists that map data to color pass the arguments *vmin* and *vmax* to
 construct a :func:`matplotlib.colors.Normalize` instance, then call it:
 
-.. ipython::
+.. code-block:: pycon
 
-   In [1]: import matplotlib as mpl
-
-   In [2]: norm = mpl.colors.Normalize(vmin=-1, vmax=1)
-
-   In [3]: norm(0)
-   Out[3]: 0.5
+   >>> import matplotlib as mpl
+   >>> norm = mpl.colors.Normalize(vmin=-1, vmax=1)
+   >>> norm(0)
+   0.5
 
 However, there are sometimes cases where it is useful to map data to
 colormaps in a non-linear fashion.
@@ -192,15 +190,12 @@ plt.show()
 # lower out-of-bounds values to the range over which the colors are
 # distributed. For instance:
 #
-# .. ipython::
+# .. code-block:: pycon
 #
-#   In [2]: import matplotlib.colors as colors
-#
-#   In [3]: bounds = np.array([-0.25, -0.125, 0, 0.5, 1])
-#
-#   In [4]: norm = colors.BoundaryNorm(boundaries=bounds, ncolors=4)
-#
-#   In [5]: print(norm([-0.2, -0.15, -0.02, 0.3, 0.8, 0.99]))
+#   >>> import matplotlib.colors as colors
+#   >>> bounds = np.array([-0.25, -0.125, 0, 0.5, 1])
+#   >>> norm = colors.BoundaryNorm(boundaries=bounds, ncolors=4)
+#   >>> print(norm([-0.2, -0.15, -0.02, 0.3, 0.8, 0.99]))
 #   [0 0 1 2 3 3]
 #
 # Note: Unlike the other norms, this norm returns values from 0 to *ncolors*-1.


### PR DESCRIPTION
## PR Summary

I was having some trouble building docs locally due to some bad interaction between
the ipython sphinx directive and running in a virtual environment (despite ipython being installed in the environment)

Rather than spending a large amount of time figuring out how to resolve those incompatibilities, I just removed
the directive that was causing the problem and replaced it with `code-block`  which is what we use everywhere else (that isn't a plot) anyway.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
