### PR TITLE
Fix unintended space after comma as a decimal separator

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1452,7 +1452,7 @@ class TestPercentFormatter:
 def test_locale_comma():
     currentLocale = locale.getlocale()
     try:
-        locale.setlocale(locale.LC_ALL, 'fy_DE.UTF-8')
+        locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')
         ticks = mticker.ScalarFormatter(useMathText=True, useLocale=True)
         fmt = '$\\mathdefault{%1.1f}$'
         x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
@@ -1462,7 +1462,7 @@ def test_locale_comma():
         x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
         assert x == ',$\\mathdefault{,0{,}5},$'
     except locale.Error:
-        pytest.skip("Locale fy_DE.UTF-8 is not supported on this machine")
+        pytest.skip("Locale de_DE.UTF-8 is not supported on this machine")
     finally:
         locale.setlocale(locale.LC_ALL, currentLocale)
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1449,20 +1449,21 @@ class TestPercentFormatter:
             assert fmt.format_pct(50, 100) == expected
 
 
-@pytest.mark.xfail(locale != "fy_DE.UTF-8",
-                   reason="Locale 'fy_DE.UTF-8' is not supported")
+@pytest.mark.xfail
 def test_locale_comma():
     currentLocale = locale.getlocale()
-    locale.setlocale(locale.LC_ALL, 'fy_DE.UTF-8')
-    ticks = mticker.ScalarFormatter(useMathText=True, useLocale=True)
-    fmt = '$\\mathdefault{%1.1f}$'
-    x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
-    assert x == '$\\mathdefault{0{,}5}$'
-    # Do not change , in the format string
-    fmt = ',$\\mathdefault{,%1.1f},$'
-    x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
-    assert x == ',$\\mathdefault{,0{,}5},$'
-    locale.setlocale(locale.LC_ALL, currentLocale)
+    try:
+        locale.setlocale(locale.LC_ALL, 'fy_DE.UTF-8')
+        ticks = mticker.ScalarFormatter(useMathText=True, useLocale=True)
+        fmt = '$\\mathdefault{%1.1f}$'
+        x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
+        assert x == '$\\mathdefault{0{,}5}$'
+        # Do not change , in the format string
+        fmt = ',$\\mathdefault{,%1.1f},$'
+        x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
+        assert x == ',$\\mathdefault{,0{,}5},$'
+    finally:
+        locale.setlocale(locale.LC_ALL, currentLocale)
 
 
 def test_majformatter_type():

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1449,6 +1449,21 @@ class TestPercentFormatter:
             assert fmt.format_pct(50, 100) == expected
 
 
+def test_locale_comma():
+    import locale
+
+    currentLocale = locale.getlocale()
+    try:
+        locale.setlocale(locale.LC_ALL, 'fy_DE.UTF-8')
+    except locale.Error as err:
+        pytest.fail("Locale 'fy_DE.UTF-8' is not supported")
+    ticks = mticker.ScalarFormatter(useMathText=True, useLocale=True)
+    fmt = '$\\mathdefault{%1.1f}$'
+    x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
+    locale.setlocale(locale.LC_ALL, currentLocale)
+    assert x == '$\\mathdefault{0{,}5}$'
+
+
 def test_majformatter_type():
     fig, ax = plt.subplots()
     with pytest.raises(TypeError):

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1457,8 +1457,12 @@ def test_locale_comma():
     ticks = mticker.ScalarFormatter(useMathText=True, useLocale=True)
     fmt = '$\\mathdefault{%1.1f}$'
     x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
-    locale.setlocale(locale.LC_ALL, currentLocale)
     assert x == '$\\mathdefault{0{,}5}$'
+    # Do not change , in the format string
+    fmt = ',$\\mathdefault{,%1.1f},$'
+    x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
+    assert x == ',$\\mathdefault{,0{,}5},$'
+    locale.setlocale(locale.LC_ALL, currentLocale)
 
 
 def test_majformatter_type():

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1449,7 +1449,6 @@ class TestPercentFormatter:
             assert fmt.format_pct(50, 100) == expected
 
 
-@pytest.mark.xfail
 def test_locale_comma():
     currentLocale = locale.getlocale()
     try:
@@ -1462,6 +1461,8 @@ def test_locale_comma():
         fmt = ',$\\mathdefault{,%1.1f},$'
         x = ticks._format_maybe_minus_and_locale(fmt, 0.5)
         assert x == ',$\\mathdefault{,0{,}5},$'
+    except locale.Error:
+        pytest.skip("Locale fy_DE.UTF-8 is not supported on this machine")
     finally:
         locale.setlocale(locale.LC_ALL, currentLocale)
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1449,14 +1449,11 @@ class TestPercentFormatter:
             assert fmt.format_pct(50, 100) == expected
 
 
+@pytest.mark.xfail(locale != "fy_DE.UTF-8",
+                   reason="Locale 'fy_DE.UTF-8' is not supported")
 def test_locale_comma():
-    import locale
-
     currentLocale = locale.getlocale()
-    try:
-        locale.setlocale(locale.LC_ALL, 'fy_DE.UTF-8')
-    except locale.Error as err:
-        pytest.fail("Locale 'fy_DE.UTF-8' is not supported")
+    locale.setlocale(locale.LC_ALL, 'fy_DE.UTF-8')
     ticks = mticker.ScalarFormatter(useMathText=True, useLocale=True)
     fmt = '$\\mathdefault{%1.1f}$'
     x = ticks._format_maybe_minus_and_locale(fmt, 0.5)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -510,8 +510,14 @@ class ScalarFormatter(Formatter):
         """
         Format *arg* with *fmt*, applying Unicode minus and locale if desired.
         """
-        return self.fix_minus(locale.format_string(fmt, (arg,), True)
-                              if self._useLocale else fmt % arg)
+        return self.fix_minus(
+                # Escape commas introduced by format_string but not those present
+                # from the beginning in fmt.
+                ",".join(locale.format_string(part, (arg,), True)
+                         .replace(",", "{,}")
+                         for part in fmt.split(","))
+                if self._useLocale
+                else fmt % arg)
 
     def get_useMathText(self):
         """


### PR DESCRIPTION
## PR Summary
Fixes #23626 
Closes #24079
Replace unintended space in locale.format_string function

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
