### PR TITLE
DOC: Fix image_rotator

### DIFF
--- a/doc/_static/image-rotator.js
+++ b/doc/_static/image-rotator.js
@@ -7,11 +7,11 @@ function getRandomInt(max) {
 
 var images_rotate = [
     {"image": "sphx_glr_plot_001_2_00x.png", "caption": "plot(x, y)", "link": "plot_types/basic/plot.html"},
-    {"image": "sphx_glr_step_001_2_00x.png", "caption": "step(x, y)", "link": "plot_types/basic/step.html"},
+    {"image": "sphx_glr_fill_between_001_2_00x.png", "caption": "fill_between(x, y1, y2)", "link": "plot_types/basic/fill_between.html"},
     {"image": "sphx_glr_scatter_plot_001_2_00x.png", "caption": "scatter(x, y)", "link": "plot_types/basic/scatter_plot.html"},
     {"image": "sphx_glr_pcolormesh_001_2_00x.png", "caption": "pcolormesh(X, Y, Z)", "link": "plot_types/arrays/pcolormesh.html"},
     {"image": "sphx_glr_contourf_001_2_00x.png", "caption": "contourf(X, Y, Z)", "link": "plot_types/arrays/contourf.html"},
-    {"image": "sphx_glr_step_001_2_00x.png", "caption": "step(x, y)", "link": "plot_types/basic/step.html"},
+    {"image": "sphx_glr_stairs_001_2_00x.png", "caption": "stairs(y)", "link": "plot_types/basic/stairs.html"},
     {"image": "sphx_glr_streamplot_001_2_00x.png", "caption": "streamplot(X, Y, U, V)", "link": "plot_types/arrays/streamplot.html"},
     {"image": "sphx_glr_bar_001_2_00x.png", "caption": "bar(x, height) / barh(y, width)", "link": "plot_types/basic/bar.html"},
     {"image": "sphx_glr_hist_plot_001_2_00x.png", "caption": "hist(x)", "link": "plot_types/stats/hist_plot.html"},


### PR DESCRIPTION
## PR summary
Fix `image_rotator` by replacing removed step with stairs (follow-up to #26233) and replacing the second step entry with the fill_between basic plot


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
