### PR TITLE
macos: Don't leak None in Timer cleanup

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1903,20 +1903,26 @@ exit:
     }
 }
 
-static PyObject*
-Timer__timer_stop(Timer* self)
+static void
+Timer__timer_stop_impl(Timer* self)
 {
     if (self->timer) {
         [self->timer invalidate];
         self->timer = NULL;
     }
+}
+
+static PyObject*
+Timer__timer_stop(Timer* self)
+{
+    Timer__timer_stop_impl(self);
     Py_RETURN_NONE;
 }
 
 static void
 Timer_dealloc(Timer* self)
 {
-    Timer__timer_stop(self);
+    Timer__timer_stop_impl(self);
     Py_TYPE(self)->tp_free((PyObject*)self);
 }
 


### PR DESCRIPTION
## PR summary

I noticed this when reviewing some other PR at some point. It doesn't have a huge impact because `None` is a singleton that is never freed, but maybe has consequences in other implementations (PyPy?).

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines