### PR TITLE
fixed gouraud error in pcolormesh 

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5820,9 +5820,13 @@ default: :rc:`scatter.edgecolors`
                                 f" see help({funcname})")
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):
-                raise TypeError('Dimensions of C %s are incompatible with'
-                                ' X (%d) and/or Y (%d); see help(%s)' % (
-                                    C.shape, Nx, Ny, funcname))
+                if (Nx, Ny) == (ncols + 1, nrows + 1):
+                    X = (X[1:, 1:] + X[:1, :-1]) / 2
+                    Y = (Y[1:, :-1] + Y[:-1, :-1]) / 2
+                else:
+                    raise TypeError('Dimensions of C %s are incompatible with'
+                                    ' X (%d) and/or Y (%d); see help(%s)' % (
+                                        C.shape, Nx, Ny, funcname))
             if shading == 'nearest':
                 # grid is specified at the center, so define corners
                 # at the midpoints between the grid centers and then use the

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1399,6 +1399,19 @@ def test_pcolormesh_alpha():
     ax4.pcolormesh(Qx, Qy, Z, cmap=cmap, shading='gouraud', zorder=1)
 
 
+@check_figures_equal()
+def test_pcolormesh_gouraud(fig_test, fig_ref):
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+    x = np.arange(-4, 5)
+    y = np.arange(-6, 7)
+    xe = np.linspace(-4.5, 4.5, 10)
+    ye = np.linspace(-6.5, 6.5, 14)
+    c = np.exp(-0.5*0.125*(x.reshape(1, -1)**2 + y.reshape(-1, 1)**2))
+    ax_ref.pcolormesh(x, y, c, shading='gouraud')
+    ax_test.pcolormesh(xe, ye, c, shading='gouraud')
+
+
 @pytest.mark.parametrize("dims,alpha", [(3, 1), (4, 0.5)])
 @check_figures_equal(extensions=["png"])
 def test_pcolormesh_rgba(fig_test, fig_ref, dims, alpha):
@@ -1476,9 +1489,13 @@ def test_pcolorargs():
     with pytest.raises(TypeError):
         ax.pcolormesh(X, Y, Z.T)
     with pytest.raises(TypeError):
-        ax.pcolormesh(x, y, Z[:-1, :-1], shading="gouraud")
+        ax.pcolormesh(x, y, Z[:-2, :-2], shading="gouraud")
     with pytest.raises(TypeError):
-        ax.pcolormesh(X, Y, Z[:-1, :-1], shading="gouraud")
+        ax.pcolormesh(X, Y, Z[:-2, :-2], shading="gouraud")
+    with pytest.raises(TypeError):
+        ax.pcolormesh(x[1:], y[1:], Z, shading="gouraud")
+    with pytest.raises(TypeError):
+        ax.pcolormesh(X[1:, 1:], Y[1:, 1:], Z, shading="gouraud")
     x[0] = np.NaN
     with pytest.raises(ValueError):
         ax.pcolormesh(x, y, Z[:-1, :-1])


### PR DESCRIPTION
##` PR summary
closes #8422

fixed unlikely exception when pcolormesh is called with cell boundaries instead of cell centers by
checking for this specific condition pcolormesh code. 

If boundaries are passed, average them to compute the center points and continue on.
`                if (Nx, Ny) == (ncols + 1, nrows + 1):
                    X = (X[1:, 1:] + X[:1, :-1]) / 2
                    Y = (Y[1:, :-1] + Y[:-1, :-1]) / 2
                else:
                    raise TypeError('Dimensions of C %s are incompatible with'
                                    ' X (%d) and/or Y (%d); see help(%s)' % (
                                        C.shape, Nx, Ny, funcname))
`
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #8422 is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ X] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ X] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
