### PR TITLE
Removed unnecessary origin keywords

### DIFF
--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -114,15 +114,10 @@ y = x.reshape(-1, 1)
 h = x * y
 
 fig, (ax1, ax2) = plt.subplots(ncols=2)
-# Note: lower and upper are the values provided
-# to origin argument in contourf.
-for (ax, origin) in [(ax1, 'upper'), (ax2, 'lower')]:
-    ax.set_title(f"origin={origin}")
-    cs = ax.contourf(h, levels=[10, 30, 50], colors=[
-                     '#808080', '#A0A0A0', '#C0C0C0'], extend='both', origin=origin)
-    cs.cmap.set_over('red')
-    cs.cmap.set_under('blue')
-    cs.changed()
+ax1.set_title("origin='upper'")
+ax2.set_title("origin='lower'")
+ax1.contourf(h, levels=np.arange(5, 70, 5), extend='both', origin="upper")
+ax2.contourf(h, levels=np.arange(5, 70, 5), extend='both', origin="lower")
 
 plt.show()
 

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -106,8 +106,7 @@ plt.show()
 # %%
 # Customizing Contour Plots with the origin Keyword
 # -------------------------------------------------
-# This code showcases contour plot customization using the origin keyword,
-# demonstrating distinct upper and lower origin perspectives.
+# This section demonstrates how to use the origin parameter in Contour
 
 x = np.arange(1, 10)
 y = x.reshape(-1, 1)

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -110,6 +110,29 @@ for ax, extend in zip(axs.flat, extends):
 plt.show()
 
 # %%
+# Customizing Contour Plots with the origin Keyword
+# ------------------
+# This section demonstrates how to use the origin parameter in Contour
+
+x = np.arange(1, 10)
+y = x.reshape(-1, 1)
+h = x * y
+
+fig, (ax1, ax2) = plt.subplots(ncols=2)
+# Note: lower and upper are the values provided 
+# to origin argument in contourf.
+for (ax, origin) in [(ax1, 'upper'), (ax2, 'lower')]:
+    ax.set_title(f"origin={origin}")
+    cs = ax.contourf(h, levels=[10, 30, 50],
+                     colors=['#808080', '#A0A0A0', '#C0C0C0'],
+                     extend='both', origin=origin)
+    cs.cmap.set_over('red')
+    cs.cmap.set_under('blue')
+    cs.changed()
+
+plt.show()
+
+# %%
 #
 # .. admonition:: References
 #

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -8,7 +8,6 @@ How to use the `.axes.Axes.contourf` method to create filled contour plots.
 import matplotlib.pyplot as plt
 import numpy as np
 
-
 delta = 0.025
 
 x = y = np.arange(-3.0, 3.01, delta)
@@ -119,7 +118,7 @@ y = x.reshape(-1, 1)
 h = x * y
 
 fig, (ax1, ax2) = plt.subplots(ncols=2)
-# Note: lower and upper are the values provided 
+# Note: lower and upper are the values provided
 # to origin argument in contourf.
 for (ax, origin) in [(ax1, 'upper'), (ax2, 'lower')]:
     ax.set_title(f"origin={origin}")

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -105,7 +105,7 @@ plt.show()
 
 # %%
 # Orient contour plots using the origin keyword
-# -----------------------------------------------
+# ---------------------------------------------
 # This code demonstrates orienting contour plot data using the "origin" keyword
 
 x = np.arange(1, 10)

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -66,19 +66,14 @@ cbar.add_lines(CS2)
 
 fig2, ax2 = plt.subplots(layout='constrained')
 levels = [-1.5, -1, -0.5, 0, 0.5, 1]
-CS3 = ax2.contourf(X, Y, Z, levels,
-                   colors=('r', 'g', 'b'),
-                   extend='both')
+CS3 = ax2.contourf(X, Y, Z, levels, colors=('r', 'g', 'b'), extend='both')
 # Our data range extends outside the range of levels; make
 # data below the lowest contour level yellow, and above the
 # highest level cyan:
 CS3.cmap.set_under('yellow')
 CS3.cmap.set_over('cyan')
 
-CS4 = ax2.contour(X, Y, Z, levels,
-                  colors=('k',),
-                  linewidths=(3,)
-                  )
+CS4 = ax2.contour(X, Y, Z, levels, colors=('k',), linewidths=(3,))
 ax2.set_title('Listed colors (3 masked regions)')
 ax2.clabel(CS4, fmt='%2.1f', colors='w', fontsize=14)
 
@@ -110,8 +105,9 @@ plt.show()
 
 # %%
 # Customizing Contour Plots with the origin Keyword
-# ------------------
-# This section demonstrates how to use the origin parameter in Contour
+# -------------------------------------------------
+# This code showcases contour plot customization using the origin keyword,
+# demonstrating distinct upper and lower origin perspectives.
 
 x = np.arange(1, 10)
 y = x.reshape(-1, 1)
@@ -122,9 +118,8 @@ fig, (ax1, ax2) = plt.subplots(ncols=2)
 # to origin argument in contourf.
 for (ax, origin) in [(ax1, 'upper'), (ax2, 'lower')]:
     ax.set_title(f"origin={origin}")
-    cs = ax.contourf(h, levels=[10, 30, 50],
-                     colors=['#808080', '#A0A0A0', '#C0C0C0'],
-                     extend='both', origin=origin)
+    cs = ax.contourf(h, levels=[10, 30, 50], colors=[
+                     '#808080', '#A0A0A0', '#C0C0C0'], extend='both', origin=origin)
     cs.cmap.set_over('red')
     cs.cmap.set_under('blue')
     cs.changed()

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -8,7 +8,6 @@ How to use the `.axes.Axes.contourf` method to create filled contour plots.
 import matplotlib.pyplot as plt
 import numpy as np
 
-origin = 'lower'
 
 delta = 0.025
 
@@ -41,14 +40,14 @@ Z[interior] = np.ma.masked
 # for purposes of illustration.
 
 fig1, ax2 = plt.subplots(layout='constrained')
-CS = ax2.contourf(X, Y, Z, 10, cmap=plt.cm.bone, origin=origin)
+CS = ax2.contourf(X, Y, Z, 10, cmap=plt.cm.bone)
 
 # Note that in the following, we explicitly pass in a subset of the contour
 # levels used for the filled contours.  Alternatively, we could pass in
 # additional levels to provide extra resolution, or leave out the *levels*
 # keyword argument to use all of the original levels.
 
-CS2 = ax2.contour(CS, levels=CS.levels[::2], colors='r', origin=origin)
+CS2 = ax2.contour(CS, levels=CS.levels[::2], colors='r')
 
 ax2.set_title('Nonsense (3 masked regions)')
 ax2.set_xlabel('word length anomaly')
@@ -70,7 +69,6 @@ fig2, ax2 = plt.subplots(layout='constrained')
 levels = [-1.5, -1, -0.5, 0, 0.5, 1]
 CS3 = ax2.contourf(X, Y, Z, levels,
                    colors=('r', 'g', 'b'),
-                   origin=origin,
                    extend='both')
 # Our data range extends outside the range of levels; make
 # data below the lowest contour level yellow, and above the
@@ -80,8 +78,8 @@ CS3.cmap.set_over('cyan')
 
 CS4 = ax2.contour(X, Y, Z, levels,
                   colors=('k',),
-                  linewidths=(3,),
-                  origin=origin)
+                  linewidths=(3,)
+                  )
 ax2.set_title('Listed colors (3 masked regions)')
 ax2.clabel(CS4, fmt='%2.1f', colors='w', fontsize=14)
 
@@ -104,7 +102,7 @@ cmap = plt.colormaps["winter"].with_extremes(under="magenta", over="yellow")
 fig, axs = plt.subplots(2, 2, layout="constrained")
 
 for ax, extend in zip(axs.flat, extends):
-    cs = ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend, origin=origin)
+    cs = ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend)
     fig.colorbar(cs, ax=ax, shrink=0.9)
     ax.set_title("extend = %s" % extend)
     ax.locator_params(nbins=4)

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -104,15 +104,16 @@ for ax, extend in zip(axs.flat, extends):
 plt.show()
 
 # %%
-# Customizing Contour Plots with the origin Keyword
-# -------------------------------------------------
-# This section demonstrates how to use the origin parameter in Contour
+# Orient contour plots using the origin keyword
+# -----------------------------------------------
+# This code demonstrates orienting contour plot data using the "origin" keyword
 
 x = np.arange(1, 10)
 y = x.reshape(-1, 1)
 h = x * y
 
 fig, (ax1, ax2) = plt.subplots(ncols=2)
+
 ax1.set_title("origin='upper'")
 ax2.set_title("origin='lower'")
 ax1.contourf(h, levels=np.arange(5, 70, 5), extend='both', origin="upper")


### PR DESCRIPTION
## PR summary

Removed origin keyword as it is not required in the provided examples.
https://matplotlib.org/devdocs/gallery/images_contours_and_fields/contourf_demo.html
 
