### PR TITLE
tight_layout support for subfigure

### DIFF
--- a/lib/matplotlib/_tight_layout.py
+++ b/lib/matplotlib/_tight_layout.py
@@ -82,7 +82,7 @@ def _auto_adjust_subplotpars(
                 bb += [martist._get_tightbbox_for_layout_only(ax, renderer)]
 
         tight_bbox_raw = Bbox.union(bb)
-        tight_bbox = fig.transFigure.inverted().transform_bbox(tight_bbox_raw)
+        tight_bbox = fig.transSubfigure.inverted().transform_bbox(tight_bbox_raw)
 
         hspaces[rowspan, colspan.start] += ax_bbox.xmin - tight_bbox.xmin  # l
         hspaces[rowspan, colspan.stop] += tight_bbox.xmax - ax_bbox.xmax  # r
@@ -97,7 +97,7 @@ def _auto_adjust_subplotpars(
         margin_left = max(hspaces[:, 0].max(), 0) + pad_inch/fig_width_inch
         suplabel = fig._supylabel
         if suplabel and suplabel.get_in_layout():
-            rel_width = fig.transFigure.inverted().transform_bbox(
+            rel_width = fig.transSubfigure.inverted().transform_bbox(
                 suplabel.get_window_extent(renderer)).width
             margin_left += rel_width + pad_inch/fig_width_inch
     if not margin_right:
@@ -105,14 +105,14 @@ def _auto_adjust_subplotpars(
     if not margin_top:
         margin_top = max(vspaces[0, :].max(), 0) + pad_inch/fig_height_inch
         if fig._suptitle and fig._suptitle.get_in_layout():
-            rel_height = fig.transFigure.inverted().transform_bbox(
+            rel_height = fig.transSubfigure.inverted().transform_bbox(
                 fig._suptitle.get_window_extent(renderer)).height
             margin_top += rel_height + pad_inch/fig_height_inch
     if not margin_bottom:
         margin_bottom = max(vspaces[-1, :].max(), 0) + pad_inch/fig_height_inch
         suplabel = fig._supxlabel
         if suplabel and suplabel.get_in_layout():
-            rel_height = fig.transFigure.inverted().transform_bbox(
+            rel_height = fig.transSubfigure.inverted().transform_bbox(
                 suplabel.get_window_extent(renderer)).height
             margin_bottom += rel_height + pad_inch/fig_height_inch
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2219,6 +2219,12 @@ class SubFigure(FigureBase):
         self._set_artist_props(self.patch)
         self.patch.set_antialiased(False)
 
+    def get_size_inches(self):
+        w, h = self.figure.get_size_inches()
+        figbbox = self.figure.bbox
+        return (w*self.bbox.width/figbbox.width,
+                h*self.bbox.height/figbbox.height)
+
     @property
     def dpi(self):
         return self._parent.dpi


### PR DESCRIPTION
## PR summary
`TightLayoutEngine` from `matplotlib.layout_engine` fails when called with a subfigure. The PR is an attempt to make it to work with subfigures.

Note that, unlike `Figure`, `Subfigure` class does not have a method of `tight_layout`.  So, we need to manually create an instance of `TightLayoutEngine` and call it with a subfigure. Here is a simple example.

```python
import matplotlib.pyplot as plt

fig = plt.figure()
fig.subplotpars.bottom = 0.3
subfigs = fig.subfigures(3, 3)
sfig = subfigs[0, 0]

sfig.patch.set_fc("y")
ax = sfig.subplots(1, 1)

from matplotlib.layout_engine import TightLayoutEngine
engine = TightLayoutEngine()
engine.execute(sfig)

plt.show()
```

![test_subfigure_tight_layout](https://github.com/matplotlib/matplotlib/assets/95962/01f4de4d-bf79-4080-8d9c-6a379c2112ed)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
