### PR TITLE
Add optional bihistogram parameter to plt.hist()

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6787,6 +6787,11 @@ such objects
         x = cbook._reshape_2D(x, 'x')
         nx = len(x)  # number of datasets
 
+        # If attempting to plot a bihistogram, only two datasets should be passed in
+        if nx != 2 and bihist:
+            raise ValueError(f"If bihist=True, only two datasets can be passed in. "
+                             f"Actual number of datasets: {nx}")
+
         # Process unit information.  _process_unit_info sets the unit and
         # converts the first dataset; then we convert each following dataset
         # one at a time.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6717,7 +6717,7 @@ default: :rc:`scatter.edgecolors`
             'bar' or on top of each other if histtype is 'step'
 
         bihist : bool, default: False
-            Plot a bihistgoram if ``True``. Plots two histgorams, one facing up
+            Plot a bihistogram if ``True``. Plots two histgorams, one facing up
             and one inverted, facing down on the same x-axis. Setting `bihist=True`
             is only valid for when *x* has exactly two arrays in it.
 

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -551,6 +551,7 @@ class Axes(_AxesBase):
         color: ColorType | Sequence[ColorType] | None = ...,
         label: str | Sequence[str] | None = ...,
         stacked: bool = ...,
+        bihist: bool = ...,
         *,
         data=...,
         **kwargs

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3212,7 +3212,7 @@ def hist(
     color: ColorType | Sequence[ColorType] | None = None,
     label: str | Sequence[str] | None = None,
     stacked: bool = False,
-    bihist=False,
+    bihist: bool = False,
     *,
     data=None,
     **kwargs,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3212,6 +3212,7 @@ def hist(
     color: ColorType | Sequence[ColorType] | None = None,
     label: str | Sequence[str] | None = None,
     stacked: bool = False,
+    bihist=False,
     *,
     data=None,
     **kwargs,
@@ -3236,6 +3237,7 @@ def hist(
         color=color,
         label=label,
         stacked=stacked,
+        bihist=bihist,
         **({"data": data} if data is not None else {}),
         **kwargs,
     )

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4532,6 +4532,13 @@ def test_hist_emptydata():
     ax.hist([[], range(10), range(10)], histtype="step")
 
 
+def test_hist_bihistogram():
+    fig, ax = plt.subplots()
+    data1 = np.random.random(size=10)
+    data2 = np.random.random(size=10)
+    ax.hist([data1, data2], bihist=True)
+
+
 def test_hist_labels():
     # test singleton labels OK
     fig, ax = plt.subplots()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This PR adds an optional boolean parameter to `plt.hist()`, `bihist` to enable plotting [bihistograms](https://www.itl.nist.gov/div898/handbook/eda/section3/bihistog.htm).

Bihistograms are one way to visualize an effect on a distribution in a pre-post analysis, making it easier to see changes in the distribution's mean and skew.

```
plt.hist([data1, data2], bihist=True, bins=50, label=['Original', 'Thresholded'])
plt.legend()
```
<img width="508" alt="image" src="https://github.com/matplotlib/matplotlib/assets/25993326/89674389-369f-4584-8bdc-9d7b3d8c645a">

## PR checklist

- [NA] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [X] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
