### PR TITLE
Tweak array_view to be more like pybind11

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -627,9 +627,9 @@ def test_invalid_arguments():
         t.transform([])
     with pytest.raises(RuntimeError):
         t.transform([1])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         t.transform([[1]])
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         t.transform([[1, 2, 3]])
 
 

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -918,15 +918,15 @@ inline void RendererAgg::_draw_path_collection_generic(GCAgg &gc,
     typedef agg::conv_curve<clipped_t> curve_t;
 
     size_t Npaths = path_generator.num_paths();
-    size_t Noffsets = offsets.size();
+    size_t Noffsets = safe_first_shape(offsets);
     size_t N = std::max(Npaths, Noffsets);
 
-    size_t Ntransforms = transforms.size();
-    size_t Nfacecolors = facecolors.size();
-    size_t Nedgecolors = edgecolors.size();
-    size_t Nlinewidths = linewidths.size();
+    size_t Ntransforms = safe_first_shape(transforms);
+    size_t Nfacecolors = safe_first_shape(facecolors);
+    size_t Nedgecolors = safe_first_shape(edgecolors);
+    size_t Nlinewidths = safe_first_shape(linewidths);
     size_t Nlinestyles = std::min(linestyles.size(), N);
-    size_t Naa = antialiaseds.size();
+    size_t Naa = safe_first_shape(antialiaseds);
 
     if ((Nfacecolors == 0 && Nedgecolors == 0) || Npaths == 0) {
         return;

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -731,22 +731,22 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
     rendererBase.reset_clipping(true);
     if (angle != 0.0) {
         agg::rendering_buffer srcbuf(
-                image.data(), (unsigned)image.dim(1),
-                (unsigned)image.dim(0), (unsigned)image.dim(1));
+                image.data(), (unsigned)image.shape(1),
+                (unsigned)image.shape(0), (unsigned)image.shape(1));
         agg::pixfmt_gray8 pixf_img(srcbuf);
 
         set_clipbox(gc.cliprect, theRasterizer);
 
         agg::trans_affine mtx;
-        mtx *= agg::trans_affine_translation(0, -image.dim(0));
+        mtx *= agg::trans_affine_translation(0, -image.shape(0));
         mtx *= agg::trans_affine_rotation(-angle * (agg::pi / 180.0));
         mtx *= agg::trans_affine_translation(x, y);
 
         agg::path_storage rect;
         rect.move_to(0, 0);
-        rect.line_to(image.dim(1), 0);
-        rect.line_to(image.dim(1), image.dim(0));
-        rect.line_to(0, image.dim(0));
+        rect.line_to(image.shape(1), 0);
+        rect.line_to(image.shape(1), image.shape(0));
+        rect.line_to(0, image.shape(0));
         rect.line_to(0, 0);
         agg::conv_transform<agg::path_storage> rect2(rect, mtx);
 
@@ -767,10 +767,10 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
     } else {
         agg::rect_i fig, text;
 
-        int deltay = y - image.dim(0);
+        int deltay = y - image.shape(0);
 
         fig.init(0, 0, width, height);
-        text.init(x, deltay, x + image.dim(1), y);
+        text.init(x, deltay, x + image.shape(1), y);
         text.clip(fig);
 
         if (gc.cliprect.x1 != 0.0 || gc.cliprect.y1 != 0.0 || gc.cliprect.x2 != 0.0 || gc.cliprect.y2 != 0.0) {
@@ -832,19 +832,19 @@ inline void RendererAgg::draw_image(GCAgg &gc,
 
     agg::rendering_buffer buffer;
     buffer.attach(
-        image.data(), (unsigned)image.dim(1), (unsigned)image.dim(0), -(int)image.dim(1) * 4);
+        image.data(), (unsigned)image.shape(1), (unsigned)image.shape(0), -(int)image.shape(1) * 4);
     pixfmt pixf(buffer);
 
     if (has_clippath) {
         agg::trans_affine mtx;
         agg::path_storage rect;
 
-        mtx *= agg::trans_affine_translation((int)x, (int)(height - (y + image.dim(0))));
+        mtx *= agg::trans_affine_translation((int)x, (int)(height - (y + image.shape(0))));
 
         rect.move_to(0, 0);
-        rect.line_to(image.dim(1), 0);
-        rect.line_to(image.dim(1), image.dim(0));
-        rect.line_to(0, image.dim(0));
+        rect.line_to(image.shape(1), 0);
+        rect.line_to(image.shape(1), image.shape(0));
+        rect.line_to(0, image.shape(0));
         rect.line_to(0, 0);
 
         agg::conv_transform<agg::path_storage> rect2(rect, mtx);
@@ -880,7 +880,7 @@ inline void RendererAgg::draw_image(GCAgg &gc,
     } else {
         set_clipbox(gc.cliprect, rendererBase);
         rendererBase.blend_from(
-            pixf, 0, (int)x, (int)(height - (y + image.dim(0))), (agg::int8u)(alpha * 255));
+            pixf, 0, (int)x, (int)(height - (y + image.shape(0))), (agg::int8u)(alpha * 255));
     }
 
     rendererBase.reset_clipping(true);
@@ -1234,7 +1234,7 @@ inline void RendererAgg::draw_gouraud_triangles(GCAgg &gc,
     set_clipbox(gc.cliprect, theRasterizer);
     bool has_clippath = render_clippath(gc.clippath.path, gc.clippath.trans, gc.snap_mode);
 
-    for (int i = 0; i < points.dim(0); ++i) {
+    for (int i = 0; i < points.shape(0); ++i) {
         typename PointArray::sub_t point = points.subarray(i);
         typename ColorArray::sub_t color = colors.subarray(i);
 

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -466,7 +466,7 @@ PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args)
         PyErr_Format(PyExc_ValueError,
                      "points and colors arrays must be the same length, got "
                      "%" NPY_INTP_FMT " points and %" NPY_INTP_FMT "colors",
-                     points.dim(0), colors.dim(0));
+                     points.shape(0), colors.shape(0));
         return NULL;
     }
 

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -456,13 +456,13 @@ PyRendererAgg_draw_gouraud_triangles(PyRendererAgg *self, PyObject *args)
                           &trans)) {
         return NULL;
     }
-    if (points.size() && !check_trailing_shape(points, "points", 3, 2)) {
+    if (points.shape(0) && !check_trailing_shape(points, "points", 3, 2)) {
         return NULL;
     }
-    if (colors.size() && !check_trailing_shape(colors, "colors", 3, 4)) {
+    if (colors.shape(0) && !check_trailing_shape(colors, "colors", 3, 4)) {
         return NULL;
     }
-    if (points.size() != colors.size()) {
+    if (points.shape(0) != colors.shape(0)) {
         PyErr_Format(PyExc_ValueError,
                      "points and colors arrays must be the same length, got "
                      "%" NPY_INTP_FMT " points and %" NPY_INTP_FMT "colors",

--- a/src/_path.h
+++ b/src/_path.h
@@ -113,7 +113,7 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
     size_t i;
     bool all_done;
 
-    size_t n = points.size();
+    size_t n = safe_first_shape(points);
 
     std::vector<uint8_t> yflag0(n);
     std::vector<uint8_t> subpath_flag(n);
@@ -247,7 +247,7 @@ inline void points_in_path(PointArray &points,
     typedef agg::conv_contour<curve_t> contour_t;
 
     size_t i;
-    for (i = 0; i < points.size(); ++i) {
+    for (i = 0; i < safe_first_shape(points); ++i) {
         result[i] = false;
     }
 
@@ -384,9 +384,9 @@ void get_path_collection_extents(agg::trans_affine &master_transform,
     }
 
     size_t Npaths = paths.size();
-    size_t Noffsets = offsets.size();
+    size_t Noffsets = safe_first_shape(offsets);
     size_t N = std::max(Npaths, Noffsets);
-    size_t Ntransforms = std::min(transforms.size(), N);
+    size_t Ntransforms = std::min(safe_first_shape(transforms), N);
     size_t i;
 
     agg::trans_affine trans;
@@ -436,9 +436,9 @@ void point_in_path_collection(double x,
         return;
     }
 
-    size_t Noffsets = offsets.size();
+    size_t Noffsets = safe_first_shape(offsets);
     size_t N = std::max(Npaths, Noffsets);
-    size_t Ntransforms = std::min(transforms.size(), N);
+    size_t Ntransforms = std::min(safe_first_shape(transforms), N);
     size_t i;
 
     agg::trans_affine trans;
@@ -776,7 +776,7 @@ int count_bboxes_overlapping_bbox(agg::rect_d &a, BBoxArray &bboxes)
         std::swap(a.y1, a.y2);
     }
 
-    size_t num_bboxes = bboxes.size();
+    size_t num_bboxes = safe_first_shape(bboxes);
     for (size_t i = 0; i < num_bboxes; ++i) {
         b = agg::rect_d(bboxes(i, 0, 0), bboxes(i, 0, 1), bboxes(i, 1, 0), bboxes(i, 1, 1));
 

--- a/src/_path.h
+++ b/src/_path.h
@@ -379,7 +379,7 @@ void get_path_collection_extents(agg::trans_affine &master_transform,
                                  agg::trans_affine &offset_trans,
                                  extent_limits &extent)
 {
-    if (offsets.size() != 0 && offsets.dim(1) != 2) {
+    if (offsets.size() != 0 && offsets.shape(1) != 2) {
         throw std::runtime_error("Offsets array must have shape (N, 2)");
     }
 
@@ -709,7 +709,7 @@ clip_path_to_rect(PathIterator &path, agg::rect_d &rect, bool inside, std::vecto
 template <class VerticesArray, class ResultArray>
 void affine_transform_2d(VerticesArray &vertices, agg::trans_affine &trans, ResultArray &result)
 {
-    if (vertices.size() != 0 && vertices.dim(1) != 2) {
+    if (vertices.size() != 0 && vertices.shape(1) != 2) {
         throw std::runtime_error("Invalid vertices array.");
     }
 
@@ -739,7 +739,7 @@ void affine_transform_2d(VerticesArray &vertices, agg::trans_affine &trans, Resu
 template <class VerticesArray, class ResultArray>
 void affine_transform_1d(VerticesArray &vertices, agg::trans_affine &trans, ResultArray &result)
 {
-    if (vertices.dim(0) != 2) {
+    if (vertices.shape(0) != 2) {
         throw std::runtime_error("Invalid vertices array.");
     }
 

--- a/src/_path.h
+++ b/src/_path.h
@@ -713,7 +713,7 @@ void affine_transform_2d(VerticesArray &vertices, agg::trans_affine &trans, Resu
         throw std::runtime_error("Invalid vertices array.");
     }
 
-    size_t n = vertices.size();
+    size_t n = vertices.shape(0);
     double x;
     double y;
     double t0;

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -83,7 +83,11 @@ static PyObject *Py_points_in_path(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    npy_intp dims[] = { (npy_intp)points.size() };
+    if (!check_trailing_shape(points, "points", 2)) {
+        return NULL;
+    }
+
+    npy_intp dims[] = { (npy_intp)points.shape(0) };
     numpy::array_view<uint8_t, 1> results(dims);
 
     CALL_CPP("points_in_path", (points_in_path(points, r, path, trans, results)));
@@ -361,7 +365,11 @@ static PyObject *Py_affine_transform(PyObject *self, PyObject *args)
         numpy::array_view<double, 2> vertices(vertices_arr);
         Py_DECREF(vertices_arr);
 
-        npy_intp dims[] = { (npy_intp)vertices.size(), 2 };
+        if(!check_trailing_shape(vertices, "vertices", 2)) {
+            return NULL;
+        }
+
+        npy_intp dims[] = { (npy_intp)vertices.shape(0), 2 };
         numpy::array_view<double, 2> result(dims);
         CALL_CPP("affine_transform", (affine_transform_2d(vertices, trans, result)));
         return result.pyobj();
@@ -369,7 +377,7 @@ static PyObject *Py_affine_transform(PyObject *self, PyObject *args)
         numpy::array_view<double, 1> vertices(vertices_arr);
         Py_DECREF(vertices_arr);
 
-        npy_intp dims[] = { (npy_intp)vertices.size() };
+        npy_intp dims[] = { (npy_intp)vertices.shape(0) };
         numpy::array_view<double, 1> result(dims);
         CALL_CPP("affine_transform", (affine_transform_1d(vertices, trans, result)));
         return result.pyobj();

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -118,10 +118,10 @@ static PyObject *Py_update_path_extents(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    if (minpos.dim(0) != 2) {
+    if (minpos.shape(0) != 2) {
         PyErr_Format(PyExc_ValueError,
                      "minpos must be of length 2, got %" NPY_INTP_FMT,
-                     minpos.dim(0));
+                     minpos.shape(0));
         return NULL;
     }
 

--- a/src/_qhull_wrapper.cpp
+++ b/src/_qhull_wrapper.cpp
@@ -267,8 +267,8 @@ delaunay(PyObject *self, PyObject *args)
         return NULL;
     }
 
-    npoints = xarray.dim(0);
-    if (npoints != yarray.dim(0)) {
+    npoints = xarray.shape(0);
+    if (npoints != yarray.shape(0)) {
         PyErr_SetString(PyExc_ValueError,
                         "x and y must be 1D arrays of the same length");
         return NULL;

--- a/src/array.h
+++ b/src/array.h
@@ -40,6 +40,13 @@ class scalar
     }
 };
 
+template <typename T, int ND>
+size_t
+safe_first_shape(scalar<T, ND>)
+{
+    return 1;
+}
+
 template <typename T>
 class empty
 {
@@ -75,6 +82,12 @@ class empty
         return 0;
     }
 };
+
+template <typename T>
+size_t safe_first_shape(empty<T>)
+{
+    return 0;
+}
 }
 
 #endif

--- a/src/array.h
+++ b/src/array.h
@@ -29,7 +29,7 @@ class scalar
         return m_value;
     }
 
-    int dim(size_t i)
+    int shape(size_t i)
     {
         return 1;
     }
@@ -65,7 +65,7 @@ class empty
         return empty<T>();
     }
 
-    int dim(size_t i) const
+    int shape(size_t i) const
     {
         return 0;
     }

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -72,10 +72,10 @@ inline int prepare_and_add_type(PyTypeObject *type, PyObject *module)
 template<typename T>
 inline bool check_trailing_shape(T array, char const* name, long d1)
 {
-    if (array.dim(1) != d1) {
+    if (array.shape(1) != d1) {
         PyErr_Format(PyExc_ValueError,
                      "%s must have shape (N, %ld), got (%ld, %ld)",
-                     name, d1, array.dim(0), array.dim(1));
+                     name, d1, array.shape(0), array.shape(1));
         return false;
     }
     return true;
@@ -84,10 +84,10 @@ inline bool check_trailing_shape(T array, char const* name, long d1)
 template<typename T>
 inline bool check_trailing_shape(T array, char const* name, long d1, long d2)
 {
-    if (array.dim(1) != d1 || array.dim(2) != d2) {
+    if (array.shape(1) != d1 || array.shape(2) != d2) {
         PyErr_Format(PyExc_ValueError,
                      "%s must have shape (N, %ld, %ld), got (%ld, %ld, %ld)",
-                     name, d1, d2, array.dim(0), array.dim(1), array.dim(2));
+                     name, d1, d2, array.shape(0), array.shape(1), array.shape(2));
         return false;
     }
     return true;

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -500,24 +500,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         return m_shape[i];
     }
 
-    /*
-       In most cases, code should use size() instead of dim(0), since
-       size() == 0 when any dimension is 0.
-    */
-    size_t size() const
-    {
-        bool empty = (ND == 0);
-        for (size_t i = 0; i < ND; i++) {
-            if (m_shape[i] == 0) {
-                empty = true;
-            }
-        }
-        if (empty) {
-            return 0;
-        } else {
-            return (size_t)shape(0);
-        }
-    }
+    size_t size() const;
 
     // Do not use this for array_view<bool, ND>.  See comment near top of file.
     const T *data() const
@@ -566,6 +549,32 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         return 1;
     }
 };
+
+/* In most cases, code should use safe_first_shape(obj) instead of obj.shape(0), since
+   safe_first_shape(obj) == 0 when any dimension is 0. */
+template <typename T, int ND>
+size_t
+safe_first_shape(const array_view<T, ND> &a)
+{
+    bool empty = (ND == 0);
+    for (size_t i = 0; i < ND; i++) {
+        if (a.shape(i) == 0) {
+            empty = true;
+        }
+    }
+    if (empty) {
+        return 0;
+    } else {
+        return (size_t)a.shape(0);
+    }
+}
+
+template <typename T, int ND>
+size_t
+array_view<T, ND>::size() const
+{
+    return safe_first_shape<T, ND>(*this);
+}
 
 } // namespace numpy
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -492,7 +492,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         return true;
     }
 
-    npy_intp dim(size_t i) const
+    npy_intp shape(size_t i) const
     {
         if (i >= ND) {
             return 0;
@@ -515,7 +515,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         if (empty) {
             return 0;
         } else {
-            return (size_t)dim(0);
+            return (size_t)shape(0);
         }
     }
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -519,11 +519,6 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         }
     }
 
-    bool empty() const
-    {
-        return size() == 0;
-    }
-
     // Do not use this for array_view<bool, ND>.  See comment near top of file.
     const T *data() const
     {


### PR DESCRIPTION
## PR summary

This will generally make it easier to port to pybind11, as then the templated code can stay the same whether using the old `numpy::array_view` or the new `pybind11::array_t`.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines