### PR TITLE
Allow separate config of minor grid params in matplotlibrc.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -139,19 +139,24 @@ class Tick(martist.Artist):
                 zorder = mlines.Line2D.zorder
         self._zorder = zorder
 
+        if major:
+            grid_name = "grid"
+        else:
+            grid_name = "grid.minor"
+
         if grid_color is None:
-            grid_color = mpl.rcParams["grid.color"]
+            grid_color = mpl.rcParams[f"{grid_name}.color"]
         if grid_linestyle is None:
-            grid_linestyle = mpl.rcParams["grid.linestyle"]
+            grid_linestyle = mpl.rcParams[f"{grid_name}.linestyle"]
         if grid_linewidth is None:
-            grid_linewidth = mpl.rcParams["grid.linewidth"]
+            grid_linewidth = mpl.rcParams[f"{grid_name}.linewidth"]
         if grid_alpha is None and not mcolors._has_alpha_channel(grid_color):
             # alpha precedence: kwarg > color alpha > rcParams['grid.alpha']
             # Note: only resolve to rcParams if the color does not have alpha
             # otherwise `grid(color=(1, 1, 1, 0.5))` would work like
             #   grid(color=(1, 1, 1, 0.5), alpha=rcParams['grid.alpha'])
             # so the that the rcParams default would override color alpha.
-            grid_alpha = mpl.rcParams["grid.alpha"]
+            grid_alpha = mpl.rcParams[f"{grid_name}.alpha"]
         grid_kw = {k[5:]: v for k, v in kwargs.items()}
 
         self.tick1line = mlines.Line2D(

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -523,6 +523,10 @@
 #grid.linewidth: 0.8        # in points
 #grid.alpha:     1.0        # transparency, between 0.0 and 1.0
 
+#grid.minor.color:     "#b0b0b0"  # minor grid color
+#grid.minor.linestyle: -          # solid
+#grid.minor.linewidth: 0.8        # in points
+#grid.minor.alpha:     1.0        # transparency, between 0.0 and 1.0
 
 ## ***************************************************************************
 ## * LEGEND                                                                  *

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1154,6 +1154,11 @@ _validators = {
     "grid.linewidth":    validate_float,     # in points
     "grid.alpha":        validate_float,
 
+    "grid.minor.color":        validate_color,  # minor grid color
+    "grid.minor.linestyle":    _validate_linestyle,  # solid
+    "grid.minor.linewidth":    validate_float,     # in points
+    "grid.minor.alpha":        validate_float,
+
     ## figure props
     # figure title
     "figure.titlesize":   validate_fontsize,


### PR DESCRIPTION
## PR summary
Adds `grid.minor.*` params to `matplotlibrc` allowing one to set different parameters for minor grids.  I've been manually turning on minor ticks with `.grid(which="minor")`, but this gets tiring and I'd like to be able to just enable this globally in the `matplotlibrc` file.  However, both the `major` and `minor` parameters are currently configured with `grid.*`, with no distinction for `minor` or `major`.  The present PR attempts to address this.

I can add examples / test / docs etc. if this might be an acceptable change.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines
