### PR TITLE
TST: Remove extra dummy Axis classes

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -662,25 +662,20 @@ class TestAsinhLocator:
                             np.arange(101, 102.01, 0.1))
 
     def test_symmetrizing(self):
-        class DummyAxis:
-            bounds = (-1, 1)
-            @classmethod
-            def get_view_interval(cls): return cls.bounds
-
         lctr = mticker.AsinhLocator(linear_width=1, numticks=3,
                                     symthresh=0.25, base=0)
-        lctr.axis = DummyAxis
+        lctr.create_dummy_axis()
 
-        DummyAxis.bounds = (-1, 2)
+        lctr.axis.set_view_interval(-1, 2)
         assert_almost_equal(lctr(), [-1, 0, 2])
 
-        DummyAxis.bounds = (-1, 0.9)
+        lctr.axis.set_view_interval(-1, 0.9)
         assert_almost_equal(lctr(), [-1, 0, 1])
 
-        DummyAxis.bounds = (-0.85, 1.05)
+        lctr.axis.set_view_interval(-0.85, 1.05)
         assert_almost_equal(lctr(), [-1, 0, 1])
 
-        DummyAxis.bounds = (1, 1.1)
+        lctr.axis.set_view_interval(1, 1.1)
         assert_almost_equal(lctr(), [1, 1.05, 1.1])
 
     def test_base_rounding(self):
@@ -897,16 +892,6 @@ class TestScalarFormatter:
         assert sf(0.5) == ''
 
 
-class FakeAxis:
-    """Allow Formatter to be called without having a "full" plot set up."""
-    def __init__(self, vmin=1, vmax=10):
-        self.vmin = vmin
-        self.vmax = vmax
-
-    def get_view_interval(self):
-        return self.vmin, self.vmax
-
-
 class TestLogFormatterExponent:
     param_data = [
         (True, 4, np.arange(-3, 4.0), np.arange(-3, 4.0),
@@ -928,7 +913,8 @@ class TestLogFormatterExponent:
                    expected):
         formatter = mticker.LogFormatterExponent(base=base,
                                                  labelOnlyBase=labelOnlyBase)
-        formatter.axis = FakeAxis(1, base**exponent)
+        formatter.create_dummy_axis()
+        formatter.axis.set_view_interval(1, base**exponent)
         vals = base**locs
         labels = [formatter(x, pos) for (x, pos) in zip(vals, positions)]
         expected = [label.replace('-', '\N{Minus Sign}') for label in expected]
@@ -937,7 +923,8 @@ class TestLogFormatterExponent:
     def test_blank(self):
         # Should be a blank string for non-integer powers if labelOnlyBase=True
         formatter = mticker.LogFormatterExponent(base=10, labelOnlyBase=True)
-        formatter.axis = FakeAxis()
+        formatter.create_dummy_axis()
+        formatter.axis.set_view_interval(1, 10)
         assert formatter(10**0.1) == ''
 
 
@@ -1197,14 +1184,16 @@ class TestLogFormatter:
     def test_LogFormatter_call(self, val):
         # test _num_to_string method used in __call__
         temp_lf = mticker.LogFormatter()
-        temp_lf.axis = FakeAxis()
+        temp_lf.create_dummy_axis()
+        temp_lf.axis.set_view_interval(1, 10)
         assert temp_lf(val) == str(val)
 
     @pytest.mark.parametrize('val', [1e-323, 2e-323, 10e-323, 11e-323])
     def test_LogFormatter_call_tiny(self, val):
         # test coeff computation in __call__
         temp_lf = mticker.LogFormatter()
-        temp_lf.axis = FakeAxis()
+        temp_lf.create_dummy_axis()
+        temp_lf.axis.set_view_interval(1, 10)
         temp_lf(val)
 
 

--- a/lib/matplotlib/ticker.pyi
+++ b/lib/matplotlib/ticker.pyi
@@ -1,9 +1,10 @@
+from collections.abc import Callable, Sequence
+from typing import Any, Literal
+
 from matplotlib.axis import Axis
 from matplotlib.transforms import Transform
 from matplotlib.projections.polar import _AxisWrapper
 
-from collections.abc import Callable, Sequence
-from typing import Any, Literal
 import numpy as np
 
 class _DummyAxis:


### PR DESCRIPTION
## PR summary

This fixes typing errors since they don't (rightly) have these mock classes in the accepted list of types. But it also saves a bit of extra code as well.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines