### PR TITLE
Fix return type of get_plot_commands

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2066,8 +2066,8 @@ def get_plot_commands():
     NON_PLOT_COMMANDS = {
         'connect', 'disconnect', 'get_current_fig_manager', 'ginput',
         'new_figure_manager', 'waitforbuttonpress'}
-    return (name for name in _get_pyplot_commands()
-            if name not in NON_PLOT_COMMANDS)
+    return [name for name in _get_pyplot_commands()
+            if name not in NON_PLOT_COMMANDS]
 
 
 def _get_pyplot_commands():


### PR DESCRIPTION
## PR Summary

The typing PR found that this was returning a generator [1], but this was an error from #24000, as 3.6 and earlier returned a list.

[1] https://github.com/matplotlib/matplotlib/pull/24976#discussion_r1152872718

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`