### PR TITLE
Clarify interaction between params of get_path_collection_extents.

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -1063,6 +1063,7 @@ def get_path_collection_extents(
         Global transformation applied to all paths.
     paths : list of `Path`
     transforms : list of `~matplotlib.transforms.Affine2DBase`
+        If non-empty, this overrides *master_transform*.
     offsets : (N, 2) array-like
     offset_transform : `~matplotlib.transforms.Affine2DBase`
         Transform applied to the offsets before offsetting the path.


### PR DESCRIPTION
That master_transform is ignored is clear looking at the implementation in _path.h (the `if (Ntransforms)` branch drops master_transform; compare with the implementation of point_in_path_collection).  One can also compare
```
from matplotlib.path import *; from matplotlib.transforms import *
get_path_collection_extents(
    Affine2D().scale(2, 3), [Path([(1, 2), (3, 4)])],
    [], [(0, 0)], IdentityTransform())
get_path_collection_extents(
    Affine2D().scale(2, 3), [Path([(1, 2), (3, 4)])],
    [IdentityTransform()], [(0, 0)], IdentityTransform())
```
(We can discuss whether the behavior makes sense, especially as point_in_path_collection has the opposite behavior; it may be a bug, I'm just documenting the actual behavior.)

## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
