### PR TITLE
Avoid calling vars() on arbitrary third-party manager_class.

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -898,7 +898,7 @@ class SubplotToolQt(QtWidgets.QDialog):
         self._figure.tight_layout()
         for attr, spinbox in self._spinboxes.items():
             spinbox.blockSignals(True)
-            spinbox.setValue(vars(self._figure.subplotpars)[attr])
+            spinbox.setValue(getattr(self._figure.subplotpars, attr))
             spinbox.blockSignals(False)
         self._figure.canvas.draw_idle()
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -324,11 +324,12 @@ def switch_backend(newbackend):
     # show is already present, as the latter may be here for backcompat.
     manager_class = getattr(getattr(backend_mod, "FigureCanvas", None),
                             "manager_class", None)
-    # We can't compare directly manager_class.pyplot_show and FMB.pyplot_show
-    # because pyplot_show is a classmethod so the above constructs are bound
-    # classmethods, & thus always different (being bound to different classes).
-    manager_pyplot_show = vars(manager_class).get("pyplot_show")
-    base_pyplot_show = vars(FigureManagerBase).get("pyplot_show")
+    # We can't compare directly manager_class.pyplot_show and FMB.pyplot_show because
+    # pyplot_show is a classmethod so the above constructs are bound classmethods, and
+    # thus always different (being bound to different classes).  We also have to use
+    # getattr_static instead of vars as manager_class could have no __dict__.
+    manager_pyplot_show = inspect.getattr_static(manager_class, "pyplot_show", None)
+    base_pyplot_show = inspect.getattr_static(FigureManagerBase, "pyplot_show", None)
     if (show is None
             or (manager_pyplot_show is not None
                 and manager_pyplot_show != base_pyplot_show)):


### PR DESCRIPTION
vars(...) may fail if the third-party manager_class has no `__dict__`, which can happen in contrieved cases involving `__slots__` or extension modules, or more simply if the backend has no FigureCanvas attribute or if the canvas class has no manager_class attribute, in which case manager_class = None.  (Note that this can only be the case if that third-party FigureCanvas doesn't inherit from FigureCanvasBase, which is probably not a great idea.)

In any case, instead of vars(), inspect.getattr_static does what we want too and also handles that case.

Also replace another (unrelated) use of vars() with a plain getattr.

See #25227 (which is still due to pycharm being outdated, but this patch should make the error less obscure and could be relevant in other (more contrieved) cases).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
