### PR TITLE
FIX: use wrapped text in Text._get_layout

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -701,6 +701,22 @@ def test_wrap():
                                         'times.')
 
 
+def test_get_window_extent_wrapped():
+    # Test that a long title that wraps to two lines has the same vertical
+    # extent as an explicit two line title.
+
+    fig1 = plt.figure(figsize=(3, 3))
+    fig1.suptitle("suptitle that is clearly too long in this case", wrap=True)
+    window_extent_test = fig1._suptitle.get_window_extent()
+
+    fig2 = plt.figure(figsize=(3, 3))
+    fig2.suptitle("suptitle that is clearly\ntoo long in this case")
+    window_extent_ref = fig2._suptitle.get_window_extent()
+
+    assert window_extent_test.y0 == window_extent_ref.y0
+    assert window_extent_test.y1 == window_extent_ref.y1
+
+
 def test_long_word_wrap():
     fig = plt.figure(figsize=(6, 4))
     text = fig.text(9.5, 8, 'Alonglineoftexttowrap', wrap=True)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -367,7 +367,7 @@ class Text(Artist):
         of a rotated text when necessary.
         """
         thisx, thisy = 0.0, 0.0
-        lines = self.get_text().split("\n")  # Ensures lines is not empty.
+        lines = self._get_wrapped_text().split("\n")  # Ensures lines is not empty.
 
         ws = []
         hs = []


### PR DESCRIPTION
## PR Summary

Fixes #25336.

Constrained layout here relies on `Text.get_tightbbox`, which calls `Text.get_window_extent`, which calls `Text._get_layout`.  The example code in the issue now produces:

![test](https://user-images.githubusercontent.com/10599679/221883565-ebff7a1e-2da6-4496-9c66-953db980655b.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
