### PR TITLE
Make variables private in Tk-backend

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -26,7 +26,7 @@ from . import _tkagg
 
 
 _log = logging.getLogger(__name__)
-cursord = {
+_CURSOR_DICT = {
     cursors.MOVE: "fleur",
     cursors.HAND: "hand2",
     cursors.POINTER: "arrow",
@@ -51,8 +51,8 @@ _blit_args = {}
 # Initialize to a non-empty string that is not a Tcl command
 _blit_tcl_name = "mpl_blit_" + uuid.uuid4().hex
 
-TK_PHOTO_COMPOSITE_OVERLAY = 0  # apply transparency rules pixel-wise
-TK_PHOTO_COMPOSITE_SET = 1  # set image buffer directly
+_TK_PHOTO_COMPOSITE_OVERLAY = 0  # apply transparency rules pixel-wise
+_TK_PHOTO_COMPOSITE_SET = 1  # set image buffer directly
 
 
 def _blit(argsid):
@@ -97,10 +97,10 @@ def blit(photoimage, aggimage, offsets, bbox=None):
         if (x1 > x2) or (y1 > y2):
             return
         bboxptr = (x1, x2, y1, y2)
-        comp_rule = TK_PHOTO_COMPOSITE_OVERLAY
+        comp_rule = _TK_PHOTO_COMPOSITE_OVERLAY
     else:
         bboxptr = (0, width, 0, height)
-        comp_rule = TK_PHOTO_COMPOSITE_SET
+        comp_rule = _TK_PHOTO_COMPOSITE_SET
 
     # NOTE: _tkagg.blit is thread unsafe and will crash the process if called
     # from a thread (GH#13293). Instead of blanking and blitting here,
@@ -434,7 +434,7 @@ class FigureCanvasTk(FigureCanvasBase):
 
     def set_cursor(self, cursor):
         try:
-            self._tkcanvas.configure(cursor=cursord[cursor])
+            self._tkcanvas.configure(cursor=_CURSOR_DICT[cursor])
         except tkinter.TclError:
             pass
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

As discussed in https://github.com/matplotlib/matplotlib/issues/26720 there was an idea to make the common parts of the tk-backend public so that it is included in the documentation. As part of that, @anntzer pointed out https://github.com/matplotlib/matplotlib/issues/26720#issuecomment-1712481909 that we probably should make "global" variables private. This PR does that.

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
