### PR TITLE
Add deprecation for setting data with non sequence type in `Line2D`

### DIFF
--- a/doc/api/next_api_changes/deprecations/25196-EP.rst
+++ b/doc/api/next_api_changes/deprecations/25196-EP.rst
@@ -1,0 +1,4 @@
+``Line2D``
+~~~~~~~~~~
+When creating a Line2D or using `.Line2D.set_xdata` and `.Line2D.set_ydata`,
+passing x/y data as non sequence is deprecated.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1274,7 +1274,14 @@ class Line2D(Artist):
         x : 1D array
         """
         if not np.iterable(x):
-            raise RuntimeError('x must be a sequence')
+            # When deprecation cycle is completed
+            # raise RuntimeError('x must be a sequence')
+            _api.warn_deprecated(
+                since=3.7,
+                message="Setting data with a non sequence type "
+                "is deprecated since %(since)s and will be "
+                "remove %(removal)s")
+            x = [x, ]
         self._xorig = copy.copy(x)
         self._invalidx = True
         self.stale = True
@@ -1288,7 +1295,14 @@ class Line2D(Artist):
         y : 1D array
         """
         if not np.iterable(y):
-            raise RuntimeError('y must be a sequence')
+            # When deprecation cycle is completed
+            # raise RuntimeError('y must be a sequence')
+            _api.warn_deprecated(
+                since=3.7,
+                message="Setting data with a non sequence type "
+                "is deprecated since %(since)s and will be "
+                "remove %(removal)s")
+            y = [y, ]
         self._yorig = copy.copy(y)
         self._invalidy = True
         self.stale = True

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -20,6 +20,7 @@ from matplotlib.path import Path
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
+from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 
 
 def test_segment_hits():
@@ -91,9 +92,12 @@ def test_invalid_line_data():
         mlines.Line2D([], 1)
 
     line = mlines.Line2D([], [])
-    with pytest.raises(RuntimeError, match='x must be'):
+    # when deprecation cycle is completed
+    # with pytest.raises(RuntimeError, match='x must be'):
+    with pytest.warns(MatplotlibDeprecationWarning):
         line.set_xdata(0)
-    with pytest.raises(RuntimeError, match='y must be'):
+    # with pytest.raises(RuntimeError, match='y must be'):
+    with pytest.warns(MatplotlibDeprecationWarning):
         line.set_ydata(0)
 
 


### PR DESCRIPTION
Follow up on https://github.com/matplotlib/matplotlib/pull/22329 to add a deprecation cycle for this API change and avoid breaking dependent libraries! :)

## PR Summary

The following will now raise a `MatplotlibDeprecationWarning` instead of `RuntimeError`:
```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
l = ax.axhline(y=0.5)
l.set_ydata(0.25)
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
