### PR TITLE
Fix what's new note for text

### DIFF
--- a/doc/users/next_whats_new/mathtext_supports_text.rst
+++ b/doc/users/next_whats_new/mathtext_supports_text.rst
@@ -1,12 +1,13 @@
 ``mathtext`` now supports ``\text``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-``\text`` can be used to obtain upright text within an equation.
+``\text`` can be used to obtain upright text within an equation and to get a plain dash
+(-).
 
 .. plot::
     :include-source: true
     :alt: Illustration of the newly added \text command, showing that it renders as normal text, including spaces, despite being part of an equation. Also show that a dash is not rendered as a minus when part of a \text command.
 
-import matplotlib.pyplot as plt
-plt.text(0.1, 0.5, r"$a = \sin(\phi) \text{ such that } \phi = \frac{x}{y}$")
-plt.text(0.1, 0.3, r"$\text{dashes (-) are retained}$")
+    import matplotlib.pyplot as plt
+    plt.text(0.1, 0.5, r"$a = \sin(\phi) \text{ such that } \phi = \frac{x}{y}$")
+    plt.text(0.1, 0.3, r"$\text{dashes (-) are retained}$")


### PR DESCRIPTION
## PR Summary
Seems like I messed up with the formatting...

https://matplotlib.org/devdocs/users/next_whats_new/mathtext_supports_text.html

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
