### PR TITLE
Bump setuptools required version because of setuptools_scm v8

### DIFF
--- a/doc/api/next_api_changes/development/26849-KS.rst
+++ b/doc/api/next_api_changes/development/26849-KS.rst
@@ -1,0 +1,5 @@
+Minimum version of setuptools bumped to 64
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To comply with requirements of ``setuptools_scm``, the minimum version of ``setuptools``
+has been increased from 42 to 64.

--- a/doc/devel/dependencies.rst
+++ b/doc/devel/dependencies.rst
@@ -228,7 +228,7 @@ Setup dependencies
   runtime dependency.
 - `PyBind11 <https://pypi.org/project/pybind11/>`_ (>= 2.6). Used to connect C/C++ code
   with Python.
-- `setuptools <https://pypi.org/project/setuptools/>`_ (>= 42).
+- `setuptools <https://pypi.org/project/setuptools/>`_ (>= 64).
 - `setuptools_scm <https://pypi.org/project/setuptools-scm/>`_ (>= 7).  Used to
   update the reported ``mpl.__version__`` based on the current git commit.
   Also a runtime dependency for editable installs.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,16 @@ requires = [
     "certifi>=2020.06.20",
     "numpy>=1.25",
     "pybind11>=2.6",
-    "setuptools>=42",
+    "setuptools>=64",
     "setuptools_scm>=7",
 ]
+
+[tool.setuptools_scm]
+version_scheme = "release-branch-semver"
+local_scheme = "node-and-date"
+write_to = "lib/matplotlib/_version.py"
+parentdir_prefix_version = "matplotlib-"
+fallback_version = "0.0+UNKNOWN"
 
 [tool.isort]
 known_pydata = "numpy, matplotlib.pyplot"

--- a/requirements/testing/mypy.txt
+++ b/requirements/testing/mypy.txt
@@ -24,5 +24,6 @@ pillow>=8
 pyparsing>=2.3.1
 python-dateutil>=2.7
 setuptools_scm>=7
+setuptools>=64
 
 importlib-resources>=3.2.0 ; python_version < "3.10"

--- a/setup.py
+++ b/setup.py
@@ -340,7 +340,10 @@ setup(  # Finally, pass this all along to setuptools to do the heavy lifting.
         "python-dateutil>=2.7",
     ] + (
         # Installing from a git checkout that is not producing a wheel.
-        ["setuptools_scm>=7"] if (
+        # setuptools_scm warns with older setuptools, which turns into errors for our
+        # test suite. However setuptools_scm does not themselves pin the version of
+        # setuptools.
+        ["setuptools_scm>=7", "setuptools>=64"] if (
             Path(__file__).with_name(".git").exists() and
             os.environ.get("CIBUILDWHEEL", "0") != "1"
         ) else []


### PR DESCRIPTION
## PR summary

Technically could work with older setuptools and setuptools_scm==7,
but encoding that matrix of dependencies is not something I think is worth worrying about,
and setuptools 64 is over a year old (though not by a _whole_ lot).

setuptools_scm has a version constraint that they do not themselves enforce on the environment
so I've added it to our own requirements, when setuptools_scm is required.

Setuptools_scm's docs are inconsistent in what version they _actually_ require, so I went with
the one that was most up to date and was in their user facing docs.
(My next choice would be 61, as that is what the runtime warning actually checks)

The config in pyproject.toml was taken from #26621

Closes #26846
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
