### PR TITLE
Fix doc build

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3534,7 +3534,7 @@ class _AxesBase(martist.Artist):
         --------
         set_xbound
         get_xlim, set_xlim
-        invert_xaxis, xaxis_inverted
+        .invert_xaxis, .xaxis_inverted
         """
         left, right = self.get_xlim()
         if left < right:
@@ -3561,7 +3561,7 @@ class _AxesBase(martist.Artist):
         --------
         get_xbound
         get_xlim, set_xlim
-        invert_xaxis, xaxis_inverted
+        .invert_xaxis, .xaxis_inverted
         """
         if upper is None and np.iterable(lower):
             lower, upper = lower
@@ -3787,7 +3787,7 @@ class _AxesBase(martist.Artist):
         --------
         set_ybound
         get_ylim, set_ylim
-        invert_yaxis, yaxis_inverted
+        .invert_yaxis, .yaxis_inverted
         """
         bottom, top = self.get_ylim()
         if bottom < top:
@@ -3814,7 +3814,7 @@ class _AxesBase(martist.Artist):
         --------
         get_ybound
         get_ylim, set_ylim
-        invert_yaxis, yaxis_inverted
+        .invert_yaxis, .yaxis_inverted
         """
         if upper is None and np.iterable(lower):
             lower, upper = lower

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -860,7 +860,7 @@ class Axes3D(Axes):
         --------
         get_xlim
         set_xbound, get_xbound
-        invert_xaxis, xaxis_inverted
+        .invert_xaxis, .xaxis_inverted
 
         Notes
         -----
@@ -932,7 +932,7 @@ class Axes3D(Axes):
         --------
         get_ylim
         set_ybound, get_ybound
-        invert_yaxis, yaxis_inverted
+        .invert_yaxis, .yaxis_inverted
 
         Notes
         -----


### PR DESCRIPTION
Attempt to fix doc build failure introduced with #25272.

I suspect this is sphinx scoping: #25272 reused methods like `Axes.set_xbounds` to generate documentation for Axes3D. However, a see also of invert_xaxis only searches within the same module (or class), and invert_xaxis is not documented for Axes3D. This PR broadens the search scope by using the leading dot. An alternative may be to attempt to explicitly document the missing methods for Axes3D (see #26818).

Only one of #26817, #26818 should be used, preferrably #26818 if it works out.

