### PR TITLE
changed incubator invite channel link to community channel

### DIFF
--- a/doc/devel/contributing.rst
+++ b/doc/devel/contributing.rst
@@ -99,7 +99,7 @@ process works, technical questions about the code, what makes for good
 documentation or a blog post, how to get involved in community work, or get a
 "pre-review" on your PR.
 
-To join, please go to our public gitter_ community channel, and ask to be added
+To join, please go to our public community_ channel, and ask to be added
 to ``#incubator``. One of our core developers will see your message and
 will add you.
 
@@ -608,3 +608,4 @@ example code you can load it into a file handle with::
     fh = cbook.get_sample_data('mydata.dat')
 
 .. _gitter: https://gitter.im/matplotlib/matplotlib
+.. _community: https://gitter.im/matplotlib/community


### PR DESCRIPTION
## PR summary
Per call, changed the channel for incubator invite requests to community. Pulled this out of #25913 cause I was doing a lot there and didn't want this getting tangled up in those reviews. 