### PR TITLE
DOC: Add redirects for old gitwash files

### DIFF
--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -1,5 +1,8 @@
 .. highlight:: bash
 
+.. redirect-from:: /devel/gitwash/development_workflow
+.. redirect-from:: /devel/gitwash/maintainer_workflow
+
 .. _development-workflow:
 
 ####################


### PR DESCRIPTION
## PR summary

These were deleted in 3.7.0, and a bunch of redirects were added in #24629, but these two were missed.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines