### PR TITLE
Fix Hidpi scaling for GTK4Cairo

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -17,6 +17,8 @@ class FigureCanvasGTK3Cairo(FigureCanvasCairo, FigureCanvasGTK3):
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
                 allocation.width, allocation.height)
+            self._renderer.width = allocation.width * scale
+            self._renderer.height = allocation.height * scale
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 

--- a/lib/matplotlib/backends/backend_gtk4cairo.py
+++ b/lib/matplotlib/backends/backend_gtk4cairo.py
@@ -19,6 +19,8 @@ class FigureCanvasGTK4Cairo(FigureCanvasCairo, FigureCanvasGTK4):
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
                 allocation.width, allocation.height)
+            self._renderer.width = allocation.width * scale
+            self._renderer.height = allocation.height * scale
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 


### PR DESCRIPTION
## PR summary
Closes #25847

There's a regression bug from Matplotlib 3.5.x to 3.6 and higher that breaks Matplotlib for HiDPI displays using the GTK4Cairo backend. I found that the reason behind this is that the renderer width is no longer set, as the associated function is removed from the general Cairo renderer.

This PR solves the named issue with two very simple lines of code, it simply just sets the same allocated width and height in the same way as in the 3.5.x series. Difference is that it no longer uses the class function to do this (as this function was removed), but I didn't want to touch too much code.

Unfortunately, I haven't been able to run tests. This may be due to my development environment (Fedora Silverblue in a Fedora 38 Toolbox container), but these two lines of codes are the only changes compared to the main branch.  I've tried to run the command in the docs, but it tells me 

```
OSError: The baseline image directory does not exist. This is most likely because the test data is not installed. You may need to install matplotlib from source to get the test data.
================================================================================= short test summary info ==================================================================================
ERROR  - OSError: The baseline image directory does not exist. This is most likely because the test data is not installed. You may need to install matplotlib from source to get the test data.
```

If anyone has any pointers about how to do this testing more properly let me know. Needless to say, I have done testing in the sense of running the build and checking the behaviour.

Here's some screencasts to illustrate the issue. This is done from a separate program using this backend, but the same behaviour happens when using matplotlib directly from the CLI, see related issue. 

Behaviour before this PR:

[Schermopname van 2023-05-09 17-19-13.webm](https://github.com/Sjoerd1993/Graphs/assets/68477016/a8f03e36-b106-497c-a2bd-68e81631255c)

Behaviour after this PR:

[Screencast from 2023-05-11 14-14-01.webm](https://github.com/matplotlib/matplotlib/assets/68477016/ae86cd27-4e54-48c1-8392-e1259b952a7f)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines


