### PR TITLE
MNT: print fontname in missing glyph warning

### DIFF
--- a/lib/matplotlib/_text_helpers.py
+++ b/lib/matplotlib/_text_helpers.py
@@ -12,11 +12,12 @@ LayoutItem = dataclasses.make_dataclass(
     "LayoutItem", ["ft_object", "char", "glyph_idx", "x", "prev_kern"])
 
 
-def warn_on_missing_glyph(codepoint):
+def warn_on_missing_glyph(codepoint, fontnames):
     _api.warn_external(
-        "Glyph {} ({}) missing from current font.".format(
-            codepoint,
-            chr(codepoint).encode("ascii", "namereplace").decode("ascii")))
+        f"Glyph {codepoint} "
+        f"({chr(codepoint).encode('ascii', 'namereplace').decode('ascii')}) "
+        f"missing from font(s) {fontnames}.")
+
     block = ("Hebrew" if 0x0590 <= codepoint <= 0x05ff else
              "Arabic" if 0x0600 <= codepoint <= 0x06ff else
              "Devanagari" if 0x0900 <= codepoint <= 0x097f else

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -443,3 +443,19 @@ def test_multi_font_type42():
 
     fig = plt.figure()
     fig.text(0.15, 0.475, "There are 几个汉字 in between!")
+
+
+@pytest.mark.parametrize('family_name, file_name',
+                         [("Noto Sans", "NotoSans-Regular.otf"),
+                          ("FreeMono", "FreeMono.otf")])
+def test_otf_font_smoke(family_name, file_name):
+    # checks that there's no segfault
+    fp = fm.FontProperties(family=[family_name])
+    if Path(fm.findfont(fp)).name != file_name:
+        pytest.skip(f"Font {family_name} may be missing")
+
+    plt.rc('font', family=[family_name], size=27)
+
+    fig = plt.figure()
+    fig.text(0.15, 0.475, "Привет мир!")
+    fig.savefig(io.BytesIO(), format="pdf")

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -817,12 +817,13 @@ def test_pdf_kerning():
 
 def test_unsupported_script(recwarn):
     fig = plt.figure()
-    fig.text(.5, .5, "\N{BENGALI DIGIT ZERO}")
+    t = fig.text(.5, .5, "\N{BENGALI DIGIT ZERO}")
     fig.canvas.draw()
     assert all(isinstance(warn.message, UserWarning) for warn in recwarn)
     assert (
         [warn.message.args for warn in recwarn] ==
-        [(r"Glyph 2534 (\N{BENGALI DIGIT ZERO}) missing from current font.",),
+        [(r"Glyph 2534 (\N{BENGALI DIGIT ZERO}) missing from font(s) "
+            + f"{t.get_fontname()}.",),
          (r"Matplotlib currently does not support Bengali natively.",)])
 
 

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -651,14 +651,13 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
     glyph_seen_fonts.insert(face->family_name);
 
     if (glyph_index || override) {
-
         charcode_error = FT_Load_Glyph(face, glyph_index, flags);
         if (charcode_error) {
             return false;
         }
         FT_Glyph thisGlyph;
         glyph_error = FT_Get_Glyph(face->glyph, &thisGlyph);
-        if (glyph_error){
+        if (glyph_error) {
             return false;
         }
 
@@ -676,9 +675,9 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
     else {
         for (size_t i = 0; i < fallbacks.size(); ++i) {
             bool was_found = fallbacks[i]->load_char_with_fallback(
-                ft_object_with_glyph, final_glyph_index, parent_glyphs, parent_char_to_font,
-                parent_glyph_to_font, charcode, flags, charcode_error, glyph_error,
-                glyph_seen_fonts, override);
+                ft_object_with_glyph, final_glyph_index, parent_glyphs,
+                parent_char_to_font, parent_glyph_to_font, charcode, flags,
+                charcode_error, glyph_error, glyph_seen_fonts, override);
             if (was_found) {
                 return true;
             }

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <iterator>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -184,11 +185,20 @@ FT2Image::draw_rect_filled(unsigned long x0, unsigned long y0, unsigned long x1,
     m_dirty = true;
 }
 
-static void ft_glyph_warn(FT_ULong charcode)
+static void ft_glyph_warn(FT_ULong charcode, std::set<FT_String*> family_names)
 {
     PyObject *text_helpers = NULL, *tmp = NULL;
+    std::set<FT_String*>::iterator it = family_names.begin();
+    std::stringstream ss;
+    ss<<*it;
+    while(++it != family_names.end()){
+        ss<<", "<<*it;
+    }
+
     if (!(text_helpers = PyImport_ImportModule("matplotlib._text_helpers")) ||
-        !(tmp = PyObject_CallMethod(text_helpers, "warn_on_missing_glyph", "k", charcode))) {
+        !(tmp = PyObject_CallMethod(text_helpers,
+                "warn_on_missing_glyph", "(k, s)",
+                charcode, ss.str().c_str()))) {
         goto exit;
     }
 exit:
@@ -197,19 +207,6 @@ exit:
     if (PyErr_Occurred()) {
         throw mpl::exception();
     }
-}
-
-static FT_UInt
-ft_get_char_index_or_warn(FT_Face face, FT_ULong charcode, bool warn = true)
-{
-    FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
-    if (glyph_index) {
-        return glyph_index;
-    }
-    if (warn) {
-        ft_glyph_warn(charcode);
-    }
-    return 0;
 }
 
 // ft_outline_decomposer should be passed to FT_Outline_Decompose.  On the
@@ -510,13 +507,13 @@ void FT2Font::set_text(
         FT_Pos last_advance;
 
         FT_Error charcode_error, glyph_error;
+        std::set<FT_String*> glyph_seen_fonts;
         FT2Font *ft_object_with_glyph = this;
         bool was_found = load_char_with_fallback(ft_object_with_glyph, glyph_index, glyphs,
                                                  char_to_font, glyph_to_font, codepoints[n], flags,
-                                                 charcode_error, glyph_error, false);
+                                                 charcode_error, glyph_error, glyph_seen_fonts, false);
         if (!was_found) {
-            ft_glyph_warn((FT_ULong)codepoints[n]);
-
+            ft_glyph_warn((FT_ULong)codepoints[n], glyph_seen_fonts);
             // render missing glyph tofu
             // come back to top-most font
             ft_object_with_glyph = this;
@@ -570,6 +567,7 @@ void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool
     // if this is parent FT2Font, cache will be filled in 2 ways:
     // 1. set_text was previously called
     // 2. set_text was not called and fallback was enabled
+    std::set <FT_String *> glyph_seen_fonts;
     if (fallback && char_to_font.find(charcode) != char_to_font.end()) {
         ft_object = char_to_font[charcode];
         // since it will be assigned to ft_object anyway
@@ -579,10 +577,12 @@ void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool
         FT_UInt final_glyph_index;
         FT_Error charcode_error, glyph_error;
         FT2Font *ft_object_with_glyph = this;
-        bool was_found = load_char_with_fallback(ft_object_with_glyph, final_glyph_index, glyphs, char_to_font,
-                                glyph_to_font, charcode, flags, charcode_error, glyph_error, true);
+        bool was_found = load_char_with_fallback(ft_object_with_glyph, final_glyph_index,
+                                                 glyphs, char_to_font, glyph_to_font,
+                                                 charcode, flags, charcode_error, glyph_error,
+                                                 glyph_seen_fonts, true);
         if (!was_found) {
-            ft_glyph_warn(charcode);
+            ft_glyph_warn(charcode, glyph_seen_fonts);
             if (charcode_error) {
                 throw_ft_error("Could not load charcode", charcode_error);
             }
@@ -592,9 +592,13 @@ void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool
         }
         ft_object = ft_object_with_glyph;
     } else {
+        //no fallback case
         ft_object = this;
-        FT_UInt glyph_index = ft_get_char_index_or_warn(face, (FT_ULong)charcode);
-
+        FT_UInt glyph_index = FT_Get_Char_Index(face, (FT_ULong) charcode);
+        if (!glyph_index){
+            glyph_seen_fonts.insert((face != NULL)?face->family_name: NULL);
+            ft_glyph_warn((FT_ULong)charcode, glyph_seen_fonts);
+        }
         if (FT_Error error = FT_Load_Glyph(face, glyph_index, flags)) {
             throw_ft_error("Could not load charcode", error);
         }
@@ -640,19 +644,21 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
                                       FT_Int32 flags,
                                       FT_Error &charcode_error,
                                       FT_Error &glyph_error,
+                                      std::set<FT_String*> &glyph_seen_fonts,
                                       bool override = false)
 {
     FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
+    glyph_seen_fonts.insert(face->family_name);
 
     if (glyph_index || override) {
+
         charcode_error = FT_Load_Glyph(face, glyph_index, flags);
         if (charcode_error) {
             return false;
         }
-
         FT_Glyph thisGlyph;
         glyph_error = FT_Get_Glyph(face->glyph, &thisGlyph);
-        if (glyph_error) {
+        if (glyph_error){
             return false;
         }
 
@@ -667,12 +673,12 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
         parent_glyphs.push_back(thisGlyph);
         return true;
     }
-
     else {
         for (size_t i = 0; i < fallbacks.size(); ++i) {
             bool was_found = fallbacks[i]->load_char_with_fallback(
                 ft_object_with_glyph, final_glyph_index, parent_glyphs, parent_char_to_font,
-                parent_glyph_to_font, charcode, flags, charcode_error, glyph_error, override);
+                parent_glyph_to_font, charcode, flags, charcode_error, glyph_error,
+                glyph_seen_fonts, override);
             if (was_found) {
                 return true;
             }
@@ -721,8 +727,7 @@ FT_UInt FT2Font::get_char_index(FT_ULong charcode, bool fallback = false)
         ft_object = this;
     }
 
-    // historically, get_char_index never raises a warning
-    return ft_get_char_index_or_warn(ft_object->get_face(), charcode, false);
+    return FT_Get_Char_Index(ft_object->get_face(), charcode);
 }
 
 void FT2Font::get_width_height(long *width, long *height)

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -5,6 +5,7 @@
 #ifndef MPL_FT2FONT_H
 #define MPL_FT2FONT_H
 #include <vector>
+#include<set>
 #include <stdint.h>
 #include <unordered_map>
 
@@ -91,6 +92,7 @@ class FT2Font
                                  FT_Int32 flags,
                                  FT_Error &charcode_error,
                                  FT_Error &glyph_error,
+                                 std::set<FT_String*> &glyph_seen_fonts,
                                  bool override);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags, FT2Font *&ft_object, bool fallback);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags);


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Modified the "missing glyph" warning to also print out the name of the font the glyph is missing from. This is mostly to help me debug why #26854 is failing on CI but working locally but there have been times where I've gotten this error and would have found it helpful to have the added context. 

<strike>second commit adds a :filter-warning: option to the `..plot` directive</strike> spun out into  #27076

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
