### PR TITLE
Fix Issue 26821: [Bug]: ValueError: The truth value... when an ndarray is passed to the color kwarg of axes3d.scatter

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2672,7 +2672,7 @@ class Axes3D(Axes):
         xs, ys, zs, s, c, color = cbook.delete_masked_points(
             xs, ys, zs, s, c, kwargs.get('color', None)
             )
-        if kwargs.get('color', None):
+        if kwargs.get("color") is not None:
             kwargs['color'] = color
 
         # For xs and ys, 2D scatter() will do the copying.

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2307,10 +2307,7 @@ def test_Poly3DCollection_init_value_error():
 def test_ndarray_color_kwargs_value_error():
     # smoke test
     # ensures ndarray can be passed to color in kwargs for 3d projection plot
-    try:
-        fig = plt.figure()
-        ax = fig.add_subplot(111, projection='3d')
-        ax.scatter(1, 0, 0, color=np.array([0, 0, 0, 1]))
-        fig.canvas.draw()
-    except ValueError:
-        pytest.fail("A ValueError was raised when it shouldn't have.")
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    ax.scatter(1, 0, 0, color=np.array([0, 0, 0, 1]))
+    fig.canvas.draw()

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2303,8 +2303,10 @@ def test_Poly3DCollection_init_value_error():
         poly = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], float)
         c = art3d.Poly3DCollection([poly], shade=True)
 
+
 def test_ndarray_color_kwargs_value_error():
-    # smoke test to ensure that ndarray can be passed to color in kwargs for a 3d projection plot
+    # smoke test 
+    # ensures ndarray can be passed to color in kwargs for 3d projection plot
     try:
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2309,5 +2309,6 @@ def test_ndarray_color_kwargs_value_error():
         fig = plt.figure()
         ax = fig.add_subplot(111, projection='3d')
         ax.scatter(1, 0, 0, color=np.array([0, 0, 0, 1]))
+        fig.canvas.draw()
     except ValueError:
         pytest.fail("A ValueError was raised when it shouldn't have.")

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2305,7 +2305,7 @@ def test_Poly3DCollection_init_value_error():
 
 
 def test_ndarray_color_kwargs_value_error():
-    # smoke test 
+    # smoke test
     # ensures ndarray can be passed to color in kwargs for 3d projection plot
     try:
         fig = plt.figure()

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2302,3 +2302,12 @@ def test_Poly3DCollection_init_value_error():
                         'or both for shade to work.'):
         poly = np.array([[0, 0, 1], [0, 1, 1], [0, 0, 0]], float)
         c = art3d.Poly3DCollection([poly], shade=True)
+
+def test_ndarray_color_kwargs_value_error():
+    # smoke test to ensure that ndarray can be passed to color in kwargs for a 3d projection plot
+    try:
+        fig = plt.figure()
+        ax = fig.add_subplot(111, projection='3d')
+        ax.scatter(1, 0, 0, color=np.array([0, 0, 0, 1]))
+    except ValueError:
+        pytest.fail("A ValueError was raised when it shouldn't have.")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

closes #26821 

relevant issue: https://github.com/matplotlib/matplotlib/issues/26821

I made this change based off of timhoffm's comment under the issue about a potential fix. (https://github.com/matplotlib/matplotlib/issues/26821#issuecomment-1724807332)

This PR allows for passing a numpy array to the color argument of ax.scatter when ax is initialized with projection='3d' instead of resulting in a ValueError

The changes passed the tests available for the relevant file (lib/mpl_toolkits/mplot3d/tests/test_axes3d.py), as well as that entire tests folder.

The changes also passed the code reproduction example in the joshuacnewton's bug summary (https://github.com/matplotlib/matplotlib/issues/26821#issue-1901885527)

<img width="463" alt="image" src="https://github.com/matplotlib/matplotlib/assets/86278218/0328a591-6a88-460c-a117-9222e8f23505">


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
