### PR TITLE
Ensure TwoSlopeNorm always has two slopes

### DIFF
--- a/doc/api/next_api_changes/behavior/25061-DS.rst
+++ b/doc/api/next_api_changes/behavior/25061-DS.rst
@@ -1,0 +1,12 @@
+TwoSlopeNorm now auto-expands to always have two slopes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In the case where either ``vmin`` or ``vmax`` are not manually specified
+to `~.TwoSlopeNorm`, and where the data it is scaling is all less than or
+greater than the center point, the limits are now auto-expanded so there
+are two symmetrically sized slopes either side of the center point.
+
+Previously ``vmin`` and ``vmax`` were clipped at the center point, which
+caused issues when displaying color bars.
+
+This does not affect behaviour when ``vmin`` and ``vmax`` are manually
+specified by the user.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1432,13 +1432,17 @@ class TwoSlopeNorm(Normalize):
 
     def autoscale_None(self, A):
         """
-        Get vmin and vmax, and then clip at vcenter
+        Get vmin and vmax.
+
+        If vcenter isn't in the range [vmin, vmax], either vmin or vmax
+        is expanded so that vcenter lies in the middle of the modified range
+        [vmin, vmax].
         """
         super().autoscale_None(A)
-        if self.vmin > self.vcenter:
-            self.vmin = self.vcenter
-        if self.vmax < self.vcenter:
-            self.vmax = self.vcenter
+        if self.vmin >= self.vcenter:
+            self.vmin = self.vcenter - (self.vmax - self.vcenter)
+        if self.vmax <= self.vcenter:
+            self.vmax = self.vcenter + (self.vcenter - self.vmin)
 
     def __call__(self, value, clip=None):
         """

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -666,7 +666,7 @@ def test_TwoSlopeNorm_scaleout_center():
     # test the vmin never goes above vcenter
     norm = mcolors.TwoSlopeNorm(vcenter=0)
     norm([1, 2, 3, 5])
-    assert norm.vmin == 0
+    assert norm.vmin == -5
     assert norm.vmax == 5
 
 
@@ -674,7 +674,7 @@ def test_TwoSlopeNorm_scaleout_center_max():
     # test the vmax never goes below vcenter
     norm = mcolors.TwoSlopeNorm(vcenter=0)
     norm([-1, -2, -3, -5])
-    assert norm.vmax == 0
+    assert norm.vmax == 5
     assert norm.vmin == -5
 
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -665,7 +665,7 @@ def test_TwoSlopeNorm_scale():
 def test_TwoSlopeNorm_scaleout_center():
     # test the vmin never goes above vcenter
     norm = mcolors.TwoSlopeNorm(vcenter=0)
-    norm([1, 2, 3, 5])
+    norm([0, 1, 2, 3, 5])
     assert norm.vmin == -5
     assert norm.vmax == 5
 
@@ -673,7 +673,7 @@ def test_TwoSlopeNorm_scaleout_center():
 def test_TwoSlopeNorm_scaleout_center_max():
     # test the vmax never goes below vcenter
     norm = mcolors.TwoSlopeNorm(vcenter=0)
-    norm([-1, -2, -3, -5])
+    norm([0, -1, -2, -3, -5])
     assert norm.vmax == 5
     assert norm.vmin == -5
 


### PR DESCRIPTION
## PR Summary
Fixes https://github.com/matplotlib/matplotlib/issues/24283.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
