### PR TITLE
TST: Use importlib for subprocess tests

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -122,11 +122,16 @@ def subprocess_run_helper(func, *args, timeout, extra_env=None):
     """
     target = func.__name__
     module = func.__module__
+    file = func.__code__.co_filename
     proc = subprocess_run_for_testing(
         [
             sys.executable,
             "-c",
-            f"from {module} import {target}; {target}()",
+            f"import importlib.util;"
+            f"_spec = importlib.util.spec_from_file_location({module!r}, {file!r});"
+            f"_module = importlib.util.module_from_spec(_spec);"
+            f"_spec.loader.exec_module(_module);"
+            f"_module.{target}()",
             *args
         ],
         env={**os.environ, "SOURCE_DATE_EPOCH": "0", **(extra_env or {})},


### PR DESCRIPTION
## PR summary

This allows running pytest with any import-mode option.

Related to https://github.com/matplotlib/matplotlib/pull/27094#issuecomment-1764618468

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines