### PR TITLE
Improve exception message for set_ticks() kwargs without labels

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2055,8 +2055,8 @@ class Axis(martist.Artist):
         minor : bool, default: False
             If ``False``, set the major ticks; if ``True``, the minor ticks.
         **kwargs
-            `.Text` properties for the labels. These take effect only if you
-            pass *labels*. In other cases, please use `~.Axes.tick_params`.
+            `.Text` properties for the labels. Using these is only allowed if
+            you pass *labels*. In other cases, please use `~.Axes.tick_params`.
 
         Notes
         -----
@@ -2066,8 +2066,11 @@ class Axis(martist.Artist):
         ticks.
         """
         if labels is None and kwargs:
-            raise ValueError('labels argument cannot be None when '
-                             'kwargs are passed')
+            first_key = next(iter(kwargs))
+            raise ValueError(
+                f"Incorrect use of keyword argument {first_key!r}. Keyword arguments "
+                "other than 'minor' modify the text labels and can only be used if "
+                "'labels' are passed as well.")
         result = self._set_tick_locations(ticks, minor=minor)
         if labels is not None:
             self.set_ticklabels(labels, minor=minor, **kwargs)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5987,7 +5987,7 @@ def test_set_ticks_kwargs_raise_error_without_labels():
     """
     fig, ax = plt.subplots()
     ticks = [1, 2, 3]
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Incorrect use of keyword argument 'alpha'"):
         ax.xaxis.set_ticks(ticks, alpha=0.5)
 
 


### PR DESCRIPTION
Followup to #24334

Closes #26283.

## PR summary
