### PR TITLE
Deprecate LocationEvent.lastevent.

### DIFF
--- a/doc/api/next_api_changes/behavior/25101-AL.rst
+++ b/doc/api/next_api_changes/behavior/25101-AL.rst
@@ -1,0 +1,4 @@
+Event objects emitted for ``axes_leave_event``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``axes_leave_event`` now emits a synthetic `.LocationEvent`, instead of reusing
+the last event object associated with a ``motion_notify_event``.

--- a/doc/api/next_api_changes/deprecations/25101-AL.rst
+++ b/doc/api/next_api_changes/deprecations/25101-AL.rst
@@ -1,0 +1,3 @@
+``LocationEvent.lastevent``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated with no replacement.


### PR DESCRIPTION
Keeping around lastevent can delay garbage collection of a torn-down axes, and can also keep around an actual GUI event object (guiEvent) associated with a long-torn down widget, which can be problematic for some GUI toolkits.

Instead, only keep track of the last inaxes attribute.

Unfortunately there are no tests for axes_enter_event/axes_leave_event, but this can be manually tested by running the
event_handling/figure_axes_enter_leave.py example.

See #24820, https://github.com/matplotlib/matplotlib/issues/22211#issuecomment-1070237468.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
