### PR TITLE
Check file path for animation and raise if it does not exist

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -193,6 +193,8 @@ class AbstractMovieWriter(abc.ABC):
             The DPI (or resolution) for the file.  This controls the size
             in pixels of the resulting movie file.
         """
+        # Check that path is valid
+        Path(outfile).parent.resolve(strict=True)
         self.outfile = outfile
         self.fig = fig
         if dpi is None:
@@ -405,6 +407,8 @@ class FileMovieWriter(MovieWriter):
             deleted by `finish`; if not *None*, no temporary files are
             deleted.
         """
+        # Check that path is valid
+        Path(outfile).parent.resolve(strict=True)
         self.fig = fig
         self.outfile = outfile
         if dpi is None:
@@ -423,7 +427,7 @@ class FileMovieWriter(MovieWriter):
         self.fname_format_str = '%s%%07d.%s'
 
     def __del__(self):
-        if self._tmpdir:
+        if hasattr(self, '_tmpdir') and self._tmpdir:
             self._tmpdir.cleanup()
 
     @property

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -506,3 +506,13 @@ def test_disable_cache_warning(anim):
         )
     assert anim._cache_frame_data is False
     anim._init_draw()
+
+
+def test_movie_writer_invalid_path(anim):
+    if sys.platform == "win32":
+        match_str = re.escape("[WinError 3] The system cannot find the path specified:")
+    else:
+        match_str = re.escape("[Errno 2] No such file or directory: '/foo")
+    with pytest.raises(FileNotFoundError, match=match_str):
+        _ = anim.save("/foo/bar/aardvark/thiscannotreallyexist.mp4",
+                      writer=animation.FFMpegFileWriter())


### PR DESCRIPTION
## PR Summary

Closes #25233

Not clear to me how to check it. As in how the animation testing actually works... Once setup, I am sure how to test for the particular error.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
