### PR TITLE
Fix size inferral when using cairocffi

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -95,7 +95,7 @@ class RendererCairo(RendererBase):
             rect, *rest = ctx.copy_clip_rectangle_list()
             if rest:
                 raise TypeError("Cannot infer surface size")
-            size = rect.width, rect.height
+            _, _, *size = rect
             ctx.restore()
         self.gc.ctx = ctx
         self.width, self.height = size


### PR DESCRIPTION
## PR summary

With that package, rectangles appear to just be tuples, not named tuples like with pycairo.

Fixes #26523

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines