### PR TITLE
Issue #26990: Split the histogram image into two for each code block. 

### DIFF
--- a/galleries/examples/misc/histogram_path.py
+++ b/galleries/examples/misc/histogram_path.py
@@ -20,7 +20,7 @@ import numpy as np
 import matplotlib.patches as patches
 import matplotlib.path as path
 
-fig, axs = plt.subplots(2)
+fig, axs = plt.subplots(1)
 
 np.random.seed(19680801)  # Fixing random state for reproducibility
 
@@ -44,14 +44,16 @@ barpath = path.Path.make_compound_path_from_polys(XY)
 # make a patch out of it, don't add a margin at y=0
 patch = patches.PathPatch(barpath)
 patch.sticky_edges.y[:] = [0]
-axs[0].add_patch(patch)
-axs[0].autoscale_view()
+axs.add_patch(patch)
+axs.autoscale_view()
+plt.show()
 
 # %%
 # Instead of creating a three-dimensional array and using
 # `~.path.Path.make_compound_path_from_polys`, we could as well create the
 # compound path directly using vertices and codes as shown below
 
+fig, axs = plt.subplots(1)
 nrects = len(left)
 nverts = nrects*(1+3+1)
 verts = np.zeros((nverts, 2))
@@ -72,9 +74,8 @@ barpath = path.Path(verts, codes)
 # make a patch out of it, don't add a margin at y=0
 patch = patches.PathPatch(barpath)
 patch.sticky_edges.y[:] = [0]
-axs[1].add_patch(patch)
-axs[1].autoscale_view()
-
+axs.add_patch(patch)
+axs.autoscale_view()
 plt.show()
 
 # %%

--- a/galleries/examples/misc/histogram_path.py
+++ b/galleries/examples/misc/histogram_path.py
@@ -20,8 +20,6 @@ import numpy as np
 import matplotlib.patches as patches
 import matplotlib.path as path
 
-fig, axs = plt.subplots(1)
-
 np.random.seed(19680801)  # Fixing random state for reproducibility
 
 # histogram our data with numpy
@@ -44,8 +42,10 @@ barpath = path.Path.make_compound_path_from_polys(XY)
 # make a patch out of it, don't add a margin at y=0
 patch = patches.PathPatch(barpath)
 patch.sticky_edges.y[:] = [0]
-axs.add_patch(patch)
-axs.autoscale_view()
+
+fig, ax = plt.subplots()
+ax.add_patch(patch)
+ax.autoscale_view()
 plt.show()
 
 # %%
@@ -53,7 +53,6 @@ plt.show()
 # `~.path.Path.make_compound_path_from_polys`, we could as well create the
 # compound path directly using vertices and codes as shown below
 
-fig, axs = plt.subplots(1)
 nrects = len(left)
 nverts = nrects*(1+3+1)
 verts = np.zeros((nverts, 2))
@@ -74,8 +73,10 @@ barpath = path.Path(verts, codes)
 # make a patch out of it, don't add a margin at y=0
 patch = patches.PathPatch(barpath)
 patch.sticky_edges.y[:] = [0]
-axs.add_patch(patch)
-axs.autoscale_view()
+
+fig, ax = plt.subplots()
+ax.add_patch(patch)
+ax.autoscale_view()
 plt.show()
 
 # %%


### PR DESCRIPTION
Fixes #26990 

- [x] Fix added for image not getting rendered properly.

Solution: Split image into two rows for two blocks of code resp.

<img width="292" alt="hist_doc" src="https://github.com/matplotlib/matplotlib/assets/76914526/3a00fa0c-8296-42c5-92e3-c45756ebc347">


<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
