### PR TITLE
On macOS, limit symbols exported by extension modules linking FreeType.

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -593,6 +593,10 @@ class FreeType(SetupPackage):
                 0, str((src_path / 'objs/.libs/libfreetype').with_suffix(
                     '.lib' if sys.platform == 'win32' else '.a')))
             ext.define_macros.append(('FREETYPE_BUILD_TYPE', 'local'))
+            if sys.platform == 'darwin':
+                name = ext.name.split('.')[-1]
+                ext.extra_link_args.append(
+                    f'-Wl,-exported_symbol,_PyInit_{name}')
 
     def do_custom_build(self, env):
         # We're using a system freetype


### PR DESCRIPTION
In my experience, mplcairo has only ever worked on macOS if imported prior to matplotlib (which means that in particular just setting the backend rcParam will not work, including via matplotlibrc), or (I have recently discovered) if using a non-local-freetype version build of ft2font.  If none of these conditions are not satisfied, various bad things happen, such as segfaults at runtime.  I realized recently the (one?) reason for this problem.  Below, I only consider the case of local-freetype builds (the only problematic case).

C-level cairo functions call FreeType for text rendering, and there are two different libfreetype libraries involved: the one statically linked into matplotlib's ft2font, and the OS-level one (which comes into play even for local-freetype builds because libcairo.so is always provided at the system level).  Note that I am actually happy that libcairo can use the system-level freetype, because it is typically more recent and lets mplcairo offer e.g. better color font (emoji, etc.) support.

On Linux, I find that the system-level libcairo.so indeed loads all the FreeType symbols it needs from the system-level libfreetype.so, so the libfreetype.a statically linked into ft2font is completely hidden to it; things are fine.  On macOS, OTOH, I find that the libfreetype.a symbols "leak" out of the extension module, and libcairo.so picks up some symbols from it (one can check this via dladdr()), but (likely) not all, which means that two different versions of of libfreetype try to access the same FT_Face objects with (likely) incompatible ABIs, hence the segfaults.

This difference in symbol priority likely comes down to difference in behavior in the macOS and Linux dynamic loaders, which I have not investigated more.  However, one solution to fix is is to explicitly limit the symbols exported by ft2font to the only one needed as an extension module, i.e. PyInit_ft2font, hiding in particular all FreeType symbols.  This also needs to be done for _backend_agg, which also links FreeType.  To do so, I rely on the linker's -exported_symbol flag, as explained e.g. at https://stackoverflow.com/questions/2222162; also note that the symbol name is mangled with a leading underscore (https://news.ycombinator.com/item?id=20143037).  I can confirm that with this fix, mplcairo can be correctly used even if imported after a matplotlib that uses a local-freetype build, and ft2font's FreeType symbols no longer leak-out.

I am actually not very happy about limiting symbol visibility, because letting the linked library's symbols leak out allows various useful tricks: mplcairo itself actually gets its cairo symbols out of pycairo, and I have likewise previously written C-extensions that access FFTW by stealing the symbols from pyFFTW; in both cases the advantage is to not actually have to link the library against libcairo.so/libfftw3.so and instead push the responsibility of packaging these libraries for the Python ecosystem to pycairo/pyFFTW.  I guess one key difference here, though, is that pycairo/pyFFTW exist exactly to provide bindings to these libraries, whereas ft2font isn't really there to provide bindings to FreeType (there's instead freetype-py, for example, for that). Still, if someone has a better understanding of the macOS dynamic loader and knows how to fix this better, I am all ears.

PS: Yes, I got a mac.
PPS: I swear I wasn't aiming for the biggest commit-message-to-patchsize-ratio.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
