### PR TITLE
Add tests for LogFormatter.format_data and format_data_short

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1131,6 +1131,20 @@ class TestLogFormatter:
         label = fmt._pprint_val(value, domain)
         assert label == expected
 
+    @pytest.mark.parametrize('value, long, short', [
+        (0.0, "0", "0           "),
+        (0, "0", "0           "),
+        (-1.0, "-10^0", "-1          "),
+        (2e-10, "2x10^-10", "2e-10       "),
+        (1e10, "10^10", "1e+10       "),
+    ])
+    def test_format_data(self, value, long, short):
+        fig, ax = plt.subplots()
+        ax.set_xscale('log')
+        fmt = ax.xaxis.get_major_formatter()
+        assert fmt.format_data(value) == long
+        assert fmt.format_data_short(value) == short
+
     def _sub_labels(self, axis, subs=()):
         """Test whether locator marks subs to be labeled."""
         fmt = axis.get_minor_formatter()


### PR DESCRIPTION
## PR summary

Partly motivated by #26346 

An interesting thing is that `format_data_short` use `%-12g` as formatter so the output is always zero-padded to 12 characters. This came in through https://github.com/matplotlib/matplotlib/commit/bbbb267295aa9ead405572ea5fa6ffddd5d1e5bd as an attempt to make the cursor look better. However, it seems like no other `format_data_short`-method is doing this.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
