### PR TITLE
Avoid event accumulation in webagg backend.

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -177,6 +177,11 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         self._current_image_mode = 'full'
         # Track mouse events to fill in the x, y position of key events.
         self._last_mouse_xy = (None, None)
+        # Keep track of the number of received images.
+        # (init with None for backends that do not send "ack" messages)
+        self._ack_cnt = None
+        # Cache-dict to store events that occurred during image processing.
+        self._event_cache = dict()
 
     def show(self):
         # show the figure window
@@ -258,10 +263,34 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 return png.getvalue()
 
     def handle_event(self, event):
+        # Check if all pending images have been processed.
+        if self._ack_cnt is not None:
+            cnt_eq = self.manager._send_cnt <= self._ack_cnt
+            if cnt_eq:
+                self.manager._send_cnt, self._ack_cnt = 0, 0  # Reset counters.
+        else:
+            # If no ack message was ever received, always process events.
+            cnt_eq = True
+
+        # Handle events as follows:
+        #   - Always process explicit "ack" and "draw" events.
+        #   - Process all other events only if "ack count" equals "send count"
         e_type = event['type']
-        handler = getattr(self, f'handle_{e_type}',
-                          self.handle_unknown_event)
-        return handler(event)
+        if cnt_eq or e_type in ["ack", "draw"]:
+            # Handle cached events of all types other than the current type.
+            self._event_cache.pop(e_type, None)
+            for cache_event_type, cache_event in self._event_cache.items():
+                getattr(self, 'handle_{0}'.format(cache_event_type),
+                        self.handle_unknown_event)(cache_event)
+            self._event_cache.clear()
+
+            # Handle the current event.
+            handler = getattr(self, 'handle_{0}'.format(e_type),
+                              self.handle_unknown_event)
+            return handler(event)
+        else:
+            # Cache the last event of each type so we can process it later.
+            self._event_cache[event["type"]] = event
 
     def handle_unknown_event(self, event):
         _log.warning('Unhandled message type %s. %s', event["type"], event)
@@ -273,7 +302,11 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         # This could also be used as a simple sanity check in the
         # future, but for now the performance increase is enough
         # to justify it, even if the server does nothing with it.
-        pass
+
+        # Keep track of the number of received ack messages.
+        if self._ack_cnt is None:
+            self._ack_cnt = 0  # To support backends that do not send "ack".
+        self._ack_cnt += 1
 
     def handle_draw(self, event):
         self.draw()
@@ -431,6 +464,8 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
         self.web_sockets = set()
         super().__init__(canvas, num)
 
+        self._send_cnt = 0  # Counter for the number of sent images.
+
     def show(self):
         pass
 
@@ -469,6 +504,8 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
             if diff is not None:
                 for s in self.web_sockets:
                     s.send_binary(diff)
+
+                self._send_cnt += 1  # Keep track of the number of sent images.
 
     @classmethod
     def get_javascript(cls, stream=None):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

This PR is intended to address the problem of event-accumulation during image-processing in the `webagg` backend
which can result in an extreme lag that makes "fast updated" events like `motion_notify_event` etc. unusable at the moment.

Not 100% sure, but this might also improve problems concerning blitting in jupyter-notebooks (e.g. #19116) but would require sending `"ack"` messages in `ipympl`. The implementation is made in a way such that `ipympl` (or more generally backends that don't send `"ack"` messages) are not affected.

The following gifs show the outcome of this change: (**left**: current behavior, **right**: result of this PR)

<img src=https://github.com/matplotlib/matplotlib/assets/22773387/3daf47fa-1666-486d-a89c-7239af5f81fe width=45%>
<img src=https://github.com/matplotlib/matplotlib/assets/22773387/280774c2-9b21-4bc0-9a3c-7318e428029d width=45%>

<p>  

<details> <summary> 🐍 code to run example </summary>

```python
import matplotlib as mpl
mpl.use("webagg")
mpl.rcParams['webagg.port']=8988
mpl.rcParams['webagg.open_in_browser']=True

import matplotlib.pyplot as plt

fig, ax = plt.subplots(figsize=(14, 8))
ax.plot([0, 1], [0, 1], 'r')
ln, = ax.plot([0, 1], [0, 0], 'g', animated=True)
ax.figure.canvas.draw()

fig._last_blit_bg = fig.canvas.copy_from_bbox(ax.bbox)

def on_resize(event):
    ax.figure.canvas.draw()
    fig._last_blit_bg = fig.canvas.copy_from_bbox(ax.bbox)

def on_move(event):
    ax.figure.canvas.restore_region(fig._last_blit_bg)
    ln.set_ydata([event.ydata, event.ydata])
    ax.draw_artist(ln)
    ax.figure.canvas.blit(ax.bbox)

fig.canvas.mpl_connect('motion_notify_event', on_move)
fig.canvas.mpl_connect('resize_event', on_resize)

plt.show()

```

</details>































## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
