### PR TITLE
Fix 'can not' -> 'cannot' typo

### DIFF
--- a/doc/api/toolkits/mplot3d/faq.rst
+++ b/doc/api/toolkits/mplot3d/faq.rst
@@ -25,14 +25,14 @@ of another object, even though it is physically behind it. This can result in
 plots that do not look "physically correct."
 
 Unfortunately, while some work is being done to reduce the occurrence of this
-artifact, it is currently an intractable problem, and can not be fully solved
+artifact, it is currently an intractable problem, and cannot be fully solved
 until matplotlib supports 3D graphics rendering at its core.
 
 The problem occurs due to the reduction of 3D data down to 2D + z-order
 scalar. A single value represents the 3rd dimension for all parts of 3D
 objects in a collection. Therefore, when the bounding boxes of two collections
 intersect, it becomes possible for this artifact to occur. Furthermore, the
-intersection of two 3D objects (such as polygons or patches) can not be
+intersection of two 3D objects (such as polygons or patches) cannot be
 rendered properly in matplotlib's 2D rendering engine.
 
 This problem will likely not be solved until OpenGL support is added to all of

--- a/doc/devel/MEP/MEP11.rst
+++ b/doc/devel/MEP/MEP11.rst
@@ -135,7 +135,7 @@ ordered from best/hardest to worst/easiest):
 
 2. Continue to ship dateutil_, pytz_, six_ and pyparsing_ in
    our installer, but use the post-install-script to install them
-   *only* if they can not already be found.
+   *only* if they cannot already be found.
 
 3. Move all of these packages inside a (new) ``matplotlib.extern``
    namespace so it is clear for outside users that these are

--- a/doc/devel/MEP/MEP14.rst
+++ b/doc/devel/MEP/MEP14.rst
@@ -62,7 +62,7 @@ has a number of shortcomings.
 - It only handles right-to-left languages, and doesn't handle many
   special features of Unicode, such as combining diacriticals.
 - The multiline support is imperfect and only supports manual
