### PR TITLE
Ignore errors loading artifacts from CircleCI

### DIFF
--- a/.circleci/fetch_doc_logs.py
+++ b/.circleci/fetch_doc_logs.py
@@ -22,7 +22,7 @@ import os
 from pathlib import Path
 import sys
 from urllib.parse import urlparse
-from urllib.request import urlopen
+from urllib.request import URLError, urlopen
 
 
 if len(sys.argv) != 2:
@@ -38,8 +38,11 @@ artifact_url = (
     f'{organization}/{repository}/{build_id}/artifacts'
 )
 print(artifact_url)
-with urlopen(artifact_url) as response:
-    artifacts = json.load(response)
+try:
+    with urlopen(artifact_url) as response:
+        artifacts = json.load(response)
+except URLError:
+    artifacts = {'items': []}
 artifact_count = len(artifacts['items'])
 print(f'Found {artifact_count} artifacts')
 


### PR DESCRIPTION
## PR Summary

Previously, this seemed to be ignored, and we'd just get a 0-artifact count. But now it seems that requesting artifacts for builds that are incomplete raises a 400 Bad Request.

So ignore those errors and return a 0-length artifact, because that is already correctly handled by the next step in the workflow.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`