### PR TITLE
[DOC] Slightly improve the LineCollection docstring

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1404,11 +1404,12 @@ class LineCollection(Collection):
         Parameters
         ----------
         segments : list of array-like
-            A sequence of (*line0*, *line1*, *line2*), where::
+            A sequence (*line0*, *line1*, *line2*) of lines, where each line is a list
+            of points::
 
-                linen = (x0, y0), (x1, y1), ... (xm, ym)
+                lineN = [(x0, y0), (x1, y1), ... (xm, ym)]
 
-            or the equivalent numpy array with two columns. Each line
+            or the equivalent Mx2 numpy array with two columns. Each line
             can have a different number of segments.
         linewidths : float or list of float, default: :rc:`lines.linewidth`
             The width of each line in points.


### PR DESCRIPTION
## PR summary

Closes #26674. There's two aspects to the issue:

- the `LineCollection` description is slightly unclear. - This is fixed here.
- `Line3DCollection` inherits `__init__` and reuses its docstring. That's problematic because the the description is 2D. I don't see a good solution here. We likely don't want to replicate the whole docstring, and also a comment like "This holds analogously for 3D with points (x0, y0, z0) and Mx3 arrays." is awkward both for the 2D and 3D docstrings.

  I therefore propose to leave it at this. If the 2D description is clear, the extension to 3D can be inferred by the user. - Not ideal, but the least bad option IMHO.


