### PR TITLE
add a mypy pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,6 +26,23 @@ repos:
       - id: no-commit-to-branch #default is master and main
       - id: trailing-whitespace
         exclude_types: [svg]
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.1.1
+    hooks:
+      - id: mypy
+        additional_dependencies: [
+          pandas-stubs,
+          types-pillow,
+          types-python-dateutil,
+          types-psutil,
+          types-docutils,
+          types-PyYAML]
+        args: [
+          "--config-file=pyproject.toml",
+          "lib/matplotlib"
+          ]
+        files: lib/matplotlib #only run when files in lib/matplotlib are changed
+        pass_filenames: false
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,15 +207,25 @@ convention = "numpy"
 "galleries/users_explain/text/text_props.py" = ["E501"]
 
 [tool.mypy]
-exclude = [
-  ".*/matplotlib/(sphinxext|backends|testing/jpl_units)",
-  ".*/mpl_toolkits",
-  # tinypages is used for testing the sphinx ext,
-  # stubtest will import and run, opening a figure if not excluded
-  ".*/tinypages",
-]
+ignore_missing_imports = true
 enable_incomplete_feature = [
   "Unpack",
+]
+exclude = [
+  #stubtest
+  ".*/matplotlib/(sphinxext|backends|testing/jpl_units)",
+  #mypy precommit
+  "galleries/",
+  "doc/",
+  "lib/matplotlib/backends/",
+  "lib/matplotlib/sphinxext",
+  "lib/matplotlib/testing/jpl_units",
+  "lib/mpl_toolkits/",
+  #removing tests causes errors in backends
+  "lib/matplotlib/tests/",
+  # tinypages is used for testing the sphinx ext,
+  # stubtest will import and run, opening a figure if not excluded
+  ".*/tinypages"
 ]
 
 [tool.rstcheck]


### PR DESCRIPTION
Add mypy pre-commit hook, not sure which args are needed to have it behave the same as the one in ci.  See discussion in #26928 -> I both forgot what I'm supposed to run locally and didn't realize I could run mypy locally. attn @ksunden 