### PR TITLE
TYP: Add common-type overloads of subplot_mosaic

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -152,6 +152,9 @@
     "HashableList": [
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.subplot_mosaic:1"
     ],
+    "HashableList[_HT]": [
+      "doc/docstring of builtins.list:17"
+    ],
     "LineStyleType": [
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.eventplot:1",
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.hlines:1",
@@ -700,6 +703,9 @@
     ],
     "matplotlib.animation.TimedAnimation.to_jshtml": [
       "doc/api/_as_gen/matplotlib.animation.TimedAnimation.rst:28:<autosummary>:1"
+    ],
+    "matplotlib.typing._HT": [
+      "doc/docstring of builtins.list:17"
     ],
     "mpl_toolkits.axislines.Axes": [
       "lib/mpl_toolkits/axisartist/axis_artist.py:docstring of mpl_toolkits.axisartist.axis_artist:7"

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1749,15 +1749,11 @@ default: %(va)s
             if isinstance(k, tuple):
                 for sub_key in k:
                     if sub_key in expanded:
-                        raise ValueError(
-                            f'The key {sub_key!r} appears multiple times.'
-                            )
+                        raise ValueError(f'The key {sub_key!r} appears multiple times.')
                     expanded[sub_key] = v
             else:
                 if k in expanded:
-                    raise ValueError(
-                        f'The key {k!r} appears multiple times.'
-                    )
+                    raise ValueError(f'The key {k!r} appears multiple times.')
                 expanded[k] = v
         return expanded
 

--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -1,4 +1,9 @@
+from collections.abc import Callable, Hashable, Iterable
 import os
+from typing import Any, IO, Literal, TypeVar, overload
+
+import numpy as np
+from numpy.typing import ArrayLike
 
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes, SubplotBase
@@ -19,13 +24,9 @@ from matplotlib.lines import Line2D
 from matplotlib.patches import Rectangle, Patch
 from matplotlib.text import Text
 from matplotlib.transforms import Affine2D, Bbox, BboxBase, Transform
-
-import numpy as np
-from numpy.typing import ArrayLike
-
-from collections.abc import Callable, Iterable
-from typing import Any, IO, Literal, overload
 from .typing import ColorType, HashableList
+
+_T = TypeVar("_T")
 
 class FigureBase(Artist):
     artists: list[Artist]
@@ -200,11 +201,38 @@ class FigureBase(Artist):
         *,
         bbox_extra_artists: Iterable[Artist] | None = ...,
     ) -> Bbox: ...
-
-    # Any in list of list is recursive list[list[Hashable | list[Hashable | ...]]] but that can't really be type checked
+    @overload
     def subplot_mosaic(
         self,
-        mosaic: str | HashableList,
+        mosaic: str,
+        *,
+        sharex: bool = ...,
+        sharey: bool = ...,
+        width_ratios: ArrayLike | None = ...,
+        height_ratios: ArrayLike | None = ...,
+        empty_sentinel: str = ...,
+        subplot_kw: dict[str, Any] | None = ...,
+        per_subplot_kw: dict[str | tuple[str, ...], dict[str, Any]] | None = ...,
+        gridspec_kw: dict[str, Any] | None = ...,
+    ) -> dict[str, Axes]: ...
+    @overload
+    def subplot_mosaic(
+        self,
+        mosaic: list[HashableList[_T]],
+        *,
+        sharex: bool = ...,
+        sharey: bool = ...,
+        width_ratios: ArrayLike | None = ...,
+        height_ratios: ArrayLike | None = ...,
+        empty_sentinel: _T = ...,
+        subplot_kw: dict[str, Any] | None = ...,
+        per_subplot_kw: dict[_T | tuple[_T, ...], dict[str, Any]] | None = ...,
+        gridspec_kw: dict[str, Any] | None = ...,
+    ) -> dict[_T, Axes]: ...
+    @overload
+    def subplot_mosaic(
+        self,
+        mosaic: list[HashableList[Hashable]],
         *,
         sharex: bool = ...,
         sharey: bool = ...,
@@ -212,9 +240,9 @@ class FigureBase(Artist):
         height_ratios: ArrayLike | None = ...,
         empty_sentinel: Any = ...,
         subplot_kw: dict[str, Any] | None = ...,
-        per_subplot_kw: dict[Any, dict[str, Any]] | None = ...,
-        gridspec_kw: dict[str, Any] | None = ...
-    ) -> dict[Any, Axes]: ...
+        per_subplot_kw: dict[Hashable | tuple[Hashable, ...], dict[str, Any]] | None = ...,
+        gridspec_kw: dict[str, Any] | None = ...,
+    ) -> dict[Hashable, Axes]: ...
 
 class SubFigure(FigureBase):
     figure: Figure

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -125,6 +125,7 @@ if TYPE_CHECKING:
 
     _P = ParamSpec('_P')
     _R = TypeVar('_R')
