### PR TITLE
FIX: adjust_bbox should not modify layout engine

### DIFF
--- a/lib/matplotlib/_tight_bbox.py
+++ b/lib/matplotlib/_tight_bbox.py
@@ -17,8 +17,6 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
     """
     origBbox = fig.bbox
     origBboxInches = fig.bbox_inches
-    orig_layout = fig.get_layout_engine()
-    fig.set_layout_engine(None)
     _boxout = fig.transFigure._boxout
 
     old_aspect = []
@@ -46,7 +44,6 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
 
         fig.bbox = origBbox
         fig.bbox_inches = origBboxInches
-        fig.set_layout_engine(orig_layout)
         fig.transFigure._boxout = _boxout
         fig.transFigure.invalidate()
         fig.patch.set_bounds(0, 0, 1, 1)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -532,6 +532,13 @@ def test_savefig_pixel_ratio(backend):
     assert ratio1 == ratio2
 
 
+def test_savefig_preserve_layout_engine(tmp_path):
+    fig = plt.figure(layout='compressed')
+    fig.savefig(tmp_path / 'foo.png', bbox_inches='tight')
+
+    assert fig.get_layout_engine()._compress
+
+
 def test_figure_repr():
     fig = plt.figure(figsize=(10, 20), dpi=10)
     assert repr(fig) == "<Figure size 100x200 with 0 Axes>"


### PR DESCRIPTION
## PR Summary
Fixes #24954 (I think!)  I don't claim to fully understand everything that's going on here, but it seems to me that these lines are doing the same job as

https://github.com/matplotlib/matplotlib/blob/018c5efbbec68f27cfea66ca2620702dd976d1b9/lib/matplotlib/backend_bases.py#L2356-L2357

Since `restore_bbox` gets called within the above context manager, the final result is the layout engine continues to be what was set with `fig.set_layout_engine(None)`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
