### PR TITLE
ci: Run mypy against typed cycler

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -65,9 +65,7 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
-          # The --ignore-missing-imports can be removed when typed cycler is released and used
           mypy --config pyproject.toml lib/matplotlib \
-             --ignore-missing-imports \
              --follow-imports silent | \
             reviewdog -f=mypy -name=mypy \
               -tee -reporter=github-check -filter-mode nofilter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ exclude = [
   # stubtest will import and run, opening a figure if not excluded
   ".*/tinypages",
 ]
-ignore_missing_imports = true
 enable_incomplete_feature = [
   "Unpack",
 ]


### PR DESCRIPTION
## PR summary

This tests against the new cycler release candidate, and then drops the flag/comment noted in the ci config.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines