### PR TITLE
Getting numeric value from unit registry on imshow function

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5721,14 +5721,14 @@ default: :rc:`scatter.edgecolors`
         if not isinstance(vmax, (int, float)):
             try:
                 vmax = vmax.to_tuple()[0]
-            except ValueError:
-                raise ValueError("vmax must be a scalar or a 1-element array")
+            except AttributeError:
+                raise AttributeError("vmax must be a scalar or a 1-element array")
 
         if not isinstance(vmin, (int, float)):
             try:
                 vmin = vmin.to_tuple()[0]
-            except ValueError:
-                raise ValueError("vmin must be a scalar or a 1-element array")
+            except AttributeError:
+                raise AttributeError("vmin must be a scalar or a 1-element array")
 
         if aspect is None:
             aspect = mpl.rcParams['image.aspect']

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5718,6 +5718,18 @@ default: :rc:`scatter.edgecolors`
         `~matplotlib.pyplot.imshow` expects RGB images adopting the straight
         (unassociated) alpha representation.
         """
+        if not isinstance(vmax, (int, float)):
+            try:
+                vmax = vmax.to_tuple()[0]
+            except ValueError:
+                raise ValueError("vmax must be a scalar or a 1-element array")
+
+        if not isinstance(vmin, (int, float)):
+            try:
+                vmin = vmin.to_tuple()[0]
+            except ValueError:
+                raise ValueError("vmin must be a scalar or a 1-element array")
+
         if aspect is None:
             aspect = mpl.rcParams['image.aspect']
         self.set_aspect(aspect)


### PR DESCRIPTION
## PR summary
closes #25062

With this it would be possible to pass unit-ful data as vmin/vmax parameters on imshow function

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #25062" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
