### PR TITLE
Use get_sample_data(..., asfileobj=False) less.

### DIFF
--- a/galleries/examples/showcase/stock_prices.py
+++ b/galleries/examples/showcase/stock_prices.py
@@ -22,16 +22,10 @@ import numpy as np
 from matplotlib.cbook import get_sample_data
 import matplotlib.transforms as mtransforms
 
-
-def convertdate(x):
-    return np.datetime64(x, 'D')
-
-
-fname = get_sample_data('Stocks.csv', asfileobj=False)
-stock_data = np.genfromtxt(fname, encoding='utf-8', delimiter=',',
-                           names=True, dtype=None, converters={0: convertdate},
-                           skip_header=1)
-
+with get_sample_data('Stocks.csv') as file:
+    stock_data = np.genfromtxt(
+        file, delimiter=',', names=True, dtype=None,
+        converters={0: lambda x: np.datetime64(x, 'D')}, skip_header=1)
 
 fig, ax = plt.subplots(1, 1, figsize=(6, 8), layout='constrained')
 

--- a/galleries/examples/subplots_axes_and_figures/figure_title.py
+++ b/galleries/examples/subplots_axes_and_figures/figure_title.py
@@ -10,6 +10,7 @@ Each axes can have a title (or actually three - one each with *loc* "left",
 We can also add figure-level x- and y-labels using `.FigureBase.supxlabel` and
 `.FigureBase.supylabel`.
 """
+
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -34,13 +35,10 @@ fig.suptitle('Different types of oscillations', fontsize=16)
 # `.FigureBase.supylabel` methods.
 
 
-def convertdate(x):
-    return np.datetime64(x, 'D')
-
-fname = get_sample_data('Stocks.csv', asfileobj=False)
-stocks = np.genfromtxt(fname, encoding='utf-8', delimiter=',',
-                       names=True, dtype=None, converters={0: convertdate},
-                       skip_header=1)
+with get_sample_data('Stocks.csv') as file:
+    stocks = np.genfromtxt(
+        file, delimiter=',', names=True, dtype=None,
+        converters={0: lambda x: np.datetime64(x, 'D')}, skip_header=1)
 
 fig, axs = plt.subplots(4, 2, figsize=(9, 5), layout='constrained',
                         sharex=True, sharey=True)
@@ -51,3 +49,5 @@ for nn, ax in enumerate(axs.flat):
     ax.set_title(column_name, fontsize='small', loc='left')
 fig.supxlabel('Year')
 fig.supylabel('Stock price relative to max')
+
+plt.show()


### PR DESCRIPTION
The kwarg to switch the returned object is a bit unsightly, and in the cases here genfromtxt handles the file object as input just fine.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
