### PR TITLE
Only do pchanged and set stale when value changes + doc consistency

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -353,7 +353,7 @@ class Artist:
 
         Parameters
         ----------
-        renderer : `.RendererBase` subclass
+        renderer : `~matplotlib.backend_bases.RendererBase` subclass, optional
             renderer that will be used to draw the figures (i.e.
             ``fig.canvas.get_renderer()``)
 
@@ -440,7 +440,7 @@ class Artist:
 
         Parameters
         ----------
-        t : `.Transform`
+        t : `~matplotlib.transforms.Transform`
         """
         self._transform = t
         self._transformSet = True
@@ -733,7 +733,7 @@ class Artist:
 
         Parameters
         ----------
-        fig : `.Figure`
+        fig : `~matplotlib.figure.Figure`
         """
         # if this is a no-op just return
         if self.figure is fig:
@@ -757,15 +757,16 @@ class Artist:
 
         Parameters
         ----------
-        clipbox : `.BboxBase` or None
-            Typically would be created from a `.TransformedBbox`. For
-            instance ``TransformedBbox(Bbox([[0, 0], [1, 1]]), ax.transAxes)``
-            is the default clipping for an artist added to an Axes.
+        clipbox : `~matplotlib.transforms.Bbox` or None
+            Will typically be created from a `.TransformedBbox`. For instance,
+            ``TransformedBbox(Bbox([[0, 0], [1, 1]]), ax.transAxes)`` is the default
+            clipping for an artist added to an Axes.
 
         """
-        self.clipbox = clipbox
-        self.pchanged()
-        self.stale = True
+        if clipbox != self.clipbox:
+            self.clipbox = clipbox
+            self.pchanged()
+            self.stale = True
 
     def set_clip_path(self, path, transform=None):
         """
@@ -986,7 +987,7 @@ class Artist:
 
         Parameters
         ----------
-        renderer : `.RendererBase` subclass.
+        renderer : `~matplotlib.backend_bases.RendererBase` subclass.
 
         Notes
         -----
@@ -1010,9 +1011,10 @@ class Artist:
                 f'alpha must be numeric or None, not {type(alpha)}')
         if alpha is not None and not (0 <= alpha <= 1):
             raise ValueError(f'alpha ({alpha}) is outside 0-1 range')
-        self._alpha = alpha
-        self.pchanged()
-        self.stale = True
+        if alpha != self._alpha:
+            self._alpha = alpha
+            self.pchanged()
+            self.stale = True
 
     def _set_alpha_for_array(self, alpha):
         """
@@ -1045,9 +1047,10 @@ class Artist:
         ----------
         b : bool
         """
-        self._visible = b
-        self.pchanged()
-        self.stale = True
+        if b != self._visible:
+            self._visible = b
+            self.pchanged()
+            self.stale = True
 
     def set_animated(self, b):
         """
@@ -1095,9 +1098,11 @@ class Artist:
         s : object
             *s* will be converted to a string by calling `str`.
         """
-        self._label = str(s) if s is not None else None
-        self.pchanged()
-        self.stale = True
+        label = str(s) if s is not None else None
+        if label != self._label:
+            self._label = label
+            self.pchanged()
+            self.stale = True
 
     def get_zorder(self):
         """Return the artist's zorder."""
@@ -1114,9 +1119,10 @@ class Artist:
         """
         if level is None:
             level = self.__class__.zorder
-        self.zorder = level
-        self.pchanged()
-        self.stale = True
+        if level != self.zorder:
+            self.zorder = level
+            self.pchanged()
+            self.stale = True
 
     @property
     def sticky_edges(self):

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -757,7 +757,7 @@ class Artist:
 
         Parameters
         ----------
-        clipbox : `~matplotlib.transforms.Bbox` or None
+        clipbox : `~matplotlib.transforms.BboxBase` or None
             Will typically be created from a `.TransformedBbox`. For instance,
             ``TransformedBbox(Bbox([[0, 0], [1, 1]]), ax.transAxes)`` is the default
             clipping for an artist added to an Axes.

--- a/lib/matplotlib/container.py
+++ b/lib/matplotlib/container.py
@@ -19,7 +19,7 @@ class Container(tuple):
     def __init__(self, kl, label=None):
         self._callbacks = cbook.CallbackRegistry(signals=["pchanged"])
         self._remove_method = None
-        self.set_label(label)
+        self._label = label
 
     def remove(self):
         for c in cbook.flatten(


### PR DESCRIPTION
## PR summary

Original purpose was to not call pchanged or set stale to True if the value did not change (some set-methods already do this). 

However, I found some doc inconsistencies so did a bit of search-and-replace as well...

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
