### PR TITLE
TST: simplify mask in pcolor writing to mask test

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1507,16 +1507,16 @@ def test_pcolorargs_with_read_only():
     y = np.linspace(0, 1, 10)
     X, Y = np.meshgrid(x, y)
     Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
-    mask = np.broadcast_to([True, False] * 5, Z.shape)
+    mask = np.zeros(10, dtype=bool)
+    mask[-1] = True
+    mask = np.broadcast_to(mask, Z.shape)
     assert mask.flags.writeable is False
     masked_Z = np.ma.array(Z, mask=mask)
     plt.pcolormesh(X, Y, masked_Z)
 
     masked_X = np.ma.array(X, mask=mask)
     masked_Y = np.ma.array(Y, mask=mask)
-    with pytest.warns(UserWarning,
-                      match='are not monotonically increasing or decreasing'):
-        plt.pcolor(masked_X, masked_Y, masked_Z)
+    plt.pcolor(masked_X, masked_Y, masked_Z)
 
 
 @check_figures_equal(extensions=["png"])


### PR DESCRIPTION
## PR summary

This PR unbreaks CI by modifying the failing test.

Since the X and Y shape match the Z shape, they represent the centres of the boxes.  `pcolor` therefore needs to work out the locations of the box corners.  In this case, every other column of X and Y were masked, so `pcolor` can't reasonably be expected to do that.

It previously passed because our use of `np.hstack` stripped the mask off, so it was the same as if we'd not added the mask to begin with.  For the test data, there were sensible numbers under the mask but this would obviously not be true in general.  We now (since #25027) use `np.ma.hstack`.

https://github.com/matplotlib/matplotlib/blob/fff2a79ce22ab39bea95067d30438bfdbe47f560/lib/matplotlib/axes/_axes.py#L5834-L5837

The point of the test is to verify that we don't attempt to write anything back to the input mask (#26230) . It doesn't matter for those purposes which elements are `True` or `False`.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
