### PR TITLE
Remove a redundant comma in `AsinhScale`

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -576,7 +576,7 @@ class AsinhScale(ScaleBase):
         if self._base > 1:
             axis.set_major_formatter(LogFormatterSciNotation(self._base))
         else:
-            axis.set_major_formatter('{x:.3g}'),
+            axis.set_major_formatter('{x:.3g}')
 
 
 class LogitTransform(Transform):


### PR DESCRIPTION
## PR Summary

This PR doesn't directly solve any real-world problems, but will make life easier in the future.

```python
if self._base > 1:
    axis.set_major_formatter(LogFormatterSciNotation(self._base))
else:
    axis.set_major_formatter('{x:.3g}'),
                                       👆
```

The comma doesn't have any effect, but triggers a lint warning: Expression value is unused. (`a,` means the tuple `(a,)`)

_Additional information_: This line was introduced in [65eff09](https://github.com/matplotlib/matplotlib/commit/65eff091b35fda2dc9af3103d74df062cf732665#diff-aa9ad5f5699f4aead65ab741dc9b34f6de86cbfe85fe6ebbc0927b38bbb775d9R545).

:warning: I'm not sure whether this kind of PR is welcomed. If not so, sorry for taking up time.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
