### PR TITLE
BLD: stop skipping musl wheel builds

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -102,7 +102,6 @@ jobs:
         twine check {wheel} &&
         python {package}/ci/check_wheel_licenses.py {wheel}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-      CIBW_SKIP: "*-musllinux*"
       CIBW_TEST_COMMAND: >-
         python {package}/ci/check_version_number.py
       # Apple Silicon machines are not available for testing, so silence the

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -91,10 +91,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CIBW_BEFORE_BUILD: >-
-        pip install certifi oldest-supported-numpy &&
+        pip install certifi numpy>=1.25 &&
         rm -rf {package}/build
       CIBW_BEFORE_BUILD_WINDOWS: >-
-        pip install certifi delvewheel oldest-supported-numpy &&
+        pip install certifi delvewheel numpy>=1.25 &&
         rm -rf {package}/build
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
         delvewheel repair -w {dest_dir} {wheel}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -102,6 +102,7 @@ jobs:
         twine check {wheel} &&
         python {package}/ci/check_wheel_licenses.py {wheel}
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+      CIBW_SKIP: "*-musllinux_aarch64"
       CIBW_TEST_COMMAND: >-
         python {package}/ci/check_version_number.py
       # Apple Silicon machines are not available for testing, so silence the

--- a/doc/api/next_api_changes/development/26443-TAC.rst
+++ b/doc/api/next_api_changes/development/26443-TAC.rst
@@ -1,0 +1,7 @@
+New wheel architectures
+~~~~~~~~~~~~~~~~~~~~~~~
+
+
+Wheels have been added for:
+
+- musl based systems

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 build-backend = "setuptools.build_meta"
 requires = [
     "certifi>=2020.06.20",
-    "oldest-supported-numpy",
+    "numpy>=1.25",
     "pybind11>=2.6",
     "setuptools>=42",
     "setuptools_scm>=7",


### PR DESCRIPTION
closes #26438

I think that this is a generically bad idea (see https://pypackaging-native.github.io/meta-topics/user_expectations_wheels/ for longer comments on this), but given the currently low cost of enabling this there is no good reason to not do this.

I opened the PR so later when I say it was a bad idea at least I am to blame for it ;)