### PR TITLE
FIX: AnnotationBbox extents before draw

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1389,11 +1389,15 @@ or callable, default: value of *xycoords*
         # docstring inherited
         if renderer is None:
             renderer = self.figure._get_renderer()
+        self.update_positions(renderer)
         return Bbox.union([child.get_window_extent(renderer)
                            for child in self.get_children()])
 
     def get_tightbbox(self, renderer=None):
         # docstring inherited
+        if renderer is None:
+            renderer = self.figure._get_renderer()
+        self.update_positions(renderer)
         return Bbox.union([child.get_tightbbox(renderer)
                            for child in self.get_children()])
 

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -257,7 +257,8 @@ def test_anchoredtext_horizontal_alignment():
     ax.add_artist(text2)
 
 
-def test_annotationbbox_extents():
+@pytest.mark.parametrize("extent_kind", ["window_extent", "tightbbox"])
+def test_annotationbbox_extents(extent_kind):
     plt.rcParams.update(plt.rcParamsDefault)
     fig, ax = plt.subplots(figsize=(4, 3), dpi=100)
 
@@ -284,31 +285,22 @@ def test_annotationbbox_extents():
                          arrowprops=dict(arrowstyle="->"))
     ax.add_artist(ab6)
 
-    fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()
-
     # Test Annotation
-    bb1w = an1.get_window_extent(renderer)
-    bb1e = an1.get_tightbbox(renderer)
+    bb1 = getattr(an1, f"get_{extent_kind}")()
 
     target1 = [332.9, 242.8, 467.0, 298.9]
-    assert_allclose(bb1w.extents, target1, atol=2)
-    assert_allclose(bb1e.extents, target1, atol=2)
+    assert_allclose(bb1.extents, target1, atol=2)
 
     # Test AnnotationBbox
-    bb3w = ab3.get_window_extent(renderer)
-    bb3e = ab3.get_tightbbox(renderer)
+    bb3 = getattr(ab3, f"get_{extent_kind}")()
 
     target3 = [-17.6, 129.0, 200.7, 167.9]
-    assert_allclose(bb3w.extents, target3, atol=2)
-    assert_allclose(bb3e.extents, target3, atol=2)
+    assert_allclose(bb3.extents, target3, atol=2)
 
-    bb6w = ab6.get_window_extent(renderer)
-    bb6e = ab6.get_tightbbox(renderer)
+    bb6 = getattr(ab6, f"get_{extent_kind}")()
 
     target6 = [180.0, -32.0, 230.0, 92.9]
-    assert_allclose(bb6w.extents, target6, atol=2)
-    assert_allclose(bb6e.extents, target6, atol=2)
+    assert_allclose(bb6.extents, target6, atol=2)
 
     # Test bbox_inches='tight'
     buf = io.BytesIO()


### PR DESCRIPTION
## PR summary

Fixes #24453

Calling `update_positions` before working out the bbox within `get_tightbbox` means constrained layout will get sensible numbers to work with so the example from the issue works as expected.  We can now also have constrained layout make space for the annotation if it is not contained within the axes:

```python
import matplotlib.pyplot as plt
from matplotlib.offsetbox import AnnotationBbox, TextArea

fig, ax = plt.subplots(layout="constrained")

ab = AnnotationBbox(
    TextArea("Some text", textprops={"size": 42}),
    (1, 0.5),
    xycoords="axes fraction",
    box_alignment=(0.5, 0.5),
    pad=0
)

ax.add_artist(ab)
fig.savefig("annotation_box.png", dpi=100)
```

![annotation_box](https://github.com/matplotlib/matplotlib/assets/10599679/2d680c06-58a6-4f6a-809e-76ba649bc052)

I'm not sure where `get_window_extent` is used, but I updated that in the same way for consistency (and to get the test passing after I removed the draw from it).

Also split the test into two so that the two methods can be checked independently of each other.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
