### PR TITLE
fix FigureCanvasTkAgg memory leak via weakrefs

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -1,4 +1,5 @@
 import uuid
+import weakref
 from contextlib import contextmanager
 import logging
 import math
@@ -198,14 +199,33 @@ class FigureCanvasTk(FigureCanvasBase):
         # event to the window containing the canvas instead.
         # See https://wiki.tcl-lang.org/3893 (mousewheel) for details
         root = self._tkcanvas.winfo_toplevel()
-        root.bind("<MouseWheel>", self.scroll_event_windows, "+")
+
+        # Prevent long-lived references via tkinter callback structure GH-24820
+        weakself = weakref.ref(self)
+        weakroot = weakref.ref(root)
+
+        def scroll_event_windows(event):
+            self = weakself()
+            if self is None:
+                root = weakroot()
+                if root is not None:
+                    root.unbind("<MouseWheel>", scroll_event_windows_id)
+                return
+            return self.scroll_event_windows(event)
+        scroll_event_windows_id = root.bind("<MouseWheel>", scroll_event_windows, "+")
 
         # Can't get destroy events by binding to _tkcanvas. Therefore, bind
         # to the window and filter.
         def filter_destroy(event):
+            self = weakself()
+            if self is None:
+                root = weakroot()
+                if root is not None:
+                    root.unbind("<Destroy>", filter_destroy_id)
+                return
             if event.widget is self._tkcanvas:
                 CloseEvent("close_event", self)._process()
-        root.bind("<Destroy>", filter_destroy, "+")
+        filter_destroy_id = root.bind("<Destroy>", filter_destroy, "+")
 
         self._tkcanvas.focus_set()
 


### PR DESCRIPTION
## PR Summary

Fixes #24820

May be worth checking if the memory leak tests can be tightened.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
