### PR TITLE
TEST - adding new date time smoke test for axes.table (issue #26859)

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -339,8 +339,14 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for table not written yet")
     @mpl.style.context("default")
     def test_table(self):
+        val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
+        val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
+        val3 = [[datetime.datetime(2022,9,c) for c in range(1,4)] for r in range(1,4)]
         fig, ax = plt.subplots()
-        ax.table(...)
+        ax.set_axis_off()
+        ax.table(cellText = val3, 
+                rowLabels = val2, 
+                colLabels = val1)   
 
     @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -339,9 +339,9 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for table not written yet")
     @mpl.style.context("default")
     def test_table(self):
-        val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1,4)])
-        val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1,4)])
-        val3 = [[datetime.datetime(2022,9,c) for c in range(1,4)] for r in range(1,4)]
+        val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
+        val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
+        val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)] for r in range(1, 4)]
         fig, ax = plt.subplots()
         ax.set_axis_off()
         ax.table(cellText = val3, rowLabels = val2, colLabels = val1)

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -344,7 +344,7 @@ class TestDatetimePlotting:
         val3 = [[datetime.datetime(2022,9,c) for c in range(1,4)] for r in range(1,4)]
         fig, ax = plt.subplots()
         ax.set_axis_off()
-        ax.table(cellText = val3,rowLabels = val2, colLabels = val1)   
+        ax.table(cellText = val3, rowLabels = val2, colLabels = val1)
 
     @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -339,14 +339,12 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for table not written yet")
     @mpl.style.context("default")
     def test_table(self):
-        val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
-        val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
+        val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1,4)])
+        val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1,4)])
         val3 = [[datetime.datetime(2022,9,c) for c in range(1,4)] for r in range(1,4)]
         fig, ax = plt.subplots()
         ax.set_axis_off()
-        ax.table(cellText = val3, 
-                rowLabels = val2, 
-                colLabels = val1)   
+        ax.table(cellText = val3,rowLabels = val2, colLabels = val1)   
 
     @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
This PR is to add a single test of axes.table to make sure it can generate a plot from arrays of datetimes, as part of the following issue: 
https://github.com/matplotlib/matplotlib/issues/26864

Screenshot of the plot when generated: 
![image](https://github.com/matplotlib/matplotlib/assets/13632703/fe7d6feb-dd53-475b-aff7-ab0d6d8f57bf)
