### PR TITLE
ci: Install pytz for Pandas nightly wheel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -236,9 +236,14 @@ jobs:
 
       - name: Install the nightly dependencies
         # Only install the nightly dependencies during the scheduled event
-        if: ${{ github.event_name == 'schedule' && matrix.name-suffix != '(Minimum Versions)' }}
+        if: |
+          github.event_name == 'schedule' &&
+          matrix.name-suffix != '(Minimum Versions)'
         run: |
-          python -m pip install -i https://pypi.anaconda.org/scipy-wheels-nightly/simple --upgrade --only-binary=:all: numpy pandas
+          python -m pip install pytz  # Must be installed for Pandas.
+          python -m pip install \
+            --index-url https://pypi.anaconda.org/scipy-wheels-nightly/simple \
+            --upgrade --only-binary=:all: numpy pandas
 
       - name: Install Matplotlib
         run: |


### PR DESCRIPTION
## PR Summary

At some point, one of our dependencies must have required `pytz`, but then recently dropped it. Pandas also requires it, but because we install the nightly wheels using `--index-url`, `pip` can only install files from that index, which does not contain `pytz`. And we want to use that index exclusively because we only want the nightly wheels, and nothing else. So explicitly install `pytz` when running nightlies.

Also, make `-i` into the more explicit `--index-url`, and word-wrap that step.

Fixes #25431

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`