### PR TITLE
Only print actually tested QT APIs when erroring

### DIFF
--- a/lib/matplotlib/backends/qt_compat.py
+++ b/lib/matplotlib/backends/qt_compat.py
@@ -133,7 +133,8 @@ elif QT_API is None:  # See above re: dict.__getitem__.
     else:
         raise ImportError(
             "Failed to import any of the following Qt binding modules: {}"
-            .format(", ".join(_ETS.values())))
+            .format(", ".join([QT_API for _, QT_API in _candidates]))
+        )
 else:  # We should not get there.
     raise AssertionError(f"Unexpected QT_API: {QT_API}")
 _version_info = tuple(QtCore.QLibraryInfo.version().segments())

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -343,6 +343,26 @@ def test_qt5backends_uses_qt5():
     _run_helper(_implcore, timeout=_test_timeout)
 
 
+def _impl_missing():
+    import sys
+    # Simulate uninstalled
+    sys.modules["PyQt6"] = None
+    sys.modules["PyQt5"] = None
+    sys.modules["PySide2"] = None
+    sys.modules["PySide6"] = None
+
+    import matplotlib.pyplot as plt
+    with pytest.raises(ImportError, match="Failed to import any of the following Qt"):
+        plt.switch_backend("qtagg")
+    # Specifically ensure that Pyside6/Pyqt6 are not in the error message for qt5agg
+    with pytest.raises(ImportError, match="^(?:(?!(PySide6|PyQt6)).)*$"):
+        plt.switch_backend("qt5agg")
+
+
+def test_qt_missing():
+    _run_helper(_impl_missing, timeout=_test_timeout)
+
+
 def _impl_test_cross_Qt_imports():
     import sys
     import importlib


### PR DESCRIPTION
## PR Summary

After I closed #25673 because the root cause of that issue is in IPython mapping "qt" to "qt5agg", I realized that perhaps we could still do better about our error message.
While this change would not have actually resolved the question of "what is asking this to be qt5??", it would have at least not also raised the question of "why is qt6 not working? It is installed."

```python
>>> plt.switch_backend("qtagg")
Traceback (most recent call last):
...
ImportError: Failed to import any of the following Qt binding modules: PyQt6, PySide6, PyQt5, PySide2
>>> plt.switch_backend("qt5agg")
Traceback (most recent call last):
...
ImportError: Failed to import any of the following Qt binding modules: PyQt5, PySide2
```

Now only outputs the bindings which were actually tested, rather than all 4 regardless of whether only qt5 bindings were tested.

## PR Checklist

<!-- Please mark any checkboxes that do not apply to this PR as [N/A]. -->
**Linked Issue**
- [N/A] Added "closes #0000" in the PR description to link it to the original issue.

**Documentation and Tests**
- [N/A] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [N/A] New plotting related features are documented with examples.

**Release Notes**
- [N/A] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [N/A] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [N/A] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at
  https://matplotlib.org/devel/gitwash/development_workflow.html.

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
