### PR TITLE
DOC: Pin mpl-sphinx-theme to 3.8.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,8 +100,6 @@ commands:
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> \
                 -r requirements/doc/doc-requirements.txt
-            python -m pip install --no-deps --user \
-                git+https://github.com/matplotlib/mpl-sphinx-theme.git
 
   mpl-install:
     steps:

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -15,7 +15,7 @@ ipykernel
 numpydoc>=1.0
 packaging>=20
 pydata-sphinx-theme~=0.13.1
-mpl-sphinx-theme~=3.7.0
+mpl-sphinx-theme~=3.8.0
 pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.12.0


### PR DESCRIPTION
## PR summary

We only want the dev version on devdocs. Releases should get their corresponding theme.

Note that even though this was unpinned for the `v3.7.x` branch as well, it inadvertently worked because the version number in `mpl-sphinx-theme`'s `main` branch was still 3.7.1, so it never replaced the version from PyPI.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines