### PR TITLE
Annotations tutorial

### DIFF
--- a/galleries/users_explain/text/annotations.py
+++ b/galleries/users_explain/text/annotations.py
@@ -575,17 +575,19 @@ ax2.annotate("Test", xy=(0.2, 0.2), xycoords="axes fraction")
 # %%
 # Another commonly used `.Transform` instance is ``Axes.transData``. This
 # transform  is the coordinate system of the data plotted in the axes. In this
-# example, it is used to draw an arrow from a point in *ax1* to text in *ax2*,
-# where the point and text are positioned relative to the coordinates of *ax1*
-# and *ax2* respectively:
+# example, it is used to draw an arrow between related data points in two
+# Axes. We have passed an empty text because in this case, the annotation
+# connects data points.
+
+x = np.linspace(-1, 1)
 
 fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(6, 3))
-
-ax1.annotate("Test1", xy=(0.5, 0.5), xycoords="axes fraction")
-ax2.annotate("Test2",
-               xy=(0.5, 0.5), xycoords=ax1.transData,
-               xytext=(0.5, 0.5), textcoords=ax2.transData,
-               arrowprops=dict(arrowstyle="->"))
+ax1.plot(x, -x**3)
+ax2.plot(x, -3*x**2)
+ax2.annotate("",
+             xy=(0, 0), xycoords=ax1.transData,
+             xytext=(0, 0), textcoords=ax2.transData,
+             arrowprops=dict(arrowstyle="<->"))
 
 # %%
 # .. _artist_annotation_coord:

--- a/galleries/users_explain/text/annotations.py
+++ b/galleries/users_explain/text/annotations.py
@@ -569,8 +569,8 @@ fig.subplots_adjust(top=0.8)
 # coordinate system to "axes fraction":
 
 fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(6, 3))
-ax1.annotate("Test", xy=(0.5, 0.5), xycoords=ax1.transAxes)
-ax2.annotate("Test", xy=(0.5, 0.5), xycoords="axes fraction")
+ax1.annotate("Test", xy=(0.2, 0.2), xycoords=ax1.transAxes)
+ax2.annotate("Test", xy=(0.2, 0.2), xycoords="axes fraction")
 
 # %%
 # Another commonly used `.Transform` instance is ``Axes.transData``. This

--- a/galleries/users_explain/text/annotations.py
+++ b/galleries/users_explain/text/annotations.py
@@ -113,16 +113,17 @@ ax.set_ylim(-2, 2)
 import matplotlib.patches as mpatches
 
 fig, ax = plt.subplots(figsize=(3, 3))
-arr = mpatches.FancyArrowPatch((1.25, 1.25), (1.75, 1.75),
+arr = mpatches.FancyArrowPatch((1.25, 1.5), (1.75, 1.5),
                                arrowstyle='->,head_width=.15', mutation_scale=20)
 ax.add_patch(arr)
-ax.annotate("label", (.5, .5), xycoords=arr, ha='center', va='center')
+ax.annotate("label", (.5, .5), xycoords=arr, ha='center', va='bottom')
 ax.set(xlim=(1, 2), ylim=(1, 2))
 
 # %%
 # Here the annotation is placed at position (.5,.5) relative to the arrow's
-# lower left corner and is vertically and horizontally centered at that
-# position. For an example of chaining annotation Artists, see the
+# lower left corner and is vertically and horizontally at that position.
+# Vertically, the bottom aligns to that reference point so that the label
+# is above the line. For an example of chaining annotation Artists, see the
 # :ref:`Artist section <artist_annotation_coord>` of
 # :ref:`annotating_coordinate_systems`.
 #


### PR DESCRIPTION
Three stylistic improvements

 - Modify "Annotating an Artist" of Annotations tutorial

  to a horizontal arrow so that the arrow line does not cross the
  artist. This is somewhat special but visually more pleasing and
  possibly a real use case.

**old:**
![grafik](https://user-images.githubusercontent.com/2836374/226949293-963b073e-a48f-4ded-bbd1-5d70b6467077.png) 

**new:**
![grafik](https://user-images.githubusercontent.com/2836374/226948698-5c29c2de-28d3-44dc-a2f1-742d7745c40a.png)

- Change coordinates in Annotations tutorial

  ... in the `transAxes` / "axes fraction" example. Brining the
  annotations closer to the coordinate axes makes it easier to
  see that they are really the same. Also, the previous positioning
  (0.5, 0.5) without centered alignment results in almost, but not
  exactly centering of the text in the Axes frame, which is not
  quite nice visually.

**old:**
![grafik](https://user-images.githubusercontent.com/2836374/226949736-098bccbb-c846-4eaf-b238-6a93f24c8dd9.png)

**new:**
![grafik](https://user-images.githubusercontent.com/2836374/226949843-1d9a2d0b-4a4a-4429-b1da-130141ad68ca.png)



- Modify "Annotating an Artist" of Annotations tutorial

  to a horizontal arrow so that the arrow line does not cross the
  artist. This is somewhat special but visually more pleasing and
  possibly a real use case.

**old:**
![grafik](https://user-images.githubusercontent.com/2836374/226950079-473308f8-2825-480a-a5a6-7790624ee865.png)

**new:**
![grafik](https://user-images.githubusercontent.com/2836374/226950232-f5cb3c7f-5d71-4a77-b90c-84d74f9a15ff.png)
