### PR TITLE
[Doc] Improve set_layout_engine docs

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2475,7 +2475,7 @@ None}, default: None
 
             - 'tight': Use the tight layout mechanism. This is a relatively
               simple algorithm that adjusts the subplot parameters so that
-              decorations do not overlap. See `.Figure.set_tight_layout` for
+              decorations do not overlap. See `.set_tight_layout` for
               further details.
 
             - 'none': Do not use a layout engine.
@@ -2618,8 +2618,7 @@ None}, default: None
 
         Parameters
         ----------
-        layout: {'constrained', 'compressed', 'tight', 'none'} or \
-`LayoutEngine` or None
+        layout : {'constrained', 'compressed', 'tight', 'none', `.LayoutEngine`, None}
 
             - 'constrained' will use `~.ConstrainedLayoutEngine`
             - 'compressed' will also use `~.ConstrainedLayoutEngine`, but with
@@ -2627,6 +2626,8 @@ None}, default: None
               ratio Axes.
             - 'tight' uses `~.TightLayoutEngine`
             - 'none' removes layout engine.
+
+            If a `.LayoutEngine` instance, that instance will be used.
 
             If `None`, the behavior is controlled by :rc:`figure.autolayout`
             (which if `True` behaves as if 'tight' was passed) and
@@ -2637,7 +2638,7 @@ None}, default: None
             Users and libraries can define their own layout engines and pass
             the instance directly as well.
 
-        kwargs: dict
+        **kwargs
             The keyword arguments are passed to the layout engine to set things
             like padding and margin sizes.  Only used if *layout* is a string.
 


### PR DESCRIPTION
## PR summary

The space before : is important. 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines

<!--
Thank you so much for your PR!  To help us review your contribution, please
consider the following points:

- A development guide is available at https://matplotlib.org/devdocs/devel/index.html.

- Help with git and github is available at https://matplotlib.org/devdocs/devel/development_workflow.html

- Create a separate branch for your changes and open the PR from this branch. Please avoid working on `main`.

- The PR title should summarize the changes, for example "Raise ValueError on
  non-numeric input to set_xlim".  Avoid non-descriptive titles such as
  "Addresses issue #8576".

- The summary should provide at least 1-2 sentences describing the pull request
  in detail (Why is this change required?  What problem does it solve?) and
  link to any relevant issues.

- If you are contributing fixes to docstrings, please pay attention to
  https://matplotlib.org/stable/devel/documenting_mpl.html#formatting-conventions.  In particular,
  note the difference between using single backquotes, double backquotes, and
  asterisks in the markup.

We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.
-->
