### PR TITLE
BLD: Remove development dependencies from sdists

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -64,6 +64,9 @@ jobs:
         run: |
           python -m build --sdist
           python ci/export_sdist_name.py
+        env:
+          # Prevent including development runtime dependencies in metadata.
+          CIBUILDWHEEL: 1
 
       - name: Check README rendering for PyPI
         run: twine check dist/*
@@ -87,7 +90,7 @@ jobs:
                  'CI: Run cibuildwheel')
       )
     needs: build_sdist
-    name: Build wheels on ${{ matrix.os }}
+    name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
     env:
       CIBW_BEFORE_BUILD: >-


### PR DESCRIPTION
## PR summary

Also, backport #26699.

Closes #26932, but only required on the `v3.8.x` branch because `main` is using Meson now and doesn't do dependencies this way.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines