### PR TITLE
Pin mpl-sphinx-theme on the v3.7.x branch

### DIFF
--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -14,7 +14,7 @@ ipywidgets
 numpydoc>=1.0
 packaging>=20
 pydata-sphinx-theme>=0.12.0
-mpl-sphinx-theme>=3.7.0
+mpl-sphinx-theme~=3.7.0
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.10
 sphinx-copybutton


### PR DESCRIPTION
## PR Summary

A similar thing was done for the `v3.6.x` branch.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`