### PR TITLE
Drop metadata table when subsetting fonts

### DIFF
--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -36,8 +36,13 @@ def get_glyphs_subset(fontfile, characters):
 
     options = subset.Options(glyph_names=True, recommended_glyphs=True)
 
-    # prevent subsetting FontForge Timestamp and other tables
-    options.drop_tables += ['FFTM', 'PfEd', 'BDF']
+    # Prevent subsetting extra tables.
+    options.drop_tables += [
+        'FFTM',  # FontForge Timestamp.
+        'PfEd',  # FontForge personal table.
+        'BDF',  # X11 BDF header.
+        'meta',  # Metadata stores design/supported languages (meaningless for subsets).
+    ]
 
     # if fontfile is a ttc, specify font number
     if fontfile.endswith(".ttc"):


### PR DESCRIPTION
## PR summary

This table contains a list of design/supported languages, which it doesn't make sense to keep in a subset.

I don't really know that there's an easy way to test, as the current known trigger is Times New Roman, which we can't ship here.

Fixes #24025

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines