### PR TITLE
Patch for Issue #25274

### DIFF
--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -24,6 +24,7 @@ class Container(tuple):
     def remove(self):
         for c in cbook.flatten(
                 self, scalarp=lambda x: isinstance(x, Artist)):
+        self.set_label("")
             if c is not None:
                 c.remove()
         if self._remove_method:


### PR DESCRIPTION
#25274 ## PR Summary

Patch for
#25274 Bug]: .remove() on ErrorbarContainer object does not remove the corresponding item from the legend #25274

Solution was simply setting label blank in remove. 

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] pytest passes for container.py
**Release Notes**
- [ ] No new Features
- [ ] No New API calls

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
