### PR TITLE
test annotate(textcoords=offset fontsize)

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -886,3 +886,19 @@ def test_metrics_cache():
     # Every string gets a miss for the first layouting (extents), then a hit
     # when drawing, but "foo\nbar" gets two hits as it's drawn twice.
     assert info.hits > info.misses
+
+
+def test_annotate_offset_fontsize():
+    # Test that offset_fontsize parameter works and uses accurate values
+    fig, ax = plt.subplots()
+    text_coords = ['offset points', 'offset fontsize']
+    # 10 points should be equal to 1 fontsize unit at fontsize=10
+    xy_text = [(10, 10), (1, 1)]
+    anns = [ax.annotate('test', xy=(0.5, 0.5),
+                        xytext=xy_text[i],
+                        fontsize='10',
+                        xycoords='data',
+                        textcoords=text_coords[i]) for i in range(2)]
+    points_coords, fontsize_coords = [ann.get_window_extent() for ann in anns]
+    fig.canvas.draw()
+    assert str(points_coords) == str(fontsize_coords)


### PR DESCRIPTION
## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->
Closes #25907. Adds a test to check that the annotation `offset_fontsize` parameter actually offsets the text by the correct fontsize units. The unit distance was measured by comparing the fontsize against the number of points in `offset_points`
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
