### PR TITLE
TST - Adding test_table() to test_datetimes.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -342,7 +342,7 @@ class TestDatetimePlotting:
         val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
         val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
         val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)]
-            for r in range(1, 4)]
+                    for r in range(1, 4)]
         fig, ax = plt.subplots()
         ax.set_axis_off()
         ax.table(cellText=val3, rowLabels=val2, colLabels=val1)

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -341,8 +341,8 @@ class TestDatetimePlotting:
     def test_table(self):
         val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
         val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
-        val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)] 
-                    for r in range(1, 4)]
+        val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)]
+            for r in range(1, 4)]
         fig, ax = plt.subplots()
         ax.set_axis_off()
         ax.table(cellText=val3, rowLabels=val2, colLabels=val1)

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -341,10 +341,11 @@ class TestDatetimePlotting:
     def test_table(self):
         val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
         val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
-        val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)] for r in range(1, 4)]
+        val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)] 
+                    for r in range(1, 4)]
         fig, ax = plt.subplots()
         ax.set_axis_off()
-        ax.table(cellText = val3, rowLabels = val2, colLabels = val1)
+        ax.table(cellText=val3, rowLabels=val2, colLabels=val1)
 
     @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -336,7 +336,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.streamplot(...)
 
-    @pytest.mark.xfail(reason="Test for table not written yet")
     @mpl.style.context("default")
     def test_table(self):
         val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -339,8 +339,12 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for table not written yet")
     @mpl.style.context("default")
     def test_table(self):
+        val1 = np.array([datetime.datetime(2023, 9, n) for n in range(1, 4)])
+        val2 = np.array([datetime.datetime(2022, 9, n) for n in range(1, 4)])
+        val3 = [[datetime.datetime(2022, 9, c) for c in range(1, 4)] for r in range(1, 4)]
         fig, ax = plt.subplots()
-        ax.table(...)
+        ax.set_axis_off()
+        ax.table(cellText = val3, rowLabels = val2, colLabels = val1)
 
     @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
Adding a new test called "test_table" inside of the test_datetimes.py that tests that the axes.table function can generate a plot with datetime arrays.
<img width="721" alt="Screenshot 2023-09-23 at 8 36 22 AM" src="https://github.com/matplotlib/matplotlib/assets/13632703/b6dc48bf-5b01-4036-9f7c-6c9b39826455">
Part of issue https://github.com/matplotlib/matplotlib/pull/26859 but does not close this issue fully.

## PR checklist

- [ N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [Y ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [Y ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines


