### PR TITLE
Fix incorrect skip check in test_backend_ps.

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -147,7 +147,7 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
         icon_path = str(cbook._get_data_path('images/matplotlib.pdf'))
         _macosx.FigureManager.set_icon(icon_path)
         FigureManagerBase.__init__(self, canvas, num)
-        self._set_window_mode(mpl.rcParams.get("macosx.window_mode", "system"))
+        self._set_window_mode(mpl.rcParams["macosx.window_mode"])
         if self.toolbar is not None:
             self.toolbar.update()
         if mpl.is_interactive():

--- a/lib/matplotlib/tests/test_backend_ps.py
+++ b/lib/matplotlib/tests/test_backend_ps.py
@@ -40,19 +40,18 @@ import matplotlib.pyplot as plt
     'eps with usetex'
 ])
 def test_savefig_to_stringio(format, use_log, rcParams, orientation, papersize):
-    if rcParams.get("ps.usedistiller") == "ghostscript":
+    mpl.rcParams.update(rcParams)
+    if mpl.rcParams["ps.usedistiller"] == "ghostscript":
         try:
             mpl._get_executable_info("gs")
         except mpl.ExecutableNotFoundError as exc:
             pytest.skip(str(exc))
-    elif rcParams.get("ps.userdistiller") == "xpdf":
+    elif mpl.rcParams["ps.usedistiller"] == "xpdf":
         try:
             mpl._get_executable_info("gs")  # Effectively checks for ps2pdf.
             mpl._get_executable_info("pdftops")
         except mpl.ExecutableNotFoundError as exc:
             pytest.skip(str(exc))
-
-    mpl.rcParams.update(rcParams)
 
     fig, ax = plt.subplots()
 
@@ -67,9 +66,9 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation, papersize):
             title += " \N{MINUS SIGN}\N{EURO SIGN}"
         ax.set_title(title)
         allowable_exceptions = []
-        if rcParams.get("text.usetex"):
+        if mpl.rcParams["text.usetex"]:
             allowable_exceptions.append(RuntimeError)
-        if rcParams.get("ps.useafm"):
+        if mpl.rcParams["ps.useafm"]:
             allowable_exceptions.append(mpl.MatplotlibDeprecationWarning)
         try:
             fig.savefig(s_buf, format=format, orientation=orientation,
@@ -87,14 +86,14 @@ def test_savefig_to_stringio(format, use_log, rcParams, orientation, papersize):
         if format == 'ps':
             # Default figsize = (8, 6) inches = (576, 432) points = (203.2, 152.4) mm.
             # Landscape orientation will swap dimensions.
-            if rcParams.get("ps.usedistiller") == "xpdf":
+            if mpl.rcParams["ps.usedistiller"] == "xpdf":
                 # Some versions specifically show letter/203x152, but not all,
                 # so we can only use this simpler test.
                 if papersize == 'figure':
                     assert b'letter' not in s_val.lower()
                 else:
                     assert b'letter' in s_val.lower()
-            elif rcParams.get("ps.usedistiller") or rcParams.get("text.usetex"):
+            elif mpl.rcParams["ps.usedistiller"] or mpl.rcParams["text.usetex"]:
                 width = b'432.0' if orientation == 'landscape' else b'576.0'
                 wanted = (b'-dDEVICEWIDTHPOINTS=' + width if papersize == 'figure'
                           else b'-sPAPERSIZE')


### PR DESCRIPTION
There was a typo in `elif rcParams.get("ps.userdistiller") == "xpdf"` which effectively always returned False (the correct spelling is "ps.usedistiller", so the get() call always returned None), which made the skip check for xpdf never run.  Thus, running the test on a machine without pdftops installed would eventually result in an ExecutableNotFoundError when matplotlib actually tries to call the distiller.

To avoid this kind of problems (dict.get hiding typos), directly update the test-specific settings into the main rcParams, and use normal brackets to access rcParams entries, as rcParams keys are a fixed set anyways.

This broke the mplcairo test suite (where I didn't bother configuring CI to have pdftops installed) so labeling as 3.8.1; "somewhat" release critical (though I guess I could just xfail the test on mplcairo's side instead).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
