### PR TITLE
Deprecated code removed in animation.py

### DIFF
--- a/doc/api/next_api_changes/removals/26872-AD.rst
+++ b/doc/api/next_api_changes/removals/26872-AD.rst
@@ -1,0 +1,6 @@
+``repeat``
+~~~~~~~~~~
+... of `.TimedAnimation` is removed without replacements.
+``save_count``
+~~~~~~~~~~~~~~
+... of `.FuncAnimation` is removed without replacements.

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1446,8 +1446,6 @@ class TimedAnimation(Animation):
         self.event_source.interval = self._interval
         return True
 
-    repeat = _api.deprecate_privatize_attribute("3.7")
-
 
 class ArtistAnimation(TimedAnimation):
     """
@@ -1787,8 +1785,6 @@ class FuncAnimation(TimedAnimation):
 
             for a in self._drawn_artists:
                 a.set_animated(self._blit)
-
-    save_count = _api.deprecate_privatize_attribute("3.7")
 
 
 def _validate_grabframe_kwargs(savefig_kwargs):

--- a/lib/matplotlib/animation.pyi
+++ b/lib/matplotlib/animation.pyi
@@ -188,7 +188,6 @@ class Animation:
     def resume(self) -> None: ...
 
 class TimedAnimation(Animation):
-    repeat: bool
     def __init__(
         self,
         fig: Figure,
@@ -204,7 +203,6 @@ class ArtistAnimation(TimedAnimation):
     def __init__(self, fig: Figure, artists: Sequence[Collection[Artist]], *args, **kwargs) -> None: ...
 
 class FuncAnimation(TimedAnimation):
-    save_count: int
     def __init__(
         self,
         fig: Figure,


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->
## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR removes 3.7-deprecated API from `lib/matplotlib/animation.py` which is mentioned in the issue here: https://github.com/matplotlib/matplotlib/issues/26865
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
