### PR TITLE
Fixed deprecated APIs in lines.py

### DIFF
--- a/doc/api/next_api_changes/behavior/26902-RP.rst
+++ b/doc/api/next_api_changes/behavior/26902-RP.rst
@@ -1,0 +1,5 @@
+``Line2D``
+~~~~~~~~~~
+
+When creating a Line2D or using `.Line2D.set_xdata` and `.Line2D.set_ydata`,
+passing x/y data as non sequence is now an error.

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1276,14 +1276,7 @@ class Line2D(Artist):
         x : 1D array
         """
         if not np.iterable(x):
-            # When deprecation cycle is completed
-            # raise RuntimeError('x must be a sequence')
-            _api.warn_deprecated(
-                since="3.7",
-                message="Setting data with a non sequence type "
-                "is deprecated since %(since)s and will be "
-                "remove %(removal)s")
-            x = [x, ]
+            raise RuntimeError('x must be a sequence')
         self._xorig = copy.copy(x)
         self._invalidx = True
         self.stale = True
@@ -1297,14 +1290,7 @@ class Line2D(Artist):
         y : 1D array
         """
         if not np.iterable(y):
-            # When deprecation cycle is completed
-            # raise RuntimeError('y must be a sequence')
-            _api.warn_deprecated(
-                since="3.7",
-                message="Setting data with a non sequence type "
-                "is deprecated since %(since)s and will be "
-                "remove %(removal)s")
-            y = [y, ]
+            raise RuntimeError('y must be a sequence')
         self._yorig = copy.copy(y)
         self._invalidy = True
         self.stale = True

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -92,12 +92,9 @@ def test_invalid_line_data():
         mlines.Line2D([], 1)
 
     line = mlines.Line2D([], [])
-    # when deprecation cycle is completed
-    # with pytest.raises(RuntimeError, match='x must be'):
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+    with pytest.raises(RuntimeError, match='x must be'):
         line.set_xdata(0)
-    # with pytest.raises(RuntimeError, match='y must be'):
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+    with pytest.raises(RuntimeError, match='y must be'):
         line.set_ydata(0)
 
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Fixed deprecated parts in set_xdata and set_ydata APIs in lines.py
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
