### PR TITLE
Expire remaining 3.6 deprecations

### DIFF
--- a/ci/mypy-stubtest-allowlist.txt
+++ b/ci/mypy-stubtest-allowlist.txt
@@ -84,13 +84,10 @@ matplotlib.transforms.TransformWrapper.input_dims
 matplotlib.transforms.TransformWrapper.is_separable
 matplotlib.transforms.TransformWrapper.output_dims
 
-# 3.6 deprecations
-matplotlib.colorbar.Colorbar.__init__
-matplotlib.figure.Figure.callbacks
+# 3.6 Pending deprecations
 matplotlib.figure.Figure.set_constrained_layout
 matplotlib.figure.Figure.set_constrained_layout_pads
 matplotlib.figure.Figure.set_tight_layout
-matplotlib.figure.SubFigure.callbacks
 
 # 3.7 deprecations
 matplotlib.cm.register_cmap
@@ -103,7 +100,6 @@ matplotlib.widgets.Slider.__init__
 matplotlib.widgets.RangeSlider.__init__
 matplotlib.widgets.TextBox.__init__
 matplotlib.widgets.Cursor.__init__
-matplotlib.widgets.MultiCursor.__init__
 matplotlib.widgets.SpanSelector.__init__
 matplotlib.widgets.ToolLineHandles.__init__
 matplotlib.widgets.ToolHandles.__init__

--- a/doc/api/next_api_changes/deprecations/25584-KS.rst
+++ b/doc/api/next_api_changes/deprecations/25584-KS.rst
@@ -1,0 +1,5 @@
+Widgets
+~~~~~~~
+
+The *visible* attribute getter of Selector widgets has been deprecated;
+use ``get_visible``

--- a/doc/api/next_api_changes/removals/25584-KS.rst
+++ b/doc/api/next_api_changes/removals/25584-KS.rst
@@ -1,0 +1,24 @@
+``Figure.callbacks`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Figure ``callbacks`` property is deprecated. The only signal was
+"dpi_changed", which can be replaced by connecting to the "resize_event" on the
+canvas ``figure.canvas.mpl_connect("resize_event", func)`` instead.
+
+
+
+Passing too many positional arguments to ``tripcolor``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... raises ``TypeError`` (extra arguments were previously ignored).
+
+
+The *filled* argument to ``Colorbar`` is removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+This behavior was already governed by the underlying ``ScalarMappable``.
+
+
+Widgets
+~~~~~~~
+
+The *visible* attribute setter of Selector widgets has been removed; use ``set_visible``
+The associated getter is also deprecated, but not yet expired.

--- a/doc/api/next_api_changes/removals/25584-KS.rst
+++ b/doc/api/next_api_changes/removals/25584-KS.rst
@@ -1,5 +1,5 @@
-``Figure.callbacks`` is deprecated
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+``Figure.callbacks`` is removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Figure ``callbacks`` property is deprecated. The only signal was
 "dpi_changed", which can be replaced by connecting to the "resize_event" on the

--- a/doc/api/next_api_changes/removals/25584-KS.rst
+++ b/doc/api/next_api_changes/removals/25584-KS.rst
@@ -1,7 +1,7 @@
 ``Figure.callbacks`` is removed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The Figure ``callbacks`` property is deprecated. The only signal was
+The Figure ``callbacks`` property has been removed. The only signal was
 "dpi_changed", which can be replaced by connecting to the "resize_event" on the
 canvas ``figure.canvas.mpl_connect("resize_event", func)`` instead.
 

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -278,7 +278,6 @@ class Colorbar:
 
     n_rasterize = 50  # rasterize solids if number of colors >= n_rasterize
 
-    @_api.delete_parameter("3.6", "filled")
     def __init__(self, ax, mappable=None, *, cmap=None,
                  norm=None,
                  alpha=None,
@@ -291,7 +290,6 @@ class Colorbar:
                  ticks=None,
                  format=None,
                  drawedges=False,
-                 filled=True,
                  extendfrac=None,
                  extendrect=False,
                  label='',
@@ -305,6 +303,7 @@ class Colorbar:
         cmap = mappable.cmap
         norm = mappable.norm
 
+        filled = True
         if isinstance(mappable, contour.ContourSet):
             cs = mappable
             alpha = cs.get_alpha()

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -260,8 +260,6 @@ class Colorbar:
     drawedges : bool
         Whether to draw lines at color boundaries.
 
-    filled : bool
-
     %(_colormap_kw_doc)s
 
     location : None or {'left', 'right', 'top', 'bottom'}

--- a/lib/matplotlib/colorbar.pyi
+++ b/lib/matplotlib/colorbar.pyi
@@ -57,7 +57,6 @@ class Colorbar:
         ticks: Sequence[float] | Locator | None = ...,
         format: str | Formatter | None = ...,
         drawedges: bool = ...,
-        filled: bool = ...,
         extendfrac: Literal["auto"] | float | Sequence[float] | None = ...,
         extendrect: bool = ...,
         label: str = ...,

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2142,10 +2142,6 @@ class SubFigure(FigureBase):
 
     See :doc:`/gallery/subplots_axes_and_figures/subfigures`
     """
-    callbacks = _api.deprecated(
-            "3.6", alternative=("the 'resize_event' signal in "
-                                "Figure.canvas.callbacks")
-            )(property(lambda self: self._fig_callbacks))
 
     def __init__(self, parent, subplotspec, *,
                  facecolor=None,
@@ -2194,7 +2190,6 @@ class SubFigure(FigureBase):
         self._subplotspec = subplotspec
         self._parent = parent
         self.figure = parent.figure
-        self._fig_callbacks = parent._fig_callbacks
 
         # subfigures use the parent axstack
         self._axstack = parent._axstack
@@ -2355,12 +2350,6 @@ class Figure(FigureBase):
         depending on the renderer option_image_nocomposite function.  If
         *suppressComposite* is a boolean, this will override the renderer.
     """
-    # Remove the self._fig_callbacks properties on figure and subfigure
-    # after the deprecation expires.
-    callbacks = _api.deprecated(
-        "3.6", alternative=("the 'resize_event' signal in "
-                            "Figure.canvas.callbacks")
-        )(property(lambda self: self._fig_callbacks))
 
     def __str__(self):
         return "Figure(%gx%g)" % tuple(self.bbox.size)
@@ -2501,7 +2490,6 @@ None}, default: None
             # everything is None, so use default:
             self.set_layout_engine(layout=layout)
 
-        self._fig_callbacks = cbook.CallbackRegistry(signals=["dpi_changed"])
         # Callbacks traditionally associated with the canvas (and exposed with
         # a proxy property), but that actually need to be on the figure for
         # pickling.
@@ -2750,7 +2738,6 @@ None}, default: None
         self.dpi_scale_trans.clear().scale(dpi)
         w, h = self.get_size_inches()
         self.set_size_inches(w, h, forward=forward)
-        self._fig_callbacks.process('dpi_changed', self)
 
     dpi = property(_get_dpi, _set_dpi, doc="The resolution in dots per inch.")
 

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -280,6 +280,8 @@ def test_tripcolor_color():
     with pytest.raises(TypeError,
                        match="positional.*'c'.*keyword-only.*'facecolors'"):
         ax.tripcolor(x, y, C=[1, 2, 3, 4])
+    with pytest.raises(TypeError, match="Unexpected positional parameter"):
+        ax.tripcolor(x, y, [1, 2], 'unused_positional')
 
     # smoke test for valid color specifications (via C or facecolors)
     ax.tripcolor(x, y, [1, 2, 3, 4])  # edges
@@ -303,9 +305,6 @@ def test_tripcolor_warnings():
     y = [0, -1, 0, 1]
     c = [0.4, 0.5]
     fig, ax = plt.subplots()
-    # additional parameters
-    with pytest.warns(DeprecationWarning, match="Additional positional param"):
-        ax.tripcolor(x, y, c, 'unused_positional')
     # facecolors takes precedence over c
     with pytest.warns(UserWarning, match="Positional parameter c .*no effect"):
         ax.tripcolor(x, y, c, facecolors=c)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -139,8 +139,7 @@ def test_deprecation_selector_visible_attribute(ax):
 
     with pytest.warns(mpl.MatplotlibDeprecationWarning,
                       match="was deprecated in Matplotlib 3.8"):
-        tool.visible = False
-    assert not tool.get_visible()
+        tool.visible
 
 
 @pytest.mark.parametrize('drag_from_anywhere, new_center',

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -138,7 +138,7 @@ def test_deprecation_selector_visible_attribute(ax):
     assert tool.get_visible()
 
     with pytest.warns(mpl.MatplotlibDeprecationWarning,
-                      match="was deprecated in Matplotlib 3.6"):
+                      match="was deprecated in Matplotlib 3.8"):
         tool.visible = False
     assert not tool.get_visible()
 

--- a/lib/matplotlib/tri/_tripcolor.py
+++ b/lib/matplotlib/tri/_tripcolor.py
@@ -80,10 +80,7 @@ def tripcolor(ax, *args, alpha=1.0, norm=None, cmap=None, vmin=None,
                 "tripcolor() missing 1 required positional argument: 'c'; or "
                 "1 required keyword-only argument: 'facecolors'")
         elif len(args) > 1:
-            _api.warn_deprecated(
-                "3.6", message=f"Additional positional parameters "
-                f"{args[1:]!r} are ignored; support for them is deprecated "
-                f"since %(since)s and will be removed %(removal)s")
+            raise TypeError(f"Unexpected positional parameters: {args[1:]!r}")
         c = np.asarray(args[0])
         if len(c) == len(tri.x):
             # having this before the len(tri.triangles) comparison gives

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2429,7 +2429,7 @@ class _SelectorWidget(AxesWidget):
 
     @property
     def visible(self):
-        _api.warn_deprecated("3.6", alternative="get_visible")
+        _api.warn_deprecated("3.8", alternative="get_visible")
         return self.get_visible()
 
     def clear(self):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2429,12 +2429,8 @@ class _SelectorWidget(AxesWidget):
 
     @property
     def visible(self):
+        _api.warn_deprecated("3.6", alternative="get_visible")
         return self.get_visible()
-
-    @visible.setter
-    def visible(self, visible):
-        _api.warn_deprecated("3.6", alternative="set_visible")
-        self.set_visible(visible)
 
     def clear(self):
         """Clear the selection and set the selector ready to make a new one."""

--- a/lib/matplotlib/widgets.pyi
+++ b/lib/matplotlib/widgets.pyi
@@ -259,6 +259,7 @@ class MultiCursor(Widget):
         self,
         canvas: Any,
         axes: Sequence[Axes],
+        *,
         useblit: bool = ...,
         horizOn: bool = ...,
         vertOn: bool = ...,
@@ -297,8 +298,6 @@ class _SelectorWidget(AxesWidget):
     def get_visible(self) -> bool: ...
     @property
     def visible(self) -> bool: ...
-    @visible.setter
-    def visible(self, visible: bool) -> None: ...
     def clear(self) -> None: ...
     @property
     def artists(self) -> tuple[Artist]: ...


### PR DESCRIPTION
## PR Summary

- Remaining mpl3.6 deprecations
- Update tests for deprecated behavior

I believe the only `3.6` deprecations that remain are still marked as "pending", those include some in axis3d and some in Figure.

The expiration for `Colorbar` filled kwarg is rather minimal.
It was originally deprecated in #21933, @jklymak do you think more clean up is needed?


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
