### PR TITLE
Adjust parent axes limits when clearing floating axes.

### DIFF
--- a/lib/mpl_toolkits/axisartist/floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/floating_axes.py
@@ -258,7 +258,6 @@ class FloatingAxesBase:
         _api.check_isinstance(GridHelperCurveLinear, grid_helper=grid_helper)
         super().__init__(*args, grid_helper=grid_helper, **kwargs)
         self.set_aspect(1.)
-        self.adjust_axes_lim()
 
     def _gen_axes_patch(self):
         # docstring inherited
@@ -282,6 +281,7 @@ class FloatingAxesBase:
         orig_patch.set_transform(self.transAxes)
         self.patch.set_clip_path(orig_patch)
         self.gridlines.set_clip_path(orig_patch)
+        self.adjust_axes_lim()
 
     def adjust_axes_lim(self):
         bbox = self.patch.get_path().get_extents(

--- a/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
@@ -82,6 +82,7 @@ def test_curvelinear4():
         tick_formatter1=angle_helper.FormatterDMS(),
         tick_formatter2=None)
     ax1 = fig.add_subplot(axes_class=FloatingAxes, grid_helper=grid_helper)
+    ax1.clear()  # Check that clear() also restores the correct limits on ax1.
 
     ax1.axis["left"].label.set_text("Test 1")
     ax1.axis["right"].label.set_text("Test 2")


### PR DESCRIPTION
Without this patch, calling clear() in a FloatingAxes will reset the limits of the (invisible, parent, rectilinear) axes to (0, 1), (0, 1), instead of the values computed by adjust_axes_lim.  For example, try adding a call to ax1.clear() in demo_floating_axes immediately after the call to setup_axes1; this previously resulted in a blown up left axes.
![test](https://user-images.githubusercontent.com/1322974/224642722-3c056d36-e55b-4d23-9017-39b6ebdb2a7b.png)

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
