### PR TITLE
added raise condition and grouped Tick constructor parameters

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -57,25 +57,12 @@ class Tick(martist.Artist):
     """
     def __init__(
         self, axes, loc, *,
-        size=None,  # points
-        width=None,
-        color=None,
-        tickdir=None,
-        pad=None,
-        labelsize=None,
-        labelcolor=None,
-        zorder=None,
-        gridOn=None,  # defaults to axes.grid depending on axes.grid.which
-        tick1On=True,
-        tick2On=True,
-        label1On=True,
-        label2On=False,
-        major=True,
-        labelrotation=0,
-        grid_color=None,
-        grid_linestyle=None,
-        grid_linewidth=None,
-        grid_alpha=None,
+        size=None, width=None, color=None, major=True, pad=None, zorder=None,  # global
+        tickdir=None, tick1On=True, tick2On=True,  # tick prop
+        labelsize=None, labelcolor=None, labelrotation=0,  # label prop
+        label1On=True, label2On=False,  # label prop
+        grid_color=None, grid_linestyle=None, grid_linewidth=None,  # grid prop
+        grid_alpha=None, gridOn=None,  # grid prop
         **kwargs,  # Other Line2D kwargs applied to gridlines.
     ):
         """
@@ -152,6 +139,11 @@ class Tick(martist.Artist):
             # so the that the rcParams default would override color alpha.
             grid_alpha = mpl.rcParams["grid.alpha"]
         grid_kw = {k[5:]: v for k, v in kwargs.items()}
+
+        remaining_kwargs = {
+            k: v for k, v in kwargs.items() if not k.startswith('grid_')}
+        if remaining_kwargs:
+            raise ValueError(f"Invalid kwargs: {remaining_kwargs.keys()}")
 
         self.tick1line = mlines.Line2D(
             [], [],


### PR DESCRIPTION
## PR summary
closes #26008 
Grouped constructor parameters as described in issue
```
def __init__(
        self, axes, loc, *,
        size=None, width=None, color=None, major=True, pad=None, zorder=None,  # global
        tickdir=None, tick1On=True, tick2On=True,  # tick prop
        labelsize=None, labelcolor=None, labelrotation=0,  # label prop
        label1On=True, label2On=False,  # label prop
        grid_color=None, grid_linestyle=None, grid_linewidth=None,  # grid prop
        grid_alpha=None, gridOn=None,  # grid prop
        **kwargs,  # Other Line2D kwargs applied to gridlines.
    ):
```

and created raise condition
```
remaining_kwargs = {
            k: v for k, v in kwargs.items() if not k.startswith('grid_')}
        if remaining_kwargs:
            raise ValueError(f"Invalid kwargs: {remaining_kwargs.keys()}")
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
