### PR TITLE
Tweak Annotation docstring.

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1745,15 +1745,15 @@ or callable, default: value of *xycoords*
             If *arrowprops* does not contain the key 'arrowstyle' the
             allowed keys are:
 
-            ==========   ======================================================
-            Key          Description
-            ==========   ======================================================
-            width        The width of the arrow in points
-            headwidth    The width of the base of the arrow head in points
-            headlength   The length of the arrow head in points
-            shrink       Fraction of total length to shrink from both ends
-            ?            Any key to :class:`matplotlib.patches.FancyArrowPatch`
-            ==========   ======================================================
+            ==========  =================================================
+            Key         Description
+            ==========  =================================================
+            width       The width of the arrow in points
+            headwidth   The width of the base of the arrow head in points
+            headlength  The length of the arrow head in points
+            shrink      Fraction of total length to shrink from both ends
+            ?           Any `.FancyArrowPatch` property
+            ==========  =================================================
 
             The arrow is attached to the edge of the text box, the exact
             position (corners or centers) depending on where it's pointing to.
@@ -1762,23 +1762,22 @@ or callable, default: value of *xycoords*
 
             This is used if 'arrowstyle' is provided in the *arrowprops*.
 
-            Valid keys are the following `~matplotlib.patches.FancyArrowPatch`
-            parameters:
+            Valid keys are the following `.FancyArrowPatch` parameters:
 
-            ===============  ==================================================
+            ===============  ===================================
             Key              Description
-            ===============  ==================================================
-            arrowstyle       the arrow style
-            connectionstyle  the connection style
-            relpos           see below; default is (0.5, 0.5)
-            patchA           default is bounding box of the text
-            patchB           default is None
-            shrinkA          default is 2 points
-            shrinkB          default is 2 points
-            mutation_scale   default is text size (in points)
-            mutation_aspect  default is 1.
-            ?                any key for :class:`matplotlib.patches.PathPatch`
-            ===============  ==================================================
+            ===============  ===================================
+            arrowstyle       The arrow style
+            connectionstyle  The connection style
+            relpos           See below; default is (0.5, 0.5)
+            patchA           Default is bounding box of the text
+            patchB           Default is None
+            shrinkA          Default is 2 points
+            shrinkB          Default is 2 points
+            mutation_scale   Default is text size (in points)
+            mutation_aspect  Default is 1
+            ?                Any `.FancyArrowPatch` property
+            ===============  ===================================
 
             The exact starting point position of the arrow is defined by
             *relpos*. It's a tuple of relative coordinates of the text box,
@@ -1798,7 +1797,7 @@ or callable, default: value of *xycoords*
               the axes and *xycoords* is 'data'.
 
         **kwargs
-            Additional kwargs are passed to `~matplotlib.text.Text`.
+            Additional kwargs are passed to `.Text`.
 
         Returns
         -------


### PR DESCRIPTION
Mostly formatting, but note that the class name for the "extra" arrowprops in the "fancy" case was wrong.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
