### PR TITLE
Use CLOSEPOLY kind code to close tricontourf polygons

### DIFF
--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1350,8 +1350,7 @@ def test_tricontour_path():
 
     # Line strip from boundary to boundary
     cs = ax.tricontour(triang, [1, 0, 0, 0, 0], levels=[0.5])
-    assert len(cs.collections) == 1
-    paths = cs.collections[0].get_paths()
+    paths = cs.get_paths()
     assert len(paths) == 1
     expected_vertices = [[2, 0], [1, 1], [0, 2]]
     assert_array_almost_equal(paths[0].vertices, expected_vertices)
@@ -1361,8 +1360,7 @@ def test_tricontour_path():
 
     # Closed line loop inside domain
     cs = ax.tricontour(triang, [0, 0, 0, 0, 1], levels=[0.5])
-    assert len(cs.collections) == 1
-    paths = cs.collections[0].get_paths()
+    paths = cs.get_paths()
     assert len(paths) == 1
     expected_vertices = [[3, 1], [3, 3], [1, 3], [1, 1], [3, 1]]
     assert_array_almost_equal(paths[0].vertices, expected_vertices)
@@ -1378,8 +1376,7 @@ def test_tricontourf_path():
 
     # Polygon inside domain
     cs = ax.tricontourf(triang, [0, 0, 0, 0, 1], levels=[0.5, 1.5])
-    assert len(cs.collections) == 1
-    paths = cs.collections[0].get_paths()
+    paths = cs.get_paths()
     assert len(paths) == 1
     expected_vertices = [[3, 1], [3, 3], [1, 3], [1, 1], [3, 1]]
     assert_array_almost_equal(paths[0].vertices, expected_vertices)
@@ -1388,8 +1385,7 @@ def test_tricontourf_path():
 
     # Polygon following boundary and inside domain
     cs = ax.tricontourf(triang, [1, 0, 0, 0, 0], levels=[0.5, 1.5])
-    assert len(cs.collections) == 1
-    paths = cs.collections[0].get_paths()
+    paths = cs.get_paths()
     assert len(paths) == 1
     expected_vertices = [[2, 0], [1, 1], [0, 2], [0, 0], [2, 0]]
     assert_array_almost_equal(paths[0].vertices, expected_vertices)
@@ -1398,8 +1394,7 @@ def test_tricontourf_path():
 
     # Polygon is outer boundary with hole
     cs = ax.tricontourf(triang, [0, 0, 0, 0, 1], levels=[-0.5, 0.5])
-    assert len(cs.collections) == 1
-    paths = cs.collections[0].get_paths()
+    paths = cs.get_paths()
     assert len(paths) == 1
     expected_vertices = [[0, 0], [4, 0], [4, 4], [0, 4], [0, 0],
                          [1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1340,3 +1340,69 @@ def test_triplot_label():
     assert labels == ['label']
     assert len(handles) == 1
     assert handles[0] is lines
+
+
+def test_tricontour_path():
+    x = [0, 4, 4, 0, 2]
+    y = [0, 0, 4, 4, 2]
+    triang = mtri.Triangulation(x, y)
+    _, ax = plt.subplots()
+
+    # Line strip from boundary to boundary
+    cs = ax.tricontour(triang, [1, 0, 0, 0, 0], levels=[0.5])
+    assert len(cs.collections) == 1
+    paths = cs.collections[0].get_paths()
+    assert len(paths) == 1
+    expected_vertices = [[2, 0], [1, 1], [0, 2]]
+    assert_array_almost_equal(paths[0].vertices, expected_vertices)
+    assert_array_equal(paths[0].codes, [1, 2, 2])
+    assert_array_almost_equal(
+        paths[0].to_polygons(closed_only=False), [expected_vertices])
+
+    # Closed line loop inside domain
+    cs = ax.tricontour(triang, [0, 0, 0, 0, 1], levels=[0.5])
+    assert len(cs.collections) == 1
+    paths = cs.collections[0].get_paths()
+    assert len(paths) == 1
+    expected_vertices = [[3, 1], [3, 3], [1, 3], [1, 1], [3, 1]]
+    assert_array_almost_equal(paths[0].vertices, expected_vertices)
+    assert_array_equal(paths[0].codes, [1, 2, 2, 2, 79])
+    assert_array_almost_equal(paths[0].to_polygons(), [expected_vertices])
+
+
+def test_tricontourf_path():
+    x = [0, 4, 4, 0, 2]
+    y = [0, 0, 4, 4, 2]
+    triang = mtri.Triangulation(x, y)
+    _, ax = plt.subplots()
+
+    # Polygon inside domain
+    cs = ax.tricontourf(triang, [0, 0, 0, 0, 1], levels=[0.5, 1.5])
+    assert len(cs.collections) == 1
+    paths = cs.collections[0].get_paths()
+    assert len(paths) == 1
+    expected_vertices = [[3, 1], [3, 3], [1, 3], [1, 1], [3, 1]]
+    assert_array_almost_equal(paths[0].vertices, expected_vertices)
+    assert_array_equal(paths[0].codes, [1, 2, 2, 2, 79])
+    assert_array_almost_equal(paths[0].to_polygons(), [expected_vertices])
+
+    # Polygon following boundary and inside domain
+    cs = ax.tricontourf(triang, [1, 0, 0, 0, 0], levels=[0.5, 1.5])
+    assert len(cs.collections) == 1
+    paths = cs.collections[0].get_paths()
+    assert len(paths) == 1
+    expected_vertices = [[2, 0], [1, 1], [0, 2], [0, 0], [2, 0]]
+    assert_array_almost_equal(paths[0].vertices, expected_vertices)
+    assert_array_equal(paths[0].codes, [1, 2, 2, 2, 79])
+    assert_array_almost_equal(paths[0].to_polygons(), [expected_vertices])
+
+    # Polygon is outer boundary with hole
+    cs = ax.tricontourf(triang, [0, 0, 0, 0, 1], levels=[-0.5, 0.5])
+    assert len(cs.collections) == 1
+    paths = cs.collections[0].get_paths()
+    assert len(paths) == 1
+    expected_vertices = [[0, 0], [4, 0], [4, 4], [0, 4], [0, 0],
+                         [1, 1], [1, 3], [3, 3], [3, 1], [1, 1]]
+    assert_array_almost_equal(paths[0].vertices, expected_vertices)
+    assert_array_equal(paths[0].codes, [1, 2, 2, 2, 79, 1, 2, 2, 2, 79])
+    assert_array_almost_equal(paths[0].to_polygons(), np.split(expected_vertices, [5]))


### PR DESCRIPTION
Closes #25114.

Previously polygons generated by `tricontourf` have finished with a kind code of `2` (`MOVETO`) rather than `79` (`CLOSEPOLY`). This wasn't a problem for rendering but was for people doing something with the generated paths such as using `to_polygons()`.

The fix is to ensure that polygons generated by `tricontour` and `tricontourf` have their last vertex identical to their first vertex, and the correct `CLOSEPOLY` code. This is the same as that produced by `contour` and `contourf`.

Simple reproducer:
```python
import matplotlib.tri as mtri
import matplotlib.pyplot as plt

x = [0, 1, 1, 0, 0.5]
y = [0, 0, 1, 1, 0.5]
z = [0, 0, 0, 0, 1.0]
triangles = [[0, 1, 4], [1, 2, 4], [2, 3, 4], [3, 0, 4]]
triang = mtri.Triangulation(x, y, triangles)

_, ax = plt.subplots()
cs = ax.tricontourf(triang, z, levels=[0.5, 2])
print(cs.get_paths()[0])
```
Before the fix this gives
```
Path(array([[0.75, 0.25],
            [0.75, 0.75],
            [0.25, 0.75],
            [0.25, 0.25]]), array([1, 2, 2, 2], dtype=uint8))
```
and after the fix
```
Path(array([[0.75, 0.25],
            [0.75, 0.75],
            [0.25, 0.75],
            [0.25, 0.25],
            [0.75, 0.25]]), array([ 1,  2,  2,  2, 79], dtype=uint8))
```

(Edited to avoid using deprecated API)