### PR TITLE
More consistent handling of 'None' vs. 'none'

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2134,7 +2134,7 @@ class Axes(_AxesBase):
             b = self.axhline(**kwargs)
         else:
             kwargs.setdefault('marker', 'o')
-            kwargs.setdefault('linestyle', 'None')
+            kwargs.setdefault('linestyle', 'none')
             a, = self.plot(lags, correls, **kwargs)
             b = None
         return lags, correls, a, b
@@ -8080,7 +8080,7 @@ such objects
             if 'linestyle' in kwargs:
                 raise _api.kwarg_error("spy", "linestyle")
             ret = mlines.Line2D(
-                x, y, linestyle='None', marker=marker, markersize=markersize,
+                x, y, linestyle='none', marker=marker, markersize=markersize,
                 **kwargs)
             self.add_line(ret)
             nr, nc = Z.shape

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -201,7 +201,7 @@ def _process_plot_format(fmt, *, ambiguous_fmt_datakey=False):
     if linestyle is None and marker is None:
         linestyle = mpl.rcParams['lines.linestyle']
     if linestyle is None:
-        linestyle = 'none'
+        linestyle = 'None'
     if marker is None:
         marker = 'None'
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -201,7 +201,7 @@ def _process_plot_format(fmt, *, ambiguous_fmt_datakey=False):
     if linestyle is None and marker is None:
         linestyle = mpl.rcParams['lines.linestyle']
     if linestyle is None:
-        linestyle = 'None'
+        linestyle = 'none'
     if marker is None:
         marker = 'None'
 

--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -15,7 +15,8 @@ LINESTYLES = {'-': 'Solid',
               '--': 'Dashed',
               '-.': 'DashDot',
               ':': 'Dotted',
-              'None': 'None',
+              'None': 'none',
+              'none': 'none'
               }
 
 DRAWSTYLES = {

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -572,7 +572,7 @@ class HandlerErrorbar(HandlerLine2D):
             legline.set_marker('none')
 
             self.update_prop(legline_marker, plotlines, legend)
-            legline_marker.set_linestyle('None')
+            legline_marker.set_linestyle('none')
 
             if legend.markerscale != 1:
                 newsz = legline_marker.get_markersize() * legend.markerscale

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -36,7 +36,7 @@ def _get_dash_pattern(style):
     if isinstance(style, str):
         style = ls_mapper.get(style, style)
     # un-dashed styles
-    if style in ['solid', 'None']:
+    if style in ['solid', 'none', 'None']:
         offset = 0
         dashes = None
     # dashed styles
@@ -240,6 +240,7 @@ class Line2D(Artist):
         '-.':   '_draw_dash_dot',
         ':':    '_draw_dotted',
         'None': '_draw_nothing',
+        'none': '_draw_nothing',
         ' ':    '_draw_nothing',
         '':     '_draw_nothing',
     }
@@ -476,7 +477,7 @@ class Line2D(Artist):
         # the error flags accordingly.
         with np.errstate(all='ignore'):
             # Check for collision
-            if self._linestyle in ['None', None]:
+            if self._linestyle in ['none', 'None', None]:
                 # If no line, return the nearby point(s)
                 ind, = np.nonzero(
                     (xt - mouseevent.x) ** 2 + (yt - mouseevent.y) ** 2
@@ -1168,8 +1169,8 @@ class Line2D(Artist):
             For examples see :doc:`/gallery/lines_bars_and_markers/linestyles`.
         """
         if isinstance(ls, str):
-            if ls in [' ', '', 'none']:
-                ls = 'None'
+            if ls in [' ', '', 'None']:
+                ls = 'none'
             _api.check_in_list([*self._lineStyles, *ls_mapper_r], ls=ls)
             if ls not in self._lineStyles:
                 ls = ls_mapper_r[ls]

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -421,8 +421,8 @@ class Patch(artist.Artist):
         """
         if ls is None:
             ls = "solid"
-        if ls in [' ', '', 'none']:
-            ls = 'None'
+        if ls in [' ', '', 'None']:
+            ls = 'none'
         self._linestyle = ls
         self._unscaled_dash_pattern = mlines._get_dash_pattern(ls)
         self._dash_pattern = mlines._scale_dashes(

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -348,7 +348,7 @@ def validate_aspect(s):
 
 
 def validate_fontsize_None(s):
-    if s is None or s == 'None':
+    if s is None or s == 'None' or s == 'none':
         return None
     else:
         return validate_fontsize(s)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4178,7 +4178,7 @@ def test_stem_markerfmt():
                 markercolor)
         if marker is not None:
             assert stem_container.markerline.get_marker() == marker
-        assert stem_container.markerline.get_linestyle() == 'None'
+        assert stem_container.markerline.get_linestyle() == 'none'
 
     fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3939,7 +3939,7 @@ def test_errorbar_line_specific_kwargs():
     x = np.arange(5)
     y = np.arange(5)
 
-    plotline, _, _ = plt.errorbar(x, y, xerr=1, yerr=1, ls='None',
+    plotline, _, _ = plt.errorbar(x, y, xerr=1, yerr=1, ls='none',
                                   marker='s', fillstyle='full',
                                   drawstyle='steps-mid',
                                   dash_capstyle='round',

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1201,7 +1201,7 @@ def test_legend_markers_from_line2d():
     # Test that markers can be copied for legend lines (#17960)
     _markers = ['.', '*', 'v']
     fig, ax = plt.subplots()
-    lines = [mlines.Line2D([0], [0], ls='None', marker=mark)
+    lines = [mlines.Line2D([0], [0], ls='none', marker=mark)
              for mark in _markers]
     labels = ["foo", "bar", "xyzzy"]
     markers = [line.get_marker() for line in lines]

--- a/lib/matplotlib/tri/_triplot.py
+++ b/lib/matplotlib/tri/_triplot.py
@@ -63,7 +63,7 @@ def triplot(ax, *args, **kwargs):
         'marker': 'None',  # No marker to draw.
         'zorder': kw.get('zorder', 1),  # Path default zorder is used.
     }
-    if linestyle not in [None, 'None', '', ' ']:
+    if linestyle not in [None, 'None', 'none', '', ' ']:
         tri_lines_x = np.insert(x[edges], 2, np.nan, axis=1)
         tri_lines_y = np.insert(y[edges], 2, np.nan, axis=1)
         tri_lines = ax.plot(tri_lines_x.ravel(), tri_lines_y.ravel(),
@@ -75,7 +75,7 @@ def triplot(ax, *args, **kwargs):
     marker = kw['marker']
     kw_markers = {
         **kw,
-        'linestyle': 'None',  # No line to draw.
+        'linestyle': 'none',  # No line to draw.
     }
     kw_markers.pop('label', None)
     if marker not in [None, 'None', '', ' ']:

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3048,7 +3048,7 @@ class Axes3D(Axes):
                 eb_lines_style[key] = kwargs[key]
 
         # Make the style dict for caps (the "hats").
-        eb_cap_style = {**base_style, 'linestyle': 'None'}
+        eb_cap_style = {**base_style, 'linestyle': 'none'}
         if capsize is None:
             capsize = mpl.rcParams["errorbar.capsize"]
         if capsize > 0:


### PR DESCRIPTION
## PR summary
closes #19300
Hello, I've made some changes to improve the consistency handling of 'None' vs 'none' when it comes to the linestyles code. Just like proposed in the issue, i chose 'none' since its looks more distant than None (like NULL) 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #19300" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
