### PR TITLE
Try/except import of Axes3D

### DIFF
--- a/lib/matplotlib/projections/__init__.py
+++ b/lib/matplotlib/projections/__init__.py
@@ -55,7 +55,11 @@ A full-fledged and heavily annotated example is in
 from .. import axes, _docstring
 from .geo import AitoffAxes, HammerAxes, LambertAxes, MollweideAxes
 from .polar import PolarAxes
-from mpl_toolkits.mplot3d import Axes3D
+
+try:
+    from mpl_toolkits.mplot3d import Axes3D
+except ImportError:
+    Axes3D = None
 
 
 class ProjectionRegistry:
@@ -87,8 +91,12 @@ projection_registry.register(
     HammerAxes,
     LambertAxes,
     MollweideAxes,
-    Axes3D,
 )
+if Axes3D is not None:
+    projection_registry.register(Axes3D)
+else:
+    # remove from namespace if not importable
+    del Axes3D
 
 
 def register_projection(cls):

--- a/lib/matplotlib/projections/__init__.py
+++ b/lib/matplotlib/projections/__init__.py
@@ -60,8 +60,8 @@ try:
     from mpl_toolkits.mplot3d import Axes3D
 except ImportError:
     import warnings
-    warnings.warn("Unable to import Axes3D. This may be due to multiple versions of"
-                  "Matplotlib being installed (e.g. as a system package and as a pip"
+    warnings.warn("Unable to import Axes3D. This may be due to multiple versions of "
+                  "Matplotlib being installed (e.g. as a system package and as a pip "
                   "package). As a result, the 3D projection is not available.")
     Axes3D = None
 

--- a/lib/matplotlib/projections/__init__.py
+++ b/lib/matplotlib/projections/__init__.py
@@ -59,6 +59,10 @@ from .polar import PolarAxes
 try:
     from mpl_toolkits.mplot3d import Axes3D
 except ImportError:
+    import warnings
+    warnings.warn("Unable to import Axes3D. This may be due to multiple versions of"
+                  "Matplotlib being installed (e.g. as a system package and as a pip"
+                  "package). As a result, the 3D projection is not available.")
     Axes3D = None
 
 


### PR DESCRIPTION
## PR summary

On some installs, the `mpl_toolkits` namespace package gets an old
version which uses deprecated (And removed) code from the main library.

On such the import of Axes3D will error with an `ImportError`.
This prevents users from using any of `matplotlib`, since it is imported
unconditionally by default.

This just try/excepts the imports (and adjusts the registration code
accordingly) to allow users to continue using matplotlib (though not 3D
and possibly not other mpl_toolkits) even with older installs occluding
the mpl_toolkits.

Addresses at least the most pressing part of #26827
(Not quite sure we want to close that or not)

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
