### PR TITLE
Minor cleanup and optimization of Sketch

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -1018,6 +1018,9 @@ class Sketch
           m_rand(0)
     {
         rewind(0);
+        const double d_M_PI = 3.14159265358979323846;
+        m_p_scale = (2.0 * d_M_PI) / (m_length * m_randomness);
+        m_log_randomness = 2.0 * log(m_randomness);
     }
 
     unsigned vertex(double *x, double *y)
@@ -1037,9 +1040,20 @@ class Sketch
             // We want the "cursor" along the sine wave to move at a
             // random rate.
             double d_rand = m_rand.get_double();
-            double d_M_PI = 3.14159265358979323846;
-            m_p += pow(m_randomness, d_rand * 2.0 - 1.0);
-            double r = sin(m_p / (m_length / (d_M_PI * 2.0))) * m_scale;
+            // Original computation
+            // p += pow(k, 2*rand - 1)
+            // r = sin(p * c)
+            // x86 computes pow(a, b) as exp(b*log(a))
+            // First, move -1 out, so
+            // p' += pow(k, 2*rand)
+            // r = sin(p * c') where c' = c / k
+            // Next, use x86 logic (will not be worse on other platforms as
+            // the log is only computed once and pow and exp are, at worst,
+            // the same)
+            // So p+= exp(2*rand*log(k))
+            // lk = 2*log(k)
+            // p += exp(rand*lk)
+            m_p += exp(d_rand * m_log_randomness);
             double den = m_last_x - *x;
             double num = m_last_y - *y;
             double len = num * num + den * den;
@@ -1047,8 +1061,10 @@ class Sketch
             m_last_y = *y;
             if (len != 0) {
                 len = sqrt(len);
-                *x += r * num / len;
-                *y += r * -den / len;
+                double r = sin(m_p * m_p_scale) * m_scale;
+                double roverlen = r / len;
+                *x += roverlen * num;
+                *y -= roverlen * den;
             }
         } else {
             m_last_x = *x;
@@ -1083,6 +1099,8 @@ class Sketch
     bool m_has_last;
     double m_p;
     RandomNumberGenerator m_rand;
+    double m_p_scale;
+    double m_log_randomness;
 };
 
 #endif // MPL_PATH_CONVERTERS_H


### PR DESCRIPTION
## PR Summary

Getting rid of a few redundant/not required computations. Have not checked the assembly code to confirm that the compiler doesn't already optimize it away though.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
