### PR TITLE
Fixed a bug where rcParams settings were being ignored for formatting axes labels

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -879,6 +879,8 @@ class Axis(martist.Artist):
         - registered callbacks
         """
         self.label._reset_visual_defaults()
+        # The above resets the label formatting using text rcParams,
+        # so we then update the formatting using axes rcParams
         self.label.set_color(mpl.rcParams['axes.labelcolor'])
         self.label.set_fontsize(mpl.rcParams['axes.labelsize'])
         self.label.set_fontweight(mpl.rcParams['axes.labelweight'])

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -879,6 +879,9 @@ class Axis(martist.Artist):
         - registered callbacks
         """
         self.label._reset_visual_defaults()
+        self.label.set_color(mpl.rcParams['axes.labelcolor'])
+        self.label.set_fontsize(mpl.rcParams['axes.labelsize'])
+        self.label.set_fontweight(mpl.rcParams['axes.labelweight'])
         self.offsetText._reset_visual_defaults()
         self.labelpad = mpl.rcParams['axes.labelpad']
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8431,3 +8431,15 @@ def test_zorder_and_explicit_rasterization():
     ln, = ax.plot(range(5), rasterized=True, zorder=1)
     with io.BytesIO() as b:
         fig.savefig(b, format='pdf')
+
+
+@mpl.style.context('default')
+def test_rc_axes_label_formatting():
+    mpl.rcParams['axes.labelcolor'] = 'red'
+    mpl.rcParams['axes.labelsize'] = 20
+    mpl.rcParams['axes.labelweight'] = 'bold'
+
+    ax = plt.axes()
+    assert ax.xaxis.label.get_color() == 'red'
+    assert ax.xaxis.label.get_fontsize() == 20
+    assert ax.xaxis.label.get_fontweight() == 'bold'


### PR DESCRIPTION
## PR Summary

Matplotlib 3.7.0 has a bug where rcParams settings are being ignored for formatting axes labels.  This bug was introduced with #21253, specifically the use of the `Text._reset_visual_defaults()` method to reset the formatting of an axis label, including during the initialization of an axis.  Since the axis label is just a `Text`, the color gets reset to `text.color` instead of `axes.labelcolor`, and `axes.labelsize` and `axes.labelweight` are ignored.  (This bug is not readily apparent when `text.color` and `axes.labelcolor` happen to be the same, as is common for many styles.)

Example script:
```python
import matplotlib as mpl
import matplotlib.pyplot as plt

with mpl.rc_context({'axes.labelcolor': 'red', 'axes.labelsize': 20, 'axes.labelweight': 'bold'}):
    plt.plot([1, 2, 1])
    plt.xlabel('xlabel')
    plt.show()
```

Output on Matplotlib 3.7.0:
![Figure_1](https://user-images.githubusercontent.com/991759/219547648-ff8d030a-fafb-42a3-a6a0-bace5ff61279.png)

Output with this PR:
![Figure_2](https://user-images.githubusercontent.com/991759/219547652-297746dc-d834-4fc5-ad76-c7ba3e28c1f4.png)

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
