### PR TITLE
added assigning and duplicating section heading to contribute guide

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -89,6 +89,9 @@ though not necessarily all at the same time:
 - It involves Python features such as decorators and context managers, which
   have subtleties due to our implementation decisions.
 
+Assigning issues and duplicating pull requests
+----------------------------------------------
+
 In general, the Matplotlib project does not assign issues. Issues are
 "assigned" or "claimed" by opening a PR; there is no other assignment
 mechanism. If you have opened such a PR, please comment on the issue thread to


### PR DESCRIPTION
The paragraph on assigning issues and duplicating PRs is the last paragraph of the section for new contributors, so I just added a section title to make it clear that it's a general policy and not just for new contributors.