### PR TITLE
In Artist.contains, check that moussevents occurred on the right canvas.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -461,28 +461,22 @@ class Artist:
         r"""Return a list of the child `.Artist`\s of this `.Artist`."""
         return []
 
-    def _default_contains(self, mouseevent, figure=None):
+    def _different_canvas(self, event):
         """
-        Base impl. for checking whether a mouseevent happened in an artist.
+        Check whether an *event* occurred on a canvas other that this artist's canvas.
 
-        1. If the artist figure is known and the event did not occur in that
-           figure (by checking its ``canvas`` attribute), reject it.
-        2. Otherwise, return `None, {}`, indicating that the subclass'
-           implementation should be used.
+        If this method returns True, the event definitely occurred on a different
+        canvas; if it returns False, either it occurred on the same canvas, or we may
+        not have enough information to know.
 
-        Subclasses should start their definition of `contains` as follows:
+        Subclasses should start their definition of `contains` as follows::
 
-            inside, info = self._default_contains(mouseevent)
-            if inside is not None:
-                return inside, info
+            if self._different_canvas(mouseevent):
+                return False, {}
             # subclass-specific implementation follows
-
-        The *figure* kwarg is provided for the implementation of
-        `.Figure.contains`.
         """
-        if figure is not None and mouseevent.canvas is not figure.canvas:
-            return False, {}
-        return None, {}
+        return (getattr(event, "canvas", None) is not None and self.figure is not None
+                and event.canvas is not self.figure.canvas)
 
     def contains(self, mouseevent):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4271,9 +4271,6 @@ class _AxesBase(martist.Artist):
 
     def contains(self, mouseevent):
         # docstring inherited.
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
         return self.patch.contains(mouseevent)
 
     def contains_point(self, point):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -242,9 +242,6 @@ class Tick(martist.Artist):
         This function always returns false.  It is more useful to test if the
         axis as a whole contains the mouse rather than the set of tick marks.
         """
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
         return False, {}
 
     def set_pad(self, val):
@@ -2230,10 +2227,8 @@ class XAxis(Axis):
 
     def contains(self, mouseevent):
         """Test whether the mouse event occurred in the x-axis."""
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
-
+        if self._different_canvas(mouseevent):
+            return False, {}
         x, y = mouseevent.x, mouseevent.y
         try:
             trans = self.axes.transAxes.inverted()
@@ -2473,10 +2468,8 @@ class YAxis(Axis):
 
     def contains(self, mouseevent):
         # docstring inherited
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
-
+        if self._different_canvas(mouseevent):
+            return False, {}
         x, y = mouseevent.x, mouseevent.y
         try:
             trans = self.axes.transAxes.inverted()

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -454,24 +454,16 @@ class Collection(artist.Artist, cm.ScalarMappable):
         Returns ``bool, dict(ind=itemlist)``, where every item in itemlist
         contains the event.
         """
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
-
-        if not self.get_visible():
+        if self._different_canvas(mouseevent) or not self.get_visible():
             return False, {}
-
         pickradius = (
             float(self._picker)
             if isinstance(self._picker, Number) and
                self._picker is not True  # the bool, not just nonzero or 1
             else self._pickradius)
-
         if self.axes:
             self.axes._unstale_viewLim()
-
         transform, offset_trf, offsets, paths = self._prepare_points()
-
         # Tests if the point is contained on one of the polygons formed
         # by the control points of each of the paths. A point is considered
         # "on" a path if it would lie within a stroke of width 2*pickradius
@@ -481,7 +473,6 @@ class Collection(artist.Artist, cm.ScalarMappable):
             mouseevent.x, mouseevent.y, pickradius,
             transform.frozen(), paths, self.get_transforms(),
             offsets, offset_trf, pickradius <= 0)
