### PR TITLE
DOC: Clarify note in get_path_collection_extents

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1042,9 +1042,10 @@ class Path:
 def get_path_collection_extents(
         master_transform, paths, transforms, offsets, offset_transform):
     r"""
-    Given a sequence of `Path`\s, `.Transform`\s objects, and offsets, as
-    found in a `.PathCollection`, returns the bounding box that encapsulates
-    all of them.
+    Get bounding box of a `.PathCollection`\s internal objects.
+
+    That is, given a sequence of `Path`\s, `.Transform`\s objects, and offsets, as found
+    in a `.PathCollection`, return the bounding box that encapsulates all of them.
 
     Parameters
     ----------
@@ -1058,12 +1059,14 @@ def get_path_collection_extents(
 
     Notes
     -----
-    The way that *paths*, *transforms* and *offsets* are combined
-    follows the same method as for collections:  Each is iterated over
-    independently, so if you have 3 paths, 2 transforms and 1 offset,
-    their combinations are as follows:
+    The way that *paths*, *transforms* and *offsets* are combined follows the same
+    method as for collections: each is iterated over independently, so if you have 3
+    paths (A, B, C), 2 transforms (α, β) and 1 offset (O), their combinations are as
+    follows:
 
-        (A, A, A), (B, B, A), (C, A, A)
+    - (A, α, O)
+    - (B, β, O)
+    - (C, α, O)
     """
     from .transforms import Bbox
     if len(paths) == 0:


### PR DESCRIPTION
## PR Summary

I found it confusing that it was listing A, A, A, A... a bunch of times, so I gave each type unique identifiers. Also, add an initial line for short docs.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`