### PR TITLE
Add option to fill first row for lables in legend,

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -125,8 +125,8 @@ ncols : int, default: 1
     For backward compatibility, the spelling *ncol* is also supported
     but it is discouraged. If both are given, *ncols* takes precedence.
 
-fill_column_first: bool, default: False
-    Add labels horizontally to the legend.
+order: {'horizontal', 'vertical'}, default: 'vertical'
+    Add labels vertically or horizontally.
 
 prop : None or `~matplotlib.font_manager.FontProperties` or dict
     The font properties of the legend. If None (default), the current
@@ -380,7 +380,7 @@ class Legend(Artist):
 
         ncols=1,     # number of columns
         mode=None,  # horizontal distribution of columns: None or "expand"
-        fill_column_first=False,  # fill columns first
+        order='vertical',  # fill labels vertically or horizontally in legend
 
         fancybox=None,  # True: fancy box, False: rounded box, None: rcParam
         shadow=None,
@@ -486,7 +486,10 @@ class Legend(Artist):
             ncols = 1
         self._ncols = ncols if ncols != 1 else ncol
 
-        if fill_column_first:
+        if order not in {'horizontal', 'vertical'}:
+            raise ValueError("order must be 'horizontal' or 'vertical'")
+
+        if order == 'horizontal':
             labels = itertools.chain(*[labels[i::self._ncols] for i in
                                        range(self._ncols)])
             handles = itertools.chain(*[handles[i::self._ncols] for i in
@@ -604,11 +607,11 @@ class Legend(Artist):
         # set the text color
 
         color_getters = {  # getter function depends on line or patch
-            'linecolor':       ['get_color',           'get_facecolor'],
+            'linecolor': ['get_color', 'get_facecolor'],
             'markerfacecolor': ['get_markerfacecolor', 'get_facecolor'],
-            'mfc':             ['get_markerfacecolor', 'get_facecolor'],
+            'mfc': ['get_markerfacecolor', 'get_facecolor'],
             'markeredgecolor': ['get_markeredgecolor', 'get_edgecolor'],
-            'mec':             ['get_markeredgecolor', 'get_edgecolor'],
+            'mec': ['get_markeredgecolor', 'get_edgecolor'],
         }
         labelcolor = mpl._val_or_rc(labelcolor, 'legend.labelcolor')
         if labelcolor is None:

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -125,6 +125,9 @@ ncols : int, default: 1
     For backward compatibility, the spelling *ncol* is also supported
     but it is discouraged. If both are given, *ncols* takes precedence.
 
+fill_column_first: bool, default: False
+    Add labels horizontally to the legend.
+
 prop : None or `~matplotlib.font_manager.FontProperties` or dict
     The font properties of the legend. If None (default), the current
     :data:`matplotlib.rcParams` will be used.
@@ -377,6 +380,7 @@ class Legend(Artist):
 
         ncols=1,     # number of columns
         mode=None,  # horizontal distribution of columns: None or "expand"
+        fill_column_first=False,  # fill columns first
 
         fancybox=None,  # True: fancy box, False: rounded box, None: rcParam
         shadow=None,
@@ -427,7 +431,8 @@ class Legend(Artist):
         super().__init__()
 
         if prop is None:
-            self.prop = FontProperties(size=mpl._val_or_rc(fontsize, "legend.fontsize"))
+            self.prop = FontProperties(
+                size=mpl._val_or_rc(fontsize, "legend.fontsize"))
         else:
             self.prop = FontProperties._from_any(prop)
             if isinstance(prop, dict) and "size" not in prop:
@@ -445,14 +450,18 @@ class Legend(Artist):
 
         self.numpoints = mpl._val_or_rc(numpoints, 'legend.numpoints')
         self.markerscale = mpl._val_or_rc(markerscale, 'legend.markerscale')
-        self.scatterpoints = mpl._val_or_rc(scatterpoints, 'legend.scatterpoints')
+        self.scatterpoints = mpl._val_or_rc(
+            scatterpoints, 'legend.scatterpoints')
         self.borderpad = mpl._val_or_rc(borderpad, 'legend.borderpad')
         self.labelspacing = mpl._val_or_rc(labelspacing, 'legend.labelspacing')
         self.handlelength = mpl._val_or_rc(handlelength, 'legend.handlelength')
         self.handleheight = mpl._val_or_rc(handleheight, 'legend.handleheight')
-        self.handletextpad = mpl._val_or_rc(handletextpad, 'legend.handletextpad')
-        self.borderaxespad = mpl._val_or_rc(borderaxespad, 'legend.borderaxespad')
-        self.columnspacing = mpl._val_or_rc(columnspacing, 'legend.columnspacing')
+        self.handletextpad = mpl._val_or_rc(
+            handletextpad, 'legend.handletextpad')
+        self.borderaxespad = mpl._val_or_rc(
+            borderaxespad, 'legend.borderaxespad')
+        self.columnspacing = mpl._val_or_rc(
+            columnspacing, 'legend.columnspacing')
         self.shadow = mpl._val_or_rc(shadow, 'legend.shadow')
         # trim handles and labels if illegal label...
         _lab, _hand = [], []
@@ -476,6 +485,12 @@ class Legend(Artist):
         if len(handles) < 2:
             ncols = 1
         self._ncols = ncols if ncols != 1 else ncol
+
+        if fill_column_first:
+            labels = itertools.chain(*[labels[i::self._ncols] for i in
+                                       range(self._ncols)])
+            handles = itertools.chain(*[handles[i::self._ncols] for i in
+                                        range(self._ncols)])
 
         if self.numpoints <= 0:
             raise ValueError("numpoints must be > 0; it was %d" % numpoints)
@@ -799,7 +814,7 @@ class Legend(Artist):
         tuple: legend_handler.HandlerTuple(),
         PathCollection: legend_handler.HandlerPathCollection(),
         PolyCollection: legend_handler.HandlerPolyCollection()
-        }
+    }
 
     # (get|set|update)_default_handler_maps are public interfaces to
     # modify the default handler map.
@@ -889,12 +904,12 @@ class Legend(Artist):
             handler = self.get_legend_handler(legend_handler_map, orig_handle)
             if handler is None:
                 _api.warn_external(
-                             "Legend does not support handles for "
-                             f"{type(orig_handle).__name__} "
-                             "instances.\nA proxy artist may be used "
-                             "instead.\nSee: https://matplotlib.org/"
-                             "stable/users/explain/axes/legend_guide.html"
-                             "#controlling-the-legend-entries")
+                    "Legend does not support handles for "
+                    f"{type(orig_handle).__name__} "
+                    "instances.\nA proxy artist may be used "
+                    "instead.\nSee: https://matplotlib.org/"
+                    "stable/users/explain/axes/legend_guide.html"
+                    "#controlling-the-legend-entries")
                 # No handle for this artist, so we just defer to None.
                 handle_list.append(None)
             else:
@@ -1266,11 +1281,11 @@ def _get_legend_handles(axs, legend_handler_map=None):
         elif (label and not label.startswith('_') and
                 not has_handler(handler_map, handle)):
             _api.warn_external(
-                             "Legend does not support handles for "
-                             f"{type(handle).__name__} "
-                             "instances.\nSee: https://matplotlib.org/stable/"
-                             "tutorials/intermediate/legend_guide.html"
-                             "#implementing-a-custom-legend-handler")
+                "Legend does not support handles for "
+                f"{type(handle).__name__} "
+                "instances.\nSee: https://matplotlib.org/stable/"
+                "tutorials/intermediate/legend_guide.html"
+                "#implementing-a-custom-legend-handler")
             continue
 
 
@@ -1363,7 +1378,8 @@ def _parse_legend_args(axs, *args, handles=None, labels=None, **kwargs):
                 "artists whose label start with an underscore are ignored "
                 "when legend() is called with no argument.")
 
-    elif len(args) == 1:  # 1 arg: user defined labels, automatic handle detection.
+    # 1 arg: user defined labels, automatic handle detection.
+    elif len(args) == 1:
         labels, = args
         if any(isinstance(l, Artist) for l in labels):
             raise TypeError("A single argument passed to legend() must be a "

--- a/lib/matplotlib/legend.pyi
+++ b/lib/matplotlib/legend.pyi
@@ -80,7 +80,7 @@ class Legend(Artist):
         borderaxespad: float | None = ...,
         columnspacing: float | None = ...,
         ncols: int = ...,
-        order: {'horizontal', 'vertical'}=...,
+        order: Literal["horizontal", "vertical"] = ...,
         mode: Literal["expand"] | None = ...,
         fancybox: bool | None = ...,
         shadow: bool | dict[str, Any] | None = ...,

--- a/lib/matplotlib/legend.pyi
+++ b/lib/matplotlib/legend.pyi
@@ -21,12 +21,15 @@ from collections.abc import Iterable
 from typing import Any, Literal, overload
 from .typing import ColorType
 
+
 class DraggableLegend(DraggableOffsetBox):
     legend: Legend
+
     def __init__(
         self, legend: Legend, use_blit: bool = ..., update: Literal["loc", "bbox"] = ...
     ) -> None: ...
     def finalize_offset(self) -> None: ...
+
 
 class Legend(Artist):
     codes: dict[str, int]
@@ -49,6 +52,7 @@ class Legend(Artist):
     axes: Axes
     parent: Axes | Figure
     legendPatch: FancyBboxPatch
+
     def __init__(
         self,
         parent: Axes | Figure,
@@ -76,6 +80,7 @@ class Legend(Artist):
         borderaxespad: float | None = ...,
         columnspacing: float | None = ...,
         ncols: int = ...,
+        order: {'horizontal', 'vertical'}=...,
         mode: Literal["expand"] | None = ...,
         fancybox: bool | None = ...,
         shadow: bool | dict[str, Any] | None = ...,
@@ -102,11 +107,13 @@ class Legend(Artist):
     def get_default_handler_map(cls) -> dict[type, HandlerBase]: ...
     @classmethod
     def set_default_handler_map(cls, handler_map: dict[type, HandlerBase]) -> None: ...
+
     @classmethod
     def update_default_handler_map(
         cls, handler_map: dict[type, HandlerBase]
     ) -> None: ...
     def get_legend_handler_map(self) -> dict[type, HandlerBase]: ...
+
     @staticmethod
     def get_legend_handler(
         legend_handler_map: dict[type, HandlerBase], orig_handle: Any
@@ -119,6 +126,7 @@ class Legend(Artist):
     def set_alignment(self, alignment: Literal["center", "left", "right"]) -> None: ...
     def get_alignment(self) -> Literal["center", "left", "right"]: ...
     def set_loc(self, loc: str | tuple[float, float] | int | None = ...) -> None: ...
+
     def set_title(
         self, title: str, prop: FontProperties | str | pathlib.Path | None = ...
     ) -> None: ...
@@ -127,6 +135,7 @@ class Legend(Artist):
     def set_frame_on(self, b: bool) -> None: ...
     draw_frame = set_frame_on
     def get_bbox_to_anchor(self) -> BboxBase: ...
+
     def set_bbox_to_anchor(
         self,
         bbox: BboxBase
@@ -135,6 +144,7 @@ class Legend(Artist):
         | None,
         transform: Transform | None = ...
     ) -> None: ...
+
     @overload
     def set_draggable(
         self,
@@ -142,6 +152,7 @@ class Legend(Artist):
         use_blit: bool = ...,
         update: Literal["loc", "bbox"] = ...,
     ) -> DraggableLegend: ...
+
     @overload
     def set_draggable(
         self,


### PR DESCRIPTION

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Makes it possible to fill legend row-wise instead of column-wise.
Addresses issue #27067
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #27067" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/27067)
- I got an error while import pyplot : `ImportError: DLL load failed while importing _image: The specified procedure could not be found.`
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
