### PR TITLE
Add test_barh to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -77,17 +77,21 @@ class TestDatetimePlotting:
     @mpl.style.context("default")
     def test_barh(self):
         mpl.rcParams["date.converter"] = 'concise'
-        N = 14
-        base = datetime.datetime(1970, 1, 1)
-        indices = np.arange(N)
-        dates = [base + datetime.timedelta(days=(7 * i)) for i in range(N)]
-        widths = [datetime.timedelta(days=(7*i)) for i in range(N)]
-        fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, layout='constrained')
-        error = np.random.rand(N)
-        ax1.barh(indices, dates, xerr=error)
-        ax2.barh(dates, indices)
-        ax3.barh(dates, dates)
-        ax4.barh(indices, width=widths, left=base)
+        fig, (ax1, ax2) = plt.subplots(2, 1, layout='constrained')
+        birth_date = np.array([datetime.datetime(2020, 4, 10),
+                               datetime.datetime(2020, 5, 30),
+                               datetime.datetime(2020, 10, 12),
+                               datetime.datetime(2020, 11, 15)])
+        year_start = datetime.datetime(2020, 1, 1)
+        year_end = datetime.datetime(2020, 12, 31)
+        age = [21, 53, 20, 24]
+        ax1.set_xlabel('Age')
+        ax1.set_ylabel('Birth Date')
+        ax1.barh(birth_date, width=age, height=datetime.timedelta(days=10))
+        ax2.set_xlim(left=year_start, right=year_end)
+        ax2.set_xlabel('Birth Date')
+        ax2.set_ylabel('Order of Birth Dates')
+        ax2.barh(np.arange(4), birth_date-year_start, left=year_start)
 
     @pytest.mark.xfail(reason="Test for boxplot not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -80,11 +80,18 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.barbs(...)
 
-    @pytest.mark.xfail(reason="Test for barh not written yet")
     @mpl.style.context("default")
     def test_barh(self):
-        fig, ax = plt.subplots()
-        ax.barh(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        N = 14
+        base = datetime.datetime(1970, 1, 1)
+        indices = np.arange(N)
+        dates = [base + datetime.timedelta(days=(7 * i)) for i in range(N)]
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        error = np.random.rand(N)
+        ax1.barh(indices, dates, xerr=error)
+        ax2.barh(dates, indices)
+        ax3.barh(dates, dates)
 
     @pytest.mark.xfail(reason="Test for boxplot not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -81,11 +81,13 @@ class TestDatetimePlotting:
         base = datetime.datetime(1970, 1, 1)
         indices = np.arange(N)
         dates = [base + datetime.timedelta(days=(7 * i)) for i in range(N)]
-        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        widths = [datetime.timedelta(days=(7*i)) for i in range(N)]
+        fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, layout='constrained')
         error = np.random.rand(N)
         ax1.barh(indices, dates, xerr=error)
         ax2.barh(dates, indices)
         ax3.barh(dates, dates)
+        ax4.barh(indices, width=widths, left=base)
 
     @pytest.mark.xfail(reason="Test for boxplot not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I have added a datetime/timedelta smoke test for `Axes.barh` in `lib/matplotlib/tests/test_datetime.py`.
This addresses the `Axes.barh` task from #26864.

The image below is the plot generated from this smoke test/example code.
![barh_smoke_test](https://github.com/matplotlib/matplotlib/assets/99672198/3676b7ee-8566-4e31-bf97-35524216bb07)

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
