### PR TITLE
ci: Re-add the login shell to nightlies jobs

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -15,6 +15,12 @@ jobs:
   upload_nightly_wheels:
     name: Upload nightly wheels to Anaconda Cloud
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        # The login shell is necessary for the provision-with-micromamba setup
+        # to work in subsequent jobs.
+        # https://github.com/mamba-org/provision-with-micromamba#important
+        shell: bash -e -l {0}
     if: github.repository_owner == 'matplotlib'
 
     steps:


### PR DESCRIPTION
## PR Summary

This is needed because of the way the micromamba provisioning works, or else anything installed in the mamba environment is not found.

I also added a comment explaining it so that it won't be accidentally removed in the future (or will if that requirement is dropped.)

Now that I know you can trigger `workflow_dispatch` runs from _any_ branch, I checked this before opening this PR: https://github.com/matplotlib/matplotlib/actions/runs/3972489758

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`