### PR TITLE
Fix triage tool due to Qt bump to 5.12

### DIFF
--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -30,7 +30,7 @@ import shutil
 import sys
 
 from matplotlib.backends.qt_compat import QtCore, QtGui, QtWidgets
-from matplotlib.backends.qt_compat import _enum, _exec
+from matplotlib.backends.qt_compat import _exec
 
 
 # matplotlib stores the baseline images under two separate subtrees,
@@ -62,13 +62,13 @@ class Thumbnail(QtWidgets.QFrame):
         layout = QtWidgets.QVBoxLayout()
 
         label = QtWidgets.QLabel(name)
-        label.setAlignment(_enum('QtCore.Qt.AlignmentFlag').AlignHCenter |
-                           _enum('QtCore.Qt.AlignmentFlag').AlignVCenter)
+        label.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter |
+                           QtCore.Qt.AlignmentFlag.AlignVCenter)
         layout.addWidget(label, 0)
 
         self.image = QtWidgets.QLabel()
-        self.image.setAlignment(_enum('QtCore.Qt.AlignmentFlag').AlignHCenter |
-                                _enum('QtCore.Qt.AlignmentFlag').AlignVCenter)
+        self.image.setAlignment(QtCore.Qt.AlignmentFlag.AlignHCenter |
+                                QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.image.setMinimumSize(800 // 3, 600 // 3)
         layout.addWidget(self.image)
         self.setLayout(layout)
@@ -86,7 +86,7 @@ class EventFilter(QtCore.QObject):
         self.window = window
 
     def eventFilter(self, receiver, event):
-        if event.type() == _enum('QtCore.QEvent.Type').KeyPress:
+        if event.type() == QtCore.QEvent.Type.KeyPress:
             self.window.keyPressEvent(event)
             return True
         else:
@@ -127,8 +127,8 @@ class Dialog(QtWidgets.QDialog):
         images_box = QtWidgets.QWidget()
         self.image_display = QtWidgets.QLabel()
         self.image_display.setAlignment(
-            _enum('QtCore.Qt.AlignmentFlag').AlignHCenter |
-            _enum('QtCore.Qt.AlignmentFlag').AlignVCenter)
+            QtCore.Qt.AlignmentFlag.AlignHCenter |
+            QtCore.Qt.AlignmentFlag.AlignVCenter)
         self.image_display.setMinimumSize(800, 600)
         images_layout.addWidget(self.image_display, 6)
         images_box.setLayout(images_layout)
@@ -167,8 +167,8 @@ class Dialog(QtWidgets.QDialog):
             pixmap = QtGui.QPixmap(os.fspath(fname))
             scaled_pixmap = pixmap.scaled(
                 thumbnail.size(),
-                _enum('QtCore.Qt.AspectRatioMode').KeepAspectRatio,
-                _enum('QtCore.Qt.TransformationMode').SmoothTransformation)
+                QtCore.Qt.AspectRatioMode.KeepAspectRatio,
+                QtCore.Qt.TransformationMode.SmoothTransformation)
             thumbnail.image.setPixmap(scaled_pixmap)
             self.pixmaps.append(scaled_pixmap)
 
@@ -177,14 +177,14 @@ class Dialog(QtWidgets.QDialog):
 
     def set_large_image(self, index):
         self.thumbnails[self.current_thumbnail].setFrameShape(
-            _enum('QtWidgets.QFrame.Shape').NoFrame)
+            QtWidgets.QFrame.Shape.NoFrame)
         self.current_thumbnail = index
         pixmap = QtGui.QPixmap(os.fspath(
             self.entries[self.current_entry]
             .thumbnails[self.current_thumbnail]))
         self.image_display.setPixmap(pixmap)
         self.thumbnails[self.current_thumbnail].setFrameShape(
-            _enum('QtWidgets.QFrame.Shape').Box)
+            QtWidgets.QFrame.Shape.Box)
 
     def accept_test(self):
         entry = self.entries[self.current_entry]
@@ -209,17 +209,17 @@ class Dialog(QtWidgets.QDialog):
         self.set_entry(min((self.current_entry + 1), len(self.entries) - 1))
 
     def keyPressEvent(self, e):
-        if e.key() == _enum('QtCore.Qt.Key').Key_Left:
+        if e.key() == QtCore.Qt.Key.Key_Left:
             self.set_large_image((self.current_thumbnail - 1) % 3)
-        elif e.key() == _enum('QtCore.Qt.Key').Key_Right:
+        elif e.key() == QtCore.Qt.Key.Key_Right:
             self.set_large_image((self.current_thumbnail + 1) % 3)
-        elif e.key() == _enum('QtCore.Qt.Key').Key_Up:
+        elif e.key() == QtCore.Qt.Key.Key_Up:
             self.set_entry(max(self.current_entry - 1, 0))
-        elif e.key() == _enum('QtCore.Qt.Key').Key_Down:
+        elif e.key() == QtCore.Qt.Key.Key_Down:
             self.set_entry(min(self.current_entry + 1, len(self.entries) - 1))
-        elif e.key() == _enum('QtCore.Qt.Key').Key_A:
+        elif e.key() == QtCore.Qt.Key.Key_A:
             self.accept_test()
-        elif e.key() == _enum('QtCore.Qt.Key').Key_R:
+        elif e.key() == QtCore.Qt.Key.Key_R:
             self.reject_test()
         else:
             super().keyPressEvent(e)


### PR DESCRIPTION
## PR summary

This broke when the Qt bump removed `_enum`

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines