### PR TITLE
DOC: Fix minor typo in API change notes

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
@@ -232,7 +232,7 @@ Deprecated rcParams validators
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 The following validators, defined in `.rcsetup`, are deprecated:
 ``validate_fontset``, ``validate_mathtext_default``, ``validate_alignment``,
-``validate_svg_fontset``, ``validate_pgf_texsystem``,
+``validate_svg_fonttype``, ``validate_pgf_texsystem``,
 ``validate_movie_frame_fmt``, ``validate_axis_locator``,
 ``validate_movie_html_fmt``, ``validate_grid_axis``,
 ``validate_axes_titlelocation``, ``validate_toolbar``,

--- a/doc/api/prev_api_changes/api_changes_3.5.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/removals.rst
@@ -351,7 +351,7 @@ rcParams
   - ``validate_orientation``
   - ``validate_pgf_texsystem``
   - ``validate_ps_papersize``
-  - ``validate_svg_fontset``
+  - ``validate_svg_fonttype``
   - ``validate_toolbar``
   - ``validate_webagg_address``
 


### PR DESCRIPTION
## PR summary

Just a small thing I noticed while I was looking at #10063.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines