### PR TITLE
Remove NumPy abs overrides from pylab

### DIFF
--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -59,6 +59,7 @@ import datetime
 # "from numpy.random import *" above
 bytes = __import__("builtins").bytes
 # We also don't want the numpy version of these functions
+abs = __import__("builtins").abs
 max = __import__("builtins").max
 min = __import__("builtins").min
 round = __import__("builtins").round


### PR DESCRIPTION
## PR summary

NumPy added abs in 1.26, which we don't want when we import * from it.

Fixes #26553

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines