### PR TITLE
feat: add new SI prefixes to ticker

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1290,8 +1290,8 @@ class TestEngFormatter:
         (True, 1001, ('1.001 k', '1 k', '1.00 k')),
         (True, 100001, ('100.001 k', '100 k', '100.00 k')),
         (True, 987654.321, ('987.654 k', '988 k', '987.65 k')),
-        # OoR value (> 1000 Y)
-        (True, 1.23e27, ('1230 Y', '1230 Y', '1230.00 Y'))
+        # OoR value (> 1000 Q)
+        (True, 1.23e33, ('1230 Q', '1230 Q', '1230.00 Q'))
     ]
 
     @pytest.mark.parametrize('unicode_minus, input, expected', raw_format_data)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1330,6 +1330,8 @@ class EngFormatter(Formatter):
 
     # The SI engineering prefixes
     ENG_PREFIXES = {
+        -30: "q",
+        -27: "r",
         -24: "y",
         -21: "z",
         -18: "a",
@@ -1346,7 +1348,9 @@ class EngFormatter(Formatter):
          15: "P",
          18: "E",
          21: "Z",
-         24: "Y"
+         24: "Y",
+         27: "R",
+         30: "Q"
     }
 
     def __init__(self, unit="", places=None, sep=" ", *, usetex=None,


### PR DESCRIPTION
## PR Summary
Add the new SI prefixes to ticker (-30, -27, 27, 30) according to BIPM [The International System of Units
9th edition (2019) - see Table 7. SI prefixes](https://www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf#page=29)

If there is Documentation or Release Note needed for this, let me know.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
