### PR TITLE
Fix for all NANs in contour

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1452,7 +1452,7 @@ class QuadContourSet(ContourSet):
         if self.logscale and self.zmin <= 0:
             z = ma.masked_where(z <= 0, z)
             _api.warn_external('Log scale: values of z <= 0 have been masked')
-            self.zmin = float(z.min())
+            self.zmin = z.min().astype(float)
         self._process_contour_level_args(args, z.dtype)
         return (x, y, z)
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1447,8 +1447,8 @@ class QuadContourSet(ContourSet):
         else:
             raise _api.nargs_error(fn, takes="from 1 to 4", given=nargs)
         z = ma.masked_invalid(z, copy=False)
-        self.zmax = float(z.max())
-        self.zmin = float(z.min())
+        self.zmax = z.max().astype(float)
+        self.zmin = z.min().astype(float)
         if self.logscale and self.zmin <= 0:
             z = ma.masked_where(z <= 0, z)
             _api.warn_external('Log scale: values of z <= 0 have been masked')

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -715,3 +715,9 @@ def test_bool_autolevel():
     assert plt.tricontour(x, y, z).levels.tolist() == [.5]
     assert plt.tricontourf(x, y, z.tolist()).levels.tolist() == [0, .5, 1]
     assert plt.tricontourf(x, y, z).levels.tolist() == [0, .5, 1]
+
+def test_all_nan():
+    x = np.array([[np.nan, np.nan], [np.nan, np.nan]])
+    assert_array_almost_equal(plt.contour(x).levels.tolist(),
+                              [-1e-13, -7.5e-14, -5e-14, -2.4e-14, 0.0,
+                                2.4e-14, 5e-14, 7.5e-14, 1e-13])

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -716,6 +716,7 @@ def test_bool_autolevel():
     assert plt.tricontourf(x, y, z.tolist()).levels.tolist() == [0, .5, 1]
     assert plt.tricontourf(x, y, z).levels.tolist() == [0, .5, 1]
 
+
 def test_all_nan():
     x = np.array([[np.nan, np.nan], [np.nan, np.nan]])
     assert_array_almost_equal(plt.contour(x).levels.tolist(),

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -719,6 +719,6 @@ def test_bool_autolevel():
 
 def test_all_nan():
     x = np.array([[np.nan, np.nan], [np.nan, np.nan]])
-    assert_array_almost_equal(plt.contour(x).levels.tolist(),
+    assert_array_almost_equal(plt.contour(x).levels,
                               [-1e-13, -7.5e-14, -5e-14, -2.4e-14, 0.0,
                                 2.4e-14, 5e-14, 7.5e-14, 1e-13])


### PR DESCRIPTION
## PR Summary

As discussed in #25330, we're removing the typecase to float with `z.min().astype(float)`.
Closes #14124.
<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
