### PR TITLE
CI: Add pre-release installs to upcoming tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -189,6 +189,12 @@ jobs:
           # possible.
           python -m pip install --upgrade pip setuptools wheel
 
+          # Install pre-release versions during our weekly upcoming dependency tests.
+          if [[ "${{ github.event_name == 'schedule' && \
+                     matrix.name-suffix != '(Minimum Versions)' }}' ]]; then
+            PRE="--pre"
+          fi
+
           # Install dependencies from PyPI.
           python -m pip install --upgrade $PRE \
             'contourpy>=1.0.1' cycler fonttools kiwisolver importlib_resources \


### PR DESCRIPTION
## PR summary

There is a spot reserved for $PRE in the package installation command, but the environment variable doesn't appear to be set anywhere... Let's add it when we are doing our weekly scheduled runs to get other packages' pre-releases, not just the ones from pandas and numpy. Note this may cause more noise and be a little harder to track down where the issue is coming from, but seems like a good thing to do to test against other upcoming packages.