### PR TITLE
TightLayoutEngine.execute runs get_tight_layout_figure twice

### DIFF
--- a/lib/matplotlib/layout_engine.py
+++ b/lib/matplotlib/layout_engine.py
@@ -180,12 +180,13 @@ class TightLayoutEngine(LayoutEngine):
         info = self._params
         renderer = fig._get_renderer()
         with getattr(renderer, "_draw_disabled", nullcontext)():
-            kwargs = get_tight_layout_figure(
-                fig, fig.axes, get_subplotspec_list(fig.axes), renderer,
-                pad=info['pad'], h_pad=info['h_pad'], w_pad=info['w_pad'],
-                rect=info['rect'])
-        if kwargs:
-            fig.subplots_adjust(**kwargs)
+            for _ in range(2):
+                kwargs = get_tight_layout_figure(
+                    fig, fig.axes, get_subplotspec_list(fig.axes), renderer,
+                    pad=info['pad'], h_pad=info['h_pad'], w_pad=info['w_pad'],
+                    rect=info['rect'])
+                if kwargs:
+                    fig.subplots_adjust(**kwargs)
 
     def set(self, *, pad=None, w_pad=None, h_pad=None, rect=None):
         """


### PR DESCRIPTION
## PR summary

If `AutoLocator` is used, changing the location of axes may change the ticklabels.
Thus the result of tight_layout may not be optimal.

```python
    fig = plt.figure(layout="tight", figsize=(3, 3))
    fig.subplots(3, 3)
    fig.set_facecolor("0.8")
```

![tightlayout_single](https://github.com/matplotlib/matplotlib/assets/95962/fb9ac1b0-9a0a-4a99-abbd-816f0b59593a)

The PR simply runs the algorithm twice.

![tightlayout_double](https://github.com/matplotlib/matplotlib/assets/95962/8f23c333-0858-4d6e-96c4-f38d6eb9c61a)

* `ConstrainedLayoutEngine` also runs its algorithm twice (`_constrained_layout.do_constrained_layout`)
* There are failing tests, because the result of running the algorithm twice can be different for running it only once. We need to update the baseline images if this PR to be accepted.
* I can add a simple test if requested.
* My intention is to have this PR merged before I further work on #26108.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
