### PR TITLE
Fix invalid range validators.

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -678,7 +678,7 @@ def reposition_colorbar(layoutgrids, cbax, renderer, *, offset=None):
         width and height padding (in fraction of figure)
     hspace, wspace : float
         width and height padding as fraction of figure size divided by
-        number of  columns or rows
+        number of columns or rows
     margin : array-like
         offset the colorbar needs to be pushed to in order to
         account for multiple colorbars

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2665,10 +2665,10 @@ class _AxesBase(martist.Artist):
 
         The padding added to each limit of the Axes is the *margin*
         times the data interval. All input parameters must be floats
-        within the range [0, 1]. Passing both positional and keyword
+        greater than -0.5. Passing both positional and keyword
         arguments is invalid and will raise a TypeError. If no
         arguments (positional or otherwise) are provided, the current
-        margins will remain in place and simply be returned.
+        margins will remain unchanged and simply be returned.
 
         Specifying any margin changes only the autoscaling; for example,
         if *xmargin* is not None, then *xmargin* times the X data

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -585,10 +585,14 @@
 #figure.constrained_layout.use: False  # When True, automatically make plot
                                        # elements fit on the figure. (Not
                                        # compatible with `autolayout`, above).
-#figure.constrained_layout.h_pad:  0.04167  # Padding around axes objects. Float representing
-#figure.constrained_layout.w_pad:  0.04167  # inches. Default is 3/72 inches (3 points)
-#figure.constrained_layout.hspace: 0.02     # Space between subplot groups. Float representing
-#figure.constrained_layout.wspace: 0.02     # a fraction of the subplot widths being separated.
+## Padding (in inches) around axes; defaults to 3/72 inches, i.e. 3 points.
+#figure.constrained_layout.h_pad:  0.04167
+#figure.constrained_layout.w_pad:  0.04167
+## Spacing between subplots, relative to the subplot sizes.  Much smaller than for
+## tight_layout (figure.subplot.hspace, figure.subplot.wspace) as constrained_layout
+## already takes surrounding texts (titles, labels, # ticklabels) into account.
+#figure.constrained_layout.hspace: 0.02
+#figure.constrained_layout.wspace: 0.02
 
 
 ## ***************************************************************************

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -552,12 +552,12 @@ def validate_sketch(s):
         raise ValueError("Expected a (scale, length, randomness) triplet")
 
 
-def _validate_greaterequal0_lessthan1(s):
+def _validate_greaterthan_minushalf(s):
     s = validate_float(s)
-    if 0 <= s < 1:
+    if s > -0.5:
         return s
     else:
-        raise RuntimeError(f'Value must be >=0 and <1; got {s}')
+        raise RuntimeError(f'Value must be >-0.5; got {s}')
 
 
 def _validate_greaterequal0_lessequal1(s):
@@ -566,12 +566,6 @@ def _validate_greaterequal0_lessequal1(s):
         return s
     else:
         raise RuntimeError(f'Value must be >=0 and <=1; got {s}')
-
-
-_range_validators = {  # Slightly nicer (internal) API.
-    "0 <= x < 1": _validate_greaterequal0_lessthan1,
-    "0 <= x <= 1": _validate_greaterequal0_lessequal1,
-}
 
 
 def validate_hatch(s):
@@ -1012,9 +1006,9 @@ _validators = {
     # If "data", axes limits are set close to the data.
     # If "round_numbers" axes limits are set to the nearest round numbers.
     "axes.autolimit_mode": ["data", "round_numbers"],
-    "axes.xmargin": _range_validators["0 <= x <= 1"],  # margin added to xaxis
-    "axes.ymargin": _range_validators["0 <= x <= 1"],  # margin added to yaxis
-    'axes.zmargin': _range_validators["0 <= x <= 1"],  # margin added to zaxis
+    "axes.xmargin": _validate_greaterthan_minushalf,  # margin added to xaxis
+    "axes.ymargin": _validate_greaterthan_minushalf,  # margin added to yaxis
+    "axes.zmargin": _validate_greaterthan_minushalf,  # margin added to zaxis
 
     "polaraxes.grid": validate_bool,  # display polar grid or not
     "axes3d.grid":    validate_bool,  # display 3d grid
@@ -1149,21 +1143,21 @@ _validators = {
     "figure.max_open_warning": validate_int,
     "figure.raise_window":     validate_bool,
 
-    "figure.subplot.left":   _range_validators["0 <= x <= 1"],
-    "figure.subplot.right":  _range_validators["0 <= x <= 1"],
-    "figure.subplot.bottom": _range_validators["0 <= x <= 1"],
-    "figure.subplot.top":    _range_validators["0 <= x <= 1"],
-    "figure.subplot.wspace": _range_validators["0 <= x < 1"],
-    "figure.subplot.hspace": _range_validators["0 <= x < 1"],
+    "figure.subplot.left":   validate_float,
+    "figure.subplot.right":  validate_float,
+    "figure.subplot.bottom": validate_float,
+    "figure.subplot.top":    validate_float,
+    "figure.subplot.wspace": validate_float,
+    "figure.subplot.hspace": validate_float,
 
     "figure.constrained_layout.use": validate_bool,  # run constrained_layout?
     # wspace and hspace are fraction of adjacent subplots to use for space.
     # Much smaller than above because we don't need room for the text.
-    "figure.constrained_layout.hspace": _range_validators["0 <= x < 1"],
-    "figure.constrained_layout.wspace": _range_validators["0 <= x < 1"],
+    "figure.constrained_layout.hspace": validate_float,
+    "figure.constrained_layout.wspace": validate_float,
     # buffer around the axes, in inches.
-    'figure.constrained_layout.h_pad': validate_float,
-    'figure.constrained_layout.w_pad': validate_float,
+    "figure.constrained_layout.h_pad": validate_float,
+    "figure.constrained_layout.w_pad": validate_float,
 
     ## Saving figure's properties
     'savefig.dpi':          validate_dpi,
@@ -1207,7 +1201,7 @@ _validators = {
     "docstring.hardcopy": validate_bool,
 
     "path.simplify":           validate_bool,
-    "path.simplify_threshold": _range_validators["0 <= x <= 1"],
+    "path.simplify_threshold": _validate_greaterequal0_lessequal1,
     "path.snap":               validate_bool,
     "path.sketch":             validate_sketch,
     "path.effects":            validate_anylist,


### PR DESCRIPTION
- The correct bound on margins value, documented in set_x/y/zmargin, is margin>-0.5.  Fix the docstring of margins() and the rc validators.
- The only constraints on tight/constrained layout margins is left<right and bottom<top, but values outside of [0, 1] can in fact be valid.  It would be annoying to enforce this at the rcparams level (this would force the user to update individual rcparams in a careful order), so just don't bother validating the values beyond "float".  (See discussion at https://github.com/matplotlib/matplotlib/pull/11231#issuecomment-388394543)
- Remove the somewhat overengineered _range_validators.
- Move the comment about the values of figure.constrained_layout.h/w_pad to the default matplotlibrc (in rcsetup.py it was far away from the actual values, which made things a bit weird).  Also reword a bit.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
