### PR TITLE
Add ninja to Cygwin builder

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -177,7 +177,10 @@ jobs:
           python -m pip install --upgrade pip 'setuptools<60' wheel
           python -m pip install kiwisolver 'numpy!=1.21.*' pillow importlib_resources
           grep -v -F -e psutil requirements/testing/all.txt >requirements_test.txt
-          python -m pip install --upgrade 'contourpy>=1.0.1' cycler fonttools \
+          python -m pip install meson-python pybind11
+          export PATH="/usr/local/bin:$PATH"
+          python -m pip install --no-build-isolation 'contourpy>=1.0.1'
+          python -m pip install --upgrade cycler fonttools \
               packaging pyparsing python-dateutil setuptools-scm \
               -r requirements_test.txt sphinx ipython
           python -m pip install --upgrade pycairo 'cairocffi>=0.8' PyGObject &&

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -86,7 +86,7 @@ jobs:
         with:
           packages: >-
             ccache gcc-g++ gdb git graphviz libcairo-devel libffi-devel
-            libgeos-devel libQt5Core-devel pkgconf libglib2.0-devel
+            libgeos-devel libQt5Core-devel pkgconf libglib2.0-devel ninja
             noto-cjk-fonts
             python3${{ matrix.python-minor-version }}-devel
             python3${{ matrix.python-minor-version }}-pip


### PR DESCRIPTION
## PR summary

Since there are no contourpy wheels, it must be built from source, and pre-packaged ninja is better than trying to build from sdist. This was always done, but broke when contourpy switched to Meson.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines