### PR TITLE
Remove additional deprecations from 3.5

### DIFF
--- a/doc/api/next_api_changes/removals/24948-ES.rst
+++ b/doc/api/next_api_changes/removals/24948-ES.rst
@@ -44,6 +44,17 @@ information; modification of the following sublists is no longer supported:
 To remove an Artist, use its `.Artist.remove` method. To add an Artist, use the
 corresponding ``Axes.add_*`` method.
 
+Passing incorrect types to ``Axes.add_*`` methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following ``Axes.add_*`` methods will now raise if passed an unexpected
+type. See their documentation for the types they expect.
+
+- `.Axes.add_collection`
+- `.Axes.add_image`
+- `.Axes.add_line`
+- `.Axes.add_patch`
+- `.Axes.add_table`
 
 
 ``ConversionInterface.convert`` no longer accepts unitless values

--- a/doc/api/next_api_changes/removals/24965-ES.rst
+++ b/doc/api/next_api_changes/removals/24965-ES.rst
@@ -1,0 +1,5 @@
+``Colorbar`` tick update parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The *update_ticks* parameter of `.Colorbar.set_ticks` and
+`.Colorbar.set_ticklabels` was ignored since 3.5 and has been removed.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2203,20 +2203,6 @@ class _AxesBase(martist.Artist):
                                   mlines.Line2D, mpatches.Patch))
                    for a in self._children)
 
-    def _deprecate_noninstance(self, _name, _types, **kwargs):
-        """
-        For each *key, value* pair in *kwargs*, check that *value* is an
-        instance of one of *_types*; if not, raise an appropriate deprecation.
-        """
-        for key, value in kwargs.items():
-            if not isinstance(value, _types):
-                _api.warn_deprecated(
-                    '3.5', name=_name,
-                    message=f'Passing argument *{key}* of unexpected type '
-                    f'{type(value).__qualname__} to %(name)s which only '
-                    f'accepts {_types} is deprecated since %(since)s and will '
-                    'become an error %(removal)s.')
-
     def add_artist(self, a):
         """
         Add an `.Artist` to the Axes; return the artist.
@@ -2260,8 +2246,7 @@ class _AxesBase(martist.Artist):
         """
         Add a `.Collection` to the Axes; return the collection.
         """
-        self._deprecate_noninstance('add_collection', mcoll.Collection,
-                                    collection=collection)
+        _api.check_isinstance(mcoll.Collection, collection=collection)
         label = collection.get_label()
         if not label:
             collection.set_label(f'_child{len(self._children)}')
@@ -2294,7 +2279,7 @@ class _AxesBase(martist.Artist):
         """
         Add an `.AxesImage` to the Axes; return the image.
         """
-        self._deprecate_noninstance('add_image', mimage.AxesImage, image=image)
+        _api.check_isinstance(mimage.AxesImage, image=image)
         self._set_artist_props(image)
         if not image.get_label():
             image.set_label(f'_child{len(self._children)}')
@@ -2311,7 +2296,7 @@ class _AxesBase(martist.Artist):
         """
         Add a `.Line2D` to the Axes; return the line.
         """
-        self._deprecate_noninstance('add_line', mlines.Line2D, line=line)
+        _api.check_isinstance(mlines.Line2D, line=line)
         self._set_artist_props(line)
         if line.get_clip_path() is None:
             line.set_clip_path(self.patch)
@@ -2328,7 +2313,7 @@ class _AxesBase(martist.Artist):
         """
         Add a `.Text` to the Axes; return the text.
         """
-        self._deprecate_noninstance('_add_text', mtext.Text, txt=txt)
+        _api.check_isinstance(mtext.Text, txt=txt)
         self._set_artist_props(txt)
         self._children.append(txt)
         txt._remove_method = self._children.remove
@@ -2387,7 +2372,7 @@ class _AxesBase(martist.Artist):
         """
         Add a `.Patch` to the Axes; return the patch.
         """
-        self._deprecate_noninstance('add_patch', mpatches.Patch, p=p)
+        _api.check_isinstance(mpatches.Patch, p=p)
         self._set_artist_props(p)
         if p.get_clip_path() is None:
             p.set_clip_path(self.patch)
@@ -2440,7 +2425,7 @@ class _AxesBase(martist.Artist):
         """
         Add a `.Table` to the Axes; return the table.
         """
-        self._deprecate_noninstance('add_table', mtable.Table, tab=tab)
+        _api.check_isinstance(mtable.Table, tab=tab)
         self._set_artist_props(tab)
         self._children.append(tab)
         tab.set_clip_path(self.patch)

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -390,11 +390,8 @@ class NavigationToolbar2WebAgg(backend_bases.NavigationToolbar2):
         if name_of_method in _ALLOWED_TOOL_ITEMS
     ]
 
-    cursor = _api.deprecate_privatize_attribute("3.5")
-
     def __init__(self, canvas):
         self.message = ''
-        self._cursor = None  # Remove with deprecation.
         super().__init__(canvas)
 
     def set_message(self, message):

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -875,9 +875,7 @@ class Colorbar:
         self._minorlocator = minorlocator
         _log.debug('locator: %r', locator)
 
-    @_api.delete_parameter("3.5", "update_ticks")
-    def set_ticks(self, ticks, update_ticks=True, labels=None, *,
-                  minor=False, **kwargs):
+    def set_ticks(self, ticks, *, labels=None, minor=False, **kwargs):
         """
         Set tick locations.
 
@@ -916,9 +914,7 @@ class Colorbar:
         else:
             return self._long_axis().get_majorticklocs()
 
-    @_api.delete_parameter("3.5", "update_ticks")
-    def set_ticklabels(self, ticklabels, update_ticks=True, *, minor=False,
-                       **kwargs):
+    def set_ticklabels(self, ticklabels, *, minor=False, **kwargs):
         """
         [*Discouraged*] Set tick labels.
 

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -999,11 +999,13 @@ def test_check_radio_buttons_image():
     rax1 = plt.axes([0.05, 0.7, 0.15, 0.15])
     rax2 = plt.axes([0.05, 0.2, 0.15, 0.15])
     rb = widgets.RadioButtons(rax1, ('Radio 1', 'Radio 2', 'Radio 3'))
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning,
+                      match='The circles attribute was deprecated'):
         rb.circles  # Trigger the old-style elliptic radiobuttons.
     cb = widgets.CheckButtons(rax2, ('Check 1', 'Check 2', 'Check 3'),
                               (False, True, True))
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning,
+                      match='The rectangles attribute was deprecated'):
         cb.rectangles  # Trigger old-style Rectangle check boxes
 
 
@@ -1034,7 +1036,8 @@ def test_check_buttons_rectangles(fig_test, fig_ref):
     # Test should be removed once .rectangles is removed
     cb = widgets.CheckButtons(fig_test.subplots(), ["", ""],
                               [False, False])
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning,
+                      match='The rectangles attribute was deprecated'):
         cb.rectangles
     ax = fig_ref.add_subplot(xticks=[], yticks=[])
     ys = [2/3, 1/3]
@@ -1056,7 +1059,8 @@ def test_check_buttons_rectangles(fig_test, fig_ref):
 def test_check_buttons_lines(fig_test, fig_ref):
     # Test should be removed once .lines is removed
     cb = widgets.CheckButtons(fig_test.subplots(), ["", ""], [True, True])
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning,
+                      match='The lines attribute was deprecated'):
         cb.lines
     for rectangle in cb._rectangles:
         rectangle.set_visible(False)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1192,8 +1192,8 @@ class CheckButtons(AxesWidget):
                 l1.set_visible(current_status[i])
                 l2.set_visible(current_status[i])
                 self._lines.append((l1, l2))
-                self.ax.add_patch(l1)
-                self.ax.add_patch(l2)
+                self.ax.add_line(l1)
+                self.ax.add_line(l2)
         if not hasattr(self, "_rectangles"):
             with _api.suppress_matplotlib_deprecation_warning():
                 _ = self.rectangles


### PR DESCRIPTION
## PR Summary

Note that there are additional changes in widgets because we missed deprecations due to a pytest peculiarity pytest-dev/pytest#9288

Also, the `cursor` removal was already documented in #24129.

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`