### PR TITLE
Add support for High DPI displays to wxAgg backend

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -14,9 +14,6 @@ import pathlib
 import sys
 import weakref
 
-import numpy as np
-import PIL.Image
-
 import matplotlib as mpl
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase,
@@ -30,6 +27,7 @@ from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
 
 import wx
+import wx.svg
 
 _log = logging.getLogger(__name__)
 
@@ -473,10 +471,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         FigureCanvasBase.__init__(self, figure)
         w, h = map(math.ceil, self.figure.bbox.size)
         # Set preferred window size hint - helps the sizer, if one is connected
-        wx.Panel.__init__(self, parent, id, size=wx.Size(w, h))
-        # Create the drawing bitmap
-        self.bitmap = wx.Bitmap(w, h)
-        _log.debug("%s - __init__() - bitmap w:%d h:%d", type(self), w, h)
+        wx.Panel.__init__(self, parent, id, size=parent.FromDIP(wx.Size(w, h)))
+        self.bitmap = None
         self._isDrawn = False
         self._rubberband_rect = None
         self._rubberband_pen_black = wx.Pen('BLACK', 1, wx.PENSTYLE_SHORT_DASH)
@@ -512,6 +508,12 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         self.SetBackgroundStyle(wx.BG_STYLE_PAINT)  # Reduce flicker.
         self.SetBackgroundColour(wx.WHITE)
 
+        if wx.Platform == '__WXMAC__':
+            # Initial scaling. Other platforms handle this automatically
+            dpiScale = self.GetDPIScaleFactor()
+            self.SetInitialSize(self.GetSize()*(1/dpiScale))
+            self._set_device_pixel_ratio(dpiScale)
+
     def Copy_to_Clipboard(self, event=None):
         """Copy bitmap of canvas to system clipboard."""
         bmp_obj = wx.BitmapDataObject()
@@ -523,6 +525,12 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
                 wx.TheClipboard.SetData(bmp_obj)
                 wx.TheClipboard.Flush()
                 wx.TheClipboard.Close()
+
+    def _update_device_pixel_ratio(self, *args, **kwargs):
+        # We need to be careful in cases with mixed resolution displays if
+        # device_pixel_ratio changes.
+        if self._set_device_pixel_ratio(self.GetDPIScaleFactor()):
+            self.draw()
 
     def draw_idle(self):
         # docstring inherited
@@ -631,7 +639,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         In this application we attempt to resize to fit the window, so it
         is better to take the performance hit and redraw the whole window.
         """
-
+        self._update_device_pixel_ratio()
         _log.debug("%s - _on_size()", type(self))
         sz = self.GetParent().GetSizer()
         if sz:
@@ -655,9 +663,10 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             return  # Empty figure
 
         # Create a new, correctly sized bitmap
-        self.bitmap = wx.Bitmap(self._width, self._height)
-
         dpival = self.figure.dpi
+        if not wx.Platform == '__WXMSW__':
+            scale = self.GetDPIScaleFactor()
+            dpival /= scale
         winch = self._width / dpival
         hinch = self._height / dpival
         self.figure.set_size_inches(winch, hinch, forward=False)
@@ -712,7 +721,11 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         else:
             x, y = pos.X, pos.Y
         # flip y so y=0 is bottom of canvas
-        return x, self.figure.bbox.height - y
+        if not wx.Platform == '__WXMSW__':
+            scale = self.GetDPIScaleFactor()
+            return x*scale, self.figure.bbox.height - y*scale
+        else:
+            return x, self.figure.bbox.height - y
 
     def _on_key_down(self, event):
         """Capture key press."""
@@ -898,8 +911,8 @@ class FigureFrameWx(wx.Frame):
         # On Windows, canvas sizing must occur after toolbar addition;
         # otherwise the toolbar further resizes the canvas.
         w, h = map(math.ceil, fig.bbox.size)
-        self.canvas.SetInitialSize(wx.Size(w, h))
-        self.canvas.SetMinSize((2, 2))
+        self.canvas.SetInitialSize(self.FromDIP(wx.Size(w, h)))
+        self.canvas.SetMinSize(self.FromDIP(wx.Size(2, 2)))
         self.canvas.SetFocus()
 
         self.Fit()
@@ -1017,9 +1030,9 @@ def _set_frame_icon(frame):
 class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
     def __init__(self, canvas, coordinates=True, *, style=wx.TB_BOTTOM):
         wx.ToolBar.__init__(self, canvas.GetParent(), -1, style=style)
+        if wx.Platform == '__WXMAC__':
+            self.SetToolBitmapSize(self.GetToolBitmapSize()*self.GetDPIScaleFactor())
 
-        if 'wxMac' in wx.PlatformInfo:
-            self.SetToolBitmapSize((24, 24))
         self.wx_ids = {}
         for text, tooltip_text, image_file, callback in self.toolitems:
             if text is None:
@@ -1028,7 +1041,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             self.wx_ids[text] = (
                 self.AddTool(
                     -1,
-                    bitmap=self._icon(f"{image_file}.png"),
+                    bitmap=self._icon(f"{image_file}.svg"),
                     bmpDisabled=wx.NullBitmap,
                     label=text, shortHelp=tooltip_text,
                     kind=(wx.ITEM_CHECK if text in ["Pan", "Zoom"]
@@ -1054,9 +1067,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         *name*, including the extension and relative to Matplotlib's "images"
         data directory.
         """
-        pilimg = PIL.Image.open(cbook._get_data_path("images", name))
-        # ensure RGBA as wx BitMap expects RGBA format
-        image = np.array(pilimg.convert("RGBA"))
+        svg = cbook._get_data_path("images", name).read_bytes()
         try:
             dark = wx.SystemSettings.GetAppearance().IsDark()
         except AttributeError:  # wxpython < 4.1
@@ -1068,11 +1079,9 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             fg_lum = (.299 * fg.red + .587 * fg.green + .114 * fg.blue) / 255
             dark = fg_lum - bg_lum > .2
         if dark:
-            fg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
-            black_mask = (image[..., :3] == 0).all(axis=-1)
-            image[black_mask, :3] = (fg.Red(), fg.Green(), fg.Blue())
-        return wx.Bitmap.FromBufferRGBA(
-            image.shape[1], image.shape[0], image.tobytes())
+            svg = svg.replace(b'fill:black;', b'fill:white;')
+        toolbarIconSize = wx.ArtProvider().GetDIPSizeHint(wx.ART_TOOLBAR)
+        return wx.BitmapBundle.FromSVG(svg, toolbarIconSize)
 
     def _update_buttons_checked(self):
         if "Pan" in self.wx_ids:
@@ -1123,7 +1132,9 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         height = self.canvas.figure.bbox.height
-        self.canvas._rubberband_rect = (x0, height - y0, x1, height - y1)
+        sf = self.GetDPIScaleFactor()
+        self.canvas._rubberband_rect = (x0/sf, (height - y0)/sf,
+                                        x1/sf, (height - y1)/sf)
         self.canvas.Refresh()
 
     def remove_rubberband(self):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -21,7 +21,7 @@ from matplotlib.backend_bases import (
     TimerBase, ToolContainerBase, cursors,
     CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
-from matplotlib import _api, cbook, backend_tools
+from matplotlib import _api, cbook, backend_tools, _c_internal_utils
 from matplotlib._pylab_helpers import Gcf
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
@@ -43,10 +43,8 @@ def _create_wxapp():
     wxapp = wx.App(False)
     wxapp.SetExitOnFrameDelete(True)
     cbook._setup_new_guiapp()
-    if wx.Platform == '__WXMSW__':
-        # Set per-process DPI awareness. See https://docs.microsoft.com/en-us/windows/win32/api/shellscalingapi/ne-shellscalingapi-process_dpi_awareness
-        import ctypes
-        ctypes.windll.shcore.SetProcessDpiAwareness(2)
+    # Set per-process DPI awareness. This is a NoOp except in MSW
+    _c_internal_utils.Win32_SetProcessDpiAwareness_max()
     return wxapp
 
 

--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -12,13 +12,13 @@ class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
         Render the figure using agg.
         """
         FigureCanvasAgg.draw(self)
-        self.bitmap = _rgba_to_wx_bitmap(self.get_renderer().buffer_rgba())
+        self.bitmap = self._create_bitmap()
         self._isDrawn = True
         self.gui_repaint(drawDC=drawDC)
 
     def blit(self, bbox=None):
         # docstring inherited
-        bitmap = _rgba_to_wx_bitmap(self.get_renderer().buffer_rgba())
+        bitmap = self._create_bitmap()
         if bbox is None:
             self.bitmap = bitmap
         else:
@@ -31,11 +31,13 @@ class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
             srcDC.SelectObject(wx.NullBitmap)
         self.gui_repaint()
 
-
-def _rgba_to_wx_bitmap(rgba):
-    """Convert an RGBA buffer to a wx.Bitmap."""
-    h, w, _ = rgba.shape
-    return wx.Bitmap.FromBufferRGBA(w, h, rgba)
+    def _create_bitmap(self):
+        """Create a wx.Bitmap from the renderer RGBA buffer"""
+        rgba = self.get_renderer().buffer_rgba()
+        h, w, _ = rgba.shape
+        bitmap = wx.Bitmap.FromBufferRGBA(w, h, rgba)
+        bitmap.SetScaleFactor(self.GetDPIScaleFactor())
+        return bitmap
 
 
 @_BackendWx.export


### PR DESCRIPTION
### Summary

This PR adds support to the `wxAgg` backend to corrertly render plots in high DPI displays in all three platforms that the wx toolkit supports: Linux, MACOS and Windows.

This PR closes issue #7720

### Background

This PR adds support for high DPI displays using the underlying toolkit support for high DPI displays: For information of wxPython support for High DPI displays, see https://docs.wxpython.org/high_dpi_overview.html

The wxPython toolkit is built on top of of the C++ wxWidgets toolkit. For a more detailed explanation of support for high DPI displays in the wx ecosystem see the WxWidgets explanation: https://docs.wxwidgets.org/3.2/overview_high_dpi.html

### Additional details

This PR correctly scales plots in high DPI displays, including figure size, font size and marker and line width. This PR also includes reading toolbar icons from svg instead of png to make them sharp at all dpi's. ~I remark this last feature comes with the caveat that automatically changing icon colors for dark themes is not done.~ _[The limitation mentioned in the previous sentence has been removed in the current version of this PR. See discussion below for details. I am crossing out the sentence and adding this note, instead of removing the sentece so the discussion still makes sense]_

### Additional testing

The variety of use cases and features of matplotlib is very large. I welcome additional testing in all platforms as it is conceivable that there may be features that I have not tested and that I have not added support for. Thank you.

