### PR TITLE
Backport PR #26126 on branch v3.7.x (Revert "Merge pull request #24555 from parthpankajtiwary/symlog-warn")

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -389,11 +389,6 @@ class InvertedSymmetricalLogTransform(Transform):
 
     def transform_non_affine(self, a):
         abs_a = np.abs(a)
-        if (abs_a < self.linthresh).all():
-            _api.warn_external(
-                "All values for SymLogScale are below linthresh, making "
-                "it effectively linear. You likely should lower the value "
-                "of linthresh. ")
         with np.errstate(divide="ignore", invalid="ignore"):
             out = np.sign(a) * self.linthresh * (
                 np.power(self.base,

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -55,20 +55,6 @@ def test_symlog_mask_nan():
     assert type(out) == type(x)
 
 
-def test_symlog_linthresh():
-    np.random.seed(19680801)
-    x = np.random.random(100)
-    y = np.random.random(100)
-
-    fig, ax = plt.subplots()
-    plt.plot(x, y, 'o')
-    ax.set_xscale('symlog')
-    ax.set_yscale('symlog')
-
-    with pytest.warns(UserWarning, match="All values .* of linthresh"):
-        fig.canvas.draw()
-
-
 @image_comparison(['logit_scales.png'], remove_text=True)
 def test_logit_scales():
     fig, ax = plt.subplots()


### PR DESCRIPTION
## PR summary

Backport of #26126. Only conflict is that the `a` argument of `transform_non_affine` was renamed to `values`.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines