### PR TITLE
#20644 Add label alignment to tick_params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,5 @@ lib/matplotlib/backends/web_backend/node_modules/
 lib/matplotlib/backends/web_backend/package-lock.json
 
 LICENSE/LICENSE_QHULL
+
+env

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -133,7 +133,7 @@ class Tick(martist.Artist):
         if labelsize is None:
             labelsize = mpl.rcParams[f"{name}.labelsize"]
 
-        self._set_labelrotation(labelrotation) # kind sus
+        self._set_labelrotation(labelrotation)
 
         if zorder is None:
             if major:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -76,6 +76,10 @@ class Tick(martist.Artist):
         grid_linestyle=None,
         grid_linewidth=None,
         grid_alpha=None,
+        label_horizontal_alignment=None,
+        label_vertical_alignment=None,
+        label_font_properties=None,
+        label_rotation_mode=None,
         **kwargs,  # Other Line2D kwargs applied to gridlines.
     ):
         """
@@ -129,7 +133,7 @@ class Tick(martist.Artist):
         if labelsize is None:
             labelsize = mpl.rcParams[f"{name}.labelsize"]
 
-        self._set_labelrotation(labelrotation)
+        self._set_labelrotation(labelrotation) # kind sus
 
         if zorder is None:
             if major:
@@ -153,6 +157,22 @@ class Tick(martist.Artist):
             grid_alpha = mpl.rcParams["grid.alpha"]
         grid_kw = {k[5:]: v for k, v in kwargs.items()}
 
+        if label_horizontal_alignment is None:
+            label_horizontal_alignment = mpl.rcParams[f"{name}.label_horizontal"]
+        self._label_horizontal_alignment = label_horizontal_alignment
+            
+        if label_vertical_alignment is None:
+            label_vertical_alignment = mpl.rcParams[f"{name}.label_vertical"]
+        self._label_vertical_alignment = label_vertical_alignment
+
+        if label_font_properties is None:
+            label_font_properties = mpl.rcParams[f"{name}.label_font"]
+        self._label_font_properties = label_font_properties
+
+        if label_rotation_mode is None:
+            label_rotation_mode = mpl.rcParams[f"{name}.label_rotation"]
+        self._label_rotation_mode = label_rotation_mode
+        
         self.tick1line = mlines.Line2D(
             [], [],
             color=color, linestyle="none", zorder=zorder, visible=tick1On,
@@ -373,6 +393,23 @@ class Tick(martist.Artist):
             self._set_labelrotation(kwargs.pop('labelrotation'))
             self.label1.set(rotation=self._labelrotation[1])
             self.label2.set(rotation=self._labelrotation[1])
+
+        if 'labelhorizontalalignment' in kwargs:
+            self._label_horizontal_alignment = kwargs.pop('horizontalalignment')
+            self.label1.set_horizontalalignment(self._label_horizontal_alignment)
+            self.label2.set_horizontalalignment(self._label_horizontal_alignment)
+        if 'labelverticalalignment' in kwargs:
+            self._label_vertical_alignment = kwargs.pop('verticalalignment')
+            self.label1.set_verticalalignment(self._label_vertical_alignment)
+            self.label2.set_verticalalignment(self._label_vertical_alignment)
+        if 'labelfontproperties' in kwargs:
+            self._label_font_properties = kwargs.pop('labelfontproperties')
+            self.label1.set_fontproperties(self._label_font_properties)
+            self.label2.set_fontproperties(self._label_font_properties)
+        if 'labelrotationmode' in kwargs:
+            self._label_rotation_mode = kwargs.pop('labelrotationmode')
+            self.label1.set_rotation_mode(self._label_rotation_mode)
+            self.label2.set_rotation_mode(self._label_rotation_mode)
 
         label_kw = {k[5:]: v for k, v in kwargs.items()
                     if k in ['labelsize', 'labelcolor']}
@@ -1039,8 +1076,9 @@ class Axis(martist.Artist):
             'tick1On', 'tick2On', 'label1On', 'label2On',
             'length', 'direction', 'left', 'bottom', 'right', 'top',
             'labelleft', 'labelbottom', 'labelright', 'labeltop',
-            'labelrotation',
-            *_gridline_param_names]
+            'labelrotation', 'label_horizontal_alignment',
+            'label_vertical_alignment', 'label_font_properties',
+            'label_rotation_mode', *_gridline_param_names]
 
         keymap = {
             # tick_params key -> axis key
@@ -1055,6 +1093,10 @@ class Axis(martist.Artist):
             'labelbottom': 'label1On',
             'labelright': 'label2On',
             'labeltop': 'label2On',
+            'labelhorizontalalignment': 'label_horizontal_alignment',
+            'labelverticalalignment': 'label_vertical_alignment',
+            'labelfontproperties': 'label_font_properties',
+            'labelrotationmode': 'label_rotation_mode',
         }
         if reverse:
             kwtrans = {

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -272,6 +272,34 @@ class TestLogLocator:
             assert all(ax.get_yticks() == axes[0].get_yticks())
             assert ax.get_ylim() == axes[0].get_ylim()
 
+    def test_tick_params_modify_label(self):
+        # Create a figure
+        fig = plt.figure()
+
+        # Generate some sample data
+        x = np.arange(0, 10, 0.1)
+        y = np.sin(x)
+
+        # Plot the data
+        ax = fig.add_subplot(111)
+        ax.plot(x, y)
+
+        # Modify the tick labels
+        tick_params = {
+            'labelhorizontalalignment': 'right',
+            'labelverticalalignment': 'top',
+            'labelfontproperties': {'family': 'serif', 'size': 12},
+            'labelrotation_mode': 'anchor'
+        }
+        ax.xaxis.set_tick_params(**tick_params)
+        ax.yaxis.set_tick_params(**tick_params)
+
+        # Verify that the tick labels have been modified
+        assert ax.xaxis.get_ticklabels()[0].get_horizontalalignment() == 'right'
+        assert ax.xaxis.get_ticklabels()[0].get_verticalalignment() == 'top'
+        assert ax.xaxis.get_ticklabels()[0].get_fontproperties().get_family() == 'serif'
+        assert ax.xaxis.get_ticklabels()[0].get_fontproperties().get_size() == 12
+        assert ax.xaxis.get_ticklabels()[0].get_rotation_mode() == 'anchor'
 
 class TestNullLocator:
     def test_set_params(self):


### PR DESCRIPTION
## PR Summary
Added label parameters to tick_params to support a larger set of label parameters.
## PR Checklist
- labelhorizontalalignment
- labelverticalalignment
- labelfontproperties
- labelrotation_mode
<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
