### PR TITLE
Add codespaces configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,27 @@
+
+{
+  "hostRequirements": {
+    "memory": "8gb",
+    "cpus": 4
+  },
+  "image": "mcr.microsoft.com/devcontainers/universal:2",
+  "features": {
+    "ghcr.io/devcontainers/features/desktop-lite:1": {},
+    "ghcr.io/rocker-org/devcontainer-features/apt-packages:1": {
+      "packages": "inkscape,ffmpeg,dvipng,lmodern,cm-super,texlive-latex-base,texlive-latex-extra,texlive-fonts-recommended,texlive-latex-recommended,texlive-pictures,texlive-xetex,fonts-wqy-zenhei,graphviz,fonts-crosextra-carlito,fonts-freefont-otf,fonts-humor-sans,fonts-noto-cjk,optipng"
+    }
+  },
+  "onCreateCommand": ".devcontainer/setup.sh",
+  "postCreateCommand": "",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "yy0931.mplstyle",
+        "eamodio.gitlens",
+        "ms-vscode.live-server"
+      ],
+      "settings": {}
+    }
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+
+curl micro.mamba.pm/install.sh | bash
+
+conda init --all
+micromamba shell init -s bash
+micromamba env create -f environment.yml --yes
+# Note that `micromamba activate mpl-dev` doesn't work, it must be run by the
+# user (same applies to `conda activate`)
+echo "envs_dirs:
+  - /home/codespace/micromamba/envs" > /opt/conda/.condarc


### PR DESCRIPTION
## PR summary

This pull request adds a [GitHub codespaces](https://docs.github.com/en/codespaces) configuration for Matplotlib. With this PR, contributors can open a pre-configured development environment and get started with contributing to Matplotlib right away from their browser. I'm not sure if you can test it as it is, as I believe this needs to be merged to main before anyone is able to open a codespace from the Matplotlib repo.

Once this is merged, it will enable users to go to matplotlib/matplotlib or their own fork and choose "Create codespaces on `<branch>`":
![Screenshot_20230616_155713](https://github.com/matplotlib/matplotlib/assets/3949932/ba9ecea0-d5af-4383-8614-fa96869dcadf)

This will open a browser window with a VSCode interface and a pre installed development environment built over an Ubuntu image. Users can then do

```
$ conda activate mpl-dev
$ python -m pip install -e .
```

After that you can run tests, build the documentation and run other commands.

This configuration also includes a [lightweight fluxbox environment](https://github.com/devcontainers/features/tree/main/src/desktop-lite)

To be done in a follow-up: documentation on how to use it and current features (like connecting to the fluxbox desktop to see plots).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
