### PR TITLE
FIX: only try to update blit caches if the canvas we expect

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1,4 +1,5 @@
 import functools
+import io
 from unittest import mock
 
 from matplotlib._api.deprecation import MatplotlibDeprecationWarning
@@ -21,6 +22,45 @@ import pytest
 @pytest.fixture
 def ax():
     return get_ax()
+
+
+def test_save_blitted_widget_as_pdf():
+    from matplotlib.widgets import CheckButtons, RadioButtons
+    from matplotlib.cbook import _get_running_interactive_framework
+    if _get_running_interactive_framework() not in ['headless', None]:
+        pytest.xfail("Callback exceptions are not raised otherwise.")
+
+    fig, ax = plt.subplots(
+        nrows=2, ncols=2, figsize=(5, 2), width_ratios=[1, 2]
+    )
+    default_rb = RadioButtons(ax[0, 0], ['Apples', 'Oranges'])
+    styled_rb = RadioButtons(
+        ax[0, 1], ['Apples', 'Oranges'],
+        label_props={'color': ['red', 'orange'],
+                     'fontsize': [16, 20]},
+        radio_props={'edgecolor': ['red', 'orange'],
+                     'facecolor': ['mistyrose', 'peachpuff']}
+    )
+
+    default_cb = CheckButtons(ax[1, 0], ['Apples', 'Oranges'],
+                              actives=[True, True])
+    styled_cb = CheckButtons(
+        ax[1, 1], ['Apples', 'Oranges'],
+        actives=[True, True],
+        label_props={'color': ['red', 'orange'],
+                     'fontsize': [16, 20]},
+        frame_props={'edgecolor': ['red', 'orange'],
+                     'facecolor': ['mistyrose', 'peachpuff']},
+        check_props={'color': ['darkred', 'darkorange']}
+    )
+
+    ax[0, 0].set_title('Default')
+    ax[0, 1].set_title('Stylized')
+    # force an Agg render
+    fig.canvas.draw()
+    # force a pdf save
+    with io.BytesIO() as result_after:
+        fig.savefig(result_after, format='pdf')
 
 
 @pytest.mark.parametrize('kwargs', [

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1088,7 +1088,7 @@ class CheckButtons(AxesWidget):
 
     def _clear(self, event):
         """Internal event handler to clear the buttons."""
-        if self.ignore(event):
+        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
             return
         self._background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self._checks)
@@ -1700,7 +1700,7 @@ class RadioButtons(AxesWidget):
 
     def _clear(self, event):
         """Internal event handler to clear the buttons."""
-        if self.ignore(event):
+        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
             return
         self._background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self._buttons)
@@ -1971,7 +1971,7 @@ class Cursor(AxesWidget):
 
     def clear(self, event):
         """Internal event handler to clear the cursor."""
-        if self.ignore(event):
+        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
             return
         if self.useblit:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
@@ -2106,7 +2106,7 @@ class MultiCursor(Widget):
 
     def clear(self, event):
         """Clear the cursor."""
-        if self.ignore(event):
+        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
             return
         if self.useblit:
             for canvas, info in self._canvas_infos.items():

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -90,6 +90,22 @@ class Widget:
         """
         return not self.active
 
+    def _changed_canvas(self):
+        """
+        Someone has switched the canvas on us!
+
+        This happens if `savefig` needs to save to a format the previous
+        backend did not support (e.g. saving a figure using an Agg based
+        backend saved to a vector format).
+
+        Returns
+        -------
+        bool
+           True if the canvas has been changed.
+
+        """
+        return self.canvas is not self.ax.figure.canvas
+
 
 class AxesWidget(Widget):
     """
@@ -1088,7 +1104,7 @@ class CheckButtons(AxesWidget):
 
     def _clear(self, event):
         """Internal event handler to clear the buttons."""
-        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
+        if self.ignore(event) or self._changed_canvas():
             return
         self._background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self._checks)
@@ -1700,7 +1716,7 @@ class RadioButtons(AxesWidget):
 
     def _clear(self, event):
         """Internal event handler to clear the buttons."""
-        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
+        if self.ignore(event) or self._changed_canvas():
             return
         self._background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self._buttons)
@@ -1971,7 +1987,7 @@ class Cursor(AxesWidget):
 
     def clear(self, event):
         """Internal event handler to clear the cursor."""
-        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
+        if self.ignore(event) or self._changed_canvas():
             return
         if self.useblit:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2106,10 +2106,16 @@ class MultiCursor(Widget):
 
     def clear(self, event):
         """Clear the cursor."""
-        if self.ignore(event) or self.canvas is not self.ax.figure.canvas:
+        if self.ignore(event):
             return
         if self.useblit:
             for canvas, info in self._canvas_infos.items():
+                # someone has switched the canvas on us!  This happens if
+                # `savefig` needs to save to a format the previous backend did
+                # not support (e.g. saving a figure using an Agg based backend
+                # saved to a vector format).
+                if canvas is not canvas.figure.canvas:
+                    continue
                 info["background"] = canvas.copy_from_bbox(canvas.figure.bbox)
 
     def onmove(self, event):


### PR DESCRIPTION
Because we may switch the canvas to a different type (that may not support blitting) when saving, check it `_clear` that the current canvas is the canvas we expect when we update the blitting caches on the draw_event callback.

Closes #25075
