### PR TITLE
DOC: made "open PR on MPL" a section in contribute guide

### DIFF
--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -227,6 +227,9 @@ Maplotlib repository to your own computer, or alternatively using
 in-browser development environment that comes with the appropriated setup to
 contribute to Matplotlib.
 
+Workflow overview
+^^^^^^^^^^^^^^^^^
+
 A brief overview of the workflow is as follows.
 
 #. `Create an account <https://github.com/join>`_ on GitHub if you do not
@@ -289,8 +292,13 @@ A brief overview of the workflow is as follows.
 
      git push -u origin my-feature
 
-Finally, go to the web page of your fork of the Matplotlib repo, and click
-'Pull request' to send your changes to the maintainers for review.
+Open a pull request on Matplotlib
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Finally, go to the web page of *your fork* of the Matplotlib repo, and click
+**Compare & pull request** to send your changes to the maintainers for review.
+The base repository is ``matplotlib/matplotlib`` and the base branch is
+generally ``main``. For more guidance, see GitHub's `pull request tutorial
+<https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork>`_.
 
 For more detailed instructions on how to set up Matplotlib for development and
 best practices for contribution, see :ref:`installing_for_devs`.

--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -304,7 +304,7 @@ For more detailed instructions on how to set up Matplotlib for development and
 best practices for contribution, see :ref:`installing_for_devs`.
 
 GitHub Codespaces workflows
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 * If you need to open a GUI window with Matplotlib output on Codespaces, our
   configuration includes a `light-weight Fluxbox-based desktop
@@ -386,7 +386,7 @@ This ensures that users are notified before the change will take effect and thus
 prevents unexpected breaking of code.
 
 Rules
-~~~~~
+^^^^^
 
 - Deprecations are targeted at the next point.release (e.g. 3.x)
 - Deprecated API is generally removed two point-releases after introduction
@@ -399,7 +399,7 @@ Rules
   API consistency lead developer
 
 Introducing
-~~~~~~~~~~~
+^^^^^^^^^^^
 
 #. Announce the deprecation in a new file
    :file:`doc/api/next_api_changes/deprecations/99999-ABC.rst` where ``99999``
@@ -440,7 +440,7 @@ Introducing
      version number.
 
 Expiring
-~~~~~~~~
+^^^^^^^^
 
 #. Announce the API changes in a new file
    :file:`doc/api/next_api_changes/[kind]/99999-ABC.rst` where ``99999``
@@ -621,7 +621,7 @@ example, use ``_log.error('hello %s', 'world')``  rather than ``_log.error('hell
 {}'.format('world'))`` or ``_log.error(f'hello {s}')``.
 
 Which logging level to use?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 There are five levels at which you can emit messages.
 


### PR DESCRIPTION
## PR summary

* pulled out "how to send PR to Matplotlib" into its own section and fleshed it out a drop b/c I felt like it was getting a little lost. 
* added a  workflow overview  section title to generate an anchor on the rhs
* changed title underlines to documented standard


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
