### PR TITLE
MAINT: add __pycache__/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,6 +92,7 @@ doc/.mpl_skip_subdirs.yaml
 *.py,cover
 cover/
 .noseids
+__pycache__
 
 # Conda files #
 ###############


### PR DESCRIPTION
Folder isn't in .gitignore and our docs recommend `git commit -a` and I think this may be the cause of some really messy commit trees :/