### PR TITLE
DOC: remove constrained_layout kwarg from tutorials and user guide

### DIFF
--- a/doc/users/faq/howto_faq.rst
+++ b/doc/users/faq/howto_faq.rst
@@ -30,7 +30,7 @@ supplied.
     import matplotlib.pyplot as plt
     import numpy as np
 
-    fig, ax = plt.subplots(1, 2, constrained_layout=True, figsize=(6, 2))
+    fig, ax = plt.subplots(1, 2, layout='constrained', figsize=(6, 2))
 
     ax[0].set_title('Ticks seem out of order / misplaced')
     x = ['5', '20', '1', '9']  # strings

--- a/tutorials/colors/colormap-manipulation.py
+++ b/tutorials/colors/colormap-manipulation.py
@@ -99,7 +99,7 @@ def plot_examples(colormaps):
     data = np.random.randn(30, 30)
     n = len(colormaps)
     fig, axs = plt.subplots(1, n, figsize=(n * 2 + 2, 3),
-                            constrained_layout=True, squeeze=False)
+                            layout='constrained', squeeze=False)
     for [ax, cmap] in zip(axs.flat, colormaps):
         psm = ax.pcolormesh(data, cmap=cmap, rasterized=True, vmin=-4, vmax=4)
         fig.colorbar(psm, ax=ax)
@@ -197,7 +197,7 @@ cdict = {'red':   [[0.0,  0.0, 0.0],
 def plot_linearmap(cdict):
     newcmp = LinearSegmentedColormap('testCmap', segmentdata=cdict, N=256)
     rgba = newcmp(np.linspace(0, 1, 256))
-    fig, ax = plt.subplots(figsize=(4, 3), constrained_layout=True)
+    fig, ax = plt.subplots(figsize=(4, 3), layout='constrained')
     col = ['r', 'g', 'b']
     for xx in [0.25, 0.5, 0.75]:
         ax.axvline(xx, color='0.7', linestyle='--')

--- a/tutorials/colors/colormapnorms.py
+++ b/tutorials/colors/colormapnorms.py
@@ -168,7 +168,7 @@ N = 100
 X, Y = np.mgrid[0:3:complex(0, N), 0:2:complex(0, N)]
 Z1 = (1 + np.sin(Y * 10.)) * X**2
 
-fig, ax = plt.subplots(2, 1, constrained_layout=True)
+fig, ax = plt.subplots(2, 1, layout='constrained')
 
 pcm = ax[0].pcolormesh(X, Y, Z1, norm=colors.PowerNorm(gamma=0.5),
                        cmap='PuBu_r', shading='auto')
@@ -207,7 +207,7 @@ Z1 = np.exp(-X**2 - Y**2)
 Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = ((Z1 - Z2) * 2)[:-1, :-1]
 
-fig, ax = plt.subplots(2, 2, figsize=(8, 6), constrained_layout=True)
+fig, ax = plt.subplots(2, 2, figsize=(8, 6), layout='constrained')
 ax = ax.flatten()
 
 # Default norm:

--- a/tutorials/intermediate/arranging_axes.py
+++ b/tutorials/intermediate/arranging_axes.py
@@ -329,7 +329,7 @@ fig.suptitle('Manually added subplots, spanning a column')
 #
 # When a  *GridSpec* is explicitly used, you can adjust the layout
 # parameters of subplots that are created from the  *GridSpec*.  Note this
-# option is not compatible with ``constrained_layout`` or
+# option is not compatible with *constrained layout* or
 # `.Figure.tight_layout` which both ignore *left* and *right* and adjust
 # subplot sizes to fill the figure.  Usually such manual placement
 # requires iterations to make the Axes tick labels not overlap the Axes.
@@ -389,7 +389,7 @@ fig.suptitle('nested gridspecs')
 def squiggle_xy(a, b, c, d, i=np.arange(0.0, 2*np.pi, 0.05)):
     return np.sin(i*a)*np.cos(i*b), np.sin(i*c)*np.cos(i*d)
 
-fig = plt.figure(figsize=(8, 8), constrained_layout=False)
+fig = plt.figure(figsize=(8, 8), layout='constrained')
 outer_grid = fig.add_gridspec(4, 4, wspace=0, hspace=0)
 
 for a in range(4):

--- a/tutorials/intermediate/constrainedlayout_guide.py
+++ b/tutorials/intermediate/constrainedlayout_guide.py
@@ -126,7 +126,7 @@ fig.colorbar(im, ax=ax, shrink=0.6)
 
 # %%
 # If you specify a list of Axes (or other iterable container) to the
-# ``ax`` argument of ``colorbar``, constrained_layout will take space from
+# ``ax`` argument of ``colorbar``, *constrained layout* will take space from
 # the specified Axes.
 
 fig, axs = plt.subplots(2, 2, figsize=(4, 4), layout="constrained")
@@ -162,8 +162,8 @@ fig.suptitle('Big Suptitle')
 # =======
 #
 # Legends can be placed outside of their parent axis.
-# Constrained-layout is designed to handle this for :meth:`.Axes.legend`.
-# However, constrained-layout does *not* handle legends being created via
+# *Constrained layout* is designed to handle this for :meth:`.Axes.legend`.
+# However, *constrained layout* does *not* handle legends being created via
 # :meth:`.Figure.legend` (yet).
 
 fig, ax = plt.subplots(layout="constrained")
@@ -186,7 +186,7 @@ axs[1].legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
 # with ``fig.savefig('outname.png', bbox_inches='tight')``.  Note,
 # however, that the legend's ``get_in_layout`` status will have to be
 # toggled again to make the saved file work, and we must manually
-# trigger a draw if we want constrained_layout to adjust the size
+# trigger a draw if we want *constrained layout* to adjust the size
 # of the Axes before printing.
 
 fig, axs = plt.subplots(1, 2, figsize=(4, 2), layout="constrained")
@@ -195,7 +195,7 @@ axs[0].plot(np.arange(10))
 axs[1].plot(np.arange(10), label='This is a plot')
 leg = axs[1].legend(loc='center left', bbox_to_anchor=(0.8, 0.5))
 leg.set_in_layout(False)
-# trigger a draw so that constrained_layout is executed once
+# trigger a draw so that constrained layout is executed once
 # before we turn it off when printing....
 fig.canvas.draw()
 # we want the legend included in the bbox_inches='tight' calcs.
@@ -288,7 +288,7 @@ fig, axs = plt.subplots(2, 2, layout="constrained",
 for ax in axs.flat:
     example_plot(ax, hide_labels=True)
 # this has no effect because the space set in the gridspec trumps the
-# space set in constrained_layout.
+# space set in *constrained layout*.
 fig.get_layout_engine().set(w_pad=4 / 72, h_pad=4 / 72, hspace=0.0,
                             wspace=0.0)
 
@@ -319,7 +319,7 @@ fig.get_layout_engine().set(w_pad=2 / 72, h_pad=2 / 72, hspace=0.2,
 # that can be set, either in a script or in the :file:`matplotlibrc`
 # file. They all have the prefix ``figure.constrained_layout``:
 #
-# - *use*: Whether to use constrained_layout. Default is False
+# - *use*: Whether to use *constrained layout*. Default is False
 # - *w_pad*, *h_pad*:    Padding around Axes objects.
 #   Float representing inches.  Default is 3./72. inches (3 pts)
 # - *wspace*, *hspace*:  Space between subplot groups.
@@ -335,7 +335,7 @@ for ax in axs.flat:
 # Use with GridSpec
 # =================
 #
-# constrained_layout is meant to be used
+# *Constrained layout* is meant to be used
 # with :func:`~matplotlib.figure.Figure.subplots`,
 # :func:`~matplotlib.figure.Figure.subplot_mosaic`, or
 # :func:`~matplotlib.gridspec.GridSpec` with
@@ -454,7 +454,7 @@ fig.suptitle('Nested plots using subfigures')
 # ================================
 #
 # There can be good reasons to manually set an Axes position.  A manual call
-# to `~.axes.Axes.set_position` will set the Axes so constrained_layout has
+# to `~.axes.Axes.set_position` will set the Axes so *constrained layout* has
 # no effect on it anymore. (Note that *constrained layout* still leaves the
 # space for the Axes that is moved).
 
@@ -497,12 +497,12 @@ fig.suptitle("fixed-aspect plots, layout='compressed'")
 #
 # *Constrained layout* usually adjusts the Axes positions on each draw
 # of the figure.  If you want to get the spacing provided by
-# *Constrained layout* but not have it update, then do the initial
+# *constrained layout* but not have it update, then do the initial
 # draw and then call ``fig.set_layout_engine('none')``.
 # This is potentially useful for animations where the tick labels may
 # change length.
 #
-# Note that *Constrained layout* is turned off for ``ZOOM`` and ``PAN``
+# Note that *constrained layout* is turned off for ``ZOOM`` and ``PAN``
 # GUI events for the backends that use the toolbar.  This prevents the
 # Axes from changing position during zooming and panning.
 #
@@ -517,7 +517,7 @@ fig.suptitle("fixed-aspect plots, layout='compressed'")
 # number of rows and columns is the same for each call.
 # The reason is that each call to `.pyplot.subplot` will create a new
 # `.GridSpec` instance if the geometry is not the same, and
-# *Constrained layout*.  So the following works fine:
+# *constrained layout*.  So the following works fine:
 
 fig = plt.figure(layout="constrained")
 
@@ -588,7 +588,7 @@ fig.suptitle('subplot2grid')
 # Debugging
 # =========
 #
-# Constrained-layout can fail in somewhat unexpected ways.  Because it uses
+# *Constrained layout* can fail in somewhat unexpected ways.  Because it uses
 # a constraint solver the solver can find solutions that are mathematically
 # correct, but that aren't at all what the user wants.  The usual failure
 # mode is for all sizes to collapse to their smallest allowable value. If
@@ -615,7 +615,7 @@ fig.suptitle('subplot2grid')
 # into rows and columns, with the relative width of the Axes in those
 # rows and columns set by *width_ratios* and *height_ratios*.
 #
-# In constrained_layout, each gridspec gets a *layoutgrid* associated with
+# In *constrained layout*, each gridspec gets a *layoutgrid* associated with
 # it.  The *layoutgrid* has a series of ``left`` and ``right`` variables
 # for each column, and ``bottom`` and ``top`` variables for each row, and
 # further it has a margin for each of left, right, bottom and top.  In each

--- a/tutorials/intermediate/legend_guide.py
+++ b/tutorials/intermediate/legend_guide.py
@@ -141,7 +141,7 @@ ax_dict['bottom'].legend(bbox_to_anchor=(1.05, 1),
 # --------------
 #
 # Sometimes it makes more sense to place a legend relative to the (sub)figure
-# rather than individual Axes.  By using ``constrained_layout`` and
+# rather than individual Axes.  By using *constrained layout* and
 # specifying "outside" at the beginning of the *loc* keyword argument,
 # the legend is drawn outside the Axes on the (sub)figure.
 


### PR DESCRIPTION
Following #25198, which removed the discouraged form `constrained_layout=True` from examples, this PR does the same for the tutorials and the user guide.  Also put the phrase "constrained layout" in italics consistent with #25144.

Although this is just documentation, I milestoned this for v3.8: it partially builds on #25144 which was not backported due to conflicts, so conflicts for this one will likely be worse!

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
