### PR TITLE
Deprecate Tick.set_label{1,2}.

### DIFF
--- a/doc/api/next_api_changes/deprecations/25841-AL.rst
+++ b/doc/api/next_api_changes/deprecations/25841-AL.rst
@@ -1,0 +1,4 @@
+``Tick.set_label1`` and ``Tick.set_label2``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are deprecated.  Calling these methods from third-party code usually has no
+effect, as the labels are overwritten at draw time by the tick formatter.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -291,6 +291,7 @@ class Tick(martist.Artist):
         renderer.close_group(self.__name__)
         self.stale = False
 
+    @_api.deprecated("3.8")
     def set_label1(self, s):
         """
         Set the label1 text.
@@ -304,6 +305,7 @@ class Tick(martist.Artist):
 
     set_label = set_label1
 
+    @_api.deprecated("3.8")
     def set_label2(self, s):
         """
         Set the label2 text.
@@ -1250,15 +1252,15 @@ class Axis(martist.Artist):
         major_ticks = self.get_major_ticks(len(major_locs))
         for tick, loc, label in zip(major_ticks, major_locs, major_labels):
             tick.update_position(loc)
-            tick.set_label1(label)
-            tick.set_label2(label)
+            tick.label1.set_text(label)
+            tick.label2.set_text(label)
         minor_locs = self.get_minorticklocs()
         minor_labels = self.minor.formatter.format_ticks(minor_locs)
         minor_ticks = self.get_minor_ticks(len(minor_locs))
         for tick, loc, label in zip(minor_ticks, minor_locs, minor_labels):
             tick.update_position(loc)
-            tick.set_label1(label)
-            tick.set_label2(label)
+            tick.label1.set_text(label)
+            tick.label2.set_text(label)
         ticks = [*major_ticks, *minor_ticks]
 
         view_low, view_high = self.get_view_interval()


### PR DESCRIPTION
... as detailed in the deprecation notice.
Closes #25833.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
