### PR TITLE
Added get_shape as an alias for get_size + tests

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -287,7 +287,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
     def get_size(self):
         """Return the size of the image as tuple (numrows, numcols)."""
         if self._A is None:
-            raise RuntimeError('You must first set the image array')
+            self.get_shape()
 
         return self._A.shape[:2]
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -275,8 +275,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def __str__(self):
         try:
-            size = self.get_size()
-            return f"{type(self).__name__}(size={size!r})"
+            shape = self.get_shape()
+            return f"{type(self).__name__}(shape={shape!r})"
         except RuntimeError:
             return type(self).__name__
 
@@ -290,6 +290,15 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
             raise RuntimeError('You must first set the image array')
 
         return self._A.shape[:2]
+
+    def get_shape(self):
+        """
+        Return the shape of the image as tuple (numrows, numcols, channels).
+        """
+        if self._A is None:
+            raise RuntimeError('You must first set the image array')
+
+        return self._A.shape
 
     def set_alpha(self, alpha):
         """

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -286,7 +286,7 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def get_size(self):
         """Return the size of the image as tuple (numrows, numcols)."""
-        return self._A.shape[:2]
+        return self.get_shape()[:2]
 
     def get_shape(self):
         """

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -286,9 +286,6 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def get_size(self):
         """Return the size of the image as tuple (numrows, numcols)."""
-        if self._A is None:
-            self.get_shape()
-
         return self._A.shape[:2]
 
     def get_shape(self):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1474,7 +1474,7 @@ def test_axesimage_get_shape():
     # generate dummy image to test get_shape method
     ax = plt.gca()
     im = AxesImage(ax)
-    with pytest.raises(RuntimeError):
+    with pytest.raises(RuntimeError, match="You must first set the image array"):
         im.get_shape()
     z = np.arange(12, dtype=float).reshape((4, 3))
     im.set_data(z)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1468,3 +1468,21 @@ def test__resample_valid_output():
         resample(np.zeros((9, 9), np.uint8), np.zeros((9, 9)))
     with pytest.raises(ValueError, match="must be C-contiguous"):
         resample(np.zeros((9, 9)), np.zeros((9, 9)).T)
+
+
+def test_axesimage_get_size():
+    # generate dummy image to test get_size method
+    ax = plt.gca()
+    im = AxesImage(ax)
+    z = np.arange(12, dtype=float).reshape((4, 3))
+    im.set_data(z)
+    assert im.get_size() == (4, 3)
+
+
+def test_axesimage_get_shape():
+    # generate dummy image to test get_shape method
+    ax = plt.gca()
+    im = AxesImage(ax)
+    z = np.arange(12, dtype=float).reshape((4, 3))
+    im.set_data(z)
+    assert im.get_shape() == (4, 3)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1470,19 +1470,13 @@ def test__resample_valid_output():
         resample(np.zeros((9, 9)), np.zeros((9, 9)).T)
 
 
-def test_axesimage_get_size():
-    # generate dummy image to test get_size method
-    ax = plt.gca()
-    im = AxesImage(ax)
-    z = np.arange(12, dtype=float).reshape((4, 3))
-    im.set_data(z)
-    assert im.get_size() == (4, 3)
-
-
 def test_axesimage_get_shape():
     # generate dummy image to test get_shape method
     ax = plt.gca()
     im = AxesImage(ax)
+    with pytest.raises(RuntimeError):
+        im.get_shape()
     z = np.arange(12, dtype=float).reshape((4, 3))
     im.set_data(z)
     assert im.get_shape() == (4, 3)
+    assert im.get_size() == im.get_shape()


### PR DESCRIPTION
## PR Summary
Fixes #22494. Continuation of draft PR #22510. Added the `get_shape` commit and wrote tests for `get_size` method and the newly added `get_shape` method.
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
