### PR TITLE
Remove explicit symbol visibility pragmas

### DIFF
--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -630,8 +630,6 @@ static PyTypeObject *PyRendererAgg_init_type()
 
 static struct PyModuleDef moduledef = { PyModuleDef_HEAD_INIT, "_backend_agg" };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC PyInit__backend_agg(void)
 {
     import_array();
@@ -646,5 +644,3 @@ PyMODINIT_FUNC PyInit__backend_agg(void)
     }
     return m;
 }
-
-#pragma GCC visibility pop

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -286,8 +286,6 @@ static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT, "_image", NULL, 0, module_functions,
 };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC PyInit__image(void)
 {
     PyObject *m;
@@ -324,5 +322,3 @@ PyMODINIT_FUNC PyInit__image(void)
 
     return m;
 }
-
-#pragma GCC visibility pop

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -868,12 +868,8 @@ static struct PyModuleDef moduledef = {
     PyModuleDef_HEAD_INIT, "_path", NULL, 0, module_functions
 };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC PyInit__path(void)
 {
     import_array();
     return PyModule_Create(&moduledef);
 }
-
-#pragma GCC visibility pop

--- a/src/_qhull_wrapper.cpp
+++ b/src/_qhull_wrapper.cpp
@@ -328,13 +328,9 @@ static struct PyModuleDef qhull_module = {
     "qhull", "Computing Delaunay triangulations.\n", -1, qhull_methods
 };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC
 PyInit__qhull(void)
 {
     import_array();
     return PyModule_Create(&qhull_module);
 }
-
-#pragma GCC visibility pop

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -340,8 +340,6 @@ static PyModuleDef _tkagg_module = {
     PyModuleDef_HEAD_INIT, "_tkagg", NULL, -1, functions
 };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC PyInit__tkagg(void)
 {
     load_tkinter_funcs();
@@ -365,5 +363,3 @@ PyMODINIT_FUNC PyInit__tkagg(void)
     }
     return PyModule_Create(&_tkagg_module);
 }
-
-#pragma GCC visibility pop

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -186,12 +186,8 @@ static PyModuleDef ttconv_module = {
     ttconv_methods,
 };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC
 PyInit__ttconv(void)
 {
     return PyModule_Create(&ttconv_module);
 }
-
-#pragma GCC visibility pop

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1605,8 +1605,6 @@ static PyTypeObject *PyFT2Font_init_type()
 
 static struct PyModuleDef moduledef = { PyModuleDef_HEAD_INIT, "ft2font" };
 
-#pragma GCC visibility push(default)
-
 PyMODINIT_FUNC PyInit_ft2font(void)
 {
     import_array();
@@ -1671,5 +1669,3 @@ PyMODINIT_FUNC PyInit_ft2font(void)
 
     return m;
 }
-
-#pragma GCC visibility pop


### PR DESCRIPTION
## PR Summary

Since Python 3.9, the `PyMODINIT_FUNC` has included explicit default visibility [1], and so works when we set visibility to be hidden globally.

[1] https://github.com/python/cpython/commit/0b60f64e4343913b4931dc27379d9808e5b78fe1

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`