### PR TITLE
Correct patheffects doc

### DIFF
--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -180,12 +180,12 @@ def _subclass_with_normal(effect_class):
 
     With this class you can use ::
 
-        artist.set_path_effects([path_effects.with{effect_class.__name__}()])
+        artist.set_path_effects([patheffects.with{effect_class.__name__}()])
 
     as a shortcut for ::
 
-        artist.set_path_effects([path_effects.{effect_class.__name__}(),
-                                 path_effects.Normal()])
+        artist.set_path_effects([patheffects.{effect_class.__name__}(),
+                                 patheffects.Normal()])
     """
     # Docstring inheritance doesn't work for locally-defined subclasses.
     withEffect.draw_path.__doc__ = effect_class.draw_path.__doc__


### PR DESCRIPTION
## PR Summary

The module is `patheffects`, not `path_effects`.

This is the updated version:
![image](https://user-images.githubusercontent.com/8114497/222916503-5a6e182f-b9ef-42ee-b618-8b4299588c8d.png)


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
