### PR TITLE
MNT: set codcov to ignore docs and galleries

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,10 +1,14 @@
 # codecov used to be able to find this anywhere, now we have to manually
 # tell it where to look
 comment: false
+ignore:
+  - doc/
+  - galleries/
 
 codecov:
   notify:
     require_ci_to_pass: no
+    threshold: 1%
 
 coverage:
   status:


### PR DESCRIPTION
No idea if this is the right way to do this and not sure how to check, but it's very confusing to have documentation prs fail on code cov. 