### PR TITLE
MNT: clarify path.sketch rcparam format + test validate_sketch

### DIFF
--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -669,8 +669,8 @@
 #path.snap: True  # When True, rectilinear axis-aligned paths will be snapped
                   # to the nearest pixel when certain criteria are met.
                   # When False, paths will never be snapped.
-#path.sketch: None  # May be None, or a triplet of the form:
-                    #  path.sketch: scale, length, randomness 
+#path.sketch: None  # May be None, or a tuple of the form:
+                    #  path.sketch: (scale, length, randomness) 
                     # - *scale* is the amplitude of the wiggle
                     #    perpendicular to the line (in pixels).
                     # - *length* is the length of the wiggle along the

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -669,14 +669,14 @@
 #path.snap: True  # When True, rectilinear axis-aligned paths will be snapped
                   # to the nearest pixel when certain criteria are met.
                   # When False, paths will never be snapped.
-#path.sketch: None  # May be None, or a 3-tuple of the form:
-                    # (scale, length, randomness).
-                    #     - *scale* is the amplitude of the wiggle
-                    #         perpendicular to the line (in pixels).
-                    #     - *length* is the length of the wiggle along the
-                    #         line (in pixels).
-                    #     - *randomness* is the factor by which the length is
-                    #         randomly scaled.
+#path.sketch: None  # May be None, or a triplet of the form:
+                    #  path.sketch: scale, length, randomness 
+                    # - *scale* is the amplitude of the wiggle
+                    #    perpendicular to the line (in pixels).
+                    # - *length* is the length of the wiggle along the
+                    #    line (in pixels).
+                    # - *randomness* is the factor by which the length is
+                    #    randomly scaled.
 #path.effects:
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -562,7 +562,7 @@ def validate_sketch(s):
     try:
         return tuple(_listify_validator(validate_float, n=3)(s))
     except ValueError:
-        raise ValueError("Expected a (scale, length, randomness) triplet")
+        raise ValueError("Expected a 'scale, length, randomness' triplet")
 
 
 def _validate_greaterthan_minushalf(s):

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -555,14 +555,17 @@ def validate_bbox(s):
 
 
 def validate_sketch(s):
+
     if isinstance(s, str):
-        s = s.lower()
+        s = s.lower().strip()
+        if s.startswith("(") and s.endswith(")"):
+            s = s[1:-1]
     if s == 'none' or s is None:
         return None
     try:
         return tuple(_listify_validator(validate_float, n=3)(s))
-    except ValueError:
-        raise ValueError("Expected a 'scale, length, randomness' triplet")
+    except ValueError as exc:
+        raise ValueError("Expected a (scale, length, randomness) tuple") from exc
 
 
 def _validate_greaterthan_minushalf(s):

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -631,36 +631,24 @@ def test_rcparams_legend_loc_from_file(tmpdir, value):
         assert mpl.rcParams["legend.loc"] == value
 
 
-@pytest.mark.parametrize("value", [(1, 2, 3), '1, 2, 3'])
+@pytest.mark.parametrize("value", [(1, 2, 3), '1, 2, 3', '(1, 2, 3)'])
 def test_validate_sketch(value):
     mpl.rcParams["path.sketch"] = value
     assert mpl.rcParams["path.sketch"] == (1, 2, 3)
     assert validate_sketch(value) == (1, 2, 3)
 
 
-@pytest.mark.parametrize("value", [1, '1', '(1, 2, 3)'])
+@pytest.mark.parametrize("value", [1, '1', '1 2 3'])
 def test_validate_sketch_error(value):
-    with pytest.raises(ValueError, match="'scale, length, randomness'"):
+    with pytest.raises(ValueError, match="scale, length, randomness"):
         validate_sketch(value)
-    with pytest.raises(ValueError, match="'scale, length, randomness'"):
+    with pytest.raises(ValueError, match="scale, length, randomness"):
         mpl.rcParams["path.sketch"] = value
 
 
-def test_rcparams_path_sketch_from_file(tmpdir):
+@pytest.mark.parametrize("value", ['1, 2, 3', '(1,2,3)'])
+def test_rcparams_path_sketch_from_file(tmpdir, value):
     rc_path = tmpdir.join("matplotlibrc")
-    rc_path.write("path.sketch: 1, 2, 3")
-
+    rc_path.write(f"path.sketch: {value}")
     with mpl.rc_context(fname=rc_path):
         assert mpl.rcParams["path.sketch"] == (1, 2, 3)
-
-
-def test_rcparams_path_sketch_from_file_error(tmpdir, caplog):
-    # rcParams parser doesn't read a tuple rcfile entry
-    rc_path = tmpdir.join("matplotlibrc")
-    rc_path.write("path.sketch: (1, 2, 3)")
-
-    with mpl.rc_context(fname=rc_path):
-        with caplog.at_level("WARNING"):
-            assert mpl.rcParams['path.sketch'] is None
-            assert ("Expected a 'scale, length, randomness' triplet"
-                     in caplog.text)

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -27,6 +27,7 @@ from matplotlib.rcsetup import (
     validate_int,
     validate_markevery,
     validate_stringlist,
+    validate_sketch,
     _validate_linestyle,
     _listify_validator)
 
@@ -628,3 +629,38 @@ def test_rcparams_legend_loc_from_file(tmpdir, value):
 
     with mpl.rc_context(fname=rc_path):
         assert mpl.rcParams["legend.loc"] == value
+
+
+@pytest.mark.parametrize("value", [(1, 2, 3), '1, 2, 3'])
+def test_validate_sketch(value):
+    mpl.rcParams["path.sketch"] = value
+    assert mpl.rcParams["path.sketch"] == (1, 2, 3)
+    assert validate_sketch(value) == (1, 2, 3)
+
+
+@pytest.mark.parametrize("value", [1, '1', '(1, 2, 3)'])
+def test_validate_sketch_error(value):
+    with pytest.raises(ValueError, match="'scale, length, randomness'"):
+        validate_sketch(value)
+    with pytest.raises(ValueError, match="'scale, length, randomness'"):
+        mpl.rcParams["path.sketch"] = value
+
+
+def test_rcparams_path_sketch_from_file(tmpdir):
+    rc_path = tmpdir.join("matplotlibrc")
+    rc_path.write("path.sketch: 1, 2, 3")
+
+    with mpl.rc_context(fname=rc_path):
+        assert mpl.rcParams["path.sketch"] == (1, 2, 3)
+
+
+def test_rcparams_path_sketch_from_file_error(tmpdir, caplog):
+    # rcParams parser doesn't read a tuple rcfile entry
+    rc_path = tmpdir.join("matplotlibrc")
+    rc_path.write("path.sketch: (1, 2, 3)")
+
+    with mpl.rc_context(fname=rc_path):
+        with caplog.at_level("WARNING"):
+            assert mpl.rcParams['path.sketch'] is None
+            assert ("Expected a 'scale, length, randomness' triplet"
+                     in caplog.text)


### PR DESCRIPTION
Tried to make it clearer that the rcParam format is `path:sketch: scale, length, randomness`. I originally read it as `path:sketch: (scale, length, randomness)` and that caused loads of test failures. 

This is spun off of #26854 since I think this param is worth clarifying. 

It's probably more sensible to just let path.sketch take a tuple as a valid arg but this tests status quo