### PR TITLE
Resolves #26421 Added an example for fig comparison decorator

### DIFF
--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -146,6 +146,11 @@ the same circle on the figures with two different methods::
        fig_ref.add_artist(red_circle)
        fig_ref.subplots().plot([0,1,2], [3,4,5], color='red')  
 
+In this example, one of the argument is ``tol=100`` where tol is used for the 
+determining the tolerance (a color value difference, where 255 is the maximal 
+difference). The test fails if the average pixel difference is greater than 
+this value.
+
 See the documentation of `~matplotlib.testing.decorators.image_comparison` and
 `~matplotlib.testing.decorators.check_figures_equal` for additional information
 about their use.


### PR DESCRIPTION
## PR summary
Added an example of figure comparison decorator check_figures_equal() in testing doc.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #26421" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

