### PR TITLE
Fix bad histogramming bins in mri/eeg example.

### DIFF
--- a/galleries/examples/specialty_plots/mri_with_eeg.py
+++ b/galleries/examples/specialty_plots/mri_with_eeg.py
@@ -13,7 +13,6 @@ import numpy as np
 import matplotlib.cbook as cbook
 import matplotlib.cm as cm
 from matplotlib.collections import LineCollection
-from matplotlib.ticker import MultipleLocator
 
 fig = plt.figure("MRI_with_EEG")
 
@@ -28,15 +27,10 @@ ax0.axis('off')
 
 # Plot the histogram of MRI intensity
 ax1 = fig.add_subplot(2, 2, 2)
-im = np.ravel(im)
-im = im[np.nonzero(im)]  # Ignore the background
-im = im / (2**16 - 1)  # Normalize
-ax1.hist(im, bins=100)
-ax1.xaxis.set_major_locator(MultipleLocator(0.4))
+im = im[im.nonzero()]  # Ignore the background
+ax1.hist(im, bins=np.arange(0, 2**16+1, 512))
+ax1.set(xlabel='Intensity (a.u.)', ylabel='MRI density', yticks=[])
 ax1.minorticks_on()
-ax1.set_yticks([])
-ax1.set_xlabel('Intensity (a.u.)')
-ax1.set_ylabel('MRI density')
 
 # Load the EEG data
 n_samples, n_rows = 800, 4
@@ -71,7 +65,6 @@ ax2.add_collection(lines)
 ax2.set_yticks(ticklocs, labels=['PG3', 'PG5', 'PG7', 'PG9'])
 
 ax2.set_xlabel('Time (s)')
-
 
 plt.tight_layout()
 plt.show()


### PR DESCRIPTION
The previous version of the histogram showed regular "spikes" which are entirely artefactual; they come from the fact that we were binning (effectively) integer data with floating point bins that did not all cover the same number of ints (even though they have the same floating point width).  Using an explicit, integer binsize avoids this issue.

old
![old](https://github.com/matplotlib/matplotlib/assets/1322974/70789520-e636-49ca-ab71-2df78b9eb776)
new
![MRI_with_EEG](https://github.com/matplotlib/matplotlib/assets/1322974/81c2dab6-53c7-4917-9fe8-48b216924cb6)

(I also no longer normalize the histogram to 0-1 as I don't think this adds much, but I can restore that too if it is strongly preferred.)

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
