### PR TITLE
DOC: remove constrained_layout kwarg from examples

### DIFF
--- a/examples/axisartist/simple_axisartist1.py
+++ b/examples/axisartist/simple_axisartist1.py
@@ -18,7 +18,7 @@ import numpy as np
 
 from mpl_toolkits import axisartist
 
-fig = plt.figure(figsize=(6, 3), constrained_layout=True)
+fig = plt.figure(figsize=(6, 3), layout="constrained")
 # To construct axes of two different classes, we need to use gridspec (or
 # MATLAB-style add_subplot calls).
 gs = fig.add_gridspec(1, 2)

--- a/examples/images_contours_and_fields/contourf_demo.py
+++ b/examples/images_contours_and_fields/contourf_demo.py
@@ -40,7 +40,7 @@ Z[interior] = np.ma.masked
 # a good idea, because they don't occur on nice boundaries, but we do it here
 # for purposes of illustration.
 
-fig1, ax2 = plt.subplots(constrained_layout=True)
+fig1, ax2 = plt.subplots(layout='constrained')
 CS = ax2.contourf(X, Y, Z, 10, cmap=plt.cm.bone, origin=origin)
 
 # Note that in the following, we explicitly pass in a subset of the contour
@@ -66,7 +66,7 @@ cbar.add_lines(CS2)
 # Now make a contour plot with the levels specified, and with the colormap
 # generated automatically from a list of colors.
 
-fig2, ax2 = plt.subplots(constrained_layout=True)
+fig2, ax2 = plt.subplots(layout='constrained')
 levels = [-1.5, -1, -0.5, 0, 0.5, 1]
 CS3 = ax2.contourf(X, Y, Z, levels,
                    colors=('r', 'g', 'b'),
@@ -101,7 +101,7 @@ cmap = plt.colormaps["winter"].with_extremes(under="magenta", over="yellow")
 # no effect:
 # cmap.set_bad("red")
 
-fig, axs = plt.subplots(2, 2, constrained_layout=True)
+fig, axs = plt.subplots(2, 2, layout="constrained")
 
 for ax, extend in zip(axs.flat, extends):
     cs = ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend, origin=origin)

--- a/examples/images_contours_and_fields/image_antialiasing.py
+++ b/examples/images_contours_and_fields/image_antialiasing.py
@@ -66,7 +66,7 @@ a = aa
 # original colormap, so it is no longer possible to invert individual
 # pixels back to their data value.
 
-fig, axs = plt.subplots(2, 2, figsize=(5, 6), constrained_layout=True)
+fig, axs = plt.subplots(2, 2, figsize=(5, 6), layout='constrained')
 axs[0, 0].imshow(a, interpolation='nearest', cmap='RdBu_r')
 axs[0, 0].set_xlim(100, 200)
 axs[0, 0].set_ylim(275, 175)
@@ -104,7 +104,7 @@ plt.show()
 # Apart from the default 'hanning' antialiasing, `~.Axes.imshow` supports a
 # number of different interpolation algorithms, which may work better or
 # worse depending on the pattern.
-fig, axs = plt.subplots(1, 2, figsize=(7, 4), constrained_layout=True)
+fig, axs = plt.subplots(1, 2, figsize=(7, 4), layout='constrained')
 for ax, interp in zip(axs, ['hanning', 'lanczos']):
     ax.imshow(a, interpolation=interp, cmap='gray')
     ax.set_title(f"interpolation='{interp}'")

--- a/examples/images_contours_and_fields/image_nonuniform.py
+++ b/examples/images_contours_and_fields/image_nonuniform.py
@@ -26,7 +26,7 @@ y = np.linspace(-4, 4, 9)
 
 z = np.sqrt(x[np.newaxis, :]**2 + y[:, np.newaxis]**2)
 
