### PR TITLE
Fix incorrect stride calculations in LogLocator.tick_values()

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -246,7 +246,7 @@ class TestLogLocator:
                                1.e+03, 2.e+03, 5.e+03, 1.e+04, 2.e+04, 5.e+04,
                                1.e+05, 2.e+05, 5.e+05, 1.e+06, 2.e+06, 5.e+06,
                                1.e+07, 2.e+07, 5.e+07, 1.e+08, 2.e+08, 5.e+08])
-        assert_array_equal(ll.tick_values(1, 1e7), test_value)
+        assert_almost_equal(ll.tick_values(1, 1e7), test_value)
 
     def test_tick_values_not_empty(self):
         mpl.rcParams['_internal.classic_mode'] = False
@@ -257,7 +257,7 @@ class TestLogLocator:
                                1.e+05, 2.e+05, 5.e+05, 1.e+06, 2.e+06, 5.e+06,
                                1.e+07, 2.e+07, 5.e+07, 1.e+08, 2.e+08, 5.e+08,
                                1.e+09, 2.e+09, 5.e+09])
-        assert_array_equal(ll.tick_values(1, 1e8), test_value)
+        assert_almost_equal(ll.tick_values(1, 1e8), test_value)
 
 
 class TestNullLocator:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2386,7 +2386,8 @@ class LogLocator(Locator):
         # Get decades between major ticks.
         stride = (max(math.ceil(numdec / (numticks - 1)), 1)
                   if mpl.rcParams['_internal.classic_mode'] else
-                  (numdec + 1) // numticks + 1)
+                  next(s for s in itertools.count(1)
+                       if numdec // s + 1 <= numticks))
 
         # if we have decided that the stride is as big or bigger than
         # the range, clip the stride back to the available range - 1


### PR DESCRIPTION
## PR Summary
Resolves #24092 

A simplification of the stride calculation in [this commit](https://github.com/matplotlib/matplotlib/commit/a06f343dee3cebf035b74f65ea00b8842af448e9) seems to have introduced some incorrect behavior, as the simplified version isn't mathematically equivalent to the old one. This caused the method to return an empty array when it shouldn't, which meant ticks would not appear on the grid axes. 

This PR reverts the stride calculation in the case where `mpl.rcParams['_internal.classic_mode']` is `False` to one equivalent to the while-loop the simplification replaced, as well as adding tests for the scenario described in #24092.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
