### PR TITLE
Rename parameter of Annotation.contains and Legend.contains.

### DIFF
--- a/doc/api/next_api_changes/deprecations/25557-AL.rst
+++ b/doc/api/next_api_changes/deprecations/25557-AL.rst
@@ -1,0 +1,3 @@
+The parameter of ``Annotation.contains`` and ``Legend.contains`` is renamed to *mouseevent*
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... consistently with `.Artist.contains`.

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1173,8 +1173,9 @@ class Legend(Artist):
 
         return l, b
 
-    def contains(self, event):
-        return self.legendPatch.contains(event)
+    @_api.rename_parameter("3.8", "event", "mouseevent")
+    def contains(self, mouseevent):
+        return self.legendPatch.contains(mouseevent)
 
     def set_draggable(self, state, use_blit=False, update='loc'):
         """

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1848,12 +1848,13 @@ or callable, default: value of *xycoords*
         # Must come last, as some kwargs may be propagated to arrow_patch.
         Text.__init__(self, x, y, text, **kwargs)
 
-    def contains(self, event):
-        if self._different_canvas(event):
+    @_api.rename_parameter("3.8", "event", "mouseevent")
+    def contains(self, mouseevent):
+        if self._different_canvas(mouseevent):
             return False, {}
-        contains, tinfo = Text.contains(self, event)
+        contains, tinfo = Text.contains(self, mouseevent)
         if self.arrow_patch is not None:
-            in_patch, _ = self.arrow_patch.contains(event)
+            in_patch, _ = self.arrow_patch.contains(mouseevent)
             contains = contains or in_patch
         return contains, tinfo
 


### PR DESCRIPTION
For all other artists the parameter name is *mouseevent*.

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
