### PR TITLE
Call out which pane is hovered for 3d hover coordinates

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1096,11 +1096,16 @@ class Axes3D(Axes):
         """
         Return the location on the axis pane underneath the cursor as a string.
         """
-        p1 = self._calc_coord(xv, yv, renderer)
+        p1, pane_idx = self._calc_coord(xv, yv, renderer)
         xs = self.format_xdata(p1[0])
         ys = self.format_ydata(p1[1])
         zs = self.format_zdata(p1[2])
-        coords = f'x={xs}, y={ys}, z={zs}'
+        if pane_idx == 0:
+            coords = f'x pane={xs}, y={ys}, z={zs}'
+        elif pane_idx == 1:
+            coords = f'x={xs}, y pane={ys}, z={zs}'
+        elif pane_idx == 2:
+            coords = f'x={xs}, y={ys}, z pane={zs}'
         return coords
 
     def _get_camera_loc(self):
@@ -1148,11 +1153,12 @@ class Axes3D(Axes):
                 scales[i] = np.inf
             else:
                 scales[i] = (p1[i] - pane_locs[i]) / vec[i]
-        scale = scales[np.argmin(abs(scales))]
+        pane_idx = np.argmin(abs(scales))
+        scale = scales[pane_idx]
 
         # Calculate the point on the closest pane
         p2 = p1 - scale*vec
-        return p2
+        return p2, pane_idx
 
     def _on_move(self, event):
         """

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1932,27 +1932,27 @@ def test_format_coord():
     xv = 0.1
     yv = 0.1
     fig.canvas.draw()
-    assert ax.format_coord(xv, yv) == 'x=10.5227, y=1.0417, z=0.1444'
+    assert ax.format_coord(xv, yv) == 'x=10.5227, y pane=1.0417, z=0.1444'
 
     # Modify parameters
     ax.view_init(roll=30, vertical_axis="y")
     fig.canvas.draw()
-    assert ax.format_coord(xv, yv) == 'x=9.1875, y=0.9761, z=0.1291'
+    assert ax.format_coord(xv, yv) == 'x pane=9.1875, y=0.9761, z=0.1291'
 
     # Reset parameters
     ax.view_init()
     fig.canvas.draw()
-    assert ax.format_coord(xv, yv) == 'x=10.5227, y=1.0417, z=0.1444'
+    assert ax.format_coord(xv, yv) == 'x=10.5227, y pane=1.0417, z=0.1444'
 
     # Check orthographic projection
     ax.set_proj_type('ortho')
     fig.canvas.draw()
-    assert ax.format_coord(xv, yv) == 'x=10.8869, y=1.0417, z=0.1528'
+    assert ax.format_coord(xv, yv) == 'x=10.8869, y pane=1.0417, z=0.1528'
 
     # Check non-default perspective projection
     ax.set_proj_type('persp', focal_length=0.1)
     fig.canvas.draw()
-    assert ax.format_coord(xv, yv) == 'x=9.0620, y=1.0417, z=0.1110'
+    assert ax.format_coord(xv, yv) == 'x=9.0620, y pane=1.0417, z=0.1110'
 
 
 def test_get_axis_position():


### PR DESCRIPTION
## PR summary
In https://github.com/matplotlib/matplotlib/pull/23485 the consensus was that we should explicitly call out the 3d axis pane which is being hovered over, but somehow that commit didn't get into that MR (see https://github.com/matplotlib/matplotlib/pull/23485#issuecomment-1442684109). This adds that notation back in.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
