### PR TITLE
Bugfix: data sanitizing for barh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2569,10 +2569,10 @@ class Axes(_AxesBase):
 
         return bar_container
 
-    # @_preprocess_data() # let 'bar' do the unpacking..
+    @_preprocess_data()
     @_docstring.dedent_interpd
     def barh(self, y, width, height=0.8, left=None, *, align="center",
-             data=None, **kwargs):
+             **kwargs):
         r"""
         Make a horizontal bar plot.
 
@@ -2616,6 +2616,15 @@ class Axes(_AxesBase):
 
             To align the bars on the top edge pass a negative *height* and
             ``align='edge'``.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs : `.Rectangle` properties
+
+        %(Rectangle:kwdoc)s
+
+        **
 
         Returns
         -------
@@ -2693,7 +2702,7 @@ class Axes(_AxesBase):
         """
         kwargs.setdefault('orientation', 'horizontal')
         patches = self.bar(x=left, height=height, width=width, bottom=y,
-                           align=align, data=data, **kwargs)
+                           align=align, **kwargs)
         return patches
 
     def bar_label(self, container, labels=None, *, fmt="%g", label_type="edge",

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1898,6 +1898,23 @@ def test_bar_decimal_center(fig_test, fig_ref):
 
 
 @check_figures_equal(extensions=["png"])
+def test_barh_data_unpacking(fig_ref, fig_test):
+    data = {'label': ['a', 'b', 'c'],
+            'value': [1, 2, 3],
+            'color': ['r', 'g', 'b']}
+    fig_ref.subplots().barh(data['label'], data['value'], color=data['color'])
+    fig_test.subplots().barh('label', 'value', color='color', data=data)
+
+
+@check_figures_equal(extensions=["png"])
+def test_barh_preprocess_composition(fig_ref, fig_test):
+    # test to prevent preprocess_data from getting deleted
+    data = {'a': 1, 'b': 2, 'c': 3}
+    fig_test.subplots().barh(data.keys(), data.values())
+    fig_ref.subplots().barh(list(data.keys()), data.values())
+
+
+@check_figures_equal(extensions=["png"])
 def test_barh_decimal_center(fig_test, fig_ref):
     ax = fig_test.subplots()
     x0 = [1.5, 8.4, 5.3, 4.2]


### PR DESCRIPTION
Data wasn't being run through sanitize_sequence on `barh` so `ax.barh(data.keys(), data.values())` was throwing errors. This PR runs input to `barh` through preprocess data and adds some tests that it's being parsed. 

<details><summary>TypeError: unhashable type: 'dict_keys'</summary>

```python-traceback
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[30], line 5
      1 fig, ax = plt.subplots()
      3 data = {'a':1, 'b':2, 'c':3}
----> 5 ax.barh(data.keys(), data.values())
      6 #ax.barh(list(data.keys()), data.values())

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\axes\_axes.py:2649, in Axes.barh(self, y, width, height, left, align, data, **kwargs)
   2539 r"""
   2540 Make a horizontal bar plot.
   2541 
   (...)
   2646 :doc:`/gallery/lines_bars_and_markers/horizontal_barchart_distribution`.
   2647 """
   2648 kwargs.setdefault('orientation', 'horizontal')
-> 2649 patches = self.bar(x=left, height=height, width=width, bottom=y,
   2650                    align=align, data=data, **kwargs)
   2651 return patches

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\__init__.py:1442, in _preprocess_data.<locals>.inner(ax, data, *args, **kwargs)
   1439 @functools.wraps(func)
   1440 def inner(ax, *args, data=None, **kwargs):
   1441     if data is None:
-> 1442         return func(ax, *map(sanitize_sequence, args), **kwargs)
   1444     bound = new_sig.bind(ax, *args, **kwargs)
   1445     auto_label = (bound.arguments.get(label_namer)
   1446                   or bound.kwargs.get(label_namer))

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\axes\_axes.py:2397, in Axes.bar(self, x, height, width, bottom, align, **kwargs)
   2395         self.set_yscale('log', nonpositive='clip')
   2396 else:  # horizontal
-> 2397     self._process_unit_info(
   2398         [("x", width), ("y", y)], kwargs, convert=False)
   2399     if log:
   2400         self.set_xscale('log', nonpositive='clip')

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\axes\_base.py:2549, in _AxesBase._process_unit_info(self, datasets, kwargs, convert)
   2547     # Update from data if axis is already set but no unit is set yet.
   2548     if axis is not None and data is not None and not axis.have_units():
-> 2549         axis.update_units(data)
   2550 for axis_name, axis in axis_map.items():
   2551     # Return if no axis is set.
   2552     if axis is None:

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\axis.py:1675, in Axis.update_units(self, data)
   1673 neednew = self.converter != converter
   1674 self.converter = converter
-> 1675 default = self.converter.default_units(data, self)
   1676 if default is not None and self.units is None:
   1677     self.set_units(default)

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\category.py:105, in StrCategoryConverter.default_units(data, axis)
    103 # the conversion call stack is default_units -> axis_info -> convert
    104 if axis.units is None:
--> 105     axis.set_units(UnitData(data))
    106 else:
    107     axis.units.update(data)

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\category.py:181, in UnitData.__init__(self, data)
    179 self._counter = itertools.count()
    180 if data is not None:
--> 181     self.update(data)

File ~\miniconda3\envs\paper\lib\site-packages\matplotlib\category.py:214, in UnitData.update(self, data)
    212 # check if convertible to number:
    213 convertible = True
--> 214 for val in OrderedDict.fromkeys(data):
    215     # OrderedDict just iterates over unique values in data.
    216     _api.check_isinstance((str, bytes), value=val)
    217     if convertible:
    218         # this will only be called so long as convertible is True.

TypeError: unhashable type: 'dict_keys'
```
</details>

