### PR TITLE
Fix setting CSS with latest GTK4

### DIFF
--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -74,7 +74,11 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
         self.set_focusable(True)
 
         css = Gtk.CssProvider()
-        css.load_from_data(b".matplotlib-canvas { background-color: white; }")
+        style = '.matplotlib-canvas { background-color: white; }'
+        if Gtk.check_version(4, 9, 3) is None:
+            css.load_from_data(style, -1)
+        else:
+            css.load_from_data(style.encode('utf-8'))
         style_ctx = self.get_style_context()
         style_ctx.add_provider(css, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
         style_ctx.add_class("matplotlib-canvas")


### PR DESCRIPTION
## PR Summary

In the upcoming 4.10 release, the type annotation was fixed [1]. There may be some overrides added in PyGObject [2] to avoid this difference, but we don't depend on a specific version of it to be able to rely on that (and it's not released yet.) This code should work with the override as well.

[1] https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/5441
[2] https://gitlab.gnome.org/GNOME/pygobject/-/merge_requests/231

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`