### PR TITLE
Tweak shape repr in _api.check_shape error message.

### DIFF
--- a/lib/matplotlib/_api/__init__.py
+++ b/lib/matplotlib/_api/__init__.py
@@ -151,12 +151,10 @@ def check_shape(shape, /, **kwargs):
         if (len(data_shape) != len(shape)
                 or any(s != t and t is not None for s, t in zip(data_shape, shape))):
             dim_labels = iter(itertools.chain(
-                'MNLIJKLH',
+                'NMLKJIH',
                 (f"D{i}" for i in itertools.count())))
-            text_shape = ", ".join(str(n)
-                                   if n is not None
-                                   else next(dim_labels)
-                                   for n in shape)
+            text_shape = ", ".join([str(n) if n is not None else next(dim_labels)
+                                    for n in shape[::-1]][::-1])
             if len(shape) == 1:
                 text_shape += ","
 

--- a/lib/matplotlib/tests/test_api.py
+++ b/lib/matplotlib/tests/test_api.py
@@ -17,17 +17,19 @@ if typing.TYPE_CHECKING:
 T = TypeVar('T')
 
 
-@pytest.mark.parametrize('target,test_shape',
-                         [((None, ), (1, 3)),
-                          ((None, 3), (1,)),
-                          ((None, 3), (1, 2)),
-                          ((1, 5), (1, 9)),
-                          ((None, 2, None), (1, 3, 1))
+@pytest.mark.parametrize('target,shape_repr,test_shape',
+                         [((None, ), "(N,)", (1, 3)),
+                          ((None, 3), "(N, 3)", (1,)),
+                          ((None, 3), "(N, 3)", (1, 2)),
+                          ((1, 5), "(1, 5)", (1, 9)),
+                          ((None, 2, None), "(M, 2, N)", (1, 3, 1))
                           ])
 def test_check_shape(target: tuple[int | None, ...],
+                     shape_repr: str,
                      test_shape: tuple[int, ...]) -> None:
-    error_pattern = (f"^'aardvark' must be {len(target)}D.*" +
-                     re.escape(f'has shape {test_shape}'))
+    error_pattern = "^" + re.escape(
+        f"'aardvark' must be {len(target)}D with shape {shape_repr}, but your input "
+        f"has shape {test_shape}")
     data = np.zeros(test_shape)
     with pytest.raises(ValueError, match=error_pattern):
         _api.check_shape(target, aardvark=data)


### PR DESCRIPTION
Fill in "None" dims *from the end* with the letters N, M, L, K, ... so as to get e.g. "(N, 2)", "(M, 2, N)", "(L, M, N)", etc.

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
