### PR TITLE
Move _SelectorWidget._props into SpanSelector

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -987,6 +987,19 @@ def test_lasso_selector(ax, kwargs):
     onselect.assert_called_once_with([(100, 100), (125, 125), (150, 150)])
 
 
+def test_lasso_selector_set_props(ax):
+    onselect = mock.Mock(spec=noop, return_value=None)
+
+    tool = widgets.LassoSelector(ax, onselect, props=dict(color='b', alpha=0.2))
+
+    artist = tool._selection_artist
+    assert mcolors.same_color(artist.get_color(), 'b')
+    assert artist.get_alpha() == 0.2
+    tool.set_props(color='r', alpha=0.3)
+    assert mcolors.same_color(artist.get_color(), 'r')
+    assert artist.get_alpha() == 0.3
+
+
 def test_CheckButtons(ax):
     check = widgets.CheckButtons(ax, ('a', 'b', 'c'), (True, False, True))
     assert check.get_status() == [True, False, True]


### PR DESCRIPTION
## PR Summary

This is the only selector widget that needs to remember its properties separately from the artist, because the artist can be recreated.

Fixes #25199

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`