### PR TITLE
Revert "Use system distutils instead of the setuptools copy"

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -130,8 +130,7 @@ stages:
         displayName: 'Install dependencies with pip'
 
       - bash: |
-          # Due to https://github.com/pypa/setuptools/pull/2896
-          SETUPTOOLS_USE_DISTUTILS=stdlib python -m pip install -ve . ||
+          python -m pip install -ve . ||
             [[ "$PYTHON_VERSION" = 'Pre' ]]
         displayName: "Install self"
 


### PR DESCRIPTION
cibuildwheel is on setuptools 66 and we don't set the env there, so try reverting matplotlib/matplotlib#22756.