### PR TITLE
Deprecate unused "frac" key in annotate() arrowprops.

### DIFF
--- a/doc/api/next_api_changes/deprecations/26780-AL.rst
+++ b/doc/api/next_api_changes/deprecations/26780-AL.rst
@@ -1,0 +1,3 @@
+Support for passing the "frac" key in ``annotate(..., arrowprops={"frac": ...})``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... has been removed.  This key has had no effect since Matplotlib 1.5.

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1838,9 +1838,12 @@ or callable, default: value of *xycoords*
                 self._arrow_relpos = arrowprops.pop("relpos", (0.5, 0.5))
             else:
                 # modified YAArrow API to be used with FancyArrowPatch
-                for key in [
-                        'width', 'headwidth', 'headlength', 'shrink', 'frac']:
+                for key in ['width', 'headwidth', 'headlength', 'shrink']:
                     arrowprops.pop(key, None)
+                if 'frac' in arrowprops:
+                    _api.warn_deprecated(
+                        "3.8", name="the (unused) 'frac' key in 'arrowprops'")
+                    arrowprops.pop("frac")
             self.arrow_patch = FancyArrowPatch((0, 0), (1, 1), **arrowprops)
         else:
             self.arrow_patch = None
@@ -1933,10 +1936,6 @@ or callable, default: value of *xycoords*
             shrink = arrowprops.get('shrink', 0.0)
             width = arrowprops.get('width', 4)
             headwidth = arrowprops.get('headwidth', 12)
-            if 'frac' in arrowprops:
-                _api.warn_external(
-                    "'frac' option in 'arrowprops' is no longer supported;"
-                    " use 'headlength' to set the head length in points.")
             headlength = arrowprops.get('headlength', 12)
 
             # NB: ms is in pts


### PR DESCRIPTION
This key has been unused for ~8y (197fc9f).

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
