### PR TITLE
ci: Don't install recommended packages on Circle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,8 +42,8 @@ commands:
       - run:
           name: Install apt packages
           command: |
-            sudo apt -qq update
-            sudo apt install -y \
+            sudo apt-get -qq update
+            sudo apt-get install -yy --no-install-recommends \
               cm-super \
               dvipng \
               ffmpeg \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,24 +44,24 @@ commands:
           command: |
             sudo apt -qq update
             sudo apt install -y \
-              inkscape \
-              ffmpeg \
-              dvipng \
-              lmodern \
               cm-super \
-              texlive-latex-base \
-              texlive-latex-extra \
-              texlive-fonts-recommended \
-              texlive-latex-recommended \
-              texlive-pictures \
-              texlive-xetex \
-              ttf-wqy-zenhei \
-              graphviz \
+              dvipng \
+              ffmpeg \
               fonts-crosextra-carlito \
               fonts-freefont-otf \
               fonts-humor-sans \
               fonts-noto-cjk \
-              optipng
+              fonts-wqy-zenhei \
+              graphviz \
+              inkscape \
+              lmodern \
+              optipng \
+              texlive-fonts-recommended \
+              texlive-latex-base \
+              texlive-latex-extra \
+              texlive-latex-recommended \
+              texlive-pictures \
+              texlive-xetex
 
   fonts-install:
     steps:


### PR DESCRIPTION
## PR summary

This is a followup to #26505 as it appears I missed the Ubuntu in the Circle-CI builds. There's probably a lot more recommended LaTeX packages here, so we'll have to see if CI is happy with it.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines