### PR TITLE
Use SVG inheritance diagrams now that linking has been fixed

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -738,16 +738,14 @@ texinfo_documents = [
 numpydoc_show_class_members = False
 
 # We want to prevent any size limit, as we'll add scroll bars with CSS.
-inheritance_graph_attrs = dict(dpi=100, size='1000.0', splines='polyline')
+inheritance_graph_attrs = dict(size='1000.0', splines='polyline')
 # Also remove minimum node dimensions, and increase line size a bit.
 inheritance_node_attrs = dict(height=0.02, margin=0.055, penwidth=1,
                               width=0.01)
 inheritance_edge_attrs = dict(penwidth=1)
 
 graphviz_dot = shutil.which('dot')
-# Still use PNG until SVG linking is fixed
-# https://github.com/sphinx-doc/sphinx/issues/3176
-# graphviz_output_format = 'svg'
+graphviz_output_format = 'svg'
 
 # -----------------------------------------------------------------------------
 # Source code links


### PR DESCRIPTION
## PR summary

With sphinx-doc/sphinx#10614 and the to-be-merged sphinx-doc/sphinx#11634, links now work in SVG inheritance diagrams, including intersphinx links to external packages.  This PR reverts PR #17913, which had switched the documentation to PNG inheritance diagrams.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
