### PR TITLE
Deprecate tostring_rgb.

### DIFF
--- a/doc/api/next_api_changes/deprecations/XXXXX-AL.rst
+++ b/doc/api/next_api_changes/deprecations/XXXXX-AL.rst
@@ -1,0 +1,3 @@
+``RendererAgg.tostring_rgb`` and ``FigureCanvasAgg.tostring_rgb``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated with no replacement.

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -280,6 +280,7 @@ class RendererAgg(RendererBase):
     def tostring_argb(self):
         return np.asarray(self._renderer).take([3, 0, 1, 2], axis=2).tobytes()
 
+    @_api.deprecated("3.8")
     def tostring_rgb(self):
         return np.asarray(self._renderer).take([0, 1, 2], axis=2).tobytes()
 
@@ -414,6 +415,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             self.renderer.clear()
         return self.renderer
 
+    @_api.deprecated("3.8")
     def tostring_rgb(self):
         """
         Get the image as RGB `bytes`.


### PR DESCRIPTION
As noted previously (#5336, see in particular the comments in the thread), silently dropping alpha can be confusing.  Also, directly accessing the buffer array is more efficient (it does not involve copying to a string buffer) and should cover most use cases.

Closes #5336.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
