### PR TITLE
ps: Add option to use figure size as paper size

### DIFF
--- a/doc/api/next_api_changes/behavior/26479-ES.rst
+++ b/doc/api/next_api_changes/behavior/26479-ES.rst
@@ -1,0 +1,6 @@
+PostScript paper type adds option to use figure size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :rc:`ps.papertype` rcParam can now be set to ``'figure'``, which will use
+a paper size that corresponds exactly with the size of the figure that is being
+saved.

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -709,7 +709,7 @@
 #tk.window_focus:   False  # Maintain shell focus for TkAgg
 
 ### ps backend params
-#ps.papersize:      letter  # {letter, legal, ledger, A0-A10, B0-B10}
+#ps.papersize:      letter  # {figure, letter, legal, ledger, A0-A10, B0-B10}
 #ps.useafm:         False   # use AFM fonts, results in small files
 #ps.usedistiller:   False   # {ghostscript, xpdf, None}
                             # Experimental: may produce smaller files.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -441,13 +441,13 @@ def validate_ps_distiller(s):
 def _validate_papersize(s):
     # Re-inline this validator when the 'auto' deprecation expires.
     s = ValidateInStrings("ps.papersize",
-                          ["auto", "letter", "legal", "ledger",
+                          ["figure", "auto", "letter", "legal", "ledger",
                            *[f"{ab}{i}" for ab in "ab" for i in range(11)]],
                           ignorecase=True)(s)
     if s == "auto":
         _api.warn_deprecated("3.8", name="ps.papersize='auto'",
-                             addendum="Pass an explicit paper type, or omit the "
-                             "*ps.papersize* rcParam entirely.")
+                             addendum="Pass an explicit paper type, figure, or omit "
+                             "the *ps.papersize* rcParam entirely.")
     return s
 
 

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -40,6 +40,18 @@ import matplotlib.pyplot as plt
     'eps with usetex'
 ])
 def test_savefig_to_stringio(format, use_log, rcParams, orientation, papersize):
+    if rcParams.get("ps.usedistiller") == "ghostscript":
+        try:
+            mpl._get_executable_info("gs")
+        except mpl.ExecutableNotFoundError as exc:
+            pytest.skip(str(exc))
+    elif rcParams.get("ps.userdistiller") == "xpdf":
+        try:
+            mpl._get_executable_info("gs")  # Effectively checks for ps2pdf.
+            mpl._get_executable_info("pdftops")
+        except mpl.ExecutableNotFoundError as exc:
+            pytest.skip(str(exc))
+
     mpl.rcParams.update(rcParams)
 
     fig, ax = plt.subplots()
@@ -55,8 +67,6 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation, papersize):
             title += " \N{MINUS SIGN}\N{EURO SIGN}"
         ax.set_title(title)
         allowable_exceptions = []
-        if rcParams.get("ps.usedistiller"):
-            allowable_exceptions.append(mpl.ExecutableNotFoundError)
         if rcParams.get("text.usetex"):
             allowable_exceptions.append(RuntimeError)
         if rcParams.get("ps.useafm"):

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -20,6 +20,7 @@ import matplotlib.pyplot as plt
 
 # This tests tends to hit a TeX cache lock on AppVeyor.
 @pytest.mark.flaky(reruns=3)
+@pytest.mark.parametrize('papersize', ['letter', 'figure'])
 @pytest.mark.parametrize('orientation', ['portrait', 'landscape'])
 @pytest.mark.parametrize('format, use_log, rcParams', [
     ('ps', False, {}),
@@ -38,7 +39,7 @@ import matplotlib.pyplot as plt
     'eps afm',
     'eps with usetex'
 ])
-def test_savefig_to_stringio(format, use_log, rcParams, orientation):
+def test_savefig_to_stringio(format, use_log, rcParams, orientation, papersize):
     mpl.rcParams.update(rcParams)
 
     fig, ax = plt.subplots()
@@ -61,8 +62,10 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation):
         if rcParams.get("ps.useafm"):
             allowable_exceptions.append(mpl.MatplotlibDeprecationWarning)
         try:
-            fig.savefig(s_buf, format=format, orientation=orientation)
-            fig.savefig(b_buf, format=format, orientation=orientation)
+            fig.savefig(s_buf, format=format, orientation=orientation,
+                        papertype=papersize)
+            fig.savefig(b_buf, format=format, orientation=orientation,
+                        papertype=papersize)
         except tuple(allowable_exceptions) as exc:
             pytest.skip(str(exc))
 
@@ -70,6 +73,27 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation):
         assert not b_buf.closed
         s_val = s_buf.getvalue().encode('ascii')
         b_val = b_buf.getvalue()
+
+        if format == 'ps':
+            # Default figsize = (8, 6) inches = (576, 432) points = (203.2, 152.4) mm.
+            # Landscape orientation will swap dimensions.
+            if rcParams.get("ps.usedistiller") == "xpdf":
+                # Some versions specifically show letter/203x152, but not all,
+                # so we can only use this simpler test.
+                if papersize == 'figure':
+                    assert b'letter' not in s_val.lower()
+                else:
+                    assert b'letter' in s_val.lower()
+            elif rcParams.get("ps.usedistiller") or rcParams.get("text.usetex"):
+                width = b'432.0' if orientation == 'landscape' else b'576.0'
+                wanted = (b'-dDEVICEWIDTHPOINTS=' + width if papersize == 'figure'
+                          else b'-sPAPERSIZE')
+                assert wanted in s_val
+            else:
+                if papersize == 'figure':
+                    assert b'%%DocumentPaperSizes' not in s_val
+                else:
+                    assert b'%%DocumentPaperSizes' in s_val
 
         # Strip out CreationDate: ghostscript and cairo don't obey
         # SOURCE_DATE_EPOCH, and that environment variable is already tested in


### PR DESCRIPTION
## PR summary

We already set the bounding box to coincide with the figure size, but setting an overall paper size can sometimes cause the resulting file to be cropped by the viewer.

We additionally need to pass this through to the distiller.

Fixes #16657

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines