### PR TITLE
Fix some bugs found by typing

### DIFF
--- a/doc/api/next_api_changes/deprecations/26444-ES.rst
+++ b/doc/api/next_api_changes/deprecations/26444-ES.rst
@@ -1,0 +1,5 @@
+Passing non-int or sequence of non-int to ``Table.auto_set_column_width``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Column numbers are ints, and formerly passing any other type was effectively
+ignored. This will become an error in the future.

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -243,14 +243,6 @@ class Fonts:
         """
         raise NotImplementedError()
 
-    def get_used_characters(self):
-        """
-        Get the set of characters that were used in the math
-        expression.  Used by backends that need to subset fonts so
-        they know which glyphs to include.
-        """
-        return self.used_characters
-
     def get_sized_alternatives_for_symbol(self, fontname, sym):
         """
         Override if your font provides multiple sizes of the same

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -24,6 +24,8 @@ The cell (0, 0) is positioned at the top left.
 Thanks to John Gill for providing the class and table.
 """
 
+import numpy as np
+
 from . import _api, _docstring
 from .artist import Artist, allow_rasterization
 from .patches import Rectangle
@@ -494,14 +496,15 @@ class Table(Artist):
         col : int or sequence of ints
             The indices of the columns to auto-scale.
         """
-        # check for col possibility on iteration
-        try:
-            iter(col)
-        except (TypeError, AttributeError):
-            self._autoColumns.append(col)
-        else:
-            for cell in col:
-                self._autoColumns.append(cell)
+        col1d = np.atleast_1d(col)
+        if not np.issubdtype(col1d.dtype, np.integer):
+            _api.warn_deprecated("3.8", name="col",
+                                 message="%(name)r must be an int or sequence of ints. "
+                                 "Passing other types is deprecated since %(since)s "
+                                 "and will be removed %(removal)s.")
+            return
+        for cell in col1d:
+            self._autoColumns.append(cell)
 
         self.stale = True
 

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -7,7 +7,7 @@ import pytest
 
 
 def test_PsfontsMap(monkeypatch):
-    monkeypatch.setattr(dr, 'find_tex_file', lambda x: x)
+    monkeypatch.setattr(dr, 'find_tex_file', lambda x: x.decode())
 
     filename = str(Path(__file__).parent / 'baseline_images/dviread/test.map')
     fontmap = dr.PsfontsMap(filename)
@@ -18,15 +18,15 @@ def test_PsfontsMap(monkeypatch):
         assert entry.texname == key
         assert entry.psname == b'PSfont%d' % n
         if n not in [3, 5]:
-            assert entry.encoding == b'font%d.enc' % n
+            assert entry.encoding == 'font%d.enc' % n
         elif n == 3:
-            assert entry.encoding == b'enc3.foo'
+            assert entry.encoding == 'enc3.foo'
         # We don't care about the encoding of TeXfont5, which specifies
         # multiple encodings.
         if n not in [1, 5]:
-            assert entry.filename == b'font%d.pfa' % n
+            assert entry.filename == 'font%d.pfa' % n
         else:
-            assert entry.filename == b'font%d.pfb' % n
+            assert entry.filename == 'font%d.pfb' % n
         if n == 4:
             assert entry.effects == {'slant': -0.1, 'extend': 1.2}
         else:
@@ -37,13 +37,13 @@ def test_PsfontsMap(monkeypatch):
     assert entry.encoding is None
     entry = fontmap[b'TeXfont7']
     assert entry.filename is None
-    assert entry.encoding == b'font7.enc'
+    assert entry.encoding == 'font7.enc'
     entry = fontmap[b'TeXfont8']
-    assert entry.filename == b'font8.pfb'
+    assert entry.filename == 'font8.pfb'
     assert entry.encoding is None
     entry = fontmap[b'TeXfont9']
     assert entry.psname == b'TeXfont9'
-    assert entry.filename == b'/absolute/font9.pfb'
+    assert entry.filename == '/absolute/font9.pfb'
     # First of duplicates only.
     entry = fontmap[b'TeXfontA']
     assert entry.psname == b'PSfontA1'

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -1,9 +1,11 @@
-import matplotlib.pyplot as plt
 import numpy as np
-from matplotlib.testing.decorators import image_comparison, check_figures_equal
+import pytest
 
-from matplotlib.table import CustomCell, Table
+import matplotlib.pyplot as plt
+import matplotlib as mpl
 from matplotlib.path import Path
+from matplotlib.table import CustomCell, Table
+from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.transforms import Bbox
 
 
@@ -176,7 +178,12 @@ def test_auto_column():
         loc="center")
     tb4.auto_set_font_size(False)
     tb4.set_fontsize(12)
-    tb4.auto_set_column_width("-101")
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
+                      match="'col' must be an int or sequence of ints"):
+        tb4.auto_set_column_width("-101")  # type: ignore [arg-type]
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
+                      match="'col' must be an int or sequence of ints"):
+        tb4.auto_set_column_width(["-101"])  # type: ignore [list-item]
 
 
 def test_table_cells():

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -971,7 +971,6 @@ class TestLogFormatterSciNotation:
     @pytest.mark.parametrize('base, value, expected', test_data)
     def test_basic(self, base, value, expected):
         formatter = mticker.LogFormatterSciNotation(base=base)
-        formatter.sublabel = {1, 2, 5, 1.2}
         with mpl.rc_context({'text.usetex': False}):
             assert formatter(value) == expected
 


### PR DESCRIPTION
## PR summary

There are 3 changes here:
- When iterables were added to `Table.auto_set_column_width` in #6047, the test added a string. Typing correctly points out that that is not accepted, and in fact it does not do anything (as shown in the test image) because column keys are ints, not strings, so the automatic width calculation is applied to nothing. So deprecate accepting random types here.
- `Fonts.used_characters` was removed in #22204, but `Fonts.get_used_characters` (which just returns that attribute) was not. This is private and can be removed directly, AFAICT.
- The `find_tex_file` monkey patch in the test returned the wrong type, which doesn't technically break anything, but was confusing when comparing with the type stubs.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines