### PR TITLE
FIX: correctly unset the layout engine in Figure.tight_layout

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3515,7 +3515,7 @@ None}, default: None
                     and previous_engine is not None:
                 _api.warn_external('The figure layout has changed to tight')
         finally:
-            self.set_layout_engine(None)
+            self.set_layout_engine('none')
 
 
 def figaspect(arg):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -660,7 +660,7 @@ def test_invalid_layouts():
 
 
 @check_figures_equal(extensions=["png"])
-def test_tightlayout_autolayout_deconfilct(fig_test, fig_ref):
+def test_tightlayout_autolayout_deconflict(fig_test, fig_ref):
     for fig, autolayout in zip([fig_ref, fig_test], [False, True]):
         with mpl.rc_context({'figure.autolayout': autolayout}):
             axes = fig.subplots(ncols=2)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -659,6 +659,15 @@ def test_invalid_layouts():
         fig.set_layout_engine("constrained")
 
 
+@check_figures_equal(extensions=["png"])
+def test_tightlayout_autolayout_deconfilct(fig_test, fig_ref):
+    for fig, autolayout in zip([fig_ref, fig_test], [False, True]):
+        with mpl.rc_context({'figure.autolayout': autolayout}):
+            axes = fig.subplots(ncols=2)
+            fig.tight_layout(w_pad=10)
+        assert isinstance(fig.get_layout_engine(), PlaceHolderLayoutEngine)
+
+
 @pytest.mark.parametrize('layout', ['constrained', 'compressed'])
 def test_layout_change_warning(layout):
     """


### PR DESCRIPTION

## PR Summary

closes #7805


## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [na] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [na] New plotting related features are documented with examples.
