### PR TITLE
Import PIL.Image explicitly over PIL

### DIFF
--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -30,7 +30,7 @@ import matplotlib.stackplot as mstack
 import matplotlib.streamplot as mstream
 
 import datetime
-import PIL
+import PIL.Image
 from collections.abc import Callable, Sequence
 from typing import Any, Literal, overload
 import numpy as np

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -15,7 +15,7 @@ import sys
 import weakref
 
 import numpy as np
-import PIL
+import PIL.Image
 
 import matplotlib as mpl
 from matplotlib.backend_bases import (

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -10,6 +10,7 @@ from pathlib import Path
 import warnings
 
 import numpy as np
+import PIL.Image
 import PIL.PngImagePlugin
 
 import matplotlib as mpl

--- a/lib/matplotlib/image.pyi
+++ b/lib/matplotlib/image.pyi
@@ -5,7 +5,7 @@ from typing import Any, BinaryIO, Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-import PIL  # type: ignore
+import PIL.Image
 
 import matplotlib.artist as martist
 from matplotlib.axes import Axes

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -88,7 +88,7 @@ if TYPE_CHECKING:
     from typing import Any, BinaryIO, Literal, TypeVar
     from typing_extensions import ParamSpec
 
-    import PIL
+    import PIL.Image
     from numpy.typing import ArrayLike
 
     from matplotlib.axis import Tick

--- a/lib/matplotlib/widgets.pyi
+++ b/lib/matplotlib/widgets.pyi
@@ -7,7 +7,7 @@ from .lines import Line2D
 from .patches import Circle, Polygon, Rectangle
 from .text import Text
 
-import PIL
+import PIL.Image
 
 from collections.abc import Callable, Collection, Iterable, Sequence
 from typing import Any, Literal


### PR DESCRIPTION
## PR summary

We seem to use `PIL.Image.*` pretty often while only importing `PIL`. This mostly works, but seems to be by fluke depending on what may or may not have imported `PIL.Image` beforehand.

For example, if you have a file that just does `import matplotlib.widgets` (which itself imports only `PIL`), then `mypy` will crash due to incomplete `PIL`.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines