### PR TITLE
POC: Add validation of converters to formatters

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1821,6 +1821,11 @@ class Axis(martist.Artist):
             _api.warn_external('FixedFormatter should only be used together '
                                'with FixedLocator')
 
+        assert isinstance(formatter, mticker.Formatter)
+
+        if hasattr(self, "converter") and self.converter is not None:
+            formatter.validate_converter(self.converter)
+
         if level == self.major:
             self.isDefault_majfmt = False
         else:

--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -164,6 +164,10 @@ class StrCategoryFormatter(ticker.Formatter):
             value = str(value)
         return value
 
+    def validate_converter(self, converter):
+        if not isinstance(converter, StrCategoryConverter):
+            raise TypeError("Expected a StrCategoryConverter for StrCategoryFormatter")
+
 
 class UnitData:
     def __init__(self, data=None):

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -651,6 +651,12 @@ class DateFormatter(ticker.Formatter):
     def set_tzinfo(self, tz):
         self.tz = _get_tzinfo(tz)
 
+    def validate_converter(self, converter):
+        if not isinstance(converter, (DateConverter, _SwitchableDateConverter)):
+            raise TypeError(
+                f"Expected a DateConverter for DateFormatter, got {type(converter)}"
+            )
+
 
 class ConciseDateFormatter(ticker.Formatter):
     """
@@ -872,6 +878,13 @@ class ConciseDateFormatter(ticker.Formatter):
     def format_data_short(self, value):
         return num2date(value, tz=self._tz).strftime('%Y-%m-%d %H:%M:%S')
 
+    def validate_converter(self, converter):
+        if not isinstance(converter, (DateConverter, _SwitchableDateConverter)):
+            raise TypeError(
+                "Expected a DateConverter for ConciseDateFormatter, "
+                f"got {type(converter)}"
+            )
+
 
 class AutoDateFormatter(ticker.Formatter):
     """
@@ -991,6 +1004,9 @@ class AutoDateFormatter(ticker.Formatter):
             raise TypeError(f'Unexpected type passed to {self!r}.')
 
         return result
+
+    def validate_converter(self, converter):
+        self._formatter.validate_converter(converter)
 
 
 class rrulewrapper:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -253,6 +253,11 @@ class Formatter(TickHelper):
         """Subclasses may want to override this to set a locator."""
         pass
 
+    def validate_converter(self, converter):
+        """Raise an exception if the converter is not valid for this formatter."""
+        # By default, accept any converter
+        pass
+
 
 class NullFormatter(Formatter):
     """Always return the empty string."""

--- a/lib/matplotlib/ticker.pyi
+++ b/lib/matplotlib/ticker.pyi
@@ -1,6 +1,7 @@
 from matplotlib.axis import Axis
-from matplotlib.transforms import Transform
 from matplotlib.projections.polar import _AxisWrapper
+from matplotlib.transforms import Transform
+from matplotlib.units import ConversionInterface
 
 from collections.abc import Callable, Sequence
 from typing import Any, Literal
@@ -31,6 +32,7 @@ class Formatter(TickHelper):
     def set_locs(self, locs: list[float]) -> None: ...
     @staticmethod
     def fix_minus(s: str) -> str: ...
+    def validate_converter(self, converter: ConversionInterface) -> None: ...
 
 class NullFormatter(Formatter): ...
 


### PR DESCRIPTION
## PR Summary

This is an alternative implementation of #25662, validating in the opposite direction
Closes #24951

In #25662, the converter holds reference to what formatters are valid.
Here, The formatter holds reference to what converters are valid.

Another difference in implementation is that the validators raise rather than return
boolean.

With respect to the original report (#24951), with current main of nc-time-axis there is
no change in behavior (no warning, produces incorrect dates). With the change proposed
in SciTools/nc-time-axis#127, it errors on validation. Their provided formatters will
provide no validation, but also will not fail
(until they implement the validator method)

ping @spencerkclark for nc-time-axis's stake in this

It is pretty minimal and easy, but tests currently fail because of the jpl_units EpochConverter.
EpochConverter does not inherit from DateConverter, but _is_ compatible (the inverse of current main of nc-time-axis).

Since we are pretty strict about not changing the jpl units, I'm looking for some other ideas...

A couple ideas:

- Use `converter.axis_info`, and automatically allow the type returned from that (for maj or min).
   - This would work for at least _most_ of the tests, but is still a bit fragile
   - e.g. jpl's EpochConverter returns AutoDateFormatter, but would still be valid with `DateFormatter` or `ConciseDateFormatter`, but that can't be teased out from axis_info
- Find a test for `DateFormatter`s which does not rely on `isinstance`
   - This is hard if because the formatter cares about attributes of the output of converters, not their internal representation
   - Could do something like `try: assert converter.convert(datetime.date(...), ...) == ...; except: raise ...`
      - (may not want to actually use `assert` for `python -O` reasons, but same idea)
- Only warn, rather than error, and adjust the tests to expect that warning.
   - Has the advantage of not actually changing behavior/not preventing people from doing things

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Linked Issue**
- [ ] Added "closes #0000" in the PR description to link it to the original issue.

**Documentation and Tests**
- [ ] Has pytest style unit tests (and `pytest` passes)
- [ ] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [ ] New plotting related features are documented with examples.

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [ ] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [ ] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
