### PR TITLE
Add datetime testing for boxplot

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -2,7 +2,7 @@ import datetime
 import numpy as np
 
 import pytest
-
+import pandas as pd
 import matplotlib.pyplot as plt
 import matplotlib as mpl
 
@@ -86,12 +86,19 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.barh(...)
 
-    @pytest.mark.xfail(reason="Test for boxplot not written yet")
+    # @pytest.mark.xfail(reason="Test for boxplot not written yet")
     @mpl.style.context("default")
     def test_boxplot(self):
-        fig, ax = plt.subplots()
-        ax.boxplot(...)
-
+        df = pd.DataFrame({'date': pd.to_datetime(['2023-01-01', '2023-02-01', '2023-03-01', '2023-04-01', '2023-05-01']),
+                'value': [10, 20, 30, 40, 50]})
+        plt.figure()
+        plt.bar(df['value'], df['date'])
+        df.boxplot(by='date')
+        plt.xlabel('Date')
+        plt.ylabel('Value')
+        plt.title('Boxplot with dates on the x-axis')
+        plt.show()
+        
     @pytest.mark.xfail(reason="Test for broken_barh not written yet")
     @mpl.style.context("default")
     def test_broken_barh(self):
@@ -395,3 +402,8 @@ class TestDatetimePlotting:
     def test_xcorr(self):
         fig, ax = plt.subplots()
         ax.xcorr(...)
+
+instance = TestDatetimePlotting()
+
+
+instance.test_boxplot()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I have added the code corresponding screenshots for the boxplot testing function in test_datetime.py file. and completed the portion for Axes.boxplot of issue #26864".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #26864" is in the body of the PR description to [Axes.boxplot issue](https://github.com/matplotlib/matplotlib/issues/26864)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
![bar](https://github.com/matplotlib/matplotlib/assets/94514710/d88173e5-ff56-4f0e-ab83-e8bbea2236b7)
![boxplot](https://github.com/matplotlib/matplotlib/assets/94514710/5a51de01-f4fe-40b0-8b44-7f43b2d0f9d2)
