### PR TITLE
Fix issue #25458 by changing "normed" to "density" in documentation

### DIFF
--- a/galleries/examples/statistics/histogram_cumulative.py
+++ b/galleries/examples/statistics/histogram_cumulative.py
@@ -8,11 +8,11 @@ step function in order to visualize the empirical cumulative
 distribution function (CDF) of a sample. We also show the theoretical CDF.
 
 A couple of other options to the ``hist`` function are demonstrated. Namely, we
-use the *normed* parameter to normalize the histogram and a couple of different
-options to the *cumulative* parameter. The *normed* parameter takes a boolean
+use the *density* parameter to normalize the histogram and a couple of different
+options to the *cumulative* parameter. The *density* parameter takes a boolean
 value. When ``True``, the bin heights are scaled such that the total area of
 the histogram is 1. The *cumulative* keyword argument is a little more nuanced.
-Like *normed*, you can pass it True or False, but you can also pass it -1 to
+Like *density*, you can pass it True or False, but you can also pass it -1 to
 reverse the distribution.
 
 Since we're showing a normalized and cumulative histogram, these curves


### PR DESCRIPTION
## PR Summary

Closes #25458 

Changes "normed" in the documentation to "density" due to the parameter being renamed in v3.3

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
