### PR TITLE
Fix patches

### DIFF
--- a/doc/api/next_api_changes/removals/26886-GC.rst
+++ b/doc/api/next_api_changes/removals/26886-GC.rst
@@ -1,0 +1,3 @@
+Remove Deprecated SimpleEvents class
+ ~~~~~~~~~~~~~~~~~~~~~~~
+ ``matplotlib.patches.ConnectionStyle._Base.SimpleEvent``

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2707,12 +2707,7 @@ class ConnectionStyle(_Style):
         points. This base class defines a __call__ method, and a few
         helper methods.
         """
-
-        @_api.deprecated("3.7")
-        class SimpleEvent:
-            def __init__(self, xy):
-                self.x, self.y = xy
-
+      
         def _in_patch(self, patch):
             """
             Return a predicate function testing whether a point *xy* is

--- a/lib/matplotlib/patches.pyi
+++ b/lib/matplotlib/patches.pyi
@@ -455,8 +455,6 @@ class BoxStyle(_Style):
 
 class ConnectionStyle(_Style):
     class _Base(ConnectionStyle):
-        class SimpleEvent:
-            def __init__(self, xy: tuple[float, float]) -> None: ...
 
         def __call__(
             self,


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This pr targets and attempts to remove the deprecation in 3.7 found in lib/matplotlib/patches.py
The deprecated items marked with @_api.deprecated("3.7") are removed.

## PR checklist


- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
