### PR TITLE
Avoid deprecated typing hints

### DIFF
--- a/lib/matplotlib/_path.pyi
+++ b/lib/matplotlib/_path.pyi
@@ -1,5 +1,7 @@
-from typing import Sequence
+from collections.abc import Sequence
+
 import numpy as np
+
 from .transforms import BboxBase
 
 def affine_transform(points: np.ndarray, trans: np.ndarray) -> np.ndarray: ...

--- a/lib/matplotlib/cbook.pyi
+++ b/lib/matplotlib/cbook.pyi
@@ -11,7 +11,6 @@ from numpy.typing import ArrayLike
 
 from typing import (
     Any,
-    ContextManager,
     Generic,
     IO,
     Literal,
@@ -68,7 +67,7 @@ def open_file_cm(
     path_or_file: str | os.PathLike | IO,
     mode: str = ...,
     encoding: str | None = ...,
-) -> ContextManager[IO]: ...
+) -> contextlib.AbstractContextManager[IO]: ...
 def is_scalar_or_string(val: Any) -> bool: ...
 @overload
 def get_sample_data(

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -81,16 +81,14 @@ import numpy as np
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable, Hashable, Iterable, Sequence
     import datetime
     import pathlib
     import os
+    from typing import Any, BinaryIO, Literal
 
     import PIL
-
     from numpy.typing import ArrayLike
-    from typing import (
-        Any, BinaryIO, Callable, Hashable, Literal, Sequence, Iterable, Type
-    )
 
     from matplotlib.axis import Tick
     from matplotlib.axes._base import _AxesBase
@@ -229,7 +227,7 @@ def set_loglevel(*args, **kwargs) -> None:
 @_copy_docstring_and_deprecators(Artist.findobj)
 def findobj(
     o: Artist | None = None,
-    match: Callable[[Artist], bool] | Type[Artist] | None = None,
+    match: Callable[[Artist], bool] | type[Artist] | None = None,
     include_self: bool = True
 ) -> list[Artist]:
     if o is None:
@@ -751,7 +749,7 @@ def figure(
     # defaults to rc figure.edgecolor
     edgecolor: ColorType | None = None,
     frameon: bool = True,
-    FigureClass: Type[Figure] = Figure,
+    FigureClass: type[Figure] = Figure,
     clear: bool = False,
     **kwargs
 ) -> Figure:

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -9,9 +9,9 @@ downstream libraries.
     The ``typing`` module and type stub files are considered provisional and may change
     at any time without a deprecation period.
 """
-from collections.abc import Sequence
+from collections.abc import Hashable, Sequence
 import pathlib
-from typing import Any, Hashable, Literal, Union
+from typing import Any, Literal, Union
 
 from . import path
 from ._enums import JoinStyle, CapStyle


### PR DESCRIPTION
## PR summary

These were all deprecated in Python 3.9 by PEP 585 and Generic Alias types (i.e., stuff like `typing.List` -> `list`).

Note, `Hashable`, and `Sized` are not deprecated, but they are aliases, so I moved them as well.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines