### PR TITLE
Mask values < vmin in PowerNorm

### DIFF
--- a/doc/api/next_api_changes/behavior/25256-DS.rst
+++ b/doc/api/next_api_changes/behavior/25256-DS.rst
@@ -1,0 +1,5 @@
+``PowerNorm`` clipping
+~~~~~~~~~~~~~~~~~~~~~~
+When ``clip=False`` (the default) was set on `~.PowerNorm`, values
+less than ``vmin`` were previously clipped to zero without being masked.
+This has been fixed to mask these values in the result.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1885,12 +1885,16 @@ class PowerNorm(Normalize):
                 result = np.ma.array(np.clip(result.filled(vmax), vmin, vmax),
                                      mask=mask)
             resdat = result.data
-            resdat -= vmin
-            resdat[resdat < 0] = 0
-            np.power(resdat, gamma, resdat)
-            resdat /= (vmax - vmin) ** gamma
+            # These values are masked later, but set to zero now to prevent
+            # invalid value warnings when taking the power
+            under_mask = resdat < vmin
+            resdat[under_mask] = vmin
 
-            result = np.ma.array(resdat, mask=result.mask, copy=False)
+            resdat = (resdat - vmin) / (vmax - vmin)
+            resdat = resdat ** gamma
+
+            mask = result.mask | under_mask
+            result = np.ma.array(resdat, mask=mask, copy=False)
         if is_scalar:
             result = result[0]
         return result

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -551,11 +551,16 @@ def test_PowerNorm():
     assert_array_almost_equal(norm(a), pnorm(a))
 
     a = np.array([-0.5, 0, 2, 4, 8], dtype=float)
-    expected = [0, 0, 1/16, 1/4, 1]
     pnorm = mcolors.PowerNorm(2, vmin=0, vmax=8)
-    assert_array_almost_equal(pnorm(a), expected)
-    assert pnorm(a[0]) == expected[0]
+    expected = [0, 0, 1/16, 1/4, 1]
+    expected_mask = [True, False, False, False, False]
+
+    normed = pnorm(a)
+    assert_array_almost_equal(normed, expected)
+    assert_array_equal(normed.mask, expected_mask)
+    assert pnorm(a[1]) == expected[1]
     assert pnorm(a[2]) == expected[2]
+
     assert_array_almost_equal(a[1:], pnorm.inverse(pnorm(a))[1:])
 
     # Clip = True


### PR DESCRIPTION
## PR Summary
Fixes https://github.com/matplotlib/matplotlib/issues/25239 (thanks @jklymak for the hint there!). I also took the oppurtunity to tidy up the code to make it clearer what's going on.

Given https://github.com/matplotlib/matplotlib/issues/25239 is a pretty bad bug (the tick labels on a colorbar are wrong) I think it's worth backporting this.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
