### PR TITLE
Remove datetime test stubs for spectral methods/table

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -14,12 +14,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.acorr(...)
 
-    @pytest.mark.xfail(reason="Test for angle_spectrum not written yet")
-    @mpl.style.context("default")
-    def test_angle_spectrum(self):
-        fig, ax = plt.subplots()
-        ax.angle_spectrum(...)
-
     @pytest.mark.xfail(reason="Test for annotate not written yet")
     @mpl.style.context("default")
     def test_annotate(self):
@@ -110,12 +104,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.clabel(...)
 
-    @pytest.mark.xfail(reason="Test for cohere not written yet")
-    @mpl.style.context("default")
-    def test_cohere(self):
-        fig, ax = plt.subplots()
-        ax.cohere(...)
-
     @pytest.mark.xfail(reason="Test for contour not written yet")
     @mpl.style.context("default")
     def test_contour(self):
@@ -127,12 +115,6 @@ class TestDatetimePlotting:
     def test_contourf(self):
         fig, ax = plt.subplots()
         ax.contourf(...)
-
-    @pytest.mark.xfail(reason="Test for csd not written yet")
-    @mpl.style.context("default")
-    def test_csd(self):
-        fig, ax = plt.subplots()
-        ax.csd(...)
 
     @pytest.mark.xfail(reason="Test for errorbar not written yet")
     @mpl.style.context("default")
@@ -241,12 +223,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.loglog(...)
 
-    @pytest.mark.xfail(reason="Test for magnitude_spectrum not written yet")
-    @mpl.style.context("default")
-    def test_magnitude_spectrum(self):
-        fig, ax = plt.subplots()
-        ax.magnitude_spectrum(...)
-
     @pytest.mark.xfail(reason="Test for matshow not written yet")
     @mpl.style.context("default")
     def test_matshow(self):
@@ -277,12 +253,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.pcolormesh(...)
 
-    @pytest.mark.xfail(reason="Test for phase_spectrum not written yet")
-    @mpl.style.context("default")
-    def test_phase_spectrum(self):
-        fig, ax = plt.subplots()
-        ax.phase_spectrum(...)
-
     @mpl.style.context("default")
     def test_plot(self):
         mpl.rcParams["date.converter"] = 'concise'
@@ -311,12 +281,6 @@ class TestDatetimePlotting:
         ax1.plot_date(x_dates, y_dates)
         ax2.plot_date(x_dates, y_ranges)
         ax3.plot_date(x_ranges, y_dates)
-
-    @pytest.mark.xfail(reason="Test for psd not written yet")
-    @mpl.style.context("default")
-    def test_psd(self):
-        fig, ax = plt.subplots()
-        ax.psd(...)
 
     @pytest.mark.xfail(reason="Test for quiver not written yet")
     @mpl.style.context("default")
@@ -347,12 +311,6 @@ class TestDatetimePlotting:
     def test_semilogy(self):
         fig, ax = plt.subplots()
         ax.semilogy(...)
-
-    @pytest.mark.xfail(reason="Test for specgram not written yet")
-    @mpl.style.context("default")
-    def test_specgram(self):
-        fig, ax = plt.subplots()
-        ax.specgram(...)
 
     @pytest.mark.xfail(reason="Test for spy not written yet")
     @mpl.style.context("default")
@@ -389,12 +347,6 @@ class TestDatetimePlotting:
     def test_streamplot(self):
         fig, ax = plt.subplots()
         ax.streamplot(...)
-
-    @pytest.mark.xfail(reason="Test for table not written yet")
-    @mpl.style.context("default")
-    def test_table(self):
-        fig, ax = plt.subplots()
-        ax.table(...)
 
     @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary


Addresses parts of #26864

This is a clean up of the stubs for methods which have been determined to not use the units machinery that is being tested in this module, this includes the various spectrum plot methods as well as the table method (xref #26953)

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
