### PR TITLE
Deprecate 'prune' kwarg to MaxNLocator

### DIFF
--- a/doc/api/next_api_changes/deprecations/25191-DS.rst
+++ b/doc/api/next_api_changes/deprecations/25191-DS.rst
@@ -1,0 +1,6 @@
+Automatically pruning ticks in ``MaxNLocator``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+The ``prune`` keyword argument to both `matplotlib.ticker.MaxNLocator` and
+`mpl_toolkits.axisartist.grid_finder.MaxNLocator` is deprecated, with
+no replacement. If tick pruning is desired, manually prune the ticks
+after they have been returned by ``MaxNLocator.tick_values()``.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1965,7 +1965,6 @@ class MaxNLocator(Locator):
                           steps=None,
                           integer=False,
                           symmetric=False,
-                          prune=None,
                           min_n_ticks=2)
 
     def __init__(self, nbins=None, **kwargs):
@@ -1992,15 +1991,6 @@ class MaxNLocator(Locator):
         symmetric : bool, default: False
             If True, autoscaling will result in a range symmetric about zero.
 
-        prune : {'lower', 'upper', 'both', None}, default: None
-            Remove edge ticks -- useful for stacked or ganged plots where
-            the upper tick of one axes overlaps with the lower tick of the
-            axes above it, primarily when :rc:`axes.autolimit_mode` is
-            ``'round_numbers'``.  If ``prune=='lower'``, the smallest tick will
-            be removed.  If ``prune == 'upper'``, the largest tick will be
-            removed.  If ``prune == 'both'``, the largest and smallest ticks
-            will be removed.  If *prune* is *None*, no ticks will be removed.
-
         min_n_ticks : int, default: 2
             Relax *nbins* and *integer* constraints if necessary to obtain
             this minimum number of ticks.
@@ -2008,6 +1998,10 @@ class MaxNLocator(Locator):
         if nbins is not None:
             kwargs['nbins'] = nbins
         self.set_params(**{**self.default_params, **kwargs})
+        if not hasattr(self, '_prune'):
+            # Make sure _prune is set without hitting deprecation warning in
+            # set_params()
+            self._prune = None
 
     @staticmethod
     def _validate_steps(steps):
@@ -2044,8 +2038,6 @@ class MaxNLocator(Locator):
             see `.MaxNLocator`
         symmetric : bool, optional
             see `.MaxNLocator`
-        prune : {'lower', 'upper', 'both', None}, optional
-            see `.MaxNLocator`
         min_n_ticks : int, optional
             see `.MaxNLocator`
         """
@@ -2056,6 +2048,11 @@ class MaxNLocator(Locator):
         if 'symmetric' in kwargs:
             self._symmetric = kwargs.pop('symmetric')
         if 'prune' in kwargs:
+            _api.warn_deprecated(
+                "3.8", message="The 'prune' keyword argument is deprecated, "
+                "and will be removed in Matplotlib %(removal)s. Tick pruning "
+                "should be done manually after the ticks have been generated."
+            )
             prune = kwargs.pop('prune')
             _api.check_in_list(['upper', 'lower', 'both', None], prune=prune)
             self._prune = prune

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from matplotlib import _api
 from matplotlib import ticker as mticker
 from matplotlib.transforms import Bbox, Transform
 
@@ -277,15 +278,26 @@ class GridFinder:
                 raise ValueError(f"Unknown update property {k!r}")
 
 
+# Sentinel to check if prune argument has been passed by user or not
+_None = object()
+
+
 class MaxNLocator(mticker.MaxNLocator):
+    @_api.delete_parameter("3.8", "prune")
     def __init__(self, nbins=10, steps=None,
                  trim=True,
                  integer=False,
                  symmetric=False,
-                 prune=None):
-        # trim argument has no effect. It has been left for API compatibility
-        super().__init__(nbins, steps=steps, integer=integer,
-                         symmetric=symmetric, prune=prune)
+                 prune=_None):
+        kwargs = {
+            'steps': steps,
+            'integer': integer,
+            'symmetric': symmetric,
+            'prune': prune
+        }
+        if prune == _None:
+            kwargs.pop('prune')
+        super().__init__(nbins, **kwargs)
         self.create_dummy_axis()
 
     def __call__(self, v1, v2):


### PR DESCRIPTION
## PR Summary
We do not seem to use `prune` in any tests or examples, so it seems resonable to deprecate because:

- There's not loads of code to support this, but it's still a little bit of bloat on the already complex `MaxNLocator`
- It's easy enough for users to replicate the behaviour by simple indexing after the tick values are returned
- `prune` is not particularly new, dating back 14 years: https://github.com/matplotlib/matplotlib/commit/0c79ba3b9d1e4e90c49301e5bb7b5a8344a7639b

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
