### PR TITLE
WARN: more direct warning ticklabels

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6063,6 +6063,21 @@ def test_retain_tick_visibility():
     ax.tick_params(axis="y", which="both", length=0)
 
 
+def test_warn_too_few_labels():
+    # note that the axis is still using an AutoLocator:
+    fig, ax = plt.subplots()
+    with pytest.warns(
+           UserWarning,
+           match=r'set_ticklabels\(\) should only be used with a fixed number'):
+        ax.set_xticklabels(['0', '0.1'])
+    # note that the axis is still using a FixedLocator:
+    fig, ax = plt.subplots()
+    ax.set_xticks([0, 0.5, 1])
+    with pytest.raises(ValueError,
+                       match='The number of FixedLocator locations'):
+        ax.set_xticklabels(['0', '0.1'])
+
+
 def test_tick_label_update():
     # test issue 9397
 


### PR DESCRIPTION
## PR summary

Closes https://github.com/matplotlib/matplotlib/issues/26398

This now warns with

```
/Users/jklymak/matplotlib/testit.py:11: UserWarning: set_ticklabels should only be used with set_ticks or a FixedLocator.
  ax.set_yticklabels(map(str, ticks))
```

```python
import numpy as np
from matplotlib import cm
import matplotlib.pyplot as plt

for adjust in [True]:
    fig, ax = plt.subplots(figsize=(5, 3))
    data = [33.4, 33.5, 33.6]
    ax.plot(data, data)
    ticks = [32.8, 33., 33.2, 33.4, 33.6, 33.8]
    # ax.set_yticks(ticks)
    ax.set_yticklabels(map(str, ticks))

    fig.subplots_adjust(top=0.96)
```

- [ ] Needs tests


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
