### PR TITLE
Fix LayoutGrid leaks

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -346,13 +346,15 @@ def make_layout_margins(layoutgrids, fig, renderer, *, w_pad=0, h_pad=0,
     """
     for sfig in fig.subfigs:  # recursively make child panel margins
         ss = sfig._subplotspec
+        gs = ss.get_gridspec()
+
         make_layout_margins(layoutgrids, sfig, renderer,
                             w_pad=w_pad, h_pad=h_pad,
                             hspace=hspace, wspace=wspace)
 
         margins = get_margin_from_padding(sfig, w_pad=0, h_pad=0,
                                           hspace=hspace, wspace=wspace)
-        layoutgrids[sfig].parent.edit_outer_margin_mins(margins, ss)
+        layoutgrids[gs].edit_outer_margin_mins(margins, ss)
 
     for ax in fig._localaxes:
         if not ax.get_subplotspec() or not ax.get_in_layout():

--- a/lib/matplotlib/_layoutgrid.py
+++ b/lib/matplotlib/_layoutgrid.py
@@ -77,14 +77,8 @@ class LayoutGrid:
 
         sol = self.solver
 
-        # These are redundant, but make life easier if
-        # we define them all.  All that is really
-        # needed is left/right, margin['left'], and margin['right']
-        self.widths = [Variable(f'{sn}widths[{i}]') for i in range(ncols)]
         self.lefts = [Variable(f'{sn}lefts[{i}]') for i in range(ncols)]
         self.rights = [Variable(f'{sn}rights[{i}]') for i in range(ncols)]
-        self.inner_widths = [Variable(f'{sn}inner_widths[{i}]')
-                             for i in range(ncols)]
         for todo in ['left', 'right', 'leftcb', 'rightcb']:
             self.margins[todo] = [Variable(f'{sn}margins[{todo}][{i}]')
                                   for i in range(ncols)]
@@ -95,9 +89,6 @@ class LayoutGrid:
             self.margins[todo] = np.empty((nrows), dtype=object)
             self.margin_vals[todo] = np.zeros(nrows)
 
-        self.heights = [Variable(f'{sn}heights[{i}]') for i in range(nrows)]
-        self.inner_heights = [Variable(f'{sn}inner_heights[{i}]')
-                              for i in range(nrows)]
         self.bottoms = [Variable(f'{sn}bottoms[{i}]') for i in range(nrows)]
         self.tops = [Variable(f'{sn}tops[{i}]') for i in range(nrows)]
         for todo in ['bottom', 'top', 'bottomcb', 'topcb']:
@@ -119,14 +110,14 @@ class LayoutGrid:
         for i in range(self.nrows):
             for j in range(self.ncols):
                 str += f'{i}, {j}: '\
-                       f'L({self.lefts[j].value():1.3f}, ' \
+                       f'L{self.lefts[j].value():1.3f}, ' \
                        f'B{self.bottoms[i].value():1.3f}, ' \
-                       f'W{self.widths[j].value():1.3f}, ' \
-                       f'H{self.heights[i].value():1.3f}, ' \
-                       f'innerW{self.inner_widths[j].value():1.3f}, ' \
-                       f'innerH{self.inner_heights[i].value():1.3f}, ' \
+                       f'R{self.rights[j].value():1.3f}, ' \
+                       f'T{self.tops[i].value():1.3f}, ' \
                        f'ML{self.margins["left"][j].value():1.3f}, ' \
-                       f'MR{self.margins["right"][j].value():1.3f}, \n'
+                       f'MR{self.margins["right"][j].value():1.3f}, ' \
+                       f'MB{self.margins["bottom"][i].value():1.3f}, ' \
+                       f'MT{self.margins["top"][i].value():1.3f}, \n'
         return str
 
     def reset_margins(self):


### PR DESCRIPTION
## PR summary

Internally, the `LayoutGrid `parent is only used in `__init__`, so doesn't need to be saved as an attribute. Externally, the constrained layout code needs the parent only for subfigure margins, but we have the parent gridspec available directly to use.

The `LayoutGrid` stores its children in a NumPy array, and saving the parent causes a reference cycle. Apparently having one reference in a C-level NumPy array causes Python to not realize it can garbage collect the cycle, causing all `LayoutGrid` and its children to leak.

Removing the `parent` attribute removes the cycle and fixes the leak.

Additionally, I've removed extraneous `Variable`s that are not used for anything other than `__repr__`, but they are not actually filled with anything real there. In the example from #25819, this saves 16 `Variable`s per iteration.

Fixes #25819

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines