### PR TITLE
Disable ``add_html_cache_busting`` on Sphinx 7.1+

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,6 +19,8 @@ import subprocess
 import sys
 from urllib.parse import urlsplit, urlunsplit
 import warnings
+
+import sphinx
 import yaml
 
 import matplotlib
@@ -408,6 +410,9 @@ def add_html_cache_busting(app, pagename, templatename, context, doctree):
     This adds the Matplotlib version as a query to the link reference in the
     HTML, if the path is not absolute (i.e., it comes from the `_static`
     directory) and doesn't already have a query.
+
+    .. note:: Sphinx 7.1 provides asset checksums; so this hook only runs on
+              Sphinx 7.0 and earlier.
     """
     from sphinx.builders.html import Stylesheet, JavaScript
 
@@ -785,4 +790,5 @@ def setup(app):
         bld_type = 'rel'
     app.add_config_value('skip_sub_dirs', 0, '')
     app.add_config_value('releaselevel', bld_type, 'env')
-    app.connect('html-page-context', add_html_cache_busting, priority=1000)
+    if sphinx.version_info[:2] < (7, 1):
+        app.connect('html-page-context', add_html_cache_busting, priority=1000)


### PR DESCRIPTION
## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

Hi,

In https://github.com/sphinx-doc/sphinx/issues/11518, @story645 noted that MPL's documentation failed when running with Sphinx 7.1. This PR disables the custom ``add_html_cache_busting()`` function within ``conf.py`` when running on Sphinx 7.1 and later, in favour of Sphinx's new native asset checksum support.

Thanks,
Adam