### PR TITLE
FIX: scaling factor for window with negative value

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -395,12 +395,12 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
     elif mode == 'psd':
         result = np.conj(result) * result
     elif mode == 'magnitude':
-        result = np.abs(result) / np.abs(window).sum()
+        result = np.abs(result) / window.sum()
     elif mode == 'angle' or mode == 'phase':
         # we unwrap the phase later to handle the onesided vs. twosided case
         result = np.angle(result)
     elif mode == 'complex':
-        result /= np.abs(window).sum()
+        result /= window.sum()
 
     if mode == 'psd':
 
@@ -424,10 +424,10 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
             result /= Fs
             # Scale the spectrum by the norm of the window to compensate for
             # windowing loss; see Bendat & Piersol Sec 11.5.2.
-            result /= (np.abs(window)**2).sum()
+            result /= (window**2).sum()
         else:
             # In this case, preserve power in the segment, not amplitude
-            result /= np.abs(window).sum()**2
+            result /= window.sum()**2
 
     t = np.arange(NFFT/2, len(x) - NFFT/2 + 1, NFFT - noverlap)/Fs
 

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -673,7 +673,7 @@ class TestSpectral:
     def test_psd_window_flattop(self):
         # flattop window
         # adaption from https://github.com/scipy/scipy/blob/v1.10.0/scipy/signal/windows/_windows.py#L562-L622
-        if self.NFFT_density_real <=1:
+        if self.NFFT_density_real <= 1:
             win = np.ones(self.NFFT_density_real)
         else:
             a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
@@ -695,18 +695,18 @@ class TestSpectral:
                                  noverlap=0,
                                  sides=self.sides,
                                  window=win)
-        spec_b, fsp_b = mlab.psd(x=self.y * win,
-                                 NFFT=self.NFFT_density,
-                                 Fs=self.Fs,
-                                 noverlap=0,
-                                 sides=self.sides,
-                                 window=mlab.window_none)
+        # spec_b, fsp_b = mlab.psd(x=self.y * win,
+        #                          NFFT=self.NFFT_density,
+        #                          Fs=self.Fs,
+        #                          noverlap=0,
+        #                          sides=self.sides,
+        #                          window=mlab.window_none)
         assert_allclose(spec*win.sum()**2,
                         spec_a*self.Fs*(win**2).sum(),
                         atol=1e-08)
-        assert_allclose(spec*win.sum()**2,
-                        spec_b*self.Fs*self.NFFT_density,
-                        atol=1e-08)
+        # assert_allclose(spec*win.sum()**2,
+        #                 spec_b*self.Fs*self.NFFT_density,
+        #                 atol=1e-08)
 
     def test_psd_windowarray(self):
         freqs = self.freqs_density

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -615,7 +615,7 @@ class TestSpectral:
                                  noverlap=0,
                                  sides=self.sides,
                                  window=mlab.window_none)
-        spec_c *= len(ycontrol1)/(np.abs(windowVals)**2).sum()
+        spec_c *= len(ycontrol1)/(windowVals**2).sum()
         assert_array_equal(fsp_g, fsp_c)
         assert_array_equal(fsp_b, fsp_c)
         assert_allclose(spec_g, spec_c, atol=1e-08)
@@ -662,13 +662,51 @@ class TestSpectral:
                                  noverlap=0,
                                  sides=self.sides,
                                  window=mlab.window_none)
-        spec_c *= len(ycontrol1)/(np.abs(windowVals)**2).sum()
+        spec_c *= len(ycontrol1)/(windowVals**2).sum()
         assert_array_equal(fsp_g, fsp_c)
         assert_array_equal(fsp_b, fsp_c)
         assert_allclose(spec_g, spec_c, atol=1e-08)
         # these should not be almost equal
         with pytest.raises(AssertionError):
             assert_allclose(spec_b, spec_c, atol=1e-08)
