### PR TITLE
Optimize imshow

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -731,8 +731,7 @@ def safe_masked_invalid(x, copy=False):
         # copy with the byte order swapped.
         x = x.byteswap(inplace=copy).newbyteorder('N')  # Swap to native order.
     try:
-        xm = np.ma.masked_invalid(x, copy=False)
-        xm.shrink_mask()
+        xm = np.ma.masked_where(~(np.isfinite(x)), x, copy=False)
     except TypeError:
         return x
     return xm

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -735,5 +735,5 @@ def _ensure_cmap(cmap):
     cmap_name = cmap if cmap is not None else mpl.rcParams["image.cmap"]
     # use check_in_list to ensure type stability of the exception raised by
     # the internal usage of this (ValueError vs KeyError)
-    _api.check_in_list(sorted(_colormaps), cmap=cmap_name)
+    _api.check_in_list(list(_colormaps), cmap=cmap_name)
     return mpl.colormaps[cmap_name]

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -735,5 +735,6 @@ def _ensure_cmap(cmap):
     cmap_name = cmap if cmap is not None else mpl.rcParams["image.cmap"]
     # use check_in_list to ensure type stability of the exception raised by
     # the internal usage of this (ValueError vs KeyError)
-    _api.check_in_list(list(_colormaps), cmap=cmap_name)
+    if cmap_name not in _colormaps:
+        _api.check_in_list(sorted(_colormaps), cmap=cmap_name)
     return mpl.colormaps[cmap_name]

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1391,7 +1391,7 @@ class Normalize:
         """If vmin or vmax are not set, use the min/max of *A* to set them."""
         A = np.asanyarray(A)
 
-        if isinstance(A, np.ma.MaskedArray) and A.mask is False:
+        if isinstance(A, np.ma.MaskedArray) and not A.mask:
             A = A.data
 
         if self.vmin is None and A.size:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1390,6 +1390,10 @@ class Normalize:
     def autoscale_None(self, A):
         """If vmin or vmax are not set, use the min/max of *A* to set them."""
         A = np.asanyarray(A)
+
+        if isinstance(A, np.ma.MaskedArray) and A.mask is False:
+            A = A.data
+
         if self.vmin is None and A.size:
             self.vmin = A.min()
         if self.vmax is None and A.size:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1391,8 +1391,10 @@ class Normalize:
         """If vmin or vmax are not set, use the min/max of *A* to set them."""
         A = np.asanyarray(A)
 
-        if isinstance(A, np.ma.MaskedArray) and not A.mask:
-            A = A.data
+        if isinstance(A, np.ma.MaskedArray):
+            # we need to make the distinction between an array, False, np.bool_(False)
+            if A.mask is False or not A.mask.shape:
+                A = A.data
 
         if self.vmin is None and A.size:
             self.vmin = A.min()

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -15,7 +15,7 @@ import pytest
 
 from matplotlib import _api, cbook
 import matplotlib.colors as mcolors
-from matplotlib.cbook import delete_masked_points, strip_math
+from matplotlib.cbook import delete_masked_points
 
 
 class Test_delete_masked_points:

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -15,7 +15,7 @@ import pytest
 
 from matplotlib import _api, cbook
 import matplotlib.colors as mcolors
-from matplotlib.cbook import delete_masked_points
+from matplotlib.cbook import delete_masked_points, strip_math
 
 
 class Test_delete_masked_points:

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -918,12 +918,6 @@ def test_safe_first_element_with_none():
     assert actual is not None and actual == datetime_lst[1]
 
 
-def test_strip_math():
-    assert strip_math(r'1 \times 2') == r'1 \times 2'
-    assert strip_math(r'$1 \times 2$') == '1 x 2'
-    assert strip_math(r'$\rm{hi}$') == 'hi'
-
-
 @pytest.mark.parametrize('fmt, value, result', [
     ('%.2f m', 0.2, '0.20 m'),
     ('{:.2f} m', 0.2, '0.20 m'),

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -918,6 +918,12 @@ def test_safe_first_element_with_none():
     assert actual is not None and actual == datetime_lst[1]
 
 
+def test_strip_math():
+    assert strip_math(r'1 \times 2') == r'1 \times 2'
+    assert strip_math(r'$1 \times 2$') == '1 x 2'
+    assert strip_math(r'$\rm{hi}$') == 'hi'
+
+
 @pytest.mark.parametrize('fmt, value, result', [
     ('%.2f m', 0.2, '0.20 m'),
     ('{:.2f} m', 0.2, '0.20 m'),


### PR DESCRIPTION
## PR summary

In this PR we apply some micro optimizations to improve the imshow performance. Benchmark:
```
Mean +- std dev: [main] 7.34 ms +- 0.07 ms -> [pr] 6.67 ms +- 0.11 ms: 1.10x faster
```

Notes:

- There is a fast path for the `MaskedArray` in case the mask is `False` (e.g. images without a NaN or Inf value)
- The `np.ma.masked_invalid` undoes the `shrink_mask` from `np.ma.masked_where`, but matplotlib applies it again. So it is faster to call `np.ma.masked_where` directly
- Another possible optimization is in `Normalize.autoscale_None`. There both the setting of `vmin` and `vmax` triggers `_changed`. It is faster to first set vmin and vmax (without triggering _changed) and then calling _changed. This would require a new method `set_vmin_vmax` or some other mechanism to avoid triggering `_changed` twice.

Benchmark script:
```
import matplotlib
# print(matplotlib)
import pyperf

setup = """
import matplotlib.pyplot as plt
import numpy as np

n=10
im=np.random.rand(100,100)

def go():
    for ii in range(n):
        plt.figure(1)
        plt.imshow(im)
"""

runner = pyperf.Runner()
runner.timeit(name="mpl", stmt="go()", setup=setup)
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
