### PR TITLE
POC: add validation of formatters to converters

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -97,6 +97,7 @@ class Tick(martist.Artist):
 
         self.set_figure(axes.figure)
         self.axes = axes
+        self.converter = None
 
         self._loc = loc
         self._major = major
@@ -1820,6 +1821,13 @@ class Axis(martist.Artist):
                 and not isinstance(level.locator, mticker.FixedLocator)):
             _api.warn_external('FixedFormatter should only be used together '
                                'with FixedLocator')
+
+        if hasattr(self, "converter") and self.converter is not None:
+            if not self.converter.validate_formatter(formatter):
+                _api.warn_external(
+                    f'Converter {self.converter.__class__.__name__!r} got unexpected '
+                    f'formatter {formatter.__class__.__name__!r}'
+                )
 
         if level == self.major:
             self.isDefault_majfmt = False

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -114,6 +114,10 @@ class StrCategoryConverter(units.ConversionInterface):
                 f'Provided unit "{unit}" is not valid for a categorical '
                 'converter, as it does not have a _mapping attribute.')
 
+    @staticmethod
+    def validate_formatter(formatter):
+        return isinstance(formatter, (StrCategoryFormatter, ticker.NullFormatter))
+
 
 class StrCategoryLocator(ticker.Locator):
     """Tick at every integer mapping of the string data."""

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1836,6 +1836,13 @@ class DateConverter(units.ConversionInterface):
             pass
         return None
 
+    @staticmethod
+    def validate_formatter(formatter):
+        return isinstance(formatter, (DateFormatter,
+                                      ConciseDateFormatter,
+                                      AutoDateFormatter,
+                                      ticker.NullFormatter))
+
 
 class ConciseDateConverter(DateConverter):
     # docstring inherited
@@ -1887,6 +1894,9 @@ class _SwitchableDateConverter:
 
     def convert(self, *args, **kwargs):
         return self._get_converter().convert(*args, **kwargs)
+
+    def validate_formatter(self, formatter):
+        return self._get_converter().validate_formatter(formatter)
 
 
 units.registry[np.datetime64] = \

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -421,6 +421,7 @@ def test_autofmt_xdate(which):
         warnings.filterwarnings(
             'ignore',
             'FixedFormatter should only be used together with FixedLocator')
+        warnings.filterwarnings('ignore', 'Converter .* got unexpected formatter .*')
         ax.xaxis.set_minor_formatter(FixedFormatter(minors))
 
     fig.autofmt_xdate(0.2, angle, 'right', which)

--- a/lib/matplotlib/units.py
+++ b/lib/matplotlib/units.py
@@ -36,6 +36,13 @@ datetime objects::
             "Return the default unit for x or None."
             return 'date'
 
+        @staticmethod
+        def validate_formatter(formatter):
+            "Return whether the formatter works with this converter"
+            return isinstance(formatter, (dates.DateFormatter,
+                                          dates.ConciseDateFormatter,
+                                          dates.AutoDateFormatter))
+
     # Finally we register our object type with the Matplotlib units registry.
     units.registry[datetime.date] = DateConverter()
 """
@@ -130,6 +137,22 @@ class ConversionInterface:
         be a sequence of scalars that can be used by the numpy array layer.
         """
         return obj
+
+    @staticmethod
+    def validate_formatter(formatter):
+        """Return whether a given formatter is valid for the converter
+
+        Parameters
+        ----------
+        formatter: `~.Formatter`
+            The formatter instance to validate.
+
+        Returns
+        -------
+        bool: if the formatter is valid
+        """
+        # For backwards compatibility, the default is to accept any formatter
+        return True
 
 
 class DecimalConverter(ConversionInterface):


### PR DESCRIPTION
## PR Summary

Closes #24951

Certainly needs tests/docs prior to merge, but opening to further the conversation.

This introduces a method to Converters to validate that a given formatter works with with the Converter.

Currently it is implemented as a staticmethod which returns a bool and then matplotlib warns if that bool is false.
One option that I would consider would be to push the warning into the method, which could then suggest the valid types with a more targetted error message.

I chose a method so that more complicated logic _could_ be used, but so far all instances I have implemented or considered do simple `isinstance` checks.
One alternative if this was sufficient would be to make the thing that gets propegated a list (tuple?) of Formatter classes and then do the isinstance check directly rather than calling the method.
This could potentially also have APIs for registering formatters as valid for a given converter (or just be directly mutable as a list).
The cost, though is that you are limited to _only_ isinstance checks there.
(Of course with the method implementation, individual classes are free to implement such registration APIs, but lacks standardization)

If the converter is not set, it does not get checked.
Default behavior of ConversionInterface (and any subclasses which do not override the method) is to accept any formatter (i.e. return True indiscriminantly).
Thus except where downstream inherits from `DateConverter` or `StrCategoryConverter` it is entirely opt-in to this additional check.
Converters that expect essentially just float values (and should work with many different formatters that are not all enumerated) retain default behavior (internally, the example is DecimalConverter).
It is only a warning, not an error, mostly to ensure that if the list is wrong, you can still do what you want.

One slight wrinkle that is perhaps slightly awkward is that the `NullFormatter` does need to return `True` as that occurs during some setup/initialization phases (as well as just the semantics that you should be able to use `NullFormatter` to disable labels anyway)

@spencerkclark I am particularly interested in your opinion here
Here is the appropriate diff for nc-time-axis that I tested with:

```diff
diff --git a/nc_time_axis/__init__.py b/nc_time_axis/__init__.py
index a5276ad..76c4d74 100644
--- a/nc_time_axis/__init__.py
+++ b/nc_time_axis/__init__.py
@@ -582,6 +582,12 @@ class NetCDFTimeConverter(mdates.DateConverter):
 
         return result
 
+    @staticmethod
+    def validate_formatter(formatter):
+        return isinstance(formatter, (mticker.NullFormatter,
+                                      AutoCFTimeFormatter,
+                                      CFTimeFormatter))
+
 
 def is_numlike(x):
     """
```

The growing pain here is that without the above change, the NetCDFTimeConverter class from `cftime` will warn for the _correct_ formatters and not the mpl-default date formatters (that don't work properly).
This is because of the `mdates.DateConverter` inheritance that is not overridden without the above diff. As such, not sure there is any path that doesn't inherit the incorrect behavior without a change in nc-time-axis.

Since this affects downstream with warnings (not direct errors, at least), I would like to consult with at least the likes of Pandas (xarray's converting/formatting support is largely via nc-time-axis, above).
If there are other downstream projects we should consult with, happy to hear more.

I do not (yet) affirmatively test that the warning _is_ issued, though it did fail a test which sets `FixedFormatter` on a date axis and already ignores a warning against using such without `FixedLocator`.


Questions:

- Is the information sufficient to make determinations?
   - Would a classmethod be better, or is an instance method necessary? (considering all other functionality of ConversionInterface is staticmethod, that is where I started)
- Would list of types be easier to manage, even if it limits flexibility?
- is checking in `set_formatter` both sufficient and not overzealous? 
   - What about if the _converter_ is changed? should we ensure warning then?
   - What if you want to change _both_, can it be done without either warning or setting to None?

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
