### PR TITLE
TST: Import MatplotlibDeprecationWarning consistently

### DIFF
--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -3,6 +3,7 @@ import re
 import numpy as np
 import pytest
 
+import matplotlib as mpl
 from matplotlib import _api
 
 
@@ -27,9 +28,9 @@ def test_classproperty_deprecation():
         @_api.classproperty
         def f(cls):
             pass
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         A.f
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         a = A()
         a.f
 
@@ -42,13 +43,13 @@ def test_deprecate_privatize_attribute():
         meth = _api.deprecate_privatize_attribute("0.0")
 
     c = C()
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert c.attr == 1
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         c.attr = 2
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert c.attr == 2
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert c.meth(42) == 42
 
 
@@ -63,14 +64,14 @@ def test_delete_parameter():
 
     for func in [func1, func2]:
         func()  # No warning.
-        with pytest.warns(_api.MatplotlibDeprecationWarning):
+        with pytest.warns(mpl.MatplotlibDeprecationWarning):
             func(foo="bar")
 
     def pyplot_wrapper(foo=_api.deprecation._deprecated_parameter):
         func1(foo)
 
     pyplot_wrapper()  # No warning.
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         func(foo="bar")
 
 
@@ -81,9 +82,9 @@ def test_make_keyword_only():
 
     func(1, arg=2)  # Check that no warning is emitted.
 
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         func(1, 2)
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         func(1, 2, 3)
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -19,7 +19,6 @@ import pytest
 import matplotlib
 import matplotlib as mpl
 from matplotlib import rc_context, patheffects
-from matplotlib._api import MatplotlibDeprecationWarning
 import matplotlib.colors as mcolors
 import matplotlib.dates as mdates
 from matplotlib.figure import Figure
@@ -4613,7 +4612,7 @@ def test_eventplot_problem_kwargs(recwarn):
                     linestyle=['dashdot', 'dotted'])
 
     assert len(recwarn) == 3
-    assert all(issubclass(wi.category, MatplotlibDeprecationWarning)
+    assert all(issubclass(wi.category, mpl.MatplotlibDeprecationWarning)
                for wi in recwarn)
 
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -8,7 +8,6 @@ import numpy as np
 import pytest
 
 from matplotlib import cbook, path, patheffects, font_manager as fm
-from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.figure import Figure
 from matplotlib.patches import Ellipse
 from matplotlib.testing._markers import needs_ghostscript, needs_usetex
@@ -60,7 +59,7 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation):
         if rcParams.get("text.usetex"):
             allowable_exceptions.append(RuntimeError)
         if rcParams.get("ps.useafm"):
-            allowable_exceptions.append(MatplotlibDeprecationWarning)
+            allowable_exceptions.append(mpl.MatplotlibDeprecationWarning)
         try:
             fig.savefig(s_buf, format=format, orientation=orientation)
             fig.savefig(b_buf, format=format, orientation=orientation)

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -8,7 +8,6 @@ from numpy.testing import (
     assert_array_almost_equal, assert_array_almost_equal_nulp, assert_array_equal)
 import matplotlib as mpl
 from matplotlib import pyplot as plt, rc_context, ticker
-from matplotlib._api import MatplotlibDeprecationWarning
 from matplotlib.colors import LogNorm, same_color
 from matplotlib.testing.decorators import image_comparison
 import pytest
@@ -367,7 +366,7 @@ def test_contour_linewidth(
         X = np.arange(4*3).reshape(4, 3)
         cs = ax.contour(X, linewidths=call_linewidths)
         assert cs.collections[0].get_linewidths()[0] == expected
-        with pytest.warns(MatplotlibDeprecationWarning, match="tlinewidths"):
+        with pytest.warns(mpl.MatplotlibDeprecationWarning, match="tlinewidths"):
             assert cs.tlinewidths[0][0] == expected
 
 
@@ -734,7 +733,7 @@ def test_deprecated_apis():
         assert cs.allsegs == [p.vertices for c in colls for p in c.get_paths()]
     with pytest.warns(PendingDeprecationWarning, match="allkinds"):
         assert cs.allkinds == [p.codes for c in colls for p in c.get_paths()]
-    with pytest.warns(MatplotlibDeprecationWarning, match="tcolors"):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning, match="tcolors"):
         assert_array_equal(cs.tcolors, [c.get_edgecolor() for c in colls])
-    with pytest.warns(MatplotlibDeprecationWarning, match="tlinewidths"):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning, match="tlinewidths"):
         assert cs.tlinewidths == [c.get_linewidth() for c in colls]

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -6,7 +6,8 @@ import functools
 import numpy as np
 import pytest
 
-from matplotlib import _api, rc_context, style
+import matplotlib as mpl
+from matplotlib import rc_context, style
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
@@ -1282,16 +1283,17 @@ def test_change_interval_multiples():
 
 
 def test_julian2num():
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
-        mdates._reset_epoch_test_example()
-        mdates.set_epoch('0000-12-31')
+    mdates._reset_epoch_test_example()
+    mdates.set_epoch('0000-12-31')
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         # 2440587.5 is julian date for 1970-01-01T00:00:00
         # https://en.wikipedia.org/wiki/Julian_day
         assert mdates.julian2num(2440588.5) == 719164.0
         assert mdates.num2julian(719165.0) == 2440589.5
