### PR TITLE
BUG: Return null Bbox when there is no intersection for bar_label center.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2769,7 +2769,7 @@ class Axes(_AxesBase):
                     lambda r, b=bar:
                         mtransforms.Bbox.intersection(
                             b.get_window_extent(r), b.get_clip_box()
-                        )
+                        ) or mtransforms.Bbox.null()
                 )
             else:  # edge
                 if orientation == "vertical":

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8040,8 +8040,8 @@ def test_centered_bar_label_nonlinear():
     ax.set_axis_off()
 
 
-def test_centered_bar_label_label_beyond_limits(tmp_path):
-    _, ax = plt.subplots()
+def test_centered_bar_label_label_beyond_limits():
+    fig, ax = plt.subplots()
 
     last = 0
     for label, value in zip(['a', 'b', 'c'], [10, 20, 50]):
@@ -8050,7 +8050,7 @@ def test_centered_bar_label_label_beyond_limits(tmp_path):
         last += value
     ax.set_xlim(None, 20)
 
-    plt.savefig(tmp_path / 'test')
+    fig.draw_without_rendering()
 
 
 def test_bar_label_location_errorbars():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8040,6 +8040,19 @@ def test_centered_bar_label_nonlinear():
     ax.set_axis_off()
 
 
+def test_centered_bar_label_label_beyond_limits(tmp_path):
+    _, ax = plt.subplots()
+
+    last = 0
+    for label, value in zip(['a', 'b', 'c'], [10, 20, 50]):
+        bar_container = ax.barh('col', value, label=label, left=last)
+        ax.bar_label(bar_container, label_type='center')
+        last += value
+    ax.set_xlim(None, 20)
+
+    plt.savefig(tmp_path / 'test')
+
+
 def test_bar_label_location_errorbars():
     ax = plt.gca()
     xs, heights = [1, 2], [3, -4]


### PR DESCRIPTION
## PR Summary

Addresses https://github.com/matplotlib/matplotlib/issues/25625

When using `bar_label(label_type='center')` and axis limits that cut off some of the bars, an exception was raised because the Bbox intersection was `None`. This PR makes sure the plot can still be created.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [X] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
