### PR TITLE
setupext: support using environment variables for dependencies

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -257,7 +257,7 @@ def get_pkg_config():
 
 def pkg_config_setup_extension(
         ext, package,
-        atleast_version=None, alt_exec=None, default_libraries=()):
+        atleast_version=None, alt_exec=None, envprefix=None, default_libraries=()):
     """Add parameters to the given *ext* for the given *package*."""
 
     # First, try to get the flags from pkg-config.
@@ -295,6 +295,13 @@ def pkg_config_setup_extension(
             conda_env_path = Path(conda_env_path)
             ext.include_dirs.append(str(conda_env_path / "Library/include"))
             ext.library_dirs.append(str(conda_env_path / "Library/lib"))
+        elif envprefix:
+            env_include = os.getenv(envprefix + '_INCLUDE_DIRS')
+            if env_include:
+                ext.include_dirs.extend(env_include.split(';'))
+            env_library_dirs = os.getenv(envprefix + '_LIBRARY_DIRS')
+            if env_library_dirs:
+                ext.library_dirs.extend(env_library_dirs.split(';'))
 
     # Default linked libs.
     ext.libraries.extend(default_libraries)
@@ -585,6 +592,7 @@ class FreeType(SetupPackage):
                 ext, 'freetype2',
                 atleast_version='9.11.3',
                 alt_exec=['freetype-config'],
+                envprefix='FREETYPE',
                 default_libraries=['freetype'])
             ext.define_macros.append(('FREETYPE_BUILD_TYPE', 'system'))
         else:
@@ -755,6 +763,12 @@ class Qhull(SetupPackage):
     def add_flags(cls, ext):
         if options.get("system_qhull"):
             ext.libraries.append("qhull_r")
+            env_include = os.getenv('QHULL_INCLUDE_DIRS')
+            if env_include:
+                ext.include_dirs.extend(env_include.split(';'))
+            env_library_dirs = os.getenv('QHULL_LIBRARY_DIRS')
+            if env_library_dirs:
+                ext.library_dirs.extend(env_library_dirs.split(';'))
         else:
             cls._extensions_to_update.append(ext)
 


### PR DESCRIPTION
## PR summary

On Windows, without Conda or the libraries being in default locations, matplotlib has problems finding freetype and qhull. Add ultimate fallback solutions using very specific environment variables named `{FREETYPE,QHULL}_{INCLUDE,LIBRARY}_DIRS`.

---

My attempts at using `CL` and `LINK` were failing; not sure if the migration to `meson` made these obsolete or not.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/documenting_mpl.html#writing-docstrings) guidelines