### PR TITLE
Fix issue #24404

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2750,6 +2750,8 @@ del _result
      (dict(c='b', edgecolor='r', edgecolors='g'), 'r'),
      (dict(color='r'), 'r'),
      (dict(color='r', edgecolor='g'), 'g'),
+     (dict(facecolors='none'), None),
+     (dict(c='b', facecolors='none'), np.array([[0, 0, 1, 1]]))
      ])
 def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
     def get_next_color():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2760,7 +2760,10 @@ def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
     _, _, result_edgecolors = \
         mpl.axes.Axes._parse_scatter_color_args(
             c, edgecolors, kwargs, xsize=2, get_next_color_func=get_next_color)
-    assert result_edgecolors == expected_edgecolors
+    if type(expected_edgecolors) == np.ndarray:
+        assert_allclose(result_edgecolors, expected_edgecolors)
+    else:
+        assert result_edgecolors == expected_edgecolors
 
 
 def test_parse_scatter_color_args_error():


### PR DESCRIPTION
## PR Summary
Fix issue #24404

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
