### PR TITLE
ci: Only attempt to upload nightlies from successful builds

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -1,3 +1,4 @@
+---
 name: Upload nightly wheels to Anaconda Cloud
 
 on:
@@ -14,13 +15,10 @@ jobs:
   upload_nightly_wheels:
     name: Upload nightly wheels to Anaconda Cloud
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
     if: github.repository_owner == 'matplotlib'
 
     steps:
-      # c.f. https://github.com/actions/download-artifact/issues/3#issuecomment-1017141067
+      # https://github.com/actions/download-artifact/issues/3#issuecomment-1017141067
       - name: Download wheel artifacts from last build on 'main'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -33,16 +31,20 @@ jobs:
           gh run --repo "${PROJECT_REPO}" \
              list --branch "${BRANCH}" \
                   --workflow "${WORKFLOW_NAME}" \
-                  --json event,status,databaseId > runs.json
-          # Filter on 'push' events to main (merged PRs) that have completed
-          jq --compact-output \
-            '[ .[] | select(.event == "push") | select(.status == "completed") ]' \
-            runs.json > pushes.json
-          # Get id of latest build of wheels
+                  --json event,status,conclusion,databaseId > runs.json
           RUN_ID=$(
             jq --compact-output \
-              'sort_by(.databaseId) | reverse | .[0].databaseId' pushes.json
+              '[
+                .[] |
+                # Filter on "push" events to main (merged PRs) ...
+                select(.event == "push") |
+                # that have completed successfully ...
+                select(.status == "completed" and .conclusion == "success")
+               ] |
+              # and get ID of latest build of wheels.
+              sort_by(.databaseId) | reverse | .[0].databaseId' runs.json
           )
+          gh run --repo "${PROJECT_REPO}" view "${RUN_ID}"
           gh run --repo "${PROJECT_REPO}" \
              download "${RUN_ID}" --name "${ARTIFACT_NAME}"
 
@@ -71,17 +73,16 @@ jobs:
           N_LATEST_UPLOADS=5
 
           # Remove all _but_ the last "${N_LATEST_UPLOADS}" package versions
-          # N.B.: `anaconda show` places the newest packages at the bottom of the output
-          # of the 'Versions' section and package versions are preceded with a '   + '.
+          # N.B.: `anaconda show` places the newest packages at the bottom of
+          # the output of the 'Versions' section and package versions are
+          # preceded with a '   + '.
           anaconda show scipy-wheels-nightly/matplotlib &> >(grep '+') | \
               sed 's/.* + //' | \
               head --lines "-${N_LATEST_UPLOADS}" > remove-package-versions.txt
 
-          if [ -s remove-package-versions.txt ]; then
-              while LANG=C IFS= read -r package_version ; do
-                  echo "# Removing scipy-wheels-nightly/matplotlib/${package_version}"
-                  anaconda --token ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }} remove \
-                    --force \
-                    "scipy-wheels-nightly/matplotlib/${package_version}"
-              done <remove-package-versions.txt
-          fi
+          while LANG=C IFS= read -r package_version ; do
+              echo "Removing scipy-wheels-nightly/matplotlib/${package_version}"
+              anaconda --token ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }} remove \
+                --force \
+                "scipy-wheels-nightly/matplotlib/${package_version}"
+          done <remove-package-versions.txt


### PR DESCRIPTION
## PR Summary

The [last job](https://github.com/matplotlib/matplotlib/actions/runs/3964030919) failed because it was looking at a build that completed, but had failed.

Also, print out status of the chosen build, and clean up yamllint warnings.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`