### PR TITLE
Restore default behavior of hexbin mincnt with C provided

### DIFF
--- a/doc/api/next_api_changes/behavior/27179-KS.rst
+++ b/doc/api/next_api_changes/behavior/27179-KS.rst
@@ -1,0 +1,7 @@
+Default behavior of ``hexbin`` with *C* provided requires at least 1 point
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The behavior changed in 3.8.0 to be inclusive of *mincnt*, however that resulted in
+errors or warnings with some reduction functions, so now the default is to require at
+least 1 point to call the reduction function. This effectively restores the default
+behavior to match that of Matplotlib 3.7 and before.

--- a/doc/api/next_api_changes/behavior/27179-KS.rst
+++ b/doc/api/next_api_changes/behavior/27179-KS.rst
@@ -1,7 +1,7 @@
 Default behavior of ``hexbin`` with *C* provided requires at least 1 point
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The behavior changed in 3.8.0 to be inclusive of *mincnt*, however that resulted in
+The behavior changed in 3.8.0 to be inclusive of *mincnt*. However that resulted in
 errors or warnings with some reduction functions, so now the default is to require at
 least 1 point to call the reduction function. This effectively restores the default
 behavior to match that of Matplotlib 3.7 and before.

--- a/doc/api/prev_api_changes/api_changes_3.8.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.8.0/behaviour.rst
@@ -165,3 +165,9 @@ PostScript paper type adds option to use figure size
 The :rc:`ps.papertype` rcParam can now be set to ``'figure'``, which will use
 a paper size that corresponds exactly with the size of the figure that is being
 saved.
+
+``hexbin`` *mincnt* parameter made consistently inclusive
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, *mincnt* was inclusive with no *C* provided but exclusive when *C* is provided.
+It is now inclusive of *mincnt* in both cases.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4873,8 +4873,8 @@ default: :rc:`scatter.edgecolors`
         yscale : {'linear', 'log'}, default: 'linear'
             Use a linear or log10 scale on the vertical axis.
 
-        mincnt : int > 0, default: *None*
-            If not *None*, only display cells with more than *mincnt*
+        mincnt : int >= 0, default: *None*
+            If not *None*, only display cells with at least *mincnt*
             number of points in the cell.
 
         marginals : bool, default: *False*
@@ -4940,6 +4940,11 @@ default: :rc:`scatter.edgecolors`
             - `numpy.mean`: average of the points
             - `numpy.sum`: integral of the point values
             - `numpy.amax`: value taken from the largest point
+
+            By default will only reduce cells with at least 1 point because some
+            reduction functions (such as `numpy.amax`) will error/warn with empty
+            input. Changing *mincnt* will adjust the cutoff, and if set to 0 will
+            pass empty input to the reduction function.
 
         data : indexable object, optional
             DATA_PARAMETER_PLACEHOLDER
@@ -5038,7 +5043,7 @@ default: :rc:`scatter.edgecolors`
                 else:
                     Cs_at_i2[i2[i]].append(C[i])
             if mincnt is None:
-                mincnt = 0
+                mincnt = 1
             accum = np.array(
                 [reduce_C_function(acc) if len(acc) >= mincnt else np.nan
                  for Cs_at_i in [Cs_at_i1, Cs_at_i2]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -971,6 +971,8 @@ def test_hexbin_empty():
     # From #23922: creating hexbin with log scaling from empty
     # dataset raises ValueError
     ax.hexbin([], [], bins='log')
+    # From #27103: np.max errors when handed empty data
+    ax.hexbin([], [], C=[], reduce_C_function=np.max)
 
 
 def test_hexbin_pickable():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Closes #27103
Closes #16865

This changes the default behavior to avoid errors/warnings on empty bins (restoring behavior when mincnt is not specified to that of before v3.8.0).

Additionally corrects the docstring and updates the release notes (retroactively).

A test case has been added to the tests of empty input with `np.max`, a function that errors on empty input.

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
