### PR TITLE
Use sys.platform over os.name

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1086,7 +1086,7 @@ def find_tex_file(filename):
     if lk:
         path = lk.search(filename)
     else:
-        if os.name == 'nt':
+        if sys.platform == 'win32':
             # On Windows only, kpathsea can use utf-8 for cmd args and output.
             # The `command_line_encoding` environment variable is set to force
             # it to always use utf-8 encoding.  See Matplotlib issue #11848.

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -2,6 +2,7 @@ import os
 from pathlib import Path
 import platform
 import re
+import shutil
 import subprocess
 import sys
 import weakref
@@ -318,7 +319,7 @@ def test_cleanup_temporaries(method_name, tmpdir, anim):
         assert list(Path(str(tmpdir)).iterdir()) == []
 
 
-@pytest.mark.skipif(os.name != "posix", reason="requires a POSIX OS")
+@pytest.mark.skipif(shutil.which("/bin/sh") is None, reason="requires a POSIX OS")
 def test_failing_ffmpeg(tmpdir, monkeypatch, anim):
     """
     Test that we correctly raise a CalledProcessError when ffmpeg fails.

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -11,7 +11,7 @@ def test_webagg_fallback(backend):
     if backend == "nbagg":
         pytest.importorskip("IPython")
     env = dict(os.environ)
-    if os.name != "nt":
+    if sys.platform != "win32":
         env["DISPLAY"] = ""
 
     env["MPLBACKEND"] = backend

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -473,7 +473,7 @@ def test_cross_Qt_imports():
 
 @pytest.mark.skipif('TF_BUILD' in os.environ,
                     reason="this test fails an azure for unknown reasons")
-@pytest.mark.skipif(os.name == "nt", reason="Cannot send SIGINT on Windows.")
+@pytest.mark.skipif(sys.platform == "win32", reason="Cannot send SIGINT on Windows.")
 def test_webagg():
     pytest.importorskip("tornado")
     proc = subprocess.Popen(

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -17,9 +17,9 @@ def test_parse_to_version_info(version_str, version_tuple):
     assert matplotlib._parse_to_version_info(version_str) == version_tuple
 
 
-@pytest.mark.skipif(
-    os.name == "nt", reason="chmod() doesn't work as is on Windows")
-@pytest.mark.skipif(os.name != "nt" and os.geteuid() == 0,
+@pytest.mark.skipif(sys.platform == "win32",
+                    reason="chmod() doesn't work as is on Windows")
+@pytest.mark.skipif(sys.platform != "win32" and os.geteuid() == 0,
                     reason="chmod() doesn't work as root")
 def test_tmpconfigdir_warning(tmpdir):
     """Test that a warning is emitted if a temporary configdir must be used."""


### PR DESCRIPTION
## PR summary

mypy does not recognize the latter [1], and there is a typing failure on Windows because of `os.geteuid`.

[1] https://github.com/python/mypy/issues/13002

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines