### PR TITLE
Fix input check in Poly3DCollection.__init__

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -905,7 +905,7 @@ class Poly3DCollection(PolyCollection):
                 kwargs['edgecolors'] = _shade_colors(
                     edgecolors, normals, lightsource
                 )
-            if facecolors is None and edgecolors in None:
+            if facecolors is None and edgecolors is None:
                 raise ValueError(
                     "You must provide facecolors, edgecolors, or both for "
                     "shade to work.")

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2260,3 +2260,13 @@ def test_surface3d_zsort_inf():
 
     ax.plot_surface(x, y, z, cmap='jet')
     ax.view_init(elev=45, azim=145)
+
+
+def test_Poly3DCollection_init_value_error():
+    # smoke test to ensure the input check works
+    # GH#26420
+    with pytest.raises(ValueError,
+                       match='You must provide facecolors, edgecolors, '
+                        'or both for shade to work.'):
+        poly = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], float)
+        c = art3d.Poly3DCollection([poly], shade=True)


### PR DESCRIPTION
## PR summary

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] closes #26420
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

So far higher level APIs like `plot_surface` and `plot_trisurf` ensure the input for calling `Poly3DCollection` is valid so usually we won't trigger the bug.
By inspecting test code coverage report, this part of code has never been tested. A test is added to ensure it works.

code for generating coverage report specifying folder - for people who may be curious
```
 python -m pytest .\lib\mpl_toolkits\mplot3d\tests\test_axes3d.py .\lib\mpl_toolkits\mplot3d\tests\test_legend3d.py --cov=./lib/mpl_toolkits/mplot3d --cov-report=html:coverage_re
```