### PR TITLE
[MNT] Do not configure axes properties via subplots(..., subplot_kw={...})

### DIFF
--- a/galleries/examples/shapes_and_collections/ellipse_demo.py
+++ b/galleries/examples/shapes_and_collections/ellipse_demo.py
@@ -22,15 +22,14 @@ ells = [Ellipse(xy=np.random.rand(2) * 10,
                 angle=np.random.rand() * 360)
         for i in range(NUM)]
 
-fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
+fig, ax = plt.subplots()
+ax.set(xlim=(0, 10), ylim=(0, 10), aspect="equal")
+
 for e in ells:
     ax.add_artist(e)
     e.set_clip_box(ax.bbox)
     e.set_alpha(np.random.rand())
     e.set_facecolor(np.random.rand(3))
-
-ax.set_xlim(0, 10)
-ax.set_ylim(0, 10)
 
 plt.show()
 
@@ -45,14 +44,12 @@ plt.show()
 angle_step = 45  # degrees
 angles = np.arange(0, 180, angle_step)
 
-fig, ax = plt.subplots(subplot_kw={'aspect': 'equal'})
+fig, ax = plt.subplots()
+ax.set(xlim=(-2.2, 2.2), ylim=(-2.2, 2.2), aspect="equal")
 
 for angle in angles:
     ellipse = Ellipse((0, 0), 4, 2, angle=angle, alpha=0.1)
     ax.add_artist(ellipse)
-
-ax.set_xlim(-2.2, 2.2)
-ax.set_ylim(-2.2, 2.2)
 
 plt.show()
 


### PR DESCRIPTION
While technical possible, this is an anti-pattern IMHO. We should keep Axes creation and customization separate.

Extracted from the deferred #14411.
