### PR TITLE
FIX: Handle masked arrays for RGBA input with ScalarMappables

### DIFF
--- a/doc/api/next_api_changes/behavior/26096-GL.rst
+++ b/doc/api/next_api_changes/behavior/26096-GL.rst
@@ -1,0 +1,4 @@
+``ScalarMappable.to_rgba()`` now respects the mask of RGB(A) arrays
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, the mask was ignored. Now the alpha channel is set to 0 if any
+component (R, G, B, or A) is masked.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -450,7 +450,7 @@ class ScalarMappable:
         treated as an RGB or RGBA array, and no mapping will be done.
         The array can be `~numpy.uint8`, or it can be floats with
         values in the 0-1 range; otherwise a ValueError will be raised.
-        If it is a masked array, the mask will be ignored.
+        If it is a masked array, any masked elements will be set to 0 alpha.
         If the last dimension is 3, the *alpha* kwarg (defaulting to 1)
         will be used to fill in the transparency.  If the last dimension
         is 4, the *alpha* kwarg is ignored; it does not
@@ -493,6 +493,10 @@ class ScalarMappable:
                 else:
                     raise ValueError("Image RGB array must be uint8 or "
                                      "floating point; found %s" % xx.dtype)
+                # Account for any masked entries in the original array
+                # If any of R, G, B, or A are masked for an entry, we set alpha to 0
+                if np.ma.is_masked(x):
+                    xx[np.any(np.ma.getmaskarray(x), axis=2), 3] = 0
                 return xx
         except AttributeError:
             # e.g., x is not an ndarray; so try mapping it

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1353,6 +1353,48 @@ def test_to_rgba_error_with_color_invalid_alpha_tuple():
         mcolors.to_rgba(('blue', 2.0))
 
 
+@pytest.mark.parametrize("bytes", (True, False))
+def test_scalarmappable_to_rgba(bytes):
+    sm = cm.ScalarMappable()
+    alpha_1 = 255 if bytes else 1
+
+    # uint8 RGBA
+    x = np.ones((2, 3, 4), dtype=np.uint8)
+    expected = x.copy() if bytes else x.astype(np.float32)/255
+    np.testing.assert_array_equal(sm.to_rgba(x, bytes=bytes), expected)
+    # uint8 RGB
+    expected[..., 3] = alpha_1
+    np.testing.assert_array_equal(sm.to_rgba(x[..., :3], bytes=bytes), expected)
+    # uint8 masked RGBA
+    xm = np.ma.masked_array(x, mask=np.zeros_like(x))
+    xm.mask[0, 0, 0] = True
+    expected = x.copy() if bytes else x.astype(np.float32)/255
+    expected[0, 0, 3] = 0
+    np.testing.assert_array_equal(sm.to_rgba(xm, bytes=bytes), expected)
+    # uint8 masked RGB
+    expected[..., 3] = alpha_1
+    expected[0, 0, 3] = 0
+    np.testing.assert_array_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
+
+    # float RGBA
+    x = np.ones((2, 3, 4), dtype=float) * 0.5
+    expected = (x * 255).astype(np.uint8) if bytes else x.copy()
+    np.testing.assert_array_equal(sm.to_rgba(x, bytes=bytes), expected)
+    # float RGB
+    expected[..., 3] = alpha_1
+    np.testing.assert_array_equal(sm.to_rgba(x[..., :3], bytes=bytes), expected)
+    # float masked RGBA
+    xm = np.ma.masked_array(x, mask=np.zeros_like(x))
+    xm.mask[0, 0, 0] = True
+    expected = (x * 255).astype(np.uint8) if bytes else x.copy()
+    expected[0, 0, 3] = 0
+    np.testing.assert_array_equal(sm.to_rgba(xm, bytes=bytes), expected)
+    # float masked RGB
+    expected[..., 3] = alpha_1
+    expected[0, 0, 3] = 0
+    np.testing.assert_array_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
+
+
 def test_failed_conversions():
     with pytest.raises(ValueError):
         mcolors.to_rgba('5')


### PR DESCRIPTION
## PR summary

Currently, the mask is ignored if a user passes in RGB(A) input arrays. This sets the alpha channel to 0 when any RGB(A) input is masked. This is relevant for RGB(A) data being used with pcolormesh. xref: https://github.com/SciTools/cartopy/pull/2166 where it will simplify downstream accounting for masks and alpha.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
