### PR TITLE
Support standard Axes in RGBAxes.

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_rgb.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_rgb.py
@@ -1,7 +1,9 @@
+from types import MethodType
+
 import numpy as np
 
 from .axes_divider import make_axes_locatable, Size
-from .mpl_axes import Axes
+from .mpl_axes import Axes, SimpleAxisArtist
 
 
 def make_rgb_axes(ax, pad=0.01, axes_class=None, **kwargs):
@@ -108,8 +110,17 @@ class RGBAxes:
             ax, pad=pad, axes_class=axes_class, **kwargs)
         # Set the line color and ticks for the axes.
         for ax1 in [self.RGB, self.R, self.G, self.B]:
-            ax1.axis[:].line.set_color("w")
-            ax1.axis[:].major_ticks.set_markeredgecolor("w")
+            if isinstance(ax1.axis, MethodType):
+                ad = Axes.AxisDict(self)
+                ad.update(
+                    bottom=SimpleAxisArtist(ax1.xaxis, 1, ax1.spines["bottom"]),
+                    top=SimpleAxisArtist(ax1.xaxis, 2, ax1.spines["top"]),
+                    left=SimpleAxisArtist(ax1.yaxis, 1, ax1.spines["left"]),
+                    right=SimpleAxisArtist(ax1.yaxis, 2, ax1.spines["right"]))
+            else:
+                ad = ax1.axis
+            ad[:].line.set_color("w")
+            ad[:].major_ticks.set_markeredgecolor("w")
 
     def imshow_rgb(self, r, g, b, **kwargs):
         """

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -781,3 +781,4 @@ def test_anchored_locator_base_call():
 
 def test_grid_with_axes_class_not_overriding_axis():
     Grid(plt.figure(), 111, (2, 2), axes_class=mpl.axes.Axes)
+    RGBAxes(plt.figure(), 111, axes_class=mpl.axes.Axes)


### PR DESCRIPTION
The same fix as the one recently applied to AxesGrid (#26020).

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
