### PR TITLE
Fix doc build (alternative)

### DIFF
--- a/doc/api/toolkits/mplot3d/axes3d.rst
+++ b/doc/api/toolkits/mplot3d/axes3d.rst
@@ -98,6 +98,10 @@ Axis limits and direction
    get_zlim
    set_zlim
    get_w_lims
+   invert_xaxis
+   xaxis_inverted
+   invert_yaxis
+   yaxis_inverted
    invert_zaxis
    zaxis_inverted
    get_xbound


### PR DESCRIPTION
Attempt to fix doc build failure introduced with #25272.

I suspect this is sphinx scoping: #25272 reused methods like `Axes.set_xbounds` to generate documentation for Axes3D. However, a see also of invert_xaxis only searches within the same module (or class), and invert_xaxis is not documented for Axes3D. This PR attempt to explicitly document the missing methods for Axes3D.

Only one of #26817, #26818 should be used, preferrably #26818 if it works out.