### PR TITLE
Deprecate backend_ps.get_bbox_header, and split it for internal use.

### DIFF
--- a/doc/api/next_api_changes/deprecations/26960-AL.rst
+++ b/doc/api/next_api_changes/deprecations/26960-AL.rst
@@ -1,0 +1,3 @@
+``backend_ps.get_bbox_header``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated, as it is considered an internal helper.

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -9,6 +9,7 @@ import functools
 from io import StringIO
 import itertools
 import logging
+import math
 import os
 import pathlib
 import shutil
@@ -915,7 +916,7 @@ class FigureCanvasPS(FigureCanvasBase):
             print(f"%%LanguageLevel: 3\n"
                   f"{dsc_comments}\n"
                   f"%%Orientation: {orientation.name}\n"
-                  f"{get_bbox_header(bbox)[0]}\n"
+                  f"{_get_bbox_header(bbox)}\n"
                   f"%%EndComments\n",
                   end="", file=fh)
 
@@ -1024,7 +1025,7 @@ class FigureCanvasPS(FigureCanvasBase):
 %!PS-Adobe-3.0 EPSF-3.0
 %%LanguageLevel: 3
 {dsc_comments}
-{get_bbox_header(bbox)[0]}
+{_get_bbox_header(bbox)}
 %%EndComments
 %%BeginProlog
 /mpldict {len(_psDefs)} dict def
@@ -1219,21 +1220,26 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
         pstoeps(tmpfile)
 
 
+@_api.deprecated("3.9")
 def get_bbox_header(lbrt, rotated=False):
     """
     Return a postscript header string for the given bbox lbrt=(l, b, r, t).
     Optionally, return rotate command.
     """
+    return _get_bbox_header(lbrt), (_get_rotate_command(lbrt) if rotated else "")
 
+
+def _get_bbox_header(lbrt):
+    """Return a PostScript header string for bounding box *lbrt*=(l, b, r, t)."""
     l, b, r, t = lbrt
-    if rotated:
-        rotate = f"{l+r:.2f} {0:.2f} translate\n90 rotate"
-    else:
-        rotate = ""
-    bbox_info = '%%%%BoundingBox: %d %d %d %d' % (l, b, np.ceil(r), np.ceil(t))
-    hires_bbox_info = f'%%HiResBoundingBox: {l:.6f} {b:.6f} {r:.6f} {t:.6f}'
+    return (f"%%BoundingBox: {int(l)} {int(b)} {math.ceil(r)} {math.ceil(t)}\n"
+            f"%%HiResBoundingBox: {l:.6f} {b:.6f} {r:.6f} {t:.6f}")
 
-    return '\n'.join([bbox_info, hires_bbox_info]), rotate
+
+def _get_rotate_command(lbrt):
+    """Return a PostScript 90° rotation command for bounding box *lbrt*=(l, b, r, t)."""
+    l, b, r, t = lbrt
+    return f"{l+r:.2f} {0:.2f} translate\n90 rotate"
 
 
 def pstoeps(tmpfile, bbox=None, rotated=False):
@@ -1243,12 +1249,6 @@ def pstoeps(tmpfile, bbox=None, rotated=False):
     None, original bbox will be used.
     """
 
-    # if rotated==True, the output eps file need to be rotated
-    if bbox:
-        bbox_info, rotate = get_bbox_header(bbox, rotated=rotated)
-    else:
-        bbox_info, rotate = None, None
-
     epsfile = tmpfile + '.eps'
     with open(epsfile, 'wb') as epsh, open(tmpfile, 'rb') as tmph:
         write = epsh.write
@@ -1257,7 +1257,7 @@ def pstoeps(tmpfile, bbox=None, rotated=False):
             if line.startswith(b'%!PS'):
                 write(b"%!PS-Adobe-3.0 EPSF-3.0\n")
                 if bbox:
-                    write(bbox_info.encode('ascii') + b'\n')
+                    write(_get_bbox_header(bbox).encode('ascii') + b'\n')
             elif line.startswith(b'%%EndComments'):
                 write(line)
                 write(b'%%BeginProlog\n'
@@ -1269,8 +1269,8 @@ def pstoeps(tmpfile, bbox=None, rotated=False):
                       b'/setpagedevice {pop} def\n'
                       b'%%EndProlog\n'
                       b'%%Page 1 1\n')
-                if rotate:
-                    write(rotate.encode('ascii') + b'\n')
+                if rotated:  # The output eps file need to be rotated.
+                    write(_get_rotate_command(bbox).encode('ascii') + b'\n')
                 break
             elif bbox and line.startswith((b'%%Bound', b'%%HiResBound',
                                            b'%%DocumentMedia', b'%%Pages')):


### PR DESCRIPTION
It's clearly an internal helper, and the two parts (the actual bbox header and the rotation command) don't really benefit from being smushed together, so make the function private and split the two parts.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
