### PR TITLE
Caching figures generated by plot directive

### DIFF
--- a/doc/users/next_whats_new/sphinx_plot_preserve.rst
+++ b/doc/users/next_whats_new/sphinx_plot_preserve.rst
@@ -1,0 +1,32 @@
+Caching sphinx directive figure outputs
+---------------------------------------
+
+The new ``:outname:`` property for the Sphinx plot directive can
+be used to cache generated images. It is used like:
+
+.. code-block:: rst
+
+    .. plot::
+       :outname: stinkbug_plot
+
+       import matplotlib.pyplot as plt
+       import matplotlib.image as mpimg
+       import numpy as np
+       img = mpimg.imread('_static/stinkbug.png')
+       imgplot = plt.imshow(img)
+
+Without ``:outname:``, the figure generated above would normally be called,
+e.g. :file:`docfile3-4-01.png` or something equally mysterious. With
+``:outname:`` the figure generated will instead be named
+:file:`stinkbug_plot-01.png` or even :file:`stinkbug_plot.png`. This makes it
+easy to understand which output image is which and, more importantly, uniquely
+keys output images to the code snippets that generated them.
+
+Configuring the cache directory
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The directory that images are cached to can be configured using the
+``plot_cache_dir`` configuration value in the Sphinx configuration file.
+
+If an image is already in ``plot_cache_dir`` when documentation is being
+generated, this image is copied to the build directory thereby pre-empting
+generation and reducing computation time in low-resource environments.

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -539,7 +539,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
                    function_name, config, context_reset=False,
                    close_figs=False,
                    code_includes=None,
-                   outname=''):
+                   outname=None):
     """
     Run a pyplot script and save the images in *output_dir*.
 

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -78,10 +78,10 @@ The ``.. plot::`` directive supports the following options:
         figure. This overwrites the caption given in the content, when the plot
         is generated from a file.
     ``:outname:`` : str
-        If specified, the names of the generated plots will start with the value
-        of `:outname:`. This is handy for preserving output results if code is
-        reordered between runs. The value of `:outname:` must be unique across
-        the generated documentation.
+        If specified, the names of the generated plots will start with the
+        value of ``:outname:``. This is handy for preserving output results if
+        code is reordered between runs. The value of ``:outname:`` must be
+        unique across the generated documentation.
 
 Additionally, this directive supports all the options of the `image directive
 <https://docutils.sourceforge.io/docs/ref/rst/directives.html#image>`_,
@@ -145,10 +145,11 @@ The plot directive has the following configuration options:
     plot_template
         Provide a customized template for preparing restructured text.
 
-    plot_preserve_dir
+    plot_cache_dir
         Files with outnames are copied to this directory and files in this
-        directory are copied back from into the build directory prior to the
-        build beginning.
+        directory are copied back into the build directory prior to the build
+        beginning.
+
 """
 
 import contextlib
@@ -158,16 +159,12 @@ import itertools
 import os
 import sys
 import shutil
-import io
 import re
 import textwrap
 import glob
+import logging
 from os.path import relpath
 from pathlib import Path
-import re
-import shutil
-import sys
-import textwrap
 import traceback
 
 from docutils.parsers.rst import directives, Directive
@@ -183,10 +180,12 @@ matplotlib.use("agg")
 
 __version__ = 2
 
-#Outnames must be unique. This variable stores the outnames that
-#have been seen so we can guarantee this and warn the user if a
-#duplicate is encountered.
-outname_list = set()
+_log = logging.getLogger(__name__)
+
+# Outnames must be unique. This variable stores the outnames that
+# have been seen so we can guarantee this and warn the user if a
+# duplicate is encountered.
+_outname_list = set()
 
 # -----------------------------------------------------------------------------
 # Registration hook
@@ -301,7 +300,7 @@ def setup(app):
     app.add_config_value('plot_apply_rcparams', False, True)
     app.add_config_value('plot_working_directory', None, True)
     app.add_config_value('plot_template', None, True)
-    app.add_config_value('plot_preserve_dir',          '',    True)
+    app.add_config_value('plot_cache_dir',  '', True)
     app.connect('doctree-read', mark_plot_labels)
     app.add_css_file('plot_directive.css')
     app.connect('build-finished', _copy_css_file)
@@ -636,9 +635,12 @@ def render_figures(code, code_path, output_dir, output_base, context,
             for fmt, dpi in formats:
                 try:
                     figman.canvas.figure.savefig(img.filename(fmt), dpi=dpi)
-                    if config.plot_preserve_dir and outname:
-                      print("Preserving '{0}' into '{1}'".format(img.filename(format), config.plot_preserve_dir))
-                      shutil.copy2(img.filename(format), config.plot_preserve_dir)
+                    if config.plot_cache_dir and outname is not None:
+                        _log.info(
+                            "Preserving '{0}' into '{1}'".format(
+                                img.filename(fmt), config.plot_cache_dir))
+                        shutil.copy2(img.filename(fmt),
+                                     config.plot_cache_dir)
                 except Exception as err:
                     raise PlotError(traceback.format_exc()) from err
                 img.formats.append(fmt)
@@ -674,19 +676,20 @@ def run(arguments, content, options, state_machine, state, lineno):
     rst_file = document.attributes['source']
     rst_dir = os.path.dirname(rst_file)
 
-    #Get output name of the images, if the option was provided
+    # Get output name of the images, if the option was provided
     outname = options.get('outname', '')
 
-    #Ensure that the outname is unique, otherwise copied images will
-    #not be what user expects
-    if outname and outname in outname_list:
-      raise Exception("The outname '{0}' is not unique!".format(outname))
+    # Ensure that the outname is unique, otherwise copied images will
+    # not be what user expects
+    if outname and outname in _outname_list:
+        raise Exception("The outname '{0}' is not unique!".format(outname))
     else:
-      outname_list.add(outname)
+        _outname_list.add(outname)
 
-    if config.plot_preserve_dir:
-      #Ensure `preserve_dir` ends with a slash, otherwise `copy2` will misbehave
-      config.plot_preserve_dir = os.path.join(config.plot_preserve_dir, '')
+    if config.plot_cache_dir:
+        # Ensure `preserve_dir` ends with a slash, otherwise `copy2`
+        # will misbehave
+        config.plot_cache_dir = os.path.join(config.plot_cache_dir, '')
 
     if len(arguments):
         if not config.plot_basedir:
@@ -733,10 +736,10 @@ def run(arguments, content, options, state_machine, state, lineno):
     else:
         source_ext = ''
 
-    #outname, if present, overrides output_base, but preserve
-    #numbering of multi-figure code snippets
+    # outname, if present, overrides output_base, but preserve
+    # numbering of multi-figure code snippets
     if outname:
-      output_base = re.sub('^[^-]*', outname, output_base)
+        output_base = re.sub('^[^-]*', outname, output_base)
 
     # ensure that LaTeX includegraphics doesn't choke in foo.bar.pdf filenames
     output_base = output_base.replace('.', '-')
@@ -798,14 +801,15 @@ def run(arguments, content, options, state_machine, state, lineno):
             else code,
             encoding='utf-8')
 
-    #If we previously preserved copies of the generated figures
-    #this copies them into the build directory so that they will
-    #not be remade
-    if config.plot_preserve_dir and outname:
-      outfiles = glob.glob(os.path.join(config.plot_preserve_dir,outname) + '*')
-      for of in outfiles:
-        print("Copying preserved copy of '{0}' into '{1}'".format(of, build_dir))
-        shutil.copy2(of, build_dir)
+    # If we previously preserved copies of the generated figures this copies
+    # them into the build directory so that they will not be remade.
+    if config.plot_cache_dir and outname:
+        outfiles = glob.glob(
+            os.path.join(config.plot_cache_dir, outname) + '*')
+        for of in outfiles:
+            _log.info("Copying preserved copy of '{0}' into '{1}'".format(
+                of, build_dir))
+            shutil.copy2(of, build_dir)
 
     # make figures
     try:
@@ -819,7 +823,7 @@ def run(arguments, content, options, state_machine, state, lineno):
                                  context_reset=context_opt == 'reset',
                                  close_figs=context_opt == 'close-figs',
                                  code_includes=source_file_includes,
-                                 outname= utname)
+                                 outname=outname)
         errors = []
     except PlotError as err:
         reporter = state.memo.reporter

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -174,3 +174,12 @@ Plot 21 is generated via an include directive:
 Plot 22 uses a different specific function in a file with plot commands:
 
 .. plot:: range6.py range10
+
+Plot 23 has an outname
+
+.. plot::
+    :context: close-figs
+    :outname: plot23out
+
+    plt.figure()
+    plt.plot(range(4))


### PR DESCRIPTION
## PR Summary
A rebase of https://github.com/matplotlib/matplotlib/pull/10149 onto current main, with conflicts solved, and the latest feedback on that PR taken into account. For context see the description of https://github.com/matplotlib/matplotlib/pull/10149.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
