### PR TITLE
Fix error generation for missing pgf.texsystem.

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -241,16 +241,7 @@ class LatexManager:
         self._finalize_tmpdir = weakref.finalize(self, self._tmpdir.cleanup)
 
         # test the LaTeX setup to ensure a clean startup of the subprocess
-        try:
-            self._setup_latex_process(expect_reply=False)
-        except FileNotFoundError as err:
-            raise RuntimeError(
-                f"{self.latex.args[0]!r} not found.  Install it or change "
-                f"rcParams['pgf.texsystem'] to an available TeX "
-                f"implementation.") from err
-        except OSError as err:
-            raise RuntimeError(
-                f"Error starting process {self.latex.args[0]!r}") from err
+        self._setup_latex_process(expect_reply=False)
         stdout, stderr = self.latex.communicate("\n\\makeatletter\\@@end\n")
         if self.latex.returncode != 0:
             raise LatexError(
@@ -258,7 +249,6 @@ class LatexManager:
                 f"while processing the following input:\n"
                 f"{self._build_latex_header()}",
                 stdout)
-
         self.latex = None  # Will be set up on first use.
         # Per-instance cache.
         self._get_box_metrics = functools.lru_cache(self._get_box_metrics)
@@ -268,10 +258,19 @@ class LatexManager:
         # Windows, we must ensure that the subprocess has quit before being
         # able to delete the tmpdir in which it runs; in order to do so, we
         # must first `kill()` it, and then `communicate()` with it.
-        self.latex = subprocess.Popen(
-            [mpl.rcParams["pgf.texsystem"], "-halt-on-error"],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            encoding="utf-8", cwd=self.tmpdir)
+        try:
+            self.latex = subprocess.Popen(
+                [mpl.rcParams["pgf.texsystem"], "-halt-on-error"],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                encoding="utf-8", cwd=self.tmpdir)
+        except FileNotFoundError as err:
+            raise RuntimeError(
+                f"{mpl.rcParams['pgf.texsystem']!r} not found; install it or change "
+                f"rcParams['pgf.texsystem'] to an available TeX implementation"
+            ) from err
+        except OSError as err:
+            raise RuntimeError(
+                f"Error starting {mpl.rcParams['pgf.texsystem']!r}") from err
 
         def finalize_latex(latex):
             latex.kill()


### PR DESCRIPTION
If pgf.texsystem isn't installed, then self.latex will not be created *at all* by _setup_latex_process, and we thus cannot access self.latex.args[0], but must instead read the rc value again.  To make this clearer, move the error handling into _setup_latex_process, instead of having it outside.

No test because that'd require setting up a test env where pgf.texsystem is explicitly *missing* (or go through lots of mocks), which seems not worth it.

This is (I think) the origin of the AttributeError in #26551.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
