### PR TITLE
TST: Add failing test

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -763,10 +763,9 @@ class Artist:
             clipping for an artist added to an Axes.
 
         """
-        if clipbox != self.clipbox:
-            self.clipbox = clipbox
-            self.pchanged()
-            self.stale = True
+        self.clipbox = clipbox
+        self.pchanged()
+        self.stale = True
 
     def set_clip_path(self, path, transform=None):
         """

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1076,6 +1076,8 @@ def test_respects_bbox():
     # Make the image invisible in axs[1], but visible in axs[0] if we pan
     # axs[1] up.
     im.set_clip_box(axs[0].bbox)
+    # and ndarray should also be okay
+    im.set_clip_box(np.array(axs[0].bbox))
     buf_before = io.BytesIO()
     fig.savefig(buf_before, format="rgba")
     assert {*buf_before.getvalue()} == {0xff}  # All white.


### PR DESCRIPTION
This is a bug-report-as-PR -- MNE-Python `main` just started failing with:
```
mne/viz/topo.py:496: in _imshow_tfr_unified
    ax.imshow(
...
/opt/hostedtoolcache/Python/3.11.4/x64/lib/python3.11/site-packages/matplotlib/artist.py:766: in set_clip_box
    if clipbox != self.clipbox:
E   ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```
So passing `bbox-like` used to work but now doesn't (i.e., the test added here should fail). cc @oscargus as this seems to have been introduced by https://github.com/matplotlib/matplotlib/pull/26326

Not sure if the correct solution here is to cast to `BboxBase` if not an instance of one or something... but at least in MNE-Python we can work around for now by passing `tuple(bbox)` or so, so no rush from our end. :shrug: 