### PR TITLE
[TST] Adjust tests to be more tolerant to floating point math operations being imprecise

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4415,7 +4415,8 @@ def test_mollweide_forward_inverse_closure():
 
     # set up 1-degree grid in longitude, latitude
     lon = np.linspace(-np.pi, np.pi, 360)
-    lat = np.linspace(-np.pi / 2.0, np.pi / 2.0, 180)
+    # The poles are degenerate and thus sensitive to floating point precision errors
+    lat = np.linspace(-np.pi / 2.0, np.pi / 2.0, 180)[1:-1]
     lon, lat = np.meshgrid(lon, lat)
     ll = np.vstack((lon.flatten(), lat.flatten())).T
 

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -425,13 +425,13 @@ def test_axvline_axvspan_do_not_modify_rlims():
 def test_cursor_precision():
     ax = plt.subplot(projection="polar")
     # Higher radii correspond to higher theta-precisions.
-    assert ax.format_coord(0, 0) == "θ=0π (0°), r=0.000"
+    assert ax.format_coord(0, 0.005) == "θ=0.0π (0°), r=0.005"
     assert ax.format_coord(0, .1) == "θ=0.00π (0°), r=0.100"
     assert ax.format_coord(0, 1) == "θ=0.000π (0.0°), r=1.000"
-    assert ax.format_coord(1, 0) == "θ=0.3π (57°), r=0.000"
+    assert ax.format_coord(1, 0.005) == "θ=0.3π (57°), r=0.005"
     assert ax.format_coord(1, .1) == "θ=0.32π (57°), r=0.100"
     assert ax.format_coord(1, 1) == "θ=0.318π (57.3°), r=1.000"
-    assert ax.format_coord(2, 0) == "θ=0.6π (115°), r=0.000"
+    assert ax.format_coord(2, 0.005) == "θ=0.6π (115°), r=0.005"
     assert ax.format_coord(2, .1) == "θ=0.64π (115°), r=0.100"
     assert ax.format_coord(2, 1) == "θ=0.637π (114.6°), r=1.000"
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -200,9 +200,9 @@ def test_bar3d_lightsource():
 
     # Testing that the custom 90° lightsource produces different shading on
     # the top facecolors compared to the default, and that those colors are
-    # precisely the colors from the colormap, due to the illumination parallel
-    # to the z-axis.
-    np.testing.assert_array_equal(color, collection._facecolor3d[1::6])
+    # precisely (within floating point rounding errors of 4 ULP) the colors
+    # from the colormap, due to the illumination parallel to the z-axis.
+    np.testing.assert_array_max_ulp(color, collection._facecolor3d[1::6], 4)
 
 
 @mpl3d_image_comparison(['contour3d.png'], style='mpl20')


### PR DESCRIPTION
## PR summary
Closes #25789, see there for detailed discussion of what changed

This is addressing the extremely small (literally Unit of Least Precision, ULP) changes to how numpy computes sin/cos on main.
Through a combination of ratios of small numbers and relying on precise edge case behavior in tests of floats, we saw 3 cases where the miniscule difference compounded to test failures.

Two cases of projections having degenerate points where the edge case is inherently unstable:
  - Mollweide projection is degenerate at the poles, we were lucky that the floating point operations precisely canceled
      - Fixed by just not testing round tripping of the poles, as they _shouldn't_ necessarily round trip
  - Formatting of polar coordinates
      - Polar coordinates are degenerate at r=0, thus we were relying on boundary behavior to get zero decimals of precision
      - Does an absolute difference mod 2 pi, thus the maximum possible is pi, and then divides by pi, thus the only way to get the tested precision was to get _exactly_ np.pi
          - The only place this can actually happen in adjacent pixels is around the origin
      - The method is used for tool tip in interactive plotting, and precisely placing the mouse at 0,0 is unlikely to impossible depending on resolution, etc
      - Fixed by moving the radius out far enough that we are no longer degenerate and have stable expected precision

one case of attempting to do equality checks on processed floats:
  - Round tripping of 3d axis colors with light source at 90 degrees
  - since pi/2 is imprecise (because all floats except sums of powers of two are) there should be some allowance for float precision error
  - The tolerance is still _really_ tight (4 ULPs, or a relative tolerance of ~1e-15)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
