### PR TITLE
Add a section to Highlight past winners for JDH plotting contest in docs

### DIFF
--- a/doc/users/resources/index.rst
+++ b/doc/users/resources/index.rst
@@ -71,9 +71,6 @@ Videos
 Tutorials
 =========
 
-
-
-
 * `Matplotlib tutorial <https://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_
   by Nicolas P. Rougier
 
@@ -89,9 +86,8 @@ Tutorials
 Galleries
 =========
 
-
 * `Past winners for JDH plotting contest <https://jhepc.github.io/gallery.html>`_
-   by Nelle Varoquaux
+  by Nelle Varoquaux
 
 * `The Python Graph Gallery <https://www.python-graph-gallery.com>`_
   by Yan Holtz

--- a/doc/users/resources/index.rst
+++ b/doc/users/resources/index.rst
@@ -72,8 +72,7 @@ Tutorials
 =========
 
 
-* `The Python Graph Gallery <https://www.python-graph-gallery.com>`_
-  by Yan Holtz
+
 
 * `Matplotlib tutorial <https://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_
   by Nicolas P. Rougier
@@ -85,3 +84,13 @@ Tutorials
 * `Beyond the Basics: Data Visualization in Python
   <https://github.com/stefmolin/python-data-viz-workshop>`_
   by Stefanie Molin
+
+=========
+Galleries
+=========
+
+
+[Past winners for JDH plotting contest](https://jhepc.github.io/gallery.html)
+
+* `The Python Graph Gallery <https://www.python-graph-gallery.com>`_
+  by Yan Holtz

--- a/doc/users/resources/index.rst
+++ b/doc/users/resources/index.rst
@@ -90,7 +90,8 @@ Galleries
 =========
 
 
-[Past winners for JDH plotting contest](https://jhepc.github.io/gallery.html)
+* `Past winners for JDH plotting contest <https://jhepc.github.io/gallery.html>`_
+   by Nelle Varoquaux
 
 * `The Python Graph Gallery <https://www.python-graph-gallery.com>`_
   by Yan Holtz


### PR DESCRIPTION
## PR summary
- Added a link to past winners for the JDH plotting contest.  Closes #11129
* Changed placement of the python graph gallery from tutorials section to galleries

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines