### PR TITLE
DOC: Use consistent font for anatomy example

### DIFF
--- a/galleries/examples/showcase/anatomy.py
+++ b/galleries/examples/showcase/anatomy.py
@@ -72,7 +72,7 @@ def annotate(x, y, text, code):
         color = 'white' if path_effects else royal_blue
         ax.text(x, y-0.2, text, zorder=100,
                 ha='center', va='top', weight='bold', color=color,
-                style='italic', fontfamily='Courier New',
+                style='italic', fontfamily='monospace',
                 path_effects=path_effects)
 
         color = 'white' if path_effects else 'black'


### PR DESCRIPTION
## PR summary

The top line uses Courier New, but the lower uses monospace, and the former is not portable.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines