### PR TITLE
Modified index.rst file of Getting Started

### DIFF
--- a/doc/users/getting_started/index.rst
+++ b/doc/users/getting_started/index.rst
@@ -29,11 +29,13 @@ Draw a first plot
 -----------------
 
 Here is a minimal example plot:
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. plot::
    :include-source:
    :align: center
 
+   
    import matplotlib.pyplot as plt
    import numpy as np
 
@@ -43,8 +45,9 @@ Here is a minimal example plot:
    fig, ax = plt.subplots()
    ax.plot(x, y)
    plt.show()
+   
 
-If a plot does not show up please check :ref:`troubleshooting-faq`.
+* If a plot does not show up please check :ref:`troubleshooting-faq`.
 
 Where to go next
 ----------------
@@ -53,3 +56,6 @@ Where to go next
   types of plots you can create with Matplotlib.
 - Learn Matplotlib from the ground up in the :ref:`Quick-start guide
   <quick_start>`.
+
+
+  


### PR DESCRIPTION
## PR summary

In Getting Started/ index.rst file -> 
* There is a line marked in given photo
![2](https://github.com/matplotlib/matplotlib/assets/133089376/d163e438-2ea3-4326-9386-54799b377cc8)

* Here It is working as ** sub_sub_section** , thus I applied the markdown character as shown -> 


![Untitled design](https://github.com/matplotlib/matplotlib/assets/133089376/e904c1fb-b70f-47af-9c79-efb8e2c577d5)

Output will be like -> 
![Screenshot from 2023-10-03 22-18-40](https://github.com/matplotlib/matplotlib/assets/133089376/3306fbd3-b860-4928-abbe-d02e350065a8)

PR address the issue #26862


## PR checklist

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

