### PR TITLE
Remove remaining deprecations from 3.5

### DIFF
--- a/doc/api/next_api_changes/removals/24948-ES.rst
+++ b/doc/api/next_api_changes/removals/24948-ES.rst
@@ -1,0 +1,104 @@
+
+Testing support
+~~~~~~~~~~~~~~~
+
+``matplotlib.test()`` has been removed
+......................................
+
+Run tests using ``pytest`` from the commandline instead. The variable
+``matplotlib.default_test_modules`` was only used for ``matplotlib.test()`` and
+is thus removed as well.
+
+To test an installed copy, be sure to specify both ``matplotlib`` and
+``mpl_toolkits`` with ``--pyargs``::
+
+    python -m pytest --pyargs matplotlib.tests mpl_toolkits.tests
+
+See :ref:`testing` for more details.
+
+
+
+Auto-removal of grids by `~.Axes.pcolor` and `~.Axes.pcolormesh`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`~.Axes.pcolor` and `~.Axes.pcolormesh` previously remove any visible axes
+major grid. This behavior is removed; please explicitly call ``ax.grid(False)``
+to remove the grid.
+
+
+
+Modification of ``Axes`` children sublists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+See :ref:`Behavioural API Changes 3.5 - Axes children combined` for more
+information; modification of the following sublists is no longer supported:
+
+* ``Axes.artists``
+* ``Axes.collections``
+* ``Axes.images``
+* ``Axes.lines``
+* ``Axes.patches``
+* ``Axes.tables``
+* ``Axes.texts``
+
+To remove an Artist, use its `.Artist.remove` method. To add an Artist, use the
+corresponding ``Axes.add_*`` method.
+
+
+
+``ConversionInterface.convert`` no longer accepts unitless values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, custom subclasses of `.units.ConversionInterface` needed to
+implement a ``convert`` method that not only accepted instances of the unit,
+but also unitless values (which are passed through as is). This is no longer
+the case (``convert`` is never called with a unitless value), and such support
+in ``.StrCategoryConverter`` is removed. Likewise, the
+``.ConversionInterface.is_numlike`` helper is removed.
+
+Consider calling `.Axis.convert_units` instead, which still supports unitless
+values.
+
+
+Normal list of `.Artist` objects now returned by `.HandlerLine2D.create_artists`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For Matplotlib 3.5 and 3.6 a proxy list was returned that simulated the return
+of `.HandlerLine2DCompound.create_artists`. Now a list containing only the
+single artist is return.
+
+
+rcParams will no longer cast inputs to str
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+rcParams that expect a (non-pathlike) str no longer cast non-str inputs using
+`str`. This will avoid confusing errors in subsequent code if e.g. a list input
+gets implicitly cast to a str.
+
+
+
+Case-insensitive scales
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, scales could be set case-insensitively (e.g.,
+``set_xscale("LoG")``).  Now all builtin scales use lowercase names.
+
+
+
+Support for ``nx1 = None`` or ``ny1 = None`` in ``AxesLocator`` and ``Divider.locate``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In `.axes_grid1.axes_divider`, various internal APIs no longer supports
+passing ``nx1 = None`` or ``ny1 = None`` to mean ``nx + 1`` or ``ny + 1``, in
+preparation for a possible future API which allows indexing and slicing of
+dividers (possibly ``divider[a:b] == divider.new_locator(a, b)``, but also
+``divider[a:] == divider.new_locator(a, <end>)``). The user-facing
+`.Divider.new_locator` API is unaffected -- it correctly normalizes ``nx1 =
+None`` and ``ny1 = None`` as needed.
+
+
+change signature of ``.FigureCanvasBase.enter_notify_event``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *xy* parameter is now required and keyword only.  This was deprecated in
+3.0 and originally slated to be removed in 3.5.

--- a/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
@@ -162,7 +162,7 @@ implement a ``convert`` method that not only accepted instances of the unit,
 but also unitless values (which are passed through as is). This is no longer
 the case (``convert`` is never called with a unitless value), and such support
 in `.StrCategoryConverter` is deprecated. Likewise, the
-`.ConversionInterface.is_numlike` helper is deprecated.
+``.ConversionInterface.is_numlike`` helper is deprecated.
 
 Consider calling `.Axis.convert_units` instead, which still supports unitless
 values.

--- a/doc/api/prev_api_changes/api_changes_3.5.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/removals.rst
@@ -282,7 +282,7 @@ Arguments
 - The *dummy* parameter of `.RendererPgf` has been removed.
 - The *props* parameter of `.Shadow` has been removed; use keyword arguments
   instead.
-- The *recursionlimit* parameter of `matplotlib.test` has been removed.
+- The *recursionlimit* parameter of ``matplotlib.test`` has been removed.
 - The *label* parameter of `.Tick` has no effect and has been removed.
 - `~.ticker.MaxNLocator` no longer accepts a positional parameter and the
   keyword argument *nbins* simultaneously because they specify the same

--- a/doc/api/testing_api.rst
+++ b/doc/api/testing_api.rst
@@ -3,11 +3,6 @@
 **********************
 
 
-:func:`matplotlib.test`
-=======================
-
-.. autofunction:: matplotlib.test
-
 :mod:`matplotlib.testing`
 =========================
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1278,12 +1278,6 @@ def is_interactive():
     return rcParams['interactive']
 
 
-default_test_modules = [
-    'matplotlib.tests',
-    'mpl_toolkits.tests',
-]
-
-
 def _init_tests():
     # The version of FreeType to install locally for running the
     # tests.  This must match the value in `setupext.py`

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1302,58 +1302,6 @@ def _init_tests():
                 "" if ft2font.__freetype_build_type__ == 'local' else "not "))
 
 
-@_api.deprecated("3.5", alternative='pytest')
-def test(verbosity=None, coverage=False, **kwargs):
-    """Run the matplotlib test suite."""
-
-    try:
-        import pytest
-    except ImportError:
-        print("matplotlib.test requires pytest to run.")
-        return -1
-
-    if not os.path.isdir(os.path.join(os.path.dirname(__file__), 'tests')):
-        print("Matplotlib test data is not installed")
-        return -1
-
-    old_backend = get_backend()
-    try:
-        use('agg')
-
-        args = kwargs.pop('argv', [])
-        provide_default_modules = True
-        use_pyargs = True
-        for arg in args:
-            if any(arg.startswith(module_path)
-                   for module_path in default_test_modules):
-                provide_default_modules = False
-                break
-            if os.path.exists(arg):
-                provide_default_modules = False
-                use_pyargs = False
-                break
-        if use_pyargs:
-            args += ['--pyargs']
-        if provide_default_modules:
-            args += default_test_modules
-
-        if coverage:
-            args += ['--cov']
-
-        if verbosity:
-            args += ['-' + 'v' * verbosity]
-
-        retcode = pytest.main(args, **kwargs)
-    finally:
-        if old_backend.lower() != 'agg':
-            use(old_backend)
-
-    return retcode
-
-
-test.__test__ = False  # pytest: this function is not a test
-
-
 def _replacer(data, value):
     """
     Either returns ``data[value]`` or passes ``data`` back, converts either to

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5792,18 +5792,6 @@ default: :rc:`scatter.edgecolors`
         C = cbook.safe_masked_invalid(C)
         return X, Y, C, shading
 
-    def _pcolor_grid_deprecation_helper(self):
-        grid_active = any(axis._major_tick_kw["gridOn"]
-                          for axis in self._axis_map.values())
-        # explicit is-True check because get_axisbelow() can also be 'line'
-        grid_hidden_by_pcolor = self.get_axisbelow() is True
-        if grid_active and not grid_hidden_by_pcolor:
-            _api.warn_deprecated(
-                "3.5", message="Auto-removal of grids by pcolor() and "
-                "pcolormesh() is deprecated since %(since)s and will be "
-                "removed %(removal)s; please call grid(False) first.")
-        self.grid(False)
-
     @_preprocess_data()
     @_docstring.dedent_interpd
     def pcolor(self, *args, shading=None, alpha=None, norm=None, cmap=None,
@@ -6008,7 +5996,6 @@ default: :rc:`scatter.edgecolors`
         collection = mcoll.PolyCollection(
             verts, array=C, cmap=cmap, norm=norm, alpha=alpha, **kwargs)
         collection._scale_norm(norm, vmin, vmax)
-        self._pcolor_grid_deprecation_helper()
 
         x = X.compressed()
         y = Y.compressed()
@@ -6242,7 +6229,6 @@ default: :rc:`scatter.edgecolors`
             coords, antialiased=antialiased, shading=shading,
             array=C, cmap=cmap, norm=norm, alpha=alpha, **kwargs)
         collection._scale_norm(norm, vmin, vmax)
-        self._pcolor_grid_deprecation_helper()
 
         coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1407,12 +1407,9 @@ class _AxesBase(martist.Artist):
         """
         A sublist of Axes children based on their type.
 
-        The type-specific children sublists will become immutable in
-        Matplotlib 3.7. Then, these artist lists will likely be replaced by
-        tuples. Use as if this is a tuple already.
-
-        This class exists only for the transition period to warn on the
-        deprecated modification of artist lists.
+        The type-specific children sublists were made immutable in Matplotlib
+        3.7.  In the future these artist lists may be replaced by tuples. Use
+        as if this is a tuple already.
         """
         def __init__(self, axes, prop_name,
                      valid_types=None, invalid_types=None):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, MutableSequence
+from collections.abc import Iterable, Sequence
 from contextlib import ExitStack
 import functools
 import inspect
@@ -1403,7 +1403,7 @@ class _AxesBase(martist.Artist):
         else:
             self.clear()
 
-    class ArtistList(MutableSequence):
+    class ArtistList(Sequence):
         """
         A sublist of Axes children based on their type.
 
@@ -1414,7 +1414,7 @@ class _AxesBase(martist.Artist):
         This class exists only for the transition period to warn on the
         deprecated modification of artist lists.
         """
-        def __init__(self, axes, prop_name, add_name,
+        def __init__(self, axes, prop_name,
                      valid_types=None, invalid_types=None):
             """
             Parameters
@@ -1425,9 +1425,6 @@ class _AxesBase(martist.Artist):
             prop_name : str
                 The property name used to access this sublist from the Axes;
                 used to generate deprecation warnings.
-            add_name : str
-                The method name used to add Artists of this sublist's type to
-                the Axes; used to generate deprecation warnings.
             valid_types : list of type, optional
                 A list of types that determine which children will be returned
                 by this sublist. If specified, then the Artists in the sublist
@@ -1442,7 +1439,6 @@ class _AxesBase(martist.Artist):
             """
             self._axes = axes
             self._prop_name = prop_name
-            self._add_name = add_name
             self._type_check = lambda artist: (
                 (not valid_types or isinstance(artist, valid_types)) and
                 (not invalid_types or not isinstance(artist, invalid_types))
@@ -1468,103 +1464,47 @@ class _AxesBase(martist.Artist):
         def __add__(self, other):
             if isinstance(other, (list, _AxesBase.ArtistList)):
                 return [*self, *other]
+            if isinstance(other, (tuple, _AxesBase.ArtistList)):
+                return (*self, *other)
             return NotImplemented
 
         def __radd__(self, other):
             if isinstance(other, list):
                 return other + list(self)
+            if isinstance(other, tuple):
+                return other + tuple(self)
             return NotImplemented
-
-        def insert(self, index, item):
-            _api.warn_deprecated(
-                '3.5',
-                name=f'modification of the Axes.{self._prop_name}',
-                obj_type='property',
-                alternative=f'Axes.{self._add_name}')
-            try:
-                index = self._axes._children.index(self[index])
-            except IndexError:
-                index = None
-            getattr(self._axes, self._add_name)(item)
-            if index is not None:
-                # Move new item to the specified index, if there's something to
-                # put it before.
-                self._axes._children[index:index] = self._axes._children[-1:]
-                del self._axes._children[-1]
-
-        def __setitem__(self, key, item):
-            _api.warn_deprecated(
-                '3.5',
-                name=f'modification of the Axes.{self._prop_name}',
-                obj_type='property',
-                alternative=f'Artist.remove() and Axes.f{self._add_name}')
-            del self[key]
-            if isinstance(key, slice):
-                key = key.start
-            if not np.iterable(item):
-                self.insert(key, item)
-                return
-
-            try:
-                index = self._axes._children.index(self[key])
-            except IndexError:
-                index = None
-            for i, artist in enumerate(item):
-                getattr(self._axes, self._add_name)(artist)
-            if index is not None:
-                # Move new items to the specified index, if there's something
-                # to put it before.
-                i = -(i + 1)
-                self._axes._children[index:index] = self._axes._children[i:]
-                del self._axes._children[i:]
-
-        def __delitem__(self, key):
-            _api.warn_deprecated(
-                '3.5',
-                name=f'modification of the Axes.{self._prop_name}',
-                obj_type='property',
-                alternative='Artist.remove()')
-            if isinstance(key, slice):
-                for artist in self[key]:
-                    artist.remove()
-            else:
-                self[key].remove()
 
     @property
     def artists(self):
-        return self.ArtistList(self, 'artists', 'add_artist', invalid_types=(
+        return self.ArtistList(self, 'artists', invalid_types=(
             mcoll.Collection, mimage.AxesImage, mlines.Line2D, mpatches.Patch,
             mtable.Table, mtext.Text))
 
     @property
     def collections(self):
-        return self.ArtistList(self, 'collections', 'add_collection',
+        return self.ArtistList(self, 'collections',
                                valid_types=mcoll.Collection)
 
     @property
     def images(self):
-        return self.ArtistList(self, 'images', 'add_image',
-                               valid_types=mimage.AxesImage)
+        return self.ArtistList(self, 'images', valid_types=mimage.AxesImage)
 
     @property
     def lines(self):
-        return self.ArtistList(self, 'lines', 'add_line',
-                               valid_types=mlines.Line2D)
+        return self.ArtistList(self, 'lines', valid_types=mlines.Line2D)
 
     @property
     def patches(self):
-        return self.ArtistList(self, 'patches', 'add_patch',
-                               valid_types=mpatches.Patch)
+        return self.ArtistList(self, 'patches', valid_types=mpatches.Patch)
 
     @property
     def tables(self):
-        return self.ArtistList(self, 'tables', 'add_table',
-                               valid_types=mtable.Table)
+        return self.ArtistList(self, 'tables', valid_types=mtable.Table)
 
     @property
     def texts(self):
-        return self.ArtistList(self, 'texts', 'add_artist',
-                               valid_types=mtext.Text)
+        return self.ArtistList(self, 'texts', valid_types=mtext.Text)
 
     def get_facecolor(self):
         """Get the facecolor of the Axes."""

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1969,7 +1969,7 @@ class FigureCanvasBase:
 
     @_api.deprecated("3.6", alternative=(
         "callbacks.process('enter_notify_event', LocationEvent(...))"))
-    def enter_notify_event(self, guiEvent=None, xy=None):
+    def enter_notify_event(self, guiEvent=None, *, xy):
         """
         Callback processing for the mouse cursor entering the canvas.
 
@@ -1983,18 +1983,7 @@ class FigureCanvasBase:
         xy : (float, float)
             The coordinate location of the pointer when the canvas is entered.
         """
-        if xy is not None:
-            x, y = xy
-            self._lastx, self._lasty = x, y
-        else:
-            x = None
-            y = None
-            _api.warn_deprecated(
-                '3.0', removal='3.5', name='enter_notify_event',
-                message='Since %(since)s, %(name)s expects a location but '
-                'your backend did not pass one. This will become an error '
-                '%(removal)s.')
-
+        self._lastx, self._lasty = x, y = xy
         event = LocationEvent('figure_enter_event', self, x, y, guiEvent)
         self.callbacks.process('figure_enter_event', event)
 

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -58,12 +58,6 @@ class StrCategoryConverter(units.ConversionInterface):
             is_numlike = all(units.ConversionInterface.is_numlike(v)
                              and not isinstance(v, (str, bytes))
                              for v in values)
-        if values.size and is_numlike:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing numbers through unit "
-                "converters is deprecated since %(since)s and support will be "
-                "removed %(removal)s; use Axis.convert_units instead.")
-            return np.asarray(values, dtype=float)
         # force an update so it also does type checking
         unit.update(values)
         return np.vectorize(unit._mapping.__getitem__, otypes=[float])(values)

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -53,11 +53,6 @@ class StrCategoryConverter(units.ConversionInterface):
         StrCategoryConverter._validate_unit(unit)
         # dtype = object preserves numerical pass throughs
         values = np.atleast_1d(np.array(value, dtype=object))
-        # pass through sequence of non binary numbers
-        with _api.suppress_matplotlib_deprecation_warning():
-            is_numlike = all(units.ConversionInterface.is_numlike(v)
-                             and not isinstance(v, (str, bytes))
-                             for v in values)
         # force an update so it also does type checking
         unit.update(values)
         return np.vectorize(unit._mapping.__getitem__, otypes=[float])(values)

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -27,7 +27,6 @@ derived from the base class (HandlerBase) with the following method::
     def legend_artist(self, legend, orig_handle, fontsize, handlebox)
 """
 
-from collections.abc import Sequence
 from itertools import cycle
 
 import numpy as np
@@ -131,9 +130,6 @@ class HandlerBase:
         artists = self.create_artists(legend, orig_handle,
                                       xdescent, ydescent, width, height,
                                       fontsize, handlebox.get_transform())
-
-        if isinstance(artists, _Line2DHandleList):
-            artists = [artists[0]]
 
         # create_artists will return a list of artists.
         for a in artists:
@@ -277,24 +273,6 @@ class HandlerLine2DCompound(HandlerNpoints):
         return [legline, legline_marker]
 
 
-class _Line2DHandleList(Sequence):
-    def __init__(self, legline):
-        self._legline = legline
-
-    def __len__(self):
-        return 2
-
-    def __getitem__(self, index):
-        if index != 0:
-            # Make HandlerLine2D return [self._legline] directly after
-            # deprecation elapses.
-            _api.warn_deprecated(
-                "3.5", message="Access to the second element returned by "
-                "HandlerLine2D is deprecated since %(since)s; it will be "
-                "removed %(removal)s.")
-        return [self._legline, self._legline][index]
-
-
 class HandlerLine2D(HandlerNpoints):
     """
     Handler for `.Line2D` instances.
@@ -331,7 +309,7 @@ class HandlerLine2D(HandlerNpoints):
 
         legline.set_transform(trans)
 
-        return _Line2DHandleList(legline)
+        return [legline]
 
 
 class HandlerPatch(HandlerBase):
@@ -790,8 +768,6 @@ class HandlerTuple(HandlerBase):
             _a_list = handler.create_artists(
                 legend, handle1,
                 next(xds_cycle), ydescent, width, height, fontsize, trans)
-            if isinstance(_a_list, _Line2DHandleList):
-                _a_list = [_a_list[0]]
             a_list.extend(_a_list)
 
         return a_list

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1070,17 +1070,6 @@ def axes(arg=None, **kwargs):
 
         %(Axes:kwdoc)s
 
-    Notes
-    -----
-    If the figure already has an Axes with key (*args*,
-    *kwargs*) then it will simply make that axes current and
-    return it.  This behavior is deprecated. Meanwhile, if you do
-    not want this behavior (i.e., you want to force the creation of a
-    new axes), you must use a unique set of args and kwargs.  The Axes
-    *label* attribute has been exposed for this purpose: if you want
-    two Axes that are otherwise identical to be added to the figure,
-    make sure you give them unique labels.
-
     See Also
     --------
     .Figure.add_axes

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -182,10 +182,7 @@ def _make_type_validator(cls, *, allow_none=False):
                 (s is None or isinstance(s, str) and s.lower() == "none")):
             return None
         if cls is str and not isinstance(s, str):
-            _api.warn_deprecated(
-                "3.5", message="Support for setting an rcParam that expects a "
-                "str value to a non-str value is deprecated since %(since)s "
-                "and support will be removed %(removal)s.")
+            raise ValueError(f'Could not convert {s!r} to str')
         try:
             return cls(s)
         except (TypeError, ValueError) as e:
@@ -218,7 +215,7 @@ def _validate_pathlike(s):
         # between "" (cwd) and "." (cwd, but gets updated by user selections).
         return os.fsdecode(s)
     else:
-        return validate_string(s)  # Emit deprecation warning.
+        return validate_string(s)
 
 
 def validate_fonttype(s):

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -710,11 +710,6 @@ def scale_factory(scale, axis, **kwargs):
     scale : {%(names)s}
     axis : `matplotlib.axis.Axis`
     """
-    if scale != scale.lower():
-        _api.warn_deprecated(
-            "3.5", message="Support for case-insensitive scales is deprecated "
-            "since %(since)s and support will be removed %(removal)s.")
-        scale = scale.lower()
     scale_cls = _api.check_getitem(_scale_mapping, scale=scale)
     return scale_cls(axis, **kwargs)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8115,19 +8115,13 @@ def test_artist_sublists():
     with pytest.raises(IndexError, match='out of range'):
         ax.lines[len(lines) + 1]
 
-    # Deleting items (multiple or single) should warn.
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        del ax.lines[-1]
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        del ax.lines[-1:]
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        del ax.lines[1:]
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        del ax.lines[0]
+    # Adding to other lists should produce a regular list.
+    assert ax.lines + [1, 2, 3] == [*lines, 1, 2, 3]
+    assert [1, 2, 3] + ax.lines == [1, 2, 3, *lines]
+
+    # Adding to other tuples should produce a regular tuples.
+    assert ax.lines + (1, 2, 3) == (*lines, 1, 2, 3)
+    assert (1, 2, 3) + ax.lines == (1, 2, 3, *lines)
 
     # Lists should be empty after removing items.
     col.remove()
@@ -8136,58 +8130,9 @@ def test_artist_sublists():
     assert not ax.images
     patch.remove()
     assert not ax.patches
+    assert not ax.tables
     text.remove()
     assert not ax.texts
-
-    # Everything else should remain empty.
-    assert not ax.lines
-    assert not ax.tables
-
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.texts property'):
-        ax.texts.append(text)
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.collections property'):
-        ax.collections.append(col)
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.images property'):
-        ax.images.append(im)
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.patches property'):
-        ax.patches.append(patch)
-    # verify things are back
-    assert list(ax.collections) == [col]
-    assert list(ax.images) == [im]
-    assert list(ax.patches) == [patch]
-    assert list(ax.texts) == [text]
-
-    # Adding items should warn.
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        ax.lines.append(lines[-2])
-    assert list(ax.lines) == [lines[-2]]
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        ax.lines.append(lines[-1])
-    assert list(ax.lines) == lines[-2:]
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        ax.lines.insert(-2, lines[0])
-    assert list(ax.lines) == [lines[0], lines[-2], lines[-1]]
-
-    # Modifying items should warn.
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        ax.lines[0] = lines[0]
-    assert list(ax.lines) == [lines[0], lines[-2], lines[-1]]
-    with pytest.warns(MatplotlibDeprecationWarning,
-                      match='modification of the Axes.lines property'):
-        ax.lines[1:1] = lines[1:-2]
-    assert list(ax.lines) == lines
-
-    # Adding to other lists should produce a regular list.
-    assert ax.lines + [1, 2, 3] == [*lines, 1, 2, 3]
-    assert [1, 2, 3] + ax.lines == [1, 2, 3, *lines]
 
     for ln in ax.lines:
         ln.remove()

--- a/lib/matplotlib/tests/test_category.py
+++ b/lib/matplotlib/tests/test_category.py
@@ -3,7 +3,6 @@ import pytest
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 import matplotlib.category as cat
@@ -100,17 +99,6 @@ class TestStrCategoryConverter:
     @pytest.mark.parametrize("value", ["hi", "мир"], ids=["ascii", "unicode"])
     def test_convert_one_string(self, value):
         assert self.cc.convert(value, self.unit, self.ax) == 0
-
-    def test_convert_one_number(self):
-        with pytest.warns(MatplotlibDeprecationWarning):
-            actual = self.cc.convert(0.0, self.unit, self.ax)
-        np.testing.assert_allclose(actual, np.array([0.]))
-
-    def test_convert_float_array(self):
-        data = np.array([1, 2, 3], dtype=float)
-        with pytest.warns(MatplotlibDeprecationWarning):
-            actual = self.cc.convert(data, self.unit, self.ax)
-        np.testing.assert_allclose(actual, np.array([1., 2., 3.]))
 
     @pytest.mark.parametrize("fvals", fvalues, ids=fids)
     def test_convert_fail(self, fvals):

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -230,8 +230,6 @@ def generate_validator_testcases(valid):
                      ),
          'fail': ((set(), ValueError),
                   (1, ValueError),
-                  ((1, 2), _api.MatplotlibDeprecationWarning),
-                  (np.array([1, 2]), _api.MatplotlibDeprecationWarning),
                   )
          },
         {'validator': _listify_validator(validate_int, n=2),

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -46,7 +46,7 @@ from numbers import Number
 import numpy as np
 from numpy import ma
 
-from matplotlib import _api, cbook
+from matplotlib import cbook
 
 
 class ConversionError(TypeError):
@@ -130,23 +130,6 @@ class ConversionInterface:
         be a sequence of scalars that can be used by the numpy array layer.
         """
         return obj
-
-    @staticmethod
-    @_api.deprecated("3.5")
-    def is_numlike(x):
-        """
-        The Matplotlib datalim, autoscaling, locators etc work with scalars
-        which are the units converted to floats given the current unit.  The
-        converter may be passed these floats, or arrays of them, even when
-        units are set.
-        """
-        if np.iterable(x):
-            for thisx in x:
-                if thisx is ma.masked:
-                    continue
-                return isinstance(thisx, Number)
-        else:
-            return isinstance(x, Number)
 
 
 class DecimalConverter(ConversionInterface):

--- a/lib/mpl_toolkits/axes_grid1/axes_divider.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_divider.py
@@ -202,17 +202,9 @@ class Divider:
             x0, y0 = x, y
 
         if nx1 is None:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing nx1=None to mean nx+1 is "
-                "deprecated since %(since)s; in a future version, nx1=None "
-                "will mean 'up to the last cell'.")
-            nx1 = nx + 1
+            nx1 = -1
         if ny1 is None:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing ny1=None to mean ny+1 is "
-                "deprecated since %(since)s; in a future version, ny1=None "
-                "will mean 'up to the last cell'.")
-            ny1 = ny + 1
+            ny1 = -1
 
         x1, w1 = x0 + ox[nx] / fig_w, (ox[nx1] - ox[nx]) / fig_w
         y1, h1 = y0 + oy[ny] / fig_h, (oy[ny1] - oy[ny]) / fig_h
@@ -299,17 +291,9 @@ class AxesLocator:
         self._nx, self._ny = nx - _xrefindex, ny - _yrefindex
 
         if nx1 is None:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing nx1=None to mean nx+1 is "
-                "deprecated since %(since)s; in a future version, nx1=None "
-                "will mean 'up to the last cell'.")
-            nx1 = nx + 1
+            nx1 = len(self._axes_divider)
         if ny1 is None:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing ny1=None to mean ny+1 is "
-                "deprecated since %(since)s; in a future version, ny1=None "
-                "will mean 'up to the last cell'.")
-            ny1 = ny + 1
+            ny1 = len(self._axes_divider[0])
 
         self._nx1 = nx1 - _xrefindex
         self._ny1 = ny1 - _yrefindex
@@ -600,11 +584,7 @@ class HBoxDivider(SubplotDivider):
         x0, y0, ox, hh = _locate(
             x, y, w, h, summed_ws, equal_hs, fig_w, fig_h, self.get_anchor())
         if nx1 is None:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing nx1=None to mean nx+1 is "
-                "deprecated since %(since)s; in a future version, nx1=None "
-                "will mean 'up to the last cell'.")
-            nx1 = nx + 1
+            nx1 = -1
         x1, w1 = x0 + ox[nx] / fig_w, (ox[nx1] - ox[nx]) / fig_w
         y1, h1 = y0, hh
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)
@@ -639,11 +619,7 @@ class VBoxDivider(SubplotDivider):
         y0, x0, oy, ww = _locate(
             y, x, h, w, summed_hs, equal_ws, fig_h, fig_w, self.get_anchor())
         if ny1 is None:
-            _api.warn_deprecated(
-                "3.5", message="Support for passing ny1=None to mean ny+1 is "
-                "deprecated since %(since)s; in a future version, ny1=None "
-                "will mean 'up to the last cell'.")
-            ny1 = ny + 1
+            ny1 = -1
         x1, w1 = x0, ww
         y1, h1 = y0 + oy[ny] / fig_h, (oy[ny1] - oy[ny]) / fig_h
         return mtransforms.Bbox.from_bounds(x1, y1, w1, h1)

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -20,7 +20,6 @@ def _tick_only(ax, bottom_on, left_on):
 class CbarAxesBase:
     def __init__(self, *args, orientation, **kwargs):
         self.orientation = orientation
-        self._locator = None  # deprecated.
         super().__init__(*args, **kwargs)
 
     def colorbar(self, mappable, *, ticks=None, **kwargs):


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`