### PR TITLE
Fixed bug: mathtext rendered width not being calculated correctly

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -701,6 +701,15 @@ def test_wrap():
                                         'times.')
 
 
+def test_mathwrap():
+    fig = plt.figure(figsize=(6, 4))
+    s = r'This is a very $\overline{\mathrm{long}}$ line of Mathtext.'
+    text = fig.text(0, 0.5, s, size=40, wrap=True)
+    fig.canvas.draw()
+    assert text._get_wrapped_text() == ('This is a very $\\overline{\\mathrm{long}}$\n'
+                                        'line of Mathtext.')
+
+
 def test_get_window_extent_wrapped():
     # Test that a long title that wraps to two lines has the same vertical
     # extent as an explicit two line title.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -642,10 +642,13 @@ class Text(Artist):
         """
         Return the width of a given text string, in pixels.
         """
+        # Determine if text contains mathtext
+        has_math = '$' in text
+
         w, h, d = self._renderer.get_text_width_height_descent(
             text,
             self.get_fontproperties(),
-            False)
+            has_math)
         return math.ceil(w)
 
     def _get_wrapped_text(self):

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -642,8 +642,6 @@ class Text(Artist):
         """
         Return the width of a given text string, in pixels.
         """
-        # Determine if text contains mathtext
-        has_math = '$' in text
 
         w, h, d = self._renderer.get_text_width_height_descent(
             text,

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -648,7 +648,7 @@ class Text(Artist):
         w, h, d = self._renderer.get_text_width_height_descent(
             text,
             self.get_fontproperties(),
-            has_math)
+            cbook.is_math_text(text))
         return math.ceil(w)
 
     def _get_wrapped_text(self):


### PR DESCRIPTION
## PR Summary
Fixes https://github.com/matplotlib/matplotlib/issues/23810

The mathtext was being treated as normal text during the width calculations, added a check that allows for it to be automatically directed to the proper backend functions. 
## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.

**Release Notes**
- [x] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [x] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
