### PR TITLE
Make sure Locators always return a tick out of bounds

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -44,7 +44,7 @@ class TestMaxNLocator:
 class TestLinearLocator:
     def test_basic(self):
         loc = mticker.LinearLocator(numticks=3)
-        test_value = np.array([-0.8, -0.3, 0.2])
+        test_value = np.array([-1.3, -0.8, -0.3, 0.2, 0.7])
         assert_almost_equal(loc.tick_values(-0.8, 0.2), test_value)
 
     def test_set_params(self):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -15,11 +15,13 @@ import matplotlib.ticker as mticker
 
 class TestMaxNLocator:
     basic_data = [
-        (20, 100, np.array([20., 40., 60., 80., 100.])),
-        (0.001, 0.0001, np.array([0., 0.0002, 0.0004, 0.0006, 0.0008, 0.001])),
-        (-1e15, 1e15, np.array([-1.0e+15, -5.0e+14, 0e+00, 5e+14, 1.0e+15])),
-        (0, 0.85e-50, np.arange(6) * 2e-51),
-        (-0.85e-50, 0, np.arange(-5, 1) * 2e-51),
+        # vmin, vmax, expected
+        (20, 100, np.array([0, 20., 40., 60., 80., 100., 120])),
+        (0.001, 0.0001, np.array([0., 0.0002, 0.0004, 0.0006, 0.0008, 0.001, 0.0012])),
+        (-1e15, 1e15,
+            np.array([-1.5e15, -1.0e+15, -5.0e+14, 0e+00, 5e+14, 1.0e+15, 1.5e15])),
+        (0, 0.85e-50, np.arange(-1, 6) * 2e-51),
+        (-0.85e-50, 0, np.arange(-5, 2) * 2e-51),
     ]
 
     integer_data = [
@@ -161,7 +163,7 @@ class TestAutoMinorLocator:
          9.50e-21, 1.05e-20, 1.10e-20],
         [5.00e-15, 1.00e-14, 1.50e-14, 2.50e-14, 3.00e-14, 3.50e-14, 4.50e-14,
          5.00e-14, 5.50e-14, 6.50e-14, 7.00e-14, 7.50e-14, 8.50e-14, 9.00e-14,
-         9.50e-14, 1.05e-13, 1.10e-13],
+         9.50e-14, 1.05e-13, 1.10e-13, 1.15e-13],
         [-1.95e-07, -1.90e-07, -1.85e-07, -1.75e-07, -1.70e-07, -1.65e-07,
          -1.55e-07, -1.50e-07, -1.45e-07, -1.35e-07, -1.30e-07, -1.25e-07,
          -1.15e-07, -1.10e-07, -1.05e-07, -9.50e-08, -9.00e-08, -8.50e-08,
@@ -169,7 +171,7 @@ class TestAutoMinorLocator:
          -3.50e-08],
         [1.21e-06, 1.22e-06, 1.23e-06, 1.24e-06, 1.26e-06, 1.27e-06, 1.28e-06,
          1.29e-06, 1.31e-06, 1.32e-06, 1.33e-06, 1.34e-06, 1.36e-06, 1.37e-06,
-         1.38e-06, 1.39e-06, 1.41e-06, 1.42e-06],
+         1.38e-06, 1.39e-06, 1.41e-06, 1.42e-06, 1.43e-06],
         [-1.435e-06, -1.430e-06, -1.425e-06, -1.415e-06, -1.410e-06,
          -1.405e-06, -1.395e-06, -1.390e-06, -1.385e-06, -1.375e-06,
          -1.370e-06, -1.365e-06, -1.355e-06, -1.350e-06, -1.345e-06],
@@ -336,7 +338,9 @@ class TestLogitLocator:
         loc = mticker.LogitLocator(nbins=100)
         for nbins in range(basic_needed, 2, -1):
             loc.set_params(nbins=nbins)
-            assert len(loc.tick_values(*lims)) <= nbins + 2
+            ticks = loc.tick_values(*lims)
+            ticks_in_bounds = ticks[(ticks < lims[0]) & (ticks > lims[1])]
+            assert len(ticks_in_bounds) <= nbins + 1
 
     @pytest.mark.parametrize(
         "lims, expected_low_ticks",

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1827,7 +1827,12 @@ class LinearLocator(Locator):
 
         if self.numticks == 0:
             return []
-        ticklocs = np.linspace(vmin, vmax, self.numticks)
+        ticklocs, step = np.linspace(vmin, vmax, self.numticks, retstep=True)
+
+        # Extend so there is a single tick out of bounds
+        ticklocs = np.concatenate(
+            ([ticklocs[0] - step], ticklocs, [ticklocs[-1] + step])
+        )
 
         return self.raise_if_exceeds(ticklocs)
 

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1948,11 +1948,25 @@ class _Edge_integer:
             return d + 1
         return d
 
+    def lt(self, x):
+        """Return the largest integer n: n*step < x."""
+        d, m = divmod(x, self.step)
+        if self.closeto(m / self.step, 0):
+            return d - 1
+        return d
+
     def ge(self, x):
         """Return the smallest n: n*step >= x."""
         d, m = divmod(x, self.step)
         if self.closeto(m / self.step, 0):
             return d
+        return d + 1
+
+    def gt(self, x):
+        """Return the smallest integer n: n*step > x."""
+        d, m = divmod(x, self.step)
+        if self.closeto(m / self.step, 1):
+            return d + 2
         return d + 1
 
 
@@ -2125,8 +2139,8 @@ class MaxNLocator(Locator):
             # The edge ticks beyond vmin and/or vmax are needed for the
             # "round_numbers" autolimit mode.
             edge = _Edge_integer(step, offset)
-            low = edge.le(_vmin - best_vmin)
-            high = edge.ge(_vmax - best_vmin)
+            low = edge.lt(_vmin - best_vmin)
+            high = edge.gt(_vmax - best_vmin)
             ticks = np.arange(low, high + 1) * step + best_vmin
             # Count only the ticks that will be displayed.
             nticks = ((ticks <= _vmax) & (ticks >= _vmin)).sum()


### PR DESCRIPTION
## PR Summary
As part of discussing whether to merge https://github.com/matplotlib/matplotlib/pull/25173, I thought it was worth drafting the changes that would be needed to make our current locators respect returning at least one tick out of bounds.

I still need to investigate:
- [ ] [SymmetricalLogLocator](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.SymmetricalLogLocator)
- [ ] [AsinhLocator](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.AsinhLocator)
- [ ] [LogitLocator](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.LogitLocator)
- [ ] [AutoMinorLocator](https://matplotlib.org/stable/api/ticker_api.html#matplotlib.ticker.AutoMinorLocator)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