-  line-breaking -- it can not break up a paragraph into lines of a
+  line-breaking -- it cannot break up a paragraph into lines of a
   certain length.
 - It also does not handle inline formatting changes in order to
   support something like Markdown, reStructuredText or HTML.  (Though
@@ -112,7 +112,7 @@ complicated than it seems at first.
 The "built-in" and "usetex" renderers have very different ways of
 handling font selection, given their different technologies.  TeX
 requires the installation of TeX-specific font packages, for example,
-and can not use TrueType fonts directly.  Unfortunately, despite the
+and cannot use TrueType fonts directly.  Unfortunately, despite the
 different semantics for font selection, the same set of font
 properties are used for each.  This is true of both the
 `.FontProperties` class and the font-related `.rcParams` (which

--- a/doc/devel/MEP/MEP19.rst
+++ b/doc/devel/MEP/MEP19.rst
@@ -36,7 +36,7 @@ has a number of shortcomings:
 - build or test products can only be saved from build off of branches
   on the main repo, not pull requests, so it is often difficult to
   "post mortem" analyse what went wrong.  This is particularly
-  frustrating when the failure can not be subsequently reproduced
+  frustrating when the failure cannot be subsequently reproduced
   locally.
 
 - It is not extremely fast.  matplotlib's cpu and memory requirements

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -446,8 +446,8 @@ Backport strategy
 
 We will always backport to the patch release branch (*v3.N.x*):
 
-- critical bug fixes (segfault, failure to import, things that the
-  user can not work around)
+- critical bug fixes (segfault, failure to import, things that the user cannot
+  work around)
 - fixes for regressions against the last two releases.
 
 Everything else (regressions against older releases, bugs/api

--- a/doc/devel/triage.rst
+++ b/doc/devel/triage.rst
@@ -157,7 +157,7 @@ The following workflow [1]_ is a good way to approach issue triaging:
    If a reproducible example is provided, but you see a simplification,
    add your simpler reproducible example.
 
-   If you can not reproduce the issue, please report that along with your
+   If you cannot reproduce the issue, please report that along with your
    OS, Python, and Matplotlib versions.
 
    If we need more information from either this or the previous step

--- a/doc/users/faq/troubleshooting_faq.rst
+++ b/doc/users/faq/troubleshooting_faq.rst
@@ -149,7 +149,7 @@ will save a lot of time.
 You will likely get a faster response writing to the mailing list than
 filing a bug in the bug tracker.  Most developers check the bug
 tracker only periodically.  If your problem has been determined to be
-a bug and can not be quickly solved, you may be asked to file a bug in
+a bug and cannot be quickly solved, you may be asked to file a bug in
 the tracker so the issue doesn't get lost.
 
 .. _git-trouble:

--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -2270,7 +2270,7 @@ recent changes, please refer to the :doc:`/users/release_notes`.
     Fix a "local variable unreferenced" bug in plotfile - MM
 
 2008-05-19
-    Fix crash when Windows can not access the registry to determine font path
+    Fix crash when Windows cannot access the registry to determine font path
     [Bug 1966974, thanks Patrik Simons] - MGD
 
 2008-05-16
@@ -2493,7 +2493,7 @@ recent changes, please refer to the :doc:`/users/release_notes`.
 
 2008-01-10
     Fix bug when displaying a tick value offset with scientific notation.
-    (Manifests itself as a warning that the \times symbol can not be found). -
+    (Manifests itself as a warning that the \times symbol cannot be found). -
     MGD
 
 2008-01-10

--- a/doc/users/prev_whats_new/dflt_style_changes.rst
+++ b/doc/users/prev_whats_new/dflt_style_changes.rst
@@ -657,7 +657,7 @@ behavior for the line width was different depending on backend:
 - PS:  1 px
 - Agg: 1 px
 
-The old line width behavior can not be restored across all backends
+The old line width behavior cannot be restored across all backends
 simultaneously, but can be restored for a single backend by setting::
 
    mpl.rcParams['hatch.linewidth'] = 0.1  # previous pdf hatch linewidth

--- a/doc/users/prev_whats_new/github_stats_3.0.2.rst
+++ b/doc/users/prev_whats_new/github_stats_3.0.2.rst
@@ -342,7 +342,7 @@ Issues (170):
 * :ghissue:`12626`: AttributeError: module 'matplotlib' has no attribute 'artist'
 * :ghissue:`11034`: Doc Typo:  matplotlib.axes.Axes.get_yticklabels  / Axis.get_ticklabels
 * :ghissue:`12624`: make_axes_locatable : Colorbar in the middle instead of bottom while saving a pdf, png.
-* :ghissue:`11094`: can not use GUI backends inside django request handlers
+* :ghissue:`11094`: cannot use GUI backends inside django request handlers
 * :ghissue:`12613`: transiently linked interactivity of unshared pair of axes generated with make_axes_locatable 
 * :ghissue:`12578`: macOS builds are broken
 * :ghissue:`12612`: gui backends do not work inside of flask request handlers

--- a/doc/users/prev_whats_new/github_stats_3.3.1.rst
+++ b/doc/users/prev_whats_new/github_stats_3.3.1.rst
@@ -114,7 +114,7 @@ Issues (25):
 * :ghissue:`18232`: different behaviour between 3.3.0 and 3.2.2 (and earlier) for ploting in a Tk canvas
 * :ghissue:`18212`: Updated WxAgg NavigationToolbar2 breaks custom toolbars
 * :ghissue:`18129`: Error reading png image from URL with imread in matplotlib 3.3
-* :ghissue:`18163`: Figure can not be closed if it has associated Agg canvas
+* :ghissue:`18163`: Figure cannot be closed if it has associated Agg canvas
 * :ghissue:`17974`: Major speed regression introduced in "plt.bar" definition clipping between 3.0.3 and 3.3.0.
 * :ghissue:`17998`: New warning: Substituting symbol \perp from STIXGeneral
 * :ghissue:`18057`: Fails to install in FreeBSD

--- a/doc/users/prev_whats_new/github_stats_3.5.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.5.0.rst
@@ -1229,7 +1229,7 @@ Issues (187):
 * :ghissue:`19259`: Set legend title font properties
 * :ghissue:`20049`: add legend.labelcolor "argument" to mplstyle stylesheet
 * :ghissue:`20452`: Wrong/not useful error message when plotting incompatible x and y
-* :ghissue:`20266`: "$$" can not be displayed by ax.text()
+* :ghissue:`20266`: "$$" cannot be displayed by ax.text()
 * :ghissue:`20517`: Wrong shape of Z in documentation of contour
 * :ghissue:`19423`: Switch to pydata-sphinx-theme
 * :ghissue:`20435`: Legend Text's ``axes`` attribute is ``None``

--- a/doc/users/prev_whats_new/github_stats_3.6.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.6.0.rst
@@ -1183,7 +1183,7 @@ Issues (202):
 * :ghissue:`22947`: [Bug]: Can't use ``plt.sca()`` on axes created using subfigures
 * :ghissue:`22623`: [ENH]: support rect with constrained_layout ("layout only to part of the figure")
 * :ghissue:`22917`: "ab;cd" missing in subplot_mosaic tutorial
-* :ghissue:`22686`: [Bug]: can not give init value for RangeSlider widget
+* :ghissue:`22686`: [Bug]: cannot give init value for RangeSlider widget
 * :ghissue:`22740`: [MNT]: Add codespell to pre-commit hooks
 * :ghissue:`22893`: rainbow text example is broken
 * :ghissue:`21571`: [Doc]: Clarify text positioning

--- a/galleries/users_explain/figure/interactive.rst
+++ b/galleries/users_explain/figure/interactive.rst
@@ -266,7 +266,7 @@ Jupyter Notebooks / JupyterLab
    the inline backend, is not.  `~ipykernel.pylab.backend_inline`
    renders the figure once and inserts a static image into the
    notebook when the cell is executed.  Because the images are static, they
-   can not be panned / zoomed, take user input, or be updated from other
+   cannot be panned / zoomed, take user input, or be updated from other
    cells.
 
 To get interactive figures in the 'classic' notebook or Jupyter lab,

--- a/galleries/users_explain/figure/interactive_guide.rst
+++ b/galleries/users_explain/figure/interactive_guide.rst
@@ -110,7 +110,7 @@ Blocking the prompt
 
 The simplest "integration" is to start the GUI event loop in
 'blocking' mode and take over the CLI.  While the GUI event loop is
-running you can not enter new commands into the prompt (your terminal
+running you cannot enter new commands into the prompt (your terminal
 may echo the characters typed into the terminal, but they will not be
 sent to the Python interpreter because it is busy running the GUI
 event loop), but the figure windows will be responsive.  Once the

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -171,7 +171,7 @@ Font fallback
 -------------
 
 There is no font that covers the entire Unicode space thus it is possible for the
-users to require a mix of glyphs that can not be satisfied from a single font.
+users to require a mix of glyphs that cannot be satisfied from a single font.
 While it has been possible to use multiple fonts within a Figure, on distinct
 `.Text` instances, it was not previous possible to use multiple fonts in the
 same `.Text` instance (as a web browser does).  As of Matplotlib 3.6 the Agg,

--- a/galleries/users_explain/text/mathtext.py
+++ b/galleries/users_explain/text/mathtext.py
@@ -145,7 +145,7 @@ Radicals can be produced with the ``\sqrt[]{}`` command.  For example::
     \sqrt{2}
 
 Any base can (optionally) be provided inside square brackets.  Note that the
-base must be a simple expression, and can not contain layout commands such as
+base must be a simple expression, and cannot contain layout commands such as
 fractions or sub/superscripts::
 
     r'$\sqrt[3]{x}$'
@@ -306,7 +306,7 @@ that is not contained in your custom fonts, you can set
 :rc:`mathtext.fallback` to either ``'cm'``, ``'stix'`` or ``'stixsans'``
 which will cause the mathtext system to use
 characters from an alternative font whenever a particular
-character can not be found in the custom font.
+character cannot be found in the custom font.
 
 Note that the math glyphs specified in Unicode have evolved over time, and many
 fonts may not have glyphs in the correct place for mathtext.

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -462,7 +462,7 @@ class UnicodeFonts(TruetypeFonts):
     complete set of math symbols is STIX.
 
     This class will "fallback" on the Bakoma fonts when a required
-    symbol can not be found in the font.
+    symbol cannot be found in the font.
     """
 
     # Some glyphs are not present in the `cmr10` font, and must be brought in

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -797,7 +797,7 @@ class HTMLWriter(FileMovieWriter):
                                              **mode_dict))
 
         # Duplicate the temporary file clean up logic from
-        # FileMovieWriter.finish.  We can not call the inherited version of
+        # FileMovieWriter.finish.  We cannot call the inherited version of
         # finish because it assumes that there is a subprocess that we either
         # need to call to merge many frames together or that there is a
         # subprocess call that we need to clean up.
@@ -963,10 +963,10 @@ class Animation:
 
                 def func(current_frame: int, total_frames: int) -> Any
 
-            where *current_frame* is the current frame number and
-            *total_frames* is the total number of frames to be saved.
-            *total_frames* is set to None, if the total number of frames can
-            not be determined. Return values may exist but are ignored.
+            where *current_frame* is the current frame number and *total_frames* is the
+            total number of frames to be saved. *total_frames* is set to None, if the
+            total number of frames cannot be determined. Return values may exist but are
+            ignored.
 
             Example code to write the progress to stdout::
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4627,7 +4627,7 @@ default: :rc:`scatter.edgecolors`
                     "ignoring the edgecolor in favor of the facecolor.  This "
                     "behavior may change in the future."
                 )
-            # We need to handle markers that can not be filled (like
+            # We need to handle markers that cannot be filled (like
             # '+' and 'x') differently than markers that can be
             # filled, but have their fillstyle set to 'none'.  This is
             # to get:
@@ -4642,7 +4642,7 @@ default: :rc:`scatter.edgecolors`
                 # promote the facecolor to be the edgecolor
                 edgecolors = colors
                 # set the facecolor to 'none' (at the last chance) because
-                # we can not fill a path if the facecolor is non-null
+                # we cannot fill a path if the facecolor is non-null
                 # (which is defendable at the renderer level).
                 colors = 'none'
             else:
@@ -4879,13 +4879,13 @@ default: :rc:`scatter.edgecolors`
 
         if xscale == 'log':
             if np.any(x <= 0.0):
-                raise ValueError("x contains non-positive values, so can not "
-                                 "be log-scaled")
+                raise ValueError(
+                    "x contains non-positive values, so cannot be log-scaled")
             tx = np.log10(tx)
         if yscale == 'log':
             if np.any(y <= 0.0):
-                raise ValueError("y contains non-positive values, so can not "
-                                 "be log-scaled")
+                raise ValueError(
+                    "y contains non-positive values, so cannot be log-scaled")
             ty = np.log10(ty)
         if extent is not None:
             xmin, xmax, ymin, ymax = extent

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -147,9 +147,9 @@ class RendererAgg(RendererBase):
             except OverflowError:
                 cant_chunk = ''
                 if rgbFace is not None:
-                    cant_chunk += "- can not split filled path\n"
+                    cant_chunk += "- cannot split filled path\n"
                 if gc.get_hatch() is not None:
-                    cant_chunk += "- can not split hatched path\n"
+                    cant_chunk += "- cannot split hatched path\n"
                 if not path.should_simplify:
                     cant_chunk += "- path.should_simplify is False\n"
                 if len(cant_chunk):
@@ -157,7 +157,7 @@ class RendererAgg(RendererBase):
                         "Exceeded cell block limit in Agg, however for the "
                         "following reasons:\n\n"
                         f"{cant_chunk}\n"
-                        "we can not automatically split up this path to draw."
+                        "we cannot automatically split up this path to draw."
                         "\n\nPlease manually simplify your path."
                     )
 

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -587,7 +587,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             return
         if not drawDC:  # not called from OnPaint use a ClientDC
             drawDC = wx.ClientDC(self)
-        # For 'WX' backend on Windows, the bitmap can not be in use by another
+        # For 'WX' backend on Windows, the bitmap cannot be in use by another
         # DC (see GraphicsContextWx._cache).
         bmp = (self.bitmap.ConvertToImage().ConvertToBitmap()
                if wx.Platform == '__WXMSW__'

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1633,8 +1633,8 @@ def _safe_first_finite(obj, *, skip_nonfinite=True):
         try:
             return np.isfinite(val) if np.isscalar(val) else True
         except TypeError:
-            # This is something that numpy can not make heads or tails
-            # of, assume "finite"
+            # This is something that NumPy cannot make heads or tails of,
+            # assume "finite"
             return True
     if skip_nonfinite is False:
         if isinstance(obj, collections.abc.Iterator):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2036,7 +2036,7 @@ default: %(va)s
                 this_level[(start_row, start_col)] = (name, slc, 'axes')
 
             # do the same thing for the nested mosaics (simpler because these
-            # can not be spans yet!)
+            # cannot be spans yet!)
             for (j, k), nested_mosaic in nested.items():
                 this_level[(j, k)] = (None, nested_mosaic, 'nested')
 

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1479,7 +1479,7 @@ def is_opentype_cff_font(filename):
     """
     Return whether the given font is a Postscript Compact Font Format Font
     embedded in an OpenType wrapper.  Used by the PostScript and PDF backends
-    that can not subset these fonts.
+    that cannot subset these fonts.
     """
     if os.path.splitext(filename)[1].lower() == '.otf':
         with open(filename, 'rb') as fd:

--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -104,9 +104,8 @@ class PlaceHolderLayoutEngine(LayoutEngine):
     """
     This layout engine does not adjust the figure layout at all.
 
-    The purpose of this `.LayoutEngine` is to act as a placeholder when the
-    user removes a layout engine to ensure an incompatible `.LayoutEngine` can
-    not be set later.
+    The purpose of this `.LayoutEngine` is to act as a placeholder when the user removes
+    a layout engine to ensure an incompatible `.LayoutEngine` cannot be set later.
 
     Parameters
     ----------

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -346,7 +346,7 @@
 #mathtext.sf:  sans
 #mathtext.tt:  monospace
 #mathtext.fallback: cm  # Select fallback font from ['cm' (Computer Modern), 'stix'
-                        # 'stixsans'] when a symbol can not be found in one of the
+                        # 'stixsans'] when a symbol cannot be found in one of the
                         # custom math fonts. Select 'None' to not perform fallback
                         # and replace the missing character by a dummy symbol.
 #mathtext.default: it  # The default font to use for math.

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -158,7 +158,7 @@ mathtext.sf  : sans\-serif
 mathtext.fontset : cm # Should be 'cm' (Computer Modern), 'stix',
                       # 'stixsans' or 'custom'
 mathtext.fallback: cm  # Select fallback font from ['cm' (Computer Modern), 'stix'
-                       # 'stixsans'] when a symbol can not be found in one of the
+                       # 'stixsans'] when a symbol cannot be found in one of the
                        # custom math fonts. Select 'None' to not perform fallback
                        # and replace the missing character by a dummy.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1936,7 +1936,7 @@ class Arc(Ellipse):
         """
         fill = kwargs.setdefault('fill', False)
         if fill:
-            raise ValueError("Arc objects can not be filled")
+            raise ValueError("Arc objects cannot be filled")
 
         super().__init__(xy, width, height, angle=angle, **kwargs)
 

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -303,11 +303,11 @@ def test_chunksize_fails():
     gc.set_foreground('r')
 
     gc.set_hatch('/')
-    with pytest.raises(OverflowError, match='can not split hatched path'):
+    with pytest.raises(OverflowError, match='cannot split hatched path'):
         ra.draw_path(gc, path, IdentityTransform())
     gc.set_hatch(None)
 
-    with pytest.raises(OverflowError, match='can not split filled path'):
+    with pytest.raises(OverflowError, match='cannot split filled path'):
         ra.draw_path(gc, path, IdentityTransform(), (1, 0, 0))
 
     # Set to zero to disable, currently defaults to 0, but let's be sure.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2309,8 +2309,7 @@ class LogLocator(Locator):
 
             if vmin <= 0.0 or not np.isfinite(vmin):
                 raise ValueError(
-                    "Data has no positive values, and therefore can not be "
-                    "log-scaled.")
+                    "Data has no positive values, and therefore cannot be log-scaled.")
 
         _log.debug('vmin %s vmax %s', vmin, vmax)
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -668,7 +668,7 @@ class Path3DCollection(PathCollection):
             ys = []
         self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
         # In the base draw methods we access the attributes directly which
-        # means we can not resolve the shuffling in the getter methods like
+        # means we cannot resolve the shuffling in the getter methods like
         # we do for the edge and face colors.
         #
         # This means we need to carry around a cache of the unsorted sizes and
@@ -727,7 +727,7 @@ class Path3DCollection(PathCollection):
         # we have to special case the sizes because of code in collections.py
         # as the draw method does
         #      self.set_sizes(self._sizes, self.figure.dpi)
-        # so we can not rely on doing the sorting on the way out via get_*
+        # so we cannot rely on doing the sorting on the way out via get_*
 
         if len(self._sizes3d) > 1:
             self._sizes = self._sizes3d[z_markers_idx]

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -25,7 +25,7 @@
 
    3. PathClipper: Clips line segments to a given rectangle.  This is
       helpful for data reduction, and also to avoid a limitation in
-      Agg where coordinates can not be larger than 24-bit signed
+      Agg where coordinates cannot be larger than 24-bit signed
       integers.
 
    4. PathSnapper: Rounds the path to the nearest center-pixels.
@@ -257,7 +257,7 @@ class PathNanRemover : protected EmbeddedQueue<4>
                 m_last_segment_valid = (std::isfinite(*x) && std::isfinite(*y));
                 queue_push(code, *x, *y);
 
-                /* Note: this test can not be short-circuited, since we need to
+                /* Note: this test cannot be short-circuited, since we need to
                    advance through the entire curve no matter what */
                 for (size_t i = 0; i < num_extra_points; ++i) {
                     m_source->vertex(x, y);


### PR DESCRIPTION
## PR Summary

There was a PR on Meson for this, and I noticed we made the same mistake several times as well.

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`