### PR TITLE
Fix Legend.set_draggable() with update="bbox"

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -77,7 +77,7 @@ class DraggableLegend(DraggableOffsetBox):
         if self._update == "loc":
             self._update_loc(self.get_loc_in_canvas())
         elif self._update == "bbox":
-            self._bbox_to_anchor(self.get_loc_in_canvas())
+            self._update_bbox_to_anchor(self.get_loc_in_canvas())
 
     def _update_loc(self, loc_in_canvas):
         bbox = self.legend.get_bbox_to_anchor()


### PR DESCRIPTION
Typo causes `Legend.set_draggable(True, update="bbox")` to be broken.