### PR TITLE
Remove unused private SpanSelector._pressv and ._prev.

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2651,10 +2651,6 @@ class SpanSelector(_SelectorWidget):
         self._extents_on_press = None
         self.snap_values = snap_values
 
-        # self._pressv is deprecated and we don't use it internally anymore
-        # but we maintain it until it is removed
-        self._pressv = None
-
         self.onmove_callback = onmove_callback
         self.minspan = minspan
 
@@ -2678,9 +2674,6 @@ class SpanSelector(_SelectorWidget):
             self._setup_edge_handles(self._handle_props)
 
         self._active_handle = None
-
-        # prev attribute is deprecated but we still need to maintain it
-        self._prev = (0, 0)
 
     def new_axes(self, ax, *, _props=None):
         """Set SpanSelector to operate on a new Axes."""
@@ -2758,10 +2751,6 @@ class SpanSelector(_SelectorWidget):
             self.update()
 
         v = event.xdata if self.direction == 'horizontal' else event.ydata
-        # self._pressv and self._prev are deprecated but we still need to
-        # maintain them
-        self._pressv = v
-        self._prev = self._get_data(event)
 
         if self._active_handle is None and not self.ignore_event_outside:
             # when the press event outside the span, we initially set the
@@ -2801,8 +2790,6 @@ class SpanSelector(_SelectorWidget):
     def _release(self, event):
         """Button release event handler."""
         self._set_cursor(False)
-        # self._pressv is deprecated but we still need to maintain it
-        self._pressv = None
 
         if not self._interactive:
             self._selection_artist.set_visible(False)
@@ -2848,9 +2835,6 @@ class SpanSelector(_SelectorWidget):
 
     def _onmove(self, event):
         """Motion notify event handler."""
-
-        # self._prev are deprecated but we still need to maintain it
-        self._prev = self._get_data(event)
 
         v = event.xdata if self.direction == 'horizontal' else event.ydata
         if self.direction == 'horizontal':


### PR DESCRIPTION
They corresponded to the old pressv/prev attributes, which have been deprecated and then removed.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
