### PR TITLE
BLD: Pre-download Qhull license to put in wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -61,6 +61,14 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Something changed somewhere that prevents the downloaded-at-build-time
+      # licenses from being included in built wheels, so pre-download them so
+      # that they exist before the build and are included.
+      - name: Pre-download bundled licenses
+        run: >
+          curl -Lo LICENSE/LICENSE_QHULL
+          https://github.com/qhull/qhull/raw/2020.2/COPYING.txt
+
       - name: Build wheels for CPython 3.11
         uses: pypa/cibuildwheel@v2.12.0
         env:


### PR DESCRIPTION
## PR Summary

We couldn't work out what exactly changed to stop the license being included, so work around that by pre-downloading it.

Fixes #25212

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`