### PR TITLE
Fix TransformedBbox.{,full_}contains.

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -9,6 +9,7 @@ from matplotlib import scale
 import matplotlib.pyplot as plt
 import matplotlib.patches as mpatches
 import matplotlib.transforms as mtransforms
+from matplotlib.transforms import Affine2D, Bbox, TransformedBbox
 from matplotlib.path import Path
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
@@ -755,3 +756,14 @@ def test_offset_copy_errors():
     with pytest.raises(ValueError,
                        match='For units of inches or points a fig kwarg is needed'):
         mtransforms.offset_copy(None, units='inches')
+
+
+def test_transformedbbox_contains():
+    bb = TransformedBbox(Bbox.unit(), Affine2D().rotate_deg(30))
+    assert bb.contains(.8, .5)
+    assert bb.contains(-.4, .85)
+    assert not bb.contains(.9, .5)
+    bb = TransformedBbox(Bbox.unit(), Affine2D().translate(.25, .5))
+    assert bb.contains(1.25, 1.5)
+    assert not bb.fully_contains(1.25, 1.5)
+    assert not bb.fully_contains(.1, .1)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1138,6 +1138,14 @@ class TransformedBbox(BboxBase):
             self._check(points)
             return points
 
+    def contains(self, x, y):
+        # Docstring inherited.
+        return self._bbox.contains(*self._transform.inverted().transform((x, y)))
+
+    def fully_contains(self, x, y):
+        # Docstring inherited.
+        return self._bbox.fully_contains(*self._transform.inverted().transform((x, y)))
+
 
 class LockableBbox(BboxBase):
     """


### PR DESCRIPTION
... by checking whether the inverse-transformed the query point is in the untransformed bbox.

Closes #12057.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
