### PR TITLE
Fix cursor_demo wrt. Line2D.set_x/ydata not accepting scalars anymore.

### DIFF
--- a/examples/event_handling/cursor_demo.py
+++ b/examples/event_handling/cursor_demo.py
@@ -56,8 +56,8 @@ class Cursor:
             self.set_cross_hair_visible(True)
             x, y = event.xdata, event.ydata
             # update the line positions
-            self.horizontal_line.set_ydata(y)
-            self.vertical_line.set_xdata(x)
+            self.horizontal_line.set_ydata([y])
+            self.vertical_line.set_xdata([x])
             self.text.set_text(f'x={x:1.2f}, y={y:1.2f}')
             self.ax.figure.canvas.draw()
 
@@ -132,8 +132,8 @@ class BlittedCursor:
             self.set_cross_hair_visible(True)
             # update the line positions
             x, y = event.xdata, event.ydata
-            self.horizontal_line.set_ydata(y)
-            self.vertical_line.set_xdata(x)
+            self.horizontal_line.set_ydata([y])
+            self.vertical_line.set_xdata([x])
             self.text.set_text(f'x={x:1.2f}, y={y:1.2f}')
 
             self.ax.figure.canvas.restore_region(self.background)
@@ -204,8 +204,8 @@ class SnappingCursor:
             x = self.x[index]
             y = self.y[index]
             # update the line positions
-            self.horizontal_line.set_ydata(y)
-            self.vertical_line.set_xdata(x)
+            self.horizontal_line.set_ydata([y])
+            self.vertical_line.set_xdata([x])
             self.text.set_text(f'x={x:1.2f}, y={y:1.2f}')
             self.ax.figure.canvas.draw()
 


### PR DESCRIPTION
Trying to run the example prior to the PR would result in exceptions being thrown on mouse moves.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
