### PR TITLE
Use classic style in old what's new entries

### DIFF
--- a/doc/users/prev_whats_new/whats_new_0.99.rst
+++ b/doc/users/prev_whats_new/whats_new_0.99.rst
@@ -33,6 +33,9 @@ installs).  See :ref:`mplot3d-examples-index` and
     from matplotlib import cm
     from mpl_toolkits.mplot3d import Axes3D
 
+
+    plt.style.use('classic')
+
     X = np.arange(-5, 5, 0.25)
     Y = np.arange(-5, 5, 0.25)
     X, Y = np.meshgrid(X, Y)
@@ -92,6 +95,9 @@ new mpl installs.   See :ref:`axes_grid1-examples-index`,
 
 
     fig = plt.figure()
+
+    plt.style.use('classic')
+
     ax = RGBAxes(fig, [0.1, 0.1, 0.8, 0.8])
 
     r, g, b = get_rgb()
@@ -138,6 +144,8 @@ well as "detach" the spine to offset it away from the data.  See
             ax.xaxis.set_ticks([])
 
     fig = plt.figure()
+
+    plt.style.use('classic')
 
     x = np.linspace(0, 2*np.pi, 100)
     y = 2*np.sin(x)

--- a/doc/users/prev_whats_new/whats_new_1.1.rst
+++ b/doc/users/prev_whats_new/whats_new_1.1.rst
@@ -58,6 +58,8 @@ to address the most common layout issues.
 
 .. plot::
 
+    plt.style.use('classic')
+
     plt.rcParams['savefig.facecolor'] = "0.8"
     plt.rcParams['figure.figsize'] = 4, 3
 

--- a/doc/users/prev_whats_new/whats_new_1.2.rst
+++ b/doc/users/prev_whats_new/whats_new_1.2.rst
@@ -78,6 +78,8 @@ minimum and maximum colorbar extensions.
 
     import matplotlib.pyplot as plt
     import numpy as np
+    
+    plt.style.use('classic')
 
     x = y = np.linspace(0., 2*np.pi, 100)
     X, Y = np.meshgrid(x, y)


### PR DESCRIPTION
## PR Summary
This PR closes #7199 
Changed 3 code example and it's plot on release 0.99
<img width="1666" alt="Screenshot 2023-04-04 at 15 17 52" src="https://user-images.githubusercontent.com/84302343/229964245-f22d01f0-0464-4c0c-ab77-c055c1320837.png">

Change from above to 

<img width="1484" alt="Screenshot 2023-04-04 at 22 20 26" src="https://user-images.githubusercontent.com/84302343/229964387-b02f0427-a4c8-4e45-ae81-0bdd9a0289a0.png">
<img width="1324" alt="Screenshot 2023-04-04 at 22 21 11" src="https://user-images.githubusercontent.com/84302343/229964488-c2f1e4d5-1baf-4ae9-8216-a986a1148857.png">
to this:

<img width="1306" alt="Screenshot 2023-04-04 at 22 21 16" src="https://user-images.githubusercontent.com/84302343/229964549-12268a58-981f-4412-b1f5-ee922fd08027.png">
<img width="1254" alt="Screenshot 2023-04-04 at 22 22 16" src="https://user-images.githubusercontent.com/84302343/229964589-c9f8f9a2-6661-41e1-a028-96033eb47db9.png">

to this 

<img width="1198" alt="Screenshot 2023-04-04 at 22 22 19" src="https://user-images.githubusercontent.com/84302343/229964600-134d28bd-8f3a-4016-9a75-64129a0aaec5.png">

Changed the release 1.1 
from this
<img width="1483" alt="Screenshot 2023-04-04 at 22 23 14" src="https://user-images.githubusercontent.com/84302343/229964732-af17a372-d147-491f-9c2e-8ab578f0b7b8.png">

to this:

<img width="1383" alt="Screenshot 2023-04-04 at 22 23 20" src="https://user-images.githubusercontent.com/84302343/229964761-92c17ba7-5b2e-4134-9959-fd2d14fc0336.png">


Changed the release 1.2 
from 
<img width="1450" alt="Screenshot 2023-04-04 at 22 25 09" src="https://user-images.githubusercontent.com/84302343/229965007-69c6608c-6676-4913-b5c5-238f307b74c7.png">

to this：

<img width="1482" alt="Screenshot 2023-04-04 at 22 25 00" src="https://user-images.githubusercontent.com/84302343/229965022-a88d4578-95a0-46c9-a8fe-234a4b4301f6.png">


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [X] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
