### PR TITLE
Fix codespaces setup.sh script

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-curl micro.mamba.pm/install.sh | bash
+"${SHELL}" <(curl -Ls micro.mamba.pm/install.sh) < /dev/null
 
 conda init --all
 micromamba shell init -s bash


### PR DESCRIPTION
## PR summary

The setup.sh script has been updated to that the micromamba installation command does not wait for stdin (see https://github.com/mamba-org/micromamba-releases/blob/main/install.sh)

This was working before, so my understanding is that this broke due to the way codespaces is configured upstream.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines