### PR TITLE
DOC: Restore banner indicating docs are unreleased

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -9,6 +9,29 @@
     margin: 0;
 }
 
+/* Make announcement an error colour for unreleased documentation, and sticky. */
+#unreleased-message.bd-header-announcement {
+    border-bottom: solid var(--pst-color-danger-highlight);
+    color: var(--pst-color-danger-text);
+    font-weight: var(--pst-admonition-font-weight-heading);
+    position: sticky;
+    top: 0;
+    z-index: 1050;
+}
+
+#unreleased-message.bd-header-announcement:after {
+    background-color: var(--pst-color-danger);
+    opacity: 1;
+}
+
+#unreleased-message.bd-header-announcement a {
+    color: var(--pst-color-danger-text);
+}
+
+#unreleased-message.bd-header-announcement + .bd-navbar {
+    top: 3rem;  /* Minimum height of announcement header. */
+}
+
 /* multi column TOC */
 .contents ul {
     list-style-type: none;

--- a/doc/_templates/sections/announcement.html
+++ b/doc/_templates/sections/announcement.html
@@ -1,0 +1,13 @@
+{%- if theme_announcement == "unreleased" -%}
+{% set header_classes = ["bd-header-announcement", "container-fluid"] %}
+  <div class="{{ header_classes | join(' ') }}" id="unreleased-message">
+    <div class="bd-header-announcement__content">
+      You are reading documentation for the unreleased version of Matplotlib.
+      <a href="https://matplotlib.org/search.html?q={{ title | striptags | urlencode }}&amp;check_keywords=yes&amp;area=default">
+        Try searching for the released version of this page instead?
+      </a>
+    </div>
+  </div>
+{%- else -%}
+  {%- extends "!sections/announcement.html" -%}
+{%- endif %}

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -462,7 +462,11 @@ html_theme_options = {
     },
     "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"],
     "secondary_sidebar_items": "page-toc.html",
-     "footer_start": ["copyright", "sphinx-version", "doc_version"],
+    "footer_start": ["copyright", "sphinx-version", "doc_version"],
+    # We override the announcement template from pydata-sphinx-theme, where
+    # this special value indicates the use of the unreleased banner. If we need
+    # an actual announcement, then just place the text here as usual.
+    "announcement": "unreleased" if not is_release_build else "",
 }
 include_analytics = is_release_build
 if include_analytics:


### PR DESCRIPTION
## PR summary

This was dropped when switching to the pydata-sphinx-theme. They have a method of adding an announcement, but because it's a pure text substitution, we can't have it automatically search like our old banner.

While the theme also supports loading from an http resource, that would mean writing some JavaScript instead of automatically creating this div at build time.

So override the theme component, and create the search link at build time.

I'm only a bit annoyed that the announcement overlays the normal navigation bar. I'm not sure it's really possible to avoid that without wrapping both in their own sticky `div`, but that would require overriding the entire theme layout, and that's a bit too much for my taste.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines