### PR TITLE
fix for pcolormesh doesn't allow shading = 'flat' in the option

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5748,9 +5748,10 @@ default: :rc:`scatter.edgecolors`
 
         if shading == 'flat':
             if (Nx, Ny) != (ncols + 1, nrows + 1):
-                raise TypeError(f"Dimensions of X({Nx}) and y({Ny}) should"
-                                f" be one larger than C {C.shape} while using"
-                                f" shading='flat' see help({funcname})")
+                raise TypeError(f"Dimensions of C {C.shape} should"
+                                f" be one smaller than X({Nx}) and Y({Ny})"
+                                f" while using shading='flat'"
+                                f" see help({funcname})")
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):
                 raise TypeError('Dimensions of C %s are incompatible with'

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5748,9 +5748,9 @@ default: :rc:`scatter.edgecolors`
 
         if shading == 'flat':
             if (Nx, Ny) != (ncols + 1, nrows + 1):
-                raise TypeError('Dimensions of C %s are incompatible with'
-                                ' X (%d) and/or Y (%d); X and y should be one larger than  C see help(%s)' % (
-                                    C.shape, Nx, Ny, funcname))
+                raise TypeError(f"Dimensions of X({Nx}) and y({Ny}) should"
+                                f"be one larger than C{C.shape}"
+                                f"see help({funcname})")
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):
                 raise TypeError('Dimensions of C %s are incompatible with'

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5749,8 +5749,8 @@ default: :rc:`scatter.edgecolors`
         if shading == 'flat':
             if (Nx, Ny) != (ncols + 1, nrows + 1):
                 raise TypeError(f"Dimensions of X({Nx}) and y({Ny}) should"
-                                f"be one larger than C{C.shape}"
-                                f"see help({funcname})")
+                                f" be one larger than C {C.shape} while using"
+                                f" shading='flat' see help({funcname})")
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):
                 raise TypeError('Dimensions of C %s are incompatible with'

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5749,7 +5749,7 @@ default: :rc:`scatter.edgecolors`
         if shading == 'flat':
             if (Nx, Ny) != (ncols + 1, nrows + 1):
                 raise TypeError('Dimensions of C %s are incompatible with'
-                                ' X (%d) and/or Y (%d); see help(%s)' % (
+                                ' X (%d) and/or Y (%d); X and y should be one larger than  C see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1443,7 +1443,7 @@ def test_samesizepcolorflaterror():
     fig, ax = plt.subplots()
     x, y = np.meshgrid(np.arange(5), np.arange(3))
     Z = x + y
-    with pytest.raises(TypeError, match=r".*one larger than C"):
+    with pytest.raises(TypeError, match=r".*one smaller than X"):
         ax.pcolormesh(x, y, Z, shading='flat')
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1438,6 +1438,13 @@ def test_pcolorflaterror():
     with pytest.raises(TypeError, match='Dimensions of C'):
         ax.pcolormesh(x, y, Z, shading='flat')
 
+def test_samesizepcolorflaterror():
+    fig, ax = plt.subplots()
+    x, y = np.meshgrid(np.arange(5), np.arange(3))
+    Z = x + y
+    with pytest.raises(TypeError, match=r".*X and y should be one larger than  C"):
+        ax.pcolormesh(x, y, Z, shading='flat')
+
 
 @pytest.mark.parametrize('snap', [False, True])
 @check_figures_equal(extensions=["png"])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1438,11 +1438,12 @@ def test_pcolorflaterror():
     with pytest.raises(TypeError, match='Dimensions of C'):
         ax.pcolormesh(x, y, Z, shading='flat')
 
+
 def test_samesizepcolorflaterror():
     fig, ax = plt.subplots()
     x, y = np.meshgrid(np.arange(5), np.arange(3))
     Z = x + y
-    with pytest.raises(TypeError, match=r".*X and y should be one larger than  C"):
+    with pytest.raises(TypeError, match=r".*one larger than C"):
         ax.pcolormesh(x, y, Z, shading='flat')
 
 


### PR DESCRIPTION
Fix for pcolormesh doesn't allow shading = 'flat' in the option #24678

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
