### PR TITLE
replaced _check_color_like method with call to to_rgba 

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1056,7 +1056,7 @@ class Line2D(Artist):
         ----------
         color : color
         """
-        mcolors._check_color_like(color=color)
+        _ = mcolors.to_rgba(color, errname="color")
         self._color = color
         self.stale = True
 
@@ -1114,7 +1114,7 @@ class Line2D(Artist):
             unfilled.
         """
         if gapcolor is not None:
-            mcolors._check_color_like(color=gapcolor)
+            _ = mcolors.to_rgba(gapcolor, errname="gapcolor")
         self._gapcolor = gapcolor
         self.stale = True
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -11,7 +11,7 @@ import weakref
 import numpy as np
 
 import matplotlib as mpl
-from . import _api, artist, cbook, _docstring
+from . import _api, artist, cbook, colors as mcolors, _docstring
 from .artist import Artist
 from .font_manager import FontProperties
 from .patches import FancyArrowPatch, FancyBboxPatch, Rectangle
@@ -993,7 +993,7 @@ class Text(Artist):
         # "auto" is only supported by axisartist, but we can just let it error
         # out at draw time for simplicity.
         if not cbook._str_equal(color, "auto"):
-            mpl.colors._check_color_like(color=color)
+            _ = mcolors.to_rgba(color, errname="color")
         self._color = color
         self.stale = True
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1776,7 +1776,7 @@ class RadioButtons(AxesWidget):
 
     @activecolor.setter
     def activecolor(self, activecolor):
-        colors._check_color_like(activecolor=activecolor)
+        _ = colors.to_rgba(activecolor, errname="activecolor")
         self._activecolor = activecolor
         self.set_radio_props({'facecolor': activecolor})
         # Make sure the deprecated version is updated.

--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -139,7 +139,7 @@ class Ticks(AttributeCopier, Line2D):
         # docstring inherited
         # Unlike the base Line2D.set_color, this also supports "auto".
         if not cbook._str_equal(color, "auto"):
-            mcolors._check_color_like(color=color)
+            _ = mcolors.to_rgba(color, errname="color")
         self._color = color
         self.stale = True
 


### PR DESCRIPTION
In #25025 there was opposition to adding a new color checking method for arrays to be consistent with the `_check_color_like` checks, and in the call today there seemed to be consensus for using `to_rgba` as the validator, especially since `_check_color_like` is using it under the hood. `_check_color_like` was used in 5 places, so just swapped out those calls w/ calls to `to_rgba`. Didn't do anything w/ the return type mostly because I wasn't sure if we wanted class objects to retain the original input. 

To keep the error messages from `check_color_like`, I went with the suggestion in this comment but didn't document it (yet) b/c I'm not sure if this is really a public keyword. 

>I would grow the signature to `to_rgba_array(..., errname=...)` (name up to bikeshedding) if you want to customize that.

_Originally posted by @anntzer in https://github.com/matplotlib/matplotlib/issues/25025#issuecomment-1410514610_