### PR TITLE
Bugfix for loc legend validation

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -23,6 +23,7 @@ information.
 
 import itertools
 import logging
+import numbers
 import time
 
 import numpy as np
@@ -517,6 +518,9 @@ class Legend(Artist):
             if not self.isaxes and loc in [0, 'best']:
                 loc = 'upper right'
 
+        type_err_message = ("loc must be string, coordinate tuple, or"
+                            f" an integer 0-10, not {loc!r}")
+
         # handle outside legends:
         self._outside_loc = None
         if isinstance(loc, str):
@@ -535,6 +539,19 @@ class Legend(Artist):
                     loc = locs[0] + ' ' + locs[1]
             # check that loc is in acceptable strings
             loc = _api.check_getitem(self.codes, loc=loc)
+        elif np.iterable(loc):
+            # coerce iterable into tuple
+            loc = tuple(loc)
+            # validate the tuple represents Real coordinates
+            if len(loc) != 2 or not all(isinstance(e, numbers.Real) for e in loc):
+                raise ValueError(type_err_message)
+        elif isinstance(loc, int):
+            # validate the integer represents a string numeric value
+            if loc < 0 or loc > 10:
+                raise ValueError(type_err_message)
+        else:
+            # all other cases are invalid values of loc
+            raise ValueError(type_err_message)
 
         if self.isaxes and self._outside_loc:
             raise ValueError(

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1219,3 +1219,79 @@ def test_ncol_ncols(fig_test, fig_ref):
     ncols = 3
     fig_test.legend(strings, ncol=ncols)
     fig_ref.legend(strings, ncols=ncols)
+
+
+def test_loc_invalid_tuple_exception():
+    # check that exception is raised if the loc arg
+    # of legend is not a 2-tuple of numbers
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match=('loc must be string, coordinate '
+                       'tuple, or an integer 0-10, not \\(1.1,\\)')):
+        ax.legend(loc=(1.1, ))
+
+    with pytest.raises(ValueError, match=('loc must be string, coordinate '
+                       'tuple, or an integer 0-10, not \\(0.481, 0.4227, 0.4523\\)')):
+        ax.legend(loc=(0.481, 0.4227, 0.4523))
+
+    with pytest.raises(ValueError, match=('loc must be string, coordinate '
+                       'tuple, or an integer 0-10, not \\(0.481, \'go blue\'\\)')):
+        ax.legend(loc=(0.481, "go blue"))
+
+
+def test_loc_valid_tuple():
+    fig, ax = plt.subplots()
+    ax.legend(loc=(0.481, 0.442))
+    ax.legend(loc=(1, 2))
+
+
+def test_loc_valid_list():
+    fig, ax = plt.subplots()
+    ax.legend(loc=[0.481, 0.442])
+    ax.legend(loc=[1, 2])
+
+
+def test_loc_invalid_list_exception():
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match=('loc must be string, coordinate '
+                       'tuple, or an integer 0-10, not \\[1.1, 2.2, 3.3\\]')):
+        ax.legend(loc=[1.1, 2.2, 3.3])
+
+
+def test_loc_invalid_type():
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match=("loc must be string, coordinate "
+                       "tuple, or an integer 0-10, not {'not': True}")):
+        ax.legend(loc={'not': True})
+
+
+def test_loc_validation_numeric_value():
+    fig, ax = plt.subplots()
+    ax.legend(loc=0)
+    ax.legend(loc=1)
+    ax.legend(loc=5)
+    ax.legend(loc=10)
+    with pytest.raises(ValueError, match=('loc must be string, coordinate '
+                       'tuple, or an integer 0-10, not 11')):
+        ax.legend(loc=11)
+
+    with pytest.raises(ValueError, match=('loc must be string, coordinate '
+                       'tuple, or an integer 0-10, not -1')):
+        ax.legend(loc=-1)
+
+
+def test_loc_validation_string_value():
+    fig, ax = plt.subplots()
+    ax.legend(loc='best')
+    ax.legend(loc='upper right')
+    ax.legend(loc='best')
+    ax.legend(loc='upper right')
+    ax.legend(loc='upper left')
+    ax.legend(loc='lower left')
+    ax.legend(loc='lower right')
+    ax.legend(loc='right')
+    ax.legend(loc='center left')
+    ax.legend(loc='center right')
+    ax.legend(loc='lower center')
+    ax.legend(loc='upper center')
+    with pytest.raises(ValueError, match="'wrong' is not a valid value for"):
+        ax.legend(loc='wrong')


### PR DESCRIPTION
Co-authored-by: John Paul Jepko <jpjepko@users.noreply.github.com>

## PR Summary
This pull request adds a check to the loc argument of legend. It checks that loc is one of the following:
- valid location string (this validation was already present)
-  a 2-tuple of floats or ints
-  a string numeric value (0-10)

The code raises a ValueError otherwise. This resolves #24605 . The docstrings already mentioned the fact that loc is a pair of floats so we did not add any changes to any docstrings. We also added test cases for the new validation checks. For details on the valid options refer to this [doc](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.legend.html) 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