-fig, axs = plt.subplots(nrows=2, ncols=2, constrained_layout=True)
+fig, axs = plt.subplots(nrows=2, ncols=2, layout='constrained')
 fig.suptitle('NonUniformImage class', fontsize='large')
 ax = axs[0, 0]
 im = NonUniformImage(ax, interpolation=interp, extent=(-4, 4, -4, 4),

--- a/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -89,7 +89,7 @@ _annotate(ax, x, y, "shading='nearest'")
 # to use, in this case ``shading='auto'`` will decide whether to use 'flat' or
 # 'nearest' shading based on the shapes of *X*, *Y* and *Z*.
 
-fig, axs = plt.subplots(2, 1, constrained_layout=True)
+fig, axs = plt.subplots(2, 1, layout='constrained')
 ax = axs[0]
 x = np.arange(ncols)
 y = np.arange(nrows)
@@ -110,7 +110,7 @@ _annotate(ax, x, y, "shading='auto'; X, Y one larger than Z (flat)")
 # be specified, where the color in the quadrilaterals is linearly interpolated
 # between the grid points.  The shapes of *X*, *Y*, *Z* must be the same.
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 x = np.arange(ncols)
 y = np.arange(nrows)
 ax.pcolormesh(x, y, Z, shading='gouraud', vmin=Z.min(), vmax=Z.max())

--- a/examples/lines_bars_and_markers/barchart.py
+++ b/examples/lines_bars_and_markers/barchart.py
@@ -23,7 +23,7 @@ x = np.arange(len(species))  # the label locations
 width = 0.25  # the width of the bars
 multiplier = 0
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 
 for attribute, measurement in penguin_means.items():
     offset = width * multiplier

--- a/examples/lines_bars_and_markers/curve_error_band.py
+++ b/examples/lines_bars_and_markers/curve_error_band.py
@@ -63,8 +63,7 @@ def draw_error_band(ax, x, y, err, **kwargs):
     ax.add_patch(PathPatch(path, **kwargs))
 
 
-axs = (plt.figure(constrained_layout=True)
-       .subplots(1, 2, sharex=True, sharey=True))
+_, axs = plt.subplots(1, 2, layout='constrained', sharex=True, sharey=True)
 errs = [
     (axs[0], "constant error", 0.05),
     (axs[1], "variable error", 0.05 * np.sin(2 * t) ** 2 + 0.04),

--- a/examples/lines_bars_and_markers/markevery_demo.py
+++ b/examples/lines_bars_and_markers/markevery_demo.py
@@ -44,7 +44,7 @@ y = np.sin(x) + 1.0 + delta
 # markevery with linear scales
 # ----------------------------
 
-fig, axs = plt.subplots(3, 3, figsize=(10, 6), constrained_layout=True)
+fig, axs = plt.subplots(3, 3, figsize=(10, 6), layout='constrained')
 for ax, markevery in zip(axs.flat, cases):
     ax.set_title(f'markevery={markevery}')
     ax.plot(x, y, 'o', ls='-', ms=4, markevery=markevery)
@@ -58,7 +58,7 @@ for ax, markevery in zip(axs.flat, cases):
 # fraction of figure size creates even distributions, because it's based on
 # fractions of the Axes diagonal, not on data coordinates or data indices.
 
-fig, axs = plt.subplots(3, 3, figsize=(10, 6), constrained_layout=True)
+fig, axs = plt.subplots(3, 3, figsize=(10, 6), layout='constrained')
 for ax, markevery in zip(axs.flat, cases):
     ax.set_title(f'markevery={markevery}')
     ax.set_xscale('log')
@@ -75,7 +75,7 @@ for ax, markevery in zip(axs.flat, cases):
 # diagonal, it changes the displayed data range, and more points will be
 # displayed when zooming.
 
-fig, axs = plt.subplots(3, 3, figsize=(10, 6), constrained_layout=True)
+fig, axs = plt.subplots(3, 3, figsize=(10, 6), layout='constrained')
 for ax, markevery in zip(axs.flat, cases):
     ax.set_title(f'markevery={markevery}')
     ax.plot(x, y, 'o', ls='-', ms=4, markevery=markevery)
@@ -89,7 +89,7 @@ for ax, markevery in zip(axs.flat, cases):
 r = np.linspace(0, 3.0, 200)
 theta = 2 * np.pi * r
 
-fig, axs = plt.subplots(3, 3, figsize=(10, 6), constrained_layout=True,
+fig, axs = plt.subplots(3, 3, figsize=(10, 6), layout='constrained',
                         subplot_kw={'projection': 'polar'})
 for ax, markevery in zip(axs.flat, cases):
     ax.set_title(f'markevery={markevery}')

--- a/examples/lines_bars_and_markers/psd_demo.py
+++ b/examples/lines_bars_and_markers/psd_demo.py
@@ -112,7 +112,7 @@ f = np.array([150, 140]).reshape(-1, 1)
 xn = (A * np.sin(2 * np.pi * f * t)).sum(axis=0)
 xn += 5 * np.random.randn(*t.shape)
 
-fig, (ax0, ax1) = plt.subplots(ncols=2, constrained_layout=True)
+fig, (ax0, ax1) = plt.subplots(ncols=2, layout='constrained')
 
 yticks = np.arange(-50, 30, 10)
 yrange = (yticks[0], yticks[-1])
@@ -152,7 +152,7 @@ A = np.array([2, 8]).reshape(-1, 1)
 f = np.array([150, 140]).reshape(-1, 1)
 xn = (A * np.exp(2j * np.pi * f * t)).sum(axis=0) + 5 * prng.randn(*t.shape)
 
-fig, (ax0, ax1) = plt.subplots(ncols=2, constrained_layout=True)
+fig, (ax0, ax1) = plt.subplots(ncols=2, layout='constrained')
 
 yticks = np.arange(-50, 30, 10)
 yrange = (yticks[0], yticks[-1])

--- a/examples/lines_bars_and_markers/scatter_hist.py
+++ b/examples/lines_bars_and_markers/scatter_hist.py
@@ -89,7 +89,7 @@ scatter_hist(x, y, ax, ax_histx, ax_histy)
 # of the axes.
 
 # Create a Figure, which doesn't have to be square.
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout='constrained')
 # Create the main axes, leaving 25% of the figure space at the top and on the
 # right to position marginals.
 ax = fig.add_gridspec(top=0.75, right=0.75).subplots()

--- a/examples/lines_bars_and_markers/timeline.py
+++ b/examples/lines_bars_and_markers/timeline.py
@@ -70,7 +70,7 @@ levels = np.tile([-5, 5, -3, 3, -1, 1],
                  int(np.ceil(len(dates)/6)))[:len(dates)]
 
 # Create figure and plot a stem plot with the date
-fig, ax = plt.subplots(figsize=(8.8, 4), constrained_layout=True)
+fig, ax = plt.subplots(figsize=(8.8, 4), layout="constrained")
 ax.set(title="Matplotlib release dates")
 
 ax.vlines(dates, 0, levels, color="tab:red")  # The vertical stems.

--- a/examples/misc/rasterization_demo.py
+++ b/examples/misc/rasterization_demo.py
@@ -44,7 +44,7 @@ theta = 0.25*np.pi
 xx = x*np.cos(theta) - y*np.sin(theta)  # rotate x by -theta
 yy = x*np.sin(theta) + y*np.cos(theta)  # rotate y by -theta
 
-fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, constrained_layout=True)
+fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2, layout="constrained")
 
 # pcolormesh without rasterization
 ax1.set_aspect(1)

