### PR TITLE
Clean up Curve ArrowStyle docs

### DIFF
--- a/galleries/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
+++ b/galleries/examples/text_labels_and_annotations/angles_on_bracket_arrows.py
@@ -23,37 +23,39 @@ def get_point_of_rotated_vertical(origin, line_length, degrees):
             origin[1] + line_length * np.cos(rad)]
 
 
-fig, ax = plt.subplots(figsize=(8, 7))
-ax.set(xlim=(0, 6), ylim=(-1, 4))
+fig, ax = plt.subplots()
+ax.set(xlim=(0, 6), ylim=(-1, 5))
 ax.set_title("Orientation of the bracket arrows relative to angleA and angleB")
 
-for i, style in enumerate(["]-[", "|-|"]):
-    for j, angle in enumerate([-40, 60]):
-        y = 2*i + j
-        arrow_centers = ((1, y), (5, y))
-        vlines = ((1, y + 0.5), (5, y + 0.5))
-        anglesAB = (angle, -angle)
-        bracketstyle = f"{style}, angleA={anglesAB[0]}, angleB={anglesAB[1]}"
-        bracket = FancyArrowPatch(*arrow_centers, arrowstyle=bracketstyle,
-                                  mutation_scale=42)
-        ax.add_patch(bracket)
-        ax.text(3, y + 0.05, bracketstyle, ha="center", va="bottom")
-        ax.vlines([i[0] for i in vlines], [y, y], [i[1] for i in vlines],
-                  linestyles="--", color="C0")
-        # Get the top coordinates for the drawn patches at A and B
-        patch_tops = [get_point_of_rotated_vertical(center, 0.5, angle)
-                      for center, angle in zip(arrow_centers, anglesAB)]
-        # Define the connection directions for the annotation arrows
-        connection_dirs = (1, -1) if angle > 0 else (-1, 1)
-        # Add arrows and annotation text
-        arrowstyle = "Simple, tail_width=0.5, head_width=4, head_length=8"
-        for vline, dir, patch_top, angle in zip(vlines, connection_dirs,
-                                                patch_tops, anglesAB):
-            kw = dict(connectionstyle=f"arc3,rad={dir * 0.5}",
-                      arrowstyle=arrowstyle, color="C0")
-            ax.add_patch(FancyArrowPatch(vline, patch_top, **kw))
-            ax.text(vline[0] - dir * 0.15, y + 0.3, f'{angle}°', ha="center",
-                    va="center")
+style = ']-['
+for i, angle in enumerate([-40, 0, 60]):
+    y = 2*i
+    arrow_centers = ((1, y), (5, y))
+    vlines = ((1, y + 0.5), (5, y + 0.5))
+    anglesAB = (angle, -angle)
+    bracketstyle = f"{style}, angleA={anglesAB[0]}, angleB={anglesAB[1]}"
+    bracket = FancyArrowPatch(*arrow_centers, arrowstyle=bracketstyle,
+                              mutation_scale=42)
+    ax.add_patch(bracket)
+    ax.text(3, y + 0.05, bracketstyle, ha="center", va="bottom", fontsize=14)
+    ax.vlines([line[0] for line in vlines], [y, y], [line[1] for line in vlines],
+              linestyles="--", color="C0")
+    # Get the top coordinates for the drawn patches at A and B
+    patch_tops = [get_point_of_rotated_vertical(center, 0.5, angle)
+                  for center, angle in zip(arrow_centers, anglesAB)]
+    # Define the connection directions for the annotation arrows
+    connection_dirs = (1, -1) if angle > 0 else (-1, 1)
+    # Add arrows and annotation text
+    arrowstyle = "Simple, tail_width=0.5, head_width=4, head_length=8"
+    for vline, dir, patch_top, angle in zip(vlines, connection_dirs,
+                                            patch_tops, anglesAB):
+        kw = dict(connectionstyle=f"arc3,rad={dir * 0.5}",
+                  arrowstyle=arrowstyle, color="C0")
+        ax.add_patch(FancyArrowPatch(vline, patch_top, **kw))
+        ax.text(vline[0] - dir * 0.15, y + 0.7, f'{angle}°', ha="center",
+                va="center")
+
+plt.show()
 
 # %%
 #

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -3197,29 +3197,18 @@ class ArrowStyle(_Style):
             Parameters
             ----------
             head_length : float, default: 0.4
-                Length of the arrow head, relative to *mutation_scale*.
+                Length of the arrow head, relative to *mutation_size*.
             head_width : float, default: 0.2
-                Width of the arrow head, relative to *mutation_scale*.
-            widthA : float, default: 1.0
-                Width of the bracket at the beginning of the arrow
-            widthB : float, default: 1.0
-                Width of the bracket at the end of the arrow
-            lengthA : float, default: 0.2
-                Length of the bracket at the beginning of the arrow
-            lengthB : float, default: 0.2
-                Length of the bracket at the end of the arrow
-            angleA : float, default 0
-                Orientation of the bracket at the beginning, as a
-                counterclockwise angle. 0 degrees means perpendicular
-                to the line.
-            angleB : float, default 0
-                Orientation of the bracket at the beginning, as a
-                counterclockwise angle. 0 degrees means perpendicular
-                to the line.
-            scaleA : float, default *mutation_size*
-                The mutation_size for the beginning bracket
-            scaleB : float, default *mutation_size*
-                The mutation_size for the end bracket
+                Width of the arrow head, relative to *mutation_size*.
+            widthA, widthB : float, default: 1.0
+                Width of the bracket.
+            lengthA, lengthB : float, default: 0.2
+                Length of the bracket.
+            angleA, angleB : float, default: 0
+                Orientation of the bracket, as a counterclockwise angle.
+                0 degrees means perpendicular to the line.
+            scaleA, scaleB : float, default: *mutation_size*
+                The scale of the brackets.
             """
 
             self.head_length, self.head_width = head_length, head_width


### PR DESCRIPTION
## PR Summary

By combining A/B parameters, to match the style of the CurveBracket, CurveFilled, etc.

Also, tweak the example image so that it is not scaled down in the docs, and explicitly shows 0°.

Fixes #25361.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`