### PR TITLE
ci: Fix typo for nightly builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -190,8 +190,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Install pre-release versions during our weekly upcoming dependency tests.
-          if [[ "${{ github.event_name == 'schedule' && \
-                     matrix.name-suffix != '(Minimum Versions)' }}' ]]; then
+          if [[ "${{ github.event_name == 'schedule' &&
+                     matrix.name-suffix != '(Minimum Versions)' }}" = "true" ]]; then
             PRE="--pre"
           fi
 


### PR DESCRIPTION
## PR summary

A small typo was introduced in #26197.

## PR checklist:

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines