### PR TITLE
FIX: move the font lock higher up the call and class tree

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -170,7 +170,6 @@ class RendererBase:
     * `draw_path_collection`
     * `draw_quad_mesh`
     """
-
     def __init__(self):
         super().__init__()
         self._texmanager = None
@@ -2147,9 +2146,10 @@ class FigureCanvasBase:
                     functools.partial(
                         print_method, orientation=orientation)
                 )
+                # we do this instead of `self.figure.draw_without_rendering`
+                # so that we can inject the orientation
                 with getattr(renderer, "_draw_disabled", nullcontext)():
                     self.figure.draw(renderer)
-
             if bbox_inches:
                 if bbox_inches == "tight":
                     bbox_inches = self.figure.get_tightbbox(

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1636,3 +1636,18 @@ def test_get_constrained_layout_pads():
     fig = plt.figure(layout=mpl.layout_engine.ConstrainedLayoutEngine(**params))
     with pytest.warns(PendingDeprecationWarning, match="will be deprecated"):
         assert fig.get_constrained_layout_pads() == expected
+
+
+def test_not_visible_figure():
+    fig = Figure()
+
+    buf = io.StringIO()
+    fig.savefig(buf, format='svg')
+    buf.seek(0)
+    assert '<g ' in buf.read()
+
+    fig.set_visible(False)
+    buf = io.StringIO()
+    fig.savefig(buf, format='svg')
+    buf.seek(0)
+    assert '<g ' not in buf.read()


### PR DESCRIPTION
## PR summary

We have for a long time (~2012) had an RLock on `RenderAgg` that was used in `FigureCanvasAgg.draw` to protect the shared cache of ft2font objects (the underlying c++ is very stateful and not thread safe). This lock was also implicitly protecting the mathtext cache when using the Agg backend.

However, given the recent improvements to the layout code there are now ways to call call `Figure.draw(renderer)` without acquiring this lock which leads to exceptions when using mathtext and a layout manager to save independent figures on different threads.

This bug also exists for the other backendends which use both the mathtext parser and the ft2font cache in the case of rendering texts as paths (in the vector backends).

The fix is to:

 - pull the lock up to `RendererBase` so all renderer instances share a single lock
 - acquire the lock in `Figure.draw` which is always the top entry point to rendering a Figure

Closes #26289


Not sure how to test this.  I guess we could add a test like:


```python
from matplotlib.figure import Figure

import io
import threading


def test_crash2():
    for i in range(100):
        fig = Figure(tight_layout=True)
        # fig = Figure()

        ax = fig.add_subplot(1, 1, 1)

        ax.text(0, 0, "test $\pm$ 1.2")  # This crashes
        # ax.text(0, 0, 'test 1.2') # This does not

        buf = io.BytesIO()
        fig.savefig(buf, format="svg")


if True:
    threads = [threading.Thread(target=test_crash2) for _ in range(10)]
    [t.start() for t in threads]
    [t.join() for t in threads]

```

but it seems a bit of a dice roll if you put in enough iterations to feel safe you never lost the race but few enough it does not take too long.

If this is an acceptable change, I think we should also add a section to the docs clarifying what level of threading we think we support and what we do not (one thread per figure should work in my opinion).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines
