### PR TITLE
Deduplicate hatch validate

### DIFF
--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -179,21 +179,17 @@ _hatch_types = [
     ]
 
 
-def _validate_hatch_pattern(hatch):
-    valid_hatch_patterns = set(r'-+|/\xXoO.*')
-    if hatch is not None:
-        invalids = set(hatch).difference(valid_hatch_patterns)
-        if invalids:
-            valid = ''.join(sorted(valid_hatch_patterns))
+def _validate_hatch_pattern(hatch): 
+    valid_hatch_patterns = set(r'-+|/\xXoO.*') 
+    if hatch is not None: 
+        invalids = set(hatch).difference(valid_hatch_patterns) 
+        if invalids: 
+            valid = ''.join(sorted(valid_hatch_patterns)) 
             invalids = ''.join(sorted(invalids))
-            _api.warn_deprecated(
-                '3.4',
-                removal='3.9',  # one release after custom hatches (#20690)
-                message=f'hatch must consist of a string of "{valid}" or '
-                        'None, but found the following invalid values '
-                        f'"{invalids}". Passing invalid values is deprecated '
-                        'since %(since)s and will become an error %(removal)s.'
-            )
+            message = f"""Unknown hatch symbol(s): {invalids}. 
+                          Hatch must consist of a string of {valid}"""
+            raise ValueError(message)
+        raise ValueError("Hatch pattern must be a string")
 
 
 def get_path(hatchpattern, density=6):

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from matplotlib import _api
 from matplotlib.path import Path
 
 
@@ -179,16 +178,17 @@ _hatch_types = [
     ]
 
 
-def _validate_hatch_pattern(hatch): 
-    valid_hatch_patterns = set(r'-+|/\xXoO.*') 
-    if hatch is not None: 
-        invalids = set(hatch).difference(valid_hatch_patterns) 
-        if invalids: 
-            valid = ''.join(sorted(valid_hatch_patterns)) 
+def _validate_hatch_pattern(hatch):
+    valid_hatch_patterns = set(r'-+|/\xXoO.*')
+    if hatch is not None:
+        invalids = set(hatch).difference(valid_hatch_patterns)
+        if invalids:
+            valid = ''.join(sorted(valid_hatch_patterns))
             invalids = ''.join(sorted(invalids))
-            message = f"""Unknown hatch symbol(s): {invalids}. 
+            message = f"""Unknown hatch symbol(s): {invalids}.
                           Hatch must consist of a string of {valid}"""
             raise ValueError(message)
+    else:
         raise ValueError("Hatch pattern must be a string")
 
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -22,6 +22,7 @@ import re
 
 import numpy as np
 
+from hatch import _validate_hatch_pattern
 from matplotlib import _api, cbook
 from matplotlib.cbook import ls_mapper
 from matplotlib.colors import Colormap, is_color_like
@@ -179,7 +180,7 @@ def _make_type_validator(cls, *, allow_none=False):
 
     def validator(s):
         if (allow_none and
-                (s is None or cbook._str_lower_equal(s, "none"))):
+                (s is None or isinstance(s, str) and s.lower() == "none")):
             return None
         if cls is str and not isinstance(s, str):
             raise ValueError(f'Could not convert {s!r} to str')
@@ -438,19 +439,6 @@ def validate_ps_distiller(s):
         return ValidateInStrings('ps.usedistiller', ['ghostscript', 'xpdf'])(s)
 
 
-def _validate_papersize(s):
-    # Re-inline this validator when the 'auto' deprecation expires.
-    s = ValidateInStrings("ps.papersize",
-                          ["figure", "auto", "letter", "legal", "ledger",
-                           *[f"{ab}{i}" for ab in "ab" for i in range(11)]],
-                          ignorecase=True)(s)
-    if s == "auto":
-        _api.warn_deprecated("3.8", name="ps.papersize='auto'",
-                             addendum="Pass an explicit paper type, figure, or omit "
-                             "the *ps.papersize* rcParam entirely.")
-    return s
-
-
 # A validator dedicated to the named line styles, based on the items in
 # ls_mapper, and a list of possible strings read from Line2D.set_linestyle
 _validate_named_linestyle = ValidateInStrings(
@@ -589,7 +577,7 @@ def _validate_int_greaterequal0(s):
         raise RuntimeError(f'Value must be >=0; got {s}')
 
 
-def validate_hatch(s):
+def _validate_hatch_pattern(s):
     r"""
     Validate a hatch pattern.
     A hatch pattern string can have any sequence of the following
@@ -604,7 +592,7 @@ def validate_hatch(s):
     return s
 
 
-validate_hatchlist = _listify_validator(validate_hatch)
+validate_hatchlist = _listify_validator(_validate_hatch_pattern)
 validate_dashlist = _listify_validator(validate_floatlist)
 
 
@@ -615,7 +603,7 @@ def _validate_minor_tick_ndivs(n):
     two major ticks.
     """
 
-    if cbook._str_lower_equal(n, 'auto'):
+    if isinstance(n, str) and n.lower() == 'auto':
         return n
     try:
         n = _validate_int_greaterequal0(n)
@@ -749,51 +737,6 @@ class _DunderChecker(ast.NodeVisitor):
         if node.attr.startswith("__") and node.attr.endswith("__"):
             raise ValueError("cycler strings with dunders are forbidden")
         self.generic_visit(node)
-
-
-# A validator dedicated to the named legend loc
-_validate_named_legend_loc = ValidateInStrings(
-    'legend.loc',
-    [
-        "best",
-        "upper right", "upper left", "lower left", "lower right", "right",
-        "center left", "center right", "lower center", "upper center",
-        "center"],
-    ignorecase=True)
-
-
-def _validate_legend_loc(loc):
-    """
-    Confirm that loc is a type which rc.Params["legend.loc"] supports.
-
-    .. versionadded:: 3.8
-
-    Parameters
-    ----------
-    loc : str | int | (float, float) | str((float, float))
-        The location of the legend.
-
-    Returns
-    -------
-    loc : str | int | (float, float) or raise ValueError exception
-        The location of the legend.
-    """
-    if isinstance(loc, str):
-        try:
-            return _validate_named_legend_loc(loc)
-        except ValueError:
-            pass
-        try:
-            loc = ast.literal_eval(loc)
-        except (SyntaxError, ValueError):
-            pass
-    if isinstance(loc, int):
-        if 0 <= loc <= 10:
-            return loc
-    if isinstance(loc, tuple):
-        if len(loc) == 2 and all(isinstance(e, Real) for e in loc):
-            return loc
-    raise ValueError(f"{loc} is not a valid legend location.")
 
 
 def validate_cycler(s):
@@ -1094,10 +1037,8 @@ _validators = {
     "axes.ymargin": _validate_greaterthan_minushalf,  # margin added to yaxis
     "axes.zmargin": _validate_greaterthan_minushalf,  # margin added to zaxis
 
-    "polaraxes.grid":    validate_bool,  # display polar grid or not
-    "axes3d.grid":       validate_bool,  # display 3d grid
-    "axes3d.automargin": validate_bool,  # automatically add margin when
-                                         # manually setting 3D axis limits
+    "polaraxes.grid": validate_bool,  # display polar grid or not
+    "axes3d.grid":    validate_bool,  # display 3d grid
 
     "axes3d.xaxis.panecolor":    validate_color,  # 3d background pane
     "axes3d.yaxis.panecolor":    validate_color,  # 3d background pane
@@ -1122,7 +1063,11 @@ _validators = {
 
     # legend properties
     "legend.fancybox": validate_bool,
-    "legend.loc": _validate_legend_loc,
+    "legend.loc": _ignorecase([
+        "best",
+        "upper right", "upper left", "lower left", "lower right", "right",
+        "center left", "center right", "lower center", "upper center",
+        "center"]),
 
     # the number of points in the legend line
     "legend.numpoints":      validate_int,
@@ -1134,7 +1079,6 @@ _validators = {
     "legend.labelcolor":     _validate_color_or_linecolor,
     # the relative size of legend markers vs. original
     "legend.markerscale":    validate_float,
-    # using dict in rcParams not yet supported, so make sure it is bool
     "legend.shadow":         validate_bool,
     # whether or not to draw a frame around legend
     "legend.frameon":        validate_bool,
@@ -1229,7 +1173,6 @@ _validators = {
     "figure.autolayout":       validate_bool,
     "figure.max_open_warning": validate_int,
     "figure.raise_window":     validate_bool,
-    "macosx.window_mode":      ["system", "tab", "window"],
 
     "figure.subplot.left":   validate_float,
     "figure.subplot.right":  validate_float,
@@ -1262,7 +1205,9 @@ _validators = {
     "tk.window_focus": validate_bool,  # Maintain shell focus for TkAgg
 
     # Set the papersize/type
-    "ps.papersize":       _validate_papersize,
+    "ps.papersize":       _ignorecase(["auto", "letter", "legal", "ledger",
+                                      *[f"{ab}{i}"
+                                        for ab in "ab" for i in range(11)]]),
     "ps.useafm":          validate_bool,
     # use ghostscript or xpdf to distill ps output
     "ps.usedistiller":    validate_ps_distiller,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -577,19 +577,8 @@ def _validate_int_greaterequal0(s):
         raise RuntimeError(f'Value must be >=0; got {s}')
 
 
-def _validate_hatch_pattern(s):
-    r"""
-    Validate a hatch pattern.
-    A hatch pattern string can have any sequence of the following
-    characters: ``\ / | - + * . x o O``.
-    """
-    if not isinstance(s, str):
-        raise ValueError("Hatch pattern must be a string")
-    _api.check_isinstance(str, hatch_pattern=s)
-    unknown = set(s) - {'\\', '/', '|', '-', '+', '*', '.', 'x', 'o', 'O'}
-    if unknown:
-        raise ValueError("Unknown hatch symbol(s): %s" % list(unknown))
-    return s
+def validate_hatch(hatch):
+    _validate_hatch_pattern(hatch)
 
 
 validate_hatchlist = _listify_validator(_validate_hatch_pattern)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Closes #24797 

Hello! I replaced the deprecated warning from `_validate_hatch_pattern()` function in hatch.py with the validate_hatch() warn from rcsetup.py. I also make `validate_hatch()` warn from rcsetup.py use the `_validate_hatch_pattern()` function. This removed the deprecated warning from the hatch validation code and made it the canonical validator for all hatch patterns.

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #24797".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #24797" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
