### PR TITLE
qt: Mark canvas for re-draw after savefig

### DIFF
--- a/lib/matplotlib/backends/backend_qtagg.py
+++ b/lib/matplotlib/backends/backend_qtagg.py
@@ -71,6 +71,15 @@ class FigureCanvasQTAgg(FigureCanvasAgg, FigureCanvasQT):
         finally:
             painter.end()
 
+    def print_figure(self, *args, **kwargs):
+        super().print_figure(*args, **kwargs)
+        # In some cases, Qt will itself trigger a paint event after closing the file
+        # save dialog. When that happens, we need to be sure that the internal canvas is
+        # re-drawn. However, if the user is using an automatically-chosen Qt backend but
+        # saving with a different backend (such as pgf), we do not want to trigger a
+        # full draw in Qt, so just set the flag for next time.
+        self._draw_pending = True
+
 
 @_BackendQT.export
 class _BackendQTAgg(_BackendQT):


### PR DESCRIPTION
## PR summary

In some cases, Qt will itself trigger a paint event after closing the file save dialog. When that happens, we need to be sure that the internal canvas is re-drawn. However, if the user is using an automatically-chosen Qt backend but saving with a different backend (such as pgf), we do not want to trigger a full draw in Qt, so just set the flag for next time.

Fixes #26272

I don't really know how to test this one.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines