### PR TITLE
seperate out folders in gallery ordering

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -6,33 +6,52 @@ Paths are relative to the conf.py file.
 from sphinx_gallery.sorting import ExplicitOrder
 
 # Gallery sections shall be displayed in the following order.
-# Non-matching sections are inserted at UNSORTED
-explicit_order_folders = [
-                          '../examples/lines_bars_and_markers',
-                          '../examples/images_contours_and_fields',
-                          '../examples/subplots_axes_and_figures',
-                          '../examples/statistics',
-                          '../examples/pie_and_polar_charts',
-                          '../examples/text_labels_and_annotations',
-                          '../examples/pyplots',
-                          '../examples/color',
-                          '../examples/shapes_and_collections',
-                          '../examples/style_sheets',
-                          '../examples/axes_grid1',
-                          '../examples/axisartist',
-                          '../examples/showcase',
-                          '../tutorials/introductory',
-                          '../tutorials/intermediate',
-                          '../tutorials/advanced',
-                          '../plot_types/basic',
-                          '../plot_types/arrays',
-                          '../plot_types/stats',
-                          '../plot_types/unstructured',
-                          '../plot_types/3D',
-                          'UNSORTED',
-                          '../examples/userdemo',
-                          '../tutorials/provisional',
-                          ]
+# Non-matching sections are inserted at the unsorted position
+
+UNSORTED = "unsorted"
+
+examples_order = [
+    '../examples/lines_bars_and_markers',
+    '../examples/images_contours_and_fields',
+    '../examples/subplots_axes_and_figures',
+    '../examples/statistics',
+    '../examples/pie_and_polar_charts',
+    '../examples/text_labels_and_annotations',
+    '../examples/pyplots',
+    '../examples/color',
+    '../examples/shapes_and_collections',
+    '../examples/style_sheets',
+    '../examples/axes_grid1',
+    '../examples/axisartist',
+    '../examples/showcase',
+    UNSORTED,
+    '../examples/userdemo',
+]
+
+tutorials_order = [
+    '../tutorials/introductory',
+    '../tutorials/intermediate',
+    '../tutorials/advanced',
+    UNSORTED,
+    '../tutorials/provisional'
+]
+
+plot_types_order = [
+    '../plot_types/basic',
+    '../plot_types/arrays',
+    '../plot_types/stats',
+    '../plot_types/unstructured',
+    '../plot_types/3D',
+    UNSORTED
+]
+
+folder_lists = [examples_order, tutorials_order, plot_types_order]
+
+explicit_order_folders = [fd for folders in folder_lists
+                          for fd in folders[:folders.index(UNSORTED)]]
+explicit_order_folders.append(UNSORTED)
+explicit_order_folders.extend([fd for folders in folder_lists
+                               for fd in folders[folders.index(UNSORTED):]])
 
 
 class MplExplicitOrder(ExplicitOrder):
@@ -42,7 +61,7 @@ class MplExplicitOrder(ExplicitOrder):
         if item in self.ordered_list:
             return f"{self.ordered_list.index(item):04d}"
         else:
-            return f"{self.ordered_list.index('UNSORTED'):04d}{item}"
+            return f"{self.ordered_list.index(UNSORTED):04d}{item}"
 
 # Subsection order:
 # Subsections are ordered by filename, unless they appear in the following


### PR DESCRIPTION
Separates each gallery ordering into its own list to make it a little cleaner to find/order each gallery. Should maybe be a conf file but this was a quick proof of concept inspired by ordering being a pain in https://github.com/matplotlib/matplotlib/issues/24746#issuecomment-1396425509

ETA: I like @QuLogic's idea https://github.com/matplotlib/matplotlib/issues/24746#issuecomment-1396482343 of putting the ordering in each readme better but don't really have the time to implement that...I think it would basically be populate these lists w/ the contents of those readmes