### PR TITLE
List Colormaps issue. Read my pull request

### DIFF
--- a/galleries/users_explain/colors/colormaps.py
+++ b/galleries/users_explain/colors/colormaps.py
@@ -410,10 +410,10 @@ for cmap_category, cmap_list in cmaps.items():
     plot_color_gradients(cmap_category, cmap_list)
 
 
-# New function to list the actually colormpas on matplotlib
-# Issue #26244
 
+# New function to list the actually colormpas on matplotlib
 def listColormaps(category):
+    # Define a dictionary that maps each category to its corresponding list of colormaps
     colormaps_by_category = {
         'Perceptually': ['viridis', 'plasma', 'inferno', 'magma', 'cividis'],
         'Sequential': ['Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
@@ -422,6 +422,8 @@ def listColormaps(category):
         'Sequential2': ['binary', 'gist_yarg', 'gist_gray', 'gray', 'bone',
                         'pink', 'spring', 'summer', 'autumn', 'winter', 'cool',
                         'Wistia', 'hot', 'afmhot', 'gist_heat', 'copper'],
+        'Diverging': ['PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu', 'RdYlBu',
+                      'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic'],
         'Cyclic': ['twilight', 'twilight_shifted', 'hsv'],
         'Qualitative': ['Pastel1', 'Pastel2', 'Paired', 'Accent', 'Dark2',
                         'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b',
@@ -432,6 +434,7 @@ def listColormaps(category):
                           'turbo', 'nipy_spectral', 'gist_ncar']
     }
 
+    # Return the list of colormaps for the given category, or an empty list if the category is not found
     return colormaps_by_category.get(category, [])
 
     

--- a/galleries/users_explain/colors/colormaps.py
+++ b/galleries/users_explain/colors/colormaps.py
@@ -409,6 +409,32 @@ for cmap_category, cmap_list in cmaps.items():
 
     plot_color_gradients(cmap_category, cmap_list)
 
+
+# New function to list the actually colormpas on matplotlib
+# Issue #26244
+
+def listColormaps(category):
+    colormaps_by_category = {
+        'Perceptually': ['viridis', 'plasma', 'inferno', 'magma', 'cividis'],
+        'Sequential': ['Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
+                       'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu',
+                       'GnBu', 'PuBu', 'YlGnBu', 'PuBuGn', 'BuGn', 'YlGn'],
+        'Sequential2': ['binary', 'gist_yarg', 'gist_gray', 'gray', 'bone',
+                        'pink', 'spring', 'summer', 'autumn', 'winter', 'cool',
+                        'Wistia', 'hot', 'afmhot', 'gist_heat', 'copper'],
+        'Cyclic': ['twilight', 'twilight_shifted', 'hsv'],
+        'Qualitative': ['Pastel1', 'Pastel2', 'Paired', 'Accent', 'Dark2',
+                        'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b',
+                        'tab20c'],
+        'Miscellaneous': ['flag', 'prism', 'ocean', 'gist_earth', 'terrain',
+                          'gist_stern', 'gnuplot', 'gnuplot2', 'CMRmap',
+                          'cubehelix', 'brg', 'gist_rainbow', 'rainbow', 'jet',
+                          'turbo', 'nipy_spectral', 'gist_ncar']
+    }
+
+    return colormaps_by_category.get(category, [])
+
+    
 # %%
 # Color vision deficiencies
 # =========================

--- a/galleries/users_explain/colors/colormaps.py
+++ b/galleries/users_explain/colors/colormaps.py
@@ -410,7 +410,6 @@ for cmap_category, cmap_list in cmaps.items():
     plot_color_gradients(cmap_category, cmap_list)
 
 
-
 # New function to list the actually colormaps on matplotlib
 def listColormaps(category):
     # Define a dictionary that maps each category to its corresponding list of colormaps

--- a/galleries/users_explain/colors/colormaps.py
+++ b/galleries/users_explain/colors/colormaps.py
@@ -411,7 +411,7 @@ for cmap_category, cmap_list in cmaps.items():
 
 
 
-# New function to list the actually colormpas on matplotlib
+# New function to list the actually colormaps on matplotlib
 def listColormaps(category):
     # Define a dictionary that maps each category to its corresponding list of colormaps
     colormaps_by_category = {


### PR DESCRIPTION
Okay, my progress was the following, I wrote a few lines in the file colormaps.py where I create a function called listColormaps() the important thing is that according to the type of colormap it will list the available patterns.

Now, I find it useful to declare in a global way the variables of the colormap types that exist, that is to say: Perceptually, Sequential, Sequential2, Cyclic, Qualitative, Miscellaneous. In such a way that if more patterns are developed it will be easier to extend the functionalities. 

Attached is the code, read the issue #26244

```py
# New function to list the actually colormaps on matplotlib
def listColormaps(category):
    # Define a dictionary that maps each category to its corresponding list of colormaps
    colormaps_by_category = {
        'Perceptually': ['viridis', 'plasma', 'inferno', 'magma', 'cividis'],
        'Sequential': ['Greys', 'Purples', 'Blues', 'Greens', 'Oranges', 'Reds',
                       'YlOrBr', 'YlOrRd', 'OrRd', 'PuRd', 'RdPu', 'BuPu',
                       'GnBu', 'PuBu', 'YlGnBu', 'PuBuGn', 'BuGn', 'YlGn'],
        'Sequential2': ['binary', 'gist_yarg', 'gist_gray', 'gray', 'bone',
                        'pink', 'spring', 'summer', 'autumn', 'winter', 'cool',
                        'Wistia', 'hot', 'afmhot', 'gist_heat', 'copper'],
        'Diverging': ['PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu', 'RdYlBu',
                      'RdYlGn', 'Spectral', 'coolwarm', 'bwr', 'seismic'],
        'Cyclic': ['twilight', 'twilight_shifted', 'hsv'],
        'Qualitative': ['Pastel1', 'Pastel2', 'Paired', 'Accent', 'Dark2',
                        'Set1', 'Set2', 'Set3', 'tab10', 'tab20', 'tab20b',
                        'tab20c'],
        'Miscellaneous': ['flag', 'prism', 'ocean', 'gist_earth', 'terrain',
                          'gist_stern', 'gnuplot', 'gnuplot2', 'CMRmap',
                          'cubehelix', 'brg', 'gist_rainbow', 'rainbow', 'jet',
                          'turbo', 'nipy_spectral', 'gist_ncar']
    }

    # Return the list of colormaps for the given category, or an empty list if the category is not found
    return colormaps_by_category.get(category, [])
```
