### PR TITLE
Add more locations for doc build deprecation warnings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -176,10 +176,12 @@ commands:
              echo "No deprecation warnings in plot_types")
             (grep -rl DeprecationWarning doc/build/html/tutorials ||
              echo "No deprecation warnings in tutorials")
+            (grep -rl DeprecationWarning doc/build/html/users ||
+             echo "No deprecation warnings in users")
             # Save deprecations that are from this absolute directory, and
             # convert to repository-relative paths.
             (grep -Ero --no-filename "$PWD/.+DeprecationWarning.+$" \
-             doc/build/html/{gallery,plot_types,tutorials} || echo) | \
+             doc/build/html/{gallery,plot_types,tutorials,users} || echo) | \
               sed "s~$PWD/~~" > doc/logs/sphinx-deprecations.log
           when: always
       - store_artifacts:


### PR DESCRIPTION
## PR Summary

There are some examples in these locations as well that may break at a later stage. Not sure if looking into the api changes is really a good idea though... Let's see.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
