### PR TITLE
Use true positional args in check_foo APIs instead of simulating them.

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -58,22 +58,20 @@ class classproperty:
         return self._fget
 
 
-# In the following check_foo() functions, the first parameter starts with an
-# underscore because it is intended to be positional-only (e.g., so that
-# `_api.check_isinstance([...], types=foo)` doesn't fail.
+# In the following check_foo() functions, the first parameter is positional-only to make
+# e.g. `_api.check_isinstance([...], types=foo)` work.
 
-def check_isinstance(_types, **kwargs):
+def check_isinstance(types, /, **kwargs):
     """
     For each *key, value* pair in *kwargs*, check that *value* is an instance
-    of one of *_types*; if not, raise an appropriate TypeError.
+    of one of *types*; if not, raise an appropriate TypeError.
 
-    As a special case, a ``None`` entry in *_types* is treated as NoneType.
+    As a special case, a ``None`` entry in *types* is treated as NoneType.
 
     Examples
     --------
     >>> _api.check_isinstance((SomeClass, None), arg=arg)
     """
-    types = _types
     none_type = type(None)
     types = ((types,) if isinstance(types, type) else
              (none_type,) if types is None else
@@ -98,23 +96,24 @@ def check_isinstance(_types, **kwargs):
                     type_name(type(v))))
 
 
-def check_in_list(_values, *, _print_supported_values=True, **kwargs):
+def check_in_list(values,  /, *, _print_supported_values=True, **kwargs):
     """
-    For each *key, value* pair in *kwargs*, check that *value* is in *_values*.
+    For each *key, value* pair in *kwargs*, check that *value* is in *values*;
+    if not, raise an appropriate ValueError.
 
     Parameters
     ----------
-    _values : iterable
+    values : iterable
         Sequence of values to check on.
     _print_supported_values : bool, default: True
-        Whether to print *_values* when raising ValueError.
+        Whether to print *values* when raising ValueError.
     **kwargs : dict
-        *key, value* pairs as keyword arguments to find in *_values*.
+        *key, value* pairs as keyword arguments to find in *values*.
 
     Raises
     ------
     ValueError
-        If any *value* in *kwargs* is not found in *_values*.
+        If any *value* in *kwargs* is not found in *values*.
 
     Examples
     --------
@@ -122,7 +121,6 @@ def check_in_list(_values, *, _print_supported_values=True, **kwargs):
     """
     if not kwargs:
         raise TypeError("No argument to check!")
-    values = _values
     for key, val in kwargs.items():
         if val not in values:
             msg = f"{val!r} is not a valid value for {key}"
@@ -131,10 +129,10 @@ def check_in_list(_values, *, _print_supported_values=True, **kwargs):
             raise ValueError(msg)
 
 
-def check_shape(_shape, **kwargs):
+def check_shape(shape, /, **kwargs):
     """
-    For each *key, value* pair in *kwargs*, check that *value* has the shape
-    *_shape*, if not, raise an appropriate ValueError.
+    For each *key, value* pair in *kwargs*, check that *value* has the shape *shape*;
+    if not, raise an appropriate ValueError.
 
     *None* in the shape is treated as a "free" size that can have any length.
     e.g. (None, 2) -> (N, 2)
@@ -147,42 +145,37 @@ def check_shape(_shape, **kwargs):
 
     >>> _api.check_shape((None, 2), arg=arg, other_arg=other_arg)
     """
-    target_shape = _shape
     for k, v in kwargs.items():
         data_shape = v.shape
 
-        if len(target_shape) != len(data_shape) or any(
-                t not in [s, None]
-                for t, s in zip(target_shape, data_shape)
-        ):
+        if (len(data_shape) != len(shape)
+                or any(s != t and t is not None for s, t in zip(data_shape, shape))):
             dim_labels = iter(itertools.chain(
                 'MNLIJKLH',
                 (f"D{i}" for i in itertools.count())))
             text_shape = ", ".join(str(n)
                                    if n is not None
                                    else next(dim_labels)
-                                   for n in target_shape)
-            if len(target_shape) == 1:
+                                   for n in shape)
+            if len(shape) == 1:
                 text_shape += ","
 
             raise ValueError(
-                f"{k!r} must be {len(target_shape)}D "
-                f"with shape ({text_shape}). "
-                f"Your input has shape {v.shape}."
+                f"{k!r} must be {len(shape)}D with shape ({text_shape}), "
+                f"but your input has shape {v.shape}"
             )
 
 
-def check_getitem(_mapping, **kwargs):
+def check_getitem(mapping, /, **kwargs):
     """
     *kwargs* must consist of a single *key, value* pair.  If *key* is in
-    *_mapping*, return ``_mapping[value]``; else, raise an appropriate
+    *mapping*, return ``mapping[value]``; else, raise an appropriate
     ValueError.
 
     Examples
     --------
     >>> _api.check_getitem({"foo": "bar"}, arg=arg)
     """
-    mapping = _mapping
     if len(kwargs) != 1:
         raise ValueError("check_getitem takes a single keyword argument")
     (k, v), = kwargs.items()


### PR DESCRIPTION
## PR Summary

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
