### PR TITLE
Replace random values by hard-coded numbers in plot-types ...

### DIFF
--- a/galleries/plot_types/basic/bar.py
+++ b/galleries/plot_types/basic/bar.py
@@ -11,9 +11,8 @@ import numpy as np
 plt.style.use('_mpl-gallery')
 
 # make data:
-np.random.seed(3)
 x = 0.5 + np.arange(8)
-y = np.random.uniform(2, 7, len(x))
+y = [4.8, 5.5, 3.5, 4.6, 6.5, 6.6, 2.6, 3.0]
 
 # plot
 fig, ax = plt.subplots()

--- a/galleries/plot_types/basic/stem.py
+++ b/galleries/plot_types/basic/stem.py
@@ -11,9 +11,8 @@ import numpy as np
 plt.style.use('_mpl-gallery')
 
 # make data
-np.random.seed(3)
 x = 0.5 + np.arange(8)
-y = np.random.uniform(2, 7, len(x))
+y = [4.8, 5.5, 3.5, 4.6, 6.5, 6.6, 2.6, 3.0]
 
 # plot
 fig, ax = plt.subplots()

--- a/galleries/plot_types/basic/step.py
+++ b/galleries/plot_types/basic/step.py
@@ -11,9 +11,8 @@ import numpy as np
 plt.style.use('_mpl-gallery')
 
 # make data
-np.random.seed(3)
 x = 0.5 + np.arange(8)
-y = np.random.uniform(2, 7, len(x))
+y = [4.8, 5.5, 3.5, 4.6, 6.5, 6.6, 2.6, 3.0]
 
 # plot
 fig, ax = plt.subplots()


### PR DESCRIPTION
... for the cases where we have only very few random numbers. This makes the code a bit simpler, because we do not have to seed. Also, a list of hard-coded numbers is slightly simpler to grasp compared to a rng function.

The values are chosen so that the figures look approximately the same as before.

This is partly also in anticipation of the switch to numpy's rng generator classes (related: #25765). While conceptually superior, they are a bit more verbose and introduce the additional local variable `rng` (IMHO this is the benefit and the downside: It explicitly ties the rng state to the local context -> clarity. But OTOH the user is bothered with this local state even if it's not important to them - like in our examples.)

