### PR TITLE
`allsegs` and `allkinds` return individual segments

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -935,9 +935,11 @@ class ContourSet(ContourLabeler, mcoll.Collection):
             )
 
     allsegs = _api.deprecated("3.8", pending=True)(property(lambda self: [
-        p.vertices for c in self.collections for p in c.get_paths()]))
+        [subp.vertices for subp in p._iter_connected_components()]
+        for p in self.get_paths()]))
     allkinds = _api.deprecated("3.8", pending=True)(property(lambda self: [
-        p.codes for c in self.collections for p in c.get_paths()]))
+        [subp.codes for subp in p._iter_connected_components()]
+        for p in self.get_paths()]))
     tcolors = _api.deprecated("3.8")(property(lambda self: [
         (tuple(rgba),) for rgba in self.to_rgba(self.cvalues, self.alpha)]))
     tlinewidths = _api.deprecated("3.8")(property(lambda self: [

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -819,14 +819,24 @@ def test_all_nan():
                                 2.4e-14, 5e-14, 7.5e-14, 1e-13])
 
 
+def test_allsegs_allkinds():
+    x, y = np.meshgrid(np.arange(0, 10, 2), np.arange(0, 10, 2))
+    z = np.sin(x) * np.cos(y)
+
+    cs = plt.contour(x, y, z, levels=[0, 0.5])
+
+    # Expect two levels, first with 5 segments and the second with 4.
+    with pytest.warns(PendingDeprecationWarning, match="all"):
+        for result in [cs.allsegs, cs.allkinds]:
+            assert len(result) == 2
+            assert len(result[0]) == 5
+            assert len(result[1]) == 4
+
+
 def test_deprecated_apis():
     cs = plt.contour(np.arange(16).reshape((4, 4)))
     with pytest.warns(mpl.MatplotlibDeprecationWarning, match="collections"):
         colls = cs.collections
-    with pytest.warns(PendingDeprecationWarning, match="allsegs"):
-        assert cs.allsegs == [p.vertices for c in colls for p in c.get_paths()]
-    with pytest.warns(PendingDeprecationWarning, match="allkinds"):
-        assert cs.allkinds == [p.codes for c in colls for p in c.get_paths()]
     with pytest.warns(mpl.MatplotlibDeprecationWarning, match="tcolors"):
         assert_array_equal(cs.tcolors, [c.get_edgecolor() for c in colls])
     with pytest.warns(mpl.MatplotlibDeprecationWarning, match="tlinewidths"):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #26863.  I think this reinstates the pre-3.8 behaviour.  Adapted @jklymak's example from https://github.com/matplotlib/matplotlib/issues/26863#issuecomment-1732807216 into the new test.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
