### PR TITLE
Use _api.nargs_error in more places

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -314,7 +314,7 @@ class Axes(_AxesBase):
                 *args,
                 **kwargs)
         if len(extra_args):
-            raise TypeError('legend only accepts two non-keyword arguments')
+            _api.nargs_error('legend', '0-2', len(args))
         self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
         self.legend_._remove_method = self._remove_legend
         return self.legend_
@@ -2970,8 +2970,7 @@ class Axes(_AxesBase):
             which inspired this method.
         """
         if not 1 <= len(args) <= 3:
-            raise TypeError('stem expected between 1 or 3 positional '
-                            f'arguments, got {args}')
+            _api.nargs_error('stem', '1-3', len(args))
         _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
 
         if len(args) == 1:
@@ -6383,7 +6382,7 @@ default: :rc:`scatter.edgecolors`
             else:
                 raise TypeError("arguments do not match valid signatures")
         else:
-            raise TypeError("need 1 argument or 3 arguments")
+            _api.nargs_error('pcolorfast', '1 or 3', len(args))
 
         if style == "quadmesh":
             # data point in each cell is value at lower left corner

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1352,11 +1352,8 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
 
     # Two arguments:
     #   * user defined handles and labels
-    elif len(args) >= 2:
+    else:
         handles, labels = args[:2]
         extra_args = args[2:]
-
-    else:
-        raise TypeError('Invalid arguments to legend.')
 
     return handles, labels, extra_args, kwargs

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -693,7 +693,7 @@ def cycler(*args, **kwargs):
     elif len(args) == 2:
         pairs = [(args[0], args[1])]
     elif len(args) > 2:
-        raise TypeError("No more than 2 positional arguments allowed")
+        _api.nargs_error('cycler', '0-2', len(args))
     else:
         pairs = kwargs.items()
 


### PR DESCRIPTION
## PR Summary

## PR Checklist

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`