### PR TITLE
Fix removal of Figure-level artists

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -249,9 +249,9 @@ class Artist:
                 _ax_flag = True
 
             if self.figure:
-                self.figure = None
                 if not _ax_flag:
-                    self.figure = True
+                    self.figure.stale = True
+                self.figure = None
 
         else:
             raise NotImplementedError('cannot remove artist')


### PR DESCRIPTION
## PR summary

PyCharm has been warning that `Artist.figure` should be a `Figure|None`, not a `bool` as is set in this block.

Based on the previous section of code, I think setting the figure to stale (if the Axes was not already set stale, meaning the Artist was on a Figure *only*) was the intended behaviour.

This [code is 8 years old](https://github.com/matplotlib/matplotlib/commit/01c4b90f28330ab9fe76456bf706e3f9b02fdc81), so I don't expect @tacaswell remembers the intention here, but the commit message does say "marks the parent axes/figure as stale", which I think indicates this PR is what's intended.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines