### PR TITLE
MNT: use less eval

### DIFF
--- a/galleries/examples/widgets/textbox.py
+++ b/galleries/examples/widgets/textbox.py
@@ -32,7 +32,7 @@ def submit(expression):
     *expression* is a string using "t" as its independent variable, e.g.
     "t ** 3".
     """
-    ydata = eval(expression)
+    ydata = eval(expression, {'np': np}, {'t': t})
     l.set_ydata(ydata)
     ax.relim()
     ax.autoscale_view()

--- a/lib/matplotlib/backends/qt_editor/_formlayout.py
+++ b/lib/matplotlib/backends/qt_editor/_formlayout.py
@@ -41,6 +41,8 @@ OTHER DEALINGS IN THE SOFTWARE.
 __version__ = '1.0.10'
 __license__ = __doc__
 
+from ast import literal_eval
+
 import copy
 import datetime
 import logging
@@ -351,7 +353,7 @@ class FormWidget(QtWidgets.QWidget):
                 else:
                     value = date_.toPython()
             else:
-                value = eval(str(field.text()))
+                value = literal_eval(str(field.text()))
             valuelist.append(value)
         return valuelist
 


### PR DESCRIPTION
## PR Summary


In the textbox example we need eval because we are taking symbolic input from the user and then plotting it.  I restricted the namespaces a bit to set a better example, but I think we fundamentally do need to use `eval` in this case.

In the qt editor eval was changed to ast.literal_eval which only handles literals so is safer.

These were the main things that I did not think were false-positives from running semgrep on our code base.

