### PR TITLE
DOC: add a note about linewidth to scatter docs

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4478,6 +4478,20 @@ class Axes(_AxesBase):
             The marker size in points**2 (typographic points are 1/72 in.).
             Default is ``rcParams['lines.markersize'] ** 2``.
 
+            The linewidth and edgecolor can visually interact with the marker
+            size.
+
+            If the linewidth is greater than 0 and the edegecolor is anything
+            but *'none'*, then the effective size of the marker will be
+            increased by half the linewidth as the stroke drawn for the edge
+            will be centered on the edge of the shape.
+
+            If the marker size is smaller than the linewidth there will be
+            visual artifacts.
+
+            To eliminate the marker edge either set *linewidth=0* or
+            *edgecolor='none'*.
+
         c : array-like or list of colors or color, optional
             The marker colors. Possible values:
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4482,7 +4482,7 @@ class Axes(_AxesBase):
             size, and can lead to artifacts if the marker size is smaller than
             the linewidth.
 
-            If the linewidth is greater than 0 and the edegecolor is anything
+            If the linewidth is greater than 0 and the edgecolor is anything
             but *'none'*, then the effective size of the marker will be
             increased by half the linewidth because the stroke will be centered
             on the edge of the shape.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4479,15 +4479,13 @@ class Axes(_AxesBase):
             Default is ``rcParams['lines.markersize'] ** 2``.
 
             The linewidth and edgecolor can visually interact with the marker
-            size.
+            size, and can lead to artifacts if the marker size is smaller than
+            the linewidth.
 
             If the linewidth is greater than 0 and the edegecolor is anything
             but *'none'*, then the effective size of the marker will be
-            increased by half the linewidth as the stroke drawn for the edge
-            will be centered on the edge of the shape.
-
-            If the marker size is smaller than the linewidth there will be
-            visual artifacts.
+            increased by half the linewidth because the stroke will be centered
+            on the edge of the shape.
 
             To eliminate the marker edge either set *linewidth=0* or
             *edgecolor='none'*.


### PR DESCRIPTION
## PR Summary

closes #25410

I do not think the long analysis in the comments of #25410 has a good home in the docs, but hopefully this is enough to point people in the right direction if things look funny.

There was another issue (that I can not find again) that reported the area of markers was too big (but they might have been using `Circle`) so also added a note about that while I was touching this docstring.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [/] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [/] New plotting related features are documented with examples.
