### PR TITLE
Do not close figures on backend switch.

### DIFF
--- a/doc/api/next_api_changes/deprecations/26472-AL.rst
+++ b/doc/api/next_api_changes/deprecations/26472-AL.rst
@@ -1,0 +1,5 @@
+Auto-closing of figures when switching backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.  Explicitly call ``plt.close("all")`` if necessary.  In the
+future, allowable backend switches (i.e. those that do not swap a GUI event
+loop with another one) will not close existing figures.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -45,7 +45,7 @@ import numpy as np
 import matplotlib as mpl
 from matplotlib import (
     _api, backend_tools as tools, cbook, colors, _docstring, text,
-    _tight_bbox, transforms, widgets, get_backend, is_interactive, rcParams)
+    _tight_bbox, transforms, widgets, is_interactive, rcParams)
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.backend_managers import ToolManager
 from matplotlib.cbook import _setattr_cm
@@ -2736,8 +2736,8 @@ class FigureManagerBase:
             # thus warrants a warning.
             return
         raise NonGuiException(
-            f"Matplotlib is currently using {get_backend()}, which is a "
-            f"non-GUI backend, so cannot show the figure.")
+            f"{type(self.canvas).__name__} is non-interactive, and thus cannot be "
+            f"shown")
 
     def destroy(self):
         pass

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -420,11 +420,16 @@ def switch_backend(newbackend: str) -> None:
     # Need to keep a global reference to the backend for compatibility reasons.
     # See https://github.com/matplotlib/matplotlib/issues/6092
     matplotlib.backends.backend = newbackend  # type: ignore[attr-defined]
+
     if not cbook._str_equal(old_backend, newbackend):
+        if get_fignums():
+            _api.warn_deprecated("3.8", message=(
+                "Auto-close()ing of figures upon backend switching is deprecated since "
+                "%(since)s and will be removed %(removal)s.  To suppress this warning, "
+                "explicitly call plt.close('all') first."))
         close("all")
 
-    # make sure the repl display hook is installed in case we become
-    # interactive
+    # Make sure the repl display hook is installed in case we become interactive.
     install_repl_displayhook()
 
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -75,7 +75,9 @@ def mpl_test_settings(request):
         try:
             yield
         finally:
-            matplotlib.use(prev_backend)
+            if backend is not None:
+                plt.close("all")
+                matplotlib.use(prev_backend)
 
 
 @pytest.fixture

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -85,13 +85,13 @@ def test_non_gui_warning(monkeypatch):
     with pytest.warns(UserWarning) as rec:
         plt.show()
         assert len(rec) == 1
-        assert ('Matplotlib is currently using pdf, which is a non-GUI backend'
+        assert ('FigureCanvasPdf is non-interactive, and thus cannot be shown'
                 in str(rec[0].message))
 
     with pytest.warns(UserWarning) as rec:
         plt.gcf().show()
         assert len(rec) == 1
-        assert ('Matplotlib is currently using pdf, which is a non-GUI backend'
+        assert ('FigureCanvasPdf is non-interactive, and thus cannot be shown'
                 in str(rec[0].message))
 
 

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -167,6 +167,7 @@ def _test_interactive_impl():
             fig = plt.figure()
             assert (type(fig.canvas).__module__ ==
                     f"matplotlib.backends.backend_{alt_backend}")
+            plt.close("all")
 
         if importlib.util.find_spec("cairocffi"):
             check_alt_backend(backend[:-3] + "cairo")

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -439,7 +439,8 @@ def test_switch_backend_no_close():
     assert len(plt.get_fignums()) == 2
     plt.switch_backend('agg')
     assert len(plt.get_fignums()) == 2
-    plt.switch_backend('svg')
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.switch_backend('svg')
     assert len(plt.get_fignums()) == 0
 
 


### PR DESCRIPTION
Do not `close("all")` figures on (allowable) backend switches, e.g. between qt5agg and qt5cairo, or qt5agg and notebook.

The NonGuiException message had to change, as the backend returned by get_backend() may no longer match the actual canvas class.

Closes #15913.  (Redo of #15918; see also #14471.)

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
