### PR TITLE
Let the left axis and right axis be aligned

### DIFF
--- a/lib/matplotlib/twinxalign.py
+++ b/lib/matplotlib/twinxalign.py
@@ -1,0 +1,34 @@
+"""
+Let the left axis and right axis be aligned 
+at the specified position in twin coordinate axis
+"""
+
+
+def twinxalign(ax_left, ax_right, v_left, v_right):
+    """
+    Let the position `v_left` on `ax_left`
+    and the position `v_right` on `ax_left` be aligned
+    """
+    left_min, left_max = ax_left.get_ybound()
+    right_min, right_max = ax_right.get_ybound()
+    k = (left_max-left_min) / (right_max-right_min)
+    b = left_min - k * right_min
+    x_right_new = k * v_right + b
+    dif = x_right_new - v_left
+    if dif >= 0:
+        right_min_new = ((left_min-dif) - b) / k
+        k_new = (left_min-v_left) / (right_min_new-v_right)
+        b_new = v_left - k_new * v_right
+        right_max_new = (left_max - b_new) / k_new
+    else:
+        right_max_new = ((left_max-dif) - b) / k
+        k_new = (left_max-v_left) / (right_max_new-v_right)
+        b_new = v_left - k_new * v_right
+        right_min_new = (left_min - b_new) / k_new    
+    def _forward(x):
+        return k_new * x + b_new
+    def _inverse(x):
+        return (x - b_new) / k_new
+    ax_right.set_ylim([right_min_new, right_max_new])
+    ax_right.set_yscale('function', functions=(_forward, _inverse))
+    return ax_left, ax_right


### PR DESCRIPTION
Let the left axis and right axis be aligned at the specified position in twin coordinate axis

## PR summary
Let the position `v_left` on `ax_left` and the position `v_right` on `ax_left` be aligned

**before twinxalign**:
![image](https://github.com/matplotlib/matplotlib/assets/19773170/d0e2c61a-63bc-4d5d-9cdc-6b10f8a8b269)

**after twinxalign**:
![image](https://github.com/matplotlib/matplotlib/assets/19773170/ccc17c09-bbb4-4128-a33f-16a686678307)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [&check;] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
