### PR TITLE
Fix typing for class FigureCanvasBase : add typing for the "canvas" constructor argument.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2632,7 +2632,7 @@ class FigureManagerBase:
     _toolbar2_class = None
     _toolmanager_toolbar_class = None
 
-    def __init__(self, canvas, num):
+    def __init__(self, canvas: FigureCanvasBase, num):
         self.canvas = canvas
         canvas.manager = self  # store a pointer to parent
         self.num = num


### PR DESCRIPTION
## PR summary
The "canvas" constructor argument of FigureCanvasBase was not typed, causing the "canvas" attribute to be typed as Any.
This caused multiple methods of the FigureCanvasBase class to lose readability and usability.
The type was added for the constructor argument, successfully improving typing of multiple class methods which used that attribute.
closes #26772
## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
