### PR TITLE
Modify `hexbin` to respect :rc:`patch.linewidth`

### DIFF
--- a/doc/api/next_api_changes/behavior/25044-YI.rst
+++ b/doc/api/next_api_changes/behavior/25044-YI.rst
@@ -1,0 +1,6 @@
+``hexbin`` now defaults to ``rcParams["patch.linewidth"]``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The default value of the *linewidths* argument of `.Axes.hexbin` has
+been changed from ``1.0`` to :rc:`patch.linewidth`. This improves the
+consistency with `.QuadMesh` in `.Axes.pcolormesh` and `.Axes.hist2d`.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4824,7 +4824,7 @@ default: :rc:`scatter.edgecolors`
             The alpha blending value, between 0 (transparent) and 1 (opaque).
 
         linewidths : float, default: *None*
-            If *None*, defaults to 1.0.
+            If *None*, defaults to :rc:`patch.linewidth`.
 
         edgecolors : {'face', 'none', *None*} or color, default: 'face'
             The color of the hexagon edges. Possible values are:
@@ -4970,7 +4970,7 @@ default: :rc:`scatter.edgecolors`
             [[.5, -.5], [.5, .5], [0., 1.], [-.5, .5], [-.5, -.5], [0., -1.]])
 
         if linewidths is None:
-            linewidths = [1.0]
+            linewidths = [mpl.rcParams['patch.linewidth']]
 
         if xscale == 'log' or yscale == 'log':
             polygons = np.expand_dims(polygon, 0) + np.expand_dims(offsets, 1)


### PR DESCRIPTION
Always thank you developpers for maintaining Matplotlib!

## PR Summary

Currently in `hexbin`, `linewidths` given to `PolyCollection` is hard-coded as `1.0`. In `pcolormesh` and `hist2d`, the default value respects :rc:`patch.linewidth` (default: `1.0`). To improve the consistency among the methods, in this very short PR I would like to suggest respecting `patch.linewidth` also in `hexbin`.

## Notes

While this PR does not change the default behavior, do we need to have some additional tests?

The default `linewidth` in `pcolormesh` and `hist2d` may be not immediately visually noticeable because the default `edgecolors` value is `none`.  (In `hexbin`, `edgecolors` defaults to `face`.)

The default linewidths in `pcolor` and `tripcolor` are also hard-coded but as `0.25`. It may be also possible to respect :rc:`patch.linewidth` also in these methods, while the plot looking changes when `edgecolors` other than `none` is given.

In principle, it should be also possible to simply remove the `linewidths` keyword from the arguments and pass it into `PolyCollection` simply via `**kwargs`, but then we need to pop `linewidths` before making marginal plots and need to modify the docstring a bit also for this.

I can also later add note in `doc/api/next_api_changes` if this is reasonable.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
