### PR TITLE
MNT: py312 deprecates pickling objects in itertools

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -192,9 +192,11 @@ class CallbackRegistry:
                           for s, d in self.callbacks.items()},
             # It is simpler to reconstruct this from callbacks in __setstate__.
             "_func_cid_map": None,
+            "_cid_gen": next(self._cid_gen)
         }
 
     def __setstate__(self, state):
+        cid_count = state.pop('_cid_gen')
         vars(self).update(state)
         self.callbacks = {
             s: {cid: _weak_or_strong_ref(func, self._remove_proxy)
@@ -203,6 +205,7 @@ class CallbackRegistry:
         self._func_cid_map = {
             s: {proxy: cid for cid, proxy in d.items()}
             for s, d in self.callbacks.items()}
+        self._cid_gen = itertools.count(cid_count)
 
     def connect(self, signal, func):
         """Register *func* to be called when signal *signal* is generated."""

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -105,6 +105,17 @@ class _AxesStack:
         """Return the active axes, or None if the stack is empty."""
         return max(self._axes, key=self._axes.__getitem__, default=None)
 
+    def __getstate__(self):
+        return {
+            **vars(self),
+            "_counter": max(self._axes.values(), default=0)
+        }
+
+    def __setstate__(self, state):
+        next_counter = state.pop('_counter')
+        vars(self).update(state)
+        self._counter = itertools.count(next_counter)
+
 
 class SubplotParams:
     """

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -39,8 +39,8 @@ def _isolated_tk_test(success_count, func=None):
         reason="$DISPLAY and $WAYLAND_DISPLAY are unset"
     )
     @pytest.mark.xfail(  # https://github.com/actions/setup-python/issues/649
-        'TF_BUILD' in os.environ and sys.platform == 'darwin' and
-        sys.version_info[:2] < (3, 11),
+        ('TF_BUILD' in os.environ or 'GITHUB_ACTION' in os.environ) and
+        sys.platform == 'darwin' and sys.version_info[:2] < (3, 11),
         reason='Tk version mismatch on Azure macOS CI'
     )
     @functools.wraps(func)

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -63,8 +63,11 @@ def _get_testable_interactive_backends():
         elif env["MPLBACKEND"].startswith('wx') and sys.platform == 'darwin':
             # ignore on OSX because that's currently broken (github #16849)
             marks.append(pytest.mark.xfail(reason='github #16849'))
-        elif (env['MPLBACKEND'] == 'tkagg' and 'TF_BUILD' in os.environ and
-              sys.platform == 'darwin' and sys.version_info[:2] < (3, 11)):
+        elif (env['MPLBACKEND'] == 'tkagg' and
+              ('TF_BUILD' in os.environ or 'GITHUB_ACTION' in os.environ) and
+              sys.platform == 'darwin' and
+              sys.version_info[:2] < (3, 11)
+              ):
             marks.append(  # https://github.com/actions/setup-python/issues/649
                 pytest.mark.xfail(reason='Tk version mismatch on Azure macOS CI'))
         envs.append(
@@ -273,7 +276,8 @@ for param in _thread_safe_backends:
                 reason='PyPy does not support Tkinter threading: '
                        'https://foss.heptapod.net/pypy/pypy/-/issues/1929',
                 strict=True))
-    elif (backend == 'tkagg' and 'TF_BUILD' in os.environ and
+    elif (backend == 'tkagg' and
+          ('TF_BUILD' in os.environ or 'GITHUB_ACTION' in os.environ) and
           sys.platform == 'darwin' and sys.version_info[:2] < (3, 11)):
         param.marks.append(  # https://github.com/actions/setup-python/issues/649
             pytest.mark.xfail('Tk version mismatch on Azure macOS CI'))
@@ -546,8 +550,11 @@ for param in _blit_backends:
     elif backend == "wx":
         param.marks.append(
             pytest.mark.skip("wx does not support blitting"))
-    elif (backend == 'tkagg' and 'TF_BUILD' in os.environ and
-          sys.platform == 'darwin' and sys.version_info[:2] < (3, 11)):
+    elif (backend == 'tkagg' and
+          ('TF_BUILD' in os.environ or 'GITHUB_ACTION' in os.environ) and
+          sys.platform == 'darwin' and
+          sys.version_info[:2] < (3, 11)
+          ):
         param.marks.append(  # https://github.com/actions/setup-python/issues/649
             pytest.mark.xfail('Tk version mismatch on Azure macOS CI')
         )

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -209,6 +209,13 @@ class Test_callback_registry:
         assert self.callbacks._func_cid_map != {}
         assert self.callbacks.callbacks != {}
 
+    def test_cid_restore(self):
+        cb = cbook.CallbackRegistry()
+        cb.connect('a', lambda: None)
+        cb2 = pickle.loads(pickle.dumps(cb))
+        cid = cb2.connect('c', lambda: None)
+        assert cid == 1
+
     @pytest.mark.parametrize('pickle', [True, False])
     def test_callback_complete(self, pickle):
         # ensure we start with an empty registry


### PR DESCRIPTION
## PR summary

Account for a deprecation in CPython.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
