### PR TITLE
[Doc] alphabetize mathtext symbols by unicode

### DIFF
--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -5,26 +5,27 @@ from matplotlib import _mathtext, _mathtext_data
 
 symbols = [
     ["Lower-case Greek",
-     6,
-     r"""\alpha \beta \gamma \chi \delta \epsilon \eta \iota \kappa
-         \lambda \mu \nu \omega \phi \pi \psi \rho \sigma \tau \theta
-         \upsilon \xi \zeta \digamma \varepsilon \varkappa \varphi
-         \varpi \varrho \varsigma \vartheta""".split()],
+     4,
+     (r"\alpha", r"\beta", r"\gamma",  r"\chi", r"\delta", r"\epsilon",
+      r"\eta", r"\iota",  r"\kappa", r"\lambda", r"\mu", r"\nu",  r"\omega",
+      r"\phi",  r"\pi", r"\psi", r"\rho",  r"\sigma",  r"\tau", r"\theta",
+      r"\upsilon", r"\xi", r"\zeta",  r"\digamma", r"\varepsilon", r"\varkappa",
+      r"\varphi", r"\varpi", r"\varrho", r"\varsigma",  r"\vartheta")],
     ["Upper-case Greek",
-     8,
-     r"""\Delta \Gamma \Lambda \Omega \Phi \Pi \Psi \Sigma \Theta
-     \Upsilon \Xi \mho \nabla""".split()],
+     4,
+     (r"\Delta", r"\Gamma", r"\Lambda", r"\Omega", r"\Phi", r"\Pi", r"\Psi",
+      r"\Sigma", r"\Theta", r"\Upsilon", r"\Xi")],
     ["Hebrew",
      6,
-     r"""\aleph \beth \daleth \gimel""".split()],
+     (r"\aleph", r"\beth", r"\gimel", r"\daleth")],
     ["Delimiters",
-     6,
+     5,
      _mathtext.Parser._delims],
     ["Big symbols",
-     6,
+     5,
      _mathtext.Parser._overunder_symbols | _mathtext.Parser._dropsub_symbols],
     ["Standard function names",
-     6,
+     5,
      {fr"\{fn}" for fn in _mathtext.Parser._function_names}],
     ["Binary operation and relation symbols",
      4,
@@ -90,14 +91,17 @@ symbols = [
      \hslash \vdots \blacksquare \ldots \blacktriangle \ddots \sharp
      \prime \blacktriangledown \Im \flat \backprime \Re \natural
      \circledS \P \copyright \ss \circledR \S \yen \AA \checkmark \$
-     \cent \triangle \QED \sinewave""".split()]
+     \cent \triangle \QED \sinewave \nabla \mho""".split()]
 ]
 
 
 def run(state_machine):
-    def render_symbol(sym):
+
+    def render_symbol(sym, ignore_variant=False):
+        if ignore_variant and sym != r"\varnothing":
+            sym = sym.replace(r"\var", "\\")
         if sym.startswith("\\"):
-            sym = sym[1:]
+            sym = sym.lstrip("\\")
             if sym not in (_mathtext.Parser._overunder_functions |
                            _mathtext.Parser._function_names):
                 sym = chr(_mathtext_data.tex2uni[sym])
@@ -105,7 +109,12 @@ def run(state_machine):
 
     lines = []
     for category, columns, syms in symbols:
-        syms = sorted(list(syms))
+        syms = sorted(syms,
+                      # Sort by Unicode and place variants immediately
+                      # after standard versions.
+                      key=lambda sym: (render_symbol(sym, ignore_variant=True),
+                                       sym.startswith(r"\var")),
+                      reverse=(category == "Hebrew"))  # Hebrew is rtl
         columns = min(columns, len(syms))
         lines.append("**%s**" % category)
         lines.append('')


### PR DESCRIPTION
Using render_symbol as the sorting key works well enough for Hebrew, I just flipped it 'cause Hebrew is right to left. It also seems to work pretty OK for the Greek?