### PR TITLE
FIX 2-tuple of colors in to_rgba_array

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -435,7 +435,7 @@ def to_rgba_array(c, alpha=None):
         (n, 4) array of RGBA colors,  where each channel (red, green, blue,
         alpha) can assume values between 0 and 1.
     """
-    if isinstance(c, tuple) and len(c) == 2:
+    if isinstance(c, tuple) and len(c) == 2 and isinstance(c[1], Real):
         if alpha is None:
             c, alpha = c
         else:

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1298,6 +1298,11 @@ def test_to_rgba_array_single_str():
         array = mcolors.to_rgba_array("rgb")
 
 
+def test_to_rgba_array_2tuple_str():
+    expected = np.array([[0, 0, 0, 1], [1, 1, 1, 1]])
+    assert_array_equal(mcolors.to_rgba_array(("k", "w")), expected)
+
+
 def test_to_rgba_array_alpha_array():
     with pytest.raises(ValueError, match="The number of colors must match"):
         mcolors.to_rgba_array(np.ones((5, 3), float), alpha=np.ones((2,)))


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Fixes #26949.  We just shouldn't assume that a 2-tuple passed to `to_rgba_array` is a single (color, alpha) pair.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
