### PR TITLE
Warning if handles and labels have a len mismatch

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1337,6 +1337,12 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
         _api.warn_external("You have mixed positional and keyword arguments, "
                            "some input may be discarded.")
 
+    if (hasattr(handles, "__len__") and
+            hasattr(labels, "__len__") and
+            len(handles) != len(labels)):
+        _api.warn_external(f"Mismatched number of handles and labels: "
+                           f"len(handles) = {len(handles)} "
+                           f"len(labels) = {len(labels)}")
     # if got both handles and labels as kwargs, make same length
     if handles and labels:
         handles, labels = zip(*zip(handles, labels))

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1357,3 +1357,21 @@ def test_loc_validation_string_value():
     ax.legend(loc='upper center')
     with pytest.raises(ValueError, match="'wrong' is not a valid value for"):
         ax.legend(loc='wrong')
+
+
+def test_legend_handle_label_mismatch():
+    pl1, = plt.plot(range(10))
+    pl2, = plt.plot(range(10))
+    with pytest.warns(UserWarning, match="number of handles and labels"):
+        legend = plt.legend(handles=[pl1, pl2], labels=["pl1", "pl2", "pl3"])
+        assert len(legend.legend_handles) == 2
+        assert len(legend.get_texts()) == 2
+
+
+def test_legend_handle_label_mismatch_no_len():
+    pl1, = plt.plot(range(10))
+    pl2, = plt.plot(range(10))
+    legend = plt.legend(handles=iter([pl1, pl2]),
+                        labels=iter(["pl1", "pl2", "pl3"]))
+    assert len(legend.legend_handles) == 2
+    assert len(legend.get_texts()) == 2


### PR DESCRIPTION
… when __ len __ exists for both
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #24050 . Following the discussion there (And in PRs #24061 and #24063) a warning is issued when the handles and labels have __ len __() and there is a mismatch in its value. A test checks whether the warning is raised.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
