### PR TITLE
MNT: Adjust for upcoming numpy repr changes

### DIFF
--- a/lib/matplotlib/_type1font.py
+++ b/lib/matplotlib/_type1font.py
@@ -396,8 +396,7 @@ class Type1Font:
             elif type == 3:     # end of file
                 break
             else:
-                raise RuntimeError('Unknown segment type %d in pfb file' %
-                                   type)
+                raise RuntimeError('Unknown segment type %d in pfb file' % type)
 
         return data
 
@@ -725,7 +724,7 @@ class Type1Font:
 
         if 'slant' in effects:
             slant = effects['slant']
-            fontname += '_Slant_%d' % int(1000 * slant)
+            fontname += f'_Slant_{int(1000 * slant)}'
             italicangle = round(
                 float(italicangle) - np.arctan(slant) / np.pi * 180,
                 5
@@ -734,21 +733,21 @@ class Type1Font:
 
         if 'extend' in effects:
             extend = effects['extend']
-            fontname += '_Extend_%d' % int(1000 * extend)
+            fontname += f'_Extend_{int(1000 * extend)}'
             modifier[0, 0] = extend
 
         newmatrix = np.dot(modifier, oldmatrix)
         array[::2] = newmatrix[0:3, 0]
         array[1::2] = newmatrix[0:3, 1]
         fontmatrix = (
-            '[%s]' % ' '.join(_format_approx(x, 6) for x in array)
+            f"[{' '.join(_format_approx(x, 6) for x in array)}]"
         )
         replacements = (
-            [(x, '/FontName/%s def' % fontname)
+            [(x, f'/FontName/{fontname} def')
              for x in self._pos['FontName']]
-            + [(x, '/ItalicAngle %a def' % italicangle)
+            + [(x, f'/ItalicAngle {italicangle} def')
                for x in self._pos['ItalicAngle']]
-            + [(x, '/FontMatrix %s readonly def' % fontmatrix)
+            + [(x, f'/FontMatrix {fontmatrix} readonly def')
                for x in self._pos['FontMatrix']]
             + [(x, '') for x in self._pos.get('UniqueID', [])]
         )

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -990,12 +990,14 @@ class PdfPages:
                 # luatex<0.85; they were renamed to \pagewidth and \pageheight
                 # on luatex>=0.85.
                 self._file.write(
-                    br'\newpage'
-                    br'\ifdefined\pdfpagewidth\pdfpagewidth'
-                    br'\else\pagewidth\fi=%ain'
-                    br'\ifdefined\pdfpageheight\pdfpageheight'
-                    br'\else\pageheight\fi=%ain'
-                    b'%%\n' % (width, height)
+                    (
+                        r'\newpage'
+                        r'\ifdefined\pdfpagewidth\pdfpagewidth'
+                        fr'\else\pagewidth\fi={width}in'
+                        r'\ifdefined\pdfpageheight\pdfpageheight'
+                        fr'\else\pageheight\fi={height}in'
+                        '%%\n'
+                    ).encode("ascii")
                 )
             figure.savefig(self._file, format="pgf", **kwargs)
             self._n_figures += 1


### PR DESCRIPTION

## PR summary

Converts some `%` format strings into f-strings.

This is needed because of numpy/numpy#22449, which makes numpy scalars have a repr with e.g. `np.float64(3.0)` rather than just `3.0`.
Thus the `!r/!a` was left off in the conversion to f-string as that is the actual required change.

closes #26460 xref #26422

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
