### PR TITLE
FIX: use locators in adjust_bbox

### DIFF
--- a/lib/matplotlib/_tight_bbox.py
+++ b/lib/matplotlib/_tight_bbox.py
@@ -23,7 +23,10 @@ def adjust_bbox(fig, bbox_inches, fixed_dpi=None):
     locator_list = []
     sentinel = object()
     for ax in fig.axes:
-        locator_list.append(ax.get_axes_locator())
+        locator = ax.get_axes_locator()
+        if locator is not None:
+            ax.apply_aspect(locator(ax, None))
+        locator_list.append(locator)
         current_pos = ax.get_position(original=False).frozen()
         ax.set_axes_locator(lambda a, r, _pos=current_pos: _pos)
         # override the method that enforces the aspect ratio on the Axes

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -546,11 +546,22 @@ def test_savefig_pixel_ratio(backend):
     assert ratio1 == ratio2
 
 
-def test_savefig_preserve_layout_engine(tmp_path):
+def test_savefig_preserve_layout_engine():
     fig = plt.figure(layout='compressed')
-    fig.savefig(tmp_path / 'foo.png', bbox_inches='tight')
+    fig.savefig(io.BytesIO(), bbox_inches='tight')
 
     assert fig.get_layout_engine()._compress
+
+
+def test_savefig_locate_colorbar():
+    fig, ax = plt.subplots()
+    pc = ax.pcolormesh(np.random.randn(2, 2))
+    cbar = fig.colorbar(pc, aspect=40)
+    fig.savefig(io.BytesIO(), bbox_inches=mpl.transforms.Bbox([[0, 0], [4, 4]]))
+
+    # Check that an aspect ratio has been applied.
+    assert (cbar.ax.get_position(original=True).bounds !=
+            cbar.ax.get_position(original=False).bounds)
 
 
 @mpl.rc_context({"savefig.transparent": True})


### PR DESCRIPTION
## PR Summary

Fixes #22625.  The problem was that `_ColorbarAxesLocator` was not used to set the aspect ratio before `adjust_bbox` stripped it off.  A simpler but presumably less efficient fix might be to trigger a draw before calling `adjust_bbox`.  We already do that if `bbox_inches == "tight"`.

https://github.com/matplotlib/matplotlib/blob/78bf53caacbb5ce0dc7aa73f07a74c99f1ed919b/lib/matplotlib/backend_bases.py#L2358-L2361

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
