### PR TITLE
Fixes Issue #26377 - Auto-escape % Symbol in Latex in pie labels

### DIFF
--- a/doc/users/next_whats_new/pie_percent_latex.rst
+++ b/doc/users/next_whats_new/pie_percent_latex.rst
@@ -1,0 +1,11 @@
+Percent sign in pie labels auto-escaped with ``usetex=True``
+------------------------------------------------------------
+
+It is common, with `.Axes.pie`, to specify labels that include a percent sign
+(``%``), which denotes a comment for LaTeX. When enabling LaTeX with
+:rc:`text.usetex` or passing ``textprops={"usetex": True}``, this would cause
+the percent sign to disappear.
+
+Now, the percent sign is automatically escaped (by adding a preceding
+backslash) so that it appears regardless of the ``usetex`` setting. If you have
+pre-escaped the percent sign, this will be detected, and remain as is.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4,6 +4,7 @@ import logging
 import math
 from numbers import Integral, Number, Real
 
+import re
 import numpy as np
 from numpy import ma
 
@@ -3377,6 +3378,9 @@ class Axes(_AxesBase):
                 else:
                     raise TypeError(
                         'autopct must be callable or a format string')
+                if mpl._val_or_rc(textprops.get("usetex"), "text.usetex"):
+                    # escape % (i.e. \%) if it is not already escaped
+                    s = re.sub(r"([^\\])%", r"\1\\%", s)
                 t = self.text(xt, yt, s,
                               clip_on=False,
                               horizontalalignment='center',

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -38,6 +38,7 @@ from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
 from matplotlib.testing.decorators import (
     image_comparison, check_figures_equal, remove_ticks_and_titles)
+from matplotlib.testing._markers import needs_usetex
 
 # Note: Some test cases are run twice: once normally and once with labeled data
 #       These two must be defined in the same test function or need to have
@@ -9008,3 +9009,16 @@ def test_boxplot_tick_labels():
     # Test the new tick_labels parameter
     axs[1].boxplot(data, tick_labels=['A', 'B', 'C'])
     assert [l.get_text() for l in axs[1].get_xticklabels()] == ['A', 'B', 'C']
+
+
+@needs_usetex
+@check_figures_equal()
+def test_latex_pie_percent(fig_test, fig_ref):
+
+    data = [20, 10, 70]
+
+    ax = fig_test.subplots()
+    ax.pie(data, autopct="%1.0f%%", textprops={'usetex': True})
+
+    ax1 = fig_ref.subplots()
+    ax1.pie(data, autopct=r"%1.0f\%%", textprops={'usetex': True})


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Fixes Issue #26377 - Adding Support For % operator in Latex. Continued From #26642
'%' operator is considered as the start of a comment in LaTeX. In order to avoid this behavior, `\%` needs to be used.
Uses Regex to substitute `\%` instead of `%`. It also resolves in case the string is already pre-escaped.
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] closes #26377
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
