### PR TITLE
DOC: fix layout pad

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -76,7 +76,7 @@ def do_constrained_layout(fig, h_pad, w_pad,
         Renderer to use.
 
     h_pad, w_pad : float
-      Padding around the axes elements in figure-normalized units.
+      Padding around the axes elements in inches.
 
     hspace, wspace : float
        Fraction of the figure to dedicate to space between the

--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -203,7 +203,7 @@ class ConstrainedLayoutEngine(LayoutEngine):
         Parameters
         ----------
         h_pad, w_pad : float
-            Padding around the axes elements in figure-normalized units.
+            Padding around the axes elements in inches.
             Default to :rc:`figure.constrained_layout.h_pad` and
             :rc:`figure.constrained_layout.w_pad`.
         hspace, wspace : float


### PR DESCRIPTION
## PR Summary

The layout pads in the constrained layout docs were incorrectly stated as being in figure-normalized units, whereas they are actually in inches.  This was correct in most places, except where it mattered the most.  

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
