### PR TITLE
moved minimum dependencies to maintainance section 

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -83,7 +83,6 @@ Development workflow
          :maxdepth: 1
 
          dependencies
-         Minimum versions <min_dep_policy>
 
 
    .. grid-item-card:: Workflow
@@ -133,6 +132,7 @@ Contribution guides
          :maxdepth: 1
 
          release_guide
+         min_dep_policy
          MEP/index
 
 .. toctree::

--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -1,8 +1,8 @@
 .. _min_deps_policy:
 
-======================================
-Minimum version of dependencies policy
-======================================
+=========================
+Dependency version policy
+=========================
 
 For the purpose of this document, 'minor version' is in the sense of
 SemVer (major, minor, patch) and includes both major and minor


### PR DESCRIPTION
Implements @rcomer's suggestion in #26196 that minimum dependencies makes more sense as part of the maintainer guidelines than installation guidelines so move the link there (until larger reorg). 

I'm not feeling the title `Minimum version of dependencies policy" but not sure about a shorter equivalent