### PR TITLE
added note about python 3 to venv

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -127,6 +127,9 @@ The simplest way to do this is to use either Python's virtual environment
         <file folder location>\Scripts\activate.bat  # Windows cmd.exe
         <file folder location>\Scripts\Activate.ps1  # Windows PowerShell
 
+      On some systems, you may need to type ``python3`` instead of ``python``.
+      For a discussion of the technical reasons, see `PEP-394 <https://peps.python.org/pep-0394>`_.
+
    .. tab-item:: conda environment
 
       Create a new `conda`_ environment with ::
@@ -143,6 +146,7 @@ The simplest way to do this is to use either Python's virtual environment
         conda activate mpl-dev
 
 Remember to activate the environment whenever you start working on Matplotlib.
+
 
 Installing Matplotlib in editable mode
 ======================================


### PR DESCRIPTION
## PR summary
Apparently on mac, python may not be added to path but python 3 is, so small note to flag that. (also demoing draft pr)