### PR TITLE
Update kiwisolver and pillow versions to be consistent with requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,9 +14,9 @@ dependencies:
   - cycler>=0.10.0
   - fonttools>=4.22.0
   - importlib-resources>=3.2.0
-  - kiwisolver>=1.0.1
+  - kiwisolver>=1.3.1
   - numpy>=1.21
-  - pillow>=6.2
+  - pillow>=8
   - pybind11>=2.6.0
   - pygobject
   - pyparsing>=2.3.1

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -246,7 +246,7 @@ def _check_versions():
     for modname, minver in [
             ("cycler", "0.10"),
             ("dateutil", "2.7"),
-            ("kiwisolver", "1.0.1"),
+            ("kiwisolver", "1.3.1"),
             ("numpy", "1.21"),
             ("pyparsing", "2.3.1"),
     ]:

--- a/requirements/testing/mypy.txt
+++ b/requirements/testing/mypy.txt
@@ -17,10 +17,10 @@ sphinx
 contourpy>=1.0.1
 cycler>=0.10
 fonttools>=4.22.0
-kiwisolver>=1.0.1
+kiwisolver>=1.3.1
 numpy>=1.19
 packaging>=20.0
-pillow>=6.2.0
+pillow>=8
 pyparsing>=2.3.1
 python-dateutil>=2.7
 setuptools_scm>=7

--- a/setup.py
+++ b/setup.py
@@ -332,10 +332,10 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "contourpy>=1.0.1",
         "cycler>=0.10",
         "fonttools>=4.22.0",
-        "kiwisolver>=1.0.1",
+        "kiwisolver>=1.3.1",
         "numpy>=1.21",
         "packaging>=20.0",
-        "pillow>=6.2.0",
+        "pillow>=8",
         "pyparsing>=2.3.1",
         "python-dateutil>=2.7",
     ] + (


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

It is documented that kiwisolver was bumped to 1.3.1 and pillow to 8 in MPL 3.8, but not consistently introduced in all files.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