+
+    def test_psd_window_flattop(self):
+        # flattop window
+        # adaption from https://github.com/scipy/scipy/blob/v1.10.0/scipy/signal/windows/_windows.py#L562-L622
+        if self.NFFT_density_real <=1:
+            win = np.ones(self.NFFT_density_real)
+        else:
+            a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
+            fac = np.linspace(-np.pi, np.pi, self.NFFT_density_real)
+            win = np.zeros(self.NFFT_density_real)
+            for k in range(len(a)):
+                win += a[k] * np.cos(k * fac)
+
+        spec, fsp = mlab.psd(x=self.y,
+                             NFFT=self.NFFT_density,
+                             Fs=self.Fs,
+                             noverlap=0,
+                             sides=self.sides,
+                             window=win,
+                             scale_by_freq=False)
+        spec_a, fsp_a = mlab.psd(x=self.y,
+                                 NFFT=self.NFFT_density,
+                                 Fs=self.Fs,
+                                 noverlap=0,
+                                 sides=self.sides,
+                                 window=win)
+        spec_b, fsp_b = mlab.psd(x=self.y * win,
+                                 NFFT=self.NFFT_density,
+                                 Fs=self.Fs,
+                                 noverlap=0,
+                                 sides=self.sides,
+                                 window=mlab.window_none)
+        assert_allclose(spec*win.sum()**2,
+                        spec_a*self.Fs*(win**2).sum(),
+                        atol=1e-08)
+        assert_allclose(spec*win.sum()**2,
+                        spec_b*self.Fs*self.NFFT_density,
+                        atol=1e-08)
 
     def test_psd_windowarray(self):
         freqs = self.freqs_density

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -697,7 +697,6 @@ class TestSpectral:
                         spec_a*self.Fs*(win**2).sum(),
                         atol=1e-08)
 
-
     def test_psd_windowarray(self):
         freqs = self.freqs_density
         spec, fsp = mlab.psd(x=self.y,

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -672,15 +672,13 @@ class TestSpectral:
 
     def test_psd_window_flattop(self):
         # flattop window
-        # adaption from https://github.com/scipy/scipy/blob/v1.10.0/scipy/signal/windows/_windows.py#L562-L622
-        if self.NFFT_density_real <= 1:
-            win = np.ones(self.NFFT_density_real)
-        else:
-            a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
-            fac = np.linspace(-np.pi, np.pi, self.NFFT_density_real)
-            win = np.zeros(self.NFFT_density_real)
-            for k in range(len(a)):
-                win += a[k] * np.cos(k * fac)
+        # adaption from https://github.com/scipy/scipy/blob\
+        # /v1.10.0/scipy/signal/windows/_windows.py#L562-L622
+        a = [0.21557895, 0.41663158, 0.277263158, 0.083578947, 0.006947368]
+        fac = np.linspace(-np.pi, np.pi, self.NFFT_density_real)
+        win = np.zeros(self.NFFT_density_real)
+        for k in range(len(a)):
+            win += a[k] * np.cos(k * fac)
 
         spec, fsp = mlab.psd(x=self.y,
                              NFFT=self.NFFT_density,
@@ -695,18 +693,10 @@ class TestSpectral:
                                  noverlap=0,
                                  sides=self.sides,
                                  window=win)
-        # spec_b, fsp_b = mlab.psd(x=self.y * win,
-        #                          NFFT=self.NFFT_density,
-        #                          Fs=self.Fs,
-        #                          noverlap=0,
-        #                          sides=self.sides,
-        #                          window=mlab.window_none)
         assert_allclose(spec*win.sum()**2,
                         spec_a*self.Fs*(win**2).sum(),
                         atol=1e-08)
-        # assert_allclose(spec*win.sum()**2,
-        #                 spec_b*self.Fs*self.NFFT_density,
-        #                 atol=1e-08)
+
 
     def test_psd_windowarray(self):
         freqs = self.freqs_density


### PR DESCRIPTION
## PR Summary
Simply drop the `np.abs()` on window to fix the wrong scaling factor for window with negative value. For more detail refer to https://github.com/matplotlib/matplotlib/issues/24821

**Caution**: With this fix, the behavior would change for window with complex value.
With `np.abs()` on window, it seems can handle complex value, but I don't think it's the right way to do it. As it can't fall back to real value case for complex value with zero imaginary part and negative real part (for example -1 + 0j).
Also, I didn't understand the need for complex window, so here I simply ignore the complex case. And this is consistent with the implementation of [scipy](https://github.com/scipy/scipy/blob/d9f75db82fdffef06187c9d8d2f0f5b36c7a791b/scipy/signal/_spectral_py.py#L1854-L1859).

Closes #24821 

Related to #22828 (not sure it can be closed, that seems to try to deal with the complex case as well, but is there one?).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
