### PR TITLE
Add mpl_round_to_int

### DIFF
--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -780,10 +780,10 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
         if (gc.cliprect.x1 != 0.0 || gc.cliprect.y1 != 0.0 || gc.cliprect.x2 != 0.0 || gc.cliprect.y2 != 0.0) {
             agg::rect_i clip;
 
-            clip.init(int(mpl_round(gc.cliprect.x1)),
-                      int(mpl_round(height - gc.cliprect.y2)),
-                      int(mpl_round(gc.cliprect.x2)),
-                      int(mpl_round(height - gc.cliprect.y1)));
+            clip.init(mpl_round_to_int(gc.cliprect.x1),
+                      mpl_round_to_int(height - gc.cliprect.y2),
+                      mpl_round_to_int(gc.cliprect.x2),
+                      mpl_round_to_int(height - gc.cliprect.y1));
             text.clip(clip);
         }
 

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -29,9 +29,14 @@
 #endif
 
 
+inline int mpl_round_to_int(double v)
+{
+    return (int)(v + ((v >= 0.0) ? 0.5 : -0.5));
+}
+
 inline double mpl_round(double v)
 {
-    return (double)(int)(v + ((v >= 0.0) ? 0.5 : -0.5));
+    return (double)mpl_round_to_int(v);
 }
 
 // 'kind' codes for paths.

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -595,7 +595,7 @@ class PathSnapper
         m_snap = should_snap(source, snap_mode, total_vertices);
 
         if (m_snap) {
-            int is_odd = (int)mpl_round(stroke_width) % 2;
+            int is_odd = mpl_round_to_int(stroke_width) % 2;
             m_snap_value = (is_odd) ? 0.5 : 0.0;
         }
 


### PR DESCRIPTION
## PR Summary

Most uses of `mpl_round` is casting back to `int`, so better keep the result as `int`. It may be possible that the compiler realizes that `(int)(double)(int)` should be simplified to `(int)` though...

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
