### PR TITLE
Make guiEvent available only within the event handlers.

### DIFF
--- a/doc/api/next_api_changes/deprecations/25559-AL.rst
+++ b/doc/api/next_api_changes/deprecations/25559-AL.rst
@@ -1,0 +1,5 @@
+Accessing ``event.guiEvent`` after event handlers return
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated: for some GUI toolkits, it is unsafe to do so.  In the
+future, ``event.guiEvent`` will be set to None once the event handlers return;
+you may separately stash the object at your own risk.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1257,11 +1257,26 @@ class Event:
     def __init__(self, name, canvas, guiEvent=None):
         self.name = name
         self.canvas = canvas
-        self.guiEvent = guiEvent
+        self._guiEvent = guiEvent
+        self._guiEvent_deleted = False
 
     def _process(self):
-        """Generate an event with name ``self.name`` on ``self.canvas``."""
+        """Process this event on ``self.canvas``, then unset ``guiEvent``."""
         self.canvas.callbacks.process(self.name, self)
+        self._guiEvent_deleted = True
+
+    @property
+    def guiEvent(self):
+        # After deprecation elapses: remove _guiEvent_deleted; make guiEvent a plain
+        # attribute set to None by _process.
+        if self._guiEvent_deleted:
+            _api.warn_deprecated(
+                "3.8", message="Accessing guiEvent outside of the original GUI event "
+                "handler is unsafe and deprecated since %(since)s; in the future, the "
+                "attribute will be set to None after quitting the event handler.  You "
+                "may separately record the value of the guiEvent attribute at your own "
+                "risk.")
+        return self._guiEvent
 
 
 class DrawEvent(Event):


### PR DESCRIPTION
## PR Summary

Closes #22211.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
