### PR TITLE
Remove plt.Axes from tests

### DIFF
--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -141,8 +141,7 @@ def test_noop_tight_bbox():
     dpi = 100
     # make the figure just the right size up front
     fig = plt.figure(frameon=False, dpi=dpi, figsize=(x_size/dpi, y_size/dpi))
-    ax = plt.Axes(fig, [0., 0., 1., 1.])
-    fig.add_axes(ax)
+    ax = fig.add_axes((0, 0, 1, 1))
     ax.set_axis_off()
     ax.xaxis.set_visible(False)
     ax.yaxis.set_visible(False)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -800,10 +800,8 @@ def test_image_preserve_size2():
     data = np.identity(n, float)
 
     fig = plt.figure(figsize=(n, n), frameon=False)
-
-    ax = plt.Axes(fig, [0.0, 0.0, 1.0, 1.0])
+    ax = fig.add_axes((0.0, 0.0, 1.0, 1.0))
     ax.set_axis_off()
-    fig.add_axes(ax)
     ax.imshow(data, interpolation='nearest', origin='lower', aspect='auto')
     buff = io.BytesIO()
     fig.savefig(buff, dpi=1)


### PR DESCRIPTION
Axes is considered private in pyplot. See also #26812.
