### PR TITLE
Fix RangeSlider.set_val when outside existing value

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1297,12 +1297,12 @@ def test_range_slider(orientation):
         else:
             return [h.get_xdata()[0] for h in slider._handles]
 
-    slider.set_val((0.2, 0.6))
-    assert_allclose(slider.val, (0.2, 0.6))
-    assert_allclose(handle_positions(slider), (0.2, 0.6))
+    slider.set_val((0.4, 0.6))
+    assert_allclose(slider.val, (0.4, 0.6))
+    assert_allclose(handle_positions(slider), (0.4, 0.6))
 
     box = slider.poly.get_extents().transformed(ax.transAxes.inverted())
-    assert_allclose(box.get_points().flatten()[idx], [0.2, .25, 0.6, .75])
+    assert_allclose(box.get_points().flatten()[idx], [0.4, .25, 0.6, .75])
 
     slider.set_val((0.2, 0.1))
     assert_allclose(slider.val, (0.1, 0.2))

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -702,7 +702,7 @@ class RangeSlider(SliderBase):
                          valmin, valmax, valfmt, dragging, valstep)
 
         # Set a value to allow _value_in_bounds() to work.
-        self.val = [valmin, valmax]
+        self.val = (valmin, valmax)
         if valinit is None:
             # Place at the 25th and 75th percentiles
             extent = valmax - valmin
@@ -947,9 +947,9 @@ class RangeSlider(SliderBase):
         """
         val = np.sort(val)
         _api.check_shape((2,), val=val)
-        vmin, vmax = val
-        vmin = self._min_in_bounds(vmin)
-        vmax = self._max_in_bounds(vmax)
+        # Reset value to allow _value_in_bounds() to work.
+        self.val = (self.valmin, self.valmax)
+        vmin, vmax = self._value_in_bounds(val)
         self._update_selection_poly(vmin, vmax)
         if self.orientation == "vertical":
             self._handles[0].set_ydata([vmin])


### PR DESCRIPTION
## PR Summary

The clipping in the setter ensures that min <= max, but if you are setting both values outside the existing range, this will incorrectly set new minimum to old maximum and vice versa.

The tests also passed accidentally because all the new ranges overlapped with the old, and did not trigger this issue.

Fixes #25338

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`