### PR TITLE
Let twin-axis aligned at the specified position

### DIFF
--- a/galleries/examples/subplots_axes_and_figures/twinx_align.py
+++ b/galleries/examples/subplots_axes_and_figures/twinx_align.py
@@ -6,7 +6,7 @@ Let twin-axis aligned at the specified position
 Let the left-axis and right-axis aligned at the specified position.
 
 In some data that need twin-axis plot, a point at left-axis and
-another point at right-axis have same meaning, they shoud be aligned.
+another point at right-axis have same meaning, they should be aligned.
 For example, we plot netvalue curve of a portfolio at twin-left-axis
 and profit raito curve at twin-right-axis, the point 1.0 at the
 left-axis and the point 0.0 at the right-axis both mean the begin

--- a/galleries/examples/subplots_axes_and_figures/twinx_align.py
+++ b/galleries/examples/subplots_axes_and_figures/twinx_align.py
@@ -12,20 +12,17 @@ and profit raito curve at twin-right-axis, the point 1.0 at the
 left-axis and the point 0.0 at the right-axis both mean the begin
 state of the portifolio, so they should be aligned.
 """
-import pandas as pd
+import numpy as np
 from matplotlib import pyplot as plt
 
 
 # Sim data
-net_in = [100, 0, 0, 0, 20, 0, 0, 0, 0, -20, 
-          0, 0, 30, 0, 0, 0, 0, 0, -30, 0]
-net_gain= [0, -2, -3, 5, 2, 3, 4, 5, 5, -1,
-           -4, -10, 2, 5, 9, 6, 0, 1, -1, 9]
-df = pd.DataFrame({"net_in": net_in, "net_gain": net_gain})
-df["total_in"] = df["net_in"].cumsum()
-df["value"] = df["total_in"] + df["net_gain"].cumsum()
-df["value_net"] = df["value"] / df["value"].iloc[0] 
-df["gain_pct"] = df["value"] / df["total_in"] - 1 
+net_value = np.array([1.0, 0.98, 0.95, 1.0, 1.22, 1.25, 1.29, 1.34,
+                      1.39, 1.18, 1.14, 1.04, 1.36, 1.41, 1.5, 1.56,
+                      1.56, 1.57, 1.26, 1.35])
+gain_pct = np.array([0.0, -0.02, -0.05, 0.0, 0.02, 0.04, 0.07,
+                     0.12, 0.16, 0.18, 0.14, 0.04, 0.05, 0.08,
+                     0.15, 0.2, 0.2, 0.21, 0.26, 0.35])
 
 
 def twinxalign(ax_left, ax_right, v_left, v_right):
@@ -48,48 +45,29 @@ def twinxalign(ax_left, ax_right, v_left, v_right):
         right_max_new = ((left_max-dif) - b) / k
         k_new = (left_max-v_left) / (right_max_new-v_right)
         b_new = v_left - k_new * v_right
-        right_min_new = (left_min - b_new) / k_new    
-    def _forward(x):
-        return k_new * x + b_new
-    def _inverse(x):
-        return (x - b_new) / k_new
+        right_min_new = (left_min - b_new) / k_new
     ax_right.set_ylim([right_min_new, right_max_new])
-    ax_right.set_yscale("function", functions=(_forward, _inverse))
     return ax_left, ax_right
 
 
-def general_plot():
+def plot_example(align=False):
+    """plot sim data"""
     plt.figure(figsize=(10, 7))
     ax1 = plt.subplot(111)
-    ax1.plot(df["value_net"], "-k")
+    ax1.plot(net_value, "-k")
     ax1.axhline(1, c="k", lw=1, ls="--")
     ax1.set_ylabel("NetValue(black)", fontsize=16)
     ax2 = ax1.twinx()
-    ax2.plot(df["gain_pct"], "-b")
+    ax2.plot(gain_pct, "-b")
     ax2.axhline(0, c="r", lw=1, ls="--")
     ax2.set_ylabel("GainPct(blue)", fontsize=16)
-    plt.title("no align plot", fontsize=16)
+    if align:
+        twinxalign(ax1, ax2, 1, 0)
+        plt.title("aligned", fontsize=16)
+    else:
+        plt.title("not align", fontsize=16)
     plt.show()
 
 
-def twinx_align_plot():
-    plt.figure(figsize=(10, 7))
-    ax1 = plt.subplot(111)
-    ax1.plot(df["value_net"], "-k")
-    ax1.axhline(1, c="k", lw=1, ls="--")
-    ax1.set_ylabel("NetValue(black)", fontsize=16)
-    ax2 = ax1.twinx()
-    ax2.plot(df["gain_pct"], "-b")
-    ax2.axhline(0, c="r", lw=1, ls="--")
-    ax2.set_ylabel("GainPct(blue)", fontsize=16)
-    twinxalign(ax1, ax2, 1, 0)
-    plt.title("align left-axis 1 with right-axis 0", fontsize=16)
-    plt.show()
-
-
-general_plot()
-twinx_align_plot()
-
-
-
-
+plot_example()
+plot_example(align=True)

--- a/galleries/examples/subplots_axes_and_figures/twinx_align.py
+++ b/galleries/examples/subplots_axes_and_figures/twinx_align.py
@@ -1,16 +1,16 @@
 """
