### PR TITLE
Handle exceptions in numpy::array_view<...>::set().

### DIFF
--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -510,8 +510,8 @@ int convert_points(PyObject *obj, void *pointsp)
     if (obj == NULL || obj == Py_None) {
         return 1;
     }
-    points->set(obj);
-    if (points->size() && !check_trailing_shape(*points, "points", 2)) {
+    if (!points->set(obj)
+        || points->size() && !check_trailing_shape(*points, "points", 2)) {
         return 0;
     }
     return 1;
@@ -523,8 +523,8 @@ int convert_transforms(PyObject *obj, void *transp)
     if (obj == NULL || obj == Py_None) {
         return 1;
     }
-    trans->set(obj);
-    if (trans->size() && !check_trailing_shape(*trans, "transforms", 3, 3)) {
+    if (!trans->set(obj)
+        || trans->size() && !check_trailing_shape(*trans, "transforms", 3, 3)) {
         return 0;
     }
     return 1;
@@ -536,8 +536,8 @@ int convert_bboxes(PyObject *obj, void *bboxp)
     if (obj == NULL || obj == Py_None) {
         return 1;
     }
-    bbox->set(obj);
-    if (bbox->size() && !check_trailing_shape(*bbox, "bbox array", 2, 2)) {
+    if (!bbox->set(obj)
+        || bbox->size() && !check_trailing_shape(*bbox, "bbox array", 2, 2)) {
         return 0;
     }
     return 1;
@@ -549,8 +549,8 @@ int convert_colors(PyObject *obj, void *colorsp)
     if (obj == NULL || obj == Py_None) {
         return 1;
     }
-    colors->set(obj);
-    if (colors->size() && !check_trailing_shape(*colors, "colors", 4)) {
+    if (!colors->set(obj)
+        || colors->size() && !check_trailing_shape(*colors, "colors", 4)) {
         return 0;
     }
     return 1;


### PR DESCRIPTION
set() can throw an exception; we must check for that to properly get that exception propagated to the python side; otherwise we get a SystemError ("method ... returned a result with an exception set"). Example repro:
```
from pylab import *
gca().add_collection(mpl.collections.LineCollection(rand(2, 2, 2), array=0))
```
(Here the C extension method receives a single tuple (rgba) color rather than an array of tuple (rgba) colors.)

I'd rather not explicitly test for the exception being raised (a ValueError) because if switching to pybind11 one naturally gets a broadcast of the scalar value into a correctly dimensionalized array; indeed mplcairo handles the above example just fine.

~Also fix an unrelated (harmless) typo in _tkagg.cpp: use a logical or instead of a bitwise or.~

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
