### PR TITLE
FIX: macosx, always put timers on main thread

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1869,7 +1869,7 @@ Timer__timer_start(Timer* self, PyObject* args)
     CFTimeInterval interval;
     PyObject* py_interval = NULL, * py_single = NULL, * py_on_timer = NULL;
     int single;
-    runloop = CFRunLoopGetCurrent();
+    runloop = CFRunLoopGetMain();
     if (!runloop) {
         PyErr_SetString(PyExc_RuntimeError, "Failed to obtain run loop");
         return NULL;


### PR DESCRIPTION
## PR Summary

The main thread is the one that is running when started, so we should put all timers we control on that thread. Otherwise, we need to start and control runloops on the other threads which may or may not be started. This is particularly important for `draw_idle()` calls that may be sent from a separate thread where work was being done, but the draw should happen on the main thread still.

closes #5675

To test, you can use the example from #5675 with some updates from other comments in there (save to file and run in interactive mode `python -i mac-threading-test.py`. Previously, the canvas would never be updated and freeze after the fact due to the extra thread waiting to have a runloop started and capture the draw events that were sent. There is a slight concern that we could hang the GUI event loop if we send too many timer events, but this seems to work just fine in practice here when I'm running this example I can change over to the pan tool and still move the canvas even while receiving the events.

```python
import random
import time
import threading
import matplotlib as mpl
import matplotlib.pyplot as plt


class Plot:

    def __init__(self):
        plt.ion()
        self.start = time.time()
        self.xdata = []
        self.ydata = []
        self.running = None
        fig = plt.figure()
        mpl.rcParams["figure.raise_window"] = True
        plt.show()
        self.axis = fig.add_subplot(111)
        self.line, = self.axis.plot([])
        threading.Thread(target=self.worker).start()

    def worker(self):
        for _ in range(50):
            self.xdata.append(len(self.xdata))
            self.ydata.append(random.random())
            self.axis.set_xlim(0, len(self.xdata))
            self.axis.set_ylim(0, max(self.ydata))
            self.line.set_data(self.xdata, self.ydata)
            time.sleep(0.1)
        print(time.time() - self.start)


if __name__ == '__main__':
    Plot()
```

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
