### PR TITLE
Make tk backend use native crosshair cursor

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -29,7 +29,7 @@ cursord = {
     cursors.MOVE: "fleur",
     cursors.HAND: "hand2",
     cursors.POINTER: "arrow",
-    cursors.SELECT_REGION: "tcross",
+    cursors.SELECT_REGION: "crosshair",
     cursors.WAIT: "watch",
     cursors.RESIZE_HORIZONTAL: "sb_h_double_arrow",
     cursors.RESIZE_VERTICAL: "sb_v_double_arrow",


### PR DESCRIPTION
## PR Summary
The `crosshair` cursor maps to a native cursor on Windows, the current `tcross` does not.