### PR TITLE
fix artist pickable logic to respect 'set_picker' boolean parameter

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -508,7 +508,7 @@ class Artist:
         --------
         .Artist.set_picker, .Artist.get_picker, .Artist.pick
         """
-        return self.figure is not None and self._picker is not None
+        return self.figure is not None and self._picker
 
     def pick(self, mouseevent):
         """


### PR DESCRIPTION


## PR summary
Closes #27068 

The existing logic did not correctly handle the set_picker boolean parameter for 'pickable' check leading to unexpected behavior when attempting to deactivate picking on a collection.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [[link the related issue](https://github.com/matplotlib/matplotlib/issues/27068)](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines