### PR TITLE
MNT: revert contour deprecations

### DIFF
--- a/doc/api/next_api_changes/deprecations/27075-JK.rst
+++ b/doc/api/next_api_changes/deprecations/27075-JK.rst
@@ -1,0 +1,5 @@
+Deprecations removed in ``contour``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``contour.allsegs``, ``contour.allkinds``, and ``contour.find_nearest_contour`` are no
+longer marked for deprecation.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -929,12 +929,12 @@ class ContourSet(ContourLabeler, mcoll.Collection):
                 ", ".join(map(repr, kwargs))
             )
 
-    allsegs = _api.deprecated("3.8", pending=True)(property(lambda self: [
+    allsegs = property(lambda self: [
         [subp.vertices for subp in p._iter_connected_components()]
-        for p in self.get_paths()]))
-    allkinds = _api.deprecated("3.8", pending=True)(property(lambda self: [
+        for p in self.get_paths()])
+    allkinds = property(lambda self: [
         [subp.codes for subp in p._iter_connected_components()]
-        for p in self.get_paths()]))
+        for p in self.get_paths()])
     tcolors = _api.deprecated("3.8")(property(lambda self: [
         (tuple(rgba),) for rgba in self.to_rgba(self.cvalues, self.alpha)]))
     tlinewidths = _api.deprecated("3.8")(property(lambda self: [
@@ -1388,7 +1388,6 @@ class ContourSet(ContourLabeler, mcoll.Collection):
 
         return idx_level_min, idx_vtx_min, proj_min
 
-    @_api.deprecated("3.8")
     def find_nearest_contour(self, x, y, indices=None, pixel=True):
         """
         Find the point in the contour plot that is closest to ``(x, y)``.


### PR DESCRIPTION
``contour.allsegs``, ``contour.allkinds``, and ``contour.find_nearest_contour`` are no longer marked for deprecation.

These are useful for post-processing and perhaps extra labelling.  It pins us down a bit more to have them available, but the benefit justifies the cost in my opinion.  

Closes #27070 #26913 