### PR TITLE
Restore autolimits status when pressing "home" key.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3985,35 +3985,30 @@ class _AxesBase(martist.Artist):
         """
         Save information required to reproduce the current view.
 
-        Called before a view is changed, such as during a pan or zoom
-        initiated by the user. You may return any information you deem
-        necessary to describe the view.
+        This method is called before a view is changed, such as during a pan or zoom
+        initiated by the user.  It returns an opaque object that describes the current
+        view, in a format compatible with :meth:`_set_view`.
 
-        .. note::
-
-            Intended to be overridden by new projection types, but if not, the
-            default implementation saves the view limits. You *must* implement
-            :meth:`_set_view` if you implement this method.
+        The default implementation saves the view limits and autoscaling state.
+        Subclasses may override this as needed, as long as :meth:`_set_view` is also
+        adjusted accordingly.
         """
-        xmin, xmax = self.get_xlim()
-        ymin, ymax = self.get_ylim()
-        return xmin, xmax, ymin, ymax
+        return {
+            "xlim": self.get_xlim(), "autoscalex_on": self.get_autoscalex_on(),
+            "ylim": self.get_ylim(), "autoscaley_on": self.get_autoscaley_on(),
+        }
 
     def _set_view(self, view):
         """
         Apply a previously saved view.
 
-        Called when restoring a view, such as with the navigation buttons.
+        This method is called when restoring a view (with the return value of
+        :meth:`_get_view` as argument), such as with the navigation buttons.
 
-        .. note::
-
-            Intended to be overridden by new projection types, but if not, the
-            default implementation restores the view limits. You *must*
-            implement :meth:`_get_view` if you implement this method.
+        Subclasses that override :meth:`_get_view` also need to override this method
+        accordingly.
         """
-        xmin, xmax, ymin, ymax = view
-        self.set_xlim((xmin, xmax))
-        self.set_ylim((ymin, ymax))
+        self.set(**view)
 
     def _prepare_view_from_bbox(self, bbox, direction='in',
                                 mode=None, twinx=False, twiny=False):

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -280,6 +280,36 @@ def test_toolbar_zoompan():
     assert ax.get_navigate_mode() == "PAN"
 
 
+def test_toolbar_home_restores_autoscale():
+    fig, ax = plt.subplots()
+    ax.plot(range(11), range(11))
+
+    tb = NavigationToolbar2(fig.canvas)
+    tb.zoom()
+
+    # Switch to log.
+    KeyEvent("key_press_event", fig.canvas, "k", 100, 100)._process()
+    KeyEvent("key_press_event", fig.canvas, "l", 100, 100)._process()
+    assert ax.get_xlim() == ax.get_ylim() == (1, 10)  # Autolimits excluding 0.
+    # Switch back to linear.
+    KeyEvent("key_press_event", fig.canvas, "k", 100, 100)._process()
+    KeyEvent("key_press_event", fig.canvas, "l", 100, 100)._process()
+    assert ax.get_xlim() == ax.get_ylim() == (0, 10)  # Autolimits.
+
+    # Zoom in from (x, y) = (2, 2) to (5, 5).
+    start, stop = ax.transData.transform([(2, 2), (5, 5)])
+    MouseEvent("button_press_event", fig.canvas, *start, MouseButton.LEFT)._process()
+    MouseEvent("button_release_event", fig.canvas, *stop, MouseButton.LEFT)._process()
+    # Go back to home.
+    KeyEvent("key_press_event", fig.canvas, "h")._process()
+
+    assert ax.get_xlim() == ax.get_ylim() == (0, 10)
+    # Switch to log.
+    KeyEvent("key_press_event", fig.canvas, "k", 100, 100)._process()
+    KeyEvent("key_press_event", fig.canvas, "l", 100, 100)._process()
+    assert ax.get_xlim() == ax.get_ylim() == (1, 10)  # Autolimits excluding 0.
+
+
 @pytest.mark.parametrize(
     "backend", ['svg', 'ps', 'pdf',
                 pytest.param('pgf', marks=needs_pgf_xelatex)]

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1000,13 +1000,16 @@ class Axes3D(Axes):
 
     def _get_view(self):
         # docstring inherited
-        return (self.get_xlim(), self.get_ylim(), self.get_zlim(),
-                self.elev, self.azim, self.roll)
+        return {
+            "xlim": self.get_xlim(), "autoscalex_on": self.get_autoscalex_on(),
+            "ylim": self.get_ylim(), "autoscaley_on": self.get_autoscaley_on(),
+            "zlim": self.get_zlim(), "autoscalez_on": self.get_autoscalez_on(),
+        }, (self.elev, self.azim, self.roll)
 
     def _set_view(self, view):
         # docstring inherited
-        xlim, ylim, zlim, elev, azim, roll = view
-        self.set(xlim=xlim, ylim=ylim, zlim=zlim)
+        props, (elev, azim, roll) = view
+        self.set(**props)
         self.elev = elev
         self.azim = azim
         self.roll = roll


### PR DESCRIPTION
When pressing the "home" key, the autoscaling state should be restored as well, as interactive zoom/pan could have turned it off. test_toolbar_home_restores_autoscale shows an example of why.  Assume one starts with `plot(range(11), range(11))`.  In linear scale this autoscales to (0, 10) (assuming no margins or the old round limits mode); in log scale this autoscales to (1, 10) (dropping the zero).  But previously, when "home" did not restore autoscale state, then a manual zoom followed by "home" (in linear scale) would set the limits to (0, 10) and turn off autoscale, after which switching to log scale interactively would give incorrect autolimits.

Closes #6630.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
