### PR TITLE
Bug #21337: Fixing axis positional logic

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2168,9 +2168,21 @@ class Axis(martist.Artist):
                and not tick.label2.get_visible()
                for tick in [major, minor]):
             return 1
+        elif all(tick.tick1line.get_visible()
+                 and not tick.tick2line.get_visible()
+                 and tick.label1.get_visible()
+                 and not tick.label2.get_visible()
+                 for tick in [major, minor]):
+            return 1
         elif all(tick.tick2line.get_visible()
                  and not tick.tick1line.get_visible()
                  and tick.label2.get_visible()
+                 and not tick.label1.get_visible()
+                 for tick in [major, minor]):
+            return 2
+        elif all(tick.tick2line.get_visible()
+                 and tick.tick1line.get_visible()
+                 and not tick.label2.get_visible()
                  and not tick.label1.get_visible()
                  for tick in [major, minor]):
             return 2
@@ -2694,7 +2706,7 @@ class YAxis(Axis):
         self.set_ticks_position('right')
         # if labels were turned off before this was called
         # leave them off
-        self.set_tick_params(which='both', labelright=label)
+        self.set_tick_params(which='right', labelright=label)
 
     def tick_left(self):
         """
@@ -2707,7 +2719,7 @@ class YAxis(Axis):
         self.set_ticks_position('left')
         # if labels were turned off before this was called
         # leave them off
-        self.set_tick_params(which='both', labelleft=label)
+        self.set_tick_params(which='left', labelleft=label)
 
     def get_ticks_position(self):
         """

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -952,6 +952,22 @@ class Axis(martist.Artist):
                     or self._major_tick_kw.get('label2On', False))
             if 'labelcolor' in kwtrans:
                 self.offsetText.set_color(kwtrans['labelcolor'])
+            if 'top' in kwtrans:
+                self.offsetText.set_visible(
+                    self._major_tick_kw.get('label1On', True)
+                    or self._major_tick_kw.get('label2On', False))
+            if 'bottom' in kwtrans:
+                self.offsetText.set_visible(
+                    self._major_tick_kw.get('label1On', False)
+                    or self._major_tick_kw.get('label2On', True))
+            if 'right' in kwtrans:
+                self.offsetText.set_visible(
+                    self._major_tick_kw.get('label1On', True)
+                    or self._major_tick_kw.get('label2On', False))
+            if 'left' in kwtrans:
+                self.offsetText.set_visible(
+                    self._major_tick_kw.get('label1On', False)
+                    or self._major_tick_kw.get('label2On', True))
 
         self.stale = True
 
@@ -2168,7 +2184,6 @@ class Axis(martist.Artist):
                and not tick.label2.get_visible()
                for tick in [major, minor]):
             return 1
-        
         elif all(tick.tick2line.get_visible()
                  and not tick.tick1line.get_visible()
                  and tick.label2.get_visible()
@@ -2177,18 +2192,6 @@ class Axis(martist.Artist):
             return 2
         elif all(tick.tick1line.get_visible()
                  and tick.tick2line.get_visible()
-                 and tick.label1.get_visible()
-                 and not tick.label2.get_visible()
-                 for tick in [major, minor]):
-            return "default"
-        elif all(tick.tick2line.get_visible()
-                 and tick.tick1line.get_visible()
-                 and not tick.label2.get_visible()
-                 and not tick.label1.get_visible()
-                 for tick in [major, minor]):
-            return "default"
-        elif all(tick.tick1line.get_visible()
-                 and not tick.tick2line.get_visible()
                  and tick.label1.get_visible()
                  and not tick.label2.get_visible()
                  for tick in [major, minor]):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2168,26 +2168,27 @@ class Axis(martist.Artist):
                and not tick.label2.get_visible()
                for tick in [major, minor]):
             return 1
-        elif all(tick.tick1line.get_visible()
-                 and not tick.tick2line.get_visible()
-                 and tick.label1.get_visible()
-                 and not tick.label2.get_visible()
-                 for tick in [major, minor]):
-            return 1
+        
         elif all(tick.tick2line.get_visible()
                  and not tick.tick1line.get_visible()
                  and tick.label2.get_visible()
                  and not tick.label1.get_visible()
                  for tick in [major, minor]):
             return 2
+        elif all(tick.tick1line.get_visible()
+                 and tick.tick2line.get_visible()
+                 and tick.label1.get_visible()
+                 and not tick.label2.get_visible()
+                 for tick in [major, minor]):
+            return "default"
         elif all(tick.tick2line.get_visible()
                  and tick.tick1line.get_visible()
                  and not tick.label2.get_visible()
                  and not tick.label1.get_visible()
                  for tick in [major, minor]):
-            return 2
+            return "default"
         elif all(tick.tick1line.get_visible()
-                 and tick.tick2line.get_visible()
+                 and not tick.tick2line.get_visible()
                  and tick.label1.get_visible()
                  and not tick.label2.get_visible()
                  for tick in [major, minor]):
@@ -2706,7 +2707,7 @@ class YAxis(Axis):
         self.set_ticks_position('right')
         # if labels were turned off before this was called
         # leave them off
-        self.set_tick_params(which='right', labelright=label)
+        self.set_tick_params(which='both', labelright=label)
 
     def tick_left(self):
         """
@@ -2719,7 +2720,7 @@ class YAxis(Axis):
         self.set_ticks_position('left')
         # if labels were turned off before this was called
         # leave them off
-        self.set_tick_params(which='left', labelleft=label)
+        self.set_tick_params(which='both', labelleft=label)
 
     def get_ticks_position(self):
         """


### PR DESCRIPTION
## PR Summary

Changed axis get tick positions. A bug caused "unknown" positions after moving ticks to the top right or the top left

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ N/A] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
