### PR TITLE
Post stubtest results to GitHub checks

### DIFF
--- a/.github/workflows/mypy-stubtest.yml
+++ b/.github/workflows/mypy-stubtest.yml
@@ -20,11 +20,35 @@ jobs:
 
       - name: Install mypy
         run: |
-          pip3 install -r requirements/testing/mypy.txt -r requirements/testing/all.txt
-          pip3 install .
+          pip3 install -r requirements/testing/mypy.txt \
+            -r requirements/testing/all.txt
+          pip3 install -e .
+
+      - name: Set up reviewdog
+        run: |
+          mkdir -p "$HOME/bin"
+          curl -sfL \
+            https://github.com/reviewdog/reviewdog/raw/master/install.sh | \
+              sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> $GITHUB_PATH
 
       - name: Run mypy stubtest
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # the ignore missing imports can be removed when typed cycler is released and used
-          MPLBACKEND=agg python -m mypy.stubtest matplotlib --mypy-config-file pyproject.toml \
-                                --allowlist ci/mypy-stubtest-allowlist.txt
+          set -o pipefail
+          MPLBACKEND=agg python -m mypy.stubtest \
+            --mypy-config-file pyproject.toml \
+            --allowlist ci/mypy-stubtest-allowlist.txt \
+            matplotlib | \
+              reviewdog \
+                -efm '%Eerror: %m' \
+                -efm '%CStub: in file %f:%l' \
+                -efm '%CStub: in file %f' \
+                -efm '%+CRuntime:%.%#' \
+                -efm '%+CMISSING' \
+                -efm '%+Cdef %.%#' \
+                -efm '%+C<%.%#>' \
+                -efm '%Z' \
+                -reporter=github-check -tee -name=mypy-stubtest \
+                -filter-mode=nofilter


### PR DESCRIPTION
## PR Summary

Unfortunately, the way that `stubtest` outputs its error messages makes it difficult to post a message on _both_ the `.py` and `.pyi` stub, so we decided to take the full message and post it only on one.

As a test, I have made PR in my repo https://github.com/QuLogic/matplotlib/pull/30 which started from the previously-unfixed #25542, and then I also added a commit with multiple argument mismatches to confirm that `stubtest` didn't output some different format.

Results are at the bottom of https://github.com/QuLogic/matplotlib/pull/30/files

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`