+    _T = TypeVar('_T')
 
 
 # We may not need the following imports here:
@@ -1602,8 +1603,56 @@ def subplots(
     return fig, axs
 
 
+@overload
 def subplot_mosaic(
-    mosaic: str | HashableList,
+    mosaic: str,
+    *,
+    sharex: bool = ...,
+    sharey: bool = ...,
+    width_ratios: ArrayLike | None = ...,
+    height_ratios: ArrayLike | None = ...,
+    empty_sentinel: str = ...,
+    subplot_kw: dict[str, Any] | None = ...,
+    gridspec_kw: dict[str, Any] | None = ...,
+    per_subplot_kw: dict[str | tuple[str, ...], dict[str, Any]] | None = ...,
+    **fig_kw: Any
+) -> tuple[Figure, dict[str, matplotlib.axes.Axes]]: ...
+
+
+@overload
+def subplot_mosaic(
+    mosaic: list[HashableList[_T]],
+    *,
+    sharex: bool = ...,
+    sharey: bool = ...,
+    width_ratios: ArrayLike | None = ...,
+    height_ratios: ArrayLike | None = ...,
+    empty_sentinel: _T = ...,
+    subplot_kw: dict[str, Any] | None = ...,
+    gridspec_kw: dict[str, Any] | None = ...,
+    per_subplot_kw: dict[_T | tuple[_T, ...], dict[str, Any]] | None = ...,
+    **fig_kw: Any
+) -> tuple[Figure, dict[_T, matplotlib.axes.Axes]]: ...
+
+
+@overload
+def subplot_mosaic(
+    mosaic: list[HashableList[Hashable]],
+    *,
+    sharex: bool = ...,
+    sharey: bool = ...,
+    width_ratios: ArrayLike | None = ...,
+    height_ratios: ArrayLike | None = ...,
+    empty_sentinel: Any = ...,
+    subplot_kw: dict[str, Any] | None = ...,
+    gridspec_kw: dict[str, Any] | None = ...,
+    per_subplot_kw: dict[Hashable | tuple[Hashable, ...], dict[str, Any]] | None = ...,
+    **fig_kw: Any
+) -> tuple[Figure, dict[Hashable, matplotlib.axes.Axes]]: ...
+
+
+def subplot_mosaic(
+    mosaic: str | list[HashableList[_T]] | list[HashableList[Hashable]],
     *,
     sharex: bool = False,
     sharey: bool = False,
@@ -1612,9 +1661,13 @@ def subplot_mosaic(
     empty_sentinel: Any = '.',
     subplot_kw: dict[str, Any] | None = None,
     gridspec_kw: dict[str, Any] | None = None,
-    per_subplot_kw: dict[Hashable, dict[str, Any]] | None = None,
-    **fig_kw
-) -> tuple[Figure, dict[Hashable, matplotlib.axes.Axes]]:
+    per_subplot_kw: dict[str | tuple[str, ...], dict[str, Any]] |
+                    dict[_T | tuple[_T, ...], dict[str, Any]] |
+                    dict[Hashable | tuple[Hashable, ...], dict[str, Any]] | None = None,
+    **fig_kw: Any
+) -> tuple[Figure, dict[str, matplotlib.axes.Axes]] | \
+     tuple[Figure, dict[_T, matplotlib.axes.Axes]] | \
+     tuple[Figure, dict[Hashable, matplotlib.axes.Axes]]:
     """
     Build a layout of Axes based on ASCII art or nested lists.
 
@@ -1716,12 +1769,13 @@ def subplot_mosaic(
 
     """
     fig = figure(**fig_kw)
-    ax_dict = fig.subplot_mosaic(
-        mosaic, sharex=sharex, sharey=sharey,
+    ax_dict = fig.subplot_mosaic(  # type: ignore[misc]
+        mosaic,  # type: ignore[arg-type]
+        sharex=sharex, sharey=sharey,
         height_ratios=height_ratios, width_ratios=width_ratios,
         subplot_kw=subplot_kw, gridspec_kw=gridspec_kw,
         empty_sentinel=empty_sentinel,
-        per_subplot_kw=per_subplot_kw,
+        per_subplot_kw=per_subplot_kw,  # type: ignore[arg-type]
     )
     return fig, ax_dict
 

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -11,7 +11,7 @@ downstream libraries.
 """
 from collections.abc import Hashable, Sequence
 import pathlib
-from typing import Any, Literal, Union
+from typing import Any, Literal, TypeVar, Union
 
 from . import path
 from ._enums import JoinStyle, CapStyle
@@ -55,5 +55,6 @@ RcStyleType = Union[
     Sequence[Union[str, pathlib.Path, dict[str, Any]]],
 ]
 
-HashableList = list[Union[Hashable, "HashableList"]]
+_HT = TypeVar("_HT", bound=Hashable)
+HashableList = list[Union[_HT, "HashableList[_HT]"]]
 """A nested list of Hashable values."""


### PR DESCRIPTION
## PR summary

I'll assert, without proof, that passing a single string, a mosaic list of strings, or a mosaic list all of the same type is more common than passing arbitrary unrelated hashables. Thus it is somewhat convenient if the return type stipulates that the resulting dictionary is also keyed with strings or the common type.

This also fixes the type of the `per_subplot_kw` argument, which also allows dictionary keys of tuples of the entries.

I don't like that we need a few ignores, but this does work from an external point of view:
```
from typing import TYPE_CHECKING

import matplotlib.pyplot as plt

if not TYPE_CHECKING:
    reveal_type = print

fig0, ax0 = plt.subplot_mosaic('ab;cd')
reveal_type(ax0)  # Should be str keys

fig1, ax1 = plt.subplot_mosaic([['a', 'b'], ['c', 'd']])
reveal_type(ax1)  # Should be str keys

fig2, ax2 = plt.subplot_mosaic([[0, 1], [2, 3]])
reveal_type(ax2)  # Should be int keys

fig3, ax3 = plt.subplot_mosaic([['a', 'b'], ['c', 'd'], [0, 1]])
reveal_type(ax3)  # Should be any Hashable keys

fig = plt.figure()

ax4 = fig.subplot_mosaic('ab;cd')
reveal_type(ax4)  # Should be str keys

ax5 = fig.subplot_mosaic([['a', 'b'], ['c', 'd']])
reveal_type(ax5)  # Should be str keys

ax6 = fig.subplot_mosaic([[0, 1], [2, 3]])
reveal_type(ax6)  # Should be int keys

ax7 = fig.subplot_mosaic([['a', 'b'], ['c', 'd'], [0, 1]])
reveal_type(ax7)  # Should be any Hashable keys
```
produces:
```
foo.py:9: note: Revealed type is "builtins.dict[builtins.str, matplotlib.axes._axes.Axes]"
foo.py:12: note: Revealed type is "builtins.dict[builtins.str, matplotlib.axes._axes.Axes]"
foo.py:15: note: Revealed type is "builtins.dict[builtins.int, matplotlib.axes._axes.Axes]"
foo.py:18: note: Revealed type is "builtins.dict[typing.Hashable, matplotlib.axes._axes.Axes]"
foo.py:23: note: Revealed type is "builtins.dict[builtins.str, matplotlib.axes._axes.Axes]"
foo.py:26: note: Revealed type is "builtins.dict[builtins.str, matplotlib.axes._axes.Axes]"
foo.py:29: note: Revealed type is "builtins.dict[builtins.int, matplotlib.axes._axes.Axes]"
foo.py:32: note: Revealed type is "builtins.dict[typing.Hashable, matplotlib.axes._axes.Axes]"
Success: no issues found in 1 source file
```
i.e., for any common-types inputs, the dictionary uses that type as key, whereas mixed types is a generic `Hashable`.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines