### PR TITLE
Privatize TexManager.texcache

### DIFF
--- a/doc/api/next_api_changes/deprecations/26056-OG.rst
+++ b/doc/api/next_api_changes/deprecations/26056-OG.rst
@@ -1,0 +1,5 @@
+``TexManager.texcache``
+~~~~~~~~~~~~~~~~~~~~~~~
+
+... is considered private and deprecated. The location of the cache directory is
+clarified in the doc-string.

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -574,7 +574,7 @@ def get_cachedir():
     Return the string path of the cache directory.
 
     The procedure used to find the directory is the same as for
-    _get_config_dir, except using ``$XDG_CACHE_HOME``/``$HOME/.cache`` instead.
+    `get_configdir`, except using ``$XDG_CACHE_HOME``/``$HOME/.cache`` instead.
     """
     return _get_config_or_cache_dir(_get_xdg_cache_dir)
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -31,7 +31,7 @@ from tempfile import TemporaryDirectory
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import cbook, dviread
+from matplotlib import _api, cbook, dviread
 
 _log = logging.getLogger(__name__)
 
@@ -57,10 +57,14 @@ class TexManager:
     """
     Convert strings to dvi files using TeX, caching the results to a directory.
 
+    The cache directory is called ``tex.cache`` and is located is the directory
+    returned by `.get_cachedir`.
+
     Repeated calls to this constructor always return the same instance.
     """
 
-    texcache = os.path.join(mpl.get_cachedir(), 'tex.cache')
+    texcache = _api.deprecate_privatize_attribute("3.8")
+    _texcache = os.path.join(mpl.get_cachedir(), 'tex.cache')
     _grey_arrayd = {}
 
     _font_families = ('serif', 'sans-serif', 'cursive', 'monospace')
@@ -102,7 +106,7 @@ class TexManager:
 
     @functools.lru_cache  # Always return the same instance.
     def __new__(cls):
-        Path(cls.texcache).mkdir(parents=True, exist_ok=True)
+        Path(cls._texcache).mkdir(parents=True, exist_ok=True)
         return object.__new__(cls)
 
     @classmethod
@@ -168,7 +172,7 @@ class TexManager:
         """
         src = cls._get_tex_source(tex, fontsize) + str(dpi)
         filehash = hashlib.md5(src.encode('utf-8')).hexdigest()
-        filepath = Path(cls.texcache)
+        filepath = Path(cls._texcache)
 
         num_letters, num_levels = 2, 2
         for i in range(0, num_letters*num_levels, num_letters):
@@ -244,7 +248,7 @@ class TexManager:
         _log.debug(cbook._pformat_subprocess(command))
         try:
             report = subprocess.check_output(
-                command, cwd=cwd if cwd is not None else cls.texcache,
+                command, cwd=cwd if cwd is not None else cls._texcache,
                 stderr=subprocess.STDOUT)
         except FileNotFoundError as exc:
             raise RuntimeError(
@@ -330,7 +334,7 @@ class TexManager:
         alpha = cls._grey_arrayd.get(key)
         if alpha is None:
             pngfile = cls.make_png(tex, fontsize, dpi)
-            rgba = mpl.image.imread(os.path.join(cls.texcache, pngfile))
+            rgba = mpl.image.imread(os.path.join(cls._texcache, pngfile))
             cls._grey_arrayd[key] = alpha = rgba[:, :, -1]
         return alpha
 

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -57,7 +57,7 @@ class TexManager:
     """
     Convert strings to dvi files using TeX, caching the results to a directory.
 
-    The cache directory is called ``tex.cache`` and is located is the directory
+    The cache directory is called ``tex.cache`` and is located in the directory
     returned by `.get_cachedir`.
 
     Repeated calls to this constructor always return the same instance.


### PR DESCRIPTION
## PR summary

Closes #25942

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
