### PR TITLE
Correct bounding box calculation for text markers

### DIFF
--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -509,14 +509,12 @@ class MarkerStyle:
         if len(text.vertices) == 0:
             return
 
-        xmin, ymin = text.vertices.min(axis=0)
-        xmax, ymax = text.vertices.max(axis=0)
-        width = xmax - xmin
-        height = ymax - ymin
-        max_dim = max(width, height)
-        self._transform = Affine2D() \
-            .translate(-xmin + 0.5 * -width, -ymin + 0.5 * -height) \
-            .scale(1.0 / max_dim)
+        bbox = text.get_extents()
+        max_dim = max(bbox.width, bbox.height)
+        self._transform = (
+            Affine2D()
+            .translate(-bbox.xmin + 0.5 * -bbox.width, -bbox.ymin + 0.5 * -bbox.height)
+            .scale(1.0 / max_dim))
         self._path = text
         self._snap = False
 

--- a/lib/matplotlib/tests/test_marker.py
+++ b/lib/matplotlib/tests/test_marker.py
@@ -156,6 +156,18 @@ def test_asterisk_marker(fig_test, fig_ref, request):
     ax_ref.set(xlim=(-0.5, 1.5), ylim=(-0.5, 1.5))
 
 
+# The bullet mathtext marker is not quite a circle, so this is not a perfect match, but
+# it is close enough to confirm that the text-based marker is centred correctly. But we
+# still need a small tolerance to work around that difference.
+@check_figures_equal(extensions=['png'], tol=1.86)
+def test_text_marker(fig_ref, fig_test):
+    ax_ref = fig_ref.add_subplot()
+    ax_test = fig_test.add_subplot()
+
+    ax_ref.plot(0, 0, marker=r'o', markersize=100, markeredgewidth=0)
+    ax_test.plot(0, 0, marker=r'$\bullet$', markersize=100, markeredgewidth=0)
+
+
 @check_figures_equal()
 def test_marker_clipping(fig_ref, fig_test):
     # Plotting multiple markers can trigger different optimized paths in


### PR DESCRIPTION
## PR summary

Points with `CLOSEPOLY` or `STOP` codes have vertex values that are meaningless, but the marker bounding box calculation still counts them. This causes several markers to not be correctly centred as expected.

Fixes #26083

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines