### PR TITLE
TST: Handle missing black more resiliently

### DIFF
--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -12,6 +12,8 @@ from matplotlib import pyplot as plt
 
 
 def test_pyplot_up_to_date(tmpdir):
+    pytest.importorskip("black")
+
     gen_script = Path(mpl.__file__).parents[2] / "tools/boilerplate.py"
     if not gen_script.exists():
         pytest.skip("boilerplate.py not found")

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -386,7 +386,8 @@ def build_pyplot(pyplot_path):
 
     # Run black to autoformat pyplot
     subprocess.run(
-        [sys.executable, "-m", "black", "--line-length=88", pyplot_path]
+        [sys.executable, "-m", "black", "--line-length=88", pyplot_path],
+        check=True
     )
 
 


### PR DESCRIPTION
## PR Summary

The test is already skipped if the boilerplate script is missing (i.e., not a git checkout), but should also be skipped if black is not installed.

Also, the boilerplate script ignored if running black failed, leading the test to show lots of line differences instead of just erroring out earlier.

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [n/a] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [n/a] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`