### PR TITLE
Cleanup wx docstrings.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -595,8 +595,6 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         """
         Update the displayed image on the GUI canvas, using the supplied
         wx.PaintDC device context.
-
-        The 'WXAgg' backend sets origin accordingly.
         """
         _log.debug("%s - gui_repaint()", type(self))
         # The "if self" check avoids a "wrapped C/C++ object has been deleted"

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -15,16 +15,6 @@ class FigureFrameWxAgg(FigureFrameWx):
 
 
 class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
-    """
-    The FigureCanvas contains the figure and does event handling.
-
-    In the wxPython backend, it is derived from wxPanel, and (usually)
-    lives inside a frame instantiated by a FigureManagerWx. The parent
-    window probably implements a wxSizer to control the displayed
-    control size - but we give a hint as to our preferred minimum
-    size.
-    """
-
     def draw(self, drawDC=None):
         """
         Render the figure using agg.

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -15,15 +15,6 @@ class FigureFrameWxCairo(FigureFrameWx):
 
 
 class FigureCanvasWxCairo(FigureCanvasCairo, _FigureCanvasWxBase):
-    """
-    The FigureCanvas contains the figure and does event handling.
-
-    In the wxPython backend, it is derived from wxPanel, and (usually) lives
-    inside a frame instantiated by a FigureManagerWx. The parent window
-    probably implements a wxSizer to control the displayed control size - but
-    we give a hint as to our preferred minimum size.
-    """
-
     def draw(self, drawDC=None):
         size = self.figure.bbox.size.astype(int)
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, *size)


### PR DESCRIPTION
- The "origin" keyword (for wx) has been deprecated in 591f92a and since then removed.
- The canvas classes docstrings are inherited, but we don't even bother marking them as being inherited for other backends.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
