### PR TITLE
ENH: Collection.set_paths

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -207,7 +207,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
         return self._paths
 
     def set_paths(self, paths):
-        raise NotImplementedError
+        self._paths = paths
+        self.stale = True
 
     def get_transforms(self):
         return self._transforms
@@ -999,10 +1000,6 @@ class PathCollection(_CollectionWithSizes):
         super().__init__(**kwargs)
         self.set_paths(paths)
         self.set_sizes(sizes)
-        self.stale = True
-
-    def set_paths(self, paths):
-        self._paths = paths
         self.stale = True
 
     def get_paths(self):

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -11,7 +11,7 @@ import matplotlib as mpl
 from matplotlib import pyplot as plt, rc_context, ticker
 from matplotlib.colors import LogNorm, same_color
 import matplotlib.patches as mpatches
-from matplotlib.testing.decorators import image_comparison
+from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import pytest
 
 
@@ -98,6 +98,14 @@ def test_contour_Nlevels():
     assert len(cs1.levels) > 1
     cs2 = ax.contour(z, levels=5)
     assert (cs1.levels == cs2.levels).all()
+
+
+@check_figures_equal(extensions=['png'])
+def test_contour_set_paths(fig_test, fig_ref):
+    cs_test = fig_test.subplots().contour([[0, 1], [1, 2]])
+    cs_ref = fig_ref.subplots().contour([[1, 0], [2, 1]])
+
+    cs_test.set_paths(cs_ref.get_paths())
 
 
 @pytest.mark.parametrize("split_collections", [False, True])


### PR DESCRIPTION
## PR summary

Closes #26340 

I didn't add a changenote because I think this is covered by "Setting properties on the ContourSet can now usually be done using standard collection setters"
https://matplotlib.org/devdocs/api/next_api_changes/behavior/25247-AL.html

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
