### PR TITLE
DOC: Fix a couple typos

### DIFF
--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -62,7 +62,7 @@ Pull Requests (62):
 * :ghpull:`25305`: DOC: add layout='none' option to Figure constructor
 * :ghpull:`25315`: Backport PR #24878 on branch v3.7.x ( [Doc]: Add alt-text to images in 3.6 release notes #24844 )
 * :ghpull:`24878`: [Doc]: Add alt-text to images in 3.6 release notes #24844
-* :ghpull:`25312`: Backport PR #25308 on branch v3.7.x (DOC: add include source to a 3.7 whats new)
+* :ghpull:`25312`: Backport PR #25308 on branch v3.7.x (DOC: add include source to a 3.7 what's new)
 * :ghpull:`25309`: Backport PR #25302 on branch v3.7.x (Cleanup gradient_bar example.)
 * :ghpull:`25299`: Backport PR #25238 on branch v3.7.x (Check file path for animation and raise if it does not exist)
 * :ghpull:`25297`: Backport PR #25295 on branch v3.7.x (Increase timeout for interactive backend tests)

--- a/examples/axisartist/simple_axis_direction03.py
+++ b/examples/axisartist/simple_axis_direction03.py
@@ -4,7 +4,7 @@ Simple axis tick label and tick directions
 ==========================================
 
 First subplot moves the tick labels to inside the spines.
-Second subplots moves the ticks to inside the spines.
+Second subplot moves the ticks to inside the spines.
 These effects can be obtained for a standard Axes by `~.Axes.tick_params`.
 """
 


### PR DESCRIPTION
## PR Summary

Fixes a typo from #25388, and a typo from generating the GitHub stats page that is causing pre-commit to complain.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`