### PR TITLE
LIC: Update the license we bundle the colorbrewer colormap data with

### DIFF
--- a/LICENSE/LICENSE_COLORBREWER
+++ b/LICENSE/LICENSE_COLORBREWER
@@ -1,38 +1,13 @@
-Apache-Style Software License for ColorBrewer Color Schemes
+Apache-Style Software License for ColorBrewer software and ColorBrewer Color Schemes
 
-Version 1.1
+Copyright (c) 2002 Cynthia Brewer, Mark Harrower, and The Pennsylvania State University.
 
-Copyright (c) 2002 Cynthia Brewer, Mark Harrower, and The Pennsylvania 
-State University. All rights reserved. Redistribution and use in source 
-and binary forms, with or without modification, are permitted provided 
-that the following conditions are met:
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-1. Redistributions as source code must retain the above copyright notice, 
-this list of conditions and the following disclaimer.
+http://www.apache.org/licenses/LICENSE-2.0
 
-2. The end-user documentation included with the redistribution, if any, 
-must include the following acknowledgment: "This product includes color 
-specifications and designs developed by Cynthia Brewer 
-(http://colorbrewer.org/)." Alternately, this acknowledgment may appear in 
-the software itself, if and wherever such third-party acknowledgments 
-normally appear.
-
-3. The name "ColorBrewer" must not be used to endorse or promote products 
-derived from this software without prior written permission. For written 
-permission, please contact Cynthia Brewer at cbrewer@psu.edu.
-
-4. Products derived from this software may not be called "ColorBrewer", 
-nor may "ColorBrewer" appear in their name, without prior written 
-permission of Cynthia Brewer.
-
-THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES, 
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY 
-AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL 
-CYNTHIA BREWER, MARK HARROWER, OR THE PENNSYLVANIA STATE UNIVERSITY BE 
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR 
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF 
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS 
-INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN 
-CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE 
-POSSIBILITY OF SUCH DAMAGE.
+Unless required by applicable law or agreed to in writing, software distributed
+under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+CONDITIONS OF ANY KIND, either express or implied. See the License for the
+specific language governing permissions and limitations under the License.


### PR DESCRIPTION
Per http://www.personal.psu.edu/cab38/ColorBrewer/ColorBrewer_updates.html the colormaps are now licensed under Apache V2.0.  This update has been made due to a possible incompatibility between Apache v1.1 and the GPL.

This change is consistent with the license in the colorbrewer (webapp) repository
https://github.com/axismaps/colorbrewer/blob/7d135fc4e19eda73f2eb1bf55fcdf4a04fe4881f/LICENCE.txt

Closes #26336
