### PR TITLE
TST: xfail Tk test on Python 3.9 Azure macOS also

### DIFF
--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -40,7 +40,7 @@ def _isolated_tk_test(success_count, func=None):
     )
     @pytest.mark.xfail(  # https://github.com/actions/setup-python/issues/649
         'TF_BUILD' in os.environ and sys.platform == 'darwin' and
-        sys.version_info[:2] == (3, 10),
+        sys.version_info[:2] < (3, 11),
         reason='Tk version mismatch on Azure macOS CI'
     )
     @functools.wraps(func)

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -64,7 +64,7 @@ def _get_testable_interactive_backends():
             # ignore on OSX because that's currently broken (github #16849)
             marks.append(pytest.mark.xfail(reason='github #16849'))
         elif (env['MPLBACKEND'] == 'tkagg' and 'TF_BUILD' in os.environ and
-              sys.platform == 'darwin' and sys.version_info[:2] == (3, 10)):
+              sys.platform == 'darwin' and sys.version_info[:2] < (3, 11)):
             marks.append(  # https://github.com/actions/setup-python/issues/649
                 pytest.mark.xfail(reason='Tk version mismatch on Azure macOS CI'))
         envs.append(
@@ -274,7 +274,7 @@ for param in _thread_safe_backends:
                        'https://foss.heptapod.net/pypy/pypy/-/issues/1929',
                 strict=True))
     elif (backend == 'tkagg' and 'TF_BUILD' in os.environ and
-          sys.platform == 'darwin' and sys.version_info[:2] == (3, 10)):
+          sys.platform == 'darwin' and sys.version_info[:2] < (3, 11)):
         param.marks.append(  # https://github.com/actions/setup-python/issues/649
             pytest.mark.xfail('Tk version mismatch on Azure macOS CI'))
 
@@ -547,7 +547,7 @@ for param in _blit_backends:
         param.marks.append(
             pytest.mark.skip("wx does not support blitting"))
     elif (backend == 'tkagg' and 'TF_BUILD' in os.environ and
-          sys.platform == 'darwin' and sys.version_info[:2] == (3, 10)):
+          sys.platform == 'darwin' and sys.version_info[:2] < (3, 11)):
         param.marks.append(  # https://github.com/actions/setup-python/issues/649
             pytest.mark.xfail('Tk version mismatch on Azure macOS CI')
         )


### PR DESCRIPTION
## PR summary

Because now Azure broke that as well.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines