### PR TITLE
Clarify behavior of norm clipping

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1228,13 +1228,18 @@ class Normalize:
             processed; i.e., ``__call__(A)`` calls ``autoscale_None(A)``.
 
         clip : bool, default: False
-            If ``True`` values falling outside the range ``[vmin, vmax]``,
-            are mapped to 0 or 1, whichever is closer, and masked values are
-            set to 1.  If ``False`` masked values remain masked.
+            Determines the behavior for mapping values outside the range
+            ``[vmin, vmax]``.
 
-            Clipping silently defeats the purpose of setting the over and
-            under colors in a colormap, so it is likely to lead to
-            surprises; therefore the default is ``clip=False``.
+            If clipping is off, values outside the range ``[vmin, vmax]`` are also
+            transformed linearly, resulting in values outside ``[0, 1]``. For a
+            standard use with colormaps, this behavior is desired because colormaps
+            mark these outside values with specific colors for *over* or *under*.
+
+            If ``True`` values falling outside the range ``[vmin, vmax]``,
+            are mapped to 0 or 1, whichever is closer. This makes these values
+            indistinguishable from regular boundary values and can lead to
+            misinterpretation of the data.
 
         Notes
         -----
@@ -1330,6 +1335,8 @@ class Normalize:
         value
             Data to normalize.
         clip : bool, optional
+            See the description of the parameter *clip* in `.Normalize`.
+
             If ``None``, defaults to ``self.clip`` (which defaults to
             ``False``).
 
@@ -1524,9 +1531,18 @@ class CenteredNorm(Normalize):
             Defaults to the largest absolute difference to *vcenter* for
             the values in the dataset.
         clip : bool, default: False
+            Determines the behavior for mapping values outside the range
+            ``[vmin, vmax]``.
+
+            If clipping is off, values outside the range ``[vmin, vmax]`` are also
+            transformed, resulting in values outside ``[0, 1]``. For a
+            standard use with colormaps, this behavior is desired because colormaps
+            mark these outside values with specific colors for *over* or *under*.
+
             If ``True`` values falling outside the range ``[vmin, vmax]``,
-            are mapped to 0 or 1, whichever is closer, and masked values are
-            set to 1.  If ``False`` masked values remain masked.
+            are mapped to 0 or 1, whichever is closer. This makes these values
+            indistinguishable from regular boundary values and can lead to
+            misinterpretation of the data.
 
         Examples
         --------
@@ -1799,13 +1815,18 @@ class FuncNorm(Normalize):
         processed; i.e., ``__call__(A)`` calls ``autoscale_None(A)``.
 
     clip : bool, default: False
-        If ``True`` values falling outside the range ``[vmin, vmax]``,
-        are mapped to 0 or 1, whichever is closer, and masked values are
-        set to 1.  If ``False`` masked values remain masked.
+        Determines the behavior for mapping values outside the range
+        ``[vmin, vmax]``.
 
-        Clipping silently defeats the purpose of setting the over and
-        under colors in a colormap, so it is likely to lead to
-        surprises; therefore the default is ``clip=False``.
+        If clipping is off, values outside the range ``[vmin, vmax]`` are also
+        transformed by the function, resulting in values outside ``[0, 1]``. For a
+        standard use with colormaps, this behavior is desired because colormaps
+        mark these outside values with specific colors for *over* or *under*.
+
+        If ``True`` values falling outside the range ``[vmin, vmax]``,
+        are mapped to 0 or 1, whichever is closer. This makes these values
+        indistinguishable from regular boundary values and can lead to
+        misinterpretation of the data.
     """
 
 
@@ -1899,13 +1920,18 @@ class PowerNorm(Normalize):
         minimum and maximum value, respectively, of the first input
         processed; i.e., ``__call__(A)`` calls ``autoscale_None(A)``.
     clip : bool, default: False
-        If ``True`` values falling outside the range ``[vmin, vmax]``,
-        are mapped to 0 or 1, whichever is closer, and masked values
-        remain masked.
+        Determines the behavior for mapping values outside the range
+        ``[vmin, vmax]``.
 
-        Clipping silently defeats the purpose of setting the over and under
-        colors, so it is likely to lead to surprises; therefore the default
-        is ``clip=False``.
+        If clipping is off, values outside the range ``[vmin, vmax]`` are also
+        transformed by the power function, resulting in values outside ``[0, 1]``. For
+        a standard use with colormaps, this behavior is desired because colormaps
+        mark these outside values with specific colors for *over* or *under*.
+
+        If ``True`` values falling outside the range ``[vmin, vmax]``,
+        are mapped to 0 or 1, whichever is closer. This makes these values
+        indistinguishable from regular boundary values and can lead to
+        misinterpretation of the data.
 
     Notes
     -----


### PR DESCRIPTION
## PR summary

Followup to https://github.com/matplotlib/matplotlib/pull/26449#discussion_r1284177392

Closes #26446 

**Major correction: Clipping does not affect masked values**

This can be seen in the following code, where the mask is reapplied

https://github.com/matplotlib/matplotlib/blob/f800bf61cd863a3d8b4d60268b924a4300ee1815/lib/matplotlib/colors.py#L1936-L1939

This code has been unmodified since 2016 and has been the same even before. I therefore believe it's better to just adapt the documentation to the existing behavior.

**Other changes**

Better explanation of the returned values for "outside" inputs and their interplay with colormaps.
