### PR TITLE
Display r and theta on hover for polar plots 

### DIFF
--- a/issue#4568.py
+++ b/issue#4568.py
@@ -1,0 +1,30 @@
+import matplotlib.pyplot as plt
+import numpy as np
+
+def fmt_r(r):
+    # Custom formatting for radial coordinates (r)
+    return f"R={r:.2f}"
+
+def fmt_theta(theta, pos=None):
+    # Custom formatting for angular coordinates (theta)
+    return f"Theta={np.degrees(theta):.2f}°"
+
+def millions(x):
+    return '$%1.1fM' % (x*1e-6)
+
+x = np.random.rand(20)
+y = 1e7 * np.random.rand(20)
+
+# Create a polar subplot using plt.subplot() and specify projection as 'polar'
+ax = plt.subplot(111, projection='polar')
+
+# Set the radial tick labels using the custom formatting
+ax.set_yticklabels([fmt_r(label) for label in ax.get_yticks()])
+
+# Set the angular tick labels using the custom formatting
+ax.set_xticklabels([fmt_theta(label) for label in ax.get_xticks()])
+
+# Plot the data
+ax.plot(x, y, 'o')
+
+plt.show()


### PR DESCRIPTION
## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "Closes https://github.com/matplotlib/matplotlib/issues/4568" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
