### PR TITLE
TST: Add test for layoutgrid memory leak

### DIFF
--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -1,3 +1,4 @@
+import gc
 import numpy as np
 import pytest
 
@@ -678,3 +679,16 @@ def test_constrained_toggle():
         assert not fig.get_constrained_layout()
         fig.set_constrained_layout(True)
         assert fig.get_constrained_layout()
+
+
+def test_layout_leak():
+    # Make sure there aren't any cyclic references when using LayoutGrid
+    # GH #25853
+    fig = plt.figure(constrained_layout=True, figsize=(10, 10))
+    fig.add_subplot()
+    fig.draw_without_rendering()
+    plt.close("all")
+    del fig
+    gc.collect()
+    assert not any(isinstance(obj, mpl._layoutgrid.LayoutGrid)
+                   for obj in gc.get_objects())


### PR DESCRIPTION
## PR summary

Adds a memory leak test to make sure we don't bring the cyclic reference back in the future. Follow-up to #25853 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
