### PR TITLE
Make default facecolor for subfigures be transparent ("none"). Fix for issue #24910

### DIFF
--- a/doc/api/next_api_changes/behavior/25255-RR.rst
+++ b/doc/api/next_api_changes/behavior/25255-RR.rst
@@ -1,0 +1,5 @@
+``SubFigure`` default facecolor is now transparent
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Subfigures default facecolor changed to ``"none"``. Previously the default was
+the value of ``figure.facecolor``.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2155,8 +2155,8 @@ class SubFigure(FigureBase):
             Defines the region in a parent gridspec where the subfigure will
             be placed.
 
-        facecolor : default: :rc:`figure.facecolor`
-            The figure patch face color.
+        facecolor : default: ``"none"``
+            Transparent face color.
 
         edgecolor : default: :rc:`figure.edgecolor`
             The figure patch edge color.
@@ -2176,7 +2176,7 @@ class SubFigure(FigureBase):
         """
         super().__init__(**kwargs)
         if facecolor is None:
-            facecolor = mpl.rcParams['figure.facecolor']
+            facecolor = "none"
         if edgecolor is None:
             edgecolor = mpl.rcParams['figure.edgecolor']
         if frameon is None:

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2156,7 +2156,7 @@ class SubFigure(FigureBase):
             be placed.
 
         facecolor : default: ``"none"``
-            Transparent face color.
+            The figure patch face color; transparent by default.
 
         edgecolor : default: :rc:`figure.edgecolor`
             The figure patch edge color.

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -287,6 +287,25 @@ def test_suptitle_fontproperties():
     assert txt.get_weight() == fps.get_weight()
 
 
+<<<<<<< HEAD
+@image_comparison(['figure_suptitle_subfigures'],
+                  extensions=['png'])
+=======
+>>>>>>> bb69a2fbc5 (RR - convert visual test to simple unit test.)
+def test_suptitle_subfigures():
+    fig = plt.figure(figsize=(4, 3))
+    sf1, sf2 = fig.subfigures(1, 2)
+    sf2.set_facecolor('white')
+    sf1.subplots()
+    sf2.subplots()
+    fig.suptitle("This is a visible suptitle.")
+
+    # verify the first subfigure facecolor is the default transparent
+    assert sf1.get_facecolor() == (0.0, 0.0, 0.0, 0.0)
+    # verify the second subfigure facecolor is white
+    assert sf2.get_facecolor() == (1.0, 1.0, 1.0, 1.0)
+
+
 @image_comparison(['alpha_background'],
                   # only test png and svg. The PDF output appears correct,
                   # but Ghostscript does not preserve the background color.
@@ -1211,12 +1230,14 @@ def test_subfigure():
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
     sub[0].colorbar(pc, ax=axs)
     sub[0].suptitle('Left Side')
+    sub[0].set_facecolor('white')
 
     axs = sub[1].subplots(1, 3)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
     sub[1].colorbar(pc, ax=axs, location='bottom')
     sub[1].suptitle('Right Side')
+    sub[1].set_facecolor('white')
 
     fig.suptitle('Figure suptitle', fontsize='xx-large')
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -287,11 +287,6 @@ def test_suptitle_fontproperties():
     assert txt.get_weight() == fps.get_weight()
 
 
-<<<<<<< HEAD
-@image_comparison(['figure_suptitle_subfigures'],
-                  extensions=['png'])
-=======
->>>>>>> bb69a2fbc5 (RR - convert visual test to simple unit test.)
 def test_suptitle_subfigures():
     fig = plt.figure(figsize=(4, 3))
     sf1, sf2 = fig.subfigures(1, 2)


### PR DESCRIPTION
## PR Summary
This issue was written because the solid facecolor on subfigures was hiding the parent figure suptitle. A few solutions were identified and discussed in the issue thread #24910 . It was decided that the best solution is to change the default facecolor value to "none" (transparent). This PR makes that change.


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
