### PR TITLE
Disable discarded animation warning on save

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -992,6 +992,15 @@ class Animation:
         is a `.MovieWriter`, a `RuntimeError` will be raised.
         """
 
+        all_anim = [self]
+        if extra_anim is not None:
+            all_anim.extend(anim for anim in extra_anim
+                            if anim._fig is self._fig)
+
+        # Disable "Animation was deleted without rendering" warning.
+        for anim in all_anim:
+            anim._draw_was_started = True
+
         if writer is None:
             writer = mpl.rcParams['animation.writer']
         elif (not isinstance(writer, str) and
@@ -1029,11 +1038,6 @@ class Animation:
             writer_kwargs['extra_args'] = extra_args
         if metadata is not None:
             writer_kwargs['metadata'] = metadata
-
-        all_anim = [self]
-        if extra_anim is not None:
-            all_anim.extend(anim for anim in extra_anim
-                            if anim._fig is self._fig)
 
         # If we have the name of a writer, instantiate an instance of the
         # registered class.

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -514,5 +514,5 @@ def test_movie_writer_invalid_path(anim):
     else:
         match_str = re.escape("[Errno 2] No such file or directory: '/foo")
     with pytest.raises(FileNotFoundError, match=match_str):
-        _ = anim.save("/foo/bar/aardvark/thiscannotreallyexist.mp4",
-                      writer=animation.FFMpegFileWriter())
+        anim.save("/foo/bar/aardvark/thiscannotreallyexist.mp4",
+                  writer=animation.FFMpegFileWriter())


### PR DESCRIPTION
## PR Summary

This tests is checking that the animation raises a reasonable error if it cannot be saved to a directory. But that triggers the warning that the animation was not saved.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`