### PR TITLE
Re-export textpath types in text

### DIFF
--- a/lib/matplotlib/text.pyi
+++ b/lib/matplotlib/text.pyi
@@ -4,6 +4,10 @@ from .font_manager import FontProperties
 from .offsetbox import DraggableAnnotation
 from .path import Path
 from .patches import FancyArrowPatch, FancyBboxPatch
+from .textpath import (  # noqa: reexported API
+    TextPath as TextPath,
+    TextToPath as TextToPath,
+)
 from .transforms import (
     Bbox,
     BboxBase,


### PR DESCRIPTION
## PR summary

The former location was deprecated in 3.7 (#23576), and accidentally removed earlier during some cleanup (#25787).

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines