### PR TITLE
Fix: pcolormesh writing to read-only input mask

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5740,9 +5740,6 @@ default: :rc:`scatter.edgecolors`
         self.add_image(im)
         return im
 
-    def _is_unwritable(self, c):
-        return np.ma.is_masked(c) and not c.mask.flags.writeable
-
     def _pcolorargs(self, funcname, *args, shading='auto', **kwargs):
         # - create X and Y if not present;
         # - reshape X and Y as needed if they are 1-D;
@@ -5767,8 +5764,7 @@ default: :rc:`scatter.edgecolors`
             else:
                 X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
                 shading = 'flat'
-            copy = self._is_unwritable(C)
-            C = cbook.safe_masked_invalid(C, copy=copy)
+            C = cbook.safe_masked_invalid(C, copy=True)
             return X, Y, C, shading
 
         if len(args) == 3:
@@ -5857,8 +5853,7 @@ default: :rc:`scatter.edgecolors`
                     Y = _interp_grid(Y.T).T
                 shading = 'flat'
 
-        copy = self._is_unwritable(C)
-        C = cbook.safe_masked_invalid(C, copy=copy)
+        C = cbook.safe_masked_invalid(C, copy=True)
         return X, Y, C, shading
 
     @_preprocess_data()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5740,6 +5740,9 @@ default: :rc:`scatter.edgecolors`
         self.add_image(im)
         return im
 
+    def _is_unwritable(self, c):
+        return np.ma.is_masked(c) and not c.mask.flags.writeable
+
     def _pcolorargs(self, funcname, *args, shading='auto', **kwargs):
         # - create X and Y if not present;
         # - reshape X and Y as needed if they are 1-D;
@@ -5764,7 +5767,8 @@ default: :rc:`scatter.edgecolors`
             else:
                 X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
                 shading = 'flat'
-            C = cbook.safe_masked_invalid(C, copy=True)
+            copy = self._is_unwritable(C)
+            C = cbook.safe_masked_invalid(C, copy=copy)
             return X, Y, C, shading
 
         if len(args) == 3:
@@ -5853,7 +5857,8 @@ default: :rc:`scatter.edgecolors`
                     Y = _interp_grid(Y.T).T
                 shading = 'flat'
 
-        C = cbook.safe_masked_invalid(C, copy=True)
+        copy = self._is_unwritable(C)
+        C = cbook.safe_masked_invalid(C, copy=copy)
         return X, Y, C, shading
 
     @_preprocess_data()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5764,7 +5764,7 @@ default: :rc:`scatter.edgecolors`
             else:
                 X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
                 shading = 'flat'
-            C = cbook.safe_masked_invalid(C)
+            C = cbook.safe_masked_invalid(C, copy=True)
             return X, Y, C, shading
 
         if len(args) == 3:
@@ -5853,7 +5853,7 @@ default: :rc:`scatter.edgecolors`
                     Y = _interp_grid(Y.T).T
                 shading = 'flat'
 
-        C = cbook.safe_masked_invalid(C)
+        C = cbook.safe_masked_invalid(C, copy=True)
         return X, Y, C, shading
 
     @_preprocess_data()

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -668,7 +668,7 @@ class Stack:
                 self.push(elem)
 
 
-def safe_masked_invalid(x, copy=True):
+def safe_masked_invalid(x, copy=False):
     x = np.array(x, subok=True, copy=copy)
     if not x.dtype.isnative:
         # If we have already made a copy, do the byteswap in place, else make a

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -668,7 +668,7 @@ class Stack:
                 self.push(elem)
 
 
-def safe_masked_invalid(x, copy=False):
+def safe_masked_invalid(x, copy=True):
     x = np.array(x, subok=True, copy=copy)
     if not x.dtype.isnative:
         # If we have already made a copy, do the byteswap in place, else make a

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1482,6 +1482,7 @@ def test_pcolorargs():
 def test_pcolorargs_with_read_only():
     x = np.arange(6).reshape(2, 3)
     xmask = np.broadcast_to([False, True, False], x.shape)  # read-only array
+    assert xmask.flags.writeable is False
     masked_x = np.ma.array(x, mask=xmask)
     plt.pcolormesh(masked_x)
 
@@ -1490,6 +1491,7 @@ def test_pcolorargs_with_read_only():
     X, Y = np.meshgrid(x, y)
     Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
     Zmask = np.broadcast_to([True, False] * 5, Z.shape)
+    assert Zmask.flags.writeable is False
     masked_Z = np.ma.array(Z, mask=Zmask)
     plt.pcolormesh(X, Y, masked_Z)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1489,7 +1489,7 @@ def test_pcolorargs():
     X, Y = np.meshgrid(x, y)
     Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
     Zmask = np.broadcast_to([True, False]*5, Z.shape)
-    masked_Z = np.ma.array(Z, mask = Zmask)
+    masked_Z = np.ma.array(Z, mask=Zmask)
     plt.pcolormesh(X, Y, masked_Z)
 
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1478,17 +1478,18 @@ def test_pcolorargs():
                       match='are not monotonically increasing or decreasing'):
         ax.pcolormesh(X, Y, Z, shading='auto')
 
-    # GH 26093
+
+def test_pcolorargs_with_read_only():
     x = np.arange(6).reshape(2, 3)
-    mask = np.broadcast_to([False, True, False], x.shape)  # read-only array
-    masked_x = np.ma.array(x, mask=mask)
+    xmask = np.broadcast_to([False, True, False], x.shape)  # read-only array
+    masked_x = np.ma.array(x, mask=xmask)
     plt.pcolormesh(masked_x)
 
     x = np.linspace(0, 1, 10)
     y = np.linspace(0, 1, 10)
     X, Y = np.meshgrid(x, y)
     Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
-    Zmask = np.broadcast_to([True, False]*5, Z.shape)
+    Zmask = np.broadcast_to([True, False] * 5, Z.shape)
     masked_Z = np.ma.array(Z, mask=Zmask)
     plt.pcolormesh(X, Y, masked_Z)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1478,6 +1478,20 @@ def test_pcolorargs():
                       match='are not monotonically increasing or decreasing'):
         ax.pcolormesh(X, Y, Z, shading='auto')
 
+    # GH 26093
+    x = np.arange(6).reshape(2, 3)
+    mask = np.broadcast_to([False, True, False], x.shape)  # read-only array
+    masked_x = np.ma.array(x, mask=mask)
+    plt.pcolormesh(masked_x)
+
+    x = np.linspace(0, 1, 10)
+    y = np.linspace(0, 1, 10)
+    X, Y = np.meshgrid(x, y)
+    Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
+    Zmask = np.broadcast_to([True, False]*5, Z.shape)
+    masked_Z = np.ma.array(Z, mask = Zmask)
+    plt.pcolormesh(X, Y, masked_Z)
+
 
 @check_figures_equal(extensions=["png"])
 def test_pcolornearest(fig_test, fig_ref):


### PR DESCRIPTION
## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #26093" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