-
         return len(ind) > 0, dict(ind=ind)
 
     def set_urls(self, urls):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -289,9 +289,8 @@ class FigureBase(Artist):
         -------
             bool, {}
         """
-        inside, info = self._default_contains(mouseevent, figure=self)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         inside = self.bbox.contains(mouseevent.x, mouseevent.y)
         return inside, {}
 

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -654,9 +654,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def contains(self, mouseevent):
         """Test whether the mouse event occurred within the image."""
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         # 1) This doesn't work for figimage; but figimage also needs a fix
         #    below (as the check cannot use x/ydata and extents).
         # 2) As long as the check below uses x/ydata, we need to test axes
@@ -1468,16 +1467,10 @@ class BboxImage(_ImageBase):
 
     def contains(self, mouseevent):
         """Test whether the mouse event occurred within the image."""
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
-
-        if not self.get_visible():  # or self.get_figure()._renderer is None:
+        if self._different_canvas(mouseevent) or not self.get_visible():
             return False, {}
-
         x, y = mouseevent.x, mouseevent.y
         inside = self.get_window_extent().contains(x, y)
-
         return inside, {}
 
     def make_image(self, renderer, magnification=1.0, unsampled=False):

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1174,9 +1174,6 @@ class Legend(Artist):
         return l, b
 
     def contains(self, event):
-        inside, info = self._default_contains(event)
-        if inside is not None:
-            return inside, info
         return self.legendPatch.contains(event)
 
     def set_draggable(self, state, use_blit=False, update='loc'):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -447,9 +447,8 @@ class Line2D(Artist):
 
             TODO: sort returned indices by distance
         """
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
 
         # Make sure we have data to plot
         if self._invalidy or self._invalidx:

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -268,9 +268,8 @@ class OffsetBox(martist.Artist):
         --------
         .Artist.contains
         """
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         for c in self.get_children():
             a, b = c.contains(mouseevent)
             if a:
@@ -1353,9 +1352,8 @@ or callable, default: value of *xycoords*
         self.stale = True
 
     def contains(self, mouseevent):
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         if not self._check_xy(None):
             return False, {}
         return self.offsetbox.contains(mouseevent)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -132,9 +132,8 @@ class Patch(artist.Artist):
         -------
         (bool, empty dict)
         """
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         radius = self._process_radius(radius)
         codes = self.get_path().codes
         if codes is not None:

--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -374,9 +374,8 @@ class QuiverKey(martist.Artist):
         self.text.set_figure(fig)
 
     def contains(self, mouseevent):
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         # Maybe the dictionary should allow one to
         # distinguish between a text hit and a vector hit.
         if (self.text.contains(mouseevent)[0] or

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -426,9 +426,8 @@ class Table(Artist):
 
     def contains(self, mouseevent):
         # docstring inherited
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(mouseevent):
+            return False, {}
         # TODO: Return index of the cell containing the cursor so that the user
         # doesn't have to bind to each one individually.
         renderer = self.figure._get_renderer()

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -213,20 +213,15 @@ class Text(Artist):
         Return whether the mouse event occurred inside the axis-aligned
         bounding-box of the text.
         """
-        inside, info = self._default_contains(mouseevent)
-        if inside is not None:
-            return inside, info
-
-        if not self.get_visible() or self._renderer is None:
+        if (self._different_canvas(mouseevent) or not self.get_visible()
+                or self._renderer is None):
             return False, {}
-
         # Explicitly use Text.get_window_extent(self) and not
         # self.get_window_extent() so that Annotation.contains does not
         # accidentally cover the entire annotation bounding box.
         bbox = Text.get_window_extent(self)
         inside = (bbox.x0 <= mouseevent.x <= bbox.x1
                   and bbox.y0 <= mouseevent.y <= bbox.y1)
-
         cattr = {}
         # if the text has a surrounding patch, also check containment for it,
         # and merge the results with the results for the text.
@@ -234,7 +229,6 @@ class Text(Artist):
             patch_inside, patch_cattr = self._bbox_patch.contains(mouseevent)
             inside = inside or patch_inside
             cattr["bbox_patch"] = patch_cattr
-
         return inside, cattr
 
     def _get_xy_display(self):
@@ -1855,9 +1849,8 @@ or callable, default: value of *xycoords*
         Text.__init__(self, x, y, text, **kwargs)
 
     def contains(self, event):
-        inside, info = self._default_contains(event)
-        if inside is not None:
-            return inside, info
+        if self._different_canvas(event):
+            return False, {}
         contains, tinfo = Text.contains(self, event)
         if self.arrow_patch is not None:
             in_patch, _ = self.arrow_patch.contains(event)


### PR DESCRIPTION
The old _default_contains check was geared towards custom contains checkers (set via set_contains), which have been removed.  Get rid of that and instead, add a check for canvas identity which is more useful.

Closes #6324.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
