### PR TITLE
DOC: use 'none' in set_layout_engine

### DIFF
--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -194,7 +194,7 @@ fig.canvas.draw()
 # we want the legend included in the bbox_inches='tight' calcs.
 leg.set_in_layout(True)
 # we don't want the layout to change at this point.
-fig.set_layout_engine(None)
+fig.set_layout_engine('none')
 try:
     fig.savefig('../../doc/_static/constrained_layout_1b.png',
                 bbox_inches='tight', dpi=100)
@@ -491,7 +491,7 @@ fig.suptitle("fixed-aspect plots, layout='compressed'")
 # ``constrained_layout`` usually adjusts the axes positions on each draw
 # of the figure.  If you want to get the spacing provided by
 # ``constrained_layout`` but not have it update, then do the initial
-# draw and then call ``fig.set_layout_engine(None)``.
+# draw and then call ``fig.set_layout_engine('none')``.
 # This is potentially useful for animations where the tick labels may
 # change length.
 #


### PR DESCRIPTION
## PR Summary

**If** I have understood correctly, passing `None` to `set_layout_engine` essentially means "set the default layout engine" where the default is determined by what `rcParams` you have set.  Passing `"none"` will set the layout engine to either `None` or `PlaceHolderLayoutEngine`, depending what was previously set.  So I think `"none"` is the more reliable way to turn the layout engine off.

https://github.com/matplotlib/matplotlib/blob/11258883230848ad88c656786f804fd1cd3bdf6e/lib/matplotlib/figure.py#L2566-L2618

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
