### PR TITLE
Smoke Test for Axes.step

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -359,8 +359,8 @@ class TestDatetimePlotting:
         ax2.step(date_x, y_ranges, 'b', where='mid', label='mid')
         ax3.step(date_x, date_y, 'r', where='post', label='post')
         ax4.step("date", "signal",
-                data={"date": date_x, "signal": y_ranges},
-                where='mid', label='mid')
+                 data={"date": date_x, "signal": y_ranges},
+                 where='mid', label='mid')
 
     @pytest.mark.xfail(reason="Test for streamplot not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -343,11 +343,24 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.stem(...)
 
-    @pytest.mark.xfail(reason="Test for step not written yet")
     @mpl.style.context("default")
     def test_step(self):
-        fig, ax = plt.subplots()
-        ax.step(...)
+        mpl.rcParams["date.converter"] = "concise"
+        limit = 5
+        fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, layout="constrained")
+
+        start_date = datetime.date(2023, 1, 1)
+        date_x = [start_date + datetime.timedelta(days=i) for i in range(1, limit)]
+        date_y = [start_date + datetime.timedelta(days=i) for i in range(1, limit)]
+        x_ranges = np.array(range(1, limit))
+        y_ranges = np.array(range(1, limit))
+
+        ax1.step(x_ranges, date_y, 'g', where='pre', label='pre')
+        ax2.step(date_x, y_ranges, 'b', where='mid', label='mid')
+        ax3.step(date_x, date_y, 'r', where='post', label='post')
+        ax4.step("date", "signal",
+                data={"date": date_x, "signal": y_ranges},
+                where='mid', label='mid')
 
     @pytest.mark.xfail(reason="Test for streamplot not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -350,16 +350,16 @@ class TestDatetimePlotting:
         fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, layout="constrained")
 
         start_date = datetime.date(2023, 1, 1)
-        date_x = [start_date + datetime.timedelta(days=i) for i in range(1, limit)]
-        date_y = [start_date + datetime.timedelta(days=i) for i in range(1, limit)]
+        x_date = [start_date + datetime.timedelta(days=i) for i in range(1, limit)]
+        y_date = [start_date + datetime.timedelta(days=i) for i in range(1, limit)]
         x_ranges = np.array(range(1, limit))
         y_ranges = np.array(range(1, limit))
 
-        ax1.step(x_ranges, date_y, 'g', where='pre', label='pre')
-        ax2.step(date_x, y_ranges, 'b', where='mid', label='mid')
-        ax3.step(date_x, date_y, 'r', where='post', label='post')
+        ax1.step(x_ranges, y_date, 'g', where='pre', label='pre')
+        ax2.step(x_date, y_ranges, 'b', where='mid', label='mid')
+        ax3.step(x_date, y_date, 'r', where='post', label='post')
         ax4.step("date", "signal",
-                 data={"date": date_x, "signal": y_ranges},
+                 data={"date": x_date, "signal": y_ranges},
                  where='mid', label='mid')
 
     @pytest.mark.xfail(reason="Test for streamplot not written yet")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Smoke test for Axes.step using datetime data in lib/matplotlib/tests/test_datetime.py. This PR addresses one of the tasks listed in https://github.com/matplotlib/matplotlib/issues/26864

The image displays the plot of the test case:
![test_step](https://github.com/matplotlib/matplotlib/assets/89607583/84f8b636-3203-4c45-9e1f-506adb18882f)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
