### PR TITLE
Improve legend(loc='best') warning and test

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1174,7 +1174,6 @@ class Legend(Artist):
                                            self.get_bbox_to_anchor(),
                                            renderer)
             legendBox = Bbox.from_bounds(l, b, width, height)
-            badness = 0
             # XXX TODO: If markers are present, it would be good to take them
             # into account when checking vertex overlaps in the next line.
             badness = (sum(legendBox.count_contains(line.vertices)
@@ -1183,10 +1182,10 @@ class Legend(Artist):
                        + legendBox.count_overlaps(bboxes)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))
-            if badness == 0:
-                return l, b
             # Include the index to favor lower codes in case of a tie.
             candidates.append((badness, idx, (l, b)))
+            if badness == 0:
+                break
 
         _, _, (l, b) = min(candidates)
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1158,13 +1158,8 @@ class Legend(Artist):
             loc, bbox, parentbbox,
             self.borderaxespad * renderer.points_to_pixels(self._fontsize))
 
-    def _find_best_position(self, width, height, renderer, consider=None):
-        """
-        Determine the best location to place the legend.
-
-        *consider* is a list of ``(x, y)`` pairs to consider as a potential
-        lower-left corner of the legend. All are display coords.
-        """
+    def _find_best_position(self, width, height, renderer):
+        """Determine the best location to place the legend."""
         assert self.isaxes  # always holds, as this is only called internally
 
         start_time = time.perf_counter()
@@ -1172,14 +1167,12 @@ class Legend(Artist):
         bboxes, lines, offsets = self._auto_legend_data()
 
         bbox = Bbox.from_bounds(0, 0, width, height)
-        if consider is None:
-            consider = [self._get_anchored_bbox(x, bbox,
-                                                self.get_bbox_to_anchor(),
-                                                renderer)
-                        for x in range(1, len(self.codes))]
 
         candidates = []
-        for idx, (l, b) in enumerate(consider):
+        for idx in range(1, len(self.codes)):
+            l, b = self._get_anchored_bbox(idx, bbox,
+                                           self.get_bbox_to_anchor(),
+                                           renderer)
             legendBox = Bbox.from_bounds(l, b, width, height)
             badness = 0
             # XXX TODO: If markers are present, it would be good to take them

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1,5 +1,7 @@
 import collections
+import itertools
 import platform
+import time
 from unittest import mock
 import warnings
 
@@ -1109,29 +1111,43 @@ def test_usetex_no_warn(caplog):
     assert "Font family ['serif'] not found." not in caplog.text
 
 
-def test_warn_big_data_best_loc():
+def test_warn_big_data_best_loc(monkeypatch):
+    # Force _find_best_position to think it took a long time.
+    counter = itertools.count(0, step=1.5)
+    monkeypatch.setattr(time, 'perf_counter', lambda: next(counter))
+
     fig, ax = plt.subplots()
     fig.canvas.draw()  # So that we can call draw_artist later.
-    for idx in range(1000):
-        ax.plot(np.arange(5000), label=idx)
+
+    # Place line across all possible legend locations.
+    x = [0.9, 0.1, 0.1, 0.9, 0.9, 0.5]
+    y = [0.95, 0.95, 0.05, 0.05, 0.5, 0.5]
+    ax.plot(x, y, 'o-', label='line')
+
     with rc_context({'legend.loc': 'best'}):
         legend = ax.legend()
-    with pytest.warns(UserWarning) as records:
+    with pytest.warns(UserWarning,
+                      match='Creating legend with loc="best" can be slow with large '
+                      'amounts of data.') as records:
         fig.draw_artist(legend)  # Don't bother drawing the lines -- it's slow.
     # The _find_best_position method of Legend is called twice, duplicating
     # the warning message.
     assert len(records) == 2
-    for record in records:
-        assert str(record.message) == (
-            'Creating legend with loc="best" can be slow with large '
-            'amounts of data.')
 
 
-def test_no_warn_big_data_when_loc_specified():
+def test_no_warn_big_data_when_loc_specified(monkeypatch):
+    # Force _find_best_position to think it took a long time.
+    counter = itertools.count(0, step=1.5)
+    monkeypatch.setattr(time, 'perf_counter', lambda: next(counter))
+
     fig, ax = plt.subplots()
     fig.canvas.draw()
-    for idx in range(1000):
-        ax.plot(np.arange(5000), label=idx)
+
+    # Place line across all possible legend locations.
+    x = [0.9, 0.1, 0.1, 0.9, 0.9, 0.5]
+    y = [0.95, 0.95, 0.05, 0.05, 0.5, 0.5]
+    ax.plot(x, y, 'o-', label='line')
+
     legend = ax.legend('best')
     fig.draw_artist(legend)  # Check that no warning is emitted.
 


### PR DESCRIPTION
## PR summary

The `consider` argument from `Legend._find_best_position`  can be removed, as no-one ever uses it and this is a private method.

Because of an early `return`, the warning that `loc='best'` is slow can sometimes not be triggered, so ensure that is the case.

Finally, improve the test for this warning. By patching the timer instead of using actually large data, we can both:
1. speed up these tests (~7.5s vs <0.2s for both), and
2. consistently trigger the warning even on systems which are fast (such as the M1 systems on Cirrus #24597.)

Also, copy the test data from `test_legend_auto3`, which correctly hits all candidate locations for the 'best' legend locator without having to fill up the entire Axes with data.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines