### PR TITLE
Undeprecate Cursor event handlers

### DIFF
--- a/examples/event_handling/cursor_demo.py
+++ b/examples/event_handling/cursor_demo.py
@@ -28,6 +28,8 @@ __ https://github.com/anntzer/mplcursors
 import matplotlib.pyplot as plt
 import numpy as np
 
+from matplotlib.backend_bases import MouseEvent
+
 
 class Cursor:
     """
@@ -71,6 +73,11 @@ ax.plot(x, y, 'o')
 cursor = Cursor(ax)
 fig.canvas.mpl_connect('motion_notify_event', cursor.on_mouse_move)
 
+# Simulate a mouse move to (0.5, 0.5), needed for online docs
+t = ax.transData
+MouseEvent(
+    "motion_notify_event", ax.figure.canvas, *t.transform((0.5, 0.5))
+)._process()
 
 # %%
 # Faster redrawing using blitting
@@ -84,6 +91,7 @@ fig.canvas.mpl_connect('motion_notify_event', cursor.on_mouse_move)
 # ``create_new_background()``). Additionally, a new background has to be
 # created whenever the figure changes. This is achieved by connecting to the
 # ``'draw_event'``.
+
 
 class BlittedCursor:
     """
@@ -152,6 +160,11 @@ ax.plot(x, y, 'o')
 blitted_cursor = BlittedCursor(ax)
 fig.canvas.mpl_connect('motion_notify_event', blitted_cursor.on_mouse_move)
 
+# Simulate a mouse move to (0.5, 0.5), needed for online docs
+t = ax.transData
+MouseEvent(
+    "motion_notify_event", ax.figure.canvas, *t.transform((0.5, 0.5))
+)._process()
 
 # %%
 # Snapping to data points
@@ -164,6 +177,7 @@ fig.canvas.mpl_connect('motion_notify_event', blitted_cursor.on_mouse_move)
 # moves far enough so that another data point must be selected. This reduces
 # the lag due to many redraws. Of course, blitting could still be added on top
 # for additional speedup.
+
 
 class SnappingCursor:
     """
@@ -218,4 +232,11 @@ ax.set_title('Snapping cursor')
 line, = ax.plot(x, y, 'o')
 snap_cursor = SnappingCursor(ax, line)
 fig.canvas.mpl_connect('motion_notify_event', snap_cursor.on_mouse_move)
+
+# Simulate a mouse move to (0.5, 0.5), needed for online docs
+t = ax.transData
+MouseEvent(
+    "motion_notify_event", ax.figure.canvas, *t.transform((0.5, 0.5))
+)._process()
+
 plt.show()

--- a/examples/widgets/annotated_cursor.py
+++ b/examples/widgets/annotated_cursor.py
@@ -24,6 +24,8 @@ from matplotlib.widgets import Cursor
 import numpy as np
 import matplotlib.pyplot as plt
 
+from matplotlib.backend_bases import MouseEvent
+
 
 class AnnotatedCursor(Cursor):
     """
@@ -312,6 +314,12 @@ cursor = AnnotatedCursor(
     color='red',
     linewidth=2)
 
+# Simulate a mouse move to (-2, 10), needed for online docs
+t = ax.transData
+MouseEvent(
+    "motion_notify_event", ax.figure.canvas, *t.transform((-2, 10))
+)._process()
+
 plt.show()
 
 # %%
@@ -338,5 +346,11 @@ cursor = AnnotatedCursor(
     ax=ax,
     useblit=True,
     color='red', linewidth=2)
+
+# Simulate a mouse move to (-2, 10), needed for online docs
+t = ax.transData
+MouseEvent(
+    "motion_notify_event", ax.figure.canvas, *t.transform((-2, 10))
+)._process()
 
 plt.show()

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1654,7 +1654,7 @@ def test_MultiCursor(horizOn, vertOn):
     # Can't use `do_event` as that helper requires the widget
     # to have a single .ax attribute.
     event = mock_event(ax1, xdata=.5, ydata=.25)
-    multi._onmove(event)
+    multi.onmove(event)
 
     # the lines in the first two ax should both move
     for l in multi.vlines:
@@ -1680,7 +1680,7 @@ def test_MultiCursor(horizOn, vertOn):
     # test a move event in an Axes not part of the MultiCursor
     # the lines in ax1 and ax2 should not have moved.
     event = mock_event(ax3, xdata=.75, ydata=.75)
-    multi._onmove(event)
+    multi.onmove(event)
     for l in multi.vlines:
         assert l.get_xdata() == (.5, .5)
     for l in multi.hlines:

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1671,7 +1671,7 @@ def test_MultiCursor(horizOn, vertOn):
     multi.horizOn = not multi.horizOn
     multi.vertOn = not multi.vertOn
     event = mock_event(ax1, xdata=.5, ydata=.25)
-    multi._onmove(event)
+    multi.onmove(event)
     assert len([line for line in multi.vlines if line.get_visible()]) == (
         0 if vertOn else 2)
     assert len([line for line in multi.hlines if line.get_visible()]) == (

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1655,6 +1655,8 @@ def test_MultiCursor(horizOn, vertOn):
     # to have a single .ax attribute.
     event = mock_event(ax1, xdata=.5, ydata=.25)
     multi.onmove(event)
+    # force a draw + draw event to exercise clear
+    ax1.figure.canvas.draw()
 
     # the lines in the first two ax should both move
     for l in multi.vlines:

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1971,7 +1971,7 @@ class Cursor(AxesWidget):
 
     needclear = _api.deprecate_privatize_attribute("3.7")
 
-    @_api.deprecated('3.7')
+    @_api.deprecated('3.5')
     def clear(self, event):
         """Internal event handler to clear the cursor."""
         self._clear(event)
@@ -1987,7 +1987,7 @@ class Cursor(AxesWidget):
         if self.useblit:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
 
-    onmove = _api.deprecate_privatize_attribute('3.7')
+    onmove = _api.deprecate_privatize_attribute('3.5')
 
     def _onmove(self, event):
         """Internal event handler to draw the cursor when the mouse moves."""
@@ -2117,7 +2117,7 @@ class MultiCursor(Widget):
                 canvas.mpl_disconnect(cid)
             info["cids"].clear()
 
-    @_api.deprecated('3.7')
+    @_api.deprecated('3.5')
     def clear(self, event):
         """Clear the cursor."""
         if self.ignore(event):
@@ -2134,7 +2134,7 @@ class MultiCursor(Widget):
             for canvas, info in self._canvas_infos.items():
                 info["background"] = canvas.copy_from_bbox(canvas.figure.bbox)
 
-    onmove = _api.deprecate_privatize_attribute('3.7')
+    onmove = _api.deprecate_privatize_attribute('3.5')
 
     def _onmove(self, event):
         if (self.ignore(event)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1953,8 +1953,8 @@ class Cursor(AxesWidget):
                  **lineprops):
         super().__init__(ax)
 
-        self.connect_event('motion_notify_event', self._onmove)
-        self.connect_event('draw_event', self._clear)
+        self.connect_event('motion_notify_event', self.onmove)
+        self.connect_event('draw_event', self.clear)
 
         self.visible = True
         self.horizOn = horizOn
@@ -1967,29 +1967,18 @@ class Cursor(AxesWidget):
         self.linev = ax.axvline(ax.get_xbound()[0], visible=False, **lineprops)
 
         self.background = None
-        self._needclear = False
+        self.needclear = False
 
-    needclear = _api.deprecate_privatize_attribute("3.7")
-
-    @_api.deprecated('3.5')
     def clear(self, event):
-        """Internal event handler to clear the cursor."""
-        self._clear(event)
-        if self.ignore(event):
-            return
-        self.linev.set_visible(False)
-        self.lineh.set_visible(False)
-
-    def _clear(self, event):
         """Internal event handler to clear the cursor."""
         if self.ignore(event):
             return
         if self.useblit:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
+        self.linev.set_visible(False)
+        self.lineh.set_visible(False)
 
-    onmove = _api.deprecate_privatize_attribute('3.5')
-
-    def _onmove(self, event):
+    def onmove(self, event):
         """Internal event handler to draw the cursor when the mouse moves."""
         if self.ignore(event):
             return
@@ -1999,11 +1988,11 @@ class Cursor(AxesWidget):
             self.linev.set_visible(False)
             self.lineh.set_visible(False)
 
-            if self._needclear:
+            if self.needclear:
                 self.canvas.draw()
-                self._needclear = False
+                self.needclear = False
             return
-        self._needclear = True
+        self.needclear = True
 
         self.linev.set_xdata((event.xdata, event.xdata))
         self.linev.set_visible(self.visible and self.vertOn)
@@ -2106,8 +2095,8 @@ class MultiCursor(Widget):
         """Connect events."""
         for canvas, info in self._canvas_infos.items():
             info["cids"] = [
-                canvas.mpl_connect('motion_notify_event', self._onmove),
-                canvas.mpl_connect('draw_event', self._clear),
+                canvas.mpl_connect('motion_notify_event', self.onmove),
+                canvas.mpl_connect('draw_event', self.clear),
             ]
 
     def disconnect(self):
@@ -2117,26 +2106,17 @@ class MultiCursor(Widget):
                 canvas.mpl_disconnect(cid)
             info["cids"].clear()
 
-    @_api.deprecated('3.5')
     def clear(self, event):
-        """Clear the cursor."""
-        if self.ignore(event):
-            return
-        self._clear(event)
-        for line in self.vlines + self.hlines:
-            line.set_visible(False)
-
-    def _clear(self, event):
         """Clear the cursor."""
         if self.ignore(event):
             return
         if self.useblit:
             for canvas, info in self._canvas_infos.items():
                 info["background"] = canvas.copy_from_bbox(canvas.figure.bbox)
+        for line in self.vlines + self.hlines:
+            line.set_visible(False)
 
-    onmove = _api.deprecate_privatize_attribute('3.5')
-
-    def _onmove(self, event):
+    def onmove(self, event):
         if (self.ignore(event)
                 or event.inaxes not in self.axes
                 or not event.canvas.widgetlock.available(self)):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1975,8 +1975,6 @@ class Cursor(AxesWidget):
             return
         if self.useblit:
             self.background = self.canvas.copy_from_bbox(self.ax.bbox)
-        self.linev.set_visible(False)
-        self.lineh.set_visible(False)
 
     def onmove(self, event):
         """Internal event handler to draw the cursor when the mouse moves."""
@@ -2113,8 +2111,6 @@ class MultiCursor(Widget):
         if self.useblit:
             for canvas, info in self._canvas_infos.items():
                 info["background"] = canvas.copy_from_bbox(canvas.figure.bbox)
-        for line in self.vlines + self.hlines:
-            line.set_visible(False)
 
     def onmove(self, event):
         if (self.ignore(event)


### PR DESCRIPTION
- Revert "Fix deprecations of *Cursor widget event handlers"
- Revert: Deprecate access to Cursor/MultiCursor event handlers.
- Add simulated mouse events to cursor demos
- remove calls to set_visible(False)

Closes #25107

## PR Summary

The event handlers were deprecated for mpl 3.7 in #19763 (with correction for the deprecation notices in #24750)
This has not been released as a final matplotlib version (only the rc).

However, one of examples demonstrated subclassing these classes specifically to override these methods.
The callbacks registered internally were for the privitized version of the functions, thus the overrides did nothing.
Given that it is suggested in our docs, we determiened in #25107 that we should undeprecate these methods.

The original PR kept the calls to `set_visible(False)` in the un-prefixed versions of `clear` for `Cursor` and `MultiCursor`.
Because clear is registered as a callback on a `draw` event, this was causing the cursor to disappear on the nbagg backend.

`clear` is not actually run in our test suite, as observed on [codecov](https://app.codecov.io/gh/matplotlib/matplotlib/commit/f3938be9f3be3446065e184b810ee0a8bcb54901/blob/lib/matplotlib/widgets.py).

In ad hoc testing, removing seemed to have limited impact on the qt backend (seemed to function as expected).
The problem from #19763 was reintroduced for the nbagg backend if the `set_visible(False)` was included.

So I removed those lines entirely for the undeprecation.
This feels odd, as I may have expected the `clear` function to explicitly turn off the cursor visibility.
But as far as I can tell, it works like I'd expect.

I suspect in the narrow case of a user calling `clear` directly (as opposed to relying on the internal callbacks)
it may not actually remove the lines and thus be unexpected behavior.
But I have no examples of doing such, and in most cases if the cursor was showing to begin with, the mouse is over the axes, and will cause the cursor to show up as soon as it moves anyway, I'd think.


Anywho, while working on these, figured I'd also add a simulted mouse event to the examples so that the docs show what they actually do (if not interactively still) a bit more.
I did so using `_process()` on the `MouseEvent` because that is what is done in our tests for simulating mouse events.
I could have made the mouse event and passed it directly to the callback method, I think, which would have avoided using an `_` method in our example.

@anntzer suggested perhaps removing the widgets/annotated_cursor example all together because event_handlers/cursor_demo does effectively the same thing but in less code.

@tacaswell voted in favor of keeping both for the time being (though did check that they are cross linked to each other).

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
