### PR TITLE
Expire wx canvas param deprecation

### DIFF
--- a/doc/api/next_api_changes/behavior/25192-DS.rst
+++ b/doc/api/next_api_changes/behavior/25192-DS.rst
@@ -1,0 +1,4 @@
+``canvas`` argument now required for ``FigureFrameWx``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``FigureFrameWx`` now requires a keyword-only ``canvas`` argument
+when it is constructed.

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -902,7 +902,7 @@ class FigureCanvasWx(_FigureCanvasWxBase):
 
 
 class FigureFrameWx(wx.Frame):
-    def __init__(self, num, fig, *, canvas_class=None):
+    def __init__(self, num, fig, *, canvas_class):
         # On non-Windows platform, explicitly set the position - fix
         # positioning bug on some Linux platforms
         if wx.Platform == '__WXMSW__':
@@ -914,16 +914,7 @@ class FigureFrameWx(wx.Frame):
         _log.debug("%s - __init__()", type(self))
         _set_frame_icon(self)
 
-        # The parameter will become required after the deprecation elapses.
-        if canvas_class is not None:
-            self.canvas = canvas_class(self, -1, fig)
-        else:
-            _api.warn_deprecated(
-                "3.6", message="The canvas_class parameter will become "
-                "required after the deprecation period starting in Matplotlib "
-                "%(since)s elapses.")
-            self.canvas = self.get_canvas(fig)
-
+        self.canvas = canvas_class(self, -1, fig)
         # Auto-attaches itself to self.canvas.manager
         manager = FigureManagerWx(self.canvas, num, self)
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
