### PR TITLE
Dokumentation Link and rename README

### DIFF
--- a/lib/matplotlib/tests/README.md
+++ b/lib/matplotlib/tests/README.md
@@ -4,5 +4,5 @@ About Matplotlib Testing Infrastructure
 Information on the testing infrastructure is provided in
 the Testing section of the Matplotlib Developers’ Guide:
 
-* https://matplotlib.org/devel/testing.html
+* [Website](https://matplotlib.org/stable/devel/testing.html)
 * <mpl_source_dir>/doc/devel/coding_guide.rst (equivalent, but in reST format)


### PR DESCRIPTION
Making the README an md file. Change the link to the right one and making it a hyperlink.

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
