### PR TITLE
Accept LA icons for the toolbar

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -747,6 +747,8 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         # Use the high-resolution (48x48 px) icon if it exists and is needed
         with Image.open(path_large if (size > 24 and path_large.exists())
                         else path_regular) as im:
+            # assure a RGBA image as foreground color is RGB
+            im = im.convert("RGBA")
             image = ImageTk.PhotoImage(im.resize((size, size)), master=self)
             button._ntimage = image
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1112,7 +1112,9 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         *name*, including the extension and relative to Matplotlib's "images"
         data directory.
         """
-        image = np.array(PIL.Image.open(cbook._get_data_path("images", name)))
+        pilimg = PIL.Image.open(cbook._get_data_path("images", name))
+        # ensure RGBA as wx BitMap expects RGBA format
+        image = np.array(pilimg.convert("RGBA"))
         try:
             dark = wx.SystemSettings.GetAppearance().IsDark()
         except AttributeError:  # wxpython < 4.1

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -4,18 +4,11 @@ import os
 import platform
 import subprocess
 import sys
-import tempfile
-import warnings
-
-from PIL import Image
 
 import pytest
 
-import matplotlib
 from matplotlib import _c_internal_utils
-from matplotlib.backend_tools import ToolToggleBase
 from matplotlib.testing import subprocess_run_helper
-import matplotlib.pyplot as plt
 
 
 _test_timeout = 60  # A reasonably safe value for slower architectures.
@@ -183,32 +176,6 @@ def test_never_update():
 
     # Note that exceptions would be printed to stderr; _isolated_tk_test
     # checks them.
-
-
-@pytest.mark.backend('TkAgg', skip_on_importerror=True)
-@_isolated_tk_test(success_count=0)
-def test_toolbar_button_la_mode_icon():
-    # test that icon in LA mode can be used for buttons
-    # see GH#25164
-    # tweaking toolbar raises an UserWarning
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore", UserWarning)
-        matplotlib.rcParams["toolbar"] = "toolmanager"
-
-    # create an icon in LA mode
-    with tempfile.TemporaryDirectory() as tempdir:
-        img = Image.new("LA", (26, 26))
-        tmp_img_path = os.path.join(tempdir, "test_la_icon.png")
-        img.save(tmp_img_path)
-
-        class CustomTool(ToolToggleBase):
-            image = tmp_img_path
-
-        fig = plt.figure()
-        toolmanager = fig.canvas.manager.toolmanager
-        toolbar = fig.canvas.manager.toolbar
-        toolmanager.add_tool("test", CustomTool)
-        toolbar.add_tool("test", "group")
 
 
 @_isolated_tk_test(success_count=2)

--- a/lib/matplotlib/tests/test_backend_tools.py
+++ b/lib/matplotlib/tests/test_backend_tools.py
@@ -1,6 +1,17 @@
+import os
+import subprocess
+import tempfile
+from PIL import Image
+
 import pytest
 
-from matplotlib.backend_tools import ToolHelpBase
+import matplotlib
+from matplotlib.backend_tools import ToolHelpBase, ToolToggleBase
+import matplotlib.pyplot as plt
+from matplotlib.testing import subprocess_run_helper
+from .test_backends_interactive import (
+        _get_testable_interactive_backends, _test_timeout,
+        )
 
 
 @pytest.mark.parametrize('rc_shortcut,expected', [
@@ -18,3 +29,41 @@ from matplotlib.backend_tools import ToolHelpBase
 ])
 def test_format_shortcut(rc_shortcut, expected):
     assert ToolHelpBase.format_shortcut(rc_shortcut) == expected
+
+
+def _test_toolbar_button_la_mode_icon_inside_subprocess():
+    matplotlib.rcParams["toolbar"] = "toolmanager"
+    # create an icon in LA mode
+    with tempfile.TemporaryDirectory() as tempdir:
+        img = Image.new("LA", (26, 26))
+        tmp_img_path = os.path.join(tempdir, "test_la_icon.png")
+        img.save(tmp_img_path)
+
+        class CustomTool(ToolToggleBase):
+            image = tmp_img_path
+            description = ""  # gtk3 backend does not allow None
+
+        fig = plt.figure()
+        toolmanager = fig.canvas.manager.toolmanager
+        toolbar = fig.canvas.manager.toolbar
+        toolmanager.add_tool("test", CustomTool)
+        toolbar.add_tool("test", "group")
+
+
+@pytest.mark.parametrize(
+        "env",
+        _get_testable_interactive_backends(),
+        )
+def test_toolbar_button_la_mode_icon(env):
+    # test that icon in LA mode can be used for buttons
+    # see GH#25164
+    try:
+        # run inside subprocess for a self-contained environment
+        proc = subprocess_run_helper(
+            _test_toolbar_button_la_mode_icon_inside_subprocess,
+            timeout=_test_timeout,
+            extra_env=env,
+            )
+    except subprocess.CalledProcessError as err:
+        pytest.fail(
+                f"subprocess failed to test intended behavior: {err.stderr}")

--- a/lib/matplotlib/tests/test_backend_tools.py
+++ b/lib/matplotlib/tests/test_backend_tools.py
@@ -1,17 +1,6 @@
-import os
-import subprocess
-import tempfile
-from PIL import Image
-
 import pytest
 
-import matplotlib
-from matplotlib.backend_tools import ToolHelpBase, ToolToggleBase
-import matplotlib.pyplot as plt
-from matplotlib.testing import subprocess_run_helper
-from .test_backends_interactive import (
-        _get_testable_interactive_backends, _test_timeout,
-        )
+from matplotlib.backend_tools import ToolHelpBase
 
 
 @pytest.mark.parametrize('rc_shortcut,expected', [
@@ -29,41 +18,3 @@ from .test_backends_interactive import (
 ])
 def test_format_shortcut(rc_shortcut, expected):
     assert ToolHelpBase.format_shortcut(rc_shortcut) == expected
-
-
-def _test_toolbar_button_la_mode_icon_inside_subprocess():
-    matplotlib.rcParams["toolbar"] = "toolmanager"
-    # create an icon in LA mode
-    with tempfile.TemporaryDirectory() as tempdir:
-        img = Image.new("LA", (26, 26))
-        tmp_img_path = os.path.join(tempdir, "test_la_icon.png")
-        img.save(tmp_img_path)
-
-        class CustomTool(ToolToggleBase):
-            image = tmp_img_path
-            description = ""  # gtk3 backend does not allow None
-
-        fig = plt.figure()
-        toolmanager = fig.canvas.manager.toolmanager
-        toolbar = fig.canvas.manager.toolbar
-        toolmanager.add_tool("test", CustomTool)
-        toolbar.add_tool("test", "group")
-
-
-@pytest.mark.parametrize(
-        "env",
-        _get_testable_interactive_backends(),
-        )
-def test_toolbar_button_la_mode_icon(env):
-    # test that icon in LA mode can be used for buttons
-    # see GH#25164
-    try:
-        # run inside subprocess for a self-contained environment
-        proc = subprocess_run_helper(
-            _test_toolbar_button_la_mode_icon_inside_subprocess,
-            timeout=_test_timeout,
-            extra_env=env,
-            )
-    except subprocess.CalledProcessError as err:
-        pytest.fail(
-                f"subprocess failed to test intended behavior: {err.stderr}")


### PR DESCRIPTION
## PR Summary
Fixes #25164 by converting a PIL icon image to RGBA when loading it. Also created unittest to check the bug in the future.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [ ] [ N/A ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] [ N/A ] New plotting related features are documented with examples.

**Release Notes**
- [ ] [ N/A ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] [ N/A ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] [ N/A ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
