### PR TITLE
DOC/BLD: plot directive srcset

### DIFF
--- a/doc/api/index.rst
+++ b/doc/api/index.rst
@@ -141,6 +141,7 @@ Alphabetical list of modules:
    scale_api.rst
    sphinxext_mathmpl_api.rst
    sphinxext_plot_directive_api.rst
+   sphinxext_figmpl_directive_api.rst
    spines_api.rst
    style_api.rst
    table_api.rst

--- a/doc/api/sphinxext_figmpl_directive_api.rst
+++ b/doc/api/sphinxext_figmpl_directive_api.rst
@@ -1,0 +1,6 @@
+=========================================
+``matplotlib.sphinxext.figmpl_directive``
+=========================================
+
+.. automodule:: matplotlib.sphinxext.figmpl_directive
+   :no-undoc-members:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -105,6 +105,7 @@ extensions = [
     'sphinx_gallery.gen_gallery',
     'matplotlib.sphinxext.mathmpl',
     'matplotlib.sphinxext.plot_directive',
+    'matplotlib.sphinxext.figmpl_directive',
     'sphinxcontrib.inkscapeconverter',
     'sphinxext.custom_roles',
     'sphinxext.github',
@@ -379,7 +380,8 @@ default_role = 'obj'
 formats = {'html': ('png', 100), 'latex': ('pdf', 100)}
 plot_formats = [formats[target] for target in ['html', 'latex']
                 if target in sys.argv] or list(formats.values())
-
+# make 2x images for srcset argument to <img>
+plot_srcset = ['2x']
 
 # GitHub extension
 

--- a/doc/users/next_whats_new/plot_directive_srcset.rst
+++ b/doc/users/next_whats_new/plot_directive_srcset.rst
@@ -1,0 +1,19 @@
+Plot Directive now can make responsive images with "srcset"
+-----------------------------------------------------------
+
+The plot sphinx directive (``matplotlib.sphinxext.plot_directive``, invoked in
+rst as ``.. plot::``) can be configured to automatically make higher res
+figures and add these to the the built html docs.  In ``conf.py``::
+
+    extensions = [
+    ...
+        'matplotlib.sphinxext.plot_directive',
+        'matplotlib.sphinxext.figmpl_directive',
+    ...]
+
+    plot_srcset = ['2x']
+
+will make png files with double the resolution for hiDPI displays.  Resulting
+html files will have image entries like::
+
+    <img src="../_images/nestedpage-index-2.png" style="" srcset="../_images/nestedpage-index-2.png, ../_images/nestedpage-index-2.2x.png 2.00x" alt="" class="plot-directive "/>

--- a/doc/users/prev_whats_new/whats_new_3.3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.3.0.rst
@@ -24,7 +24,7 @@ The `.Figure` class has a provisional method to generate complex grids of named
 `.axes.Axes` based on nested list input or ASCII art:
 
 .. plot::
-   :include-source: True
+   :include-source:
 
    axd = plt.figure(constrained_layout=True).subplot_mosaic(
        [['.', 'histx'],
@@ -38,7 +38,7 @@ The `.Figure` class has a provisional method to generate complex grids of named
 or as a string (with single-character Axes labels):
 
 .. plot::
-   :include-source: True
+   :include-source:
 
    axd = plt.figure(constrained_layout=True).subplot_mosaic(
        """

--- a/lib/matplotlib/sphinxext/figmpl_directive.py
+++ b/lib/matplotlib/sphinxext/figmpl_directive.py
@@ -1,0 +1,288 @@
+"""
+Add a ``figure-mpl`` directive that is a responsive version of ``figure``.
+
+This implementation is very similar to ``.. figure::``, except it also allows a
+``srcset=`` argument to be passed to the image tag, hence allowing responsive
+resolution images.
+
+There is no particular reason this could not be used standalone, but is meant
+to be used with :doc:`/api/sphinxext_plot_directive_api`.
+
+Note that the directory organization is a bit different than ``.. figure::``.
+See the *FigureMpl* documentation below.
+
+"""
+from docutils import nodes
+
+from docutils.parsers.rst import directives
+from docutils.parsers.rst.directives.images import Figure, Image
+
+import os
+from os.path import relpath
+from pathlib import PurePath, Path
+import shutil
+
+from sphinx.errors import ExtensionError
+
+import matplotlib
+
+
+class figmplnode(nodes.General, nodes.Element):
+    pass
+
+
+class FigureMpl(Figure):
+    """
+    Implements a directive to allow an optional hidpi image.
+
+    Meant to be used with the *plot_srcset* configuration option in conf.py,
+    and gets set in the TEMPLATE of plot_directive.py
+
+    e.g.::
+
+        .. figure-mpl:: plot_directive/some_plots-1.png
+            :alt: bar
+            :srcset: plot_directive/some_plots-1.png,
+                     plot_directive/some_plots-1.2x.png 2.00x
+            :class: plot-directive
+
+    The resulting html (at ``some_plots.html``) is::
+
+        <img src="sphx_glr_bar_001_hidpi.png"
+            srcset="_images/some_plot-1.png,
+                    _images/some_plots-1.2x.png 2.00x",
+            alt="bar"
+            class="plot_directive" />
+
+    Note that the handling of subdirectories is different than that used by the sphinx
+    figure directive::
+
+        .. figure-mpl:: plot_directive/nestedpage/index-1.png
+            :alt: bar
+            :srcset: plot_directive/nestedpage/index-1.png
+                     plot_directive/nestedpage/index-1.2x.png 2.00x
+            :class: plot_directive
+
+    The resulting html (at ``nestedpage/index.html``)::
+
+        <img src="../_images/nestedpage-index-1.png"
+            srcset="../_images/nestedpage-index-1.png,
+                    ../_images/_images/nestedpage-index-1.2x.png 2.00x",
+            alt="bar"
+            class="sphx-glr-single-img" />
+
+    where the subdirectory is included in the image name for uniqueness.
+    """
+
+    has_content = False
+    required_arguments = 1
+    optional_arguments = 2
+    final_argument_whitespace = False
+    option_spec = {
+        'alt': directives.unchanged,
+        'height': directives.length_or_unitless,
+        'width': directives.length_or_percentage_or_unitless,
+        'scale': directives.nonnegative_int,
+        'align': Image.align,
+        'class': directives.class_option,
+        'caption': directives.unchanged,
+        'srcset': directives.unchanged,
+    }
+
+    def run(self):
+
+        image_node = figmplnode()
+
+        imagenm = self.arguments[0]
+        image_node['alt'] = self.options.get('alt', '')
+        image_node['align'] = self.options.get('align', None)
+        image_node['class'] = self.options.get('class', None)
+        image_node['width'] = self.options.get('width', None)
+        image_node['height'] = self.options.get('height', None)
+        image_node['scale'] = self.options.get('scale', None)
+        image_node['caption'] = self.options.get('caption', None)
+
+        # we would like uri to be the highest dpi version so that
+        # latex etc will use that.  But for now, lets just make
+        # imagenm... maybe pdf one day?
+
+        image_node['uri'] = imagenm
+        image_node['srcset'] = self.options.get('srcset', None)
+
+        return [image_node]
+
+
+def _parse_srcsetNodes(st):
+    """
+    parse srcset...
+    """
+    entries = st.split(',')
+    srcset = {}
+    for entry in entries:
+        spl = entry.strip().split(' ')
+        if len(spl) == 1:
+            srcset[0] = spl[0]
+        elif len(spl) == 2:
+            mult = spl[1][:-1]
+            srcset[float(mult)] = spl[0]
+        else:
+            raise ExtensionError(f'srcset argument "{entry}" is invalid.')
+    return srcset
+
+
+def _copy_images_figmpl(self, node):
+
+    # these will be the temporary place the plot-directive put the images eg:
+    # ../../../build/html/plot_directive/users/explain/artists/index-1.png
+    if node['srcset']:
+        srcset = _parse_srcsetNodes(node['srcset'])
+    else:
+        srcset = None
+
+    # the rst file's location:  eg /Users/username/matplotlib/doc/users/explain/artists
+    docsource = PurePath(self.document['source']).parent
+
+    # get the relpath relative to root:
+    srctop = self.builder.srcdir
+    rel = relpath(docsource, srctop).replace('.', '').replace(os.sep, '-')
+    if len(rel):
+        rel += '-'
+    # eg: users/explain/artists
+
+    imagedir = PurePath(self.builder.outdir, self.builder.imagedir)
+    # eg: /Users/username/matplotlib/doc/build/html/_images/users/explain/artists
+
+    Path(imagedir).mkdir(parents=True, exist_ok=True)
+
+    # copy all the sources to the imagedir:
+    if srcset:
+        for src in srcset.values():
+            # the entries in srcset are relative to docsource's directory
+            abspath = PurePath(docsource, src)
+            name = rel + abspath.name
+            shutil.copyfile(abspath, imagedir / name)
+    else:
+        abspath = PurePath(docsource, node['uri'])
+        name = rel + abspath.name
+        shutil.copyfile(abspath, imagedir / name)
+
+    return imagedir, srcset, rel
+
+
+def visit_figmpl_html(self, node):
+
+    imagedir, srcset, rel = _copy_images_figmpl(self, node)
+
+    # /doc/examples/subd/plot_1.rst
+    docsource = PurePath(self.document['source'])
+    # /doc/
+    # make sure to add the trailing slash:
+    srctop = PurePath(self.builder.srcdir, '')
+    # examples/subd/plot_1.rst
+    relsource = relpath(docsource, srctop)
+    # /doc/build/html
+    desttop = PurePath(self.builder.outdir, '')
+    # /doc/build/html/examples/subd
+    dest = desttop / relsource
+
+    # ../../_images/ for dirhtml and ../_images/ for html
+    imagerel = PurePath(relpath(imagedir, dest.parent)).as_posix()
+    if self.builder.name == "dirhtml":
+        imagerel = f'..{imagerel}'
+
+    # make uri also be relative...
+    nm = PurePath(node['uri'][1:]).name
+    uri = f'{imagerel}/{rel}{nm}'
+
+    # make srcset str.  Need to change all the prefixes!
+    maxsrc = uri
+    srcsetst = ''
+    if srcset:
+        maxmult = -1
+        for mult, src in srcset.items():
+            nm = PurePath(src[1:]).name
+            # ../../_images/plot_1_2_0x.png
+            path = f'{imagerel}/{rel}{nm}'
+            srcsetst += path
+            if mult == 0:
+                srcsetst += ', '
+            else:
+                srcsetst += f' {mult:1.2f}x, '
+
+            if mult > maxmult:
+                maxmult = mult
+                maxsrc = path
+
+        # trim trailing comma and space...
+        srcsetst = srcsetst[:-2]
+
+    alt = node['alt']
+    if node['class'] is not None:
+        classst = ' '.join(node['class'])
+        classst = f'class="{classst}"'
+
+    else:
+        classst = ''
+
+    stylers = ['width', 'height', 'scale']
+    stylest = ''
+    for style in stylers:
+        if node[style]:
+            stylest += f'{style}: {node[style]};'
+
+    figalign = node['align'] if node['align'] else 'center'
+
+# <figure class="align-default" id="id1">
+# <a class="reference internal image-reference" href="_images/index-1.2x.png">
+# <img alt="_images/index-1.2x.png" src="_images/index-1.2x.png" style="width: 53%;" />
+# </a>
+# <figcaption>
+# <p><span class="caption-text">Figure caption is here....</span>
+# <a class="headerlink" href="#id1" title="Permalink to this image">#</a></p>
+# </figcaption>
+# </figure>
+    img_block = (f'<img src="{uri}" style="{stylest}" srcset="{srcsetst}" '
+                 f'alt="{alt}" {classst}/>')
+    html_block = f'<figure class="align-{figalign}">\n'
+    html_block += f'  <a class="reference internal image-reference" href="{maxsrc}">\n'
+    html_block += f'    {img_block}\n  </a>\n'
+    if node['caption']:
+        html_block += '  <figcaption>\n'
+        html_block += f'   <p><span class="caption-text">{node["caption"]}</span></p>\n'
+        html_block += '  </figcaption>\n'
+    html_block += '</figure>\n'
+    self.body.append(html_block)
+
+
+def visit_figmpl_latex(self, node):
+
+    if node['srcset'] is not None:
+        imagedir, srcset = _copy_images_figmpl(self, node)
+        maxmult = -1
+        # choose the highest res version for latex:
+        maxmult = max(srcset, default=-1)
+        node['uri'] = PurePath(srcset[maxmult]).name
+
+    self.visit_figure(node)
+
+
+def depart_figmpl_html(self, node):
+    pass
+
+
+def depart_figmpl_latex(self, node):
+    self.depart_figure(node)
+
+
+def figurempl_addnode(app):
+    app.add_node(figmplnode,
+                 html=(visit_figmpl_html, depart_figmpl_html),
+                 latex=(visit_figmpl_latex, depart_figmpl_latex))
+
+
+def setup(app):
+    app.add_directive("figure-mpl", FigureMpl)
+    figurempl_addnode(app)
+    metadata = {'parallel_read_safe': True, 'parallel_write_safe': True,
+                'version': matplotlib.__version__}
+    return metadata

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -139,6 +139,30 @@ The plot directive has the following configuration options:
 
     plot_template
         Provide a customized template for preparing restructured text.
+
+    plot_srcset
+        Allow the srcset image option for responsive image resolutions. List of
+        strings with the multiplicative factors followed by an "x".
+        e.g. ["2.0x", "1.5x"].  "2.0x" will create a png with the default "png"
+        resolution from plot_formats, multiplied by 2. If plot_srcset is
+        specified, the plot directive uses the
+        :doc:`/api/sphinxext_figmpl_directive_api` (instead of the usual figure
+        directive) in the intermediary rst file that is generated.
+        The plot_srcset option is incompatible with *singlehtml* builds, and an
+        error will be raised.
+
+Notes on how it works
+---------------------
+
+The plot directive runs the code it is given, either in the source file or the
+code under the directive. The figure created (if any) is saved in the sphinx
+build directory under a subdirectory named ``plot_directive``.  It then creates
+an intermediate rst file that calls a ``.. figure:`` directive (or
+``.. figmpl::`` directive if ``plot_srcset`` is being used) and has links to
+the ``*.png`` files in the ``plot_directive`` directory.  These translations can
+be customized by changing the *plot_template*.  See the source of
+:doc:`/api/sphinxext_plot_directive_api` for the templates defined in *TEMPLATE*
+and *TEMPLATE_SRCSET*.
 """
 
 import contextlib
@@ -157,6 +181,8 @@ import traceback
 from docutils.parsers.rst import directives, Directive
 from docutils.parsers.rst.directives.images import Image
 import jinja2  # Sphinx dependency.
+
+from sphinx.errors import ExtensionError
 
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
@@ -280,6 +306,7 @@ def setup(app):
     app.add_config_value('plot_apply_rcparams', False, True)
     app.add_config_value('plot_working_directory', None, True)
     app.add_config_value('plot_template', None, True)
+    app.add_config_value('plot_srcset', [], True)
     app.connect('doctree-read', mark_plot_labels)
     app.add_css_file('plot_directive.css')
     app.connect('build-finished', _copy_css_file)
@@ -331,7 +358,7 @@ def _split_code_at_show(text, function_name):
 # Template
 # -----------------------------------------------------------------------------
 
-TEMPLATE = """
+_SOURCECODE = """
 {{ source_code }}
 
 .. only:: html
@@ -351,6 +378,50 @@ TEMPLATE = """
    {%- endif -%}
    )
    {% endif %}
+"""
+
+TEMPLATE_SRCSET = _SOURCECODE + """
+   {% for img in images %}
+   .. figure-mpl:: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
+      {% for option in options -%}
+      {{ option }}
+      {% endfor %}
+      {%- if caption -%}
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
+      {% endif -%}
+      {%- if srcset -%}
+        :srcset: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
+        {%- for sr in srcset -%}
+            , {{ build_dir }}/{{ img.basename }}.{{ sr }}.{{ default_fmt }} {{sr}}
+        {%- endfor -%}
+      {% endif %}
+
+   {% if html_show_formats and multi_image %}
+   (
+    {%- for fmt in img.formats -%}
+    {%- if not loop.first -%}, {% endif -%}
+    :download:`{{ fmt }} <{{ build_dir }}/{{ img.basename }}.{{ fmt }}>`
+    {%- endfor -%}
+   )
+   {% endif %}
+
+
+   {% endfor %}
+
+.. only:: not html
+
+   {% for img in images %}
+   .. figure-mpl:: {{ build_dir }}/{{ img.basename }}.*
+      {% for option in options -%}
+      {{ option }}
+      {% endfor -%}
+
+      {{ caption }}  {# appropriate leading whitespace added beforehand #}
+   {% endfor %}
+
+"""
+
+TEMPLATE = _SOURCECODE + """
 
    {% for img in images %}
    .. figure:: {{ build_dir }}/{{ img.basename }}.{{ default_fmt }}
@@ -514,6 +585,21 @@ def get_plot_formats(config):
     return formats
 
 
+def _parse_srcset(entries):
+    """
+    Parse srcset for multiples...
+    """
+    srcset = {}
+    for entry in entries:
+        entry = entry.strip()
+        if len(entry) >= 2:
+            mult = entry[:-1]
+            srcset[float(mult)] = entry
+        else:
+            raise ExtensionError(f'srcset argument {entry!r} is invalid.')
+    return srcset
+
+
 def render_figures(code, code_path, output_dir, output_base, context,
                    function_name, config, context_reset=False,
                    close_figs=False,
@@ -524,6 +610,7 @@ def render_figures(code, code_path, output_dir, output_base, context,
     Save the images under *output_dir* with file names derived from
     *output_base*
     """
+
     if function_name is not None:
         output_base = f'{output_base}_{function_name}'
     formats = get_plot_formats(config)
@@ -531,7 +618,6 @@ def render_figures(code, code_path, output_dir, output_base, context,
     # Try to determine if all images already exist
 
     is_doctest, code_pieces = _split_code_at_show(code, function_name)
-
     # Look for single-figure output files first
     img = ImageFile(output_base, output_dir)
     for format, dpi in formats:
@@ -610,9 +696,18 @@ def render_figures(code, code_path, output_dir, output_base, context,
                 img = ImageFile("%s_%02d_%02d" % (output_base, i, j),
                                 output_dir)
             images.append(img)
+
             for fmt, dpi in formats:
                 try:
                     figman.canvas.figure.savefig(img.filename(fmt), dpi=dpi)
+                    if fmt == formats[0][0] and config.plot_srcset:
+                        # save a 2x, 3x etc version of the default...
+                        srcset = _parse_srcset(config.plot_srcset)
+                        for mult, suffix in srcset.items():
+                            fm = f'{suffix}.{fmt}'
+                            img.formats.append(fm)
+                            figman.canvas.figure.savefig(img.filename(fm),
+                                                         dpi=int(dpi * mult))
                 except Exception as err:
                     raise PlotError(traceback.format_exc()) from err
                 img.formats.append(fmt)
@@ -630,11 +725,16 @@ def run(arguments, content, options, state_machine, state, lineno):
     config = document.settings.env.config
     nofigs = 'nofigs' in options
 
+    if config.plot_srcset and setup.app.builder.name == 'singlehtml':
+        raise ExtensionError(
+            'plot_srcset option not compatible with single HTML writer')
+
     formats = get_plot_formats(config)
     default_fmt = formats[0][0]
 
     options.setdefault('include-source', config.plot_include_source)
     options.setdefault('show-source-link', config.plot_html_show_source_link)
+
     if 'class' in options:
         # classes are parsed into a list of string, and output by simply
         # printing the list, abusing the fact that RST guarantees to strip
@@ -655,7 +755,6 @@ def run(arguments, content, options, state_machine, state, lineno):
         else:
             source_file_name = os.path.join(setup.confdir, config.plot_basedir,
                                             directives.uri(arguments[0]))
-
         # If there is content, it will be passed as a caption.
         caption = '\n'.join(content)
 
@@ -776,9 +875,11 @@ def run(arguments, content, options, state_machine, state, lineno):
         errors = [sm]
 
     # Properly indent the caption
-    caption = '\n' + '\n'.join('      ' + line.strip()
-                               for line in caption.split('\n'))
-
+    if caption and config.plot_srcset:
+        caption = f':caption: {caption}'
+    elif caption:
+        caption = '\n' + '\n'.join('      ' + line.strip()
+                                   for line in caption.split('\n'))
     # generate output restructuredtext
     total_lines = []
     for j, (code_piece, images) in enumerate(results):
@@ -805,18 +906,24 @@ def run(arguments, content, options, state_machine, state, lineno):
             src_name = output_base + source_ext
         else:
             src_name = None
+        if config.plot_srcset:
+            srcset = [*_parse_srcset(config.plot_srcset).values()]
+            template = TEMPLATE_SRCSET
+        else:
+            srcset = None
+            template = TEMPLATE
 
-        result = jinja2.Template(config.plot_template or TEMPLATE).render(
+        result = jinja2.Template(config.plot_template or template).render(
             default_fmt=default_fmt,
             build_dir=build_dir_link,
             src_name=src_name,
             multi_image=len(images) > 1,
             options=opts,
+            srcset=srcset,
             images=images,
             source_code=source_code,
             html_show_formats=config.plot_html_show_formats and len(images),
             caption=caption)
-
         total_lines.extend(result.split("\n"))
         total_lines.extend("\n")
 

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -182,3 +182,44 @@ def test_show_source_link_false(tmp_path, plot_html_show_source_link):
     build_sphinx_html(tmp_path, doctree_dir, html_dir, extra_args=[
         '-D', f'plot_html_show_source_link={plot_html_show_source_link}'])
     assert len(list(html_dir.glob("**/index-1.py"))) == 0
+
+
+def test_srcset_version(tmp_path):
+    shutil.copytree(Path(__file__).parent / 'tinypages', tmp_path,
+                    dirs_exist_ok=True)
+    html_dir = tmp_path / '_build' / 'html'
+    img_dir = html_dir / '_images'
+    doctree_dir = tmp_path / 'doctrees'
+
+    build_sphinx_html(tmp_path, doctree_dir, html_dir, extra_args=[
+        '-D', 'plot_srcset=2x'])
+
+    def plot_file(num, suff=''):
+        return img_dir / f'some_plots-{num}{suff}.png'
+
+    # check some-plots
+    for ind in [1, 2, 3, 5, 7, 11, 13, 15, 17]:
+        assert plot_file(ind).exists()
+        assert plot_file(ind, suff='.2x').exists()
+
+    assert (img_dir / 'nestedpage-index-1.png').exists()
+    assert (img_dir / 'nestedpage-index-1.2x.png').exists()
+    assert (img_dir / 'nestedpage-index-2.png').exists()
+    assert (img_dir / 'nestedpage-index-2.2x.png').exists()
+    assert (img_dir / 'nestedpage2-index-1.png').exists()
+    assert (img_dir / 'nestedpage2-index-1.2x.png').exists()
+    assert (img_dir / 'nestedpage2-index-2.png').exists()
+    assert (img_dir / 'nestedpage2-index-2.2x.png').exists()
+
+    # Check html for srcset
+
+    assert ('srcset="_images/some_plots-1.png, _images/some_plots-1.2x.png 2.00x"'
+            in (html_dir / 'some_plots.html').read_text(encoding='utf-8'))
+
+    st = ('srcset="../_images/nestedpage-index-1.png, '
+          '../_images/nestedpage-index-1.2x.png 2.00x"')
+    assert st in (html_dir / 'nestedpage/index.html').read_text(encoding='utf-8')
+
+    st = ('srcset="../_images/nestedpage2-index-2.png, '
+          '../_images/nestedpage2-index-2.2x.png 2.00x"')
+    assert st in (html_dir / 'nestedpage2/index.html').read_text(encoding='utf-8')

--- a/lib/matplotlib/tests/tinypages/conf.py
+++ b/lib/matplotlib/tests/tinypages/conf.py
@@ -3,7 +3,8 @@ from packaging.version import parse as parse_version
 
 # -- General configuration ------------------------------------------------
 
-extensions = ['matplotlib.sphinxext.plot_directive']
+extensions = ['matplotlib.sphinxext.plot_directive',
+              'matplotlib.sphinxext.figmpl_directive']
 templates_path = ['_templates']
 source_suffix = '.rst'
 master_doc = 'index'

--- a/lib/matplotlib/tests/tinypages/index.rst
+++ b/lib/matplotlib/tests/tinypages/index.rst
@@ -12,6 +12,9 @@ Contents:
     :maxdepth: 2
 
     some_plots
+    nestedpage/index
+    nestedpage2/index
+
 
 Indices and tables
 ==================

--- a/lib/matplotlib/tests/tinypages/nestedpage/index.rst
+++ b/lib/matplotlib/tests/tinypages/nestedpage/index.rst
@@ -1,0 +1,20 @@
+#################
+Nested page plots
+#################
+
+Plot 1 does not use context:
+
+.. plot::
+
+    plt.plot(range(10))
+    plt.title('FIRST NESTED 1')
+    a = 10
+
+Plot 2 doesn't use context either; has length 6:
+
+.. plot::
+
+    plt.plot(range(6))
+    plt.title('FIRST NESTED 2')
+
+

--- a/lib/matplotlib/tests/tinypages/nestedpage2/index.rst
+++ b/lib/matplotlib/tests/tinypages/nestedpage2/index.rst
@@ -1,0 +1,25 @@
+#####################
+Nested page plots TWO
+#####################
+
+Plot 1 does not use context:
+
+.. plot::
+
+    plt.plot(range(10))
+    plt.title('NESTED2 Plot 1')
+    a = 10
+
+Plot 2 doesn't use context either; has length 6:
+
+
+.. plot::
+
+    plt.plot(range(6))
+    plt.title('NESTED2 Plot 2')
+
+
+.. plot::
+
+    plt.plot(range(6))
+    plt.title('NESTED2 PlotP 3')


### PR DESCRIPTION
## PR Summary

Closes #25497

The `.. plot::` directive currently makes 100 dpi figures, which don't look good on hiDPI screens.  

This PR uses a new sphinx directive "figmpl" in the plot-directive to add a `srcset=` entry to the image tag to allow high resolution images (2x in this case).  


### Old
<img width="619" alt="Old" src="https://user-images.githubusercontent.com/1562854/226462970-3fd85f16-3fd4-42ae-a986-3854df309d1e.png">

### New

<img width="619" alt="New" src="https://user-images.githubusercontent.com/1562854/226463083-bf6a56b1-df26-482a-9df6-aae45e99025b.png">

 - [x] needs tests
 - [x] not 100% sure it is back compatible for external users  
 - [x] needs better docs