### PR TITLE
[TST] Make jpl units instantiated with datetimes consistent with mpl converters

### DIFF
--- a/lib/matplotlib/testing/jpl_units/EpochConverter.py
+++ b/lib/matplotlib/testing/jpl_units/EpochConverter.py
@@ -12,9 +12,7 @@ class EpochConverter(units.ConversionInterface):
     classes.
     """
 
-    # julian date reference for "Jan 1, 0001" minus 1 day because
-    # Matplotlib really wants "Jan 0, 0001"
-    jdRef = 1721425.5 - 1
+    jdRef = 1721425.5
 
     @staticmethod
     def axisinfo(unit, axis):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -856,8 +856,8 @@ def test_axvspan_epoch():
     units.register()
 
     # generate some data
-    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 20))
-    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
+    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
+    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 22))
     dt = units.Duration("ET", units.day.convert("sec"))
 
     ax = plt.gca()
@@ -871,8 +871,8 @@ def test_axhspan_epoch():
     units.register()
 
     # generate some data
-    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 20))
-    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
+    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
+    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 22))
     dt = units.Duration("ET", units.day.convert("sec"))
 
     ax = plt.gca()

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -156,6 +156,17 @@ def test_jpl_barh_units():
     ax.set_xlim([b - 1 * day, b + w[-1] + (1.001) * day])
 
 
+def test_jpl_datetime_units_consistent():
+    import matplotlib.testing.jpl_units as units
+    units.register()
+
+    dt = datetime(2009, 4, 26)
+    jpl = units.Epoch("ET", dt=dt)
+    dt_conv = munits.registry.get_converter(dt).convert(dt, None, None)
+    jpl_conv = munits.registry.get_converter(jpl).convert(jpl, None, None)
+    assert dt_conv == jpl_conv
+
+
 def test_empty_arrays():
     # Check that plotting an empty array with a dtype works
     plt.scatter(np.array([], dtype='datetime64[ns]'), np.array([]))

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -134,7 +134,7 @@ def test_jpl_bar_units():
     day = units.Duration("ET", 24.0 * 60.0 * 60.0)
     x = [0 * units.km, 1 * units.km, 2 * units.km]
     w = [1 * day, 2 * day, 3 * day]
-    b = units.Epoch("ET", dt=datetime(2009, 4, 25))
+    b = units.Epoch("ET", dt=datetime(2009, 4, 26))
     fig, ax = plt.subplots()
     ax.bar(x, w, bottom=b)
     ax.set_ylim([b - 1 * day, b + w[-1] + (1.001) * day])
@@ -149,7 +149,7 @@ def test_jpl_barh_units():
     day = units.Duration("ET", 24.0 * 60.0 * 60.0)
     x = [0 * units.km, 1 * units.km, 2 * units.km]
     w = [1 * day, 2 * day, 3 * day]
-    b = units.Epoch("ET", dt=datetime(2009, 4, 25))
+    b = units.Epoch("ET", dt=datetime(2009, 4, 26))
 
     fig, ax = plt.subplots()
     ax.barh(x, w, left=b)


### PR DESCRIPTION
## PR summary

This is a minimal change to make the usage from our tests consistent with expectations.

As far as I can tell, the inconsistency for datetimes actually _predates_ the switch of mpl epoch from Jan 0, 0000 to Jan 1, 1970.
We only ever actually instantiate with datetime objects in tests (or via adding/subtracting durations, which don't actually care about the epoch).
I suspect that usage of `jpl_units.Epoch` that _arent_ instantiated datetimes are actually incorrect due to the mpl epoch change.
They are accidentally measuring from mpl epoch due to usage of `date2num` and `num2date`, But they think they are measuring form Jan 1, 0000 (1 day off from what the code assumes is mpl's epoch).
Thus in effect, they are actually measuring from 1969-12-31 when run through the `EpochConverter`.

This change does not affect any of that usage, only correcting the offset when passed as a datetime object.

The change to `EpochConverter` is simply getting rid of the off by 1 from the outdated mpl epoch.
The changes to tests were done to make the output image unchanged but consistent with the date ranges in code.

@TD22057, do you have any opinions on these changes (or the inconsistencies that aren't addressed by this diff)?

A minimal example of the inconsistency:

```python
>>> from matplotlib.testing import jpl_units
>>> import datetime
>>> dt = datetime.datetime(2023, 5, 4)
>>> mpl.dates.DateConverter().convert(dt, None, None)
19481.0
>>> ep = jpl_units.Epoch("ET", dt=dt)
>>> jpl_units.EpochConverter().convert(ep, None, None)
19482.0  # Off by 1 for the same input datetime!!
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
