### PR TITLE
Add test_step to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -336,11 +336,15 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.stem(...)
 
-    @pytest.mark.xfail(reason="Test for step not written yet")
     @mpl.style.context("default")
     def test_step(self):
-        fig, ax = plt.subplots()
-        ax.step(...)
+        mpl.rcParams["date.converter"] = "concise"
+        N = 6
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        x = np.array([datetime.datetime(2023, 9, n) for n in range(1, N)])
+        ax1.step(x, range(1, N))
+        ax2.step(range(1, N), x)
+        ax3.step(x, x)
 
     @pytest.mark.xfail(reason="Test for streamplot not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
Added code for test_step method in test_datetime.py mentioned in https://github.com/matplotlib/matplotlib/issues/26864

![Figure_1](https://github.com/matplotlib/matplotlib/assets/2171807/ced6b5bc-2031-4434-aa9a-d52c24b8fdde)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
