### PR TITLE
DOC: Fix accidental cases of blockquotes

### DIFF
--- a/doc/api/prev_api_changes/api_changes_0.54.rst
+++ b/doc/api/prev_api_changes/api_changes_0.54.rst
@@ -76,137 +76,136 @@ Object interface - Application programmers
 Autoscaling
 ~~~~~~~~~~~
 
-  The x and y axis instances no longer have autoscale view.  These are
-  handled by axes.autoscale_view
+The x and y axis instances no longer have autoscale view.  These are
+handled by axes.autoscale_view
 
 Axes creation
 ~~~~~~~~~~~~~
 
-    You should not instantiate your own Axes any more using the OO API.
-    Rather, create a Figure as before and in place of::
+You should not instantiate your own Axes any more using the OO API.
+Rather, create a Figure as before and in place of::
 
-      f = Figure(figsize=(5,4), dpi=100)
-      a = Subplot(f, 111)
-      f.add_axis(a)
+    f = Figure(figsize=(5,4), dpi=100)
+    a = Subplot(f, 111)
+    f.add_axis(a)
 
-    use::
+use::
 
-      f = Figure(figsize=(5,4), dpi=100)
-      a = f.add_subplot(111)
+    f = Figure(figsize=(5,4), dpi=100)
+    a = f.add_subplot(111)
 
-    That is, add_axis no longer exists and is replaced by::
+That is, add_axis no longer exists and is replaced by::
 
-      add_axes(rect, axisbg=defaultcolor, frameon=True)
-      add_subplot(num, axisbg=defaultcolor, frameon=True)
+    add_axes(rect, axisbg=defaultcolor, frameon=True)
+    add_subplot(num, axisbg=defaultcolor, frameon=True)
 
 Artist methods
 ~~~~~~~~~~~~~~
 
-  If you define your own Artists, you need to rename the _draw method
-  to draw
+If you define your own Artists, you need to rename the _draw method
+to draw
 
 Bounding boxes
 ~~~~~~~~~~~~~~
 
-   matplotlib.transforms.Bound2D is replaced by
-   matplotlib.transforms.Bbox.  If you want to construct a bbox from
-   left, bottom, width, height (the signature for Bound2D), use
-   matplotlib.transforms.lbwh_to_bbox, as in
+matplotlib.transforms.Bound2D is replaced by
+matplotlib.transforms.Bbox.  If you want to construct a bbox from
+left, bottom, width, height (the signature for Bound2D), use
+matplotlib.transforms.lbwh_to_bbox, as in::
 
     bbox = clickBBox = lbwh_to_bbox(left, bottom, width, height)
 
-   The Bbox has a different API than the Bound2D.  e.g., if you want to
-   get the width and height of the bbox
+The Bbox has a different API than the Bound2D.  e.g., if you want to
+get the width and height of the bbox
 
-     OLD::
-        width  = fig.bbox.x.interval()
-        height = fig.bbox.y.interval()
+**OLD**::
 
-     New::
-        width  = fig.bbox.width()
-        height = fig.bbox.height()
+     width  = fig.bbox.x.interval()
+     height = fig.bbox.y.interval()
 
+**NEW**::
 
+     width  = fig.bbox.width()
+     height = fig.bbox.height()
 
 
 Object constructors
 ~~~~~~~~~~~~~~~~~~~
 
-  You no longer pass the bbox, dpi, or transforms to the various
-  Artist constructors.  The old way or creating lines and rectangles
-  was cumbersome because you had to pass so many attributes to the
-  Line2D and Rectangle classes not related directly to the geometry
-  and properties of the object.  Now default values are added to the
-  object when you call axes.add_line or axes.add_patch, so they are
-  hidden from the user.
+You no longer pass the bbox, dpi, or transforms to the various
+Artist constructors.  The old way or creating lines and rectangles
+was cumbersome because you had to pass so many attributes to the
+Line2D and Rectangle classes not related directly to the geometry
+and properties of the object.  Now default values are added to the
+object when you call axes.add_line or axes.add_patch, so they are
+hidden from the user.
 
-  If you want to define a custom transformation on these objects, call
-  o.set_transform(trans) where trans is a Transformation instance.
+If you want to define a custom transformation on these objects, call
+o.set_transform(trans) where trans is a Transformation instance.
 
-  In prior versions of you wanted to add a custom line in data coords,
-  you would have to do
+In prior versions of you wanted to add a custom line in data coords,
+you would have to do::
 
-        l =  Line2D(dpi, bbox, x, y,
-                    color = color,
-                    transx = transx,
-                    transy = transy,
-                    )
+    l = Line2D(dpi, bbox, x, y,
+               color = color,
+               transx = transx,
+               transy = transy,
+               )
 
-  now all you need is
+now all you need is::
 
-        l =  Line2D(x, y, color=color)
+    l = Line2D(x, y, color=color)
 
-  and the axes will set the transformation for you (unless you have
-  set your own already, in which case it will eave it unchanged)
+and the axes will set the transformation for you (unless you have
+set your own already, in which case it will eave it unchanged)
 
 Transformations
 ~~~~~~~~~~~~~~~
 
-  The entire transformation architecture has been rewritten.
-  Previously the x and y transformations where stored in the xaxis and
-  yaxis instances.  The problem with this approach is it only allows
-  for separable transforms (where the x and y transformations don't
-  depend on one another).  But for cases like polar, they do.  Now
-  transformations operate on x,y together.  There is a new base class
-  matplotlib.transforms.Transformation and two concrete
-  implementations, matplotlib.transforms.SeparableTransformation and
-  matplotlib.transforms.Affine.  The SeparableTransformation is
-  constructed with the bounding box of the input (this determines the
-  rectangular coordinate system of the input, i.e., the x and y view
-  limits), the bounding box of the display, and possibly nonlinear
-  transformations of x and y.  The 2 most frequently used
-  transformations, data coordinates -> display and axes coordinates ->
-  display are available as ax.transData and ax.transAxes.  See
-  alignment_demo.py which uses axes coords.
+The entire transformation architecture has been rewritten.
+Previously the x and y transformations where stored in the xaxis and
+yaxis instances.  The problem with this approach is it only allows
+for separable transforms (where the x and y transformations don't
+depend on one another).  But for cases like polar, they do.  Now
+transformations operate on x,y together.  There is a new base class
+matplotlib.transforms.Transformation and two concrete
+implementations, matplotlib.transforms.SeparableTransformation and
+matplotlib.transforms.Affine.  The SeparableTransformation is
+constructed with the bounding box of the input (this determines the
+rectangular coordinate system of the input, i.e., the x and y view
+limits), the bounding box of the display, and possibly nonlinear
+transformations of x and y.  The 2 most frequently used
+transformations, data coordinates -> display and axes coordinates ->
+display are available as ax.transData and ax.transAxes.  See
+alignment_demo.py which uses axes coords.
 
-  Also, the transformations should be much faster now, for two reasons
+Also, the transformations should be much faster now, for two reasons
 
-   * they are written entirely in extension code
+* they are written entirely in extension code
 
-   * because they operate on x and y together, they can do the entire
-     transformation in one loop.  Earlier I did something along the
-     lines of::
+* because they operate on x and y together, they can do the entire
+  transformation in one loop.  Earlier I did something along the
+  lines of::
 
-       xt = sx*func(x) + tx
-       yt = sy*func(y) + ty
+    xt = sx*func(x) + tx
+    yt = sy*func(y) + ty
 
-     Although this was done in numerix, it still involves 6 length(x)
-     for-loops (the multiply, add, and function evaluation each for x
-     and y).  Now all of that is done in a single pass.
+  Although this was done in numerix, it still involves 6 length(x)
+  for-loops (the multiply, add, and function evaluation each for x
+  and y).  Now all of that is done in a single pass.
 
+If you are using transformations and bounding boxes to get the
+cursor position in data coordinates, the method calls are a little
+different now.  See the updated examples/coords_demo.py which shows
+you how to do this.
 
-  If you are using transformations and bounding boxes to get the
-  cursor position in data coordinates, the method calls are a little
-  different now.  See the updated examples/coords_demo.py which shows
-  you how to do this.
+Likewise, if you are using the artist bounding boxes to pick items
+on the canvas with the GUI, the bbox methods are somewhat
+different.  You will need to see the updated
+examples/object_picker.py.
 
-  Likewise, if you are using the artist bounding boxes to pick items
-  on the canvas with the GUI, the bbox methods are somewhat
-  different.  You will need to see the updated
-  examples/object_picker.py.
-
-  See unit/transforms_unit.py for many examples using the new
-  transformations.
+See unit/transforms_unit.py for many examples using the new
+transformations.
 
 
 .. highlight:: none

--- a/doc/api/prev_api_changes/api_changes_0.98.0.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.0.rst
@@ -282,44 +282,33 @@ Old method                                    New method
 
 New methods:
 
-  * :meth:`draw_path(self, gc, path, transform, rgbFace)
-    <matplotlib.backend_bases.RendererBase.draw_path>`
-
-  * :meth:`draw_markers(self, gc, marker_path, marker_trans, path,
-    trans, rgbFace)
-    <matplotlib.backend_bases.RendererBase.draw_markers>`
-
-  * :meth:`draw_path_collection(self, master_transform, cliprect,
-    clippath, clippath_trans, paths, all_transforms, offsets,
-    offsetTrans, facecolors, edgecolors, linewidths, linestyles,
-    antialiaseds)
-    <matplotlib.backend_bases.RendererBase.draw_path_collection>`
-    *[optional]*
+* :meth:`draw_path(self, gc, path, transform, rgbFace)
+  <matplotlib.backend_bases.RendererBase.draw_path>`
+* :meth:`draw_markers(self, gc, marker_path, marker_trans, path,
+  trans, rgbFace)
+  <matplotlib.backend_bases.RendererBase.draw_markers>`
+* :meth:`draw_path_collection(self, master_transform, cliprect,
+  clippath, clippath_trans, paths, all_transforms, offsets,
+  offsetTrans, facecolors, edgecolors, linewidths, linestyles,
+  antialiaseds)
+  <matplotlib.backend_bases.RendererBase.draw_path_collection>`
+  *[optional]*
 
 Changed methods:
 
-  * ``draw_image(self, x, y, im, bbox)`` is now
-    :meth:`draw_image(self, x, y, im, bbox, clippath, clippath_trans)
-    <matplotlib.backend_bases.RendererBase.draw_image>`
+* ``draw_image(self, x, y, im, bbox)`` is now
+  :meth:`draw_image(self, x, y, im, bbox, clippath, clippath_trans)
+  <matplotlib.backend_bases.RendererBase.draw_image>`
 
 Removed methods:
 
-  * ``draw_arc``
-
-  * ``draw_line_collection``
-
-  * ``draw_line``
-
-  * ``draw_lines``
-
-  * ``draw_point``
-
-  * ``draw_quad_mesh``
-
-  * ``draw_poly_collection``
-
-  * ``draw_polygon``
-
-  * ``draw_rectangle``
-
-  * ``draw_regpoly_collection``
+* ``draw_arc``
+* ``draw_line_collection``
+* ``draw_line``
+* ``draw_lines``
+* ``draw_point``
+* ``draw_quad_mesh``
+* ``draw_poly_collection``
+* ``draw_polygon``
+* ``draw_rectangle``
+* ``draw_regpoly_collection``

--- a/doc/api/prev_api_changes/api_changes_0.98.x.rst
+++ b/doc/api/prev_api_changes/api_changes_0.98.x.rst
@@ -33,16 +33,15 @@ Changes for 0.98.x
   are given as a fraction of the font-size. Also, *scatteryoffsets*,
   *fancybox* and *columnspacing* are added as keyword parameters.
 
-        ================   ================
-        Deprecated         New
-        ================   ================
-        pad                borderpad
-        labelsep           labelspacing
-        handlelen          handlelength
-        handlestextsep     handletextpad
-        axespad            borderaxespad
-        ================   ================
-
+  ================   ================
+  Deprecated         New
+  ================   ================
+  pad                borderpad
+  labelsep           labelspacing
+  handlelen          handlelength
+  handlestextsep     handletextpad
+  axespad            borderaxespad
+  ================   ================
 
 * Removed the configobj and experimental traits rc support
 

--- a/doc/api/prev_api_changes/api_changes_1.3.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.3.x.rst
@@ -24,52 +24,52 @@ Code removal
 * The following items that were deprecated in version 1.2 or earlier
   have now been removed completely.
 
-    - The Qt 3.x backends (``qt`` and ``qtagg``) have been removed in
-      favor of the Qt 4.x backends (``qt4`` and ``qt4agg``).
+  - The Qt 3.x backends (``qt`` and ``qtagg``) have been removed in
+    favor of the Qt 4.x backends (``qt4`` and ``qt4agg``).
 
-    - The FltkAgg and Emf backends have been removed.
+  - The FltkAgg and Emf backends have been removed.
 
-    - The ``matplotlib.nxutils`` module has been removed.  Use the
-      functionality on `matplotlib.path.Path.contains_point` and
-      friends instead.
+  - The ``matplotlib.nxutils`` module has been removed.  Use the
+    functionality on `matplotlib.path.Path.contains_point` and
+    friends instead.
 
-    - Instead of ``axes.Axes.get_frame``, use ``axes.Axes.patch``.
+  - Instead of ``axes.Axes.get_frame``, use ``axes.Axes.patch``.
 
-    - The following keyword arguments to the `~.axes.Axes.legend` function have
-      been renamed:
+  - The following keyword arguments to the `~.axes.Axes.legend` function have
+    been renamed:
 
-      - *pad* -> *borderpad*
-      - *labelsep* -> *labelspacing*
-      - *handlelen* -> *handlelength*
-      - *handletextsep* -> *handletextpad*
-      - *axespad* -> *borderaxespad*
+    - *pad* -> *borderpad*
+    - *labelsep* -> *labelspacing*
+    - *handlelen* -> *handlelength*
+    - *handletextsep* -> *handletextpad*
+    - *axespad* -> *borderaxespad*
 
-      Related to this, the following rcParams have been removed:
+    Related to this, the following rcParams have been removed:
 
-      - ``legend.pad``,
-      - ``legend.labelsep``,
-      - ``legend.handlelen``,
-      - ``legend.handletextsep`` and
-      - ``legend.axespad``
+    - ``legend.pad``,
+    - ``legend.labelsep``,
+    - ``legend.handlelen``,
+    - ``legend.handletextsep`` and
+    - ``legend.axespad``
 
-    - For the `~.axes.Axes.hist` function, instead of *width*, use *rwidth*
-      (relative width).
+  - For the `~.axes.Axes.hist` function, instead of *width*, use *rwidth*
+    (relative width).
 
-    - On `.patches.Circle`, the *resolution* keyword argument has been removed.
-      For a circle made up of line segments, use
-      `.patches.CirclePolygon`.
+  - On `.patches.Circle`, the *resolution* keyword argument has been removed.
+    For a circle made up of line segments, use
+    `.patches.CirclePolygon`.
 
-    - The printing functions in the Wx backend have been removed due
-      to the burden of keeping them up-to-date.
+  - The printing functions in the Wx backend have been removed due
+    to the burden of keeping them up-to-date.
 
-    - ``mlab.liaupunov`` has been removed.
+  - ``mlab.liaupunov`` has been removed.
 
-    - ``mlab.save``, ``mlab.load``, ``pylab.save`` and ``pylab.load`` have
-      been removed.  We recommend using `numpy.savetxt` and
-      `numpy.loadtxt` instead.
+  - ``mlab.save``, ``mlab.load``, ``pylab.save`` and ``pylab.load`` have
+    been removed.  We recommend using `numpy.savetxt` and
+    `numpy.loadtxt` instead.
 
-    - ``widgets.HorizontalSpanSelector`` has been removed.  Use
-      `.widgets.SpanSelector` instead.
+  - ``widgets.HorizontalSpanSelector`` has been removed.  Use
+    `.widgets.SpanSelector` instead.
 
 Code deprecation
 ----------------
@@ -83,15 +83,15 @@ Code deprecation
   `.collections.Collection` classes.  Use the following mapping to update
   your code:
 
-    - ``point_in_path`` -> `.path.Path.contains_point`
-    - ``get_path_extents`` -> `.path.Path.get_extents`
-    - ``point_in_path_collection`` -> `.collections.Collection.contains`
-    - ``path_in_path`` -> `.path.Path.contains_path`
-    - ``path_intersects_path`` -> `.path.Path.intersects_path`
-    - ``convert_path_to_polygons`` -> `.path.Path.to_polygons`
-    - ``cleanup_path`` -> `.path.Path.cleaned`
-    - ``points_in_path`` -> `.path.Path.contains_points`
-    - ``clip_path_to_rect`` -> `.path.Path.clip_to_bbox`
+  - ``point_in_path`` -> `.path.Path.contains_point`
+  - ``get_path_extents`` -> `.path.Path.get_extents`
+  - ``point_in_path_collection`` -> `.collections.Collection.contains`
+  - ``path_in_path`` -> `.path.Path.contains_path`
+  - ``path_intersects_path`` -> `.path.Path.intersects_path`
+  - ``convert_path_to_polygons`` -> `.path.Path.to_polygons`
+  - ``cleanup_path`` -> `.path.Path.cleaned`
+  - ``points_in_path`` -> `.path.Path.contains_points`
+  - ``clip_path_to_rect`` -> `.path.Path.clip_to_bbox`
 
 * ``matplotlib.colors.normalize`` and ``matplotlib.colors.no_norm`` have
   been deprecated in favour of `matplotlib.colors.Normalize` and

--- a/doc/api/prev_api_changes/api_changes_1.4.x.rst
+++ b/doc/api/prev_api_changes/api_changes_1.4.x.rst
@@ -7,16 +7,16 @@ Code changes
 * A major refactoring of the axes module was made. The axes module has been
   split into smaller modules:
 
-    - the ``_base`` module, which contains a new private ``_AxesBase`` class.
-      This class contains all methods except plotting and labelling methods.
-    - the `~matplotlib.axes` module, which contains the `.axes.Axes` class.
-      This class inherits from ``_AxesBase``, and contains all plotting and
-      labelling methods.
-    - the ``_subplot`` module, with all the classes concerning subplotting.
+  - the ``_base`` module, which contains a new private ``_AxesBase`` class.
+    This class contains all methods except plotting and labelling methods.
+  - the `~matplotlib.axes` module, which contains the `.axes.Axes` class.
+    This class inherits from ``_AxesBase``, and contains all plotting and
+    labelling methods.
+  - the ``_subplot`` module, with all the classes concerning subplotting.
 
-There are a couple of things that do not exists in the `~matplotlib.axes`
-module's namespace anymore. If you use them, you need to import them from their
-original location:
+  There are a couple of things that do not exists in the `~matplotlib.axes`
+  module's namespace anymore. If you use them, you need to import them from their
+  original location:
 
   - ``math`` -> ``import math``
   - ``ma`` -> ``from numpy import ma``
@@ -91,11 +91,11 @@ original location:
   :ref:`legend_guide` for further details. Further legend changes
   include:
 
-   * ``matplotlib.axes.Axes._get_legend_handles`` now returns a generator of
-     handles, rather than a list.
+  * ``matplotlib.axes.Axes._get_legend_handles`` now returns a generator of
+    handles, rather than a list.
 
-   * The :func:`~matplotlib.pyplot.legend` function's *loc* positional
-     argument has been deprecated. Use the *loc* keyword argument instead.
+  * The :func:`~matplotlib.pyplot.legend` function's *loc* positional
+    argument has been deprecated. Use the *loc* keyword argument instead.
 
 * The :rc:`savefig.transparent` has been added to control
   default transparency when saving figures.
@@ -107,11 +107,11 @@ original location:
   that `.Annotation` and `.AnnotationBbox` can share a common sensibly named
   api for getting/setting the location of the text or box.
 
-    - *xyann* -> set the location of the annotation
-    - *xy* -> set where the arrow points to
-    - *anncoords* -> set the units of the annotation location
-    - *xycoords* -> set the units of the point location
-    - ``set_position()`` -> `.Annotation` only set location of annotation
+  - *xyann* -> set the location of the annotation
+  - *xy* -> set where the arrow points to
+  - *anncoords* -> set the units of the annotation location
+  - *xycoords* -> set the units of the point location
+  - ``set_position()`` -> `.Annotation` only set location of annotation
 
 * `matplotlib.mlab.specgram`, `matplotlib.mlab.psd`,  `matplotlib.mlab.csd`,
   `matplotlib.mlab.cohere`, ``matplotlib.mlab.cohere_pairs``,

--- a/doc/api/prev_api_changes/api_changes_1.5.0.rst
+++ b/doc/api/prev_api_changes/api_changes_1.5.0.rst
@@ -374,8 +374,8 @@ directly.
 patheffects.svg
 ~~~~~~~~~~~~~~~
 
- - remove ``get_proxy_renderer`` method from ``AbstractPathEffect`` class
- - remove ``patch_alpha`` and ``offset_xy`` from ``SimplePatchShadow``
+- remove ``get_proxy_renderer`` method from ``AbstractPathEffect`` class
+- remove ``patch_alpha`` and ``offset_xy`` from ``SimplePatchShadow``
 
 
 Remove ``testing.image_util.py``

--- a/doc/api/prev_api_changes/api_changes_3.0.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.0.0.rst
@@ -225,7 +225,7 @@ looking automatic ticks in many instances.  The much nicer
 ``interval_multiples=True`` is the new default.  See below to get the
 old behavior back:
 
-  .. plot::
+.. plot::
 
     import matplotlib.pyplot as plt
     import datetime

--- a/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/behavior.rst
@@ -88,16 +88,16 @@ enough to be accommodated by the default data limit margins.
 While the new behavior is algorithmically simpler, it is conditional on
 properties of the `.Collection` object:
 
-  1. ``offsets = None``, ``transform`` is a child of ``Axes.transData``: use the paths
-     for the automatic limits (i.e. for `.LineCollection` in `.Axes.streamplot`).
-  2.  ``offsets != None``, and ``offset_transform`` is child of ``Axes.transData``:
+1. ``offsets = None``, ``transform`` is a child of ``Axes.transData``: use the paths
+   for the automatic limits (i.e. for `.LineCollection` in `.Axes.streamplot`).
+2. ``offsets != None``, and ``offset_transform`` is child of ``Axes.transData``:
 
-    a) ``transform`` is child of ``Axes.transData``: use the ``path + offset`` for
-        limits (i.e., for `.Axes.bar`).
-    b) ``transform`` is not a child of ``Axes.transData``: just use the offsets
-        for the limits (i.e. for scatter)
+   a) ``transform`` is child of ``Axes.transData``: use the ``path + offset`` for
+      limits (i.e., for `.Axes.bar`).
+   b) ``transform`` is not a child of ``Axes.transData``: just use the offsets
+      for the limits (i.e. for scatter)
 
-  3. otherwise return a null `.Bbox`.
+3. otherwise return a null `.Bbox`.
 
 While this seems complicated, the logic is simply to use the information from
 the object that are in data space for the limits, but not information that is

--- a/doc/api/prev_api_changes/api_changes_3.3.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/behaviour.rst
@@ -52,7 +52,7 @@ its ``stdin``, ``stdout``, and ``stderr`` attributes are utf8-encoded.
 ``pyplot.xticks()`` and ``pyplot.yticks()``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Previously, passing labels without passing the ticks to either `.pyplot.xticks`
-and `.pyplot.yticks` would result in
+and `.pyplot.yticks` would result in::
 
     TypeError: object of type 'NoneType' has no len()
 

--- a/doc/devel/MEP/MEP11.rst
+++ b/doc/devel/MEP/MEP11.rst
@@ -47,30 +47,30 @@ Detailed description
 
 matplotlib depends on the following third-party Python libraries:
 
-   - Numpy
-   - dateutil (pure Python)
-   - pytz (pure Python)
-   - six -- required by dateutil (pure Python)
-   - pyparsing (pure Python)
-   - PIL (optional)
-   - GUI frameworks: pygtk, gobject, tkinter, PySide, PyQt4, wx (all
-     optional, but one is required for an interactive GUI)
+- Numpy
+- dateutil (pure Python)
+- pytz (pure Python)
+- six -- required by dateutil (pure Python)
+- pyparsing (pure Python)
+- PIL (optional)
+- GUI frameworks: pygtk, gobject, tkinter, PySide, PyQt4, wx (all
+  optional, but one is required for an interactive GUI)
 
 Current behavior
 ----------------
 
 When installing from source, a :program:`git` checkout or pip_:
 
-  - :file:`setup.py` attempts to ``import numpy``.  If this fails, the
-    installation fails.
+- :file:`setup.py` attempts to ``import numpy``.  If this fails, the
+  installation fails.
 
-  - For each of dateutil_, pytz_ and six_, :file:`setup.py` attempts to
-    import them (from the top-level namespace).  If that fails,
-    matplotlib installs its local copy of the library into the
-    top-level namespace.
+- For each of dateutil_, pytz_ and six_, :file:`setup.py` attempts to
+  import them (from the top-level namespace).  If that fails,
+  matplotlib installs its local copy of the library into the
+  top-level namespace.
 
-  - pyparsing_ is always installed inside of the matplotlib
-    namespace.
+- pyparsing_ is always installed inside of the matplotlib
+  namespace.
 
 This behavior is most surprising when used with pip_, because no
 pip_ dependency resolution is performed, even though it is likely to

--- a/doc/devel/MEP/MEP12.rst
+++ b/doc/devel/MEP/MEP12.rst
@@ -112,11 +112,11 @@ sections described above. "Clean-up" should involve:
 * Replace uses of `pylab` interface with `.pyplot` (+ `numpy`,
   etc.). See `c25ef1e
   <https://github.com/tonysyu/matplotlib/commit/c25ef1e02b3a0ecb279492409dac0de9b3d2c0e2>`_
-* Remove shebang line, e.g.:
+* Remove shebang line, e.g.::
 
       #!/usr/bin/env python
 
-* Use consistent imports. In particular:
+* Use consistent imports. In particular::
 
       import numpy as np
 

--- a/doc/devel/MEP/MEP14.rst
+++ b/doc/devel/MEP/MEP14.rst
@@ -388,10 +388,10 @@ There are three main pieces to the implementation:
 
 1) Rewriting the freetype wrapper, and removing ttconv.
 
- a) Once (1) is done, as a proof of concept, we can move to the
-    upstream STIX .otf fonts
+   a) Once (1) is done, as a proof of concept, we can move to the
+      upstream STIX .otf fonts
 
- b) Add support for web fonts loaded from a remote URL.  (Enabled by using freetype for font subsetting).
+   b) Add support for web fonts loaded from a remote URL.  (Enabled by using freetype for font subsetting).
 
 2) Refactoring the existing "builtin" and "usetex" code into separate text engines and to follow the API outlined above.
 

--- a/doc/devel/MEP/MEP19.rst
+++ b/doc/devel/MEP/MEP19.rst
@@ -184,9 +184,9 @@ The test framework itself
 
 - We should investigate ways to make it take less time
 
-   - Eliminating redundant tests, if possible
+  - Eliminating redundant tests, if possible
 
-   - General performance improvements to matplotlib will help
+  - General performance improvements to matplotlib will help
 
 - We should be covering more things, particularly more backends
 

--- a/doc/devel/MEP/MEP25.rst
+++ b/doc/devel/MEP/MEP25.rst
@@ -113,31 +113,31 @@ Implementation
 1. Create base ``Controller`` objects that are able to manage
    ``Artist`` objects (e.g., ``Hist``)
 
-    Comments:
+   Comments:
 
-    * initialization should happen via unpacking ``**``, so we need a
-      copy of call signature parameter for the ``Artist`` we're
-      ultimately trying to control. Unfortunate hard-coded
-      repetition...
-    * should the additional ``**kwargs`` accepted by each ``Artist``
-      be tracked at the ``Controller``
-    * how does a ``Controller`` know which artist belongs where? E.g.,
-      do we need to pass ``axes`` references?
+   * initialization should happen via unpacking ``**``, so we need a
+     copy of call signature parameter for the ``Artist`` we're
+     ultimately trying to control. Unfortunate hard-coded
+     repetition...
+   * should the additional ``**kwargs`` accepted by each ``Artist``
+     be tracked at the ``Controller``
+   * how does a ``Controller`` know which artist belongs where? E.g.,
+     do we need to pass ``axes`` references?
 
-    Progress:
+   Progress:
 
-    * A simple NB demonstrating some functionality for
-      ``Line2DController`` objects:
-      https://nbviewer.jupyter.org/gist/theengineear/f0aa8d79f64325e767c0
+   * A simple NB demonstrating some functionality for
+     ``Line2DController`` objects:
+     https://nbviewer.jupyter.org/gist/theengineear/f0aa8d79f64325e767c0
 
 2. Write in protocols for the ``Controller`` to *update* the model.
 
-    Comments:
+   Comments:
 
-    * how should containers be dealt with? E.g., what happens to old
-      patches when we re-bin a histogram?
-    * in the link from (1), the old line is completely destroyed and
-      redrawn, what if something is referencing it?
+   * how should containers be dealt with? E.g., what happens to old
+     patches when we re-bin a histogram?
+   * in the link from (1), the old line is completely destroyed and
+     redrawn, what if something is referencing it?
 
 3. Create method by which a json object can be assembled from the
    ``Controllers``

--- a/doc/devel/MEP/MEP27.rst
+++ b/doc/devel/MEP/MEP27.rst
@@ -51,26 +51,26 @@ Two main places for generic code appear in the classes derived from
 
 1. ``FigureManagerBase`` has **three** jobs at the moment:
 
-    1. The documentation describes it as a *Helper class for pyplot
-       mode, wraps everything up into a neat bundle*
-    2. But it doesn't just wrap the canvas and toolbar, it also does
-       all of the windowing tasks itself.  The conflation of these two
-       tasks gets seen the best in the following line:
-       ``self.set_window_title("Figure %d" % num)`` This combines
-       backend specific code ``self.set_window_title(title)`` with
-       matplotlib generic code ``title = "Figure %d" % num``.
-    3. Currently the backend specific subclass of ``FigureManager``
-       decides when to end the mainloop.  This also seems very wrong
-       as the figure should have no control over the other figures.
+   1. The documentation describes it as a *Helper class for pyplot
+      mode, wraps everything up into a neat bundle*
+   2. But it doesn't just wrap the canvas and toolbar, it also does
+      all of the windowing tasks itself.  The conflation of these two
+      tasks gets seen the best in the following line:
+      ``self.set_window_title("Figure %d" % num)`` This combines
+      backend specific code ``self.set_window_title(title)`` with
+      matplotlib generic code ``title = "Figure %d" % num``.
+   3. Currently the backend specific subclass of ``FigureManager``
+      decides when to end the mainloop.  This also seems very wrong
+      as the figure should have no control over the other figures.
 
 
 2. ``ShowBase`` has two jobs:
 
-    1. It has the job of going through all figure managers registered
-       in ``_pylab_helpers.Gcf`` and telling them to show themselves.
-    2. And secondly it has the job of performing the backend specific
-       ``mainloop`` to block the main programme and thus keep the
-       figures from dying.
+   1. It has the job of going through all figure managers registered
+      in ``_pylab_helpers.Gcf`` and telling them to show themselves.
+   2. And secondly it has the job of performing the backend specific
+      ``mainloop`` to block the main programme and thus keep the
+      figures from dying.
 
 Implementation
 ==============

--- a/doc/devel/MEP/MEP28.rst
+++ b/doc/devel/MEP/MEP28.rst
@@ -80,14 +80,14 @@ the seaborn API to the underlying matplotlib functions.
 
 This will be achieved in the following way:
 
-  1. ``cbook.boxplot_stats`` will be modified to allow pre- and post-
-     computation transformation functions to be passed in (e.g., ``np.log``
-     and ``np.exp`` for lognormally distributed data)
-  2. ``Axes.boxplot`` will be modified to also accept and naïvely pass them
-     to ``cbook.boxplots_stats`` (Alt: pass the stat function and a dict
-     of its optional parameters).
-  3. Outdated parameters from ``Axes.boxplot`` will be deprecated and
-     later removed.
+1. ``cbook.boxplot_stats`` will be modified to allow pre- and post-
+   computation transformation functions to be passed in (e.g., ``np.log``
+   and ``np.exp`` for lognormally distributed data)
+2. ``Axes.boxplot`` will be modified to also accept and naïvely pass them
+   to ``cbook.boxplots_stats`` (Alt: pass the stat function and a dict
+   of its optional parameters).
+3. Outdated parameters from ``Axes.boxplot`` will be deprecated and
+   later removed.
 
 Importance
 ----------
@@ -164,9 +164,9 @@ and ``Axes.bxp``.
 
 The parameters to be deprecated and removed include:
 
-  1. ``usermedians`` - processed by 10 SLOC, 3 ``if`` blocks, a ``for`` loop
-  2. ``conf_intervals`` - handled by 15 SLOC, 6 ``if`` blocks, a ``for`` loop
-  3. ``sym`` - processed by 12 SLOC, 4 ``if`` blocks
+1. ``usermedians`` - processed by 10 SLOC, 3 ``if`` blocks, a ``for`` loop
+2. ``conf_intervals`` - handled by 15 SLOC, 6 ``if`` blocks, a ``for`` loop
+3. ``sym`` - processed by 12 SLOC, 4 ``if`` blocks
 
 Removing the ``sym`` option allows all code in handling the remaining
 styling parameters to be moved to ``Axes.bxp``. This doesn't remove
@@ -199,19 +199,20 @@ An accelerated timeline could look like the following:
 #. v2.0.1 add transforms to ``cbook.boxplots_stats``, expose in ``Axes.boxplot``
 #. v2.1.0 Initial Deprecations , and using 2D NumPy arrays as input
 
-    a. Using 2D NumPy arrays as input. The semantics around 2D arrays are generally confusing.
-    b. ``usermedians``, ``conf_intervals``, ``sym`` parameters
+   a. Using 2D NumPy arrays as input. The semantics around 2D arrays are generally confusing.
+   b. ``usermedians``, ``conf_intervals``, ``sym`` parameters
 
 #. v2.2.0
 
-    a. remove ``usermedians``, ``conf_intervals``, ``sym`` parameters
-    b. deprecate ``notch`` in favor of ``shownotches`` to be consistent with
-       other parameters and ``Axes.bxp``
+   a. remove ``usermedians``, ``conf_intervals``, ``sym`` parameters
+   b. deprecate ``notch`` in favor of ``shownotches`` to be consistent with
+      other parameters and ``Axes.bxp``
 
 #. v2.3.0
-    a. remove ``notch`` parameter
-    b. move all style and artist toggling logic to ``Axes.bxp`` such ``Axes.boxplot``
-       is little more than a broker between ``Axes.bxp`` and ``cbook.boxplots_stats``
+
+   a. remove ``notch`` parameter
+   b. move all style and artist toggling logic to ``Axes.bxp`` such ``Axes.boxplot``
+      is little more than a broker between ``Axes.bxp`` and ``cbook.boxplots_stats``
 
 
 Anticipated Impacts to Users

--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -359,19 +359,19 @@ Introducing
 3. Make appropriate changes to the type hints in the associated ``.pyi`` file.
    The general guideline is to match runtime reported behavior.
 
-  - Items marked with ``@_api.deprecated`` or ``@_api.deprecate_privatize_attribute``
-    are generally kept during the expiry period, and thus no changes are needed on
-    introduction.
-  - Items decorated with ``@_api.rename_parameter`` or ``@_api.make_keyword_only``
-    report the *new* (post deprecation) signature at runtime, and thus *should* be
-    updated on introduction.
-  - Items decorated with ``@_api.delete_parameter`` should include a default value hint
-    for the deleted parameter, even if it did not previously have one (e.g.
-    ``param: <type> = ...``). Even so, the decorator changes the default value to a
-    sentinel value which should not be included in the type stub. Thus, Mypy Stubtest
-    needs to be informed of the inconsistency by placing the method into
-    :file:`ci/mypy-stubtest-allowlist.txt` under a heading indicating the deprecation
-    version number.
+   - Items marked with ``@_api.deprecated`` or ``@_api.deprecate_privatize_attribute``
+     are generally kept during the expiry period, and thus no changes are needed on
+     introduction.
+   - Items decorated with ``@_api.rename_parameter`` or ``@_api.make_keyword_only``
+     report the *new* (post deprecation) signature at runtime, and thus *should* be
+     updated on introduction.
+   - Items decorated with ``@_api.delete_parameter`` should include a default value hint
+     for the deleted parameter, even if it did not previously have one (e.g.
+     ``param: <type> = ...``). Even so, the decorator changes the default value to a
+     sentinel value which should not be included in the type stub. Thus, Mypy Stubtest
+     needs to be informed of the inconsistency by placing the method into
+     :file:`ci/mypy-stubtest-allowlist.txt` under a heading indicating the deprecation
+     version number.
 
 Expiring
 ~~~~~~~~
@@ -386,17 +386,17 @@ Expiring
 2. Change the code functionality and remove any related deprecation warnings.
 3. Make appropriate changes to the type hints in the associated ``.pyi`` file.
 
-  - Items marked with ``@_api.deprecated`` or ``@_api.deprecate_privatize_attribute``
-    are to be removed on expiry.
-  - Items decorated with ``@_api.rename_parameter`` or ``@_api.make_keyword_only``
-    will have been updated at introduction, and require no change now.
-  - Items decorated with ``@_api.delete_parameter`` will need to be updated to the
-    final signature, in the same way as the ``.py`` file signature is updated.
-    The entry in :file:`ci/mypy-stubtest-allowlist.txt` should be removed.
-  - Any other entries in :file:`ci/mypy-stubtest-allowlist.txt` under a version's
-    deprecations should be double checked, as only ``delete_parameter`` should normally
-    require that mechanism for deprecation. For removed items that were not in the stub
-    file, only deleting from the allowlist is required.
+   - Items marked with ``@_api.deprecated`` or ``@_api.deprecate_privatize_attribute``
+     are to be removed on expiry.
+   - Items decorated with ``@_api.rename_parameter`` or ``@_api.make_keyword_only``
+     will have been updated at introduction, and require no change now.
+   - Items decorated with ``@_api.delete_parameter`` will need to be updated to the
+     final signature, in the same way as the ``.py`` file signature is updated.
+     The entry in :file:`ci/mypy-stubtest-allowlist.txt` should be removed.
+   - Any other entries in :file:`ci/mypy-stubtest-allowlist.txt` under a version's
+     deprecations should be double checked, as only ``delete_parameter`` should normally
+     require that mechanism for deprecation. For removed items that were not in the stub
+     file, only deleting from the allowlist is required.
 
 Adding new API
 --------------

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -328,8 +328,8 @@ The additional Python packages required to build the
 
 The content of :file:`doc-requirements.txt` is also shown below:
 
-   .. include:: ../../requirements/doc/doc-requirements.txt
-      :literal:
+.. include:: ../../requirements/doc/doc-requirements.txt
+   :literal:
 
 Additional external dependencies
 --------------------------------

--- a/doc/devel/triage.rst
+++ b/doc/devel/triage.rst
@@ -31,24 +31,24 @@ A third party can give useful feedback or even add
 comments on the issue.
 The following actions are typically useful:
 
-  - documenting issues that are missing elements to reproduce the problem
-    such as code samples
+- documenting issues that are missing elements to reproduce the problem
+  such as code samples
 
-  - suggesting better use of code formatting (e.g. triple back ticks in the
-    markdown).
+- suggesting better use of code formatting (e.g. triple back ticks in the
+  markdown).
 
-  - suggesting to reformulate the title and description to make them more
-    explicit about the problem to be solved
+- suggesting to reformulate the title and description to make them more
+  explicit about the problem to be solved
 
-  - linking to related issues or discussions while briefly describing
-    how they are related, for instance "See also #xyz for a similar
-    attempt at this" or "See also #xyz where the same thing was
-    reported" provides context and helps the discussion
+- linking to related issues or discussions while briefly describing
+  how they are related, for instance "See also #xyz for a similar
+  attempt at this" or "See also #xyz where the same thing was
+  reported" provides context and helps the discussion
 
-  - verifying that the issue is reproducible
+- verifying that the issue is reproducible
 
-  - classify the issue as a feature request, a long standing bug or a
-    regression
+- classify the issue as a feature request, a long standing bug or a
+  regression
 
 .. topic:: Fruitful discussions
 

--- a/doc/sphinxext/math_symbol_table.py
+++ b/doc/sphinxext/math_symbol_table.py
@@ -115,18 +115,18 @@ def run(state_machine):
                       key=lambda sym: (render_symbol(sym, ignore_variant=True),
                                        sym.startswith(r"\var")),
                       reverse=(category == "Hebrew"))  # Hebrew is rtl
+        rendered_syms = [f"{render_symbol(sym)} ``{sym}``" for sym in syms]
         columns = min(columns, len(syms))
         lines.append("**%s**" % category)
         lines.append('')
-        max_width = max(map(len, syms)) * 2 + 16
-        header = "    " + (('=' * max_width) + ' ') * columns
-        lines.append(header)
-        for part in range(0, len(syms), columns):
+        max_width = max(map(len, rendered_syms))
+        header = (('=' * max_width) + ' ') * columns
+        lines.append(header.rstrip())
+        for part in range(0, len(rendered_syms), columns):
             row = " ".join(
-                f"{render_symbol(sym)} ``{sym}``".rjust(max_width)
-                for sym in syms[part:part + columns])
-            lines.append(f"    {row}")
-        lines.append(header)
+                sym.rjust(max_width) for sym in rendered_syms[part:part + columns])
+            lines.append(row)
+        lines.append(header.rstrip())
         lines.append('')
 
     state_machine.insert_input(lines, "Symbol table")

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -728,6 +728,6 @@ Prefixed pkg-config for building
 Handling of pkg-config has been fixed in so far as it is now possible to set it
 using the environment variable ``PKG_CONFIG``. This is important if your
 toolchain is prefixed. This is done in a simpilar way as setting ``CC``
-or ``CXX`` before building. An example follows.
+or ``CXX`` before building. An example follows::
 
     export PKG_CONFIG=x86_64-pc-linux-gnu-pkg-config

--- a/doc/users/prev_whats_new/whats_new_2.2.rst
+++ b/doc/users/prev_whats_new/whats_new_2.2.rst
@@ -300,7 +300,7 @@ Added support for QT in new ToolManager
 ---------------------------------------
 
 Now it is possible to use the ToolManager with Qt5
-For example
+For example::
 
   import matplotlib
 

--- a/doc/users/prev_whats_new/whats_new_2.2.rst
+++ b/doc/users/prev_whats_new/whats_new_2.2.rst
@@ -24,15 +24,15 @@ more finely tuned with the new `~.set_constrained_layout_pads`.
 
 Features include:
 
-  - Automatic spacing for subplots with a fixed-size padding in inches around
-    subplots and all their decorators, and space between as a fraction
-    of subplot size between subplots.
-  - Spacing for `~.Figure.suptitle`, and colorbars that are attached to
-    more than one axes.
-  - Nested `~.GridSpec` layouts using `~.GridSpecFromSubplotSpec`.
+- Automatic spacing for subplots with a fixed-size padding in inches around
+  subplots and all their decorators, and space between as a fraction
+  of subplot size between subplots.
+- Spacing for `~.Figure.suptitle`, and colorbars that are attached to
+  more than one axes.
+- Nested `~.GridSpec` layouts using `~.GridSpecFromSubplotSpec`.
 
-  For more details and capabilities please see the new tutorial:
-  :ref:`constrainedlayout_guide`
+For more details and capabilities please see the new tutorial:
+:ref:`constrainedlayout_guide`
 
 Note the new API to access this:
 

--- a/doc/users/prev_whats_new/whats_new_3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.0.rst
@@ -147,7 +147,7 @@ Add ``ax.get_gridspec`` to ``SubplotBase``
 New method ``SubplotBase.get_gridspec`` is added so that users can
 easily get the gridspec that went into making an axes:
 
-  .. code::
+.. code::
 
     import matplotlib.pyplot as plt
 

--- a/doc/users/prev_whats_new/whats_new_3.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.1.0.rst
@@ -22,7 +22,7 @@ The automatic date formatter used by default can be quite verbose.  A new
 formatter can be accessed that tries to make the tick labels appropriately
 concise.
 
-  .. plot::
+.. plot::
 
     import datetime
     import matplotlib.pyplot as plt

--- a/doc/users/prev_whats_new/whats_new_3.3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.3.0.rst
@@ -183,7 +183,7 @@ colorbar inherits the *extend* argument from the norm, so with
 ``extend='both'``, for example, the colorbar will have triangular extensions
 for out-of-range values with colors that differ from adjacent in-range colors.
 
-  .. plot::
+.. plot::
 
     import matplotlib.pyplot as plt
     from matplotlib.colors import BoundaryNorm

--- a/doc/users/project/citing.rst
+++ b/doc/users/project/citing.rst
@@ -21,8 +21,8 @@ DOIs
 The following DOI represents *all* Matplotlib versions. Please select a more
 specific DOI from the list below, referring to the version used for your publication.
 
-   .. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.592536.svg
-      :target: https://doi.org/10.5281/zenodo.592536
+.. image:: https://zenodo.org/badge/DOI/10.5281/zenodo.592536.svg
+   :target: https://doi.org/10.5281/zenodo.592536
 
 By version
 ~~~~~~~~~~

--- a/galleries/examples/statistics/errorbars_and_boxes.py
+++ b/galleries/examples/statistics/errorbars_and_boxes.py
@@ -9,16 +9,16 @@ y- directions. To do this, we have to write our own custom function
 called ``make_error_boxes``. Close inspection of this function will
 reveal the preferred pattern in writing functions for matplotlib:
 
-  1. an `~.axes.Axes` object is passed directly to the function
-  2. the function operates on the ``Axes`` methods directly, not through
-     the ``pyplot`` interface
-  3. plotting keyword arguments that could be abbreviated are spelled out for
-     better code readability in the future (for example we use *facecolor*
-     instead of *fc*)
-  4. the artists returned by the ``Axes`` plotting methods are then
-     returned by the function so that, if desired, their styles
-     can be modified later outside of the function (they are not
-     modified in this example).
+1. an `~.axes.Axes` object is passed directly to the function
+2. the function operates on the ``Axes`` methods directly, not through
+   the ``pyplot`` interface
+3. plotting keyword arguments that could be abbreviated are spelled out for
+   better code readability in the future (for example we use *facecolor*
+   instead of *fc*)
+4. the artists returned by the ``Axes`` plotting methods are then
+   returned by the function so that, if desired, their styles
+   can be modified later outside of the function (they are not
+   modified in this example).
 """
 
 import matplotlib.pyplot as plt

--- a/galleries/tutorials/pyplot.py
+++ b/galleries/tutorials/pyplot.py
@@ -416,7 +416,7 @@ plt.show()
 #
 # :mod:`matplotlib.pyplot` supports not only linear axis scales, but also
 # logarithmic and logit scales. This is commonly used if data spans many orders
-# of magnitude. Changing the scale of an axis is easy:
+# of magnitude. Changing the scale of an axis is easy::
 #
 #     plt.xscale('log')
 #

--- a/galleries/users_explain/artists/imshow_extent.py
+++ b/galleries/users_explain/artists/imshow_extent.py
@@ -185,17 +185,17 @@ generate_imshow_demo_grid(extents=[None])
 #
 # For ``origin='lower'``:
 #
-#    - [0, 0] is at (left, bottom)
-#    - [M', 0] is at (left, top)
-#    - [0, N'] is at (right, bottom)
-#    - [M', N'] is at (right, top)
+# - [0, 0] is at (left, bottom)
+# - [M', 0] is at (left, top)
+# - [0, N'] is at (right, bottom)
+# - [M', N'] is at (right, top)
 #
 # ``origin='upper'`` reverses the vertical axes direction and filling:
 #
-#    - [0, 0] is at (left, top)
-#    - [M', 0] is at (left, bottom)
-#    - [0, N'] is at (right, top)
-#    - [M', N'] is at (right, bottom)
+# - [0, 0] is at (left, top)
+# - [M', 0] is at (left, bottom)
+# - [0, N'] is at (right, top)
+# - [M', N'] is at (right, bottom)
 #
 # In summary, the position of the [0, 0] index as well as the extent are
 # influenced by *origin*:

--- a/galleries/users_explain/axes/arranging_axes.py
+++ b/galleries/users_explain/axes/arranging_axes.py
@@ -417,10 +417,10 @@ plt.show()
 # More reading
 # ============
 #
-#  - More details about :ref:`subplot mosaic <mosaic>`.
-#  - More details about :ref:`constrained layout
-#    <constrainedlayout_guide>`, used to align
-#    spacing in most of these examples.
+# - More details about :ref:`subplot mosaic <mosaic>`.
+# - More details about :ref:`constrained layout
+#   <constrainedlayout_guide>`, used to align
+#   spacing in most of these examples.
 #
 # .. admonition:: References
 #

--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -216,12 +216,12 @@ Event attributes
 All Matplotlib events inherit from the base class
 `matplotlib.backend_bases.Event`, which stores the attributes:
 
-    ``name``
-        the event name
-    ``canvas``
-        the FigureCanvas instance generating the event
-    ``guiEvent``
-        the GUI event that triggered the Matplotlib event
+``name``
+    the event name
+``canvas``
+    the FigureCanvas instance generating the event
+``guiEvent``
+    the GUI event that triggered the Matplotlib event
 
 The most common events that are the bread and butter of event handling
 are key press/release events and mouse press/release and movement
@@ -229,13 +229,13 @@ events.  The `.KeyEvent` and `.MouseEvent` classes that handle
 these events are both derived from the LocationEvent, which has the
 following attributes
 
-    ``x``, ``y``
-        mouse x and y position in pixels from left and bottom of canvas
-    ``inaxes``
-        the `~.axes.Axes` instance over which the mouse is, if any; else None
-    ``xdata``, ``ydata``
-        mouse x and y position in data coordinates, if the mouse is over an
-        axes
+``x``, ``y``
+    mouse x and y position in pixels from left and bottom of canvas
+``inaxes``
+    the `~.axes.Axes` instance over which the mouse is, if any; else None
+``xdata``, ``ydata``
+    mouse x and y position in data coordinates, if the mouse is over an
+    axes
 
 Let's look a simple example of a canvas, where a simple line segment
 is created every time a mouse is pressed::
@@ -266,13 +266,13 @@ is created every time a mouse is pressed::
 
 The `.MouseEvent` that we just used is a `.LocationEvent`, so we have access to
 the data and pixel coordinates via ``(event.x, event.y)`` and ``(event.xdata,
-event.ydata)``.  In addition to the ``LocationEvent`` attributes, it also has
+event.ydata)``.  In addition to the ``LocationEvent`` attributes, it also has:
 
-    ``button``
-        the button pressed: None, `.MouseButton`, 'up', or 'down' (up and down are used for scroll events)
+``button``
+    the button pressed: None, `.MouseButton`, 'up', or 'down' (up and down are used for scroll events)
 
-    ``key``
-        the key pressed: None, any character, 'shift', 'win', or 'control'
+``key``
+    the key pressed: None, any character, 'shift', 'win', or 'control'
 
 Draggable rectangle exercise
 ----------------------------
@@ -523,18 +523,18 @@ as `.Line2D`, `.Text`, `.Patch`, `.Polygon`, `.AxesImage`, etc.)
 
 The ``picker`` property can be set using various types:
 
-    ``None``
-        Picking is disabled for this artist (default).
-    ``boolean``
-        If True, then picking will be enabled and the artist will fire a
-        pick event if the mouse event is over the artist.
-    ``callable``
-        If picker is a callable, it is a user supplied function which
-        determines whether the artist is hit by the mouse event.  The
-        signature is ``hit, props = picker(artist, mouseevent)`` to
-        determine the hit test.  If the mouse event is over the artist,
-        return ``hit = True``; ``props`` is a dictionary of properties that
-        become additional attributes on the `.PickEvent`.
+``None``
+    Picking is disabled for this artist (default).
+``boolean``
+    If True, then picking will be enabled and the artist will fire a
+    pick event if the mouse event is over the artist.
+``callable``
+    If picker is a callable, it is a user supplied function which
+    determines whether the artist is hit by the mouse event.  The
+    signature is ``hit, props = picker(artist, mouseevent)`` to
+    determine the hit test.  If the mouse event is over the artist,
+    return ``hit = True``; ``props`` is a dictionary of properties that
+    become additional attributes on the `.PickEvent`.
 
 The artist's ``pickradius`` property can additionally be set to a tolerance
 value in points (there are 72 points per inch) that determines how far the
@@ -551,11 +551,11 @@ pick callbacks on mouse press events.  The handler typically looks like ::
 
 The `.PickEvent` passed to your callback always has the following attributes:
 
-    ``mouseevent``
-        The `.MouseEvent` that generate the pick event.  See event-attributes_
-        for a list of useful attributes on the mouse event.
-    ``artist``
-        The `.Artist` that generated the pick event.
+``mouseevent``
+    The `.MouseEvent` that generate the pick event.  See event-attributes_
+    for a list of useful attributes on the mouse event.
+``artist``
+    The `.Artist` that generated the pick event.
 
 Additionally, certain artists like `.Line2D` and `.PatchCollection` may attach
 additional metadata, like the indices of the data that meet the

--- a/galleries/users_explain/text/annotations.py
+++ b/galleries/users_explain/text/annotations.py
@@ -223,22 +223,22 @@ t = ax.text(0.5, 0.5, "Direction",
 
 # %%
 # The arguments are the name of the box style with its attributes as
-# keyword arguments. Currently, following box styles are implemented.
+# keyword arguments. Currently, following box styles are implemented:
 #
-#   ==========   ==============   ==========================
-#   Class        Name             Attrs
-#   ==========   ==============   ==========================
-#   Circle       ``circle``       pad=0.3
-#   DArrow       ``darrow``       pad=0.3
-#   Ellipse      ``ellipse``      pad=0.3
-#   LArrow       ``larrow``       pad=0.3
-#   RArrow       ``rarrow``       pad=0.3
-#   Round        ``round``        pad=0.3,rounding_size=None
-#   Round4       ``round4``       pad=0.3,rounding_size=None
-#   Roundtooth   ``roundtooth``   pad=0.3,tooth_size=None
-#   Sawtooth     ``sawtooth``     pad=0.3,tooth_size=None
-#   Square       ``square``       pad=0.3
-#   ==========   ==============   ==========================
+# ==========   ==============   ==========================
+# Class        Name             Attrs
+# ==========   ==============   ==========================
+# Circle       ``circle``       pad=0.3
+# DArrow       ``darrow``       pad=0.3
+# Ellipse      ``ellipse``      pad=0.3
+# LArrow       ``larrow``       pad=0.3
+# RArrow       ``rarrow``       pad=0.3
+# Round        ``round``        pad=0.3,rounding_size=None
+# Round4       ``round4``       pad=0.3,rounding_size=None
+# Roundtooth   ``roundtooth``   pad=0.3,tooth_size=None
+# Sawtooth     ``sawtooth``     pad=0.3,tooth_size=None
+# Square       ``square``       pad=0.3
+# ==========   ==============   ==========================
 #
 # .. figure:: /gallery/shapes_and_collections/images/sphx_glr_fancybox_demo_001.png
 #    :target: /gallery/shapes_and_collections/fancybox_demo.html
@@ -335,17 +335,17 @@ ax.annotate("",
 #    :align: center
 #
 # The creation of the connecting path between two points is controlled by
-# ``connectionstyle`` key and the following styles are available.
+# ``connectionstyle`` key and the following styles are available:
 #
-#    ==========   =============================================
-#    Name         Attrs
-#    ==========   =============================================
-#    ``angle``    angleA=90,angleB=0,rad=0.0
-#    ``angle3``   angleA=90,angleB=0
-#    ``arc``      angleA=0,angleB=0,armA=None,armB=None,rad=0.0
-#    ``arc3``     rad=0.0
-#    ``bar``      armA=0.0,armB=0.0,fraction=0.3,angle=None
-#    ==========   =============================================
+# ==========   =============================================
+# Name         Attrs
+# ==========   =============================================
+# ``angle``    angleA=90,angleB=0,rad=0.0
+# ``angle3``   angleA=90,angleB=0
+# ``arc``      angleA=0,angleB=0,armA=None,armB=None,rad=0.0
+# ``arc3``     rad=0.0
+# ``bar``      armA=0.0,armB=0.0,fraction=0.3,angle=None
+# ==========   =============================================
 #
 # Note that "3" in ``angle3`` and ``arc3`` is meant to indicate that the
 # resulting path is a quadratic spline segment (three control
@@ -361,24 +361,24 @@ ax.annotate("",
 #    :align: center
 #
 # The connecting path (after clipping and shrinking) is then mutated to
-# an arrow patch, according to the given ``arrowstyle``.
+# an arrow patch, according to the given ``arrowstyle``:
 #
-#     ==========   =============================================
-#     Name         Attrs
-#     ==========   =============================================
-#     ``-``        None
-#     ``->``       head_length=0.4,head_width=0.2
-#     ``-[``       widthB=1.0,lengthB=0.2,angleB=None
-#     ``|-|``      widthA=1.0,widthB=1.0
-#     ``-|>``      head_length=0.4,head_width=0.2
-#     ``<-``       head_length=0.4,head_width=0.2
-#     ``<->``      head_length=0.4,head_width=0.2
-#     ``<|-``      head_length=0.4,head_width=0.2
-#     ``<|-|>``    head_length=0.4,head_width=0.2
-#     ``fancy``    head_length=0.4,head_width=0.4,tail_width=0.4
-#     ``simple``   head_length=0.5,head_width=0.5,tail_width=0.2
-#     ``wedge``    tail_width=0.3,shrink_factor=0.5
-#     ==========   =============================================
+# ==========   =============================================
+# Name         Attrs
+# ==========   =============================================
+# ``-``        None
+# ``->``       head_length=0.4,head_width=0.2
+# ``-[``       widthB=1.0,lengthB=0.2,angleB=None
+# ``|-|``      widthA=1.0,widthB=1.0
+# ``-|>``      head_length=0.4,head_width=0.2
+# ``<-``       head_length=0.4,head_width=0.2
+# ``<->``      head_length=0.4,head_width=0.2
+# ``<|-``      head_length=0.4,head_width=0.2
+# ``<|-|>``    head_length=0.4,head_width=0.2
+# ``fancy``    head_length=0.4,head_width=0.4,tail_width=0.4
+# ``simple``   head_length=0.5,head_width=0.5,tail_width=0.2
+# ``wedge``    tail_width=0.3,shrink_factor=0.5
+# ==========   =============================================
 #
 # .. figure:: /gallery/text_labels_and_annotations/images/sphx_glr_fancyarrow_demo_001.png
 #    :target: /gallery/text_labels_and_annotations/fancyarrow_demo.html

--- a/galleries/users_explain/text/mathtext.py
+++ b/galleries/users_explain/text/mathtext.py
@@ -202,14 +202,14 @@ command to add a little whitespace between them::
 
 The choices available with all fonts are:
 
-    ========================= ================================
-    Command                   Result
-    ========================= ================================
-    ``\mathrm{Roman}``        :mathmpl:`\mathrm{Roman}`
-    ``\mathit{Italic}``       :mathmpl:`\mathit{Italic}`
-    ``\mathtt{Typewriter}``   :mathmpl:`\mathtt{Typewriter}`
-    ``\mathcal{CALLIGRAPHY}`` :mathmpl:`\mathcal{CALLIGRAPHY}`
-    ========================= ================================
+========================= ================================
+Command                   Result
+========================= ================================
+``\mathrm{Roman}``        :mathmpl:`\mathrm{Roman}`
+``\mathit{Italic}``       :mathmpl:`\mathit{Italic}`
+``\mathtt{Typewriter}``   :mathmpl:`\mathtt{Typewriter}`
+``\mathcal{CALLIGRAPHY}`` :mathmpl:`\mathcal{CALLIGRAPHY}`
+========================= ================================
 
 .. role:: math-stix(mathmpl)
    :fontset: stix
@@ -217,51 +217,46 @@ The choices available with all fonts are:
 When using the `STIX <http://www.stixfonts.org/>`_ fonts, you also have the
 choice of:
 
-    ================================ =========================================
-    Command                          Result
-    ================================ =========================================
-    ``\mathbb{blackboard}``          :math-stix:`\mathbb{blackboard}`
-    ``\mathrm{\mathbb{blackboard}}`` :math-stix:`\mathrm{\mathbb{blackboard}}`
-    ``\mathfrak{Fraktur}``           :math-stix:`\mathfrak{Fraktur}`
-    ``\mathsf{sansserif}``           :math-stix:`\mathsf{sansserif}`
-    ``\mathrm{\mathsf{sansserif}}``  :math-stix:`\mathrm{\mathsf{sansserif}}`
-    ``\mathbfit{bolditalic}``        :math-stix:`\mathbfit{bolditalic}`
-    ================================ =========================================
+================================ =========================================
+Command                          Result
+================================ =========================================
+``\mathbb{blackboard}``          :math-stix:`\mathbb{blackboard}`
+``\mathrm{\mathbb{blackboard}}`` :math-stix:`\mathrm{\mathbb{blackboard}}`
+``\mathfrak{Fraktur}``           :math-stix:`\mathfrak{Fraktur}`
+``\mathsf{sansserif}``           :math-stix:`\mathsf{sansserif}`
+``\mathrm{\mathsf{sansserif}}``  :math-stix:`\mathrm{\mathsf{sansserif}}`
+``\mathbfit{bolditalic}``        :math-stix:`\mathbfit{bolditalic}`
+================================ =========================================
 
 There are also five global "font sets" to choose from, which are
 selected using the ``mathtext.fontset`` parameter in :ref:`matplotlibrc
 <matplotlibrc-sample>`.
 
 ``dejavusans``: DejaVu Sans
-
     .. mathmpl::
        :fontset: dejavusans
 
        \mathcal{R} \prod_{i=\alpha}^{\infty} a_i \sin\left(2\pi fx_i\right)
 
 ``dejavuserif``: DejaVu Serif
-
     .. mathmpl::
        :fontset: dejavuserif
 
        \mathcal{R} \prod_{i=\alpha}^{\infty} a_i \sin\left(2\pi fx_i\right)
 
 ``cm``: Computer Modern (TeX)
-
     .. mathmpl::
        :fontset: cm
 
        \mathcal{R} \prod_{i=\alpha}^{\infty} a_i \sin\left(2\pi fx_i\right)
 
 ``stix``: STIX (designed to blend well with Times)
-
     .. mathmpl::
        :fontset: stix
 
        \mathcal{R} \prod_{i=\alpha}^{\infty} a_i \sin\left(2\pi fx_i\right)
 
 ``stixsans``: STIX sans-serif
-
     .. mathmpl::
        :fontset: stixsans
 
@@ -285,17 +280,17 @@ patient users only.  By setting :rc:`mathtext.fontset` to ``custom``,
 you can then set the following parameters, which control which font file to use
 for a particular set of math characters.
 
-    ============================== =================================
-    Parameter                      Corresponds to
-    ============================== =================================
-    ``mathtext.it``                ``\mathit{}`` or default italic
-    ``mathtext.rm``                ``\mathrm{}`` Roman (upright)
-    ``mathtext.tt``                ``\mathtt{}`` Typewriter (monospace)
-    ``mathtext.bf``                ``\mathbf{}`` bold
-    ``mathtext.bfit``              ``\mathbfit{}`` bold italic
-    ``mathtext.cal``               ``\mathcal{}`` calligraphic
-    ``mathtext.sf``                ``\mathsf{}`` sans-serif
-    ============================== =================================
+============================== =================================
+Parameter                      Corresponds to
+============================== =================================
+``mathtext.it``                ``\mathit{}`` or default italic
+``mathtext.rm``                ``\mathrm{}`` Roman (upright)
+``mathtext.tt``                ``\mathtt{}`` Typewriter (monospace)
+``mathtext.bf``                ``\mathbf{}`` bold
+``mathtext.bfit``              ``\mathbfit{}`` bold italic
+``mathtext.cal``               ``\mathcal{}`` calligraphic
+``mathtext.sf``                ``\mathsf{}`` sans-serif
+============================== =================================
 
 Each parameter should be set to a fontconfig font descriptor (as defined in the
 yet-to-be-written font chapter).
@@ -318,32 +313,32 @@ Accents
 An accent command may precede any symbol to add an accent above it.  There are
 long and short forms for some of them.
 
-    ============================== =================================
-    Command                        Result
-    ============================== =================================
-    ``\acute a`` or ``\'a``        :mathmpl:`\acute a`
-    ``\bar a``                     :mathmpl:`\bar a`
-    ``\breve a``                   :mathmpl:`\breve a`
-    ``\dot a`` or ``\.a``          :mathmpl:`\dot a`
-    ``\ddot a`` or ``\''a``        :mathmpl:`\ddot a`
-    ``\dddot a``                   :mathmpl:`\dddot a`
-    ``\ddddot a``                  :mathmpl:`\ddddot a`
-    ``\grave a`` or ``\`a``        :mathmpl:`\grave a`
-    ``\hat a`` or ``\^a``          :mathmpl:`\hat a`
-    ``\tilde a`` or ``\~a``        :mathmpl:`\tilde a`
-    ``\vec a``                     :mathmpl:`\vec a`
-    ``\overline{abc}``             :mathmpl:`\overline{abc}`
-    ============================== =================================
+============================== =================================
+Command                        Result
+============================== =================================
+``\acute a`` or ``\'a``        :mathmpl:`\acute a`
+``\bar a``                     :mathmpl:`\bar a`
+``\breve a``                   :mathmpl:`\breve a`
+``\dot a`` or ``\.a``          :mathmpl:`\dot a`
+``\ddot a`` or ``\''a``        :mathmpl:`\ddot a`
+``\dddot a``                   :mathmpl:`\dddot a`
+``\ddddot a``                  :mathmpl:`\ddddot a`
+``\grave a`` or ``\`a``        :mathmpl:`\grave a`
+``\hat a`` or ``\^a``          :mathmpl:`\hat a`
+``\tilde a`` or ``\~a``        :mathmpl:`\tilde a`
+``\vec a``                     :mathmpl:`\vec a`
+``\overline{abc}``             :mathmpl:`\overline{abc}`
+============================== =================================
 
 In addition, there are two special accents that automatically adjust to the
 width of the symbols below:
 
-    ============================== =================================
-    Command                        Result
-    ============================== =================================
-    ``\widehat{xyz}``              :mathmpl:`\widehat{xyz}`
-    ``\widetilde{xyz}``            :mathmpl:`\widetilde{xyz}`
-    ============================== =================================
+============================== =================================
+Command                        Result
+============================== =================================
+``\widehat{xyz}``              :mathmpl:`\widehat{xyz}`
+``\widetilde{xyz}``            :mathmpl:`\widetilde{xyz}`
+============================== =================================
 
 Care should be taken when putting accents on lower-case i's and j's.  Note that
 in the following ``\imath`` is used to avoid the extra dot over the i::

--- a/galleries/users_explain/text/pgf.py
+++ b/galleries/users_explain/text/pgf.py
@@ -40,13 +40,13 @@ for all applications must be located on your :envvar:`PATH`.
 
 `.rcParams` that control the behavior of the pgf backend:
 
-    =================  =====================================================
-    Parameter          Documentation
-    =================  =====================================================
-    pgf.preamble       Lines to be included in the LaTeX preamble
-    pgf.rcfonts        Setup fonts from rc params using the fontspec package
-    pgf.texsystem      Either "xelatex" (default), "lualatex" or "pdflatex"
-    =================  =====================================================
+=================  =====================================================
+Parameter          Documentation
+=================  =====================================================
+pgf.preamble       Lines to be included in the LaTeX preamble
+pgf.rcfonts        Setup fonts from rc params using the fontspec package
+pgf.texsystem      Either "xelatex" (default), "lualatex" or "pdflatex"
+=================  =====================================================
 
 .. note::
 

--- a/galleries/users_explain/toolkits/axisartist.rst
+++ b/galleries/users_explain/toolkits/axisartist.rst
@@ -180,11 +180,11 @@ AxisArtist
 AxisArtist can be considered as a container artist with following
 attributes which will draw ticks, labels, etc.
 
- * line
- * major_ticks, major_ticklabels
- * minor_ticks, minor_ticklabels
- * offsetText
- * label
+* line
+* major_ticks, major_ticklabels
+* minor_ticks, minor_ticklabels
+* offsetText
+* label
 
 line
 ----

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -27,71 +27,71 @@ and explicit interfaces.
 
 Modules include:
 
-    :mod:`matplotlib.axes`
-        The `~.axes.Axes` class.  Most pyplot functions are wrappers for
-        `~.axes.Axes` methods.  The axes module is the highest level of OO
-        access to the library.
+:mod:`matplotlib.axes`
+    The `~.axes.Axes` class.  Most pyplot functions are wrappers for
+    `~.axes.Axes` methods.  The axes module is the highest level of OO
+    access to the library.
 
-    :mod:`matplotlib.figure`
-        The `.Figure` class.
+:mod:`matplotlib.figure`
+    The `.Figure` class.
 
-    :mod:`matplotlib.artist`
-        The `.Artist` base class for all classes that draw things.
+:mod:`matplotlib.artist`
+    The `.Artist` base class for all classes that draw things.
 
-    :mod:`matplotlib.lines`
-        The `.Line2D` class for drawing lines and markers.
+:mod:`matplotlib.lines`
+    The `.Line2D` class for drawing lines and markers.
 
-    :mod:`matplotlib.patches`
-        Classes for drawing polygons.
+:mod:`matplotlib.patches`
+    Classes for drawing polygons.
 
-    :mod:`matplotlib.text`
-        The `.Text` and `.Annotation` classes.
+:mod:`matplotlib.text`
+    The `.Text` and `.Annotation` classes.
 
-    :mod:`matplotlib.image`
-        The `.AxesImage` and `.FigureImage` classes.
+:mod:`matplotlib.image`
+    The `.AxesImage` and `.FigureImage` classes.
 
-    :mod:`matplotlib.collections`
-        Classes for efficient drawing of groups of lines or polygons.
+:mod:`matplotlib.collections`
+    Classes for efficient drawing of groups of lines or polygons.
 
-    :mod:`matplotlib.colors`
-        Color specifications and making colormaps.
+:mod:`matplotlib.colors`
+    Color specifications and making colormaps.
 
-    :mod:`matplotlib.cm`
-        Colormaps, and the `.ScalarMappable` mixin class for providing color
-        mapping functionality to other classes.
+:mod:`matplotlib.cm`
+    Colormaps, and the `.ScalarMappable` mixin class for providing color
+    mapping functionality to other classes.
 
-    :mod:`matplotlib.ticker`
-        Calculation of tick mark locations and formatting of tick labels.
+:mod:`matplotlib.ticker`
+    Calculation of tick mark locations and formatting of tick labels.
 
-    :mod:`matplotlib.backends`
-        A subpackage with modules for various GUI libraries and output formats.
+:mod:`matplotlib.backends`
+    A subpackage with modules for various GUI libraries and output formats.
 
 The base matplotlib namespace includes:
 
-    `~matplotlib.rcParams`
-        Default configuration settings; their defaults may be overridden using
-        a :file:`matplotlibrc` file.
+`~matplotlib.rcParams`
+    Default configuration settings; their defaults may be overridden using
+    a :file:`matplotlibrc` file.
 
-    `~matplotlib.use`
-        Setting the Matplotlib backend.  This should be called before any
-        figure is created, because it is not possible to switch between
-        different GUI backends after that.
+`~matplotlib.use`
+    Setting the Matplotlib backend.  This should be called before any
+    figure is created, because it is not possible to switch between
+    different GUI backends after that.
 
 The following environment variables can be used to customize the behavior:
 
-    :envvar:`MPLBACKEND`
-        This optional variable can be set to choose the Matplotlib backend. See
-        :ref:`what-is-a-backend`.
+:envvar:`MPLBACKEND`
+    This optional variable can be set to choose the Matplotlib backend. See
+    :ref:`what-is-a-backend`.
 
-    :envvar:`MPLCONFIGDIR`
-        This is the directory used to store user customizations to
-        Matplotlib, as well as some caches to improve performance. If
-        :envvar:`MPLCONFIGDIR` is not defined, :file:`{HOME}/.config/matplotlib`
-        and :file:`{HOME}/.cache/matplotlib` are used on Linux, and
-        :file:`{HOME}/.matplotlib` on other platforms, if they are
-        writable. Otherwise, the Python standard library's `tempfile.gettempdir`
-        is used to find a base directory in which the :file:`matplotlib`
-        subdirectory is created.
+:envvar:`MPLCONFIGDIR`
+    This is the directory used to store user customizations to
+    Matplotlib, as well as some caches to improve performance. If
+    :envvar:`MPLCONFIGDIR` is not defined, :file:`{HOME}/.config/matplotlib`
+    and :file:`{HOME}/.cache/matplotlib` are used on Linux, and
+    :file:`{HOME}/.matplotlib` on other platforms, if they are
+    writable. Otherwise, the Python standard library's `tempfile.gettempdir`
+    is used to find a base directory in which the :file:`matplotlib`
+    subdirectory is created.
 
 Matplotlib was initially written by John D. Hunter (1968-2012) and is now
 developed and maintained by a host of others.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2789,18 +2789,18 @@ class NavigationToolbar2:
 
     They must also define
 
-      :meth:`save_figure`
-         save the current figure
+    :meth:`save_figure`
+        Save the current figure.
 
-      :meth:`draw_rubberband` (optional)
-         draw the zoom to rect "rubberband" rectangle
+    :meth:`draw_rubberband` (optional)
+        Draw the zoom to rect "rubberband" rectangle.
 
-      :meth:`set_message` (optional)
-         display message
+    :meth:`set_message` (optional)
+        Display message.
 
-      :meth:`set_history_buttons` (optional)
-         you can change the history back / forward buttons to
-         indicate disabled / enabled state.
+    :meth:`set_history_buttons` (optional)
+        You can change the history back / forward buttons to indicate disabled / enabled
+        state.
 
     and override ``__init__`` to set up the toolbar -- without forgetting to
     call the base-class init.  Typically, ``__init__`` needs to set up toolbar

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -332,8 +332,9 @@ class RendererAgg(RendererBase):
 
     def stop_filter(self, post_processing):
         """
-        Save the plot in the current canvas as an image and apply
-        the *post_processing* function.
+        Save the current canvas as an image and apply post processing.
+
+        The *post_processing* function::
 
            def post_processing(image, dpi):
              # ny, nx, depth = image.shape

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -924,7 +924,7 @@ class Colorbar:
             This keyword argument is ignored and will be removed.
             Deprecated
 
-         minor : bool
+        minor : bool
             If True, set minor ticks instead of major ticks.
 
         **kwargs

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -277,21 +277,21 @@ loc : str or pair of floats, default: {default}
     be spelled ``'right'``, and each "string" location can also be given as a
     numeric value:
 
-        ==================   =============
-        Location String      Location Code
-        ==================   =============
-        'best' (Axes only)   0
-        'upper right'        1
-        'upper left'         2
-        'lower left'         3
-        'lower right'        4
-        'right'              5
-        'center left'        6
-        'center right'       7
-        'lower center'       8
-        'upper center'       9
-        'center'             10
-        ==================   =============
+    ==================   =============
+    Location String      Location Code
+    ==================   =============
+    'best' (Axes only)   0
+    'upper right'        1
+    'upper left'         2
+    'lower left'         3
+    'lower right'        4
+    'right'              5
+    'center left'        6
+    'center right'       7
+    'lower center'       8
+    'upper center'       9
+    'center'             10
+    ==================   =============
     {outside}"""
 
 _loc_doc_best = """

--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -46,27 +46,27 @@ Options
 
 The ``mathmpl`` role and directive both support the following options:
 
-    fontset : str, default: 'cm'
-        The font set to use when displaying math. See :rc:`mathtext.fontset`.
+fontset : str, default: 'cm'
+    The font set to use when displaying math. See :rc:`mathtext.fontset`.
 
-    fontsize : float
-        The font size, in points. Defaults to the value from the extension
-        configuration option defined below.
+fontsize : float
+    The font size, in points. Defaults to the value from the extension
+    configuration option defined below.
 
 Configuration options
 ---------------------
 
 The mathtext extension has the following configuration options:
 
-    mathmpl_fontsize : float, default: 10.0
-        Default font size, in points.
+mathmpl_fontsize : float, default: 10.0
+    Default font size, in points.
 
