### PR TITLE
Suppress pyparsing warning

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -13,7 +13,7 @@ from functools import lru_cache, partial
 import re
 
 from pyparsing import (
-    Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore)
+    Group, Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore)
 
 from matplotlib import _api
 
@@ -64,7 +64,7 @@ def _make_fontconfig_parser():
     name = Regex(r"[a-z]+")
     value = Regex(r"([^%s]|(\\[%s]))*" % (_value_punc, _value_punc))
     # replace trailing `| name` by oneOf(_CONSTANTS) in mpl 3.9.
-    prop = (name + Suppress("=") + comma_separated(value)) | name
+    prop = Group((name + Suppress("=") + comma_separated(value)) | name)
     return (
         Optional(comma_separated(family)("families"))
         + Optional("-" + comma_separated(size)("sizes"))


### PR DESCRIPTION
Co-authored-by: Antony Lee <anntzer.lee@gmail.com>

## PR Summary

Closes #24972

I do not think that it is possible to test in any other way than running with `-W all`.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
