### PR TITLE
Add datetime testing for boxplot

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -89,8 +89,17 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for boxplot not written yet")
     @mpl.style.context("default")
     def test_boxplot(self):
-        fig, ax = plt.subplots()
-        ax.boxplot(...)
+        data = [datetime.datetime(2023, 10, 5, 18, 52, 59),
+                datetime.datetime(2023, 10, 4, 18, 53, 0),
+                datetime.datetime(2023, 10, 3, 18, 53, 1),
+                datetime.datetime(2023, 10, 2, 18, 53, 2),
+                datetime.datetime(2023, 10, 1, 18, 53, 3)]
+        datums = np.array([datetime.datetime.toordinal(d) for d in data])
+        plt.boxplot(datums, labels=['my data'], showfliers=True)
+        plt.xlabel('Datetime')
+        plt.ylabel('value')
+        plt.title('Boxplot of datetime data')
+        plt.show()
 
     @pytest.mark.xfail(reason="Test for broken_barh not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I have added the code corresponding screenshots for the boxplot testing function in test_datetime.py file. and completed the portion for Axes.boxplot of issue https://github.com/matplotlib/matplotlib/issues/26864"
this is the screenshot of  boxplot by given code..
![boxplot_final](https://github.com/matplotlib/matplotlib/assets/94514710/ad74a1a8-ea0e-48ab-9d62-845d7bd0810e)

-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #26864 " is in the body of the PR description to [Boxplot for datetime](https://github.com/matplotlib/matplotlib/issues/26864)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
