### PR TITLE
Remove unused methods from AFM

### DIFF
--- a/lib/matplotlib/_afm.py
+++ b/lib/matplotlib/_afm.py
@@ -1,5 +1,5 @@
 """
-A python interface to Adobe Font Metrics Files.
+A Python interface to Adobe Font Metrics Files.
 
 Although a number of other Python implementations exist, and may be more
 complete than this, it was decided not to go with them because they were
@@ -16,19 +16,13 @@ It is pretty easy to use, and has no external dependencies:
 >>> from pathlib import Path
 >>> afm_path = Path(mpl.get_data_path(), 'fonts', 'afm', 'ptmr8a.afm')
 >>>
->>> from matplotlib.afm import AFM
+>>> from matplotlib._afm import AFM
 >>> with afm_path.open('rb') as fh:
 ...     afm = AFM(fh)
 >>> afm.string_width_height('What the heck?')
 (6220.0, 694)
 >>> afm.get_fontname()
 'Times-Roman'
->>> afm.get_kern_dist('A', 'f')
-0
->>> afm.get_kern_dist('A', 'y')
--92.0
->>> afm.get_bbox_char('!')
-[130, -9, 238, 676]
 
 As in the Adobe Font Metrics File Format Specification, all dimensions
 are given in units of 1/1000 of the scale factor (point size) of the font
@@ -363,11 +357,6 @@ class AFM:
         self._metrics, self._metrics_by_name = _parse_char_metrics(fh)
         self._kern, self._composite = _parse_optional(fh)
 
-    def get_bbox_char(self, c, isord=False):
-        if not isord:
-            c = ord(c)
-        return self._metrics[c].bbox
-
     def string_width_height(self, s):
         """
         Return the string width (including kerning) and string height
@@ -423,10 +412,6 @@ class AFM:
 
         return left, miny, total_width, maxy - miny, -miny
 
-    def get_str_bbox(self, s):
-        """Return the string bounding box."""
-        return self.get_str_bbox_and_descent(s)[:4]
-
     def get_name_char(self, c, isord=False):
         """Get the name of the character, i.e., ';' is 'semicolon'."""
         if not isord:
@@ -444,19 +429,6 @@ class AFM:
     def get_width_from_char_name(self, name):
         """Get the width of the character from a type1 character name."""
         return self._metrics_by_name[name].width
-
-    def get_height_char(self, c, isord=False):
-        """Get the bounding box (ink) height of character *c* (space is 0)."""
-        if not isord:
-            c = ord(c)
-        return self._metrics[c].bbox[-1]
-
-    def get_kern_dist(self, c1, c2):
-        """
-        Return the kerning pair distance (possibly 0) for chars *c1* and *c2*.
-        """
-        name1, name2 = self.get_name_char(c1), self.get_name_char(c2)
-        return self.get_kern_dist_from_name(name1, name2)
 
     def get_kern_dist_from_name(self, name1, name2):
         """
@@ -505,10 +477,6 @@ class AFM:
         """Return the fontangle as float."""
         return self._header[b'ItalicAngle']
 
-    def get_capheight(self):
-        """Return the cap height as float."""
-        return self._header[b'CapHeight']
-
     def get_xheight(self):
         """Return the xheight as float."""
         return self._header[b'XHeight']
@@ -516,17 +484,3 @@ class AFM:
     def get_underline_thickness(self):
         """Return the underline thickness as float."""
         return self._header[b'UnderlineThickness']
-
-    def get_horizontal_stem_width(self):
-        """
-        Return the standard horizontal stem width as float, or *None* if
-        not specified in AFM file.
-        """
-        return self._header.get(b'StdHW', None)
-
-    def get_vertical_stem_width(self):
-        """
-        Return the standard vertical stem width as float, or *None* if
-        not specified in AFM file.
-        """
-        return self._header.get(b'StdVW', None)


### PR DESCRIPTION
## PR Summary

I guess that one first should decide if the `_afm` module should be as complete as possible or only contain what is actually used?

Anyway, these methods are not used anywhere in the code base and I guess that one purpose of making it a private module was to be able to remove unused code.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
