### PR TITLE
Trim Gouraud triangles that contain NaN

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -142,6 +142,25 @@ def test_pcolormesh_pre_transform_limits():
     assert_almost_equal(expected, ax.dataLim.get_points())
 
 
+def test_pcolormesh_gouraud_nans():
+    np.random.seed(19680801)
+
+    values = np.linspace(0, 180, 3)
+    radii = np.linspace(100, 1000, 10)
+    z, y = np.meshgrid(values, radii)
+    x = np.radians(np.random.rand(*z.shape) * 100)
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection="polar")
+    # Setting the limit to cause clipping of the r values causes NaN to be
+    # introduced; these should not crash but be ignored as in other path
+    # operations.
+    ax.set_rlim(101, 1000)
+    ax.pcolormesh(x, y, z, shading="gouraud")
+
+    fig.canvas.draw()
+
+
 def test_Affine2D_from_values():
     points = np.array([[0, 0],
                        [10, 20],

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -1193,6 +1193,9 @@ inline void RendererAgg::_draw_gouraud_triangle(PointArray &points,
             tpoints[i][j] = points(i, j);
         }
         trans.transform(&tpoints[i][0], &tpoints[i][1]);
+        if(std::isnan(tpoints[i][0]) || std::isnan(tpoints[i][1])) {
+            return;
+        }
     }
 
     span_alloc_t span_alloc;


### PR DESCRIPTION
## PR summary

Agg enters an infinite loop if you give it points that are NaN, due to converting the values to fixed-point integers, and then oscillating between the large values that result from that conversion.

NaN values may be introduced after transforming the input, so we need to trim those after transformation. This matches what is done in normal paths.

The test itself is mostly a smoketest to ensure we don't crash.

Closes #26765

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines