### PR TITLE
ENH: Update numpy exceptions imports

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -21,7 +21,13 @@ import traceback
 import types
 import weakref
 
+from packaging.version import parse as parse_version
 import numpy as np
+
+if parse_version(np.__version__) >= parse_version("1.25.0"):
+    from numpy.exceptions import VisibleDeprecationWarning
+else:
+    from numpy import VisibleDeprecationWarning
 
 import matplotlib
 from matplotlib import _api, _c_internal_utils
@@ -1064,7 +1070,7 @@ def _combine_masks(*args):
                 raise ValueError("Masked arrays must be 1-D")
             try:
                 x = np.asanyarray(x)
-            except (np.VisibleDeprecationWarning, ValueError):
+            except (VisibleDeprecationWarning, ValueError):
                 # NumPy 1.19 raises a warning about ragged arrays, but we want
                 # to accept basically anything here.
                 x = np.asanyarray(x, dtype=object)
@@ -1658,7 +1664,7 @@ def index_of(y):
         pass
     try:
         y = _check_1d(y)
-    except (np.VisibleDeprecationWarning, ValueError):
+    except (VisibleDeprecationWarning, ValueError):
         # NumPy 1.19 will warn on ragged input, and we can't actually use it.
         pass
     else:

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -21,12 +21,11 @@ import traceback
 import types
 import weakref
 
-from packaging.version import parse as parse_version
 import numpy as np
 
-if parse_version(np.__version__) >= parse_version("1.25.0"):
-    from numpy.exceptions import VisibleDeprecationWarning
-else:
+try:
+    from numpy.exceptions import VisibleDeprecationWarning  # numpy >= 1.25
+except ImportError:
     from numpy import VisibleDeprecationWarning
 
 import matplotlib


### PR DESCRIPTION
## PR summary

Due to NumPy's main namespace being changed in https://github.com/numpy/numpy/pull/24316, here I update warning imports.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
