### PR TITLE
Added setter & getter functions for missing kwargs

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -379,6 +379,14 @@ default: %(va)s
     def get_facecolor(self):
         """Get the face color of the Figure rectangle."""
         return self.patch.get_facecolor()
+    
+    def get_subplotspec(self):
+        """Get the subplotspec of the Figure rectangle."""
+        return self.patch.get_subplotspec()
+    
+    def get_parent(self):
+        """Get the parent of the Figure rectangle."""
+        return self.patch.get_parent()
 
     def get_frameon(self):
         """
@@ -424,6 +432,26 @@ default: %(va)s
         """
         self.patch.set_facecolor(color)
 
+    def set_parent(self, parent):
+        """
+        Set the parent figure of the Figure rectangle.
+
+        Parameters
+        ----------
+        parent : parent
+        """
+        self.patch.set_parent(parent)
+
+    def set_subplotspec(self, subplotspec):
+        """
+        Set the subplotspec figure of the Figure rectangle.
+
+        Parameters
+        ----------
+        parent : parent
+        """
+        self.patch.set_subplotspec(subplotspec)
+        
     def set_frameon(self, b):
         """
         Set the figure's background patch visibility, i.e.


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This is the first PR I am proposing, for the 'good first issue' - https://github.com/matplotlib/matplotlib/issues/24617. 
This change made the functions for the missing getter and setter functions for key word parameters.
The functions (getter and setter) are missing for parameters - parent, subplotspec. 
So, I have added these functions in the file. This is my approach for the issue #24617

##Review
Since, this is my first contribution in the open source, I would like to know the feedback and tips to improve my contributions. 
