### PR TITLE
Move papersize="auto" deprecation to backend_bases.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2105,6 +2105,12 @@ class FigureCanvasBase:
         if dpi == 'figure':
             dpi = getattr(self.figure, '_original_dpi', self.figure.dpi)
 
+        if kwargs.get("papertype") == 'auto':
+            # When deprecation elapses, remove backend_ps._get_papertype & its callers.
+            _api.warn_deprecated(
+                "3.8", name="papertype='auto'", addendum="Pass an explicit paper type, "
+                "'figure', or omit the *papertype* argument entirely.")
+
         # Remove the figure manager, if any, to avoid resizing the GUI widget.
         with cbook._setattr_cm(self, manager=None), \
              self._switch_canvas_and_return_print_method(format, backend) \

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -867,9 +867,6 @@ class FigureCanvasPS(FigureCanvasBase):
         # find the appropriate papertype
         width, height = self.figure.get_size_inches()
         if papertype == 'auto':
-            _api.warn_deprecated("3.8", name="papertype='auto'",
-                                 addendum="Pass an explicit paper type, 'figure', or "
-                                 "omit the *papertype* argument entirely.")
             papertype = _get_papertype(*orientation.swap_if_landscape((width, height)))
 
         if is_eps or papertype == 'figure':
@@ -1053,9 +1050,6 @@ showpage
                     self.figure.get_size_inches())
             else:
                 if papertype == 'auto':
-                    _api.warn_deprecated("3.8", name="papertype='auto'",
-                                         addendum="Pass an explicit paper type, or "
-                                         "omit the *papertype* argument entirely.")
                     papertype = _get_papertype(width, height)
                 paper_width, paper_height = papersize[papertype]
 


### PR DESCRIPTION
This makes it easier for mplcairo (which also outputs PostScript natively) to inherit the deprecation and be able to run the matplotlib test suite both with matplotlib 3.7 (where there should be no warning) and with matplotlib 3.8 (where there should be a warning).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
