### PR TITLE
FIX: do not cache exceptions

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -385,4 +385,6 @@ def warn_external(message, category=None):
                         frame.f_globals.get("__name__", "")):
             break
         frame = frame.f_back
+    # premetively break reference cycle between locals and the frame
+    del frame
     warnings.warn(message, category, stacklevel)

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -67,6 +67,8 @@ def _get_running_interactive_framework():
                 if frame.f_code in codes:
                     return "tk"
                 frame = frame.f_back
+        # premetively break reference cycle between locals and the frame
+        del frame
     macosx = sys.modules.get("matplotlib.backends._macosx")
     if macosx and macosx.event_loop_is_running():
         return "macosx"

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -26,6 +26,7 @@ Future versions may implement the Level 2 or 2.1 specifications.
 #   - 'light' is an invalid weight value, remove it.
 
 from base64 import b64encode
+from collections import namedtuple
 import copy
 import dataclasses
 from functools import lru_cache
@@ -128,6 +129,7 @@ font_family_aliases = {
     'sans',
 }
 
+_ExceptionProxy = namedtuple('_ExceptionProxy', ['klass', 'message'])
 
 # OS Font paths
 try:
@@ -1288,8 +1290,8 @@ class FontManager:
         ret = self._findfont_cached(
             prop, fontext, directory, fallback_to_default, rebuild_if_missing,
             rc_params)
-        if isinstance(ret, Exception):
-            raise ret
+        if isinstance(ret, _ExceptionProxy):
+            raise ret.klass(ret.message)
         return ret
 
     def get_font_names(self):
@@ -1440,10 +1442,12 @@ class FontManager:
                                      fallback_to_default=False)
             else:
                 # This return instead of raise is intentional, as we wish to
-                # cache the resulting exception, which will not occur if it was
+                # cache that it was not found, which will not occur if it was
                 # actually raised.
-                return ValueError(f"Failed to find font {prop}, and fallback "
-                                  f"to the default font was disabled")
+                return _ExceptionProxy(
+                    ValueError,
+                    f"Failed to find font {prop}, and fallback to the default font was disabled"
+                )
         else:
             _log.debug('findfont: Matching %s to %s (%r) with score of %f.',
                        prop, best_font.name, best_font.fname, best_score)
@@ -1463,9 +1467,9 @@ class FontManager:
                     prop, fontext, directory, rebuild_if_missing=False)
             else:
                 # This return instead of raise is intentional, as we wish to
-                # cache the resulting exception, which will not occur if it was
+                # cache that it was not found, which will not occur if it was
                 # actually raised.
-                return ValueError("No valid font could be found")
+                return _ExceptionProxy(ValueError, "No valid font could be found")
 
         return _cached_realpath(result)
 


### PR DESCRIPTION
This leads to caching the tracebacks which can keep user's objects in local namespaces alive indefinitely.  This can lead to very surprising memory issues for users and will result in incorrect tracebacks.

Responsive to #25406

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
