### PR TITLE
precommit warns on main + instructions for fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,8 @@ repos:
         args: ["--pytest-test-first"]
       - id: trailing-whitespace
         exclude_types: [svg]
+      - id: no-commit-to-branch #default is master and main
+        name: don't commit to main branch. rename `git branch -m <newname>` then rebase `git rebase -i upstream\main`
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:


### PR DESCRIPTION
Added a branch project rule to the pre-commit so that it complains if you try to commit directly to main. I figure folks who really need to push to main also know how to work around it. based on convo in call w/ @greglucas 

Not quite sure this is the best way to handle the error message but figure we need to give folks a fix. 
Um sorry, did not mean to open this branch on the mpl repo. (Also don't know how I did that since I branched from my local fork 😦)