### PR TITLE
FIX: labels at start of contours

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -370,7 +370,7 @@ class ContourLabeler:
         # path always starts with a MOVETO, and we consider there's an implicit
         # MOVETO (closing the last path) at the end.
         movetos = (codes == Path.MOVETO).nonzero()[0]
-        start = movetos[movetos < idx][-1]
+        start = movetos[movetos <= idx][-1]
         try:
             stop = movetos[movetos > idx][0]
         except IndexError:

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -1,6 +1,7 @@
 import datetime
 import platform
 import re
+from unittest import mock
 
 import contourpy  # type: ignore
 import numpy as np
@@ -231,6 +232,31 @@ def test_labels(split_collections):
         CS.add_label_near(x, y, inline=True, transform=False)
 
     _maybe_split_collections(split_collections)
+
+
+def test_label_contour_start():
+    # Set up data and figure/axes that result in automatic labelling adding the
+    # label to the start of a contour
+
+    _, ax = plt.subplots(dpi=100)
+    lats = lons = np.linspace(-np.pi / 2, np.pi / 2, 50)
+    lons, lats = np.meshgrid(lons, lats)
+    wave = 0.75 * (np.sin(2 * lats) ** 8) * np.cos(4 * lons)
+    mean = 0.5 * np.cos(2 * lats) * ((np.sin(2 * lats)) ** 2 + 2)
+    data = wave + mean
+
+    cs = ax.contour(lons, lats, data)
+
+    with mock.patch.object(
+            cs, '_split_path_and_get_label_rotation',
+            wraps=cs._split_path_and_get_label_rotation) as mocked_splitter:
+        # Smoke test that we can add the labels
+        cs.clabel(fontsize=9)
+
+    # Verify at least one label was added to the start of a contour.  I.e. the
+    # splitting method was called with idx=0 at least once.
+    idxs = [cargs[0][1] for cargs in mocked_splitter.call_args_list]
+    assert 0 in idxs
 
 
 @pytest.mark.parametrize("split_collections", [False, True])


### PR DESCRIPTION
## PR summary

Fixes #26308.

I'm not loving my test so if anyone can see a neater way to test this, that would be great!

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
