### PR TITLE
MNT: deprecate unused numdecs LogLocator param

### DIFF
--- a/ci/mypy-stubtest-allowlist.txt
+++ b/ci/mypy-stubtest-allowlist.txt
@@ -118,6 +118,8 @@ matplotlib.contour.ContourSet.allsegs
 matplotlib.contour.ContourSet.tcolors
 matplotlib.contour.ContourSet.tlinewidths
 matplotlib.figure.FigureBase.get_tightbbox
+matplotlib.ticker.LogLocator.__init__
+matplotlib.ticker.LogLocator.set_params
 
 # positional-only argument name lacking leading underscores
 matplotlib.axes._base._AxesBase.axis

--- a/doc/api/next_api_changes/deprecations/25651-REC.rst
+++ b/doc/api/next_api_changes/deprecations/25651-REC.rst
@@ -1,0 +1,3 @@
+*numdecs* parameter and attribute of ``LogLocator``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated without replacement, because they have no effect.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -11,6 +11,7 @@ import pytest
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
+from matplotlib._api import MatplotlibDeprecationWarning
 
 
 class TestMaxNLocator:
@@ -233,9 +234,11 @@ class TestLogLocator:
         See if change was successful. Should not raise exception.
         """
         loc = mticker.LogLocator()
-        loc.set_params(numticks=7, numdecs=8, subs=[2.0], base=4)
+        with pytest.warns(MatplotlibDeprecationWarning, match="numdecs"):
+            loc.set_params(numticks=7, numdecs=8, subs=[2.0], base=4)
         assert loc.numticks == 7
-        assert loc.numdecs == 8
+        with pytest.warns(MatplotlibDeprecationWarning, match="numdecs"):
+            assert loc.numdecs == 8
         assert loc._base == 4
         assert list(loc._subs) == [2.0]
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -11,7 +11,6 @@ import pytest
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-from matplotlib._api import MatplotlibDeprecationWarning
 
 
 class TestMaxNLocator:
@@ -234,10 +233,10 @@ class TestLogLocator:
         See if change was successful. Should not raise exception.
         """
         loc = mticker.LogLocator()
-        with pytest.warns(MatplotlibDeprecationWarning, match="numdecs"):
+        with pytest.warns(mpl.MatplotlibDeprecationWarning, match="numdecs"):
             loc.set_params(numticks=7, numdecs=8, subs=[2.0], base=4)
         assert loc.numticks == 7
-        with pytest.warns(MatplotlibDeprecationWarning, match="numdecs"):
+        with pytest.warns(mpl.MatplotlibDeprecationWarning, match="numdecs"):
             assert loc.numdecs == 8
         assert loc._base == 4
         assert list(loc._subs) == [2.0]

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2244,6 +2244,7 @@ class LogLocator(Locator):
 
     """
 
+    @_api.delete_parameter("3.8", "numdecs")
     def __init__(self, base=10.0, subs=(1.0,), numdecs=4, numticks=None):
         """Place ticks on the locations : subs[j] * base**i."""
         if numticks is None:
@@ -2253,9 +2254,10 @@ class LogLocator(Locator):
                 numticks = 'auto'
         self._base = float(base)
         self._set_subs(subs)
-        self.numdecs = numdecs
+        self._numdecs = numdecs
         self.numticks = numticks
 
+    @_api.delete_parameter("3.8", "numdecs")
     def set_params(self, base=None, subs=None, numdecs=None, numticks=None):
         """Set parameters within this locator."""
         if base is not None:
@@ -2263,9 +2265,19 @@ class LogLocator(Locator):
         if subs is not None:
             self._set_subs(subs)
         if numdecs is not None:
-            self.numdecs = numdecs
+            self._numdecs = numdecs
         if numticks is not None:
             self.numticks = numticks
+
+    @_api.deprecated("3.8", addendum="This attribute has no effect.")
+    @property
+    def numdecs(self):
+        return self._numdecs
+
+    @_api.deprecated("3.8", addendum="This attribute has no effect.")
+    @numdecs.setter
+    def numdecs(self, numdecs):
+        self._numdecs = numdecs
 
     def _set_subs(self, subs):
         """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2269,15 +2269,7 @@ class LogLocator(Locator):
         if numticks is not None:
             self.numticks = numticks
 
-    @_api.deprecated("3.8", addendum="This attribute has no effect.")
-    @property
-    def numdecs(self):
-        return self._numdecs
-
-    @_api.deprecated("3.8", addendum="This attribute has no effect.")
-    @numdecs.setter
-    def numdecs(self, numdecs):
-        self._numdecs = numdecs
+    numdecs = _api.deprecate_privatize_attribute("3.8", addendum="This attribute has no effect.")
 
     def _set_subs(self, subs):
         """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2269,7 +2269,8 @@ class LogLocator(Locator):
         if numticks is not None:
             self.numticks = numticks
 
-    numdecs = _api.deprecate_privatize_attribute("3.8", addendum="This attribute has no effect.")
+    numdecs = _api.deprecate_privatize_attribute(
+        "3.8", addendum="This attribute has no effect.")
 
     def _set_subs(self, subs):
         """


### PR DESCRIPTION
## PR Summary

As far as I can tell, this parameter is not used for anything.

Closes #25638 

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  http://matplotlib.org/devel/documenting_mpl.html#formatting.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
