### PR TITLE
Avoid Py_VerboseFlag deprecation from Python 3.12

### DIFF
--- a/lib/matplotlib/tri/_triangulation.py
+++ b/lib/matplotlib/tri/_triangulation.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 
 from matplotlib import _api
@@ -55,7 +57,7 @@ class Triangulation:
         if triangles is None:
             # No triangulation specified, so use matplotlib._qhull to obtain
             # Delaunay triangulation.
-            self.triangles, self._neighbors = _qhull.delaunay(x, y)
+            self.triangles, self._neighbors = _qhull.delaunay(x, y, sys.flags.verbose)
             self.is_delaunay = True
         else:
             # Triangulation specified. Copy, since we may correct triangle

--- a/src/_qhull_wrapper.cpp
+++ b/src/_qhull_wrapper.cpp
@@ -258,10 +258,12 @@ delaunay(PyObject *self, PyObject *args)
     npy_intp npoints;
     const double* x;
     const double* y;
+    int verbose = 0;
 
-    if (!PyArg_ParseTuple(args, "O&O&",
+    if (!PyArg_ParseTuple(args, "O&O&i:delaunay",
                           &xarray.converter_contiguous, &xarray,
-                          &yarray.converter_contiguous, &yarray)) {
+                          &yarray.converter_contiguous, &yarray,
+                          &verbose)) {
         return NULL;
     }
 
@@ -288,7 +290,7 @@ delaunay(PyObject *self, PyObject *args)
     }
 
     CALL_CPP("qhull.delaunay",
-             (ret = delaunay_impl(npoints, x, y, Py_VerboseFlag == 0)));
+             (ret = delaunay_impl(npoints, x, y, verbose == 0)));
 
     return ret;
 }
@@ -302,7 +304,7 @@ version(PyObject *self, PyObject *arg)
 
 static PyMethodDef qhull_methods[] = {
     {"delaunay", delaunay, METH_VARARGS,
-     "delaunay(x, y, /)\n"
+     "delaunay(x, y, verbose, /)\n"
      "--\n\n"
      "Compute a Delaunay triangulation.\n"
      "\n"
@@ -311,6 +313,8 @@ static PyMethodDef qhull_methods[] = {
      "x, y : 1d arrays\n"
      "    The coordinates of the point set, which must consist of at least\n"
      "    three unique points.\n"
+     "verbose : int\n"
+     "    Python's verbosity level.\n"
      "\n"
      "Returns\n"
      "-------\n"


### PR DESCRIPTION
## PR summary

This C-level variable is [deprecated in Python 3.12](https://docs.python.org/3.12/whatsnew/3.12.html#id4); the documented replacement there is for _initialization_ and there isn't really a [quick way to get it at runtime](https://github.com/python/cpython/issues/99872), so it seemed easier to fetch the value from Python.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines