### PR TITLE
added test_axhspan in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -40,29 +40,19 @@ class TestDatetimePlotting:
         start_date = datetime.datetime(2023, 1, 1)
         time_delta = datetime.timedelta(days=1)
 
-        values = np.random.randint(1, 10, 30)
-        bin_edges = [start_date + i * time_delta for i in range(31)]
+        fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True, figsize=(10, 8))
 
-        fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True)
-
-        ax1.hist(
-            [start_date + i * time_delta for i in range(30)],
-            bins=bin_edges,
-            weights=values)
-
+        ax1.set_ylim(start_date, start_date + 29*time_delta)
         for i in range(np.random.randint(1, 5)):
-            ymin = np.random.randint(1, 8)
-            ymax = ymin + np.random.randint(1, 3)
+            ymin = start_date + np.random.randint(0, 30) * time_delta
+            ymax = ymin + np.random.randint(1, 3) * time_delta
             ax1.axhspan(ymin=ymin, ymax=ymax, facecolor='green', alpha=0.5)
 
-        ax2.hist(
-            [start_date + i * time_delta for i in range(30)],
-            bins=bin_edges,
-            weights=values)
-
-        y_values = np.unique(values)
-        for i, y in enumerate(y_values[::2]):
-            ax2.axhspan(ymin=y, ymax=y+1, facecolor='green', alpha=0.5)
+        ax2.set_ylim(start_date, start_date + 29*time_delta)
+        for i in range(0, 30, 2):
+            ymin = start_date + i * time_delta
+            ymax = ymin + time_delta
+            ax2.axhspan(ymin=ymin, ymax=ymax, facecolor='green', alpha=0.5)
 
     @pytest.mark.xfail(reason="Test for axline not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -32,11 +32,37 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.axhline(...)
 
-    @pytest.mark.xfail(reason="Test for axhspan not written yet")
     @mpl.style.context("default")
     def test_axhspan(self):
-        fig, ax = plt.subplots()
-        ax.axhspan(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        np.random.seed(19680801)
+
+        start_date = datetime.datetime(2023, 1, 1)
+        time_delta = datetime.timedelta(days=1)
+
+        values = np.random.randint(1, 10, 30)
+        bin_edges = [start_date + i * time_delta for i in range(31)]
+
+        fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True)
+
+        ax1.hist(
+            [start_date + i * time_delta for i in range(30)],
+            bins=bin_edges,
+            weights=values)
+
+        for i in range(np.random.randint(1, 5)):
+            ymin = np.random.randint(1, 8)
+            ymax = ymin + np.random.randint(1, 3)
+            ax1.axhspan(ymin=ymin, ymax=ymax, facecolor='green', alpha=0.5)
+
+        ax2.hist(
+            [start_date + i * time_delta for i in range(30)],
+            bins=bin_edges,
+            weights=values)
+
+        y_values = np.unique(values)
+        for i, y in enumerate(y_values[::2]):
+            ax2.axhspan(ymin=y, ymax=y+1, facecolor='green', alpha=0.5)
 
     @pytest.mark.xfail(reason="Test for axline not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -35,24 +35,39 @@ class TestDatetimePlotting:
     @mpl.style.context("default")
     def test_axhspan(self):
         mpl.rcParams["date.converter"] = 'concise'
-        np.random.seed(19680801)
 
         start_date = datetime.datetime(2023, 1, 1)
-        time_delta = datetime.timedelta(days=1)
+        dates = [start_date + datetime.timedelta(days=i) for i in range(31)]
+        numbers = list(range(1, 32))
 
-        fig, (ax1, ax2) = plt.subplots(2, 1, constrained_layout=True, figsize=(10, 8))
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1,
+                                            constrained_layout=True,
+                                            figsize=(10, 12))
 
-        ax1.set_ylim(start_date, start_date + 29*time_delta)
-        for i in range(np.random.randint(1, 5)):
-            ymin = start_date + np.random.randint(0, 30) * time_delta
-            ymax = ymin + np.random.randint(1, 3) * time_delta
-            ax1.axhspan(ymin=ymin, ymax=ymax, facecolor='green', alpha=0.5)
+        ax1.plot(dates, numbers, marker='o', color='blue')
+        for i in range(0, 31, 2):
+            ax1.axhspan(ymin=i+1, ymax=i+2, facecolor='green', alpha=0.5)
+        ax1.set_title('Datetime vs. Number')
+        ax1.set_xlabel('Date')
+        ax1.set_ylabel('Number')
 
-        ax2.set_ylim(start_date, start_date + 29*time_delta)
-        for i in range(0, 30, 2):
-            ymin = start_date + i * time_delta
-            ymax = ymin + time_delta
+        ax2.plot(numbers, dates, marker='o', color='blue')
+        for i in range(0, 31, 2):
+            ymin = start_date + datetime.timedelta(days=i)
+            ymax = ymin + datetime.timedelta(days=1)
             ax2.axhspan(ymin=ymin, ymax=ymax, facecolor='green', alpha=0.5)
+        ax2.set_title('Number vs. Datetime')
+        ax2.set_xlabel('Number')
+        ax2.set_ylabel('Date')
+
+        ax3.plot(dates, dates, marker='o', color='blue')
+        for i in range(0, 31, 2):
+            ymin = start_date + datetime.timedelta(days=i)
+            ymax = ymin + datetime.timedelta(days=1)
+            ax3.axhspan(ymin=ymin, ymax=ymax, facecolor='green', alpha=0.5)
+        ax3.set_title('Datetime vs. Datetime')
+        ax3.set_xlabel('Date')
+        ax3.set_ylabel('Date')
 
     @pytest.mark.xfail(reason="Test for axline not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->
I´ve added code for `test_axhspan` method in `test_datetime.py` mentioned in issue [#26864](https://github.com/matplotlib/matplotlib/issues/26864)

Image output: (edited)
![download](https://github.com/matplotlib/matplotlib/assets/72991416/deba38d7-bda6-4a57-8647-0105abf154df)




## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] resolves [#26864](https://github.com/matplotlib/matplotlib/issues/26864)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

