### PR TITLE
Include child Axes inaxes calculation

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2007,6 +2007,12 @@ class FigureCanvasBase:
                      if a.patch.contains_point(xy) and a.get_visible()]
         if axes_list:
             axes = cbook._topmost_artist(axes_list)
+            prev_axes = None
+            while prev_axes != axes:
+                prev_axes = axes
+                axes_list = [a for a in axes.child_axes
+                             if a.patch.contains_point(xy) and a.get_visible()]
+                axes = cbook._topmost_artist([axes, *axes_list])
         else:
             axes = None
 


### PR DESCRIPTION
## PR Summary

This makes `InsetAxes` count for this field, and allows widgets to work in them.

Now, one question is that `inaxes` now is the innermost Axes only. That means `axes_leave_event` is triggered for a parent `Axes` when entering the child. Is that the behaviour that's desired? If we instead want this to only trigger when _completely_ outside the parent `Axes`, we'd have to do something like make `inaxes` a list (or a private-but-related field if we don't want to change API.)

Fixes #25030

## PR Checklist

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`