### PR TITLE
Backport PR #25268 on branch v3.7.x (Fix import of styles with relative path)

### DIFF
--- a/lib/matplotlib/style/core.py
+++ b/lib/matplotlib/style/core.py
@@ -153,7 +153,7 @@ def use(style):
                     path = (importlib_resources.files(pkg)
                             / f"{name}.{STYLE_EXTENSION}")
                     style = _rc_params_in_file(path)
-                except (ModuleNotFoundError, IOError) as exc:
+                except (ModuleNotFoundError, OSError, TypeError) as exc:
                     # There is an ambiguity whether a dotted name refers to a
                     # package.style_name or to a dotted file path.  Currently,
                     # we silently try the first form and then the second one;

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -205,3 +205,5 @@ def test_style_from_module(tmp_path, monkeypatch):
     assert mpl.rcParams["lines.linewidth"] == 42
     mpl.style.use("mpl_test_style_pkg.mplstyle")
     assert mpl.rcParams["lines.linewidth"] == 84
+    mpl.style.use("./mpl_test_style_pkg.mplstyle")
+    assert mpl.rcParams["lines.linewidth"] == 84


### PR DESCRIPTION
Fix import of styles with relative path

(cherry picked from commit ee7d75eeaecf795d6d2134607139a5864c101b60)

Conflict was caused by pyupgrade changing IOError to OSError (which are
aliases of each other since py3.3)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
