### PR TITLE
Update axislines.py

### DIFF
--- a/lib/mpl_toolkits/axisartist/axislines.py
+++ b/lib/mpl_toolkits/axisartist/axislines.py
@@ -124,9 +124,7 @@ class _FixedAxisArtistHelperBase(_AxisArtistHelperBase):
                 {"bottom": 0, "top": 0, "left": 1, "right": 1}, loc=loc))
         if (nth_coord == 0 and loc not in ["left", "right"]
                 or nth_coord == 1 and loc not in ["bottom", "top"]):
-            _api.warn_deprecated(
-                "3.7", message=f"{loc=!r} is incompatible with "
-                "{nth_coord=}; support is deprecated since %(since)s")
+            raise ValueError("x=None is not supported")
         self._loc = loc
         self._pos = {"bottom": 0, "top": 1, "left": 0, "right": 1}[loc]
         super().__init__()


### PR DESCRIPTION
Removed  _api.warn_deprecated("3.7", message="x=None is deprecated") and Replaced with raise ValueError("x=None is not supported")

<!--
Thank you so much for your PR! To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail (Why is this change required? What problem does it solve?) and link to relevant issues and PRs. Also please summarize the changes in the title, for example "Raise ValueError on non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses issue #8576". -->
This PR, titled "Title of Your PR," addresses issue #26962. It [briefly describe why the change is necessary and what problem it solves]. It includes [summarize the main changes made in this PR].

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #26865" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!-- We understand that PRs can sometimes be overwhelming, especially as the reviews start coming in. Please let us know if the reviews are unclear or the recommended next step seems overly demanding, if you would like help in addressing a reviewer's comments, or if you have been waiting too long to hear back on your PR. -->
