### PR TITLE
Added sanitize_sequence to kwargs in _preprocess_data

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -1462,7 +1462,10 @@ def _preprocess_data(func=None, *, replace_names=None, label_namer=None):
     @functools.wraps(func)
     def inner(ax, *args, data=None, **kwargs):
         if data is None:
-            return func(ax, *map(sanitize_sequence, args), **kwargs)
+            return func(
+                ax,
+                *map(sanitize_sequence, args),
+                **{k: sanitize_sequence(v) for k, v in kwargs.items()})
 
         bound = new_sig.bind(ax, *args, **kwargs)
         auto_label = (bound.arguments.get(label_namer)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -835,6 +835,12 @@ def test_errorbar_dashes(fig_test, fig_ref):
     ax_test.errorbar(x, y, xerr=np.abs(y), yerr=np.abs(y), dashes=[2, 2])
 
 
+def test_errorbar_mapview_kwarg():
+    D = {ii: ii for ii in range(10)}
+    fig, ax = plt.subplots()
+    ax.errorbar(x=D.keys(), y=D.values(), xerr=D.values())
+
+
 @image_comparison(['single_point', 'single_point'])
 def test_single_point():
     # Issue #1796: don't let lines.marker affect the grid


### PR DESCRIPTION
I accidentally broke #25702 trying to rebase it 🤦‍♀️ so this is my amends (and for future I will make a new branch/PR for these sorts of rebases). @jovianw's PR makes it so that **kwargs are also passed through `_sanitize_sequence` and adds a test. 

This pr supercedes #26577, which is why I touched it. 
Let me know if it's considered enough of a new feature to need a what's new. 