### PR TITLE
Fix issue with shared log axis

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -259,6 +259,19 @@ class TestLogLocator:
                                1.e+09, 2.e+09, 5.e+09])
         assert_almost_equal(ll.tick_values(1, 1e8), test_value)
 
+    def test_multiple_shared_axes(self):
+        rng = np.random.default_rng(19680801)
+        dummy_data = [rng.normal(size=100), [], []]
+        fig, axes = plt.subplots(len(dummy_data), sharex=True, sharey=True)
+
+        for ax, data in zip(axes.flatten(), dummy_data):
+            ax.hist(data, bins=10)
+            ax.set_yscale('log', nonpositive='clip')
+
+        for ax in axes.flatten():
+            assert all(ax.get_yticks() == axes[0].get_yticks())
+            assert ax.get_ylim() == axes[0].get_ylim()
+
 
 class TestNullLocator:
     def test_set_params(self):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2404,7 +2404,8 @@ class LogLocator(Locator):
                 "log-scaled.")
             vmin, vmax = 1, 10
         else:
-            minpos = self.axis.get_minpos()
+            # Consider shared axises
+            minpos = min(axis.get_minpos() for axis in self.axis._get_shared_axis())
             if not np.isfinite(minpos):
                 minpos = 1e-300  # This should never take effect.
             if vmin <= 0:


### PR DESCRIPTION
Co-authored-by: Antony Lee <anntzer.lee@gmail.com>

## PR Summary

Closes #14527

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
