### PR TITLE
DOC: in API reference, in long signatures display each parameter on its own line 

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -86,6 +86,8 @@ sys.path.append('.')
 # General configuration
 # ---------------------
 
+maximum_signature_line_length = 88
+
 # Unless we catch the warning explicitly somewhere, a warning should cause the
 # docs build to fail. This is especially useful for getting rid of deprecated
 # usage in the gallery.

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - packaging
   - pydata-sphinx-theme
   - pyyaml
-  - sphinx>=1.8.1,!=2.0.0
+  - sphinx>=7.1.1
   - sphinx-copybutton
   - sphinx-gallery>=0.12
   - sphinx-design


### PR DESCRIPTION
## PR summary
In the docs, for long signatures, display every parameter on its own line to improve legibility.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

--------

https://github.com/sphinx-doc/sphinx/pull/11011 introduced a sphinx-native way to display parameters on separate lines, setting the value of [maximum_signature_line_length](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-maximum_signature_line_length) in conf.py.

Here's a before/after for [`matplotlib.pyplot.subplots`](https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.subplots.html)
- Before:
![image](https://github.com/matplotlib/matplotlib/assets/31036680/b39985f7-f2dd-4c0e-b219-09dbd814384c)

- After:
![image](https://github.com/matplotlib/matplotlib/assets/31036680/67a214d8-4d63-431b-a9cc-ff38d5a143b6)

And signatures that don't exceed `maximum_signature_line_length` characters would stay the same. Feel free to change the number of characters set by `maximum_signature_line_length`, I just set it to 88 because it's a common convention in python code files, but I have no strong opinion on what would be the "perfect" number.
