### PR TITLE
DOC: Fix removal doc for Animation attributes

### DIFF
--- a/doc/api/next_api_changes/removals/26872-AD.rst
+++ b/doc/api/next_api_changes/removals/26872-AD.rst
@@ -1,6 +1,5 @@
-``repeat``
-~~~~~~~~~~
-... of `.TimedAnimation` is removed without replacements.
-``save_count``
-~~~~~~~~~~~~~~
-... of `.FuncAnimation` is removed without replacements.
+``Animation`` attributes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The attributes ``repeat`` of `.TimedAnimation` and subclasses and
+``save_count`` of `.FuncAnimation` are considered private and removed.


### PR DESCRIPTION
## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->

I just noticed that I overlooked making the right changes to the removal documentation when removing deprecated code from animation.py: https://github.com/matplotlib/matplotlib/pull/26872. 

I'm sorry I missed this earlier!

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
