### PR TITLE
tk blitting to destroyed canvases should be a noop, not a segfault.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -61,6 +61,8 @@ def _blit(argsid):
     the ``_blit_args`` dict, since arguments cannot be passed directly.
     """
     photoimage, dataptr, offsets, bboxptr, comp_rule = _blit_args.pop(argsid)
+    if not photoimage.tk.call("info", "commands", photoimage):
+        return
     _tkagg.blit(photoimage.tk.interpaddr(), str(photoimage), dataptr,
                 comp_rule, offsets, bboxptr)
 

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -71,7 +71,7 @@ def test_blit():
     import matplotlib.pyplot as plt
     import numpy as np
     import matplotlib.backends.backend_tkagg  # noqa
-    from matplotlib.backends import _tkagg
+    from matplotlib.backends import _backend_tk, _tkagg
 
     fig, ax = plt.subplots()
     photoimage = fig.canvas._tkphoto
@@ -92,6 +92,10 @@ def test_blit():
                 (0, 1, 2, 3), bad_box)
         except ValueError:
             print("success")
+
+    # Test blitting to a destroyed canvas.
+    plt.close(fig)
+    _backend_tk.blit(photoimage, data, (0, 1, 2, 3))
 
 
 @_isolated_tk_test(success_count=1)


### PR DESCRIPTION
Choosing to noop (rather than erroring) is consistent with other backends.

Closes #16580, closes #23809.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
