### PR TITLE
ci: Set apt to retry operations on failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           case "${{ runner.os }}" in
           Linux)
+            echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
             sudo apt-get update -yy
             sudo apt-get install -yy \
               ccache \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,6 +90,7 @@ stages:
           set -e
           case "$(python -c 'import sys; print(sys.platform)')" in
           linux)
+            echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
             sudo apt update
             sudo apt install \
               cm-super \


### PR DESCRIPTION
## PR Summary

At some point, Azure servers were having a small hiccup, and I noticed this setup in some unrelated repository. Allowing a couple retries _may_ help with minor issues like those.

## PR Checklist

**Documentation and Tests**
- [n/a] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`