-        # set back to the default
-        mdates._reset_epoch_test_example()
-        mdates.set_epoch('1970-01-01T00:00:00')
+    # set back to the default
+    mdates._reset_epoch_test_example()
+    mdates.set_epoch('1970-01-01T00:00:00')
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert mdates.julian2num(2440588.5) == 1.0
         assert mdates.num2julian(2.0) == 2440589.5
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -20,7 +20,6 @@ from matplotlib.path import Path
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
-from matplotlib._api.deprecation import MatplotlibDeprecationWarning
 
 
 def test_segment_hits():
@@ -94,10 +93,10 @@ def test_invalid_line_data():
     line = mlines.Line2D([], [])
     # when deprecation cycle is completed
     # with pytest.raises(RuntimeError, match='x must be'):
-    with pytest.warns(MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         line.set_xdata(0)
     # with pytest.raises(RuntimeError, match='y must be'):
-    with pytest.warns(MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         line.set_ydata(0)
 
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -9,7 +9,6 @@ import pytest
 import matplotlib as mpl
 from matplotlib.testing import subprocess_run_for_testing
 from matplotlib import pyplot as plt
-from matplotlib._api import MatplotlibDeprecationWarning
 
 
 def test_pyplot_up_to_date(tmpdir):
@@ -56,9 +55,9 @@ def test_copy_docstring_and_deprecators(recwarn):
     wrapper_func(None, kwo=None)
     wrapper_func(new=None, kwo=None)
     assert not recwarn
-    with pytest.warns(MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         wrapper_func(old=None)
-    with pytest.warns(MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         wrapper_func(None, None)
 
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -555,33 +555,33 @@ def test_deprecation(monkeypatch):
     monkeypatch.setitem(
         mpl._deprecated_map, "patch.linewidth",
         ("0.0", "axes.linewidth", lambda old: 2 * old, lambda new: new / 2))
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert mpl.rcParams["patch.linewidth"] \
             == mpl.rcParams["axes.linewidth"] / 2
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         mpl.rcParams["patch.linewidth"] = 1
     assert mpl.rcParams["axes.linewidth"] == 2
 
     monkeypatch.setitem(
         mpl._deprecated_ignore_map, "patch.edgecolor",
         ("0.0", "axes.edgecolor"))
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert mpl.rcParams["patch.edgecolor"] \
             == mpl.rcParams["axes.edgecolor"]
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         mpl.rcParams["patch.edgecolor"] = "#abcd"
     assert mpl.rcParams["axes.edgecolor"] != "#abcd"
 
     monkeypatch.setitem(
         mpl._deprecated_ignore_map, "patch.force_edgecolor",
         ("0.0", None))
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         assert mpl.rcParams["patch.force_edgecolor"] is None
 
     monkeypatch.setitem(
         mpl._deprecated_remain_as_none, "svg.hashsalt",
         ("0.0",))
-    with pytest.warns(_api.MatplotlibDeprecationWarning):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
         mpl.rcParams["svg.hashsalt"] = "foobar"
     assert mpl.rcParams["svg.hashsalt"] == "foobar"  # Doesn't warn.
     mpl.rcParams["svg.hashsalt"] = None  # Doesn't warn.

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -2,7 +2,7 @@ import functools
 import io
 from unittest import mock
 
-from matplotlib._api.deprecation import MatplotlibDeprecationWarning
+import matplotlib as mpl
 from matplotlib.backend_bases import MouseEvent
 import matplotlib.colors as mcolors
 import matplotlib.widgets as widgets
@@ -137,9 +137,8 @@ def test_deprecation_selector_visible_attribute(ax):
 
     assert tool.get_visible()
 
-    with pytest.warns(
-        MatplotlibDeprecationWarning,
-            match="was deprecated in Matplotlib 3.6"):
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
+                      match="was deprecated in Matplotlib 3.6"):
         tool.visible = False
     assert not tool.get_visible()
 

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -4,7 +4,7 @@ import platform
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
-from matplotlib import _api, cbook
+from matplotlib import cbook
 from matplotlib.backend_bases import MouseEvent
 from matplotlib.colors import LogNorm
 from matplotlib.patches import Circle, Ellipse
@@ -417,7 +417,7 @@ def test_image_grid_label_mode_deprecation_warning():
     imdata = np.arange(9).reshape((3, 3))
 
     fig = plt.figure()
-    with pytest.warns(_api.MatplotlibDeprecationWarning,
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
                       match="Passing an undefined label_mode"):
         grid = ImageGrid(fig, (0, 0, 1, 1), (2, 1), label_mode="foo")
 


### PR DESCRIPTION
## PR Summary

Just a minor thing I noticed in https://github.com/matplotlib/matplotlib/pull/25651/files/fe0b069b06e3ee98108a20b30d9c1f10915ee77d#diff-fd4f809a4a2ca8b97875eff013bac232c55ca3f92f165117f778960ca1795869

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`