### PR TITLE
Rename py namespace to mpl in extension code

### DIFF
--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -128,11 +128,11 @@ RendererAgg::restore_region(BufferRegion &region, int xx1, int yy1, int xx2, int
     rendererBase.copy_from(rbuf, &rect, x, y);
 }
 
-bool RendererAgg::render_clippath(py::PathIterator &clippath,
+bool RendererAgg::render_clippath(mpl::PathIterator &clippath,
                                   const agg::trans_affine &clippath_trans,
                                   e_snap_mode snap_mode)
 {
-    typedef agg::conv_transform<py::PathIterator> transformed_path_t;
+    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removed_t;
     /* Unlike normal Paths, the clip path cannot be clipped to the Figure bbox,
      * because it needs to remain a complete closed path, so there is no

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -244,7 +244,7 @@ class RendererAgg
     template <class R>
     void set_clipbox(const agg::rect_d &cliprect, R &rasterizer);
 
-    bool render_clippath(py::PathIterator &clippath, const agg::trans_affine &clippath_trans, e_snap_mode snap_mode);
+    bool render_clippath(mpl::PathIterator &clippath, const agg::trans_affine &clippath_trans, e_snap_mode snap_mode);
 
     template <class PathIteratorType>
     void _draw_path(PathIteratorType &path, bool has_clippath, const facepair_t &face, GCAgg &gc);
@@ -340,11 +340,11 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
         rendererBase.reset_clipping(true);
 
         // Create and transform the path
-        typedef agg::conv_transform<py::PathIterator> hatch_path_trans_t;
+        typedef agg::conv_transform<mpl::PathIterator> hatch_path_trans_t;
         typedef agg::conv_curve<hatch_path_trans_t> hatch_path_curve_t;
         typedef agg::conv_stroke<hatch_path_curve_t> hatch_path_stroke_t;
 
-        py::PathIterator hatch_path(gc.hatchpath);
+        mpl::PathIterator hatch_path(gc.hatchpath);
         agg::trans_affine hatch_trans;
         hatch_trans *= agg::trans_affine_scaling(1.0, -1.0);
         hatch_trans *= agg::trans_affine_translation(0.0, 1.0);
@@ -447,7 +447,7 @@ template <class PathIterator>
 inline void
 RendererAgg::draw_path(GCAgg &gc, PathIterator &path, agg::trans_affine &trans, agg::rgba &color)
 {
-    typedef agg::conv_transform<py::PathIterator> transformed_path_t;
+    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removed_t;
     typedef PathClipper<nan_removed_t> clipped_t;
     typedef PathSnapper<clipped_t> snapped_t;
@@ -490,7 +490,7 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
                                       agg::trans_affine &trans,
                                       agg::rgba color)
 {
-    typedef agg::conv_transform<py::PathIterator> transformed_path_t;
+    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removed_t;
     typedef PathSnapper<nan_removed_t> snap_t;
     typedef agg::conv_curve<snap_t> curve_t;

--- a/src/_backend_agg_basic_types.h
+++ b/src/_backend_agg_basic_types.h
@@ -14,7 +14,7 @@
 
 struct ClipPath
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
 };
 
@@ -103,7 +103,7 @@ class GCAgg
 
     e_snap_mode snap_mode;
 
-    py::PathIterator hatchpath;
+    mpl::PathIterator hatchpath;
     agg::rgba hatch_color;
     double hatch_linewidth;
 

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -209,7 +209,7 @@ static void PyRendererAgg_dealloc(PyRendererAgg *self)
 static PyObject *PyRendererAgg_draw_path(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     PyObject *faceobj = NULL;
     agg::rgba face;
@@ -263,9 +263,9 @@ static PyObject *PyRendererAgg_draw_text_image(PyRendererAgg *self, PyObject *ar
 PyObject *PyRendererAgg_draw_markers(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
-    py::PathIterator marker_path;
+    mpl::PathIterator marker_path;
     agg::trans_affine marker_path_trans;
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     PyObject *faceobj = NULL;
     agg::rgba face;
@@ -328,7 +328,7 @@ PyRendererAgg_draw_path_collection(PyRendererAgg *self, PyObject *args)
 {
     GCAgg gc;
     agg::trans_affine master_transform;
-    py::PathGenerator paths;
+    mpl::PathGenerator paths;
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     agg::trans_affine offset_trans;

--- a/src/_path.h
+++ b/src/_path.h
@@ -856,7 +856,7 @@ inline bool segments_intersect(const double &x1,
 template <class PathIterator1, class PathIterator2>
 bool path_intersects_path(PathIterator1 &p1, PathIterator2 &p2)
 {
-    typedef PathNanRemover<py::PathIterator> no_nans_t;
+    typedef PathNanRemover<mpl::PathIterator> no_nans_t;
     typedef agg::conv_curve<no_nans_t> curve_t;
 
     if (p1.total_vertices() < 2 || p2.total_vertices() < 2) {
@@ -920,7 +920,7 @@ bool path_intersects_rectangle(PathIterator &path,
                                double rect_x2, double rect_y2,
                                bool filled)
 {
-    typedef PathNanRemover<py::PathIterator> no_nans_t;
+    typedef PathNanRemover<mpl::PathIterator> no_nans_t;
     typedef agg::conv_curve<no_nans_t> curve_t;
 
     if (path.total_vertices() == 0) {
@@ -966,7 +966,7 @@ void convert_path_to_polygons(PathIterator &path,
                               int closed_only,
                               std::vector<Polygon> &result)
 {
-    typedef agg::conv_transform<py::PathIterator> transformed_path_t;
+    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removal_t;
     typedef PathClipper<nan_removal_t> clipped_t;
     typedef PathSimplifier<clipped_t> simplify_t;
@@ -1032,7 +1032,7 @@ void cleanup_path(PathIterator &path,
                   std::vector<double> &vertices,
                   std::vector<unsigned char> &codes)
 {
-    typedef agg::conv_transform<py::PathIterator> transformed_path_t;
+    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removal_t;
     typedef PathClipper<nan_removal_t> clipped_t;
     typedef PathSnapper<clipped_t> snapped_t;
@@ -1189,7 +1189,7 @@ bool convert_to_string(PathIterator &path,
                        std::string& buffer)
 {
     size_t buffersize;
-    typedef agg::conv_transform<py::PathIterator> transformed_path_t;
+    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
     typedef PathNanRemover<transformed_path_t> nan_removal_t;
     typedef PathClipper<nan_removal_t> clipped_t;
     typedef PathSimplifier<clipped_t> simplify_t;

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -35,7 +35,7 @@ const char *Py_point_in_path__doc__ =
 static PyObject *Py_point_in_path(PyObject *self, PyObject *args)
 {
     double x, y, r;
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     bool result;
 
@@ -68,7 +68,7 @@ static PyObject *Py_points_in_path(PyObject *self, PyObject *args)
 {
     numpy::array_view<const double, 2> points;
     double r;
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
 
     if (!PyArg_ParseTuple(args,
@@ -97,7 +97,7 @@ const char *Py_update_path_extents__doc__ =
 
 static PyObject *Py_update_path_extents(PyObject *self, PyObject *args)
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     agg::rect_d rect;
     numpy::array_view<double, 1> minpos;
@@ -177,7 +177,7 @@ const char *Py_get_path_collection_extents__doc__ =
 static PyObject *Py_get_path_collection_extents(PyObject *self, PyObject *args)
 {
     agg::trans_affine master_transform;
-    py::PathGenerator paths;
+    mpl::PathGenerator paths;
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     agg::trans_affine offset_trans;
@@ -227,7 +227,7 @@ static PyObject *Py_point_in_path_collection(PyObject *self, PyObject *args)
 {
     double x, y, radius;
     agg::trans_affine master_transform;
-    py::PathGenerator paths;
+    mpl::PathGenerator paths;
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     agg::trans_affine offset_trans;
@@ -280,9 +280,9 @@ const char *Py_path_in_path__doc__ =
 
 static PyObject *Py_path_in_path(PyObject *self, PyObject *args)
 {
-    py::PathIterator a;
+    mpl::PathIterator a;
     agg::trans_affine atrans;
-    py::PathIterator b;
+    mpl::PathIterator b;
     agg::trans_affine btrans;
     bool result;
 
@@ -314,7 +314,7 @@ const char *Py_clip_path_to_rect__doc__ =
 
 static PyObject *Py_clip_path_to_rect(PyObject *self, PyObject *args)
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::rect_d rect;
     bool inside;
     std::vector<Polygon> result;
@@ -407,8 +407,8 @@ const char *Py_path_intersects_path__doc__ =
 
 static PyObject *Py_path_intersects_path(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    py::PathIterator p1;
-    py::PathIterator p2;
+    mpl::PathIterator p1;
+    mpl::PathIterator p2;
     agg::trans_affine t1;
     agg::trans_affine t2;
     int filled = 0;
@@ -453,7 +453,7 @@ const char *Py_path_intersects_rectangle__doc__ =
 
 static PyObject *Py_path_intersects_rectangle(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     double rect_x1, rect_y1, rect_x2, rect_y2;
     bool filled = false;
     const char *names[] = { "path", "rect_x1", "rect_y1", "rect_x2", "rect_y2", "filled", NULL };
@@ -489,7 +489,7 @@ const char *Py_convert_path_to_polygons__doc__ =
 
 static PyObject *Py_convert_path_to_polygons(PyObject *self, PyObject *args, PyObject *kwds)
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     double width = 0.0, height = 0.0;
     int closed_only = 1;
@@ -524,7 +524,7 @@ const char *Py_cleanup_path__doc__ =
 
 static PyObject *Py_cleanup_path(PyObject *self, PyObject *args)
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     bool remove_nans;
     agg::rect_d clip_rect;
@@ -631,7 +631,7 @@ const char *Py_convert_to_string__doc__ =
 
 static PyObject *Py_convert_to_string(PyObject *self, PyObject *args)
 {
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
     agg::rect_d cliprect;
     PyObject *simplifyobj;

--- a/src/_ttconv.cpp
+++ b/src/_ttconv.cpp
@@ -12,6 +12,7 @@
 #include <vector>
 
 namespace py = pybind11;
+using namespace pybind11::literals;
 
 /**
  * An implementation of TTStreamWriter that writes to a Python
@@ -75,10 +76,10 @@ PYBIND11_MODULE(_ttconv, m) {
               "fonts to Postscript Type 3, Postscript Type 42 and "
               "Pdf Type 3 fonts.";
     m.def("convert_ttf_to_ps", &convert_ttf_to_ps,
-        py::arg("filename"),
-        py::arg("output"),
-        py::arg("fonttype"),
-        py::arg("glyph_ids") = py::none(),
+        "filename"_a,
+        "output"_a,
+        "fonttype"_a,
+        "glyph_ids"_a = py::none(),
         "Converts the Truetype font into a Type 3 or Type 42 Postscript font, "
         "optionally subsetting the font to only the desired set of characters.\n"
         "\n"

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -195,7 +195,7 @@ exit:
     Py_XDECREF(text_helpers);
     Py_XDECREF(tmp);
     if (PyErr_Occurred()) {
-        throw py::exception();
+        throw mpl::exception();
     }
 }
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -378,7 +378,7 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
     array_view(PyObject *arr, bool contiguous = false) : m_arr(NULL), m_data(NULL)
     {
         if (!set(arr, contiguous)) {
-            throw py::exception();
+            throw mpl::exception();
         }
     }
 
@@ -413,11 +413,11 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
     {
         PyObject *arr = PyArray_SimpleNew(ND, shape, type_num_of<T>::value);
         if (arr == NULL) {
-            throw py::exception();
+            throw mpl::exception();
         }
         if (!set(arr, true)) {
             Py_DECREF(arr);
-            throw py::exception();
+            throw mpl::exception();
         }
         Py_DECREF(arr);
     }

--- a/src/py_adaptors.h
+++ b/src/py_adaptors.h
@@ -18,12 +18,11 @@ extern "C" {
 int convert_path(PyObject *obj, void *pathp);
 }
 
-namespace py
-{
+namespace mpl {
 
 /************************************************************
- * py::PathIterator acts as a bridge between Numpy and Agg.  Given a
- * pair of Numpy arrays, vertices and codes, it iterates over
+ * mpl::PathIterator acts as a bridge between NumPy and Agg.  Given a
+ * pair of NumPy arrays, vertices and codes, it iterates over
  * those vertices and codes, using the standard Agg vertex source
  * interface:
  *
@@ -66,14 +65,14 @@ class PathIterator
         : m_vertices(NULL), m_codes(NULL), m_iterator(0)
     {
         if (!set(vertices, codes, should_simplify, simplify_threshold))
-            throw py::exception();
+            throw mpl::exception();
     }
 
     inline PathIterator(PyObject *vertices, PyObject *codes)
         : m_vertices(NULL), m_codes(NULL), m_iterator(0)
     {
         if (!set(vertices, codes))
-            throw py::exception();
+            throw mpl::exception();
     }
 
     inline PathIterator(const PathIterator &other)
@@ -233,11 +232,11 @@ class PathGenerator
 
         item = PySequence_GetItem(m_paths, i % m_npaths);
         if (item == NULL) {
-            throw py::exception();
+            throw mpl::exception();
         }
         if (!convert_path(item, &path)) {
             Py_DECREF(item);
-            throw py::exception();
+            throw mpl::exception();
         }
         Py_DECREF(item);
         return path;

--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -343,7 +343,7 @@ int convert_trans_affine(PyObject *obj, void *transp)
 
 int convert_path(PyObject *obj, void *pathp)
 {
-    py::PathIterator *path = (py::PathIterator *)pathp;
+    mpl::PathIterator *path = (mpl::PathIterator *)pathp;
 
     PyObject *vertices_obj = NULL;
     PyObject *codes_obj = NULL;
@@ -404,7 +404,7 @@ exit:
 
 int convert_pathgen(PyObject *obj, void *pathgenp)
 {
-    py::PathGenerator *paths = (py::PathGenerator *)pathgenp;
+    mpl::PathGenerator *paths = (mpl::PathGenerator *)pathgenp;
     if (!paths->set(obj)) {
         PyErr_SetString(PyExc_TypeError, "Not an iterable of paths");
         return 0;
@@ -415,7 +415,7 @@ int convert_pathgen(PyObject *obj, void *pathgenp)
 int convert_clippath(PyObject *clippath_tuple, void *clippathp)
 {
     ClipPath *clippath = (ClipPath *)clippathp;
-    py::PathIterator path;
+    mpl::PathIterator path;
     agg::trans_affine trans;
 
     if (clippath_tuple != NULL && clippath_tuple != Py_None) {

--- a/src/py_converters_11.cpp
+++ b/src/py_converters_11.cpp
@@ -1,13 +1,13 @@
 #include "py_converters_11.h"
 
-void convert_trans_affine(const pybind11::object& transform, agg::trans_affine& affine)
+void convert_trans_affine(const py::object& transform, agg::trans_affine& affine)
 {
     // If None assume identity transform so leave affine unchanged
     if (transform.is_none()) {
         return;
     }
 
-    auto array = pybind11::array_t<double, pybind11::array::c_style>::ensure(transform);
+    auto array = py::array_t<double, py::array::c_style>::ensure(transform);
     if (!array || array.ndim() != 2 || array.shape(0) != 3 || array.shape(1) != 3) {
         throw std::invalid_argument("Invalid affine transformation matrix");
     }

--- a/src/py_converters_11.h
+++ b/src/py_converters_11.h
@@ -6,8 +6,10 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+namespace py = pybind11;
+
 #include "agg_trans_affine.h"
 
-void convert_trans_affine(const pybind11::object& transform, agg::trans_affine& affine);
+void convert_trans_affine(const py::object& transform, agg::trans_affine& affine);
 
 #endif

--- a/src/py_exceptions.h
+++ b/src/py_exceptions.h
@@ -6,8 +6,8 @@
 #include <exception>
 #include <stdexcept>
 
-namespace py
-{
+namespace mpl {
+
 class exception : public std::exception
 {
   public:
@@ -23,7 +23,7 @@ class exception : public std::exception
     {                                                                        \
         a;                                                                   \
     }                                                                        \
-    catch (const py::exception &)                                            \
+    catch (const mpl::exception &)                                           \
     {                                                                        \
         {                                                                    \
             cleanup;                                                         \

--- a/src/tri/_tri_wrapper.cpp
+++ b/src/tri/_tri_wrapper.cpp
@@ -1,5 +1,7 @@
 #include "_tri.h"
 
+using namespace pybind11::literals;
+
 PYBIND11_MODULE(_tri, m) {
     py::class_<Triangulation>(m, "Triangulation")
         .def(py::init<const Triangulation::CoordinateArray&,
@@ -9,13 +11,13 @@ PYBIND11_MODULE(_tri, m) {
                       const Triangulation::EdgeArray&,
                       const Triangulation::NeighborArray&,
                       bool>(),
-            py::arg("x"),
-            py::arg("y"),
-            py::arg("triangles"),
-            py::arg("mask"),
-            py::arg("edges"),
-            py::arg("neighbors"),
-            py::arg("correct_triangle_orientations"),
+            "x"_a,
+            "y"_a,
+            "triangles"_a,
+            "mask"_a,
+            "edges"_a,
+            "neighbors"_a,
+            "correct_triangle_orientations"_a,
             "Create a new C++ Triangulation object.\n"
             "This should not be called directly, use the python class\n"
             "matplotlib.tri.Triangulation instead.\n")
@@ -31,8 +33,8 @@ PYBIND11_MODULE(_tri, m) {
     py::class_<TriContourGenerator>(m, "TriContourGenerator")
         .def(py::init<Triangulation&,
                       const TriContourGenerator::CoordinateArray&>(),
-            py::arg("triangulation"),
-            py::arg("z"),
+            "triangulation"_a,
+            "z"_a,
             "Create a new C++ TriContourGenerator object.\n"
             "This should not be called directly, use the functions\n"
             "matplotlib.axes.tricontour and tricontourf instead.\n")
@@ -43,7 +45,7 @@ PYBIND11_MODULE(_tri, m) {
 
     py::class_<TrapezoidMapTriFinder>(m, "TrapezoidMapTriFinder")
         .def(py::init<Triangulation&>(),
-            py::arg("triangulation"),
+            "triangulation"_a,
             "Create a new C++ TrapezoidMapTriFinder object.\n"
             "This should not be called directly, use the python class\n"
             "matplotlib.tri.TrapezoidMapTriFinder instead.\n")


### PR DESCRIPTION
## PR summary

Then we can use the standard `pybind11` namespace alias of `py`.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines