### PR TITLE
Better axis labels for examples

### DIFF
--- a/galleries/examples/axisartist/simple_axis_direction01.py
+++ b/galleries/examples/axisartist/simple_axis_direction01.py
@@ -1,7 +1,7 @@
 """
-=======================
-Simple Axis Direction01
-=======================
+=====================
+Simple axis direction
+=====================
 
 """
 import matplotlib.pyplot as plt
@@ -13,10 +13,10 @@ ax1 = fig.add_subplot(axes_class=axisartist.Axes)
 fig.subplots_adjust(right=0.8)
 
 ax1.axis["left"].major_ticklabels.set_axis_direction("top")
-ax1.axis["left"].label.set_text("Label")
+ax1.axis["left"].label.set_text("Left label")
 
 ax1.axis["right"].label.set_visible(True)
-ax1.axis["right"].label.set_text("Label")
+ax1.axis["right"].label.set_text("Right label")
 ax1.axis["right"].label.set_axis_direction("left")
 
 plt.show()

--- a/galleries/examples/axisartist/simple_axis_direction03.py
+++ b/galleries/examples/axisartist/simple_axis_direction03.py
@@ -1,8 +1,11 @@
 """
-=======================
-Simple Axis Direction03
-=======================
+==========================================
+Simple axis tick label and tick directions
+==========================================
 
+First subplot moves the tick labels to inside the spines.
+Second subplots moves the ticks to inside the spines.
+These effects can be obtained for a standard Axes by `~.Axes.tick_params`.
 """
 
 import matplotlib.pyplot as plt
@@ -21,15 +24,15 @@ fig = plt.figure(figsize=(5, 2))
 fig.subplots_adjust(wspace=0.4, bottom=0.3)
 
 ax1 = setup_axes(fig, 121)
-ax1.set_xlabel("X-label")
-ax1.set_ylabel("Y-label")
+ax1.set_xlabel("ax1 X-label")
+ax1.set_ylabel("ax1 Y-label")
 
 ax1.axis[:].invert_ticklabel_direction()
 
 ax2 = setup_axes(fig, 122)
-ax2.set_xlabel("X-label")
-ax2.set_ylabel("Y-label")
+ax2.set_xlabel("ax2 X-label")
+ax2.set_ylabel("ax2 Y-label")
 
-ax2.axis[:].major_ticks.set_tick_out(True)
+ax2.axis[:].major_ticks.set_tick_out(False)
 
 plt.show()


### PR DESCRIPTION
## PR Summary

Not so clear which label is which if the same label text is used.

Also, changed the casing of the example name. 1 and 3 are not ideal, but not really sure what a better name should be.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
