### PR TITLE
Release mouse grabs when owning Axes is removed

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -931,6 +931,7 @@ default: %(va)s
         self._axobservers.process("_axes_change_event", self)
         self.stale = True
         self._localaxes.remove(ax)
+        self.canvas.release_mouse(ax)
 
         # Break link between any shared axes
         for name in ax._axis_names:

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -95,6 +95,16 @@ def test_non_gui_warning(monkeypatch):
                 in str(rec[0].message))
 
 
+def test_grab_clear():
+    fig, ax = plt.subplots()
+
+    fig.canvas.grab_mouse(ax)
+    assert fig.canvas.mouse_grabber == ax
+
+    fig.clear()
+    assert fig.canvas.mouse_grabber is None
+
+
 @pytest.mark.parametrize(
     "x, y", [(42, 24), (None, 42), (None, None), (200, 100.01), (205.75, 2.0)])
 def test_location_event_position(x, y):


### PR DESCRIPTION
## PR Summary

Otherwise, _nothing_ will remove the grab, and no other Axes can grab the mouse (either raising the `RuntimeError` exception, or in the case of widgets, ignoring mouse events altogether.)

Fixes #25345

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`