### PR TITLE
DOC: ensure that the bounding box is scaled with dpi in example

### DIFF
--- a/galleries/users_explain/figure/figure_intro.rst
+++ b/galleries/users_explain/figure/figure_intro.rst
@@ -251,7 +251,9 @@ would be saved if ``bbox_inches='tight'`` were used in savefig.
     ax.set_aspect(1)
     bb = ax.get_tightbbox()
     bb = bb.padded(10)
+    bb = bb.transformed(fig.dpi_scale_trans.inverted())
     fancy = FancyBboxPatch(bb.p0, bb.width, bb.height, fc='none',
                            ec=(0, 0.0, 0, 0.5), lw=2, linestyle='--',
-                           transform=None, clip_on=False)
+                           transform=fig.dpi_scale_trans,
+                           clip_on=False, boxstyle='Square, pad=0')
     ax.add_patch(fancy)


### PR DESCRIPTION
closes #26264

The three changes are:
 - convert the tightbox to inches (via dpi_scale_trans)
 - set the padding added in `FancyBboxPatch` to 0
 - set the transform on `fancy` to be `fig.dpi_scale_trans` so at draw time it goes back to the correct pixels