### PR TITLE
[Doc] link style sheets reference to customization tutorial

### DIFF
--- a/doc/api/style_api.rst
+++ b/doc/api/style_api.rst
@@ -20,13 +20,13 @@ the builtin styles.
 .. imported variables have to be specified explicitly due to
    https://github.com/sphinx-doc/sphinx/issues/6607
 
-.. data:: matplotlib.style.library
+.. data:: library
 
-   A dict mapping from style name to `.RcParams` defining that style.
+   A dict mapping from style name to `.rcParams` defining that style.
 
    This is meant to be read-only. Use `.reload_library` to update.
 
-.. data:: matplotlib.style.available
+.. data:: available
 
    List of the names of the available styles.
 

--- a/galleries/examples/style_sheets/style_sheets_reference.py
+++ b/galleries/examples/style_sheets/style_sheets_reference.py
@@ -5,8 +5,15 @@ Style sheets reference
 
 This script demonstrates the different available style sheets on a
 common set of example plots: scatter plot, image, bar graph, patches,
-line plot and histogram,
+line plot and histogram.
 
+Any of these style sheets can be imported (i.e. activated) by its name with:
+
+>>> plt.style.use('ggplot')
+
+while name of the available style sheets (printed in corner of the plots below) can be found in the list `matplotlib.style.available`.
+
+See more details in :ref:`Customizing Matplotlib using style sheets<customizing-with-style-sheets>`.
 """
 
 import matplotlib.pyplot as plt

--- a/galleries/examples/style_sheets/style_sheets_reference.py
+++ b/galleries/examples/style_sheets/style_sheets_reference.py
@@ -16,7 +16,8 @@ The names of the available style sheets can be found
 in the list `matplotlib.style.available`
 (they are also printed in the corner of each plot below).
 
-See more details in :ref:`Customizing Matplotlib using style sheets<customizing-with-style-sheets>`.
+See more details in :ref:`Customizing Matplotlib
+using style sheets<customizing-with-style-sheets>`.
 """
 
 import matplotlib.pyplot as plt

--- a/galleries/examples/style_sheets/style_sheets_reference.py
+++ b/galleries/examples/style_sheets/style_sheets_reference.py
@@ -7,11 +7,14 @@ This script demonstrates the different available style sheets on a
 common set of example plots: scatter plot, image, bar graph, patches,
 line plot and histogram.
 
-Any of these style sheets can be imported (i.e. activated) by its name with:
+Any of these style sheets can be imported (i.e. activated) by its name.
+For example for the ggplot style:
 
 >>> plt.style.use('ggplot')
 
-while name of the available style sheets (printed in corner of the plots below) can be found in the list `matplotlib.style.available`.
+The names of the available style sheets can be found
+in the list `matplotlib.style.available`
+(they are also printed in the corner of each plot below).
 
 See more details in :ref:`Customizing Matplotlib using style sheets<customizing-with-style-sheets>`.
 """


### PR DESCRIPTION
## PR summary

While sharing the [Style sheets reference](https://matplotlib.org/stable/gallery/style_sheets/style_sheets_reference.html) gallery page to a colleague, I realized it's not self-contained in the sense that it doesn't explain how to use style sheets nor does it link to the corresponding [Customizing Matplotlib with style sheets](https://matplotlib.org/stable/tutorials/introductory/customizing.html#using-style-sheets) tutorial.

In this small expansion of the top docstring of `style_sheets_reference.py`, I added:
- a short repl code example for `plt.style.use` and a mention to `matplotlib.style.available` (which is used in the script, but it's quite buried)
- a link to the Customizing Matplotlib tutotorial (to the subsection on style sheet usage)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

*However, since I don't have a proper devel setup, I unfortunately didn't check that the Sphinx compilation runs fine. Hopefully my change is small enough that I didn't introduce a syntax error, but it's far from sure...*