### PR TITLE
Backport PR #27059: ci: Clean up Python 3.12 builds

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -145,20 +145,6 @@ jobs:
         env:
           CIBW_BUILD: "cp312-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          # Remove this once NumPy with Python 3.12 wheels is not pre-release.
-          CIBW_BEFORE_BUILD: >-
-            pip install certifi "pybind11>=2.6" "setuptools>=42" "setuptools_scm>=7" &&
-            pip install --pre "numpy>=1.25" &&
-            rm -rf {package}/build
-          CIBW_BEFORE_BUILD_WINDOWS: >-
-            pip install certifi delvewheel "pybind11>=2.6" "setuptools>=42" "setuptools_scm>=7" &&
-            pip install --pre "numpy>=1.25" &&
-            rm -rf {package}/build
-          CIBW_ENVIRONMENT: PIP_NO_BUILD_ISOLATION=0
-          # Remove this once contourpy has Python 3.12 wheels.
-          CIBW_BEFORE_TEST: >-
-            pip install "meson>=1.2.0" "meson-python>=0.13.1" "ninja" "pybind11>=2.10.4" &&
-            pip install --pre "numpy>=1.25"
 
       - name: Build wheels for CPython 3.11
         uses: pypa/cibuildwheel@fff9ec32ed25a9c576750c91e06b410ed0c15db7 # v2.16.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,10 +78,8 @@ jobs:
             pyside6-ver: '!=6.5.1'
             extra-requirements: '-r requirements/testing/extra.txt'
           - os: ubuntu-22.04
-            python-version: '3.12-dev'
+            python-version: '3.12'
             pyside6-ver: '!=6.5.1'
-            pre: true
-            no-build-isolation: true
           - os: macos-latest
             python-version: 3.9
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
@@ -196,10 +194,8 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
 
           # Install pre-release versions during our weekly upcoming dependency tests.
-          # Also install for 3.12 to get working NumPy (remove when 1.26 is released)
-          if [[ "${{ github.event_name == 'schedule' &&
-                     matrix.name-suffix != '(Minimum Versions)' }}" = "true"
-                || "${{ matrix.pre }}" = "true" ]]; then
+          if [[ "${{ github.event_name }}" == 'schedule'
+                && "${{ matrix.name-suffix }}" != '(Minimum Versions)' ]]; then
             PRE="--pre"
           fi
 
@@ -244,7 +240,7 @@ jobs:
             echo 'PyQt5 is available' ||
             echo 'PyQt5 is not available'
           if [[ "${{ runner.os }}" != 'macOS'
-                && "${{ matrix.python-version != '3.12-dev'}}" = "true" ]]; then
+                && "${{ matrix.python-version }}" != '3.12' ]]; then
             python -mpip install --upgrade pyside2${{ matrix.pyside2-ver }} &&
               python -c 'import PySide2.QtCore' &&
               echo 'PySide2 is available' ||
@@ -257,14 +253,14 @@ jobs:
               echo 'PyQt6 is not available'
           fi
           if [[ "${{ runner.os }}" != 'macOS'
-                && "${{ matrix.python-version != '3.12-dev'}}" = "true" ]]; then
+                && "${{ matrix.python-version }}" != '3.12' ]]; then
             python -mpip install --upgrade pyside6${{ matrix.pyside6-ver }} &&
               python -c 'import PySide6.QtCore' &&
               echo 'PySide6 is available' ||
               echo 'PySide6 is not available'
           fi
 
-          if [[ "${{ matrix.python-version != '3.12-dev'}}" = "true" ]]; then
+          if [[ "${{ matrix.python-version }}" != '3.12' ]]; then
             python -mpip install --upgrade \
               -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}" \
               wxPython &&


### PR DESCRIPTION
## PR summary

Manual backport of #27059. Conflict was the change to Meson on `main`.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines