### PR TITLE
precommit warns on main + instructions for fix

### DIFF
--- a/.github/workflows/clean_pr.yml
+++ b/.github/workflows/clean_pr.yml
@@ -45,3 +45,8 @@ jobs:
             printf 'Changes to the following files have no effect and should not be backported:\n%s\n' "$lib"
             exit 1
           fi
+      - name: Check for branches opened against main
+        if: github.ref_name == 'main'
+        run: |
+          printf 'PR branch should not be main. See https://matplotlib.org/devdocs/devel/development_workflow.html#make-a-new-feature-branch'
+          exit 1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,8 +23,10 @@ repos:
       - id: mixed-line-ending
       - id: name-tests-test
         args: ["--pytest-test-first"]
+      - id: no-commit-to-branch #default is master and main
       - id: trailing-whitespace
         exclude_types: [svg]
+
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -63,10 +63,15 @@ what the changes in the branch are for.  For example ``add-ability-to-fly``, or
     git branch my-new-feature upstream/main
     git checkout my-new-feature
 
+If you started making changes on your local ``main`` branch, you can convert the
+branch to a feature branch by renaming it::
+
+   git branch -m <newname>
+
 Generally, you will want to keep your feature branches on your public GitHub
 fork of Matplotlib.  To do this, you ``git push`` this new branch up to your
-GitHub repo.  Generally (if you followed the instructions in these pages, and by
-default), git will have a link to your fork of the GitHub repo, called
+GitHub repo.  Generally, if you followed the instructions in these pages, and by
+default, git will have a link to your fork of the GitHub repo, called
 ``origin``.  You push up to your own fork with::
 
    git push origin my-new-feature
@@ -78,6 +83,12 @@ In git >= 1.7 you can ensure that the link is correctly set by using the
 
 From now on git will know that ``my-new-feature`` is related to the
 ``my-new-feature`` branch in the GitHub repo.
+
+If you first opened the pull request from your ``main`` branch and then
+converted it to a feature branch, you will need to close the original pull
+request and open a new pull request from the renamed branch. See
+`GitHub: working with branches
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#working-with-branches>`_.
 
 .. _edit-flow:
 


### PR DESCRIPTION
Added a branch protect rule to the pre-commit so that it complains if you try to commit directly to main. I figure folks who really need to push to main also know how to work around it. based on convo in call w/ @greglucas

Not quite sure this is the best way to handle the error message but figure we need to give folks a fix.

Is a replacement for #26170 which I'm not sure how I accidentally created directly on the repo. 