### PR TITLE
reorganize contributing landing page

### DIFF
--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -18,6 +18,8 @@ contribute. Everyone within the community
 is expected to abide by our
 `code of conduct <https://github.com/matplotlib/matplotlib/blob/main/CODE_OF_CONDUCT.md>`_.
 
+
+
 Below, you can find a number of ways to contribute, and how to connect with the
 Matplotlib community.
 
@@ -77,7 +79,9 @@ There are a few typical new contributor profiles:
   and gaining context on this area by reading the issues and pull requests
   touching these subjects is a reasonable approach.
 
-Get Connected
+.. _get_connected:
+
+Get connected
 =============
 
 Do I really have something to contribute to Matplotlib?
@@ -145,6 +149,7 @@ though not necessarily all at the same time:
 - It involves Python features such as decorators and context managers, which
   have subtleties due to our implementation decisions.
 
+.. _managing_issues_prs:
 
 Work on an issue
 ----------------

--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -148,8 +148,8 @@ The simplest way to do this is to use either Python's virtual environment
 Remember to activate the environment whenever you start working on Matplotlib.
 
 
-Installing Matplotlib in editable mode
-======================================
+Install Matplotlib in editable mode
+===================================
 Install Matplotlib in editable mode from the :file:`matplotlib` directory
 using the command ::
 

--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -145,8 +145,8 @@ If you don't think your request is ready to be merged, just say so in your pull
 request message and use the "Draft PR" feature of GitHub. This is a good way of
 getting some preliminary code review.
 
-Some other things you might want to do
-======================================
+Manage commit history
+=====================
 
 Explore your repository
 -----------------------
@@ -163,8 +163,8 @@ To see a linear list of commits for this branch::
 
 .. _recovering-from-mess-up:
 
-Recovering from mess-ups
-------------------------
+Recover from mistakes
+---------------------
 
 Sometimes, you mess up merges or rebases. Luckily, in git it is
 relatively straightforward to recover from such mistakes.
@@ -193,8 +193,8 @@ If you forgot to make a backup branch::
 
 .. _rewriting-commit-history:
 
-Rewriting commit history
-------------------------
+Rewrite commit history
+----------------------
 
 .. note::
 
@@ -285,7 +285,7 @@ to replace your already published commits with the new ones.
 
 .. _rebase-on-main:
 
-Rebasing on ``upstream/main``
+Rebase onto ``upstream/main``
 -----------------------------
 
 Let's say you thought of some work you'd like to do. You
@@ -363,8 +363,8 @@ to replace your already published commits with the new ones.
 .. _force-push:
 
 
-Pushing, with force
--------------------
+Push with force
+---------------
 
 
 If you have in some way re-written already pushed history (e.g. via

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -5,72 +5,141 @@ Contribute
 ##########
 
 Thank you for your interest in helping to improve Matplotlib! There are various
-ways to contribute to Matplotlib. All of them are super valuable! For example:
+ways to contribute: optimizing and refactoring code, detailing unclear
+documentation and writing new examples, reporting and fixing bugs and requesting
+and implementing new features, helping the community...
 
-- cleaning up and optimizing the code base
-- creating and sharing examples of using the library
-- detailing unclear and missing documentation
-- reporting and fixing bugs
-- requesting and implementing new features
-- helping the community with all of the above
+.. card::
+
+   .. grid:: 1 1 2 2
+
+      .. grid-item::
+         :class: sd-fs-5
+         :child-align: spaced
+
+         :octicon:`info;1em;sd-text-info` :ref:`Where should I start? <start-contributing>`
+
+         :octicon:`question;1em;sd-text-info` :ref:`Where should I ask questions? <get_connected>`
+
+         :octicon:`issue-opened;1em;sd-text-info` :ref:`What are "good-first-issues"? <new_contributors>`
+
+         :octicon:`git-pull-request;1em;sd-text-info` :ref:`How do I claim an issue? <managing_issues_prs>`
+
+         .. :octicon:`codespaces;1em;sd-text-info` placeholder for codespaces link
+
+      .. grid-item::
+
+         .. grid:: 1
+            :gutter: 1
+            :class-row: sd-fs-5
+
+            .. grid-item-card::
+               :link: request-a-new-feature
+               :link-type: ref
+
+               :octicon:`light-bulb;1em;sd-text-info` Request new feature
+
+            .. grid-item-card::
+               :link: submitting-a-bug-report
+               :link-type: ref
+
+               :octicon:`bug;1em;sd-text-info` Submit bug report
+
+            .. grid-item-card::
+               :link: contributing-code
+               :link-type: ref
+
+               :octicon:`code;1em;sd-text-info` Contribute code
+
+            .. grid-item-card::
+               :link: documenting-matplotlib
+               :link-type: ref
+
+               :octicon:`note;1em;sd-text-info` Write documentation
+
+If you are new to contributing, we recommend that you first read our
+:ref:`contributing guide<contributing>`. If you are contributing code or
+documentation, please follow our guides for setting up and managing a
+:ref:`development environment and workflow<development_environment>`.
+For code, documentation, or triage, please follow the corresponding
+:ref:`contribution guidelines <contribution_guideline>`.
 
 
-If you have any questions on the
-process or how to fix something feel free to ask on `gitter
-<https://gitter.im/matplotlib/matplotlib>`_ for short questions and on
-`discourse <https://discourse.matplotlib.org>`_ for longer questions.
+.. _development_environment:
 
-.. rst-class:: sd-d-inline-block
+Development workflow
+====================
 
-    .. button-ref:: submitting-a-bug-report
-        :class: sd-fs-6
-        :color: primary
+.. grid:: 1 1 2 2
 
-        Report a bug
+   .. grid-item-card:: Install
 
-.. rst-class:: sd-d-inline-block
+      .. toctree::
+         :maxdepth: 2
 
-    .. button-ref:: request-a-new-feature
-        :class: sd-fs-6
-        :color: primary
+         development_setup
 
-        Request a feature
+      .. toctree::
+         :maxdepth: 1
 
-.. rst-class:: sd-d-inline-block
+         dependencies
+         Minimum versions <min_dep_policy>
 
-    .. button-ref:: contributing-code
-        :class: sd-fs-6
-        :color: primary
 
-        Contribute code
+   .. grid-item-card:: Workflow
 
-.. rst-class:: sd-d-inline-block
+      .. toctree::
+         :maxdepth: 2
 
-    .. button-ref:: documenting-matplotlib
-        :class: sd-fs-6
-        :color: primary
+         development_workflow
 
-        Write documentation
 
-.. toctree::
-   :maxdepth: 2
 
-   contribute.rst
-   triage.rst
-   development_setup.rst
-   development_workflow.rst
-   testing.rst
-   document.rst
-   style_guide.rst
-   coding_guide.rst
-   release_guide.rst
-   dependencies.rst
-   min_dep_policy.rst
-   maintainer_workflow.rst
-   MEP/index
+.. _contribution_guideline:
+
+Contribution guides
+===================
+
+.. grid:: 1 1 2 2
+   :class-row: sf-fs-1
+
+   .. grid-item-card:: Code
+
+      | :ref:`coding_guidelines`
+
+      .. toctree::
+         :maxdepth: 1
+
+         coding_guide
+         testing
+
+   .. grid-item-card:: Documentation
+
+      .. toctree::
+         :maxdepth: 1
+
+         document
+         style_guide
+
+   .. grid-item-card:: Triage
+
+      | :ref:`bug_triaging`
+      | :ref:`triage_team`
+      | :ref:`triage_workflow`
+
+   .. grid-item-card:: Maintenance
+
+      .. toctree::
+         :maxdepth: 1
+
+         maintainer_workflow
+         release_guide
+         MEP/index
 
 .. toctree::
    :hidden:
 
-   license.rst
+   contribute
+   triage
+   license
    color_changes

--- a/doc/devel/triage.rst
+++ b/doc/devel/triage.rst
@@ -62,6 +62,8 @@ The following actions are typically useful:
    explores how to lead online discussions in the context of open source.
 
 
+.. _triage_team:
+
 Triage team
 -----------
 
@@ -120,6 +122,8 @@ can do the following important tasks:
     question or has been considered as unclear for many years, then it
     should be closed.
 
+
+.. _triage_workflow:
 
 A typical workflow for triaging issues
 --------------------------------------


### PR DESCRIPTION
<s>I added `setup environment` as a button and  merged {new feature, report bug}->{open issue} to keep things small. Also added a section/preamble in the contributing guide about opening issues to create an anchor for the button. 

I'm slightly ambivalent in a three buttons are process and one is infrastructure way, but it's also the thing I'm most often looking for when I go to contribute. There definitely needs to be a larger scale reorg, but this seemed like an easy enough start. </s>

Reworked the landing page so that navigation is grouped in cards and grids. Goal is to make the page a bit more skimmable, see last comment for example. 

My general proposal is keep the get connected/intro stuff and consolidate everything else w/ the document that discusses it- so optimally here I'd move the "open an issue" content into the triage document - mostly cause I think the triaging docs are good guidance for writing a good issue. But I'd want #25913 cleared out first. 