### PR TITLE
Fix distribution of test data

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -495,12 +495,12 @@ class Tests(OptionalPackage):
                 'tests/test_*.ipynb',
             ],
             'mpl_toolkits': [
-                *_pkg_data_helper('mpl_toolkits/axes_grid1',
-                                  'tests/baseline_images'),
-                *_pkg_data_helper('mpl_toolkits/axisartist'
-                                  'tests/baseline_images'),
-                *_pkg_data_helper('mpl_toolkits/mplot3d'
-                                  'tests/baseline_images'),
+                *_pkg_data_helper('mpl_toolkits',
+                                  'axes_grid1/tests/baseline_images'),
+                *_pkg_data_helper('mpl_toolkits',
+                                  'axisartist/tests/baseline_images'),
+                *_pkg_data_helper('mpl_toolkits',
+                                  'mplot3d/tests/baseline_images'),
             ]
         }
 


### PR DESCRIPTION
## PR Summary

This is not caught in CI, because test data is not distirbuted by default, but it is downstream.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`