### PR TITLE
Add test_contourf in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -122,11 +122,29 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.contour(...)
 
-    @pytest.mark.xfail(reason="Test for contourf not written yet")
     @mpl.style.context("default")
     def test_contourf(self):
-        fig, ax = plt.subplots()
-        ax.contourf(...)
+        mpl.rcParams["date.converter"] = "concise"
+        range_threshold = 10
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout="constrained")
+
+        x_dates = np.array(
+            [datetime.datetime(2023, 10, delta) for delta in range(1, range_threshold)]
+        )
+        y_dates = np.array(
+            [datetime.datetime(2023, 10, delta) for delta in range(1, range_threshold)]
+        )
+        x_ranges = np.array(range(1, range_threshold))
+        y_ranges = np.array(range(1, range_threshold))
+
+        X_dates, Y_dates = np.meshgrid(x_dates, y_dates)
+        X_ranges, Y_ranges = np.meshgrid(x_ranges, y_ranges)
+
+        Z_ranges = np.cos(X_ranges / 4) + np.sin(Y_ranges / 4)
+
+        ax1.contourf(X_dates, Y_dates, Z_ranges)
+        ax2.contourf(X_dates, Y_ranges, Z_ranges)
+        ax3.contourf(X_ranges, Y_dates, Z_ranges)
 
     @pytest.mark.xfail(reason="Test for csd not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
Attempting adding code for `test_contourf` method in `test_datetime.py` mentioned in [#26864](https://github.com/matplotlib/matplotlib/issues/26864)

**Image output -**
![matplotlib_contourf](https://github.com/matplotlib/matplotlib/assets/20207952/34dd6fa2-d032-4451-ae34-c28f1310b62c)


## PR checklist

- [x] resolves [#26864](https://github.com/matplotlib/matplotlib/issues/26864)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

