### PR TITLE
Updated WebAgg JS to check and send request over wss if using HTTPS

### DIFF
--- a/lib/matplotlib/backends/web_backend/all_figures.html
+++ b/lib/matplotlib/backends/web_backend/all_figures.html
@@ -24,7 +24,9 @@
           figure_div.id = "figure-div";
           main_div.appendChild(figure_div);
           var websocket_type = mpl.get_websocket_type();
-          var websocket = new websocket_type("{{ ws_uri }}" + fig_id + "/ws");
+          var uri = "{{ ws_uri }}" + fig_id + "/ws";
+          if (window.location.protocol === "https:") uri = uri.replace('ws:', 'wss:')
+          var websocket = new websocket_type(uri);
           var fig = new mpl.figure(fig_id, websocket, mpl_ondownload, figure_div);
 
           fig.focus_on_mouseover = true;

--- a/lib/matplotlib/backends/web_backend/single_figure.html
+++ b/lib/matplotlib/backends/web_backend/single_figure.html
@@ -19,8 +19,9 @@
       ready(
         function () {
           var websocket_type = mpl.get_websocket_type();
-          var websocket = new websocket_type(
-              "{{ ws_uri }}" + {{ str(fig_id) }} + "/ws");
+          var uri = "{{ ws_uri }}" + {{ str(fig_id) }} + "/ws";
+          if (window.location.protocol === 'https:') uri = uri.replace('ws:', 'wss:')
+          var websocket = new websocket_type(uri);
           var fig = new mpl.figure(
               {{ str(fig_id) }}, websocket, mpl_ondownload,
               document.getElementById("figure"));


### PR DESCRIPTION
## PR Summary

Added a small change to the JavaScript for the WebAgg backend. The added JavaScript code will check the protocol and updated the websocket uri to `wss:` if `https:` is being used.

This is to fix an issue with matplotlib running behind a reverse proxy that adds HTTPS and secure HTTP headers like HSTS. The connection to the insecure websocket i.e. `ws:` is blocked by the browser with the message:

```
Mixed Content: The page at 'https:/<some_website>/' was loaded over HTTPS,  but attempted to connect to the insecure 
WebSocket endpoint 'ws://<some_website>/1/ws'. This request has been blocked; this endpoint must be available over WSS.
``` 

## PR Checklist

**Documentation and Tests**
- [ ] ~~Has pytest style unit tests (and `pytest` passes)~~ N/A
- [ ] ~~Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).~~ N/A
- [ ] ~~New plotting related features are documented with examples.~~ N/A

**Release Notes**
- [ ] ~~New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`~~ N/A
- [ ] ~~API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`~~ N/A
- [ ] ~~Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`~~ N/A

Not sure whether or not I need to update any documentation, so please let me know if I do.

Thank you