-================================================
-Let twin-axis aligned at the specified positions
-================================================
+===============================================
+Let twin-axis aligned at the specified position
+===============================================
 
-Let the left-axis and right-axis aligned at the specified positions.
+Let the left-axis and right-axis aligned at the specified position.
 
 In some data that need twin-axis plot, a point at left-axis and
 another point at right-axis have same meaning, they shoud be aligned.
 For example, we plot netvalue curve of a portfolio at twin-left-axis
 and profit raito curve at twin-right-axis, the point 1.0 at the
 left-axis and the point 0.0 at the right-axis both mean the begin
-state or the portifolio, so the should be aligned.
+state of the portifolio, so they should be aligned.
 """
 import pandas as pd
 from matplotlib import pyplot as plt
@@ -58,19 +58,37 @@ def twinxalign(ax_left, ax_right, v_left, v_right):
     return ax_left, ax_right
 
 
-plt.figure(figsize=(10, 7))
-ax1 = plt.subplot(111)
-ax1.plot(df["value_net"], "-k")
-ax1.axhline(1, c="k", lw=1, ls="--")
-ax1.set_ylabel("NetValue(black)", fontsize=16)
-ax2 = ax1.twinx()
-ax2.plot(df["gain_pct"], "-b")
-ax2.axhline(0, c="r", lw=1, ls="--")
-ax2.set_ylabel("GainPct(blue)", fontsize=16)
-twinxalign(ax1, ax2, 1, 0)
-plt.title("align left-axis 1 with right-axis 0", fontsize=16)
-plt.show()
+def general_plot():
+    plt.figure(figsize=(10, 7))
+    ax1 = plt.subplot(111)
+    ax1.plot(df["value_net"], "-k")
+    ax1.axhline(1, c="k", lw=1, ls="--")
+    ax1.set_ylabel("NetValue(black)", fontsize=16)
+    ax2 = ax1.twinx()
+    ax2.plot(df["gain_pct"], "-b")
+    ax2.axhline(0, c="r", lw=1, ls="--")
+    ax2.set_ylabel("GainPct(blue)", fontsize=16)
+    plt.title("no align plot", fontsize=16)
+    plt.show()
 
+
+def twinx_align_plot():
+    plt.figure(figsize=(10, 7))
+    ax1 = plt.subplot(111)
+    ax1.plot(df["value_net"], "-k")
+    ax1.axhline(1, c="k", lw=1, ls="--")
+    ax1.set_ylabel("NetValue(black)", fontsize=16)
+    ax2 = ax1.twinx()
+    ax2.plot(df["gain_pct"], "-b")
+    ax2.axhline(0, c="r", lw=1, ls="--")
+    ax2.set_ylabel("GainPct(blue)", fontsize=16)
+    twinxalign(ax1, ax2, 1, 0)
+    plt.title("align left-axis 1 with right-axis 0", fontsize=16)
+    plt.show()
+
+
+general_plot()
+twinx_align_plot()
 
 
 

--- a/galleries/examples/subplots_axes_and_figures/twinx_align.py
+++ b/galleries/examples/subplots_axes_and_figures/twinx_align.py
@@ -12,9 +12,9 @@ and profit raito curve at twin-right-axis, the point 1.0 at the
 left-axis and the point 0.0 at the right-axis both mean the begin
 state of the portifolio, so they should be aligned.
 """
-import numpy as np
 
-from matplotlib import pyplot as plt
+import matplotlib.pyplot as plt
+import numpy as np
 
 # Sim data
 net_value = np.array([1.0, 0.98, 0.95, 1.0, 1.22, 1.25, 1.29, 1.34,
@@ -51,7 +51,7 @@ def twinxalign(ax_left, ax_right, v_left, v_right):
 
 
 def plot_example(align=False):
-    """plot sim data"""
+    """Plot sim data"""
     plt.figure(figsize=(10, 7))
     ax1 = plt.subplot(111)
     ax1.plot(net_value, "-k")

--- a/galleries/examples/subplots_axes_and_figures/twinx_align.py
+++ b/galleries/examples/subplots_axes_and_figures/twinx_align.py
@@ -1,0 +1,77 @@
+"""
+================================================
+Let twin-axis aligned at the specified positions
+================================================
+
+Let the left-axis and right-axis aligned at the specified positions.
+
+In some data that need twin-axis plot, a point at left-axis and
+another point at right-axis have same meaning, they shoud be aligned.
+For example, we plot netvalue curve of a portfolio at twin-left-axis
+and profit raito curve at twin-right-axis, the point 1.0 at the
+left-axis and the point 0.0 at the right-axis both mean the begin
+state or the portifolio, so the should be aligned.
+"""
+import pandas as pd
+from matplotlib import pyplot as plt
+
+
+# Sim data
+net_in = [100, 0, 0, 0, 20, 0, 0, 0, 0, -20, 
+          0, 0, 30, 0, 0, 0, 0, 0, -30, 0]
+net_gain= [0, -2, -3, 5, 2, 3, 4, 5, 5, -1,
+           -4, -10, 2, 5, 9, 6, 0, 1, -1, 9]
+df = pd.DataFrame({"net_in": net_in, "net_gain": net_gain})
+df["total_in"] = df["net_in"].cumsum()
+df["value"] = df["total_in"] + df["net_gain"].cumsum()
+df["value_net"] = df["value"] / df["value"].iloc[0] 
+df["gain_pct"] = df["value"] / df["total_in"] - 1 
+
+
+def twinxalign(ax_left, ax_right, v_left, v_right):
+    """
+    Let the position `v_left` on `ax_left`
+    and the position `v_right` on `ax_right` be aligned
+    """
+    left_min, left_max = ax_left.get_ybound()
+    right_min, right_max = ax_right.get_ybound()
+    k = (left_max-left_min) / (right_max-right_min)
+    b = left_min - k * right_min
+    x_right_new = k * v_right + b
+    dif = x_right_new - v_left
+    if dif >= 0:
+        right_min_new = ((left_min-dif) - b) / k
+        k_new = (left_min-v_left) / (right_min_new-v_right)
+        b_new = v_left - k_new * v_right
+        right_max_new = (left_max - b_new) / k_new
+    else:
+        right_max_new = ((left_max-dif) - b) / k
+        k_new = (left_max-v_left) / (right_max_new-v_right)
+        b_new = v_left - k_new * v_right
+        right_min_new = (left_min - b_new) / k_new    
+    def _forward(x):
+        return k_new * x + b_new
+    def _inverse(x):
+        return (x - b_new) / k_new
+    ax_right.set_ylim([right_min_new, right_max_new])
+    ax_right.set_yscale("function", functions=(_forward, _inverse))
+    return ax_left, ax_right
+
+
+plt.figure(figsize=(10, 7))
+ax1 = plt.subplot(111)
+ax1.plot(df["value_net"], "-k")
+ax1.axhline(1, c="k", lw=1, ls="--")
+ax1.set_ylabel("NetValue(black)", fontsize=16)
+ax2 = ax1.twinx()
+ax2.plot(df["gain_pct"], "-b")
+ax2.axhline(0, c="r", lw=1, ls="--")
+ax2.set_ylabel("GainPct(blue)", fontsize=16)
+twinxalign(ax1, ax2, 1, 0)
+plt.title("align left-axis 1 with right-axis 0", fontsize=16)
+plt.show()
+
+
+
+
+

--- a/galleries/examples/subplots_axes_and_figures/twinx_align.py
+++ b/galleries/examples/subplots_axes_and_figures/twinx_align.py
@@ -13,8 +13,8 @@ left-axis and the point 0.0 at the right-axis both mean the begin
 state of the portifolio, so they should be aligned.
 """
 import numpy as np
-from matplotlib import pyplot as plt
 
+from matplotlib import pyplot as plt
 
 # Sim data
 net_value = np.array([1.0, 0.98, 0.95, 1.0, 1.22, 1.25, 1.29, 1.34,


### PR DESCRIPTION
## PR summary

Let the left-axis and right-axis aligned at the specified position.

In some data that need twin-axis plot, a point at left-axis and another point at right-axis have same meaning, they shoud be aligned.

For example, we plot netvalue curve of a portfolio at twin-left-axis and profit raito curve at twin-right-axis, the point 1.0 at the
left-axis and the point 0.0 at the right-axis both mean the begin state of the portifolio, so they should be aligned.

**general twinx plot:**
![image](https://github.com/matplotlib/matplotlib/assets/19773170/d36dee21-7945-4112-911d-1a5d75905353)

**twinx aligned plot:**
![image](https://github.com/matplotlib/matplotlib/assets/19773170/341fd8dd-f04b-49aa-bd40-dfe0240687b9)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

[&#10004;] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->