### PR TITLE
Fix pickling of axes property cycle.

### DIFF
--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -723,7 +723,7 @@ class Sankey:
             fc = kwargs.pop('fc', kwargs.pop('facecolor', None))
             lw = kwargs.pop('lw', kwargs.pop('linewidth', None))
         if fc is None:
-            fc = next(self.ax._get_patches_for_fill.prop_cycler)['color']
+            fc = self.ax._get_patches_for_fill.get_next_color()
         patch = PathPatch(Path(vertices, codes), fc=fc, lw=lw, **kwargs)
         self.ax.add_patch(patch)
 

--- a/lib/matplotlib/tests/test_cycles.py
+++ b/lib/matplotlib/tests/test_cycles.py
@@ -1,3 +1,6 @@
+import contextlib
+from io import StringIO
+
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
@@ -120,15 +123,22 @@ def test_valid_input_forms():
 
 def test_cycle_reset():
     fig, ax = plt.subplots()
+    prop0 = StringIO()
+    prop1 = StringIO()
+    prop2 = StringIO()
 
-    # Can't really test a reset because only a cycle object is stored
-    # but we can test the first item of the cycle.
-    prop = next(ax._get_lines.prop_cycler)
+    with contextlib.redirect_stdout(prop0):
+        plt.getp(ax.plot([1, 2], label="label")[0])
+
     ax.set_prop_cycle(linewidth=[10, 9, 4])
-    assert prop != next(ax._get_lines.prop_cycler)
+    with contextlib.redirect_stdout(prop1):
+        plt.getp(ax.plot([1, 2], label="label")[0])
+    assert prop1.getvalue() != prop0.getvalue()
+
     ax.set_prop_cycle(None)
-    got = next(ax._get_lines.prop_cycler)
-    assert prop == got
+    with contextlib.redirect_stdout(prop2):
+        plt.getp(ax.plot([1, 2], label="label")[0])
+    assert prop2.getvalue() == prop0.getvalue()
 
 
 def test_invalid_input_forms():

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -292,3 +292,12 @@ def test_dynamic_norm():
 def test_vertexselector():
     line, = plt.plot([0, 1], picker=True)
     pickle.loads(pickle.dumps(VertexSelector(line)))
+
+
+def test_cycler():
+    ax = plt.figure().add_subplot()
+    ax.set_prop_cycle(c=["c", "m", "y", "k"])
+    ax.plot([1, 2])
+    ax = pickle.loads(pickle.dumps(ax))
+    l, = ax.plot([3, 4])
+    assert l.get_color() == "m"


### PR DESCRIPTION
Instead of relying on itertools.cycle (which is unpicklable, and leads to the axes property cycle being reset to the rcparams value upon unpickling), use a plain, trivially picklable, list-and-index representation (the property cycle is guaranteed to be finite because Axes.set_prop_cycle passes its argument through matplotlib.cycler, which already iterates through all cycler values for validation purposes).

Unfortunately this is not enough to really get rid of the get_next_color/get_next_color_func awkwardness, which also serves the additional purpose of not unnecessarily advancing the prop_cycle when it does not contain a "color" key and a color is requested.

Closes #26082.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
