### PR TITLE
Expire mpl_toolkits deprecations.

### DIFF
--- a/doc/api/next_api_changes/removals/25373-AL.rst
+++ b/doc/api/next_api_changes/removals/25373-AL.rst
@@ -1,0 +1,17 @@
+Removed deprecated APIs
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The following deprecated APIs have been removed:
+
+- In the `~.axes_size` module, the following classes: ``AddList`` (use
+  ``sum(sizes, start=Fixed(0))`` instead), ``Padded`` (use ``size + pad``
+  instead), ``SizeFromFunc``, ``GetExtentHelper``.
+- ``AxisArtistHelper.delta1``, ``AxisArtistHelper.delta2``,
+  ``GridHelperBase.new_gridlines``, ``GridHelperRectlinear.new_gridlines``.
+- ``Axes3D.dist``, ``axis3d.Axis.set_pane_pos``, ``axis3d.move_from_center``,
+  ``axis3d.tick_update_position``.
+- Support for positionally passing arguments *emit* and *auto* to
+  `.Axes.set_xlim`, `.Axes.set_ylim`, and `.Axes3D.set_zlim`.
+
+Unless a replacement is stated, inline the previous definition if the
+functionality is still needed.

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -463,7 +463,7 @@ instead of ``\usepackage{ucs}\usepackage[utf8x]{inputenc}``.
 
 Exception changes
 -----------------
-- `mpl_toolkits.axes_grid1.axes_size.GetExtentHelper` now raises `ValueError`
+- ``mpl_toolkits.axes_grid1.axes_size.GetExtentHelper`` now raises `ValueError`
   for invalid directions instead of `KeyError`.
 - Previously, subprocess failures in the animation framework would raise either
   in a `RuntimeError` or a `ValueError` depending on when the error occurred.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3568,9 +3568,8 @@ class _AxesBase(martist.Artist):
                 raise ValueError("Axis limits cannot be NaN or Inf")
             return converted_limit
 
-    @_api.make_keyword_only("3.6", "emit")
-    def set_xlim(self, left=None, right=None, emit=True, auto=False,
-                 *, xmin=None, xmax=None):
+    def set_xlim(self, left=None, right=None, *,
+                 emit=True, auto=False, xmin=None, xmax=None):
         """
         Set the x-axis view limits.
 
@@ -3800,9 +3799,8 @@ class _AxesBase(martist.Artist):
         """
         return tuple(self.viewLim.intervaly)
 
-    @_api.make_keyword_only("3.6", "emit")
-    def set_ylim(self, bottom=None, top=None, emit=True, auto=False,
-                 *, ymin=None, ymax=None):
+    def set_ylim(self, bottom=None, top=None, *,
+                 emit=True, auto=False, ymin=None, ymax=None):
         """
         Set the y-axis view limits.
 

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -37,18 +37,6 @@ class Add(_Base):
         return a_rel_size + b_rel_size, a_abs_size + b_abs_size
 
 
-@_api.deprecated(
-    "3.6", alternative="sum(sizes, start=Fixed(0))")
-class AddList(_Base):
-    def __init__(self, add_list):
-        self._list = add_list
-
-    def get_size(self, renderer):
-        sum_rel_size = sum([a.get_size(renderer)[0] for a in self._list])
-        sum_abs_size = sum([a.get_size(renderer)[1] for a in self._list])
-        return sum_rel_size, sum_abs_size
-
-
 class Fixed(_Base):
     """
     Simple fixed size with absolute part = *fixed_size* and relative part = 0.
@@ -204,24 +192,6 @@ class Fraction(_Base):
             return rel_size, abs_size
 
 
-@_api.deprecated("3.6", alternative="size + pad")
-class Padded(_Base):
-    """
-    Return an instance where the absolute part of *size* is
-    increase by the amount of *pad*.
-    """
-
-    def __init__(self, size, pad):
-        self._size = size
-        self._pad = pad
-
-    def get_size(self, renderer):
-        r, a = self._size.get_size(renderer)
-        rel_size = r
-        abs_size = a + self._pad
-        return rel_size, abs_size
-
-
 def from_any(size, fraction_ref=None):
     """
     Create a Fixed unit when the first argument is a float, or a
@@ -237,43 +207,6 @@ def from_any(size, fraction_ref=None):
         if size[-1] == "%":
             return Fraction(float(size[:-1]) / 100, fraction_ref)
     raise ValueError("Unknown format")
-
-
-@_api.deprecated("3.6")
-class SizeFromFunc(_Base):
-    def __init__(self, func):
-        self._func = func
-
-    def get_size(self, renderer):
-        rel_size = 0.
-
-        bb = self._func(renderer)
-        dpi = renderer.points_to_pixels(72.)
-        abs_size = bb/dpi
-
-        return rel_size, abs_size
-
-
-@_api.deprecated("3.6")
-class GetExtentHelper:
-    _get_func_map = {
-        "left":   lambda self, axes_bbox: axes_bbox.xmin - self.xmin,
-        "right":  lambda self, axes_bbox: self.xmax - axes_bbox.xmax,
-        "bottom": lambda self, axes_bbox: axes_bbox.ymin - self.ymin,
-        "top":    lambda self, axes_bbox: self.ymax - axes_bbox.ymax,
-    }
-
-    def __init__(self, ax, direction):
-        _api.check_in_list(self._get_func_map, direction=direction)
-        self._ax_list = [ax] if isinstance(ax, Axes) else ax
-        self._direction = direction
-
-    def __call__(self, renderer):
-        get_func = self._get_func_map[self._direction]
-        vl = [get_func(ax.get_tightbbox(renderer, call_axes_locator=False),
-                       ax.bbox)
-              for ax in self._ax_list]
-        return max(vl)
 
 
 class _AxesDecorationsSize(_Base):

--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -90,11 +90,6 @@ class AxisArtistHelper:
         def update_lim(self, axes):
             pass
 
-        delta1 = _api.deprecated("3.6")(
-            property(lambda self: 0.00001, lambda self, value: None))
-        delta2 = _api.deprecated("3.6")(
-            property(lambda self: 0.00001, lambda self, value: None))
-
         def _to_xy(self, values, const):
             """
             Create a (*values.shape, 2)-shape array representing (x, y) pairs.
@@ -323,29 +318,6 @@ class GridHelperBase:
         """
         return []
 
-    @_api.deprecated("3.6")
-    def new_gridlines(self, ax):
-        """
-        Create and return a new GridlineCollection instance.
-
-        *which* : "major" or "minor"
-        *axis* : "both", "x" or "y"
-
-        """
-        gridlines = GridlinesCollection(
-            None, transform=ax.transData, colors=mpl.rcParams['grid.color'],
-            linestyles=mpl.rcParams['grid.linestyle'],
-            linewidths=mpl.rcParams['grid.linewidth'])
-        ax._set_artist_props(gridlines)
-        gridlines.set_grid_helper(self)
-
-        ax.axes._set_artist_props(gridlines)
-        # gridlines.set_clip_path(self.axes.patch)
-        # set_clip_path need to be deferred after Axes.cla is completed.
-        # It is done inside the cla.
-
-        return gridlines
-
 
 class GridHelperRectlinear(GridHelperBase):
 
@@ -454,21 +426,6 @@ class Axes(maxes.Axes):
     @property
     def axis(self):
         return self._axislines
-
-    @_api.deprecated("3.6")
-    def new_gridlines(self, grid_helper=None):
-        """
-        Create and return a new GridlineCollection instance.
-
-        *which* : "major" or "minor"
-        *axis* : "both", "x" or "y"
-
-        """
-        if grid_helper is None:
-            grid_helper = self.get_grid_helper()
-
-        gridlines = grid_helper.new_gridlines(self)
-        return gridlines
 
     def clear(self):
         # docstring inherited

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -57,7 +57,6 @@ class Axes3D(Axes):
     _axis_names = ("x", "y", "z")
     Axes._shared_axes["z"] = cbook.Grouper()
 
-    dist = _api.deprecate_privatize_attribute("3.6")
     vvec = _api.deprecate_privatize_attribute("3.7")
     eye = _api.deprecate_privatize_attribute("3.7")
     sx = _api.deprecate_privatize_attribute("3.7")
@@ -683,9 +682,8 @@ class Axes3D(Axes):
         return minx, maxx, miny, maxy, minz, maxz
 
     # set_xlim, set_ylim are directly inherited from base Axes.
-    @_api.make_keyword_only("3.6", "emit")
-    def set_zlim(self, bottom=None, top=None, emit=True, auto=False,
-                 *, zmin=None, zmax=None):
+    def set_zlim(self, bottom=None, top=None, *,
+                 emit=True, auto=False, zmin=None, zmax=None):
         """
         Set 3D z limits.
 

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -13,15 +13,6 @@ from matplotlib import (
 from . import art3d, proj3d
 
 
-@_api.deprecated("3.6", alternative="a vendored copy of _move_from_center")
-def move_from_center(coord, centers, deltas, axmask=(True, True, True)):
-    """
-    For each coordinate where *axmask* is True, move *coord* away from
-    *centers* by *deltas*.
-    """
-    return _move_from_center(coord, centers, deltas, axmask=axmask)
-
-
 def _move_from_center(coord, centers, deltas, axmask=(True, True, True)):
     """
     For each coordinate where *axmask* is True, move *coord* away from
@@ -29,12 +20,6 @@ def _move_from_center(coord, centers, deltas, axmask=(True, True, True)):
     """
     coord = np.asarray(coord)
     return coord + axmask * np.copysign(1, coord - centers) * deltas
-
-
-@_api.deprecated("3.6", alternative="a vendored copy of _tick_update_position")
-def tick_update_position(tick, tickxs, tickys, labelpos):
-    """Update tick line and label position and style."""
-    _tick_update_position(tick, tickxs, tickys, labelpos)
 
 
 def _tick_update_position(tick, tickxs, tickys, labelpos):
@@ -198,17 +183,6 @@ class Axis(maxis.XAxis):
                 obj.set_transform(self.axes.transData)
         return ticks
 
-    @_api.deprecated("3.6")
-    def set_pane_pos(self, xys):
-        """Set pane position."""
-        self._set_pane_pos(xys)
-
-    def _set_pane_pos(self, xys):
-        xys = np.asarray(xys)
-        xys = xys[:, :2]
-        self.pane.xy = xys
-        self.stale = True
-
     def set_pane_color(self, color, alpha=None):
         """
         Set pane color.
@@ -333,14 +307,12 @@ class Axis(maxis.XAxis):
 
         mins, maxs, centers, deltas, tc, highs = self._get_coord_info(renderer)
 
-        info = self._axinfo
-        index = info['i']
+        index = self._axinfo['i']
         if not highs[index]:
             plane = self._PLANES[2 * index]
         else:
             plane = self._PLANES[2 * index + 1]
-        xys = [tc[p] for p in plane]
-        self._set_pane_pos(xys)
+        self.pane.set_xy([tc[p][:2] for p in plane])
         self.pane.draw(renderer)
 
         renderer.close_group('pane3d')


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
