### PR TITLE
Fixes for pycodestyle v2.11

### DIFF
--- a/galleries/examples/misc/packed_bubbles.py
+++ b/galleries/examples/misc/packed_bubbles.py
@@ -76,8 +76,7 @@ class BubbleChart:
 
     def collides_with(self, bubble, bubbles):
         distance = self.outline_distance(bubble, bubbles)
-        idx_min = np.argmin(distance)
-        return idx_min if type(idx_min) == np.ndarray else [idx_min]
+        return np.argmin(distance, keepdims=True)
 
     def collapse(self, n_iterations=50):
         """

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -622,7 +622,7 @@ class DviFont:
                        for char in range(nchars)]
 
     def __eq__(self, other):
-        return (type(self) == type(other)
+        return (type(self) is type(other)
                 and self.texname == other.texname and self.size == other.size)
 
     def __ne__(self, other):

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -853,7 +853,7 @@ class FontProperties:
         pattern syntax for use here.
         """
         for key, val in parse_fontconfig_pattern(pattern).items():
-            if type(val) == list:
+            if type(val) is list:
                 getattr(self, "set_" + key)(val[0])
             else:
                 getattr(self, "set_" + key)(val)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2949,12 +2949,12 @@ def test_as_mpl_axes_api():
 
     # testing axes creation with plt.axes
     ax = plt.axes((0, 0, 1, 1), projection=prj)
-    assert type(ax) == PolarAxes
+    assert type(ax) is PolarAxes
     plt.close()
 
     # testing axes creation with subplot
     ax = plt.subplot(121, projection=prj)
-    assert type(ax) == PolarAxes
+    assert type(ax) is PolarAxes
     plt.close()
 
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -226,7 +226,7 @@ class Test_callback_registry:
 
         # test that we can add a callback
         cid1 = self.connect(self.signal, mini_me.dummy, pickle)
-        assert type(cid1) == int
+        assert type(cid1) is int
         self.is_not_empty()
 
         # test that we don't add a second callback
@@ -251,7 +251,7 @@ class Test_callback_registry:
 
         # test that we can add a callback
         cid1 = self.connect(self.signal, mini_me.dummy, pickle)
-        assert type(cid1) == int
+        assert type(cid1) is int
         self.is_not_empty()
 
         self.disconnect(cid1)
@@ -269,7 +269,7 @@ class Test_callback_registry:
 
         # test that we can add a callback
         cid1 = self.connect(self.signal, mini_me.dummy, pickle)
-        assert type(cid1) == int
+        assert type(cid1) is int
         self.is_not_empty()
 
         self.disconnect("foo")

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1463,7 +1463,7 @@ def test_str_norms(fig_test, fig_ref):
     axrs[3].imshow(t, norm=colors.SymLogNorm(linthresh=2, vmin=.3, vmax=.7))
     axrs[4].imshow(t, norm="logit", clim=(.3, .7))
 
-    assert type(axts[0].images[0].norm) == colors.LogNorm  # Exactly that class
+    assert type(axts[0].images[0].norm) is colors.LogNorm  # Exactly that class
     with pytest.raises(ValueError):
         axts[0].imshow(t, norm="foobar")
 

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -37,22 +37,22 @@ def test_symlog_mask_nan():
     x = np.arange(-1.5, 5, 0.5)
     out = slti.transform_non_affine(slt.transform_non_affine(x))
     assert_allclose(out, x)
-    assert type(out) == type(x)
+    assert type(out) is type(x)
 
     x[4] = np.nan
     out = slti.transform_non_affine(slt.transform_non_affine(x))
     assert_allclose(out, x)
-    assert type(out) == type(x)
+    assert type(out) is type(x)
 
     x = np.ma.array(x)
     out = slti.transform_non_affine(slt.transform_non_affine(x))
     assert_allclose(out, x)
-    assert type(out) == type(x)
+    assert type(out) is type(x)
 
     x[3] = np.ma.masked
     out = slti.transform_non_affine(slt.transform_non_affine(x))
     assert_allclose(out, x)
-    assert type(out) == type(x)
+    assert type(out) is type(x)
 
 
 @image_comparison(['logit_scales.png'], remove_text=True)


### PR DESCRIPTION
## PR summary

`flake8` is currently failing in CI with

```
E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`
```
I think this is the relevant change: https://github.com/PyCQA/pycodestyle/pull/1086

In the bubble example, it looks like the type check was there just to make sure we get an array-like out of the method.  We can achieve that with the _keepdims_ keyword.

Everywhere else I just replaced `==` with `is` as that preserves existing behaviour so seems safest.  Possibly some places could have used `isinstance` instead but I do not know if there is an advantage to changing it to that (and I also do not know those parts of the code well enough to make that call).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
