### PR TITLE
Remove deprecated code from _fontconfig_patterns

### DIFF
--- a/doc/api/next_api_changes/removals/26884-JS.rst
+++ b/doc/api/next_api_changes/removals/26884-JS.rst
@@ -1,0 +1,5 @@
+``parse_fontconfig_pattern`` raises on unknown constant names
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, in a fontconfig pattern like ``DejaVu Sans:foo``, the unknown
+``foo`` constant name would be silently ignored.  This now raises an error.

--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -13,9 +13,7 @@ from functools import lru_cache, partial
 import re
 
 from pyparsing import (
-    Group, Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore)
-
-from matplotlib import _api
+    Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore, oneOf)
 
 
 _family_punc = r'\\\-:,'
@@ -63,8 +61,7 @@ def _make_fontconfig_parser():
     size = Regex(r"([0-9]+\.?[0-9]*|\.[0-9]+)")
     name = Regex(r"[a-z]+")
     value = Regex(fr"([^{_value_punc}]|(\\[{_value_punc}]))*")
-    # replace trailing `| name` by oneOf(_CONSTANTS) in mpl 3.9.
-    prop = Group((name + Suppress("=") + comma_separated(value)) | name)
+    prop = (name + Suppress("=") + comma_separated(value)) | oneOf(_CONSTANTS)
     return (
         Optional(comma_separated(family)("families"))
         + Optional("-" + comma_separated(size)("sizes"))
@@ -97,12 +94,6 @@ def parse_fontconfig_pattern(pattern):
         props["size"] = [*parse["sizes"]]
     for prop in parse.get("properties", []):
         if len(prop) == 1:
-            if prop[0] not in _CONSTANTS:
-                _api.warn_deprecated(
-                    "3.7", message=f"Support for unknown constants "
-                    f"({prop[0]!r}) is deprecated since %(since)s and "
-                    f"will be removed %(removal)s.")
-                continue
             prop = _CONSTANTS[prop[0]]
         k, *v = prop
         props.setdefault(k, []).extend(map(_value_unescape, v))

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -73,5 +73,5 @@ def test_fontconfig_str():
 
 
 def test_fontconfig_unknown_constant():
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(ValueError, match="ParseException"):
         FontProperties(":unknown")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
 This PR removes the deprecated code during the version 3.7 from lib/matplotlib/gridspec.py and lib/matplotlib/_fontconfig_patterns.py issues here: https://github.com/matplotlib/matplotlib/issues/26865.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
