### PR TITLE
MNT: pre-commit rst linter + small linting fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
       - id: no-commit-to-branch #default is master and main
       - id: trailing-whitespace
         exclude_types: [svg]
-
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:
@@ -44,10 +43,15 @@ repos:
           "--skip",
           "doc/users/project/credits.rst"
           ]
-
   - repo: https://github.com/pycqa/isort
     rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
         files: ^galleries/tutorials/|^galleries/examples/|^galleries/plot_types/
+  - repo: https://github.com/rstcheck/rstcheck
+    rev: v6.2.0
+    hooks:
+      - id: rstcheck
+        additional_dependencies:
+          - sphinx>=1.8.1

--- a/doc/_templates/autofunctions.rst
+++ b/doc/_templates/autofunctions.rst
@@ -14,7 +14,9 @@ Functions
 .. autosummary::
    :template: autosummary.rst
    :toctree:
+
 {% for item in functions %}{% if item not in ['plotting', 'colormaps'] %}
    {{ item }}{% endif %}{% endfor %}
+
 {% endif %}
 {% endblock %}

--- a/doc/_templates/automodule.rst
+++ b/doc/_templates/automodule.rst
@@ -1,8 +1,10 @@
 {{ fullname | escape | underline}}
 
 {% if fullname in ['mpl_toolkits.axes_grid1.colorbar'] %}
-.. To prevent problems with the autosummary for the colorbar doc
-   treat this separately (sphinx-doc/sphinx/issues/4874)
+
+.. To prevent problems with the autosummary for the colorbar doc treat this
+   separately (sphinx-doc/sphinx/issues/4874)
+
 .. automodule:: {{ fullname }}
    :members:
 
@@ -21,8 +23,10 @@ Classes
 .. autosummary::
    :template: autosummary.rst
    :toctree:
+
 {% for item in classes %}{% if item not in ['zip', 'map', 'reduce'] %}
    {{ item }}{% endif %}{% endfor %}
+
 {% endif %}
 {% endblock %}
 
@@ -38,6 +42,7 @@ Functions
 
 {% for item in functions %}{% if item not in ['zip', 'map', 'reduce'] %}
    {{ item }}{% endif %}{% endfor %}
+
 {% endif %}
 {% endblock %}
 {% endif %}

--- a/doc/_templates/autosummary.rst
+++ b/doc/_templates/autosummary.rst
@@ -5,6 +5,7 @@
 
 
 {% if objtype in ['class'] %}
+
 .. auto{{ objtype }}:: {{ objname }}
     :show-inheritance:
     :special-members: __call__
@@ -16,11 +17,13 @@
 
 {% if objtype in ['class', 'method', 'function'] %}
 {% if objname in ['AxesGrid', 'Scalable', 'HostAxes', 'FloatingAxes',
-                      'ParasiteAxesAuxTrans', 'ParasiteAxes'] %}
+'ParasiteAxesAuxTrans', 'ParasiteAxes'] %}
+
 .. Filter out the above aliases to other classes, as sphinx gallery
    creates no example file for those (sphinx-gallery/sphinx-gallery#365)
 
 {% else %}
+
 .. minigallery:: {{module}}.{{objname}}
    :add-heading:
 

--- a/doc/_templates/autosummary_class_only.rst
+++ b/doc/_templates/autosummary_class_only.rst
@@ -5,6 +5,7 @@
 
 
 {% if objtype in ['class'] %}
+
 .. auto{{ objtype }}:: {{ objname }}
     :no-members:
 

--- a/doc/api/next_api_changes/behavior/25775-HZ.rst
+++ b/doc/api/next_api_changes/behavior/25775-HZ.rst
@@ -4,7 +4,7 @@ Default antialiasing behavior changes for ``Text`` and ``Annotation``
 ``matplotlib.pyplot.annotate()`` and ``matplotlib.pyplot.text()`` now support parameter *antialiased* when initializing.
 Examples:
 
-.. code-block::
+.. code-block:: python
 
     mpl.text.Text(.5, .5, "foo\nbar", antialiased=True)
     plt.text(0.5, 0.5, '6 inches x 2 inches', antialiased=True)

--- a/doc/api/prev_api_changes/api_changes_2.1.2.rst
+++ b/doc/api/prev_api_changes/api_changes_2.1.2.rst
@@ -13,7 +13,7 @@ didn't handle linewidths or linestyles etc.
 
 This logic did not exist in `.axes.Axes.legend`.  It was included (erroneously)
 in Matplotlib 2.1.1 when the legend argument parsing was unified
-[#9324](https://github.com/matplotlib/matplotlib/pull/9324).  This change
+`#9324 <https://github.com/matplotlib/matplotlib/pull/9324>`_.  This change
 removes that check in `.axes.Axes.legend` again to restore the old behavior.
 
 This logic has also been dropped from `.Figure.legend`, where it

--- a/doc/api/prev_api_changes/api_changes_2.1.2.rst
+++ b/doc/api/prev_api_changes/api_changes_2.1.2.rst
@@ -12,9 +12,9 @@ list of conditions was incomplete, didn't handle RGB tuples,
 didn't handle linewidths or linestyles etc.
 
 This logic did not exist in `.axes.Axes.legend`.  It was included (erroneously)
-in Matplotlib 2.1.1 when the legend argument parsing was unified
-`#9324 <https://github.com/matplotlib/matplotlib/pull/9324>`_.  This change
-removes that check in `.axes.Axes.legend` again to restore the old behavior.
+in Matplotlib 2.1.1 when the legend argument parsing was unified :ghpull:`9324`.  
+This change removes that check in `.axes.Axes.legend` again to restore the old 
+behavior.
 
 This logic has also been dropped from `.Figure.legend`, where it
 was previously undocumented. Repeated

--- a/doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/behaviour.rst
@@ -132,7 +132,7 @@ consistently exposes all the attributes and methods related to the line marker
 (:ghissue:`11358`). This makes it easy to change the marker features after
 instantiating a legend.
 
-.. code::
+.. code-block:: python
 
     import matplotlib.pyplot as plt
 
@@ -147,7 +147,7 @@ instantiating a legend.
 The former legend handler for Line2D objects has been renamed
 `.HandlerLine2DCompound`. To revert to the previous behaviour, one can use
 
-.. code::
+.. code-block:: python
 
     import matplotlib.legend as mlegend
     from matplotlib.legend_handler import HandlerLine2DCompound

--- a/doc/api/prev_api_changes/api_changes_3.7.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.7.0/behaviour.rst
@@ -51,7 +51,7 @@ Now, the halfrange remains fixed when vcenter is changed, and **vmin** and
 
 For example, this is what the values were when changing vcenter previously.
 
-.. code-block::
+.. code-block:: python
 
     norm = CenteredNorm(vcenter=0, halfrange=1)
     # Move vcenter up by one
@@ -61,7 +61,7 @@ For example, this is what the values were when changing vcenter previously.
 
 and now, with that same example
 
-.. code-block::
+.. code-block:: python
 
     norm = CenteredNorm(vcenter=0, halfrange=1)
     norm.vcenter = 1

--- a/doc/devel/MEP/MEP23.rst
+++ b/doc/devel/MEP/MEP23.rst
@@ -34,8 +34,8 @@ This is and may continue to be the desired method of operation for
 most use cases.
 
 Sometimes when there are too many figures open at the same time, it is
-desirable to be able to group these under the same window
-`see <https://github.com/matplotlib/matplotlib/issues/2194>`_.
+desirable to be able to group these under the same window. See :ghpull:`2194`.
+
 
 The proposed solution modifies `.FigureManagerBase` to contain and manage more
 than one ``Canvas``. The settings parameter :rc:`backend.multifigure` control

--- a/doc/devel/MEP/MEP23.rst
+++ b/doc/devel/MEP/MEP23.rst
@@ -35,7 +35,7 @@ most use cases.
 
 Sometimes when there are too many figures open at the same time, it is
 desirable to be able to group these under the same window
-[see](https://github.com/matplotlib/matplotlib/issues/2194).
+`see <https://github.com/matplotlib/matplotlib/issues/2194>`_.
 
 The proposed solution modifies `.FigureManagerBase` to contain and manage more
 than one ``Canvas``. The settings parameter :rc:`backend.multifigure` control
@@ -44,7 +44,7 @@ when the **MultiFigure** behaviour is desired.
 **Note**
 
 It is important to note, that the proposed solution, assumes that the
-[MEP22](https://github.com/matplotlib/matplotlib/wiki/Mep22) is
+`MEP22 <https://github.com/matplotlib/matplotlib/wiki/Mep22>`_. is
 already in place. This is simply because the actual implementation of
 the ``Toolbar`` makes it pretty hard to switch between canvases.
 

--- a/doc/devel/MEP/MEP28.rst
+++ b/doc/devel/MEP/MEP28.rst
@@ -264,6 +264,7 @@ value of ``statfxn`` would be ``cbook.boxplot_stats``, but users could
 pass their own function. Then ``transform_in`` and ``transform_out`` would
 then be passed as elements of the ``statfxn_args`` parameter.
 
+.. rstcheck: ignore-next-code-block
 .. code:: python
 
    def boxplot_stats(data, ..., transform_in=None, transform_out=None):

--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -170,18 +170,18 @@ also welcome to post feature requests or pull requests.
 
 If you are reporting a bug, please do your best to include the following:
 
-1. A short, top-level summary of the bug. In most cases, this should be 1-2
+#. A short, top-level summary of the bug. In most cases, this should be 1-2
    sentences.
 
-2. A short, self-contained code snippet to reproduce the bug, ideally allowing
+#. A short, self-contained code snippet to reproduce the bug, ideally allowing
    a simple copy and paste to reproduce. Please do your best to reduce the code
    snippet to the minimum required.
 
-3. The actual outcome of the code snippet.
+#. The actual outcome of the code snippet.
 
-4. The expected outcome of the code snippet.
+#. The expected outcome of the code snippet.
 
-5. The Matplotlib version, Python version and platform that you are using. You
+#. The Matplotlib version, Python version and platform that you are using. You
    can grab the version with the following commands::
 
       >>> import matplotlib
@@ -229,52 +229,54 @@ contribute to Matplotlib.
 
 A brief overview of the workflow is as follows.
 
-1. `Create an account <https://github.com/join>`_ on GitHub if you do not
+#. `Create an account <https://github.com/join>`_ on GitHub if you do not
    already have one.
 
-2. Fork the `project repository <https://github.com/matplotlib/matplotlib>`_:
-   click on the 'Fork' button near the top of the page. This creates a copy of
-   the code under your account on the GitHub server.
+#. Fork the `project repository <https://github.com/matplotlib/matplotlib>`_ by
+   clicking on the :octicon:`repo-forked` **Fork** button near the top of the page.
+   This creates a copy of the code under your account on the GitHub server.
 
-.. tab-set::
+#. Set up a development environment:
 
-    .. tab-item:: Local development
+   .. tab-set::
 
-        3. Clone this copy to your local disk::
+      .. tab-item:: Local development
 
-             git clone https://github.com/<YOUR GITHUB USERNAME>/matplotlib.git
+          Clone this copy to your local disk::
 
-    .. tab-item:: Using GitHub Codespaces
+            git clone https://github.com/<YOUR GITHUB USERNAME>/matplotlib.git
 
-        3. Check out the Matplotlib repository and activate your development
-           environment:
+      .. tab-item:: Using GitHub Codespaces
 
-           * Open codespaces on your fork by clicking on the green "Code" button
+          Check out the Matplotlib repository and activate your development environment:
+
+          #. Open codespaces on your fork by clicking on the green "Code" button
              on the GitHub web interface and selecting the "Codespaces" tab.
-           * Next, click on "Open codespaces on <your branch name>". You will be
+
+          #. Next, click on "Open codespaces on <your branch name>". You will be
              able to change branches later, so you can select the default
              ``main`` branch.
-           * After the codespace is created, you will be taken to a new browser
+
+          #. After the codespace is created, you will be taken to a new browser
              tab where you can use the terminal to activate a pre-defined conda
              environment called ``mpl-dev``::
 
-               conda activate mpl-dev
+              conda activate mpl-dev
 
 
-
-4. Install the local version of Matplotlib with::
+#. Install the local version of Matplotlib with::
 
      python -m pip install -e .
 
    See :ref:`installing_for_devs` for detailed instructions.
 
-5. Create a branch to hold your changes::
+#. Create a branch to hold your changes::
 
      git checkout -b my-feature origin/main
 
    and start making changes. Never work in the ``main`` branch!
 
-6. Work on this task using Git to do the version control. Codespaces persist for
+#. Work on this task using Git to do the version control. Codespaces persist for
    some time (check the `documentation for details
    <https://docs.github.com/codespaces/getting-started/the-codespace-lifecycle>`_)
    and can be managed on https://github.com/codespaces. When you're done editing
@@ -301,11 +303,11 @@ GitHub Codespaces workflows
   <https://github.com/devcontainers/features/tree/main/src/desktop-lite>`_.
   You can use it by connecting to this desktop via your web browser. To do this:
 
-  1. Press ``F1`` or ``Ctrl/Cmd+Shift+P`` and select
+  #. Press ``F1`` or ``Ctrl/Cmd+Shift+P`` and select
      ``Ports: Focus on Ports View`` in the VSCode session to bring it into
      focus. Open the ports view in your tool, select the ``noVNC`` port, and
      click the Globe icon.
-  2. In the browser that appears, click the Connect button and enter the desktop
+  #. In the browser that appears, click the Connect button and enter the desktop
      password (``vscode`` by default).
 
   Check the `GitHub instructions
@@ -391,10 +393,11 @@ Rules
 Introducing
 ~~~~~~~~~~~
 
-1. Announce the deprecation in a new file
+#. Announce the deprecation in a new file
    :file:`doc/api/next_api_changes/deprecations/99999-ABC.rst` where ``99999``
    is the pull request number and ``ABC`` are the contributor's initials.
-2. If possible, issue a `~matplotlib.MatplotlibDeprecationWarning` when the
+
+#. If possible, issue a `~matplotlib.MatplotlibDeprecationWarning` when the
    deprecated API is used. There are a number of helper tools for this:
 
    - Use ``_api.warn_deprecated()`` for general deprecation warnings
@@ -411,7 +414,7 @@ Introducing
 
    You can use standard rst cross references in *alternative*.
 
-3. Make appropriate changes to the type hints in the associated ``.pyi`` file.
+#. Make appropriate changes to the type hints in the associated ``.pyi`` file.
    The general guideline is to match runtime reported behavior.
 
    - Items marked with ``@_api.deprecated`` or ``@_api.deprecate_privatize_attribute``
@@ -431,15 +434,17 @@ Introducing
 Expiring
 ~~~~~~~~
 
-1. Announce the API changes in a new file
+#. Announce the API changes in a new file
    :file:`doc/api/next_api_changes/[kind]/99999-ABC.rst` where ``99999``
    is the pull request number and ``ABC`` are the contributor's initials, and
    ``[kind]`` is one of the folders :file:`behavior`, :file:`development`,
    :file:`removals`. See :file:`doc/api/next_api_changes/README.rst` for more
    information. For the content, you can usually copy the deprecation notice
    and adapt it slightly.
-2. Change the code functionality and remove any related deprecation warnings.
-3. Make appropriate changes to the type hints in the associated ``.pyi`` file.
+
+#. Change the code functionality and remove any related deprecation warnings.
+
+#. Make appropriate changes to the type hints in the associated ``.pyi`` file.
 
    - Items marked with ``@_api.deprecated`` or ``@_api.deprecate_privatize_attribute``
      are to be removed on expiry.

--- a/doc/devel/document.rst
+++ b/doc/devel/document.rst
@@ -668,7 +668,7 @@ in that case, they can be documented as an ``.. ACCEPTS:`` block, e.g. for
 
 .. code-block:: python
 
-   def set_xlim(self, ...):
+   def set_xlim(self, left=None, right=None):
        """
        Set the x-axis view limits.
 

--- a/doc/users/next_whats_new/antialiasing_text_annotation.rst
+++ b/doc/users/next_whats_new/antialiasing_text_annotation.rst
@@ -6,7 +6,7 @@ When *antialiased* is set to ``False``, antialiasing will not be applied to the 
 When *antialiased* is not specified, antialiasing will be set by :rc:`text.antialiased` at the creation time of ``Text`` and ``Annotation`` object.
 Examples:
 
-.. code-block::
+.. code-block:: python
 
     mpl.text.Text(.5, .5, "foo\nbar", antialiased=True)
     plt.text(0.5, 0.5, '6 inches x 2 inches', antialiased=True)
@@ -15,7 +15,7 @@ Examples:
 If the text contains math expression, *antialiased* applies to the whole text.
 Examples:
 
-.. code-block::
+.. code-block:: python
 
     # no part will be antialiased for the text below
     plt.text(0.5, 0.25, r"$I'm \sqrt{x}$", antialiased=False)

--- a/doc/users/next_whats_new/boldsym_mathtext.rst
+++ b/doc/users/next_whats_new/boldsym_mathtext.rst
@@ -6,7 +6,7 @@ Supports using the ``\boldsymbol{}`` command in mathtext:
 To change symbols to bold enclose the text in a font command as
 shown:
 
-.. code-block::
+.. code-block:: none
 
     r'$\boldsymbol{a+2+\alpha}$'
 

--- a/doc/users/next_whats_new/mathtext_features.rst
+++ b/doc/users/next_whats_new/mathtext_features.rst
@@ -5,7 +5,7 @@
 
 To use it to enclose the math in a substack command as shown:
 
-.. code-block::
+.. code-block:: none
 
     r'$\sum_{\substack{1\leq i\leq 3\\ 1\leq j\leq 5}}$'
 
@@ -23,7 +23,7 @@ The ``\middle`` delimiter has been added, and can now be used with the
 To use the middle command enclose it in between the ``\left`` and
 ``\right`` delimiter command as shown:
 
-.. code-block::
+.. code-block:: none
 
     r'$\left( \frac{a}{b} \middle| q \right)$'
 

--- a/doc/users/next_whats_new/updated_mathtext.rst
+++ b/doc/users/next_whats_new/updated_mathtext.rst
@@ -6,9 +6,9 @@ Supports use of bold-italic font style in mathtext using the ``\mathbfit{}`` com
 To change font to bold and italic enclose the text in a font command as
 shown:
 
-.. code-block::
+.. code-block:: none
 
-    r'$\mathbfit{\eta \leq C(\delta(\eta))}$
+    r'$\mathbfit{\eta \leq C(\delta(\eta))}$'
 
 .. math::
    \mathbfit{\eta \leq C(\delta(\eta))}

--- a/doc/users/prev_whats_new/dflt_style_changes.rst
+++ b/doc/users/prev_whats_new/dflt_style_changes.rst
@@ -13,7 +13,7 @@ are designed to work well in the most common cases.
 A 'classic' style sheet is provided so reverting to the 1.x default
 values is a single line of python
 
-.. code::
+.. code-block:: python
 
   import matplotlib.style
   import matplotlib as mpl
@@ -102,14 +102,14 @@ denote the first 10 colors in :rc:`axes.prop_cycle`. See
 
 To restore the old color cycle use
 
-.. code::
+.. code-block:: python
 
    from cycler import cycler
    mpl.rcParams['axes.prop_cycle'] = cycler(color='bgrcmyk')
 
 or set
 
-.. code::
+.. code-block:: cfg
 
    axes.prop_cycle    : cycler('color', 'bgrcmyk')
 
@@ -156,13 +156,13 @@ map.  For details on all of the colormaps available in matplotlib see
 
 The previous default can be restored using
 
-.. code::
+.. code-block:: python
 
    mpl.rcParams['image.cmap'] = 'jet'
 
 or setting
 
-.. code::
+.. code-block:: cfg
 
    image.cmap    : 'jet'
 

--- a/doc/users/prev_whats_new/github_stats_3.0.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.0.0.rst
@@ -128,7 +128,7 @@ The following 478 authors contributed 9809 commits.
 * Drew J. Sonne
 * Duncan Macleod
 * Dylan Evans
-* E. G. Patrick Bos
+* E\. G\. Patrick Bos
 * Egor Panfilov
 * Elijah Schutz
 * Elizabeth Seiver
@@ -205,7 +205,7 @@ The following 478 authors contributed 9809 commits.
 * Isaac Slavitt
 * Ismo Toijala
 * J Alammar
-* J. Goutin
+* J\. Goutin
 * Jaap Versteegh
 * Jacob McDonald
 * jacob-on-github
@@ -464,7 +464,7 @@ The following 478 authors contributed 9809 commits.
 * Tuan Dung Tran
 * u55
 * ultra-andy
-* V. R
+* V\. R
 * vab9
 * Valentin Schmidt
 * Vedant Nanda

--- a/doc/users/prev_whats_new/github_stats_3.2.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.2.0.rst
@@ -119,7 +119,7 @@ The following 164 authors contributed 3455 commits.
 * Nicolas Courtemanche
 * Nikita Kniazev
 * njwhite
-* O. Castany
+* O\. Castany
 * Oliver Natt
 * Olivier
 * Om Sitapara
@@ -142,7 +142,7 @@ The following 164 authors contributed 3455 commits.
 * Richard Ji-Cathriner
 * RoryIAngus
 * Ryan May
-* S. Fukuda
+* S\. Fukuda
 * Samesh
 * Samesh Lakhotia
 * sasoripathos
@@ -164,7 +164,7 @@ The following 164 authors contributed 3455 commits.
 * Tim Hoffmann
 * Tom Flannaghan
 * Travis CI
-* V. Armando Solé
+* V\. Armando Solé
 * Vincent L.M. Mazoyer
 * Viraj Mohile
 * Wafa Soofi

--- a/doc/users/prev_whats_new/github_stats_3.4.0.rst
+++ b/doc/users/prev_whats_new/github_stats_3.4.0.rst
@@ -82,7 +82,7 @@ The following 177 authors contributed 3852 commits.
 * ImportanceOfBeingErnest
 * Isuru Fernando
 * ItsRLuo
-* J. Scott Berg
+* J\. Scott Berg
 * Jae-Joon Lee
 * Jakub Klus
 * Janakarajan Natarajan

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -517,7 +517,8 @@ also prevents unsafe usage by strictly defining the parameters that a
 user can set.
 
 To use, call ``set_params()`` on a `.Locator` instance with desired arguments:
-::
+
+.. code-block:: python
 
     loc = matplotlib.ticker.LogLocator()
     # Set given attributes for loc.

--- a/doc/users/prev_whats_new/whats_new_3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.0.rst
@@ -147,7 +147,7 @@ Add ``ax.get_gridspec`` to ``SubplotBase``
 New method ``SubplotBase.get_gridspec`` is added so that users can
 easily get the gridspec that went into making an axes:
 
-.. code::
+.. code-block:: python
 
     import matplotlib.pyplot as plt
 

--- a/doc/users/prev_whats_new/whats_new_3.4.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.4.0.rst
@@ -494,7 +494,7 @@ display an image of the colormap.
 
 .. only:: html
 
-    .. code-block::
+    .. code-block:: ipython
 
         In[1]: cmap = plt.get_cmap('viridis').with_extremes(bad='r', under='g', over='b')
 

--- a/doc/users/prev_whats_new/whats_new_3.5.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.5.0.rst
@@ -284,7 +284,7 @@ Simplifying the font setting for usetex mode
 Now the :rc:`font.family` accepts some font names as value for a more
 user-friendly setup.
 
-.. code-block::
+.. code-block:: python
 
     plt.rcParams.update({
         "text.usetex": True,
@@ -561,7 +561,7 @@ to block callback signals from being processed by the ``CallbackRegistry``.
 The optional keyword, *signal*, can be used to block a specific signal
 from being processed and let all other signals pass.
 
-.. code-block::
+.. code-block:: python
 
     import matplotlib.pyplot as plt
 

--- a/galleries/users_explain/text/mathtext.py
+++ b/galleries/users_explain/text/mathtext.py
@@ -221,6 +221,7 @@ fig.text(.1, .1, r'even: $ \delta $ = $ \$4 $')
 # ``\mathcal{CALLIGRAPHY}`` :mathmpl:`\mathcal{CALLIGRAPHY}`
 # ========================= ================================
 #
+# .. rstcheck: ignore-directives=role
 # .. role:: math-stix(mathmpl)
 #    :fontset: stix
 #

--- a/galleries/users_explain/toolkits/axisartist.rst
+++ b/galleries/users_explain/toolkits/axisartist.rst
@@ -341,63 +341,18 @@ On the other hand, there is a concept of "axis_direction". This is a
 default setting of above properties for each, "bottom", "left", "top",
 and "right" axis.
 
-.. list-table::
-
-  * -
-    -
-    - left
-    - bottom
-    - right
-    - top
-  * - axislabel
-    - direction
-    - '-'
-    - '+'
-    - '+'
-    - '-'
-  * - axislabel
-    - rotation
-    - 180
-    - 0
-    - 0
-    - 180
-  * - axislabel
-    - va
-    - center
-    - top
-    - center
-    - bottom
-  * - axislabel
-    - ha
-    - right
-    - center
-    - right
-    - center
-  * - ticklabel
-    - direction
-    - '-'
-    - '+'
-    - '+'
-    - '-'
-  * - ticklabels
-    - rotation
-    - 90
-    - 0
-    - -90
-    - 180
-  * - ticklabel
-    - ha
-    - right
-    - center
-    - right
-    - center
-  * - ticklabel
-    - va
-    - center
-    - baseline
-    - center
-    - baseline
-
+========== ========== ========= ========== ========= ==========
+label type  parameter    left      bottom      right      top
+========== ========== ========= ========== ========= ==========
+axislabel   direction      '-'       '+'        '+'      '-'
+axislabel   rotation      180         0          0       180
+axislabel   va           center    top       center     bottom
+axislabel   ha           right    center      right     center
+ticklabel   direction      '-'       '+'        '+'      '-'
+ticklabel   rotation       90         0        -90       180
+ticklabel   ha           right    center      right     center
+ticklabel   va           center   baseline    center   baseline
+========== ========== ========= ========== ========= ==========
 
 And, 'set_axis_direction("top")' means to adjust the text rotation
 etc, for settings suitable for "top" axis. The concept of axis

--- a/galleries/users_explain/toolkits/axisartist.rst
+++ b/galleries/users_explain/toolkits/axisartist.rst
@@ -341,18 +341,63 @@ On the other hand, there is a concept of "axis_direction". This is a
 default setting of above properties for each, "bottom", "left", "top",
 and "right" axis.
 
-========== =========== ========= ========== ========= ==========
-   ?           ?        left      bottom      right      top
----------- ----------- --------- ---------- --------- ----------
-axislabel   direction      '-'       '+'        '+'      '-'
-axislabel   rotation      180         0          0       180
-axislabel   va           center    top       center     bottom
-axislabel   ha           right    center      right     center
-ticklabel   direction      '-'       '+'        '+'      '-'
-ticklabels  rotation       90         0        -90       180
-ticklabel   ha           right    center      right     center
-ticklabel   va           center   baseline    center   baseline
-========== =========== ========= ========== ========= ==========
+.. list-table::
+
+  * -
+    -
+    - left
+    - bottom
+    - right
+    - top
+  * - axislabel
+    - direction
+    - '-'
+    - '+'
+    - '+'
+    - '-'
+  * - axislabel
+    - rotation
+    - 180
+    - 0
+    - 0
+    - 180
+  * - axislabel
+    - va
+    - center
+    - top
+    - center
+    - bottom
+  * - axislabel
+    - ha
+    - right
+    - center
+    - right
+    - center
+  * - ticklabel
+    - direction
+    - '-'
+    - '+'
+    - '+'
+    - '-'
+  * - ticklabels
+    - rotation
+    - 90
+    - 0
+    - -90
+    - 180
+  * - ticklabel
+    - ha
+    - right
+    - center
+    - right
+    - center
+  * - ticklabel
+    - va
+    - center
+    - baseline
+    - center
+    - baseline
+
 
 And, 'set_axis_direction("top")' means to adjust the text rotation
 etc, for settings suitable for "top" axis. The concept of axis

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,3 +140,66 @@ ignore_missing_imports = true
 enable_incomplete_feature = [
   "Unpack",
 ]
+
+[tool.rstcheck]
+ignore_directives = [
+    # matplotlib.sphinxext.mathmpl
+    "mathmpl",
+    # matplotlib.sphinxext.plot_directive
+    "plot",
+    # sphinxext.math_symbol_table
+    "math_symbol_table",
+    # sphinxext.redirect_from
+    "redirect-from",
+    # sphinx-design
+    "dropdown",
+    "grid",
+    "tab-set",
+    # sphinx-gallery
+    "minigallery",
+    "image-sg",
+    # sphinx.ext.autodoc
+    "automodule",
+    "autoclass",
+    "autofunction",
+    "autodata",
+    "automethod",
+    "autoattribute",
+    "autoproperty",
+    # sphinx.ext.autosummary
+    "autosummary",
+    # sphinx.ext.ifconfig
+    "ifconfig",
+    # sphinx.ext.inheritance_diagram
+    "inheritance-diagram",
+    # include directive is causing attribute errors
+    "include"
+]
+ignore_roles = [
+    # sphinxext.custom_roles
+    "rc",
+    # matplotlib.sphinxext.mathmpl
+    "mathmpl",
+    "math-stix",
+    # sphinxext.github
+    "ghissue",
+    "ghpull",
+    "ghuser",
+    # sphinx-design
+    "octicon",
+]
+ignore_substitutions = [
+    "Artist",
+    "Axes",
+    "Axis",
+    "Figure",
+    "release"
+]
+
+ignore_messages = [
+    "Hyperlink target \".*\" is not referenced.",
+    "Duplicate implicit target name: \".*\".",
+    "Duplicate explicit target name: \".*\".",
+    # error in role directive is `.. role:: math-stix(mathmpl)
+    "Error in \"role\" directive:",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -200,6 +200,4 @@ ignore_messages = [
     "Hyperlink target \".*\" is not referenced.",
     "Duplicate implicit target name: \".*\".",
     "Duplicate explicit target name: \".*\".",
-    # error in role directive is `.. role:: math-stix(mathmpl)
-    "Error in \"role\" directive:",
 ]


### PR DESCRIPTION
Adds [rstcheck](https://github.com/rstcheck/rstcheck) as a pre-commit hook, mostly cause I seem to have a mental block about underlines being same length as title. This pre-commit also has the advantage of being pretty configurable. 

The .rst files in this PR are the linting errors I could fix because I wanted to minimize the ignored errors as much as possible.