### PR TITLE
Removed the deprecated code from `axis.py`

### DIFF
--- a/doc/api/next_api_changes/removals/26871-AG.rst
+++ b/doc/api/next_api_changes/removals/26871-AG.rst
@@ -1,0 +1,3 @@
+``matplotlib.axis.Axis.set_ticklabels``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... a param was renamed to labels from ticklabels.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1941,7 +1941,6 @@ class Axis(martist.Artist):
     def _format_with_dict(tickd, x, pos):
         return tickd.get(x, "")
 
-    @_api.rename_parameter("3.7", "ticklabels", "labels")
     def set_ticklabels(self, labels, *, minor=False, fontdict=None, **kwargs):
         r"""
         [*Discouraged*] Set this Axis' tick labels with list of string labels.


### PR DESCRIPTION
## PR summary
This PR removes the deprecated code during the version 3.7 from l`ib/matplotlib/axis.py` which is a sub issue in the parent issues here: https://github.com/matplotlib/matplotlib/issues/26865

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
