### PR TITLE
Add note that subfigure is still provisional to docstring

### DIFF
--- a/galleries/examples/subplots_axes_and_figures/subfigures.py
+++ b/galleries/examples/subplots_axes_and_figures/subfigures.py
@@ -14,7 +14,7 @@ Matplotlib also has "subfigures", accessed by calling
 that subfigures can also have their own child subfigures.
 
 .. note::
-    ``subfigure`` is new in v3.4, and the API is still provisional.
+    The *subfigure* concept is new in v3.4, and the API is still provisional.
 
 """
 import matplotlib.pyplot as plt

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1552,6 +1552,9 @@ default: %(va)s
         the same as a figure, but cannot print itself.
         See :doc:`/gallery/subplots_axes_and_figures/subfigures`.
 
+        .. note::
+            The *subfigure* concept is new in v3.4, and the API is still provisional.
+
         Parameters
         ----------
         nrows, ncols : int, default: 1
@@ -2151,6 +2154,9 @@ class SubFigure(FigureBase):
         axsR = sfigs[1].subplots(2, 1)
 
     See :doc:`/gallery/subplots_axes_and_figures/subfigures`
+
+    .. note::
+        The *subfigure* concept is new in v3.4, and the API is still provisional.
     """
 
     def __init__(self, parent, subplotspec, *,


### PR DESCRIPTION
Assuming we still leave is provisional in 3.8 per https://github.com/matplotlib/matplotlib/issues/25947#issuecomment-1557689476

This matches the notes at https://matplotlib.org/stable/gallery/subplots_axes_and_figures/subfigures.html#figure-subfigures

