### PR TITLE
Support pickling of figures with aligned x/y labels.

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -788,6 +788,19 @@ class Grouper:
     def __init__(self, init=()):
         self._mapping = {weakref.ref(x): [weakref.ref(x)] for x in init}
 
+    def __getstate__(self):
+        return {
+            **vars(self),
+            # Convert weak refs to strong ones.
+            "_mapping": {k(): [v() for v in vs] for k, vs in self._mapping.items()},
+        }
+
+    def __setstate__(self, state):
+        vars(self).update(state)
+        # Convert strong refs to weak ones.
+        self._mapping = {weakref.ref(k): [*map(weakref.ref, vs)]
+                         for k, vs in self._mapping.items()}
+
     def __contains__(self, item):
         return weakref.ref(item) in self._mapping
 

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -58,6 +58,7 @@ def _generate_complete_test_figure(fig_ref):
     # Ensure lists also pickle correctly.
     plt.subplot(3, 3, 1)
     plt.plot(list(range(10)))
+    plt.ylabel("hello")
 
     plt.subplot(3, 3, 2)
     plt.contourf(data, hatches=['//', 'ooo'])
@@ -68,6 +69,7 @@ def _generate_complete_test_figure(fig_ref):
 
     plt.subplot(3, 3, 4)
     plt.imshow(data)
+    plt.ylabel("hello\nworld!")
 
     plt.subplot(3, 3, 5)
     plt.pcolor(data)
@@ -88,6 +90,8 @@ def _generate_complete_test_figure(fig_ref):
 
     plt.subplot(3, 3, 9)
     plt.errorbar(x, x * -0.5, xerr=0.2, yerr=0.4)
+
+    fig_ref.align_ylabels()  # Test handling of _align_label_groups Groupers.
 
 
 @mpl.style.context("default")


### PR DESCRIPTION
## PR Summary

Closes #25329.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
