### PR TITLE
DOC: clarify how colorbar steals space

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1220,12 +1220,16 @@ default: %(va)s
                 fig.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax)
 
         cax : `~matplotlib.axes.Axes`, optional
-            Axes into which the colorbar will be drawn.
+            Axes into which the colorbar will be drawn.  If `None`, then space
+            will be stolen from the Axes(s) specified in *ax*
 
         ax : `~.axes.Axes` or iterable or `numpy.ndarray` of Axes, optional
-            One or more parent axes from which space for a new colorbar axes
-            will be stolen, if *cax* is None.  This has no effect if *cax* is
-            set.
+            If `None`, defaults to ``mappable.axes``.
+
+            If *cax* is None, specifies the one or more parent axes from which
+            space for a new colorbar axes will be stolen.
+
+            This has no effect if *cax* is set.
 
         use_gridspec : bool, optional
             If *cax* is ``None``, a new *cax* is created as an instance of

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1225,13 +1225,11 @@ default: %(va)s
             specified in *ax*.
 
         ax : `~.axes.Axes` or iterable or `numpy.ndarray` of Axes, optional
-            If `None`, defaults to the axes that contains the mappable used to
-            create the colorbar.
+            The one or more parent Axes from which space for a new colorbar Axes
+            will be stolen. This parameter is only used if *cax* is not set.
 
-            If *cax* is None, specifies the one or more parent axes from which
-            space for a new colorbar axes will be stolen.
-
-            This has no effect if *cax* is set.
+            Defaults to the Axes that contains the mappable used to create the
+            colorbar.
 
         use_gridspec : bool, optional
             If *cax* is ``None``, a new *cax* is created as an instance of

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1220,11 +1220,13 @@ default: %(va)s
                 fig.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax)
 
         cax : `~matplotlib.axes.Axes`, optional
-            Axes into which the colorbar will be drawn.  If `None`, then space
-            will be stolen from the Axes(s) specified in *ax*
+            Axes into which the colorbar will be drawn.  If `None`, then a new
+            Axes is created and the space for it will be stolen from the Axes(s)
+            specified in *ax*.
 
         ax : `~.axes.Axes` or iterable or `numpy.ndarray` of Axes, optional
-            If `None`, defaults to ``mappable.axes``.
+            If `None`, defaults to the axes that contains the mappable used to
+            create the colorbar.
 
             If *cax* is None, specifies the one or more parent axes from which
             space for a new colorbar axes will be stolen.
@@ -1270,6 +1272,7 @@ default: %(va)s
         However, this has negative consequences in other circumstances, e.g.
         with semi-transparent images (alpha < 1) and colorbar extensions;
         therefore, this workaround is not used by default (see issue #1188).
+
         """
 
         if ax is None:


### PR DESCRIPTION
## PR summary

In looking at #25871 I noted that the documentation on colorbar was not clear about the default behavior.

The docstring from `ax` explains the default behavior of the `cax` parameter and nothing explained the default value of `ax`.
