### PR TITLE
Pin NumPy below v2 for 3.7.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -322,7 +322,7 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "cycler>=0.10",
         "fonttools>=4.22.0",
         "kiwisolver>=1.0.1",
-        "numpy>=1.20",
+        "numpy>=1.20,<2",
         "packaging>=20.0",
         "pillow>=6.2.0",
         "pyparsing>=2.3.1",


### PR DESCRIPTION
## PR summary

Pre-emptively pinning away from the major API break for the last bugfix release of the 3.7.x series.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines