### PR TITLE
Capitalize headings in example Gallery

### DIFF
--- a/examples/axes_grid1/README.txt
+++ b/examples/axes_grid1/README.txt
@@ -2,5 +2,5 @@
 
 .. _axes_grid1-examples-index:
 
-axes_grid1
-==========
+Axes Grid
+=========

--- a/examples/axes_grid1/README.txt
+++ b/examples/axes_grid1/README.txt
@@ -2,5 +2,5 @@
 
 .. _axes_grid1-examples-index:
 
-Axes grid
-=========
+The axes_grid1 module
+=====================

--- a/examples/axes_grid1/README.txt
+++ b/examples/axes_grid1/README.txt
@@ -2,5 +2,5 @@
 
 .. _axes_grid1-examples-index:
 
-Axes Grid
+Axes grid
 =========

--- a/examples/axisartist/README.txt
+++ b/examples/axisartist/README.txt
@@ -2,5 +2,5 @@
 
 .. _axisartist-examples-index:
 
-Axis Artist
+Axis artist
 ===========

--- a/examples/axisartist/README.txt
+++ b/examples/axisartist/README.txt
@@ -2,5 +2,5 @@
 
 .. _axisartist-examples-index:
 
-Axis artist
-===========
+The axisartist module
+=====================

--- a/examples/axisartist/README.txt
+++ b/examples/axisartist/README.txt
@@ -2,5 +2,5 @@
 
 .. _axisartist-examples-index:
 
-axisartist
-==========
+Axis Artist
+===========

--- a/examples/pyplots/README.txt
+++ b/examples/pyplots/README.txt
@@ -1,4 +1,4 @@
 .. _pyplots_examples:
 
-pyplot
+Pyplot
 ======

--- a/examples/pyplots/README.txt
+++ b/examples/pyplots/README.txt
@@ -1,4 +1,4 @@
 .. _pyplots_examples:
 
-Pyplot
-======
+The pyplot module
+=================

--- a/examples/specialty_plots/README.txt
+++ b/examples/specialty_plots/README.txt
@@ -1,4 +1,4 @@
 .. _specialty_plots_examples:
 
-Specialty Plots
+Specialty plots
 ===============


### PR DESCRIPTION
The headings in the example section are mostly upper case, but also a few lowercase headings::
<img width="305" alt="image" src="https://user-images.githubusercontent.com/44469195/213144557-acb230bb-c680-48d9-94a9-39a4705ebf9f.png">

This pr capitalizes all headings.