### PR TITLE
[DOC]: improve consistency of plot types gallery

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -38,8 +38,8 @@ tutorials_order = [
 
 plot_types_order = [
     '../galleries/plot_types/basic',
-    '../galleries/plot_types/arrays',
     '../galleries/plot_types/stats',
+    '../galleries/plot_types/arrays',
     '../galleries/plot_types/unstructured',
     '../galleries/plot_types/3D',
     UNSORTED

--- a/galleries/plot_types/3D/README.rst
+++ b/galleries/plot_types/3D/README.rst
@@ -1,6 +1,7 @@
 .. _3D_plots:
 
-3D
---
+3D and volumetric data
+----------------------
 
-3D plots using the `mpl_toolkits.mplot3d` library.
+Plots of three-dimensional :math:`(x,y,z)`, surface :math:`f(x,y)=z`, and
+volumetric :math:`V_{x, y, z}` data using the `mpl_toolkits.mplot3d` library.

--- a/galleries/plot_types/README.rst
+++ b/galleries/plot_types/README.rst
@@ -5,8 +5,7 @@
 Plot types
 ==========
 
-Overview of many common plotting commands in Matplotlib.
+Overview of many common plotting commands provided by Matplotlib.
 
-Note that we have stripped all labels, but they are present by default.
-See the `gallery <../gallery/index.html>`_ for many more examples and
+See the `gallery <../gallery/index.html>`_ for more examples and
 the `tutorials page <../tutorials/index.html>`_ for longer examples.

--- a/galleries/plot_types/arrays/README.rst
+++ b/galleries/plot_types/arrays/README.rst
@@ -1,6 +1,8 @@
 .. _array_plots:
 
-Plots of arrays and fields
---------------------------
+Gridded data:
+-------------
 
-Plotting for arrays of data ``Z(x, y)`` and fields ``U(x, y), V(x, y)``.
+Plots of arrays and images :math:`Z_{i, j}` and fields :math:`U_{i, j}, V_{i, j}`
+on `regular grids <https://en.wikipedia.org/wiki/Regular_grid>`_ and
+corresponding coordinate grids :math:`X_{i,j}, Y_{i,j}`.

--- a/galleries/plot_types/basic/README.rst
+++ b/galleries/plot_types/basic/README.rst
@@ -1,6 +1,7 @@
 .. _basic_plots:
 
-Basic
------
+Pairwise data
+-------------
 
-Basic plot types, usually y versus x.
+Plots of pairwise :math:`(x, y)`, tabular :math:`(var\_0, \cdots, var\_n)`,
+and functional :math:`f(x)=y` data.

--- a/galleries/plot_types/stats/README.rst
+++ b/galleries/plot_types/stats/README.rst
@@ -1,6 +1,7 @@
 .. _stats_plots:
 
-Statistics plots
-----------------
+Statistical distributions
+-------------------------
 
-Plots for statistical analysis.
+Plots of the distribution of at least one variable in a dataset. Some of these
+methods also compute the distributions.

--- a/galleries/plot_types/unstructured/README.rst
+++ b/galleries/plot_types/unstructured/README.rst
@@ -1,9 +1,7 @@
 .. _unstructured_plots:
 
-Unstructured coordinates
--------------------------
+Irregularly gridded data
+------------------------
 
-Sometimes we collect data ``z`` at coordinates ``(x,y)`` and want to visualize
-as a contour.  Instead of gridding the data and then using
-`~.axes.Axes.contour`, we can use a triangulation algorithm and fill the
-triangles.
+Plots of data :math:`Z_{x, y}` on `unstructured grids <https://en.wikipedia.org/wiki/Unstructured_grid>`_ ,
+unstructured coordinate grids :math:`(x, y)`, and 2D functions :math:`f(x, y) = z`.


### PR DESCRIPTION
Changed the plot type headings of the plot type gallery sections so that they'd hopefully be more informative and also generally more consistent in that for the most part they're describing the type of data assumed by each batch of functions. I also tried to have most of the section subheadings follow the same format of describing the assumptions of the structure of the data. Moved stats to be near the discrete/linear plots and unstructured next to gridded to keep the larger structure 0/1D, 2D, 3D. 

I'm not completely feeling this in terms of general audience friendly (attn: @esibinga) but think this provides a more useful side panel/toc for navigation.