### PR TITLE
added a note to avoid f-strings in logging

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -457,7 +457,7 @@ Then they will receive messages like
 
 Avoid using pre-computed strings (``f-strings``, ``str.format``,etc.) for logging because of security and 
 performance issues, and because they interfere with style handlers. 
-e.g. `_log.error('hello %s', 'world')` versus  `_log.error('hello {}'.format('world'))`.
+e.g. ``_log.error('hello %s', 'world')`` versus  ``_log.error('hello {}'.format('world'))``.
 
 
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -455,28 +455,9 @@ Then they will receive messages like
    DEBUG:matplotlib.yourmodulename:Here is some information
    DEBUG:matplotlib.yourmodulename:Here is some more detailed information
 
-**NOTE:** Please avoid using pre-computed stirngs(``f-strings``, ``str.format``,etc.) for logging.
-There are security & performance
-issues, and it interferes with style handlers. 
-See `here <https://github.com/matplotlib/matplotlib/pull/25073#issuecomment-1403711269>`_
-for more details.
-
-**Correct**
-
-.. code-block:: python
-
-   _log.error('hello %s', 'world')
-
-**Incorrect**
-
-.. code-block:: python
-
-   _log.error('hello {}'.format('world'))
-
-.. code-block:: python
-
-   s = 'world'
-   _log.error(f'hello {s}')
+Avoid using pre-computed strings (``f-strings``, ``str.format``,etc.) for logging because of security and 
+performance issues, and because they interfere with style handlers. 
+e.g. `_log.error('hello %s', 'world')` versus  `_log.error('hello {}'.format('world'))`.
 
 
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -456,8 +456,8 @@ Then they will receive messages like
    DEBUG:matplotlib.yourmodulename:Here is some more detailed information
 
 Avoid using pre-computed strings (``f-strings``, ``str.format``,etc.) for logging because of security and 
-performance issues, and because they interfere with style handlers. 
-e.g. ``_log.error('hello %s', 'world')`` versus  ``_log.error('hello {}'.format('world'))``.
+performance issues, and because they interfere with style handlers. For example, use ``_log.error('hello %s', 'world')``  rather than   
+``_log.error('hello {}'.format('world'))`` or ``_log.error(f'hello {s}')``.
 
 
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -455,8 +455,8 @@ Then they will receive messages like
    DEBUG:matplotlib.yourmodulename:Here is some information
    DEBUG:matplotlib.yourmodulename:Here is some more detailed information
 
-Avoid using pre-computed strings (``f-strings``, ``str.format``,etc.) for logging because of security and 
-performance issues, and because they interfere with style handlers. For example, use ``_log.error('hello %s', 'world')``  rather than   
+Avoid using pre-computed strings (``f-strings``, ``str.format``,etc.) for logging because of security and
+performance issues, and because they interfere with style handlers. For example, use ``_log.error('hello %s', 'world')``  rather than
 ``_log.error('hello {}'.format('world'))`` or ``_log.error(f'hello {s}')``.
 
 

--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -455,6 +455,31 @@ Then they will receive messages like
    DEBUG:matplotlib.yourmodulename:Here is some information
    DEBUG:matplotlib.yourmodulename:Here is some more detailed information
 
+**NOTE:** Please avoid using pre-computed stirngs(``f-strings``, ``str.format``,etc.) for logging.
+There are security & performance
+issues, and it interferes with style handlers. 
+See `here <https://github.com/matplotlib/matplotlib/pull/25073#issuecomment-1403711269>`_
+for more details.
+
+**Correct**
+
+.. code-block:: python
+
+   _log.error('hello %s', 'world')
+
+**Incorrect**
+
+.. code-block:: python
+
+   _log.error('hello {}'.format('world'))
+
+.. code-block:: python
+
+   s = 'world'
+   _log.error(f'hello {s}')
+
+
+
 Which logging level to use?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## PR Summary
As per #25080, a note has been added to the `contributing.rst`

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
