### PR TITLE
Tweak AnnotationBbox coords specification.

### DIFF
--- a/galleries/examples/text_labels_and_annotations/demo_text_path.py
+++ b/galleries/examples/text_labels_and_annotations/demo_text_path.py
@@ -113,11 +113,7 @@ if __name__ == "__main__":
         offsetbox.add_artist(text_patch)
 
         # place the anchored offset box using AnnotationBbox
-        ab = AnnotationBbox(offsetbox, (xpos, 0.5),
-                            xycoords='data',
-                            boxcoords="offset points",
-                            box_alignment=(0.5, 0.5),
-                            )
+        ab = AnnotationBbox(offsetbox, (xpos, 0.5), box_alignment=(0.5, 0.5))
 
         ax2.add_artist(ab)
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1224,9 +1224,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         return f"AnnotationBbox({self.xy[0]:g},{self.xy[1]:g})"
 
     @_docstring.dedent_interpd
-    def __init__(self, offsetbox, xy, xybox=None, *,
-                 xycoords='data',
-                 boxcoords=None,
+    def __init__(self, offsetbox, xy, xybox=None, xycoords='data', boxcoords=None, *,
                  frameon=True, pad=0.4,  # FancyBboxPatch boxstyle.
                  annotation_clip=None,
                  box_alignment=(0.5, 0.5),

--- a/lib/matplotlib/offsetbox.pyi
+++ b/lib/matplotlib/offsetbox.pyi
@@ -240,7 +240,6 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         offsetbox: OffsetBox,
         xy: tuple[float, float],
         xybox: tuple[float, float] | None = ...,
-        *,
         xycoords: str
         | tuple[str, str]
         | martist.Artist
@@ -252,6 +251,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
         | Transform
         | Callable[[RendererBase], Bbox | Transform]
         | None = ...,
+        *,
         frameon: bool = ...,
         pad: float = ...,
         annotation_clip: bool | None = ...,


### PR DESCRIPTION
In AnnotationBbox, it makes sense to allow passing xycoords and boxcoords positionally, because (similarly to annotate()) something like `AnnotationBbox(box, xy1, xy2, "axes transform", "offset points")` (for example) actually reads better than
`AnnotationBbox(box, xy1, xy2, xycoords="axes transform", boxcoords="offset points")` once you've seen this often enough and learn that the positional order is just (annotated_xy, box_xy, annotated_coords, box_coords).  (The alternative that's fully explicit would be
`AnnotationBbox(box, xy=xy1, xybox=xy2, xycoords=..., boxcoords=...)` but even that doesn't read too well because the xy kwargs names don't rhyme exactly with the coords names; or one could reorder the args to `AnnotationBbox(box, xy=xy1, xycoords=..., xybox=xy2, boxcoords=...)`, but that's really a mouthful and doesn't help API usability.)

So let's just allow passing the coordinate systems positionally (undoing the change in Matplotlib 3.6 that made them kwonly).  The following kwargs do remain kwonly, though.

In demo_text_path: xycoords defaults to "data" so doesn't need to be specified; xybox is not specified so boxcoords is not needed.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
