### PR TITLE
fix floating comparison in path.arc

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -943,16 +943,20 @@ class Path:
            polylines, quadratic or cubic Bezier curves
            <https://web.archive.org/web/20190318044212/http://www.spaceroots.org/documents/ellipse/index.html>`_.
         """
+        # we want to get the same result when the input changes within [-tol, tol]
+        # this behavior is only for internal use to offset floating-point error
+        # so it should not be relied on by the user
+        tol = 1e-6
+
         halfpi = np.pi * 0.5
 
         eta1 = theta1
         eta2 = theta2 - 360 * np.floor((theta2 - theta1) / 360)
         # Ensure 2pi range is not flattened to 0 due to floating-point errors,
         # but don't try to expand existing 0 range.
-        # theta1 != theta2 and eta2 <= eta1
-        if (not np.isclose(theta2, theta1) and
-                (np.isclose(eta2, eta1) or
-                    (not np.isclose(eta2, eta1) and eta2 < eta1))):
+        # condition: theta1 != theta2 and eta2 <= eta1
+        # implementation note: use np.isclose() may break when theta1 = 0
+        if abs(theta1 - theta2) >= tol and (eta2 <= eta1 + tol):
             eta2 += 360
         eta1, eta2 = np.deg2rad([eta1, eta2])
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -949,7 +949,10 @@ class Path:
         eta2 = theta2 - 360 * np.floor((theta2 - theta1) / 360)
         # Ensure 2pi range is not flattened to 0 due to floating-point errors,
         # but don't try to expand existing 0 range.
-        if theta2 != theta1 and eta2 <= eta1:
+        # theta1 != theta2 and eta2 <= eta1
+        if (not np.isclose(theta2, theta1) and
+                (np.isclose(eta2, eta1) or
+                    (not np.isclose(eta2, eta1) and eta2 < eta1))):
             eta2 += 360
         eta1, eta2 = np.deg2rad([eta1, eta2])
 

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -475,6 +475,22 @@ def test_full_arc(offset):
     np.testing.assert_allclose(maxs, 1)
 
 
+@pytest.mark.parametrize('offset', range(-720, 361, 45))
+def test_full_arc_rounding(offset):
+    # GH 26972 - edge case for floating point rounding
+    # we want get the same result when input of arc
+    # changes within [-tol, tol], where tol = 1e-6
+    tol = 1e-6
+    low = offset
+    high = 360 + offset + tol
+
+    path = Path.arc(low, high)
+    mins = np.min(path.vertices, axis=0)
+    maxs = np.max(path.vertices, axis=0)
+    np.testing.assert_allclose(mins, -1)
+    np.testing.assert_allclose(maxs, 1)
+
+
 def test_disjoint_zero_length_segment():
     this_path = Path(
         np.array([


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #26972. When drawing the spine for the radial axis, we call `Path.arc` to draw. In `Path.arc`, we are using `==` for floating point comparison which may results in wrong results. The solution is to compare with a tolerance.

Tests on `Path.arc` is added to ensure that it's robust about the input change within [-1e-6, 1e-6]

~~The solution is to replace this with `np.isclose()`~~ `np.isclose(0, 1e-6)` will give false, which is not we want.

~~However, a large number of tests will break and I'm checking whether the difference of results will be noticed by human eyes.~~ Failing locally, we think this is irrelevant

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
