### PR TITLE
Adds tests for nargs_err in legend, stem, pcolorfast and cycler.

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -642,20 +642,20 @@ def test_sticky_shared_axes(fig_test, fig_ref):
 
 
 def test_nargs_stem():
-    with pytest.raises(TypeError, match='0 were given') as e:
+    with pytest.raises(TypeError, match='0 were given'):
         # stem() takes 1-3 arguments.
         plt.stem()
 
 
 def test_nargs_legend():
-    with pytest.raises(TypeError, match='3 were given') as e:
+    with pytest.raises(TypeError, match='3 were given'):
         ax = plt.subplot()
         # legend() takes 0-2 arguments.
         ax.legend(['First'], ['Second'], 3)
 
 
 def test_nargs_pcolorfast():
-    with pytest.raises(TypeError, match='2 were given') as e:
+    with pytest.raises(TypeError, match='2 were given'):
         ax = plt.subplot()
         # pcolorfast() takes 1 or 3 arguments,
         # not passing any arguments fails at C = args[-1]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -641,6 +641,31 @@ def test_sticky_shared_axes(fig_test, fig_ref):
     ax0.pcolormesh(Z)
 
 
+def test_nargs_stem():
+    with pytest.raises(TypeError) as e:
+        # stem() takes 1-3 arguments.
+        plt.stem()
+    assert "stem() takes 1-3" in str(e.value)
+
+
+def test_nargs_legend():
+    with pytest.raises(TypeError) as e:
+        ax = plt.subplot()
+        # legend() takes 0-2 arguments.
+        ax.legend(['First'], ['Second'], 3)
+    assert "legend() takes 0-2" in str(e.value)
+
+
+def test_nargs_pcolorfast():
+    with pytest.raises(TypeError) as e:
+        ax = plt.subplot()
+        # pcolorfast() takes 1 or 3 arguments,
+        # not passing any arguments fails at C = args[-1]
+        # before nargs_err is raised.
+        ax.pcolorfast([(0, 1), (0, 2)], [[1, 2, 3], [1, 2, 3]])
+    assert "pcolorfast() takes 1 or 3" in str(e.value)
+
+
 @image_comparison(['offset_points'], remove_text=True)
 def test_basic_annotate():
     # Setup some data

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -642,28 +642,25 @@ def test_sticky_shared_axes(fig_test, fig_ref):
 
 
 def test_nargs_stem():
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError, match='0 were given') as e:
         # stem() takes 1-3 arguments.
         plt.stem()
-    assert "stem() takes 1-3" in str(e.value)
 
 
 def test_nargs_legend():
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError, match='3 were given') as e:
         ax = plt.subplot()
         # legend() takes 0-2 arguments.
         ax.legend(['First'], ['Second'], 3)
-    assert "legend() takes 0-2" in str(e.value)
 
 
 def test_nargs_pcolorfast():
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError, match='2 were given') as e:
         ax = plt.subplot()
         # pcolorfast() takes 1 or 3 arguments,
         # not passing any arguments fails at C = args[-1]
         # before nargs_err is raised.
         ax.pcolorfast([(0, 1), (0, 2)], [[1, 2, 3], [1, 2, 3]])
-    assert "pcolorfast() takes 1 or 3" in str(e.value)
 
 
 @image_comparison(['offset_points'], remove_text=True)

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -118,6 +118,14 @@ def test_rcparams_init():
         mpl.RcParams({'figure.figsize': (3.5, 42, 1)})
 
 
+def test_nargs_cycler():
+    from matplotlib.rcsetup import cycler as ccl
+    with pytest.raises(TypeError) as e:
+        # cycler() takes 0-2 arguments.
+        ccl(ccl(color=list('rgb')), 2, 3)
+    assert "cycler() takes 0-2" in str(e.value)
+
+
 def test_Bug_2543():
     # Test that it possible to add all values to itself / deepcopy
     # https://github.com/matplotlib/matplotlib/issues/2543

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -120,7 +120,7 @@ def test_rcparams_init():
 
 def test_nargs_cycler():
     from matplotlib.rcsetup import cycler as ccl
-    with pytest.raises(TypeError, match='3 were given') as e:
+    with pytest.raises(TypeError, match='3 were given'):
         # cycler() takes 0-2 arguments.
         ccl(ccl(color=list('rgb')), 2, 3)
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -120,10 +120,9 @@ def test_rcparams_init():
 
 def test_nargs_cycler():
     from matplotlib.rcsetup import cycler as ccl
-    with pytest.raises(TypeError) as e:
+    with pytest.raises(TypeError, match='3 were given') as e:
         # cycler() takes 0-2 arguments.
         ccl(ccl(color=list('rgb')), 2, 3)
-    assert "cycler() takes 0-2" in str(e.value)
 
 
 def test_Bug_2543():


### PR DESCRIPTION
## PR summary
Resolves #25864 and adds tests for nargs_err in _axes.py and rcsetup.py. 
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
