### PR TITLE
Added smoke test for Axes.text in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -355,11 +355,33 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.streamplot(...)
 
-    @pytest.mark.xfail(reason="Test for text not written yet")
     @mpl.style.context("default")
     def test_text(self):
-        fig, ax = plt.subplots()
-        ax.text(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout="constrained")
+
+        limit_value = 10
+        font_properties = {'family': 'serif', 'size': 12, 'weight': 'bold'}
+        test_date = datetime.datetime(2023, 10, 1)
+
+        x_data = np.array(range(1, limit_value))
+        y_data = np.array(range(1, limit_value))
+
+        x_dates = np.array(
+            [datetime.datetime(2023, 10, n) for n in range(1, limit_value)]
+        )
+        y_dates = np.array(
+            [datetime.datetime(2023, 10, n) for n in range(1, limit_value)]
+        )
+
+        ax1.plot(x_dates, y_data)
+        ax1.text(test_date, 5, "Inserted Text", **font_properties)
+
+        ax2.plot(x_data, y_dates)
+        ax2.text(7, test_date, "Inserted Text", **font_properties)
+
+        ax3.plot(x_dates, y_dates)
+        ax3.text(test_date, test_date, "Inserted Text", **font_properties)
 
     @pytest.mark.xfail(reason="Test for tricontour not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Smoke test for 'Axes.text' using datetime data in 'lib/matplotlib/tests/test_datetime.py'. This PR addresses one of the tasks listed in https://github.com/matplotlib/matplotlib/issues/26864

The image below is the generated plot:
![text_plot](https://github.com/matplotlib/matplotlib/assets/89607583/1b527fd6-4673-4434-b3d4-a49077783b9e)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
