### PR TITLE
Use transformed paths for contour labelling decisions

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -370,7 +370,10 @@ class ContourLabeler:
         # path always starts with a MOVETO, and we consider there's an implicit
         # MOVETO (closing the last path) at the end.
         movetos = (codes == Path.MOVETO).nonzero()[0]
-        start = movetos[movetos < idx][-1]
+        try:
+            start = movetos[movetos < idx][-1]
+        except IndexError:
+            start = idx
         try:
             stop = movetos[movetos > idx][0]
         except IndexError:


### PR DESCRIPTION
## PR summary

In Cartopy, contour paths can wrap around the edges of the globe.  So a path that would be complete in data space can break into segments in screen space.  Matplotlib's contour labelling has never accounted for this.

Currently, Cartopy has a [workaround](https://github.com/SciTools/cartopy/blob/6ead89b723ec4357a182a06504d7c50a04ca75a2/lib/cartopy/mpl/contour.py#L22) where it removes all the paths from each `PathCollection`, transforms them to axes space, and adds them back in (sometimes as more shorter paths).  The changes introduced at #25247 break the workaround (https://github.com/SciTools/cartopy/issues/2207).  I tried removing the workaround and found the test image gets a spurious horizontal line around 45 degrees north, where the label is being inserted right on the edge.

![result](https://github.com/SciTools/cartopy/assets/10599679/2a761e43-2f80-4e1f-9f8c-b9af36426b02)

This PR proposes transforming the paths to screen space before making the decisions about where to put the labels and how to update the paths.  With this change (and a smaller font) we now get

![result](https://github.com/matplotlib/matplotlib/assets/10599679/67efd77f-b1f4-4f6c-85e4-5cd06203aafb)

I see two problems:

* The back and forth between data and screen space introduced by this change feels a bit hacky, so I would welcome advice on better ways to resolve this.
* I do not know how to test this without Cartopy.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
