### PR TITLE
DOC: plot-directive warning filter option

### DIFF
--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -174,3 +174,11 @@ Plot 21 is generated via an include directive:
 Plot 22 uses a different specific function in a file with plot commands:
 
 .. plot:: range6.py range10
+
+Plot 23 filters a missing glyph warning
+
+.. plot:: 
+    :filter-warning: Glyph
+
+    plt.text(.5, .5, "Hello 🙃 World!")
+   


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Ended up not needing it in #26989, but figure an option to filter a warning might be useful? This is the most basic implementation

```rst

.. plot-directive::
  :filter-warning: Ignore
```
where the string input is whatever can be passed into warnings.filterwarning, Possibly needs tests. 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
