### PR TITLE
ENH: macosx allow figures to be opened in tabs or windows

### DIFF
--- a/doc/users/next_whats_new/macosx_windows_tabs.rst
+++ b/doc/users/next_whats_new/macosx_windows_tabs.rst
@@ -1,0 +1,7 @@
+macosx: New figures can be opened in either windows or tabs
+-----------------------------------------------------------
+
+There is a new :rc:`macosx.window_mode`` rcParam to control how
+new figures are opened with the macosx backend. The default is
+**system** which uses the system settings, or one can specify either
+**tab** or **window** to explicitly choose the mode used to open new figures.

--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -145,6 +145,7 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
         icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
         _macosx.FigureManager.set_icon(icon_path)
         FigureManagerBase.__init__(self, canvas, num)
+        self._set_window_mode(mpl.rcParams.get("macosx.window_mode", "system"))
         if self.toolbar is not None:
             self.toolbar.update()
         if mpl.is_interactive():

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -701,6 +701,10 @@
                                 # background by default
 #savefig.orientation: portrait  # orientation of saved figure, for PostScript output only
 
+### macosx backend params
+#macosx.window_mode : system   # How to open new figures (system, tab, window)
+                               # system uses the MacOS system preferences
+
 ### tk backend params
 #tk.window_focus:   False  # Maintain shell focus for TkAgg
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1214,6 +1214,7 @@ _validators = {
     "figure.autolayout":       validate_bool,
     "figure.max_open_warning": validate_int,
     "figure.raise_window":     validate_bool,
+    "macosx.window_mode":      ["system", "tab", "window"],
 
     "figure.subplot.left":   validate_float,
     "figure.subplot.right":  validate_float,

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -854,7 +854,7 @@ static PyTypeObject FigureManagerType = {
         {"_set_window_mode",
          (PyCFunction)FigureManager__set_window_mode,
          METH_VARARGS,
-         "Set the window open mode (auto, tab, window)"},
+         "Set the window open mode (system, tab, window)"},
         {"set_icon",
          (PyCFunction)FigureManager_set_icon,
          METH_STATIC | METH_VARARGS,

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -690,6 +690,25 @@ FigureManager_init(FigureManager *self, PyObject *args, PyObject *kwds)
 }
 
 static PyObject*
+FigureManager__set_window_mode(FigureManager* self, PyObject* args)
+{
+    const char* window_mode;
+    if (!PyArg_ParseTuple(args, "s", &window_mode) || !self->window) {
+        return NULL;
+    }
+
+    NSString* window_mode_str = [NSString stringWithUTF8String: window_mode];
+    if ([window_mode_str isEqualToString: @"tab"]) {
+        [self->window setTabbingMode: NSWindowTabbingModePreferred];
+    } else if ([window_mode_str isEqualToString: @"window"]) {
+        [self->window setTabbingMode: NSWindowTabbingModeDisallowed];
+    } else { // system settings
+        [self->window setTabbingMode: NSWindowTabbingModeAutomatic];
+    }
+    Py_RETURN_NONE;
+}
+
+static PyObject*
 FigureManager_repr(FigureManager* self)
 {
     return PyUnicode_FromFormat("FigureManager object %p wrapping NSWindow %p",
@@ -832,6 +851,10 @@ static PyTypeObject FigureManagerType = {
         {"destroy",
          (PyCFunction)FigureManager_destroy,
          METH_NOARGS},
+        {"_set_window_mode",
+         (PyCFunction)FigureManager__set_window_mode,
+         METH_VARARGS,
+         "Set the window open mode (auto, tab, window)"},
         {"set_icon",
          (PyCFunction)FigureManager_set_icon,
          METH_STATIC | METH_VARARGS,


### PR DESCRIPTION
## PR summary

Allow users to select how new figures are created when opening new windows. The default is to keep using the system preferences, but one can also select "tab" or "window" to override the default system preferences. I've called the new rcParam `figure.window_mode`, but definitely open to other suggestions. This is currently only enabled on macosx backend, but I could see it being possible on others in the future as well which is why I put it under `figure.*` and not under the more specific `macosx.*`, but I could also see how this would lead to confusion when users set this and don't get the desired result.

closes #13164

Example of the first figure opening in a new window, and the next two figures opening in a separate window with tabs.
```python
import matplotlib.pyplot as plt
import matplotlib as mpl
import numpy as np

x = np.linspace(0, 2, 100)

mpl.rcParams["macosx.window_mode"] = "window"
f1 = plt.figure(1)
plt.plot(x,x**2)

mpl.rcParams["macosx.window_mode"] = "tab"
f2 = plt.figure(2)
plt.plot(x,x**2)

f3 = plt.figure(3)
plt.plot(x,x**2)

plt.show()
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
