### PR TITLE
DOC: Fix broken cross-reference when building PDF

### DIFF
--- a/doc/users/explain/figures.rst
+++ b/doc/users/explain/figures.rst
@@ -124,8 +124,8 @@ figures inside a parent Figure; see
 It is possible to directly instantiate a `.Figure` instance without using the
 pyplot interface.  This is usually only necessary if you want to create your
 own GUI application or service that you do not want carrying the pyplot global
-state.  See the embedding examples in :doc:`/gallery/user_interfaces/index` for
-examples of how to do this.
+state.  See the embedding examples in :ref:`user_interfaces` for examples of
+how to do this.
 
 Figure options
 --------------


### PR DESCRIPTION
## PR Summary

Not sure why the original didn't work, perhaps because I need to use older `sphinx-gallery` to produce working PDF structures.

But this file has a target specified at the top, so use that instead. This fixed the PDF build for 3.7.0rc1.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`