### PR TITLE
Fix unmatched offsetText label color

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2253,15 +2253,18 @@ class XAxis(Axis):
         )
         self.label_position = 'bottom'
 
+        if mpl.rcParams['xtick.labelcolor'] == 'inherit':
+            tick_color = mpl.rcParams['xtick.color']
+        else:
+            tick_color = mpl.rcParams['xtick.labelcolor']
+
         self.offsetText.set(
             x=1, y=0,
             verticalalignment='top', horizontalalignment='right',
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['xtick.labelsize'],
-            color=mpl.rcParams['xtick.color'] if
-            mpl.rcParams['xtick.labelcolor'] == 'inherit' else
-            mpl.rcParams['xtick.labelcolor'],
+            color=tick_color
         )
         self.offset_text_position = 'bottom'
 
@@ -2514,6 +2517,12 @@ class YAxis(Axis):
                 mtransforms.IdentityTransform(), self.axes.transAxes),
         )
         self.label_position = 'left'
+
+        if mpl.rcParams['ytick.labelcolor'] == 'inherit':
+            tick_color = mpl.rcParams['ytick.color']
+        else:
+            tick_color = mpl.rcParams['ytick.labelcolor']
+
         # x in axes coords, y in display coords(!).
         self.offsetText.set(
             x=0, y=0.5,
@@ -2521,9 +2530,7 @@ class YAxis(Axis):
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['ytick.labelsize'],
-            color=mpl.rcParams['ytick.color'] if
-            mpl.rcParams['ytick.labelcolor'] == 'inherit' else
-            mpl.rcParams['ytick.labelcolor'],
+            color=tick_color
         )
         self.offset_text_position = 'left'
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2259,7 +2259,9 @@ class XAxis(Axis):
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['xtick.labelsize'],
-            color=mpl.rcParams['xtick.color'],
+            color=mpl.rcParams['xtick.color'] if
+            mpl.rcParams['xtick.labelcolor'] == 'inherit' else
+            mpl.rcParams['xtick.labelcolor'],
         )
         self.offset_text_position = 'bottom'
 
@@ -2519,7 +2521,9 @@ class YAxis(Axis):
             transform=mtransforms.blended_transform_factory(
                 self.axes.transAxes, mtransforms.IdentityTransform()),
             fontsize=mpl.rcParams['ytick.labelsize'],
-            color=mpl.rcParams['ytick.color'],
+            color=mpl.rcParams['ytick.color'] if
+            mpl.rcParams['ytick.labelcolor'] == 'inherit' else
+            mpl.rcParams['ytick.labelcolor'],
         )
         self.offset_text_position = 'left'
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7811,6 +7811,36 @@ def test_ytickcolor_is_not_yticklabelcolor():
         assert tick.label1.get_color() == 'blue'
 
 
+def test_xticklabelcolor_if_not_xtickcolor():
+    plt.rcParams['xtick.labelcolor'] = 'blue'
+    ax = plt.axes()
+    ticks = ax.xaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.label1.get_color() == 'blue'
+
+    plt.rcParams['xtick.color'] = 'yellow'
+    plt.rcParams['xtick.labelcolor'] = 'inherit'
+    ax = plt.axes()
+    ticks = ax.xaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.label1.get_color() == 'yellow'
+
+
+def test_yticklabelcolor_if_not_ytickcolor():
+    plt.rcParams['ytick.labelcolor'] = 'green'
+    ax = plt.axes()
+    ticks = ax.yaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.label1.get_color() == 'green'
+
+    plt.rcParams['ytick.color'] = 'red'
+    plt.rcParams['ytick.labelcolor'] = 'inherit'
+    ax = plt.axes()
+    ticks = ax.yaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.label1.get_color() == 'red'
+
+
 @pytest.mark.parametrize('size', [size for size in mfont_manager.font_scalings
                                   if size is not None] + [8, 10, 12])
 @mpl.style.context('default')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7811,34 +7811,26 @@ def test_ytickcolor_is_not_yticklabelcolor():
         assert tick.label1.get_color() == 'blue'
 
 
-def test_xticklabelcolor_if_not_xtickcolor():
+def test_xaxis_offsetText_color():
     plt.rcParams['xtick.labelcolor'] = 'blue'
     ax = plt.axes()
-    ticks = ax.xaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.label1.get_color() == 'blue'
+    assert ax.xaxis.offsetText.get_color() == 'blue'
 
     plt.rcParams['xtick.color'] = 'yellow'
     plt.rcParams['xtick.labelcolor'] = 'inherit'
     ax = plt.axes()
-    ticks = ax.xaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.label1.get_color() == 'yellow'
+    assert ax.xaxis.offsetText.get_color() == 'yellow'
 
 
-def test_yticklabelcolor_if_not_ytickcolor():
+def test_yaxis_offsetText_color():
     plt.rcParams['ytick.labelcolor'] = 'green'
     ax = plt.axes()
-    ticks = ax.yaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.label1.get_color() == 'green'
+    assert ax.yaxis.offsetText.get_color() == 'green'
 
     plt.rcParams['ytick.color'] = 'red'
     plt.rcParams['ytick.labelcolor'] = 'inherit'
     ax = plt.axes()
-    ticks = ax.yaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.label1.get_color() == 'red'
+    assert ax.yaxis.offsetText.get_color() == 'red'
 
 
 @pytest.mark.parametrize('size', [size for size in mfont_manager.font_scalings


### PR DESCRIPTION
## PR Summary
Fixes #25165
Updates the offset text color according to the tick attribute "labelcolor" or "color"

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
