### PR TITLE
Fix new warnings in compiled extensions

### DIFF
--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -511,7 +511,7 @@ int convert_points(PyObject *obj, void *pointsp)
         return 1;
     }
     if (!points->set(obj)
-        || points->size() && !check_trailing_shape(*points, "points", 2)) {
+        || (points->size() && !check_trailing_shape(*points, "points", 2))) {
         return 0;
     }
     return 1;
@@ -524,7 +524,7 @@ int convert_transforms(PyObject *obj, void *transp)
         return 1;
     }
     if (!trans->set(obj)
-        || trans->size() && !check_trailing_shape(*trans, "transforms", 3, 3)) {
+        || (trans->size() && !check_trailing_shape(*trans, "transforms", 3, 3))) {
         return 0;
     }
     return 1;
@@ -537,7 +537,7 @@ int convert_bboxes(PyObject *obj, void *bboxp)
         return 1;
     }
     if (!bbox->set(obj)
-        || bbox->size() && !check_trailing_shape(*bbox, "bbox array", 2, 2)) {
+        || (bbox->size() && !check_trailing_shape(*bbox, "bbox array", 2, 2))) {
         return 0;
     }
     return 1;
@@ -550,7 +550,7 @@ int convert_colors(PyObject *obj, void *colorsp)
         return 1;
     }
     if (!colors->set(obj)
-        || colors->size() && !check_trailing_shape(*colors, "colors", 4)) {
+        || (colors->size() && !check_trailing_shape(*colors, "colors", 4))) {
         return 0;
     }
     return 1;


### PR DESCRIPTION
## PR summary

These are triggered by `-Wparenthesis`, from #25850.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines