### PR TITLE
Changing _log.info to warnings.warn and importing the warnings module.

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -14,6 +14,7 @@ from collections import OrderedDict
 import dateutil.parser
 import itertools
 import logging
+import warnings
 
 import numpy as np
 
@@ -220,7 +221,7 @@ class UnitData:
             if val not in self._mapping:
                 self._mapping[val] = next(self._counter)
         if data.size and convertible:
-            _log.info('Using categorical units to plot a list of strings '
+            warnings.warn('Using categorical units to plot a list of strings '
                       'that are all parsable as floats or dates. If these '
                       'strings should be plotted as numbers, cast to the '
                       'appropriate data type before plotting.')


### PR DESCRIPTION
## PR summary
Changing the _log.info to warnings.warn when passing string-formatted numbers as data, closes #23422 as for now. 
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

