### PR TITLE
Add feature: adapt_limit argument

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7175,19 +7175,19 @@ such objects
 
         x_min, x_max = xedges[0], xedges[-1]
         y_min, y_max = yedges[0], yedges[-1]
-        if adapt_lim.isinstance(str) or adapt_lim == True:
+        if adapt_lim.isinstance(str) or adapt_lim is True:
             mask = ~np.isnan(h)
             mask_flat_x = np.any(mask, axis=1)
             mask_flat_y = np.any(mask, axis=0)
 
-            if adapt_lim == True or adapt_lim.lower() == 'x':
+            if adapt_lim is True or adapt_lim.lower() == 'x':
                 x_min = xedges[:-1][mask_flat_x].min()
                 x_max = xedges[1:][mask_flat_x].max()
                 x_pad = 0.01 * (x_max - x_min)
                 x_min -= x_pad
                 x_max += x_pad
             
-            if adapt_lim == True or adapt_lim.lower() == 'y':
+            if adapt_lim is True or adapt_lim.lower() == 'y':
                 y_min = yedges[:-1][mask_flat_y].min()
                 y_max = yedges[1:][mask_flat_y].max()
                 y_pad = 0.01 * (y_max - y_min)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7075,7 +7075,7 @@ such objects
     @_preprocess_data(replace_names=["x", "y", "weights"])
     @_docstring.dedent_interpd
     def hist2d(self, x, y, bins=10, range=None, density=False, weights=None,
-               cmin=None, cmax=None, **kwargs):
+               cmin=None, cmax=None, adapt_lim=False, **kwargs):
         """
         Make a 2D histogram plot.
 
@@ -7173,9 +7173,30 @@ such objects
         if cmax is not None:
             h[h > cmax] = None
 
+        x_min, x_max = xedges[0], xedges[-1]
+        y_min, y_max = yedges[0], yedges[-1]
+        if adapt_lim.isinstance(str) or adapt_lim == True:
+            mask = ~np.isnan(h)
+            mask_flat_x = np.any(mask, axis=1)
+            mask_flat_y = np.any(mask, axis=0)
+
+            if adapt_lim == True or adapt_lim.lower() == 'x':
+                x_min = xedges[:-1][mask_flat_x].min()
+                x_max = xedges[1:][mask_flat_x].max()
+                x_pad = 0.01 * (x_max - x_min)
+                x_min -= x_pad
+                x_max += x_pad
+            
+            if adapt_lim == True or adapt_lim.lower() == 'y':
+                y_min = yedges[:-1][mask_flat_y].min()
+                y_max = yedges[1:][mask_flat_y].max()
+                y_pad = 0.01 * (y_max - y_min)
+                y_min -= y_pad
+                y_max += y_pad
+
         pc = self.pcolormesh(xedges, yedges, h.T, **kwargs)
-        self.set_xlim(xedges[0], xedges[-1])
-        self.set_ylim(yedges[0], yedges[-1])
+        self.set_xlim(x_min, x_max)
+        self.set_ylim(y_min, y_max)
 
         return h, xedges, yedges, pc
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7186,7 +7186,7 @@ such objects
                 x_pad = 0.01 * (x_max - x_min)
                 x_min -= x_pad
                 x_max += x_pad
-            
+
             if adapt_lim is True or adapt_lim.lower() == 'y':
                 y_min = yedges[:-1][mask_flat_y].min()
                 y_max = yedges[1:][mask_flat_y].max()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7175,7 +7175,7 @@ such objects
 
         x_min, x_max = xedges[0], xedges[-1]
         y_min, y_max = yedges[0], yedges[-1]
-        if adapt_lim.isinstance(str) or adapt_lim is True:
+        if adapt_lim is True or isinstance(adapt_lim, str):
             mask = ~np.isnan(h)
             mask_flat_x = np.any(mask, axis=1)
             mask_flat_y = np.any(mask, axis=0)

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -583,6 +583,7 @@ class Axes(_AxesBase):
         weights: ArrayLike | None = ...,
         cmin: float | None = ...,
         cmax: float | None = ...,
+        adapt_lim: bool | str = ...,
         *,
         data=...,
         **kwargs

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3180,6 +3180,7 @@ def hist2d(
     weights: ArrayLike | None = None,
     cmin: float | None = None,
     cmax: float | None = None,
+    adapt_lim: bool | str = False,
     *,
     data=None,
     **kwargs,
@@ -3193,6 +3194,7 @@ def hist2d(
         weights=weights,
         cmin=cmin,
         cmax=cmax,
+        adapt_lim=adapt_lim,
         **({"data": data} if data is not None else {}),
         **kwargs,
     )


### PR DESCRIPTION
## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #26288 "
- [ ] new and changed code is tested
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and GitHub is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example, "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
Back on your PR.
-->
This PR is to address issue #26288. 