### PR TITLE
#25220

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -585,6 +585,8 @@ non-rectilinear Axes.
    Axes.get_xaxis_text2_transform
    Axes.get_yaxis_text1_transform
    Axes.get_yaxis_text2_transform
+   
+   Axes.transData
 
 
 Other

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -561,6 +561,12 @@ class _AxesBase(martist.Artist):
 
     _subclass_uses_cla = False
 
+    transData = None
+    """
+    a transformation object that converts data coordinates into a
+    coordinate system used to display data on graph axes
+    """
+
     @property
     def _axis_map(self):
         """A mapping of axis names, e.g. 'x', to `Axis` instances."""


### PR DESCRIPTION
I added in _base.py defining the Axes.transData attribute and added documentation generation for it to axes_api.rst. It seems to me that this is enough for the user to understand from the github documentation what Axes.transData is.