### PR TITLE
Group shape/dtype validation logic in image_resample.

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1,5 +1,6 @@
 from contextlib import ExitStack
 from copy import copy
+import functools
 import io
 import os
 from pathlib import Path
@@ -1453,3 +1454,17 @@ def test_str_norms(fig_test, fig_ref):
     assert type(axts[0].images[0].norm) == colors.LogNorm  # Exactly that class
     with pytest.raises(ValueError):
         axts[0].imshow(t, norm="foobar")
+
+
+def test__resample_valid_output():
+    resample = functools.partial(mpl._image.resample, transform=Affine2D())
+    with pytest.raises(ValueError, match="must be a NumPy array"):
+        resample(np.zeros((9, 9)), None)
+    with pytest.raises(ValueError, match="different dimensionalities"):
+        resample(np.zeros((9, 9)), np.zeros((9, 9, 4)))
+    with pytest.raises(ValueError, match="must be RGBA"):
+        resample(np.zeros((9, 9, 4)), np.zeros((9, 9, 3)))
+    with pytest.raises(ValueError, match="Mismatched types"):
+        resample(np.zeros((9, 9), np.uint8), np.zeros((9, 9)))
+    with pytest.raises(ValueError, match="must be C-contiguous"):
+        resample(np.zeros((9, 9)), np.zeros((9, 9)).T)


### PR DESCRIPTION
Move it all to a single place rather than having some of it interspersed with the dtype dispatch later.

Also reorder the dtype dispatch to be consistent in the 2D and 3D cases, and remove _array from many local variable names.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
