### PR TITLE
Add test_axhline in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -26,12 +26,18 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.arrow(...)
 
-    @pytest.mark.xfail(reason="Test for axhline not written yet")
     @mpl.style.context("default")
     def test_axhline(self):
         mpl.rcParams["date.converter"] = 'concise'
-        fig, ax = plt.subplots(layout='constrained')
-        ax.axhline(y=datetime.datetime(2020, 6, 1), xmin=0.2, xmax=0.8)
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        ax1.set_ylim(bottom=datetime.datetime(2020, 4, 1),
+                     top=datetime.datetime(2020, 8, 1))
+        ax2.set_ylim(bottom=np.datetime64('2005-01-01'),
+                     top=np.datetime64('2005-04-01'))
+        ax3.set_ylim(bottom=datetime.datetime(2023, 9, 1),
+                     top=datetime.datetime(2023, 11, 1))
+        ax1.axhline(y=datetime.datetime(2020, 6, 3), xmin=0.5, xmax=0.7)
+        ax2.axhline(np.datetime64('2005-02-25T03:30'), xmin=0.1, xmax=0.9)
 
     @pytest.mark.xfail(reason="Test for axhspan not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -29,8 +29,20 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for axhline not written yet")
     @mpl.style.context("default")
     def test_axhline(self):
-        fig, ax = plt.subplots()
-        ax.axhline(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, ax = plt.subplots(layout='constrained')
+        birth_date = np.array([datetime.datetime(2020, 4, 10),
+                               datetime.datetime(2020, 5, 30),
+                               datetime.datetime(2020, 10, 12),
+                               datetime.datetime(2020, 11, 15)])
+        year_start = datetime.datetime(2020, 1, 1)
+        year_end = datetime.datetime(2020, 12, 31)
+        age = [21, 53, 20, 24]
+        ax.set_xlabel('Birth Date')
+        ax.set_ylabel('Age')
+        ax.set_ylim(bottom=year_start, top=year_end)
+        ax.bar(x=age, height=birth_date)
+        ax.axhline(y=datetime.datetime(2020, 6, 1))
 
     @pytest.mark.xfail(reason="Test for axhspan not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -38,6 +38,7 @@ class TestDatetimePlotting:
                      top=datetime.datetime(2023, 11, 1))
         ax1.axhline(y=datetime.datetime(2020, 6, 3), xmin=0.5, xmax=0.7)
         ax2.axhline(np.datetime64('2005-02-25T03:30'), xmin=0.1, xmax=0.9)
+        ax3.axhline(y=datetime.datetime(2023, 10, 24), xmin=0.4, xmax=0.7)
 
     @pytest.mark.xfail(reason="Test for axhspan not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -31,18 +31,7 @@ class TestDatetimePlotting:
     def test_axhline(self):
         mpl.rcParams["date.converter"] = 'concise'
         fig, ax = plt.subplots(layout='constrained')
-        birth_date = np.array([datetime.datetime(2020, 4, 10),
-                               datetime.datetime(2020, 5, 30),
-                               datetime.datetime(2020, 10, 12),
-                               datetime.datetime(2020, 11, 15)])
-        year_start = datetime.datetime(2020, 1, 1)
-        year_end = datetime.datetime(2020, 12, 31)
-        age = [21, 53, 20, 24]
-        ax.set_xlabel('Birth Date')
-        ax.set_ylabel('Age')
-        ax.set_ylim(bottom=year_start, top=year_end)
-        ax.bar(x=age, height=birth_date)
-        ax.axhline(y=datetime.datetime(2020, 6, 1))
+        ax.axhline(y=datetime.datetime(2020, 6, 1), xmin=0.2, xmax=0.8)
 
     @pytest.mark.xfail(reason="Test for axhspan not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I have added a datetime (no timedelta; this function does not support it, and I believe that is correct) smoke test for `Axes.axhline` in `lib/matplotlib/test/test_datetime.py`.
This addresses the `Axes.axhline` task from #26864.

The image below is the plot generated from my example code.
![test_axhline](https://github.com/matplotlib/matplotlib/assets/99672198/6af3ad20-6ea6-4ea6-89d0-910571959f0d)


<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
