### PR TITLE
Stop building 32-bit Linux wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -35,20 +35,29 @@ jobs:
     name: Build wheels on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_ARCHS_MACOS: "x86_64 universal2 arm64"
-      MACOSX_DEPLOYMENT_TARGET: "10.12"
+      CIBW_BEFORE_BUILD: >-
+        pip install certifi oldest-supported-numpy &&
+        git clean -fxd build
       CIBW_BEFORE_BUILD_WINDOWS: >-
         pip install certifi delvewheel oldest-supported-numpy &&
         git clean -fxd build
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
         delvewheel repair -w {dest_dir} {wheel}
+      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_SKIP: "*-musllinux*"
+      MACOSX_DEPLOYMENT_TARGET: "10.12"
+      MPL_DISABLE_FH4: "yes"
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-latest, macos-11]
-        cibw_archs: ["auto"]
         include:
           - os: ubuntu-20.04
+            cibw_archs: "x86_64"
+          - os: ubuntu-20.04
             cibw_archs: "aarch64"
+          - os: windows-latest
+            cibw_archs: "auto"
+          - os: macos-11
+            cibw_archs: "x86_64 universal2 arm64"
 
     steps:
       - name: Set up QEMU
@@ -73,49 +82,24 @@ jobs:
         uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BUILD: "cp311-*"
-          CIBW_SKIP: "*-musllinux*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD: >-
-            pip install certifi oldest-supported-numpy &&
-            git clean -fxd build
-          MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.10
         uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BUILD: "cp310-*"
-          CIBW_SKIP: "*-musllinux*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD: >-
-            pip install certifi oldest-supported-numpy &&
-            git clean -fxd build
-          MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.9
         uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BUILD: "cp39-*"
-          CIBW_SKIP: "*-musllinux*"
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_I686_IMAGE: manylinux2014
-          CIBW_BEFORE_BUILD: >-
-            pip install certifi oldest-supported-numpy &&
-            git clean -fxd build
-          MPL_DISABLE_FH4: "yes"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for PyPy
         uses: pypa/cibuildwheel@v2.12.1
         env:
           CIBW_BUILD: "pp39-*"
-          CIBW_SKIP: "*-musllinux*"
-          CIBW_BEFORE_BUILD: >-
-            pip install certifi oldest-supported-numpy &&
-            git clean -fxd build
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
         if: matrix.cibw_archs != 'aarch64'
 

--- a/doc/api/next_api_changes/development/25475-ES.rst
+++ b/doc/api/next_api_changes/development/25475-ES.rst
@@ -1,0 +1,5 @@
+Wheels for 32-bit Linux are no longer distributed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Pre-compiled wheels for 32-bit Linux are no longer provided on PyPI since
+Matplotlib 3.8.


### PR DESCRIPTION
## PR Summary

NumPy dropped these builds first in 1.21.2 (Aug 15, 2021) for Python 3.10 only, and for all builds in 1.22 (Dec 31, 2021).
SciPy dropped these builds first in 1.8.0 (Feb 5, 2022) for Python 3.10 only, and for all builds in 1.9.2 (Oct 8, 2022).

Also, simplify workflow file to remove some duplication.

Theoretically we could join all the `Build wheels for CPython 3.X` steps, but I left them separate so that there wouldn't be a timeout for a single step taking too long (though I don't think that'd happen).

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`