### PR TITLE
DOC: add include source to a 3.7 whats new

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.7.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.7.0.rst
@@ -383,6 +383,7 @@ Additional custom styling of button widgets may be achieved via the
 *label_props*, *frame_props*, and *check_props* arguments to `.CheckButtons`.
 
 .. plot::
+   :include-source: true
 
    from matplotlib.widgets import CheckButtons, RadioButtons
 


### PR DESCRIPTION
Without this we only get the example image, not the source to make it.
