### PR TITLE
Stop building universal2 and win32 wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -107,7 +107,7 @@ jobs:
         python {package}/ci/check_version_number.py
       # Apple Silicon machines are not available for testing, so silence the
       # warning from cibuildwheel. Remove the skip when they're available.
-      CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64"
+      CIBW_TEST_SKIP: "*-macosx_arm64"
       MACOSX_DEPLOYMENT_TARGET: "10.12"
       MPL_DISABLE_FH4: "yes"
     strategy:
@@ -120,7 +120,7 @@ jobs:
           - os: windows-latest
             cibw_archs: "auto64"
           - os: macos-11
-            cibw_archs: "x86_64 universal2 arm64"
+            cibw_archs: "x86_64 arm64"
 
     steps:
       - name: Set up QEMU

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -118,7 +118,7 @@ jobs:
           - os: ubuntu-20.04
             cibw_archs: "aarch64"
           - os: windows-latest
-            cibw_archs: "auto"
+            cibw_archs: "auto64"
           - os: macos-11
             cibw_archs: "x86_64 universal2 arm64"
 

--- a/doc/api/next_api_changes/development/25475-ES.rst
+++ b/doc/api/next_api_changes/development/25475-ES.rst
@@ -1,5 +1,5 @@
-Wheels for 32-bit Linux are no longer distributed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Wheels for 32-bit systems are no longer distributed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Pre-compiled wheels for 32-bit Linux are no longer provided on PyPI since
-Matplotlib 3.8.
+Pre-compiled wheels for 32-bit Linux and Windows are no longer provided on PyPI
+since Matplotlib 3.8.

--- a/doc/api/next_api_changes/development/25475-ES.rst
+++ b/doc/api/next_api_changes/development/25475-ES.rst
@@ -1,5 +1,9 @@
-Wheels for 32-bit systems are no longer distributed
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Wheels for some systems are no longer distributed
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Pre-compiled wheels for 32-bit Linux and Windows are no longer provided on PyPI
 since Matplotlib 3.8.
+
+Multi-architecture ``universal2`` wheels for macOS are no longer provided on PyPI since
+Matplotlib 3.8. In general, ``pip`` will always prefer the architecture-specific
+(``amd64``- or ``arm64``-only) wheels, so these provided little benefit.


### PR DESCRIPTION
## PR summary

Upstream `cibuildwheel` dropped wheels for these systems. There are some good arguments for that related to support from NumPy (who has no universal2 wheels and will drop win32 soon) to ease of cross-compile with Meson (which we'll be porting to soon.)

This is up for discussion in the dev meeting tomorrow.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines