### PR TITLE
API: forbid unsafe savefig kwargs to AbstractMovieWriter.grab_frame

### DIFF
--- a/doc/api/next_api_changes/behavior/25361-TAC.rst
+++ b/doc/api/next_api_changes/behavior/25361-TAC.rst
@@ -1,0 +1,18 @@
+Reject size related keyword arguments to MovieWriter *grab_frame* method
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Although we pass `.Figure.savefig` keyword arguments through the
+`.AbstractMovieWriter.grab_frame` some of the arguments will result in invalid
+output if passed.  To be successfully stitched into a movie, each frame
+must be exactly the same size, thus *bbox_inches* and *dpi* are excluded.
+Additionally, the movie writers are opinionated about the format of each
+frame, so the *format* argument is also excluded.  Passing these
+arguments will now raise `TypeError` for all writers (it already did so for some
+arguments and some writers).  The *bbox_inches* argument is already ignored (with
+a warning) if passed to `.Animation.save`.
+
+
+Additionally, if :rc:`savefig.bbox` is set to ``'tight'``,
+`.AbstractMovieWriter.grab_frame` will now error.  Previously this rcParam
+would be temporarily overridden (with a warning) in `.Animation.save`, it is
+now additionally overridden in `.AbstractMovieWriter.saving`.

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -690,9 +690,8 @@
 #savefig.edgecolor: auto        # figure edge color when saving
 #savefig.format:    png         # {png, ps, pdf, svg}
 #savefig.bbox:      standard    # {tight, standard}
-                                # 'tight' is incompatible with pipe-based animation
-                                # backends (e.g. 'ffmpeg') but will work with those
-                                # based on temporary files (e.g. 'ffmpeg_file')
+                                # 'tight' is incompatible with generating frames
+                                # for animation
 #savefig.pad_inches:  0.1       # padding to be used, when bbox is set to 'tight'
 #savefig.directory:   ~         # default directory in savefig dialog, gets updated after
                                 # interactive saves, unless set to the empty string (i.e.

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -62,6 +62,8 @@ class NullMovieWriter(animation.AbstractMovieWriter):
         self._count = 0
 
     def grab_frame(self, **savefig_kwargs):
+        from matplotlib.animation import _validate_grabframe_kwargs
+        _validate_grabframe_kwargs(savefig_kwargs)
         self.savefig_kwargs = savefig_kwargs
         self._count += 1
 
@@ -191,6 +193,38 @@ def test_save_animation_smoketest(tmpdir, writer, frame_format, output, anim):
                   codec=codec)
 
     del anim
+
+
+@pytest.mark.parametrize('writer, frame_format, output', gen_writers())
+def test_grabframe(tmpdir, writer, frame_format, output):
+    WriterClass = animation.writers[writer]
+
+    if frame_format is not None:
+        plt.rcParams["animation.frame_format"] = frame_format
+
+    fig, ax = plt.subplots()
+
+    dpi = None
+    codec = None
+    if writer == 'ffmpeg':
+        # Issue #8253
+        fig.set_size_inches((10.85, 9.21))
+        dpi = 100.
+        codec = 'h264'
+
+    test_writer = WriterClass()
+    # Use temporary directory for the file-based writers, which produce a file
+    # per frame with known names.
+    with tmpdir.as_cwd():
+        with test_writer.saving(fig, output, dpi):
+            # smoke test it works
+            test_writer.grab_frame()
+            for k in {'dpi', 'bbox_inches', 'format'}:
+                with pytest.raises(
+                        TypeError,
+                        match=f"grab_frame got an unexpected keyword argument {k!r}"
+                ):
+                    test_writer.grab_frame(**{k: object()})
 
 
 @pytest.mark.parametrize('writer', [


### PR DESCRIPTION

## PR Summary

closes #25608


Per https://github.com/matplotlib/matplotlib/issues/25608#issuecomment-1496915151 I do not think there is a way to make these keywords work in the context of a saved animation.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [na] New plotting related features are documented with examples.

**Release Notes**
- [na] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
