### PR TITLE
CI: Update scientific-python/upload-nightly-action to 0.2.0

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -59,7 +59,7 @@ jobs:
           ls -l dist/
 
       - name: Upload wheels to Anaconda Cloud as nightlies
-        uses: scientific-python/upload-nightly-action@8f0394fd2aa0c85d7364a9958652e8994e06b23c # 0.1.0
+        uses: scientific-python/upload-nightly-action@5fb764c5bce1ac2297084c0f7161b1919f17c74f # 0.2.0
         with:
           artifacts_path: dist
           anaconda_nightly_upload_token: ${{ secrets.ANACONDA_ORG_UPLOAD_TOKEN }}


### PR DESCRIPTION
## PR summary

The [`scientific-python/upload-nightly-action`](https://github.com/scientific-python/upload-nightly-action/) action has received stability updates in [`0.2.0`](https://github.com/scientific-python/upload-nightly-action/releases/tag/0.2.0) that provides a reproducible runtime environment for the action, which should mitigate issues with stability.

c.f. https://github.com/scientific-python/upload-nightly-action/pull/44

This PR is being opened manually instead of relying on Dependabot to catch it

https://github.com/matplotlib/matplotlib/blob/a99673c970bc1dac1e54175ed3166e5190c9d793/.github/dependabot.yml#L1-L6

as Dependabot runs on a weekly basis and this update mitigates an Issue that affects users now (c.f. https://github.com/scientific-python/upload-nightly-action/issues/43).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
