### PR TITLE
[DOC]: Noto Sans for windows docs builds

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.6.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.6.0.rst
@@ -558,8 +558,8 @@ them in order to locate a required glyph.
    fig = plt.figure(figsize=(4.75, 1.85))
 
    text = "There are 几个汉字 in between!"
-   fig.text(0.05, 0.65, text, family=["Noto Sans CJK JP"])
-   fig.text(0.05, 0.45, text, family=["DejaVu Sans", "Noto Sans CJK JP"])
+   fig.text(0.05, 0.65, text, family=["Noto Sans CJK JP", "Noto Sans TC"])
+   fig.text(0.05, 0.45, text, family=["DejaVu Sans", "Noto Sans CJK JP", "Noto Sans TC"])
 
 This currently works with the Agg (and all of the GUI embeddings), svg, pdf,
 ps, and inline backends.

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -185,7 +185,7 @@ SVG, PDF, and PS backends will "fallback" through multiple fonts in a single
    fig, ax = plt.subplots()
    ax.text(
        .5, .5, "There are 几个汉字 in between!",
-       family=['DejaVu Sans', 'Noto Sans CJK JP'],
+       family=['DejaVu Sans', 'Noto Sans CJK JP', 'Noto Sans TC'],
        ha='center'
    )
 


### PR DESCRIPTION
Windows splits Noto Sans into separate files for each character set, which means that these two examples fail to build on windows. This change takes advantage of fallback to make these two examples work on windows without changing existing behavior.  I'm not sure if I should be using the Simplified Chinese or the Traditional Chinese character set - the characters look the same to me using both fonts. 