### PR TITLE
Final remove

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -15,8 +15,6 @@ import re
 from pyparsing import (
     Group, Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore)
 
-from matplotlib import _api
-
 
 _family_punc = r'\\\-:,'
 _family_unescape = partial(re.compile(r'\\(?=[%s])' % _family_punc).sub, '')
@@ -97,12 +95,6 @@ def parse_fontconfig_pattern(pattern):
         props["size"] = [*parse["sizes"]]
     for prop in parse.get("properties", []):
         if len(prop) == 1:
-            if prop[0] not in _CONSTANTS:
-                _api.warn_deprecated(
-                    "3.7", message=f"Support for unknown constants "
-                    f"({prop[0]!r}) is deprecated since %(since)s and "
-                    f"will be removed %(removal)s.")
-                continue
             prop = _CONSTANTS[prop[0]]
         k, *v = prop
         props.setdefault(k, []).extend(map(_value_unescape, v))

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -265,6 +265,7 @@ class GridSpecBase:
         if not isinstance(sharey, str):
             sharey = "all" if sharey else "none"
 
+
         if subplot_kw is None:
             subplot_kw = {}
         # don't mutate kwargs passed by user...
@@ -565,6 +566,8 @@ class SubplotSpec:
                     f"integer, not {arg!r}") from None
         elif len(args) == 3:
             rows, cols, num = args
+        else:
+            continue
 
         gs = GridSpec._check_gridspec_exists(figure, rows, cols)
         if gs is None:

--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -17,7 +17,7 @@ from numbers import Integral
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib import _api, _pylab_helpers, _tight_layout
+from matplotlib import _pylab_helpers, _tight_layout
 from matplotlib.transforms import Bbox
 
 _log = logging.getLogger(__name__)
@@ -265,8 +265,6 @@ class GridSpecBase:
         if not isinstance(sharey, str):
             sharey = "all" if sharey else "none"
 
-        _api.check_in_list(["all", "row", "col", "none", False, True],
-                           sharex=sharex, sharey=sharey)
         if subplot_kw is None:
             subplot_kw = {}
         # don't mutate kwargs passed by user...
@@ -567,8 +565,6 @@ class SubplotSpec:
                     f"integer, not {arg!r}") from None
         elif len(args) == 3:
             rows, cols, num = args
-        else:
-            raise _api.nargs_error("subplot", takes="1 or 3", given=len(args))
 
         gs = GridSpec._check_gridspec_exists(figure, rows, cols)
         if gs is None:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This PR removes the deprecated code during the version 3.7 from lib/matplotlib/gridspec.py and lib/matplotlib/_fontconfig_patterns.py
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [-] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
