### PR TITLE
FIX: Tk photoimage resize

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -176,7 +176,8 @@ class FigureCanvasTk(FigureCanvasBase):
             width=w, height=h, borderwidth=0, highlightthickness=0)
         self._tkphoto = tk.PhotoImage(
             master=self._tkcanvas, width=w, height=h)
-        self._tkcanvas.create_image(w//2, h//2, image=self._tkphoto)
+        self._tkcanvas_image_region = self._tkcanvas.create_image(
+            w//2, h//2, image=self._tkphoto)
         self._tkcanvas.bind("<Configure>", self.resize)
         if sys.platform == 'win32':
             self._tkcanvas.bind("<Map>", self._update_device_pixel_ratio)
@@ -256,10 +257,10 @@ class FigureCanvasTk(FigureCanvasBase):
         hinch = height / dpival
         self.figure.set_size_inches(winch, hinch, forward=False)
 
-        self._tkcanvas.delete(self._tkphoto)
+        self._tkcanvas.delete(self._tkcanvas_image_region)
         self._tkphoto = tk.PhotoImage(
             master=self._tkcanvas, width=int(width), height=int(height))
-        self._tkcanvas.create_image(
+        self._tkcanvas_image_region = self._tkcanvas.create_image(
             int(width / 2), int(height / 2), image=self._tkphoto)
         ResizeEvent("resize_event", self)._process()
         self.draw_idle()

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -258,8 +258,7 @@ class FigureCanvasTk(FigureCanvasBase):
         self.figure.set_size_inches(winch, hinch, forward=False)
 
         self._tkcanvas.delete(self._tkcanvas_image_region)
-        self._tkphoto = tk.PhotoImage(
-            master=self._tkcanvas, width=int(width), height=int(height))
+        self._tkphoto.configure(width=int(width), height=int(height))
         self._tkcanvas_image_region = self._tkcanvas.create_image(
             int(width / 2), int(height / 2), image=self._tkphoto)
         ResizeEvent("resize_event", self)._process()


### PR DESCRIPTION
## PR Summary
This PR fixes a long-standing misuse of `tk.Canvas.delete` in `FigureCanvasTk`. It deletes the image region on the canvas that points to the image, which would otherwise hang around until the canvas is destroyed. It seems to silently do nothing when presented with a `tk.PhotoImage` object.

I also discovered that `tk.PhotoImage` doesn't need to be deleted or destroyed at all; it's `__del__` method takes care of that. but furthermore, we can reuse `_tkphoto` instead of recreating it, which in principle saves some churn... but more importantly, it eliminates flickering in an edge case I encountered (namely, overriding `draw_idle` to debounce draws more aggressively to a steady fps).

Unfortunately, this does not seem to have a perceptible impact on `memleak.py` (resize happens once per loop, right?). I suppose the image regions are quite small tk objects even if they are leaking, and the `tk.PhotoImage` objects were being correctly cleaned up during the attribute assignment.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [X] ~Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).~
- [X] ~New plotting related features are documented with examples.~

**Release Notes**
- [X] ~New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`~
- [X] ~API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`~
- [X] ~Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`~
