### PR TITLE
Remove print_figure overrides in backend subclasses

### DIFF
--- a/lib/matplotlib/backends/backend_qtagg.py
+++ b/lib/matplotlib/backends/backend_qtagg.py
@@ -71,10 +71,6 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         finally:
             painter.end()
 
-    def print_figure(self, *args, **kwargs):
-        super().print_figure(*args, **kwargs)
-        self.draw()
-
 
 @_BackendQT.export
 class _BackendQTAgg(_BackendQT):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -614,15 +614,6 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         'xpm': 'X pixmap',
     }
 
-    def print_figure(self, filename, *args, **kwargs):
-        # docstring inherited
-        super().print_figure(filename, *args, **kwargs)
-        # Restore the current view; this is needed because the artist contains
-        # methods rely on particular attributes of the rendered figure for
-        # determining things like bounding boxes.
-        if self._isDrawn:
-            self.draw()
-
     def _on_paint(self, event):
         """Called when wxPaintEvt is generated."""
         _log.debug("%s - _on_paint()", type(self))


### PR DESCRIPTION
## PR Summary

AFAICT, `print_figure` is only called in `savefig`, and thus has no relation to backend drawing. We went through a lot of trouble to make `savefig` self-contained, so if this really had any effect, it would be a bug in it instead. But other backends don't do this override and seem to work fine, so these seem superfluous as well.

After this change, just opening a window in Qt and using the save button did not seem to break anything, nor did running `savefig` with an interactive window open. I did not test Wx, but given the callers of `print_figure`, I don't see how it could be different.

Fixes #5234

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`