--- a/examples/scales/asinh_demo.py
+++ b/examples/scales/asinh_demo.py
@@ -65,7 +65,7 @@ ax1.set_title('asinh')
 
 # %%
 # Compare "asinh" graphs with different scale parameter "linear_width":
-fig2 = plt.figure(constrained_layout=True)
+fig2 = plt.figure(layout='constrained')
 axs = fig2.subplots(1, 3, sharex=True)
 for ax, (a0, base) in zip(axs, ((0.2, 2), (1.0, 0), (5.0, 10))):
     ax.set_title(f'linear_width={a0:.3g}')

--- a/examples/scales/scales.py
+++ b/examples/scales/scales.py
@@ -24,8 +24,7 @@ y.sort()
 x = np.arange(len(y))
 
 # plot with various axes scales
-fig, axs = plt.subplots(3, 2, figsize=(6, 8),
-                        constrained_layout=True)
+fig, axs = plt.subplots(3, 2, figsize=(6, 8), layout='constrained')
 
 # linear
 ax = axs[0, 0]

--- a/examples/shapes_and_collections/hatch_style_reference.py
+++ b/examples/shapes_and_collections/hatch_style_reference.py
@@ -17,7 +17,7 @@ import matplotlib.pyplot as plt
 
 from matplotlib.patches import Rectangle
 
-fig, axs = plt.subplots(2, 5, constrained_layout=True, figsize=(6.4, 3.2))
+fig, axs = plt.subplots(2, 5, layout='constrained', figsize=(6.4, 3.2))
 
 hatches = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
 
@@ -34,7 +34,7 @@ for ax, h in zip(axs.flat, hatches):
 # %%
 # Hatching patterns can be repeated to increase the density.
 
-fig, axs = plt.subplots(2, 5, constrained_layout=True, figsize=(6.4, 3.2))
+fig, axs = plt.subplots(2, 5, layout='constrained', figsize=(6.4, 3.2))
 
 hatches = ['//', '\\\\', '||', '--', '++', 'xx', 'oo', 'OO', '..', '**']
 
@@ -44,7 +44,7 @@ for ax, h in zip(axs.flat, hatches):
 # %%
 # Hatching patterns can be combined to create additional patterns.
 
-fig, axs = plt.subplots(2, 5, constrained_layout=True, figsize=(6.4, 3.2))
+fig, axs = plt.subplots(2, 5, layout='constrained', figsize=(6.4, 3.2))
 
 hatches = ['/o', '\\|', '|*', '-\\', '+o', 'x*', 'o-', 'O|', 'O.', '*-']
 

--- a/examples/spines/spines.py
+++ b/examples/spines/spines.py
@@ -22,7 +22,7 @@ x = np.linspace(0, 2 * np.pi, 100)
 y = 2 * np.sin(x)
 
 # Constrained layout makes sure the labels don't overlap the axes.
-fig, (ax0, ax1, ax2) = plt.subplots(nrows=3, constrained_layout=True)
+fig, (ax0, ax1, ax2) = plt.subplots(nrows=3, layout='constrained')
 
 ax0.plot(x, y)
 ax0.set_title('normal spines')

--- a/examples/statistics/barchart_demo.py
+++ b/examples/statistics/barchart_demo.py
@@ -45,7 +45,7 @@ def format_score(score):
 
 
 def plot_student_results(student, scores_by_test, cohort_size):
-    fig, ax1 = plt.subplots(figsize=(9, 7), constrained_layout=True)
+    fig, ax1 = plt.subplots(figsize=(9, 7), layout='constrained')
     fig.canvas.manager.set_window_title('Eldorado K-8 Fitness Chart')
 
     ax1.set_title(student.name)

--- a/examples/statistics/time_series_histogram.py
+++ b/examples/statistics/time_series_histogram.py
@@ -32,7 +32,7 @@ import numpy.matlib
 
 from matplotlib.colors import LogNorm
 
-fig, axes = plt.subplots(nrows=3, figsize=(6, 8), constrained_layout=True)
+fig, axes = plt.subplots(nrows=3, figsize=(6, 8), layout='constrained')
 
 # Make some data; a 1D random walk + small fraction of sine waves
 num_series = 1000

--- a/examples/style_sheets/style_sheets_reference.py
+++ b/examples/style_sheets/style_sheets_reference.py
@@ -117,7 +117,7 @@ def plot_figure(style_label=""):
     prng = np.random.RandomState(96917002)
 
     fig, axs = plt.subplots(ncols=6, nrows=1, num=style_label,
-                            figsize=(14.8, 2.8), constrained_layout=True)
+                            figsize=(14.8, 2.8), layout='constrained')
 
     # make a suptitle, in the same style for all subfigures,
     # except those with dark backgrounds, which get a lighter color:

--- a/examples/subplots_axes_and_figures/axes_box_aspect.py
+++ b/examples/subplots_axes_and_figures/axes_box_aspect.py
@@ -74,10 +74,10 @@ plt.show()
 # height. `~.Axes.set_box_aspect` provides an easy solution to that by allowing
 # to have the normal plot's axes use the images dimensions as box aspect.
 #
-# This example also shows that ``constrained_layout`` interplays nicely with
+# This example also shows that *constrained layout* interplays nicely with
 # a fixed box aspect.
 
-fig4, (ax, ax2) = plt.subplots(ncols=2, constrained_layout=True)
+fig4, (ax, ax2) = plt.subplots(ncols=2, layout="constrained")
 
 np.random.seed(19680801)  # Fixing random state for reproducibility
 im = np.random.rand(16, 27)
