### PR TITLE
Deprecate papersize=auto in PostScript

### DIFF
--- a/doc/api/next_api_changes/deprecations/25784-ES.rst
+++ b/doc/api/next_api_changes/deprecations/25784-ES.rst
@@ -1,0 +1,6 @@
+Automatic papersize selection in PostScript
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Setting :rc:`ps.papersize` to ``'auto'`` or passing ``papersize='auto'`` to
+`.Figure.savefig` is deprecated. Either pass an explicit paper type name, or
+omit this parameter to use the default from the rcParam.

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -869,16 +869,20 @@ class FigureCanvasPS(FigureCanvasBase):
         if papertype == 'auto':
             papertype = _get_papertype(
                 *orientation.swap_if_landscape((width, height)))
-        paper_width, paper_height = orientation.swap_if_landscape(
-            papersize[papertype])
 
-        if mpl.rcParams['ps.usedistiller']:
-            # distillers improperly clip eps files if pagesize is too small
-            if width > paper_width or height > paper_height:
-                papertype = _get_papertype(
-                    *orientation.swap_if_landscape((width, height)))
-                paper_width, paper_height = orientation.swap_if_landscape(
-                    papersize[papertype])
+        if is_eps:
+            paper_width, paper_height = width, height
+        else:
+            paper_width, paper_height = orientation.swap_if_landscape(
+                papersize[papertype])
+
+            if mpl.rcParams['ps.usedistiller']:
+                # distillers improperly clip eps files if pagesize is too small
+                if width > paper_width or height > paper_height:
+                    papertype = _get_papertype(
+                        *orientation.swap_if_landscape((width, height)))
+                    paper_width, paper_height = orientation.swap_if_landscape(
+                        papersize[papertype])
 
         # center the figure on the paper
         xo = 72 * 0.5 * (paper_width - width)

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -867,8 +867,10 @@ class FigureCanvasPS(FigureCanvasBase):
         # find the appropriate papertype
         width, height = self.figure.get_size_inches()
         if papertype == 'auto':
-            papertype = _get_papertype(
-                *orientation.swap_if_landscape((width, height)))
+            _api.warn_deprecated("3.8", name="papertype='auto'",
+                                 addendum="Pass an explicit paper type, or omit the "
+                                 "*papertype* argument entirely.")
+            papertype = _get_papertype(*orientation.swap_if_landscape((width, height)))
 
         if is_eps:
             paper_width, paper_height = width, height
@@ -1059,6 +1061,9 @@ showpage
                     self.figure.get_size_inches())
             else:
                 if papertype == 'auto':
+                    _api.warn_deprecated("3.8", name="papertype='auto'",
+                                         addendum="Pass an explicit paper type, or "
+                                         "omit the *papertype* argument entirely.")
                     papertype = _get_papertype(width, height)
                 paper_width, paper_height = papersize[papertype]
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -438,6 +438,19 @@ def validate_ps_distiller(s):
         return ValidateInStrings('ps.usedistiller', ['ghostscript', 'xpdf'])(s)
 
 
+def _validate_papersize(s):
+    # Re-inline this validator when the 'auto' deprecation expires.
+    s = ValidateInStrings("ps.papersize",
+                          ["auto", "letter", "legal", "ledger",
+                           *[f"{ab}{i}" for ab in "ab" for i in range(11)]],
+                          ignorecase=True)(s)
+    if s == "auto":
+        _api.warn_deprecated("3.8", name="ps.papersize='auto'",
+                             addendum="Pass an explicit paper type, or omit the "
+                             "*ps.papersize* rcParam entirely.")
+    return s
+
+
 # A validator dedicated to the named line styles, based on the items in
 # ls_mapper, and a list of possible strings read from Line2D.set_linestyle
 _validate_named_linestyle = ValidateInStrings(
@@ -1180,9 +1193,7 @@ _validators = {
     "tk.window_focus": validate_bool,  # Maintain shell focus for TkAgg
 
     # Set the papersize/type
-    "ps.papersize":       _ignorecase(["auto", "letter", "legal", "ledger",
-                                      *[f"{ab}{i}"
-                                        for ab in "ab" for i in range(11)]]),
+    "ps.papersize":       _validate_papersize,
     "ps.useafm":          validate_bool,
     # use ghostscript or xpdf to distill ps output
     "ps.usedistiller":    validate_ps_distiller,

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -336,3 +336,12 @@ def test_colorbar_shift(tmp_path):
     norm = mcolors.BoundaryNorm([-1, -0.5, 0.5, 1], cmap.N)
     plt.scatter([0, 1], [1, 1], c=[0, 1], cmap=cmap, norm=norm)
     plt.colorbar()
+
+
+def test_auto_papersize_deprecation():
+    fig = plt.figure()
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        fig.savefig(io.BytesIO(), format='eps', papertype='auto')
+
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        mpl.rcParams['ps.papersize'] = 'auto'


### PR DESCRIPTION
## PR Summary

This automatic selection is not very good, and it's probably better for the user to explicitly select a paper type.

Additionally, I've corrected an inconsistency in EPS, which used the paper size _only_ if not using `usetex` and no distiller. In the latter cases, the paper size is ignored and the distiller is told to use `-dEPSCrop` instead. So this makes the former case consistent with those.

## PR Checklist

**Linked Issue**
- [x] Added "closes #0000" in the PR description to link it to the original issue.

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [x] Documentation is sphinx and numpydoc compliant (the docs should [build](https://matplotlib.org/devel/documenting_mpl.html#building-the-docs) without error).
- [n/a] New plotting related features are documented with examples.

**Release Notes**
- [n/a] New features are marked with a `.. versionadded::` directive in the docstring and documented in `doc/users/next_whats_new/`
- [n/a] API changes are marked with a `.. versionchanged::` directive in the docstring and documented in `doc/api/next_api_changes/`
- [x] Release notes conform with instructions in  `next_whats_new/README.rst` or `next_api_changes/README.rst`