### PR TITLE
DOC: Add tags infrastructure for gallery examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ galleries/examples/*/*.svgz
 result_images
 doc/_static/constrained_layout*.png
 doc/.mpl_skip_subdirs.yaml
+doc/_tags
 
 # Nose/Pytest generated files #
 ###############################

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -3,6 +3,11 @@
     --pst-color-link-hover: var(--pst-color-secondary);
     --sd-color-primary: var(--pst-color-primary);
     --sd-color-primary-text: var(--pst-color-text-base);
+    --sd-color-secondary: #ee9040;
+    --sd-color-success: #28a745;
+    --sd-color-dark: #323232;
+    --sd-color-danger: #dc3545;
+    --sd-color-light: #c9c9c9;
 }
 
 .simple li>p {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -118,6 +118,7 @@ extensions = [
     'sphinxext.redirect_from',
     'sphinx_copybutton',
     'sphinx_design',
+    'sphinx_tags',
 ]
 
 exclude_patterns = [
@@ -282,6 +283,18 @@ if 'plot_gallery=0' in sys.argv:
     logger = logging.getLogger('sphinx')
     logger.addFilter(gallery_image_warning_filter)
 
+# Sphinx tags configuration
+tags_create_tags = True
+tags_page_title = "All tags"
+tags_create_badges = True
+tags_badge_colors = {
+    "animation": "primary",
+    "component:*": "secondary",
+    "event-handling": "success",
+    "interactivity:*": "dark",
+    "plot-type:*": "danger",
+    "*": "light"  # default value
+}
 
 mathmpl_fontsize = 11.0
 mathmpl_srcset = ['2x']

--- a/environment.yml
+++ b/environment.yml
@@ -39,7 +39,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery>=0.12
   - sphinx-design
-  - sphinx-tags
+  - sphinx-tags>=0.3.0
   - pip
   - pip:
       - mpl-sphinx-theme

--- a/environment.yml
+++ b/environment.yml
@@ -39,6 +39,7 @@ dependencies:
   - sphinx-copybutton
   - sphinx-gallery>=0.12
   - sphinx-design
+  - sphinx-tags
   - pip
   - pip:
       - mpl-sphinx-theme

--- a/galleries/examples/README.txt
+++ b/galleries/examples/README.txt
@@ -16,5 +16,6 @@ You can also find :ref:`external resources <resources-index>` and
 a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
 
 
-.. note::
+.. admonition:: Tagging!
+
     You can also browse the example gallery by :ref:`tags <tagoverview>`.

--- a/galleries/examples/README.txt
+++ b/galleries/examples/README.txt
@@ -14,3 +14,7 @@ and source code.
 For longer tutorials, see our :ref:`tutorials page <tutorials>`.
 You can also find :ref:`external resources <resources-index>` and
 a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
+
+
+.. note::
+    You can also browse the example gallery by :ref:`tags <tagoverview>`.

--- a/galleries/examples/animation/animated_histogram.py
+++ b/galleries/examples/animation/animated_histogram.py
@@ -55,3 +55,6 @@ ax.set_ylim(top=55)  # set safe limit to ensure that all data is visible.
 ani = animation.FuncAnimation(fig, prepare_animation(bar_container), 50,
                               repeat=False, blit=True)
 plt.show()
+
+# %%
+# .. tags:: plot-type:histogram, animation

--- a/galleries/examples/animation/animated_histogram.py
+++ b/galleries/examples/animation/animated_histogram.py
@@ -57,4 +57,4 @@ ani = animation.FuncAnimation(fig, prepare_animation(bar_container), 50,
 plt.show()
 
 # %%
-# .. tags:: plot-type:histogram, animation
+# .. tags:: plot-type: histogram, animation

--- a/galleries/examples/animation/multiple_axes.py
+++ b/galleries/examples/animation/multiple_axes.py
@@ -81,4 +81,4 @@ plt.show()
 #    - `matplotlib.patches.ConnectionPatch`
 #    - `matplotlib.animation.FuncAnimation`
 #
-# .. tags:: component:axes, animation
+# .. tags:: component: axes, animation

--- a/galleries/examples/animation/multiple_axes.py
+++ b/galleries/examples/animation/multiple_axes.py
@@ -80,3 +80,5 @@ plt.show()
 #
 #    - `matplotlib.patches.ConnectionPatch`
 #    - `matplotlib.animation.FuncAnimation`
+#
+# .. tags:: component:axes, animation

--- a/galleries/examples/event_handling/resample.py
+++ b/galleries/examples/event_handling/resample.py
@@ -77,4 +77,4 @@ ax.set_xlim(16, 365)
 plt.show()
 
 # %%
-# .. tags:: interactivity:zoom, event-handling
+# .. tags:: interactivity: zoom, event-handling

--- a/galleries/examples/event_handling/resample.py
+++ b/galleries/examples/event_handling/resample.py
@@ -75,3 +75,6 @@ ax.set_autoscale_on(False)  # Otherwise, infinite loop
 ax.callbacks.connect('xlim_changed', d.update)
 ax.set_xlim(16, 365)
 plt.show()
+
+# %%
+# .. tags:: interactivity:zoom, event-handling

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -21,3 +21,4 @@ sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.12.0
 sphinx-copybutton
 sphinx-design
+sphinx-tags

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -21,4 +21,4 @@ sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-gallery>=0.12.0
 sphinx-copybutton
 sphinx-design
-sphinx-tags
+sphinx-tags>=0.3.0


### PR DESCRIPTION
## PR summary

Adds [sphinx-tags](https://sphinx-tags.readthedocs.io/en/latest/index.html) as a dependency and some basic configuration to display tags with color, using [sphinx-design](https://sphinx-design.readthedocs.io/en/latest/).

This is a proof-of-concept implementation of tags for the gallery of examples. The actual tags will be the result of the Google Season of Docs project by @esibinga.

This PR is mostly a demo of how this would work in practice, and feedback is appreciated.

Related: #26851 

There is no release note but this may need one when it is ready to merge.

cc @story645 

Previews:

- [Example gallery entry page, with the link to all tags](https://output.circle-artifacts.com/output/job/63217eb6-7b19-4d1f-b35a-9aa17e8da975/artifacts/0/doc/build/html/gallery/index.html)
- [Tagged animation example](https://output.circle-artifacts.com/output/job/63217eb6-7b19-4d1f-b35a-9aa17e8da975/artifacts/0/doc/build/html/gallery/animation/animated_histogram.html) (**scroll to the bottom to see the tags**)
- [Tagged example](https://output.circle-artifacts.com/output/job/63217eb6-7b19-4d1f-b35a-9aa17e8da975/artifacts/0/doc/build/html/gallery/event_handling/resample.html) (**scroll to the bottom to see the tags**)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

