### PR TITLE
Simplify outdated Image.contains check.

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -654,14 +654,9 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
 
     def contains(self, mouseevent):
         """Test whether the mouse event occurred within the image."""
-        if self._different_canvas(mouseevent):
-            return False, {}
-        # 1) This doesn't work for figimage; but figimage also needs a fix
-        #    below (as the check cannot use x/ydata and extents).
-        # 2) As long as the check below uses x/ydata, we need to test axes
-        #    identity instead of `self.axes.contains(event)` because even if
-        #    axes overlap, x/ydata is only valid for event.inaxes anyways.
-        if self.axes is not mouseevent.inaxes:
+        if (self._different_canvas(mouseevent)
+                # This doesn't work for figimage.
+                or not self.axes.contains(mouseevent)[0]):
             return False, {}
         # TODO: make sure this is consistent with patch and patch
         # collection on nonlinear transformed coordinates.
@@ -670,16 +665,9 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         trans = self.get_transform().inverted()
         x, y = trans.transform([mouseevent.x, mouseevent.y])
         xmin, xmax, ymin, ymax = self.get_extent()
-        if xmin > xmax:
-            xmin, xmax = xmax, xmin
-        if ymin > ymax:
-            ymin, ymax = ymax, ymin
-
-        if x is not None and y is not None:
-            inside = (xmin <= x <= xmax) and (ymin <= y <= ymax)
-        else:
-            inside = False
-
+        # This checks xmin <= x <= xmax *or* xmax <= x <= xmin.
+        inside = (x is not None and (x - xmin) * (x - xmax) <= 0
+                  and y is not None and (y - ymin) * (y - ymax) <= 0)
         return inside, {}
 
     def write_png(self, fname):


### PR DESCRIPTION
See discussion at https://github.com/matplotlib/matplotlib/pull/18737/files#r506773948

## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
