### PR TITLE
Correctly hide download buttons using CSS

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -62,12 +62,11 @@ html[data-theme="dark"] .sphx-glr-thumbcontainer {
     padding: 0;
 }
 
-/* hide note linking to the download section at the bottom of galleries
- * as suggested in https://github.com/sphinx-gallery/sphinx-gallery/issues/760
+/* hide download buttons in example headers
+ * https://sphinx-gallery.github.io/stable/advanced.html#hide-the-download-buttons-in-the-example-headers
  */
 div.sphx-glr-download-link-note {
-    height: 0px;
-    visibility: hidden;
+    display: none;
 }
 
 /* re-style the download button */


### PR DESCRIPTION
`visibility:hidden; height: 0px` still keeps margins, creating a large amount of whitespace. `display: none` is the correct way to remove an HTML element completely.


before (with margins highlighted):
![image](https://user-images.githubusercontent.com/2836374/232205468-3de378ae-227a-48cc-a129-14174ae17ebe.png)

now:
![image](https://user-images.githubusercontent.com/2836374/232205491-f1492045-dc5f-4a11-8b15-1060b2325233.png)


Also reported upstream: https://github.com/sphinx-gallery/sphinx-gallery/pull/1131