-    mathmpl_srcset : list of str, default: []
-        Additional image sizes to generate when embedding in HTML, to support
-        `responsive resolution images
-        <https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images>`__.
-        The list should contain additional x-descriptors (``'1.5x'``, ``'2x'``,
-        etc.) to generate (1x is the default and always included.)
+mathmpl_srcset : list of str, default: []
+    Additional image sizes to generate when embedding in HTML, to support
+    `responsive resolution images
+    <https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Responsive_images>`__.
+    The list should contain additional x-descriptors (``'1.5x'``, ``'2x'``,
+    etc.) to generate (1x is the default and always included.)
 
 """
 

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -47,36 +47,36 @@ Options
 
 The ``.. plot::`` directive supports the following options:
 
-    ``:format:`` : {'python', 'doctest'}
-        The format of the input.  If unset, the format is auto-detected.
+``:format:`` : {'python', 'doctest'}
+    The format of the input.  If unset, the format is auto-detected.
 
-    ``:include-source:`` : bool
-        Whether to display the source code. The default can be changed using
-        the ``plot_include_source`` variable in :file:`conf.py` (which itself
-        defaults to False).
+``:include-source:`` : bool
+    Whether to display the source code. The default can be changed using
+    the ``plot_include_source`` variable in :file:`conf.py` (which itself
+    defaults to False).
 
-    ``:show-source-link:`` : bool
-        Whether to show a link to the source in HTML. The default can be
-        changed using the ``plot_html_show_source_link`` variable in
-        :file:`conf.py` (which itself defaults to True).
+``:show-source-link:`` : bool
+    Whether to show a link to the source in HTML. The default can be
+    changed using the ``plot_html_show_source_link`` variable in
+    :file:`conf.py` (which itself defaults to True).
 
-    ``:context:`` : bool or str
-        If provided, the code will be run in the context of all previous plot
-        directives for which the ``:context:`` option was specified.  This only
-        applies to inline code plot directives, not those run from files. If
-        the ``:context: reset`` option is specified, the context is reset
-        for this and future plots, and previous figures are closed prior to
-        running the code. ``:context: close-figs`` keeps the context but closes
-        previous figures before running the code.
+``:context:`` : bool or str
+    If provided, the code will be run in the context of all previous plot
+    directives for which the ``:context:`` option was specified.  This only
+    applies to inline code plot directives, not those run from files. If
+    the ``:context: reset`` option is specified, the context is reset
+    for this and future plots, and previous figures are closed prior to
+    running the code. ``:context: close-figs`` keeps the context but closes
+    previous figures before running the code.
 
-    ``:nofigs:`` : bool
-        If specified, the code block will be run, but no figures will be
-        inserted.  This is usually useful with the ``:context:`` option.
+``:nofigs:`` : bool
+    If specified, the code block will be run, but no figures will be
+    inserted.  This is usually useful with the ``:context:`` option.
 
-    ``:caption:`` : str
-        If specified, the option's argument will be used as a caption for the
-        figure. This overwrites the caption given in the content, when the plot
-        is generated from a file.
+``:caption:`` : str
+    If specified, the option's argument will be used as a caption for the
+    figure. This overwrites the caption given in the content, when the plot
+    is generated from a file.
 
 Additionally, this directive supports all the options of the `image directive
 <https://docutils.sourceforge.io/docs/ref/rst/directives.html#image>`_,
@@ -88,68 +88,68 @@ Configuration options
 
 The plot directive has the following configuration options:
 
-    plot_include_source
-        Default value for the include-source option (default: False).
+plot_include_source
+    Default value for the include-source option (default: False).
 
-    plot_html_show_source_link
-        Whether to show a link to the source in HTML (default: True).
+plot_html_show_source_link
+    Whether to show a link to the source in HTML (default: True).
 
-    plot_pre_code
-        Code that should be executed before each plot. If None (the default),
-        it will default to a string containing::
+plot_pre_code
+    Code that should be executed before each plot. If None (the default),
+    it will default to a string containing::
 
-            import numpy as np
-            from matplotlib import pyplot as plt
+        import numpy as np
+        from matplotlib import pyplot as plt
 
-    plot_basedir
-        Base directory, to which ``plot::`` file names are relative to.
-        If None or empty (the default), file names are relative to the
-        directory where the file containing the directive is.
+plot_basedir
+    Base directory, to which ``plot::`` file names are relative to.
+    If None or empty (the default), file names are relative to the
+    directory where the file containing the directive is.
 
-    plot_formats
-        File formats to generate (default: ['png', 'hires.png', 'pdf']).
-        List of tuples or strings::
+plot_formats
+    File formats to generate (default: ['png', 'hires.png', 'pdf']).
+    List of tuples or strings::
 
-            [(suffix, dpi), suffix, ...]
+        [(suffix, dpi), suffix, ...]
 
-        that determine the file format and the DPI. For entries whose
-        DPI was omitted, sensible defaults are chosen. When passing from
-        the command line through sphinx_build the list should be passed as
-        suffix:dpi,suffix:dpi, ...
+    that determine the file format and the DPI. For entries whose
+    DPI was omitted, sensible defaults are chosen. When passing from
+    the command line through sphinx_build the list should be passed as
+    suffix:dpi,suffix:dpi, ...
 
-    plot_html_show_formats
-        Whether to show links to the files in HTML (default: True).
+plot_html_show_formats
+    Whether to show links to the files in HTML (default: True).
 
-    plot_rcparams
-        A dictionary containing any non-standard rcParams that should
-        be applied before each plot (default: {}).
+plot_rcparams
+    A dictionary containing any non-standard rcParams that should
+    be applied before each plot (default: {}).
 
-    plot_apply_rcparams
-        By default, rcParams are applied when ``:context:`` option is not used
-        in a plot directive.  If set, this configuration option overrides this
-        behavior and applies rcParams before each plot.
+plot_apply_rcparams
+    By default, rcParams are applied when ``:context:`` option is not used
+    in a plot directive.  If set, this configuration option overrides this
+    behavior and applies rcParams before each plot.
 
-    plot_working_directory
-        By default, the working directory will be changed to the directory of
-        the example, so the code can get at its data files, if any.  Also its
-        path will be added to `sys.path` so it can import any helper modules
-        sitting beside it.  This configuration option can be used to specify
-        a central directory (also added to `sys.path`) where data files and
-        helper modules for all code are located.
+plot_working_directory
+    By default, the working directory will be changed to the directory of
+    the example, so the code can get at its data files, if any.  Also its
+    path will be added to `sys.path` so it can import any helper modules
+    sitting beside it.  This configuration option can be used to specify
+    a central directory (also added to `sys.path`) where data files and
+    helper modules for all code are located.
 
-    plot_template
-        Provide a customized template for preparing restructured text.
+plot_template
+    Provide a customized template for preparing restructured text.
 
-    plot_srcset
-        Allow the srcset image option for responsive image resolutions. List of
-        strings with the multiplicative factors followed by an "x".
-        e.g. ["2.0x", "1.5x"].  "2.0x" will create a png with the default "png"
-        resolution from plot_formats, multiplied by 2. If plot_srcset is
-        specified, the plot directive uses the
-        :doc:`/api/sphinxext_figmpl_directive_api` (instead of the usual figure
-        directive) in the intermediary rst file that is generated.
-        The plot_srcset option is incompatible with *singlehtml* builds, and an
-        error will be raised.
+plot_srcset
+    Allow the srcset image option for responsive image resolutions. List of
+    strings with the multiplicative factors followed by an "x".
+    e.g. ["2.0x", "1.5x"].  "2.0x" will create a png with the default "png"
+    resolution from plot_formats, multiplied by 2. If plot_srcset is
+    specified, the plot directive uses the
+    :doc:`/api/sphinxext_figmpl_directive_api` (instead of the usual figure
+    directive) in the intermediary rst file that is generated.
+    The plot_srcset option is incompatible with *singlehtml* builds, and an
+    error will be raised.
 
 Notes on how it works
 ---------------------

--- a/lib/matplotlib/tri/_triinterpolate.py
+++ b/lib/matplotlib/tri/_triinterpolate.py
@@ -355,13 +355,13 @@ class CubicTriInterpolator(TriInterpolator):
     curvature (implementation based on an algorithm from [2]_ - PCG sparse
     solver):
 
-        .. math::
+    .. math::
 
-            E(z) = \frac{1}{2} \int_{\Omega} \left(
-                \left( \frac{\partial^2{z}}{\partial{x}^2} \right)^2 +
-                \left( \frac{\partial^2{z}}{\partial{y}^2} \right)^2 +
-                2\left( \frac{\partial^2{z}}{\partial{y}\partial{x}} \right)^2
-            \right) dx\,dy
+        E(z) = \frac{1}{2} \int_{\Omega} \left(
+            \left( \frac{\partial^2{z}}{\partial{x}^2} \right)^2 +
+            \left( \frac{\partial^2{z}}{\partial{y}^2} \right)^2 +
+            2\left( \frac{\partial^2{z}}{\partial{y}\partial{x}} \right)^2
+        \right) dx\,dy
 
     If the case *kind* ='geom' is chosen by the user, a simple geometric
     approximation is used (weighted average of the triangle normal

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2569,9 +2569,9 @@ class SpanSelector(_SelectorWidget):
 
     props : dict, optional
         Dictionary of `matplotlib.patches.Patch` properties.
-        Default:
+        Default::
 
-            ``dict(facecolor='red', alpha=0.5)``
+            dict(facecolor='red', alpha=0.5)
 
     onmove_callback : func(min, max), min/max are floats, default: None
         Called on mouse move while the span is being selected.
@@ -3858,9 +3858,9 @@ class PolygonSelector(_SelectorWidget):
     props : dict, optional
         Properties with which the line is drawn, see `matplotlib.lines.Line2D`
         for valid properties.
-        Default:
+        Default::
 
-            ``dict(color='k', linestyle='-', linewidth=2, alpha=0.5)``
+            dict(color='k', linestyle='-', linewidth=2, alpha=0.5)
 
     handle_props : dict, optional
         Artist properties for the markers drawn at the vertices of the polygon.

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -552,9 +552,9 @@ const char *PyFT2Font_get_kerning__doc__ =
     "--\n\n"
     "Get the kerning between *left* and *right* glyph indices.\n"
     "*mode* is a kerning mode constant:\n\n"
-    "    - KERNING_DEFAULT  - Return scaled and grid-fitted kerning distances\n"
-    "    - KERNING_UNFITTED - Return scaled but un-grid-fitted kerning distances\n"
-    "    - KERNING_UNSCALED - Return the kerning vector in original font units\n";
+    "- KERNING_DEFAULT  - Return scaled and grid-fitted kerning distances\n"
+    "- KERNING_UNFITTED - Return scaled but un-grid-fitted kerning distances\n"
+    "- KERNING_UNSCALED - Return the kerning vector in original font units\n";
 
 static PyObject *PyFT2Font_get_kerning(PyFT2Font *self, PyObject *args)
 {


### PR DESCRIPTION
## PR summary

In a couple cases, these are probably supposed to be code blocks, so swap `:` to `::` (or add the latter.)

Otherwise, for simplicity, I only dedented everything as necessary (i.e., no re-wrapping,) in order to produce a simpler diff. Thus is should be possible to view the diff with whitespace ignored and see very few changes.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines