### PR TITLE
Support make_compound_path concatenating only empty paths.

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -318,29 +318,25 @@ class Path:
 
     @classmethod
     def make_compound_path(cls, *args):
+        r"""
+        Concatenate a list of `Path`\s into a single `.Path`, removing all `.STOP`\s.
         """
-        Make a compound path from a list of `Path` objects. Blindly removes
-        all `Path.STOP` control points.
-        """
-        # Handle an empty list in args (i.e. no args).
         if not args:
             return Path(np.empty([0, 2], dtype=np.float32))
-        vertices = np.concatenate([x.vertices for x in args])
+        vertices = np.concatenate([path.vertices for path in args])
         codes = np.empty(len(vertices), dtype=cls.code_type)
         i = 0
         for path in args:
+            size = len(path.vertices)
             if path.codes is None:
-                codes[i] = cls.MOVETO
-                codes[i + 1:i + len(path.vertices)] = cls.LINETO
+                if size:
+                    codes[i] = cls.MOVETO
+                    codes[i+1:i+size] = cls.LINETO
             else:
-                codes[i:i + len(path.codes)] = path.codes
-            i += len(path.vertices)
-        # remove STOP's, since internal STOPs are a bug
-        not_stop_mask = codes != cls.STOP
-        vertices = vertices[not_stop_mask, :]
-        codes = codes[not_stop_mask]
-
-        return cls(vertices, codes)
+                codes[i:i+size] = path.codes
+            i += size
+        not_stop_mask = codes != cls.STOP  # Remove STOPs, as internal STOPs are a bug.
+        return cls(vertices[not_stop_mask], codes[not_stop_mask])
 
     def __repr__(self):
         return f"Path({self.vertices!r}, {self.codes!r})"

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -203,8 +203,14 @@ def test_log_transform_with_zero():
 def test_make_compound_path_empty():
     # We should be able to make a compound path with no arguments.
     # This makes it easier to write generic path based code.
-    r = Path.make_compound_path()
-    assert r.vertices.shape == (0, 2)
+    empty = Path.make_compound_path()
+    assert empty.vertices.shape == (0, 2)
+    r2 = Path.make_compound_path(empty, empty)
+    assert r2.vertices.shape == (0, 2)
+    assert r2.codes.shape == (0,)
+    r3 = Path.make_compound_path(Path([(0, 0)]), empty)
+    assert r3.vertices.shape == (1, 2)
+    assert r3.codes.shape == (1,)
 
 
 def test_make_compound_path_stops():


### PR DESCRIPTION
Previously `codes[i]` would fail if codes (i.e. the concatenated path) had length zero.

Split out as preparatory work for #25247 (which introduces empty paths for contour levels that don't actually result in any level being drawn).

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
