### PR TITLE
Stop recommending `ncol` in legend examples

### DIFF
--- a/examples/lines_bars_and_markers/horizontal_barchart_distribution.py
+++ b/examples/lines_bars_and_markers/horizontal_barchart_distribution.py
@@ -60,7 +60,7 @@ def survey(results, category_names):
         r, g, b, _ = color
         text_color = 'white' if r * g * b < 0.5 else 'darkgrey'
         ax.bar_label(rects, label_type='center', color=text_color)
-    ax.legend(ncol=len(category_names), bbox_to_anchor=(0, 1),
+    ax.legend(ncols=len(category_names), bbox_to_anchor=(0, 1),
               loc='lower left', fontsize='small')
 
     return fig, ax

--- a/examples/text_labels_and_annotations/legend_demo.py
+++ b/examples/text_labels_and_annotations/legend_demo.py
@@ -47,7 +47,7 @@ fig, (ax0, ax1) = plt.subplots(2, 1)
 for n in range(1, 5):
     ax0.plot(x, x**n, label=f"{n=}")
 leg = ax0.legend(loc="upper left", bbox_to_anchor=[0, 1],
-                 ncol=2, shadow=True, title="Legend", fancybox=True)
+                 ncols=2, shadow=True, title="Legend", fancybox=True)
 leg.get_title().set_color("red")
 
 # Demonstrate some more complex labels.

--- a/examples/user_interfaces/mplcvd.py
+++ b/examples/user_interfaces/mplcvd.py
@@ -295,5 +295,5 @@ if __name__ == '__main__':
     th = np.linspace(0, 2*np.pi, 1024)
     for j in [1, 2, 4, 6]:
         axd['lines'].plot(th, np.sin(th * j), label=f'$\\omega={j}$')
-    axd['lines'].legend(ncol=2, loc='upper right')
+    axd['lines'].legend(ncols=2, loc='upper right')
     plt.show()

--- a/examples/userdemo/simple_legend01.py
+++ b/examples/userdemo/simple_legend01.py
@@ -15,7 +15,7 @@ ax.plot([3, 2, 1], label="test2")
 # Place a legend above this subplot, expanding itself to
 # fully use the given bounding box.
 ax.legend(bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
-           ncol=2, mode="expand", borderaxespad=0.)
+           ncols=2, mode="expand", borderaxespad=0.)
 
 ax = fig.add_subplot(223)
 ax.plot([1, 2, 3], label="test1")

--- a/tutorials/intermediate/legend_guide.py
+++ b/tutorials/intermediate/legend_guide.py
@@ -127,7 +127,7 @@ ax_dict['top'].plot([3, 2, 1], label="test2")
 # Place a legend above this subplot, expanding itself to
 # fully use the given bounding box.
 ax_dict['top'].legend(bbox_to_anchor=(0., 1.02, 1., .102), loc='lower left',
-                      ncol=2, mode="expand", borderaxespad=0.)
+                      ncols=2, mode="expand", borderaxespad=0.)
 
 ax_dict['bottom'].plot([1, 2, 3], label="test1")
 ax_dict['bottom'].plot([3, 2, 1], label="test2")


### PR DESCRIPTION
## PR Summary

Since 958e329b198a9036fc121d11775815ded7c9acad the preferred keyword for controlling the number of columns in a legend is `ncols`. However,
```shell
$git grep ncol= a30c0b13386ca9469ffcfed5fa24fd21aaba49c5  # current main
```
reveals several uses of the old keyword. This pull request replaces most of them with the new recommended `ncols`, but three uses of `ncol` should remain in place:
- an old what's new entry: https://github.com/matplotlib/matplotlib/blob/a30c0b13386ca9469ffcfed5fa24fd21aaba49c5/doc/users/prev_whats_new/whats_new_0.98.4.rst#L40
- the definition of the old keyword for backwards compatibility: https://github.com/matplotlib/matplotlib/blob/a30c0b13386ca9469ffcfed5fa24fd21aaba49c5/lib/matplotlib/legend.py#L383
- a test that checks that the old keyword still works: https://github.com/matplotlib/matplotlib/blob/a30c0b13386ca9469ffcfed5fa24fd21aaba49c5/lib/matplotlib/tests/test_legend.py#L1220

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
