### PR TITLE
Remove unused argument in Container

### DIFF
--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -16,7 +16,7 @@ class Container(tuple):
     def __new__(cls, *args, **kwargs):
         return tuple.__new__(cls, args[0])
 
-    def __init__(self, kl, label=None):
+    def __init__(self, label=None):
         self._callbacks = cbook.CallbackRegistry(signals=["pchanged"])
         self._remove_method = None
         self.set_label(label)
@@ -71,7 +71,7 @@ class BarContainer(Container):
         self.errorbar = errorbar
         self.datavalues = datavalues
         self.orientation = orientation
-        super().__init__(patches, **kwargs)
+        super().__init__(**kwargs)
 
 
 class ErrorbarContainer(Container):
@@ -103,7 +103,7 @@ class ErrorbarContainer(Container):
         self.lines = lines
         self.has_xerr = has_xerr
         self.has_yerr = has_yerr
-        super().__init__(lines, **kwargs)
+        super().__init__(**kwargs)
 
 
 class StemContainer(Container):
@@ -138,4 +138,4 @@ class StemContainer(Container):
         self.markerline = markerline
         self.stemlines = stemlines
         self.baseline = baseline
-        super().__init__(markerline_stemlines_baseline, **kwargs)
+        super().__init__(**kwargs)


### PR DESCRIPTION
## PR Summary

Not sure if a deprecation is required for this, but it is not documented and not used.

https://matplotlib.org/stable/api/container_api.html#matplotlib.container.Container

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
