### PR TITLE
add test_stackplot in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -318,11 +318,40 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.spy(...)
 
-    @pytest.mark.xfail(reason="Test for stackplot not written yet")
     @mpl.style.context("default")
     def test_stackplot(self):
-        fig, ax = plt.subplots()
-        ax.stackplot(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        N = 10
+        fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True)
+
+        stacked_nums = np.array([range(1, N)] * 4)
+
+        dates_days = np.array(
+            [datetime.datetime(2023, 1, i) for i in range(1, N)]
+        )
+        dates_years = np.array(
+            [datetime.datetime(1970 + i, 1, 1) for i in range(1, N)]
+        )
+
+        timedelta_days = np.array(
+            [i * datetime.timedelta(days=1) for i in range(1, N)]
+        )
+        timedelta_hours = np.array(
+            [i * datetime.timedelta(hours=24) for i in range(1, N)]
+        )
+        timedelta_seconds = np.array(
+            [i * datetime.timedelta(seconds=86400) for i in range(1, N)]
+        )
+
+        ax1.stackplot(dates_years, stacked_nums)
+
+        ax2.stackplot(
+            dates_days, dates_days, timedelta_days, timedelta_hours, timedelta_seconds
+        )
+        ax2.set_ylim(
+            datetime.datetime(2022, 12, 31),
+            datetime.datetime(2023, 2, 8)
+        )
 
     @pytest.mark.xfail(reason="Test for stairs not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -322,36 +322,12 @@ class TestDatetimePlotting:
     def test_stackplot(self):
         mpl.rcParams["date.converter"] = 'concise'
         N = 10
-        fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True)
+        fig, ax = plt.subplots(constrained_layout=True)
 
         stacked_nums = np.array([range(1, N)] * 4)
+        dates = np.array([datetime.datetime(2020 + i, 1, 1) for i in range(N - 1)])
 
-        dates_days = np.array(
-            [datetime.datetime(2023, 1, i) for i in range(1, N)]
-        )
-        dates_years = np.array(
-            [datetime.datetime(1970 + i, 1, 1) for i in range(1, N)]
-        )
-
-        timedelta_days = np.array(
-            [i * datetime.timedelta(days=1) for i in range(1, N)]
-        )
-        timedelta_hours = np.array(
-            [i * datetime.timedelta(hours=24) for i in range(1, N)]
-        )
-        timedelta_seconds = np.array(
-            [i * datetime.timedelta(seconds=86400) for i in range(1, N)]
-        )
-
-        ax1.stackplot(dates_years, stacked_nums)
-
-        ax2.stackplot(
-            dates_days, dates_days, timedelta_days, timedelta_hours, timedelta_seconds
-        )
-        ax2.set_ylim(
-            datetime.datetime(2022, 12, 31),
-            datetime.datetime(2023, 2, 8)
-        )
+        ax.stackplot(dates, stacked_nums)
 
     @pytest.mark.xfail(reason="Test for stairs not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -322,11 +322,10 @@ class TestDatetimePlotting:
     def test_stackplot(self):
         mpl.rcParams["date.converter"] = 'concise'
         N = 10
-        fig, ax = plt.subplots(constrained_layout=True)
-
-        stacked_nums = np.array([range(1, N)] * 4)
+        stacked_nums = np.tile(np.arange(1, N), (4, 1))
         dates = np.array([datetime.datetime(2020 + i, 1, 1) for i in range(N - 1)])
 
+        fig, ax = plt.subplots(layout='constrained')
         ax.stackplot(dates, stacked_nums)
 
     @pytest.mark.xfail(reason="Test for stairs not written yet")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Adds the test_stackplot method in test_datetime.py. The test creates the following stackplots:

1. `datetime` x-axis, stacked numerical y-axis
2. ~~`datetime` x-axis, `datetime` plus stacked `datetime.timedelta` y-axis~~ (not implemented for this pull request)

Stacking multiple `datetime` arrays caused a compile error, because numpy does not support adding two `datetime` objects together. I don't believe it makes much sense to stack `datetime` values in this way, so I have not implemented this test.

This pull request closes the `Axes.stackplot` task in issue [#26859](https://github.com/matplotlib/matplotlib/pull/26859)

**Plot output**
![test_stackplot output](https://github.com/matplotlib/matplotlib/assets/19280099/e0ed0a7e-5404-41ad-902c-a9051c580082)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->


- [X] Resolves `Axes.stackplot` in [#26864](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
