### PR TITLE
_check_color_like function for list inputs

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -241,7 +241,15 @@ def _check_color_like(**kwargs):
     for k, v in kwargs.items():
         if not is_color_like(v):
             raise ValueError(f"{v!r} is not a valid value for {k}")
-
+            
+def check_color_like_list(**kwargs):
+    """ 
+    For each *key, lst* pair in *kwargs*, check that every element *v* in *lst* is color-like. 
+    """ 
+    for k, lst in kwargs.items():
+        invalid_colors = list(filter(lambda v: not is_color_like(v), lst))
+        if invalid_colors:
+            raise ValueError(f"{invalid_colors} are not valid value(s) for {k}")
 
 def same_color(c1, c2):
     """


### PR DESCRIPTION
**PR Summary**
This PR addresses issue (#25005) by creating a function that validates color inputs in a list format ex. check_color_like_list(colors=['red', 'green', 'yellow']).

This function uses the is_color_like(v) function to determine if each color in each list is a valid color input. Currently, it can take multiple lists of colors as inputs, I am not sure if this is necessary or not.

**PR Checklist**
- [ ] Documentation and Tests
 
- [ ] Has pytest style unit tests (and pytest passes)

- [ ]  Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