@@ -139,7 +139,7 @@ plt.show()
 # following creates a 2 by 3 subplot grid with all square Axes.
 
 fig7, axs = plt.subplots(2, 3, subplot_kw=dict(box_aspect=1),
-                         sharex=True, sharey=True, constrained_layout=True)
+                         sharex=True, sharey=True, layout="constrained")
 
 for i, ax in enumerate(axs.flat):
     ax.scatter(i % 3, -((i // 3) - 0.5)*200, c=[plt.cm.hsv(i / 6)], s=300)

--- a/examples/subplots_axes_and_figures/colorbar_placement.py
+++ b/examples/subplots_axes_and_figures/colorbar_placement.py
@@ -42,9 +42,9 @@ for col in range(2):
 # %%
 # Relatively complicated colorbar layouts are possible using this
 # paradigm.  Note that this example works far better with
-# ``constrained_layout=True``
+# ``layout='constrained'``
 
-fig, axs = plt.subplots(3, 3, constrained_layout=True)
+fig, axs = plt.subplots(3, 3, layout='constrained')
 for ax in axs.flat:
     pcm = ax.pcolormesh(np.random.random((20, 20)))
 
@@ -60,7 +60,7 @@ fig.colorbar(pcm, ax=[axs[2, 1]], location='left')
 # Placing colorbars for axes with a fixed aspect ratio pose a particular
 # challenge as the parent axes changes size depending on the data view.
 
-fig, axs = plt.subplots(2, 2,  constrained_layout=True)
+fig, axs = plt.subplots(2, 2,  layout='constrained')
 cmaps = ['RdBu_r', 'viridis']
 for col in range(2):
     for row in range(2):
@@ -79,7 +79,7 @@ for col in range(2):
 # axes in axes coordinates.  Note that if you zoom in on the axes, and
 # change the shape of the axes, the colorbar will also change position.
 
-fig, axs = plt.subplots(2, 2, constrained_layout=True)
+fig, axs = plt.subplots(2, 2, layout='constrained')
 cmaps = ['RdBu_r', 'viridis']
 for col in range(2):
     for row in range(2):

--- a/examples/subplots_axes_and_figures/demo_constrained_layout.py
+++ b/examples/subplots_axes_and_figures/demo_constrained_layout.py
@@ -3,7 +3,7 @@
 Resizing axes with constrained layout
 =====================================
 
-Constrained layout attempts to resize subplots in
+*Constrained layout* attempts to resize subplots in
 a figure so that there are no overlaps between axes objects and labels
 on the axes.
 
@@ -23,17 +23,17 @@ def example_plot(ax):
 
 
 # %%
-# If we don't use constrained_layout, then labels overlap the axes
+# If we don't use *constrained layout*, then labels overlap the axes
 
-fig, axs = plt.subplots(nrows=2, ncols=2, constrained_layout=False)
+fig, axs = plt.subplots(nrows=2, ncols=2, layout=None)
 
 for ax in axs.flat:
     example_plot(ax)
 
 # %%
-# adding ``constrained_layout=True`` automatically adjusts.
+# adding ``layout='constrained'`` automatically adjusts.
 
-fig, axs = plt.subplots(nrows=2, ncols=2, constrained_layout=True)
+fig, axs = plt.subplots(nrows=2, ncols=2, layout='constrained')
 
 for ax in axs.flat:
     example_plot(ax)
@@ -41,7 +41,7 @@ for ax in axs.flat:
 # %%
 # Below is a more complicated example using nested gridspecs.
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout='constrained')
 
 import matplotlib.gridspec as gridspec
 

--- a/examples/subplots_axes_and_figures/figure_title.py
+++ b/examples/subplots_axes_and_figures/figure_title.py
@@ -17,7 +17,7 @@ from matplotlib.cbook import get_sample_data
 
 x = np.linspace(0.0, 5.0, 501)
 
-fig, (ax1, ax2) = plt.subplots(1, 2, constrained_layout=True, sharey=True)
+fig, (ax1, ax2) = plt.subplots(1, 2, layout='constrained', sharey=True)
 ax1.plot(x, np.cos(6*x) * np.exp(-x))
 ax1.set_title('damped')
 ax1.set_xlabel('time (s)')
@@ -33,7 +33,7 @@ fig.suptitle('Different types of oscillations', fontsize=16)
 # A global x- or y-label can be set using the `.FigureBase.supxlabel` and
 # `.FigureBase.supylabel` methods.
 
-fig, axs = plt.subplots(3, 5, figsize=(8, 5), constrained_layout=True,
+fig, axs = plt.subplots(3, 5, figsize=(8, 5), layout='constrained',
                         sharex=True, sharey=True)
 
 fname = get_sample_data('percent_bachelors_degrees_women_usa.csv',

--- a/examples/subplots_axes_and_figures/gridspec_multicolumn.py
+++ b/examples/subplots_axes_and_figures/gridspec_multicolumn.py
@@ -18,7 +18,7 @@ def format_axes(fig):
         ax.text(0.5, 0.5, "ax%d" % (i+1), va="center", ha="center")
         ax.tick_params(labelbottom=False, labelleft=False)
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout="constrained")
 
 gs = GridSpec(3, 3, figure=fig)
 ax1 = fig.add_subplot(gs[0, :])

--- a/examples/subplots_axes_and_figures/mosaic.py
+++ b/examples/subplots_axes_and_figures/mosaic.py
@@ -60,7 +60,7 @@ np.random.seed(19680801)
 hist_data = np.random.randn(1_500)
 
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout="constrained")
 ax_array = fig.subplots(2, 2, squeeze=False)
 
 ax_array[0, 0].bar(["a", "b", "c"], [5, 7, 9])
@@ -76,7 +76,7 @@ identify_axes(
 # Using `.Figure.subplot_mosaic` we can produce the same mosaic but give the
 # axes semantic names
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout="constrained")
 ax_dict = fig.subplot_mosaic(
     [
         ["bar", "plot"],
@@ -116,7 +116,7 @@ mosaic = """
 # figure mosaic as above (but now labeled with ``{"A", "B", "C",
 # "D"}`` rather than ``{"bar", "plot", "hist", "image"}``).
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout="constrained")
 ax_dict = fig.subplot_mosaic(mosaic)
 identify_axes(ax_dict)
 
@@ -128,7 +128,7 @@ mosaic = "AB;CD"
 # will give you the same composition, where the ``";"`` is used
 # as the row separator instead of newline.
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout="constrained")
 ax_dict = fig.subplot_mosaic(mosaic)
 identify_axes(ax_dict)
 
@@ -145,7 +145,7 @@ identify_axes(ax_dict)
 # If we want to re-arrange our four Axes to have ``"C"`` be a horizontal
 # span on the bottom and ``"D"`` be a vertical span on the right we would do
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     """
     ABD
     CCD
@@ -158,7 +158,7 @@ identify_axes(axd)
 # we can specify some spaces in the grid to be blank
 
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     """
     A.C
     BBB
@@ -173,7 +173,7 @@ identify_axes(axd)
 # to mark the empty space, we can use *empty_sentinel* to specify the
 # character to use.
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     """
     aX
     Xb
@@ -188,7 +188,7 @@ identify_axes(axd)
 # Internally there is no meaning attached to the letters we use, any
 # Unicode code point is valid!
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     """αб
        ℝ☢"""
 )
@@ -212,7 +212,7 @@ identify_axes(axd)
 # `.Figure.subplot_mosaic` calling sequence.
 
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     """
     .a.
     bAc
@@ -265,7 +265,7 @@ identify_axes(axd)
 
 mosaic = """AA
             BC"""
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout="constrained")
 left, right = fig.subfigures(nrows=1, ncols=2)
 axd = left.subplot_mosaic(mosaic)
 identify_axes(axd)
@@ -283,7 +283,7 @@ identify_axes(axd)
 # of the Axes created.
 
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     "AB", subplot_kw={"projection": "polar"}
 )
 identify_axes(axd)
@@ -330,7 +330,7 @@ identify_axes(axd)
 # merged with *per_subplot_kw* taking priority:
 
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     "AB;CD",
     subplot_kw={"facecolor": "xkcd:tangerine"},
     per_subplot_kw={
@@ -349,7 +349,7 @@ identify_axes(axd)
 # passing in a list (internally we convert the string shorthand to a nested
 # list), for example using spans, blanks, and *gridspec_kw*:
 
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     [
         ["main", "zoom"],
         ["main", "BLANK"],
@@ -373,7 +373,7 @@ outer_nested_mosaic = [
     ["main", inner],
     ["bottom", "bottom"],
 ]
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     outer_nested_mosaic, empty_sentinel=None
 )
 identify_axes(axd, fontsize=36)
@@ -384,7 +384,7 @@ identify_axes(axd, fontsize=36)
 mosaic = np.zeros((4, 4), dtype=int)
 for j in range(4):
     mosaic[j, j] = j + 1
-axd = plt.figure(constrained_layout=True).subplot_mosaic(
+axd = plt.figure(layout="constrained").subplot_mosaic(
     mosaic,
     empty_sentinel=0,
 )

--- a/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/examples/subplots_axes_and_figures/secondary_axis.py
@@ -19,7 +19,7 @@ import numpy as np
 import matplotlib.dates as mdates
 from matplotlib.ticker import AutoMinorLocator
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 x = np.arange(0, 360, 1)
 y = np.sin(2 * x * np.pi / 180)
 ax.plot(x, y)
@@ -49,7 +49,7 @@ plt.show()
 #   In this case, the xscale of the parent is logarithmic, so the child is
 #   made logarithmic as well.
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 x = np.arange(0.02, 1, 0.02)
 np.random.seed(19680801)
 y = np.random.randn(len(x)) ** 2
@@ -93,7 +93,7 @@ plt.show()
 #   arguments *left*, *right* such that values outside the data range are
 #   mapped well outside the plot limits.
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 xdata = np.arange(1, 11, 0.4)
 ydata = np.random.randn(len(xdata))
 ax.plot(xdata, ydata, label='Plotted data')
@@ -131,7 +131,7 @@ plt.show()
 dates = [datetime.datetime(2018, 1, 1) + datetime.timedelta(hours=k * 6)
          for k in range(240)]
 temperature = np.random.randn(len(dates)) * 4 + 6.7
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 
 ax.plot(dates, temperature)
 ax.set_ylabel(r'$T\ [^oC]$')

--- a/examples/subplots_axes_and_figures/subfigures.py
+++ b/examples/subplots_axes_and_figures/subfigures.py
@@ -31,7 +31,7 @@ def example_plot(ax, fontsize=12, hide_labels=False):
 
 np.random.seed(19680808)
 # gridspec inside gridspec
-fig = plt.figure(constrained_layout=True, figsize=(10, 4))
+fig = plt.figure(layout='constrained', figsize=(10, 4))
 subfigs = fig.subfigures(1, 2, wspace=0.07)
 
 axsLeft = subfigs[0].subplots(1, 2, sharey=True)
@@ -62,7 +62,7 @@ plt.show()
 # `matplotlib.figure.Figure.add_subfigure`.  This requires getting
 # the gridspec that the subplots are laid out on.
 
-fig, axs = plt.subplots(2, 3, constrained_layout=True, figsize=(10, 4))
+fig, axs = plt.subplots(2, 3, layout='constrained', figsize=(10, 4))
 gridspec = axs[0, 0].get_subplotspec().get_gridspec()
 
 # clear the left column for the subfigure:
@@ -90,7 +90,7 @@ plt.show()
 # Subfigures can have different widths and heights.  This is exactly the
 # same example as the first example, but *width_ratios* has been changed:
 
-fig = plt.figure(constrained_layout=True, figsize=(10, 4))
+fig = plt.figure(layout='constrained', figsize=(10, 4))
 subfigs = fig.subfigures(1, 2, wspace=0.07, width_ratios=[2, 1])
 
 axsLeft = subfigs[0].subplots(1, 2, sharey=True)
@@ -119,7 +119,7 @@ plt.show()
 # %%
 # Subfigures can be also be nested:
 
-fig = plt.figure(constrained_layout=True, figsize=(10, 8))
+fig = plt.figure(layout='constrained', figsize=(10, 8))
 
 fig.suptitle('fig')
 

--- a/examples/text_labels_and_annotations/arrow_demo.py
+++ b/examples/text_labels_and_annotations/arrow_demo.py
@@ -148,7 +148,7 @@ if __name__ == '__main__':
     }
 
     size = 4
-    fig = plt.figure(figsize=(3 * size, size), constrained_layout=True)
+    fig = plt.figure(figsize=(3 * size, size), layout="constrained")
     axs = fig.subplot_mosaic([["length", "width", "alpha"]])
 
     for display, ax in axs.items():

--- a/examples/text_labels_and_annotations/date.py
+++ b/examples/text_labels_and_annotations/date.py
@@ -33,7 +33,7 @@ import matplotlib.dates as mdates
 # the date column.
 data = cbook.get_sample_data('goog.npz', np_load=True)['price_data']
 
-fig, axs = plt.subplots(3, 1, figsize=(6.4, 7), constrained_layout=True)
+fig, axs = plt.subplots(3, 1, figsize=(6.4, 7), layout='constrained')
 # common to all three:
 for ax in axs:
     ax.plot('date', 'adj_close', data=data)

--- a/examples/text_labels_and_annotations/figlegend_demo.py
+++ b/examples/text_labels_and_annotations/figlegend_demo.py
@@ -31,8 +31,8 @@ plt.show()
 
 # %%
 # Sometimes we do not want the legend to overlap the axes.  If you use
-# constrained_layout you can specify "outside right upper", and
-# constrained_layout will make room for the legend.
+# *constrained layout* you can specify "outside right upper", and
+# *constrained layout* will make room for the legend.
 
 fig, axs = plt.subplots(1, 2, layout='constrained')
 

--- a/examples/text_labels_and_annotations/label_subplots.py
+++ b/examples/text_labels_and_annotations/label_subplots.py
@@ -18,7 +18,7 @@ import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 
 fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
-                              constrained_layout=True)
+                              layout='constrained')
 
 for label, ax in axs.items():
     # label physical distance in and down:
@@ -34,7 +34,7 @@ plt.show()
 # with each other, in which case we use a slightly different transform:
 
 fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
-                              constrained_layout=True)
+                              layout='constrained')
 
 for label, ax in axs.items():
     # label physical distance to the left and up:
@@ -49,7 +49,7 @@ plt.show()
 # use the *loc* keyword argument:
 
 fig, axs = plt.subplot_mosaic([['a)', 'c)'], ['b)', 'c)'], ['d)', 'd)']],
-                              constrained_layout=True)
+                              layout='constrained')
 
 for label, ax in axs.items():
     ax.set_title('Normal Title', fontstyle='italic')

--- a/examples/text_labels_and_annotations/legend_demo.py
+++ b/examples/text_labels_and_annotations/legend_demo.py
@@ -64,7 +64,7 @@ plt.show()
 # %%
 # Here we attach legends to more complex plots.
 
-fig, axs = plt.subplots(3, 1, constrained_layout=True)
+fig, axs = plt.subplots(3, 1, layout="constrained")
 top_ax, middle_ax, bottom_ax = axs
 
 top_ax.bar([0, 1, 2], [0.2, 0.3, 0.1], width=0.4, label="Bar 1",
@@ -87,7 +87,7 @@ plt.show()
 # %%
 # Now we'll showcase legend entries with more than one legend key.
 
-fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True)
+fig, (ax1, ax2) = plt.subplots(2, 1, layout='constrained')
 
 # First plot: two legend keys for a single entry
 p1 = ax1.scatter([1], [5], c='r', marker='s', s=100)

--- a/examples/text_labels_and_annotations/titles_demo.py
+++ b/examples/text_labels_and_annotations/titles_demo.py
@@ -21,7 +21,7 @@ plt.show()
 # The vertical position is automatically chosen to avoid decorations
 # (i.e. labels and ticks) on the topmost x-axis:
 
-fig, axs = plt.subplots(1, 2, constrained_layout=True)
+fig, axs = plt.subplots(1, 2, layout='constrained')
 
 ax = axs[0]
 ax.plot(range(10))
@@ -41,7 +41,7 @@ plt.show()
 # Automatic positioning can be turned off by manually specifying the *y*
 # keyword argument for the title or setting :rc:`axes.titley` in the rcParams.
 
-fig, axs = plt.subplots(1, 2, constrained_layout=True)
+fig, axs = plt.subplots(1, 2, layout='constrained')
 
 ax = axs[0]
 ax.plot(range(10))

--- a/examples/ticks/date_concise_formatter.py
+++ b/examples/ticks/date_concise_formatter.py
@@ -31,7 +31,7 @@ N = len(dates)
 np.random.seed(19680801)
 y = np.cumsum(np.random.randn(N))
 
-fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+fig, axs = plt.subplots(3, 1, layout='constrained', figsize=(6, 6))
 lims = [(np.datetime64('2005-02'), np.datetime64('2005-04')),
         (np.datetime64('2005-02-03'), np.datetime64('2005-02-15')),
         (np.datetime64('2005-02-03 11:00'), np.datetime64('2005-02-04 13:20'))]
@@ -51,7 +51,7 @@ plt.show()
 # for this example the labels do not need to be rotated as they do for the
 # default formatter because the labels are as small as possible.
 
-fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+fig, axs = plt.subplots(3, 1, layout='constrained', figsize=(6, 6))
 for nn, ax in enumerate(axs):
     locator = mdates.AutoDateLocator(minticks=3, maxticks=7)
     formatter = mdates.ConciseDateFormatter(locator)
@@ -76,7 +76,7 @@ munits.registry[np.datetime64] = converter
 munits.registry[datetime.date] = converter
 munits.registry[datetime.datetime] = converter
 
-fig, axs = plt.subplots(3, 1, figsize=(6, 6), constrained_layout=True)
+fig, axs = plt.subplots(3, 1, figsize=(6, 6), layout='constrained')
 for nn, ax in enumerate(axs):
     ax.plot(dates, y)
     ax.set_xlim(lims[nn])
@@ -109,7 +109,7 @@ plt.show()
 # Here we modify the labels to be "day month year", instead of the ISO
 # "year month day":
 
-fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+fig, axs = plt.subplots(3, 1, layout='constrained', figsize=(6, 6))
 
 for nn, ax in enumerate(axs):
     locator = mdates.AutoDateLocator()
@@ -175,7 +175,7 @@ munits.registry[np.datetime64] = converter
 munits.registry[datetime.date] = converter
 munits.registry[datetime.datetime] = converter
 
-fig, axs = plt.subplots(3, 1, constrained_layout=True, figsize=(6, 6))
+fig, axs = plt.subplots(3, 1, layout='constrained', figsize=(6, 6))
 for nn, ax in enumerate(axs):
     ax.plot(dates, y)
     ax.set_xlim(lims[nn])

--- a/examples/ticks/date_index_formatter.py
+++ b/examples/ticks/date_index_formatter.py
@@ -25,12 +25,11 @@ from matplotlib.ticker import Formatter
 # low, close, volume, adj_close from the mpl-data/sample_data directory. The
 # record array stores the date as an np.datetime64 with a day unit ('D') in
 # the date column (``r.date``).
-r = (cbook.get_sample_data('goog.npz', np_load=True)['price_data']
-     .view(np.recarray))
+r = cbook.get_sample_data('goog.npz', np_load=True)['price_data'].view(np.recarray)
 r = r[:9]  # get the first 9 days
 
-fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(6, 6),
-                               constrained_layout={'hspace': .15})
+fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(6, 6), layout='constrained')
+fig.get_layout_engine().set(hspace=0.15)
 
 # First we'll do it the default way, with gaps on weekends
 ax1.plot(r.date, r.adj_close, 'o-')

--- a/examples/ticks/date_precision_and_epochs.py
+++ b/examples/ticks/date_precision_and_epochs.py
@@ -129,7 +129,7 @@ y = np.arange(0, len(x))
 _reset_epoch_for_tutorial()  # Don't do this.  Just for this tutorial.
 mdates.set_epoch(new_epoch)
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 ax.plot(xold, y)
 ax.set_title('Epoch: ' + mdates.get_epoch())
 ax.xaxis.set_tick_params(rotation=40)
@@ -138,7 +138,7 @@ plt.show()
 # %%
 # For dates plotted using the more recent epoch, the plot is smooth:
 
-fig, ax = plt.subplots(constrained_layout=True)
+fig, ax = plt.subplots(layout='constrained')
 ax.plot(x, y)
 ax.set_title('Epoch: ' + mdates.get_epoch())
 ax.xaxis.set_tick_params(rotation=40)

--- a/examples/ticks/ticks_too_many.py
+++ b/examples/ticks/ticks_too_many.py
@@ -21,7 +21,7 @@ a numeric type as in the following examples.
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2.5))
+fig, ax = plt.subplots(1, 2, layout='constrained', figsize=(6, 2.5))
 x = ['1', '5', '2', '3']
 y = [1, 4, 2, 3]
 ax[0].plot(x, y, 'd')
@@ -60,7 +60,7 @@ ax[1].set_xlabel('Floats')
 # converted from strings to datetime objects to get the proper date locators
 # and formatters.
 
-fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2.75))
+fig, ax = plt.subplots(1, 2, layout='constrained', figsize=(6, 2.75))
 x = ['2021-10-01', '2021-11-02', '2021-12-03', '2021-09-01']
 y = [0, 2, 3, 1]
 ax[0].plot(x, y, 'd')

--- a/examples/units/units_sample.py
+++ b/examples/units/units_sample.py
@@ -20,7 +20,7 @@ import numpy as np
 
 cms = cm * np.arange(0, 10, 2)
 
-fig, axs = plt.subplots(2, 2, constrained_layout=True)
+fig, axs = plt.subplots(2, 2, layout='constrained')
 
 axs[0, 0].plot(cms, cms)
 

--- a/examples/user_interfaces/gtk4_spreadsheet_sgskip.py
+++ b/examples/user_interfaces/gtk4_spreadsheet_sgskip.py
@@ -50,7 +50,7 @@ class DataManager(Gtk.ApplicationWindow):
         sw.set_child(self.treeview)
 
         # Matplotlib stuff
-        fig = Figure(figsize=(6, 4), constrained_layout=True)
+        fig = Figure(figsize=(6, 4), layout='constrained')
 
         self.canvas = FigureCanvas(fig)  # a Gtk.DrawingArea
         self.canvas.set_hexpand(True)

--- a/examples/userdemo/connectionstyle_demo.py
+++ b/examples/userdemo/connectionstyle_demo.py
@@ -30,7 +30,7 @@ def demo_con_style(ax, connectionstyle):
             transform=ax.transAxes, ha="left", va="top")
 
 
-fig, axs = plt.subplots(3, 5, figsize=(7, 6.3), constrained_layout=True)
+fig, axs = plt.subplots(3, 5, figsize=(7, 6.3), layout="constrained")
 demo_con_style(axs[0, 0], "angle3,angleA=90,angleB=0")
 demo_con_style(axs[1, 0], "angle3,angleA=0,angleB=90")
 demo_con_style(axs[0, 1], "arc3,rad=0.")

--- a/examples/widgets/rectangle_selector.py
+++ b/examples/widgets/rectangle_selector.py
@@ -41,7 +41,7 @@ def toggle_selector(event):
                 selector.set_active(True)
 
 
-fig = plt.figure(constrained_layout=True)
+fig = plt.figure(layout='constrained')
 axs = fig.subplots(2)
 
 N = 100000  # If N is large one can see improvement by using blitting.


### PR DESCRIPTION
## PR Summary

The form `constrained_layout=True` is discouraged in the relevant [docstrings](https://matplotlib.org/devdocs/api/figure_api.html#matplotlib.figure.Figure) since v3.5 (#19892), but is still used across the examples.  This PR updates the examples with the preferred form.  For the strings, I tried to choose single vs double quotes to be consistent with any strings on nearby lines.  Also puts instances of the phrase "constrained layout" in italics, consistent with the decision for the constrained layout tutorial at #25144.

The tutorials and user guide also have `constrained_layout=True` in places, but I think that can be a separate PR.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
