### PR TITLE
Let collections return linewidths "as is", without cycling.

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -407,7 +407,7 @@ class HandlerLineCollection(HandlerLine2D):
 
     def _default_update_prop(self, legend_handle, orig_handle):
         lw = orig_handle.get_linewidths()[0]
-        dashes = orig_handle._us_linestyles[0]
+        dashes = orig_handle._unscaled_linestyles[0]
         color = orig_handle.get_colors()[0]
         legend_handle.set_color(color)
         legend_handle.set_linestyle(dashes)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -605,7 +605,7 @@ def test_lslw_bcast():
     col.set_linewidths([1, 2, 3])
 
     assert col.get_linestyles() == [(0, None)] * 6
-    assert col.get_linewidths() == [1, 2, 3] * 2
+    assert (col.get_linewidths() == [1, 2, 3]).all()
 
     col.set_linestyles(['-', '-', '-'])
     assert col.get_linestyles() == [(0, None)] * 3


### PR DESCRIPTION
Previously, collections would return a "cycled" version of linewidths which is internally used to scale dashes (this scaling needs to be done at property setting time, because of the interaction with styles).

While it makes sense to store the cycled scaled dashes, there's no need to also store the cycled linewidths or pass that to the backend code -- directly using the uncycled linewidths seems simpler.  This also makes collection.get_linewidths() return something much closer to whatever was passed in -- see the test change in test_lslw_bcast.

Also, "broadcasting" has a technical meaning in numpy; it's not the same thing as cycling.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
