### PR TITLE
Fix backend tests on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,13 +62,21 @@ jobs:
             python-version: 3.9
             extra-requirements: '-r requirements/testing/extra.txt'
             CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
+            # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
+            pyside6-ver: '!=6.5.1'
           - os: ubuntu-20.04
             python-version: '3.10'
             extra-requirements: '-r requirements/testing/extra.txt'
+            # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
+            pyside6-ver: '!=6.5.1'
           - os: ubuntu-20.04
             python-version: '3.11'
+            # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
+            pyside6-ver: '!=6.5.1'
           - os: macos-latest
             python-version: 3.9
+            # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
+            pyside6-ver: '!=6.5.1'
 
     steps:
       - uses: actions/checkout@v3

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -38,6 +38,11 @@ def _isolated_tk_test(success_count, func=None):
         sys.platform == "linux" and not _c_internal_utils.display_is_valid(),
         reason="$DISPLAY and $WAYLAND_DISPLAY are unset"
     )
+    @pytest.mark.xfail(  # https://github.com/actions/setup-python/issues/649
+        'TF_BUILD' in os.environ and sys.platform == 'darwin' and
+        sys.version_info[:2] == (3, 10),
+        reason='Tk version mismatch on Azure macOS CI'
+    )
     @functools.wraps(func)
     def test_func():
         # even if the package exists, may not actually be importable this can

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -63,6 +63,10 @@ def _get_testable_interactive_backends():
         elif env["MPLBACKEND"].startswith('wx') and sys.platform == 'darwin':
             # ignore on OSX because that's currently broken (github #16849)
             marks.append(pytest.mark.xfail(reason='github #16849'))
+        elif (env['MPLBACKEND'] == 'tkagg' and 'TF_BUILD' in os.environ and
+              sys.platform == 'darwin' and sys.version_info[:2] == (3, 10)):
+            marks.append(  # https://github.com/actions/setup-python/issues/649
+                pytest.mark.xfail(reason='Tk version mismatch on Azure macOS CI'))
         envs.append(
             pytest.param(
                 {**env, 'BACKEND_DEPS': ','.join(deps)},
@@ -271,6 +275,10 @@ for param in _thread_safe_backends:
                 reason='PyPy does not support Tkinter threading: '
                        'https://foss.heptapod.net/pypy/pypy/-/issues/1929',
                 strict=True))
+    elif (backend == 'tkagg' and 'TF_BUILD' in os.environ and
+          sys.platform == 'darwin' and sys.version_info[:2] == (3, 10)):
+        param.marks.append(  # https://github.com/actions/setup-python/issues/649
+            pytest.mark.xfail('Tk version mismatch on Azure macOS CI'))
 
 
 @pytest.mark.parametrize("env", _thread_safe_backends)
@@ -540,6 +548,11 @@ for param in _blit_backends:
     elif backend == "wx":
         param.marks.append(
             pytest.mark.skip("wx does not support blitting"))
+    elif (backend == 'tkagg' and 'TF_BUILD' in os.environ and
+          sys.platform == 'darwin' and sys.version_info[:2] == (3, 10)):
+        param.marks.append(  # https://github.com/actions/setup-python/issues/649
+            pytest.mark.xfail('Tk version mismatch on Azure macOS CI')
+        )
 
 
 @pytest.mark.parametrize("env", _blit_backends)


### PR DESCRIPTION
## PR summary

Fixes #25988 by skipping that version of PySide6, and fixes the Azure macOS build by xfailing the tests as in #23095.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines