### PR TITLE
MNT: add VNClte porte by default

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,5 +23,10 @@
       ],
       "settings": {}
     }
-  }
+},
+"portsAttributes": {
+	"6080": {
+		"label": "desktop"
+	}
+}
 }


### PR DESCRIPTION
## PR summary

This should auto-expose the VNClite port for use in the browser.