### PR TITLE
FIX: Allow different colormap name from registered name

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -146,6 +146,11 @@ class ColormapRegistry(Mapping):
                                "that was already in the registry.")
 
         self._cmaps[name] = cmap.copy()
+        # Someone may set the extremes of a builtin colormap and want to register it
+        # with a different name for future lookups. The object would still have the
+        # builtin name, so we should update it to the registered name
+        if self._cmaps[name].name != name:
+            self._cmaps[name].name = name
 
     def unregister(self, name):
         """

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -774,7 +774,7 @@ class Colormap:
         return cmapobject
 
     def __eq__(self, other):
-        if (not isinstance(other, Colormap) or self.name != other.name or
+        if (not isinstance(other, Colormap) or
                 self.colorbar_extend != other.colorbar_extend):
             return False
         # To compare lookup tables the Colormaps have to be initialized

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -195,10 +195,10 @@ def test_colormap_equals():
     # Make sure we can compare different sizes without failure
     cm_copy._lut = cm_copy._lut[:10, :]
     assert cm_copy != cmap
-    # Test different names are not equal
+    # Test different names are equal if the lookup table is the same
     cm_copy = cmap.copy()
     cm_copy.name = "Test"
-    assert cm_copy != cmap
+    assert cm_copy == cmap
     # Test colorbar extends
     cm_copy = cmap.copy()
     cm_copy.colorbar_extend = not cmap.colorbar_extend
@@ -1649,3 +1649,15 @@ def test_cm_set_cmap_error():
     bad_cmap = 'AardvarksAreAwkward'
     with pytest.raises(ValueError, match=bad_cmap):
         sm.set_cmap(bad_cmap)
+
+
+def test_set_cmap_mismatched_name():
+    cmap = matplotlib.colormaps["viridis"].with_extremes(over='r')
+    # register it with different names
+    cmap.name = "test-cmap"
+    matplotlib.colormaps.register(name='wrong-cmap', cmap=cmap)
+
+    plt.set_cmap("wrong-cmap")
+    cmap_returned = plt.get_cmap("wrong-cmap")
+    assert cmap_returned == cmap
+    assert cmap_returned.name == "wrong-cmap"


### PR DESCRIPTION
## PR Summary

When registering a colormap you can use a different name than the `cmap.name` attribute now. This will set the colormap based on the registered name rather than `cmap.name`.

closes #5087

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [-] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [-] New plotting related features are documented with examples.

**Release Notes**
- [-] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [-] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [-] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
