### PR TITLE
Prevents axes limits from being resized by axes.fill_between

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5409,7 +5409,10 @@ default: :rc:`scatter.edgecolors`
                             np.column_stack([ind[where], dep2[where]])])
         if ind_dir == "y":
             pts = pts[:, ::-1]
-        self.update_datalim(pts, updatex=True, updatey=True)
+
+        if "transform" not in kwargs:
+            self.update_datalim(pts, updatex=True, updatey=True)
+
         self.add_collection(collection, autolim=False)
         self._request_autoscale_view()
         return collection

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5410,7 +5410,7 @@ default: :rc:`scatter.edgecolors`
         if ind_dir == "y":
             pts = pts[:, ::-1]
 
-        up_x, up_y = True, True
+        up_x = up_y = True
         if "transform" in kwargs:
             up_x, up_y = kwargs["transform"].contains_branch_seperately(self.transData)
         self.update_datalim(pts, updatex=up_x, updatey=up_y)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5410,8 +5410,10 @@ default: :rc:`scatter.edgecolors`
         if ind_dir == "y":
             pts = pts[:, ::-1]
 
-        if "transform" not in kwargs:
-            self.update_datalim(pts, updatex=True, updatey=True)
+        up_x, up_y = True, True
+        if "transform" in kwargs:
+            up_x, up_y = kwargs["transform"].contains_branch_seperately(self.transData)
+        self.update_datalim(pts, updatex=up_x, updatey=up_y)
 
         self.add_collection(collection, autolim=False)
         self._request_autoscale_view()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8558,3 +8558,19 @@ def test_ecdf_invalid():
         plt.ecdf([1, np.nan])
     with pytest.raises(ValueError):
         plt.ecdf(np.ma.array([1, 2], mask=[True, False]))
+
+
+def test_fill_between_axes_limits():
+    fig, ax = plt.subplots()
+    x = np.arange(0, 4 * np.pi, 0.01)
+    y = 0.1*np.sin(x)
+    threshold = 0.075
+    ax.plot(x, y, color='black')
+
+    original_lims = (ax.get_xlim(), ax.get_ylim())
+
+    ax.axhline(threshold, color='green', lw=2, alpha=0.7)
+    ax.fill_between(x, 0, 1, where=y > threshold,
+                    color='green', alpha=0.5, transform=ax.get_xaxis_transform())
+
+    assert (ax.get_xlim(), ax.get_ylim()) == original_lims


### PR DESCRIPTION
## PR Summary

Closes #25682 by preventing `Axes.fill_between()` from automatically adjusting the axes limits when using axes coordinates. When axes coordinates are not in use and thus no transformation is passed to `Axes.fill_between()`, then adjusting the axes limits is necessary, but previously, in some cases, a transformation might have been in use and using axes coordinates could have caused the axes limits to be resized improperly.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
