### PR TITLE
Replace usage of WenQuanYi Zen Hei by Noto Sans CJK

### DIFF
--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -252,7 +252,7 @@ testing the following will be used if they are installed.
 - pytest-xvfb_ to run tests without windows popping up (Linux)
 - pytz_ used to test pytz int
 - sphinx_ used to test our sphinx extensions
-- WenQuanYi Zen Hei and `Noto Sans CJK <https://fonts.google.com/noto/use>`_
+- `Noto Sans CJK <https://fonts.google.com/noto/use>`_
   fonts for testing font fallback and non-western fonts
 - xarray_ used to test compatibility with xarray
 

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -252,7 +252,7 @@ testing the following will be used if they are installed.
 - pytest-xvfb_ to run tests without windows popping up (Linux)
 - pytz_ used to test pytz int
 - sphinx_ used to test our sphinx extensions
-- `Noto Sans CJK <https://fonts.google.com/noto/use>`_
+- WenQuanYi Zen Hei and   `Noto Sans CJK <https://fonts.google.com/noto/use>`_
   fonts for testing font fallback and non-western fonts
 - xarray_ used to test compatibility with xarray
 

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -252,7 +252,7 @@ testing the following will be used if they are installed.
 - pytest-xvfb_ to run tests without windows popping up (Linux)
 - pytz_ used to test pytz int
 - sphinx_ used to test our sphinx extensions
-- WenQuanYi Zen Hei and   `Noto Sans CJK <https://fonts.google.com/noto/use>`_
+- WenQuanYi Zen Hei and `Noto Sans CJK <https://fonts.google.com/noto/use>`_
   fonts for testing font fallback and non-western fonts
 - xarray_ used to test compatibility with xarray
 

--- a/doc/users/prev_whats_new/whats_new_3.6.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.6.0.rst
@@ -558,10 +558,8 @@ them in order to locate a required glyph.
    fig = plt.figure(figsize=(4.75, 1.85))
 
    text = "There are 几个汉字 in between!"
-   fig.text(0.05, 0.85, text, family=["Noto Sans CJK"])
    fig.text(0.05, 0.65, text, family=["Noto Sans CJK JP"])
    fig.text(0.05, 0.45, text, family=["DejaVu Sans", "Noto Sans CJK JP"])
-   fig.text(0.05, 0.25, text, family=["DejaVu Sans", "Noto Sans CJK"])
 
 This currently works with the Agg (and all of the GUI embeddings), svg, pdf,
 ps, and inline backends.

--- a/doc/users/prev_whats_new/whats_new_3.6.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.6.0.rst
@@ -558,10 +558,10 @@ them in order to locate a required glyph.
    fig = plt.figure(figsize=(4.75, 1.85))
 
    text = "There are 几个汉字 in between!"
-   fig.text(0.05, 0.85, text, family=["WenQuanYi Zen Hei"])
+   fig.text(0.05, 0.85, text, family=["Noto Sans CJK"])
    fig.text(0.05, 0.65, text, family=["Noto Sans CJK JP"])
    fig.text(0.05, 0.45, text, family=["DejaVu Sans", "Noto Sans CJK JP"])
-   fig.text(0.05, 0.25, text, family=["DejaVu Sans", "WenQuanYi Zen Hei"])
+   fig.text(0.05, 0.25, text, family=["DejaVu Sans", "Noto Sans CJK"])
 
 This currently works with the Agg (and all of the GUI embeddings), svg, pdf,
 ps, and inline backends.

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -185,7 +185,7 @@ SVG, PDF, and PS backends will "fallback" through multiple fonts in a single
    fig, ax = plt.subplots()
    ax.text(
        .5, .5, "There are 几个汉字 in between!",
-       family=['DejaVu Sans', 'Noto Sans CJK'],
+       family=['DejaVu Sans', 'Noto Sans CJK JP'],
        ha='center'
    )
 

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -185,7 +185,7 @@ SVG, PDF, and PS backends will "fallback" through multiple fonts in a single
    fig, ax = plt.subplots()
    ax.text(
        .5, .5, "There are 几个汉字 in between!",
-       family=['DejaVu Sans', 'WenQuanYi Zen Hei'],
+       family=['DejaVu Sans', 'Noto Sans CJK'],
        ha='center'
    )
 


### PR DESCRIPTION
## PR Summary

This PR  replaces usage of WenQuanYi Zen Hei with the Noto Sans CJK font, which is already used in other examples and still available on Homebrew. This provides a more convenient and consistent experience for macOS users. The changes were made to the relevant examples in the docs/galleries, and the documentation was updated to reflect the font change.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [x] New plotting related features are documented with examples.


<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
