### PR TITLE
Qt wheelEvent: use x coordinate if ALT is press

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -310,7 +310,9 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         # provided (`isNull()`) and is unreliable on X11 ("xcb").
         if (event.pixelDelta().isNull()
                 or QtWidgets.QApplication.instance().platformName() == "xcb"):
-            steps = event.angleDelta().y() / 120
+            # When using the 'alt' modifier QWheelEvent reverse the coordinates
+            steps = event.angleDelta().y() / 120 if ("alt" not in self._mpl_modifiers()
+                                                     ) else event.angleDelta().x() / 120
         else:
             steps = event.pixelDelta().y()
         if steps:


### PR DESCRIPTION
## PR summary
Based on what I found [here ](https://bugreports.qt.io/browse/QTBUG-91556)and [here](https://bugreports.qt.io/browse/QTCREATORBUG-25612) it looks like Qt default behaviour is to reverse the axis coordinates for the `WheelEvent` when the `'alt'` key is pressed, so I made a small modification to the `wheelEvent` method inside the `FigureCanvasQT` class to check if the key is pressed, if so, instead of using `angleDelta().y()`  we use `angleDelta().x()` to get the correct vertical movement.

I couldn't find a reference to the x axis anywhere in the code, and since the `wheelEvent` method only used the vertical movement, i don't think this would rise an issue in the future.

I don't know if this happens for `pixelDelta()` , since I can't test it.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #25671 " is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
