### PR TITLE
add test_plot_date in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -252,11 +252,24 @@ class TestDatetimePlotting:
         ax2.plot(range(1, N), x)
         ax3.plot(x, x)
 
-    @pytest.mark.xfail(reason="Test for plot_date not written yet")
     @mpl.style.context("default")
     def test_plot_date(self):
-        fig, ax = plt.subplots()
-        ax.plot_date(...)
+        mpl.rcParams["date.converter"] = "concise"
+        range_threshold = 10
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout="constrained")
+
+        x_dates = np.array(
+            [datetime.datetime(2023, 10, delta) for delta in range(1, range_threshold)]
+        )
+        y_dates = np.array(
+            [datetime.datetime(2023, 10, delta) for delta in range(1, range_threshold)]
+        )
+        x_ranges = np.array(range(1, range_threshold))
+        y_ranges = np.array(range(1, range_threshold))
+
+        ax1.plot_date(x_dates, y_dates)
+        ax2.plot_date(x_dates, y_ranges)
+        ax3.plot_date(x_ranges, y_dates)
 
     @pytest.mark.xfail(reason="Test for psd not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
Adding code for `test_plot_date` method in `test_datetime.py` mentioned in [#26864](https://github.com/matplotlib/matplotlib/issues/26864)

**Image output -**
![test_plot_date_image](https://github.com/matplotlib/matplotlib/assets/20207952/7800a5cf-6ef2-4ae1-b365-9db3606e54a7)

## PR checklist

- [x] resolves [#26864](https://github.com/matplotlib/matplotlib/issues/26864)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

