### PR TITLE
DOC: Fix figure annotation example

### DIFF
--- a/galleries/examples/text_labels_and_annotations/annotation_demo.py
+++ b/galleries/examples/text_labels_and_annotations/annotation_demo.py
@@ -53,7 +53,7 @@ from matplotlib.text import OffsetFrom
 #   any key for matplotlib.patches.polygon  (e.g., facecolor)
 
 # Create our figure and data we'll use for plotting
-fig, ax = plt.subplots(figsize=(3, 3))
+fig, ax = plt.subplots(figsize=(4, 4))
 
 t = np.arange(0.0, 5.0, 0.01)
 s = np.cos(2*np.pi*t)
@@ -63,7 +63,8 @@ line, = ax.plot(t, s)
 ax.annotate('figure pixels',
             xy=(10, 10), xycoords='figure pixels')
 ax.annotate('figure points',
-            xy=(80, 80), xycoords='figure points')
+            xy=(107, 110), xycoords='figure points',
+            fontsize=12)
 ax.annotate('figure fraction',
             xy=(.025, .975), xycoords='figure fraction',
             horizontalalignment='left', verticalalignment='top',
@@ -72,14 +73,14 @@ ax.annotate('figure fraction',
 # The following examples show off how these arrows are drawn.
 
 ax.annotate('point offset from data',
-            xy=(2, 1), xycoords='data',
-            xytext=(-15, 25), textcoords='offset points',
+            xy=(3, 1), xycoords='data',
+            xytext=(-10, 90), textcoords='offset points',
             arrowprops=dict(facecolor='black', shrink=0.05),
-            horizontalalignment='right', verticalalignment='bottom')
+            horizontalalignment='center', verticalalignment='bottom')
 
 ax.annotate('axes fraction',
-            xy=(3, 1), xycoords='data',
-            xytext=(0.8, 0.95), textcoords='axes fraction',
+            xy=(2, 1), xycoords='data',
+            xytext=(0.36, 0.68), textcoords='axes fraction',
             arrowprops=dict(facecolor='black', shrink=0.05),
             horizontalalignment='right', verticalalignment='top')
 


### PR DESCRIPTION
## PR summary
The first example in the [Annotation Demo](https://matplotlib.org/devdocs/gallery/text_labels_and_annotations/annotation_demo.html#specifying-text-points-and-annotation-points) is very cramped, with text disappearing offscreen. I propose some minor changes to the script, shown in the before and after images below.

**Before:**
<a href='https://postimages.org/' target='_blank'><img src='https://i.postimg.cc/vmM4TBPy/old-figure.png' border='0' alt='old-figure'/></a>

**After:**
<a href='https://postimages.org/' target='_blank'><img src='https://i.postimg.cc/5tqFSvHj/new-figure.png' border='0' alt='new-figure'/></a>