### PR TITLE
Backport PR #26493: Disable ``add_html_cache_busting`` on Sphinx 7.1+

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -20,6 +20,8 @@ import sys
 from urllib.parse import urlsplit, urlunsplit
 import warnings
 
+import sphinx
+
 import matplotlib
 
 from datetime import timezone
@@ -347,6 +349,9 @@ def add_html_cache_busting(app, pagename, templatename, context, doctree):
     This adds the Matplotlib version as a query to the link reference in the
     HTML, if the path is not absolute (i.e., it comes from the `_static`
     directory) and doesn't already have a query.
+
+    .. note:: Sphinx 7.1 provides asset checksums; so this hook only runs on
+              Sphinx 7.0 and earlier.
     """
     from sphinx.builders.html import Stylesheet, JavaScript
 
@@ -723,4 +728,5 @@ def setup(app):
     else:
         bld_type = 'rel'
     app.add_config_value('releaselevel', bld_type, 'env')
-    app.connect('html-page-context', add_html_cache_busting, priority=1000)
+    if sphinx.version_info[:2] < (7, 1):
+        app.connect('html-page-context', add_html_cache_busting, priority=1000)


### PR DESCRIPTION
## PR summary

(cherry picked from commit 48e28914d02dc5d50e3945b29f3d83da645b765f)

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines