### PR TITLE
Remove nonfunctional Axes3D.set_frame_on and get_frame_on methods.

### DIFF
--- a/doc/api/next_api_changes/removals/25648-TS.rst
+++ b/doc/api/next_api_changes/removals/25648-TS.rst
@@ -1,0 +1,6 @@
+``Axes3D.set_frame_on`` and ``Axes3D.get_frame_on`` removed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``Axes3D.set_frame_on`` is documented as "Set whether the 3D axes panels are
+drawn.". However, it has no effect on 3D axes and is being removed in
+favor of ``Axes3D.set_axis_on`` and ``Axes3D.set_axis_off``.

--- a/doc/api/toolkits/mplot3d/axes3d.rst
+++ b/doc/api/toolkits/mplot3d/axes3d.rst
@@ -77,8 +77,6 @@ Appearance
    set_axis_off
    set_axis_on
    grid
-   get_frame_on
-   set_frame_on
 
 
 Axis

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1319,21 +1319,6 @@ class Axes3D(Axes):
 
     # Axes rectangle characteristics
 
-    def get_frame_on(self):
-        """Get whether the 3D axes panels are drawn."""
-        return self._frameon
-
-    def set_frame_on(self, b):
-        """
-        Set whether the 3D axes panels are drawn.
-
-        Parameters
-        ----------
-        b : bool
-        """
-        self._frameon = bool(b)
-        self.stale = True
-
     def grid(self, visible=True, **kwargs):
         """
         Set / unset 3D grid.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1319,6 +1319,14 @@ class Axes3D(Axes):
 
     # Axes rectangle characteristics
 
+    def get_frame_on(self):
+        """Currently not implemented for 3D axes, and returns *None*."""
+        return None
+
+    def set_frame_on(self, b):
+        """Currently not implemented for 3D axes, and returns *None*."""
+        return None
+
     def grid(self, visible=True, **kwargs):
         """
         Set / unset 3D grid.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1319,13 +1319,10 @@ class Axes3D(Axes):
 
     # Axes rectangle characteristics
 
-    def get_frame_on(self):
-        """Currently not implemented for 3D axes, and returns *None*."""
-        return None
-
-    def set_frame_on(self, b):
-        """Currently not implemented for 3D axes, and returns *None*."""
-        return None
+    # The frame_on methods are not available for 3D axes.
+    # Python will raise a TypeError if they are called.
+    get_frame_on = None
+    set_frame_on = None
 
     def grid(self, visible=True, **kwargs):
         """


### PR DESCRIPTION
## PR Summary
Fixes #24689. Remove `Axes3D.set_frame_on` and `get_frame_on` from the codebase and from the link in the documentation.

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
