### PR TITLE
Restore figaspect() API documentation

### DIFF
--- a/doc/api/figure_api.rst
+++ b/doc/api/figure_api.rst
@@ -306,3 +306,8 @@ FigureBase parent class
 =======================
 
 .. autoclass:: FigureBase
+
+Helper functions
+================
+
+.. autofunction:: figaspect


### PR DESCRIPTION
This was accidentally lost through #26629.
