### PR TITLE
FIX: Correctly report command keypress on mac for Tk + Gtk

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -354,7 +354,7 @@ class FigureCanvasTk(FigureCanvasBase):
             ("ctrl", 1 << 2, "control"),
             ("alt", 1 << 4, "alt"),
             ("shift", 1 << 0, "shift"),
-            ("super", 1 << 3, "super"),
+            ("cmd", 1 << 3, "cmd"),
         ] if sys.platform == "darwin" else [
             ("ctrl", 1 << 2, "control"),
             ("alt", 1 << 3, "alt"),

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2169,6 +2169,9 @@ def _unikey_or_keysym_to_mplkey(unikey, keysym):
         key = key.replace("page_", "page")
     if key.endswith(("_l", "_r")):  # alt_l, ctrl_l, shift_l.
         key = key[:-2]
+    if sys.platform == "darwin" and key == "meta":
+        # meta should be reported as command on mac
+        key = "cmd"
     key = {
         "return": "enter",
         "prior": "pageup",  # Used by tk.


### PR DESCRIPTION
## PR Summary

Tk and Gtk reported "super" when "command" was pressed, while qt and macosx reported "cmd". Make all backends consistent by reporting "cmd" in all of them.

@Co-authored-by: Antony Lee <anntzer.lee@gmail.com>

follow-up to:  #23473 
Note the extra change to cbook, which accounts for the single key command press, where it isn't a modifier.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [-] Has pytest style unit tests (and `pytest` passes)
- [-] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [-] New plotting related features are documented with examples.

**Release Notes**
- [-] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [?] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [-] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
