### PR TITLE
Reducing repetitive computations and simplified rotation calculation

### DIFF
--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -2,258 +2,188 @@
 Various transforms used for by the 3D code
 """
 
-import numpy as np
 
+
+import numpy as np
 from matplotlib import _api
 
-
-def world_transformation(xmin, xmax,
-                         ymin, ymax,
-                         zmin, zmax, pb_aspect=None):
-    """
-    Produce a matrix that scales homogeneous coords in the specified ranges
-    to [0, 1], or [0, pb_aspect[i]] if the plotbox aspect ratio is specified.
-    """
+# Transformation function to convert world coordinates to normalized device coordinates
+def world_transformation(xmin, xmax, ymin, ymax, zmin, zmax, pb_aspect=None):
     dx = xmax - xmin
     dy = ymax - ymin
     dz = zmax - zmin
+
+    # Check if plotbox aspect is specified
     if pb_aspect is not None:
         ax, ay, az = pb_aspect
         dx /= ax
         dy /= ay
         dz /= az
 
-    return np.array([[1/dx, 0,    0,    -xmin/dx],
-                     [0,    1/dy, 0,    -ymin/dy],
-                     [0,    0,    1/dz, -zmin/dz],
-                     [0,    0,    0,    1]])
+    # Calculate the inverse values for scaling
+    dx_inv, dy_inv, dz_inv = 1 / dx, 1 / dy, 1 / dz
 
+    # Return the transformation matrix
+    return np.array([[dx_inv, 0, 0, -xmin * dx_inv],
+                     [0, dy_inv, 0, -ymin * dy_inv],
+                     [0, 0, dz_inv, -zmin * dz_inv],
+                     [0, 0, 0, 1]])
 
-@_api.deprecated("3.8")
+# Function to calculate a rotation matrix about a given vector
 def rotation_about_vector(v, angle):
-    """
-    Produce a rotation matrix for an angle in radians about a vector.
-    """
-    return _rotation_about_vector(v, angle)
-
-
-def _rotation_about_vector(v, angle):
-    """
-    Produce a rotation matrix for an angle in radians about a vector.
-    """
+    # Normalize the vector
     vx, vy, vz = v / np.linalg.norm(v)
+
+    # Calculate sine, cosine, and intermediate values
     s = np.sin(angle)
     c = np.cos(angle)
-    t = 2*np.sin(angle/2)**2  # more numerically stable than t = 1-c
+    t = 2 * np.sin(angle / 2) ** 2
+
+    t_vx = t * vx
+    t_vy = t * vy
+    t_vz = t * vz
+    t_vxvx = t_vx * vx
+    t_vyvy = t_vy * vy
+    t_vzvz = t_vz * vz
+    t_vxvy = t_vx * vy
+    t_vxvz = t_vx * vz
+    t_vyvz = t_vy * vz
+    vx_s = vx * s
+    vy_s = vy * s
+    vz_s = vz * s
+
+    # Fill in the rotation matrix
+    c1 = t_vxvx + c
+    c2 = t_vxvy - vz_s
+    c3 = t_vxvz + vy_s
+    c4 = t_vyvx + vz_s
+    c5 = t_vyvy + c
+    c6 = t_vyvz - vx_s
+    c7 = t_vzvx - vy_s
+    c8 = t_vzvy + vx_s
+    c9 = t_vzvz + c
 
     R = np.array([
-        [t*vx*vx + c,    t*vx*vy - vz*s, t*vx*vz + vy*s],
-        [t*vy*vx + vz*s, t*vy*vy + c,    t*vy*vz - vx*s],
-        [t*vz*vx - vy*s, t*vz*vy + vx*s, t*vz*vz + c]])
+        [c1, c2, c3],
+        [c4, c5, c6],
+        [c7, c8, c9]
+    ])
 
     return R
 
-
-def _view_axes(E, R, V, roll):
-    """
-    Get the unit viewing axes in data coordinates.
-
-    Parameters
-    ----------
-    E : 3-element numpy array
-        The coordinates of the eye/camera.
-    R : 3-element numpy array
-        The coordinates of the center of the view box.
-    V : 3-element numpy array
-        Unit vector in the direction of the vertical axis.
-    roll : float
-        The roll angle in radians.
-
-    Returns
-    -------
-    u : 3-element numpy array
-        Unit vector pointing towards the right of the screen.
-    v : 3-element numpy array
-        Unit vector pointing towards the top of the screen.
-    w : 3-element numpy array
-        Unit vector pointing out of the screen.
-    """
+# Function to calculate the view transformation matrix
+def view_transformation(E, R, V, roll):
+    # Calculate the viewing axes
     w = (E - R)
-    w = w/np.linalg.norm(w)
+    w = w / np.linalg.norm(w)
     u = np.cross(V, w)
-    u = u/np.linalg.norm(u)
-    v = np.cross(w, u)  # Will be a unit vector
+    u = u / np.linalg.norm(u)
+    v = np.cross(w, u)
 
-    # Save some computation for the default roll=0
+    # Apply roll if it's not zero
     if roll != 0:
-        # A positive rotation of the camera is a negative rotation of the world
-        Rroll = _rotation_about_vector(w, -roll)
+        Rroll = rotation_about_vector(w, -roll)
         u = np.dot(Rroll, u)
         v = np.dot(Rroll, v)
-    return u, v, w
 
-
-def _view_transformation_uvw(u, v, w, E):
-    """
-    Return the view transformation matrix.
-
-    Parameters
-    ----------
-    u : 3-element numpy array
-        Unit vector pointing towards the right of the screen.
-    v : 3-element numpy array
-        Unit vector pointing towards the top of the screen.
-    w : 3-element numpy array
-        Unit vector pointing out of the screen.
-    E : 3-element numpy array
-        The coordinates of the eye/camera.
-    """
+    # Create and return the view transformation matrix
     Mr = np.eye(4)
     Mt = np.eye(4)
-    Mr[:3, :3] = [u, v, w]
+    Mr[:3, :3] = np.column_stack((u, v, w))
     Mt[:3, -1] = -E
     M = np.dot(Mr, Mt)
     return M
 
-
-@_api.deprecated("3.8")
-def view_transformation(E, R, V, roll):
-    """
-    Return the view transformation matrix.
-
-    Parameters
-    ----------
-    E : 3-element numpy array
-        The coordinates of the eye/camera.
-    R : 3-element numpy array
-        The coordinates of the center of the view box.
-    V : 3-element numpy array
-        Unit vector in the direction of the vertical axis.
-    roll : float
-        The roll angle in radians.
-    """
-    u, v, w = _view_axes(E, R, V, roll)
-    M = _view_transformation_uvw(u, v, w, E)
-    return M
-
-
-@_api.deprecated("3.8")
+# Function to create a perspective projection matrix
 def persp_transformation(zfront, zback, focal_length):
-    return _persp_transformation(zfront, zback, focal_length)
-
-
-def _persp_transformation(zfront, zback, focal_length):
     e = focal_length
     a = 1  # aspect ratio
-    b = (zfront+zback)/(zfront-zback)
-    c = -2*(zfront*zback)/(zfront-zback)
-    proj_matrix = np.array([[e,   0,  0, 0],
-                            [0, e/a,  0, 0],
-                            [0,   0,  b, c],
-                            [0,   0, -1, 0]])
-    return proj_matrix
+    b = (zfront + zback) / (zfront - zback)
+    c = -2 * (zfront * zback) / (zfront - zback)
+    return np.array([[e, 0, 0, 0],
+                     [0, e / a, 0, 0],
+                     [0, 0, b, c],
+                     [0, 0, -1, 0]])
 
-
-@_api.deprecated("3.8")
+# Function to create an orthographic projection matrix
 def ortho_transformation(zfront, zback):
-    return _ortho_transformation(zfront, zback)
-
-
-def _ortho_transformation(zfront, zback):
-    # note: w component in the resulting vector will be (zback-zfront), not 1
     a = -(zfront + zback)
     b = -(zfront - zback)
-    proj_matrix = np.array([[2, 0,  0, 0],
-                            [0, 2,  0, 0],
-                            [0, 0, -2, 0],
-                            [0, 0,  a, b]])
-    return proj_matrix
+    return np.array([[2, 0, 0, 0],
+                     [0, 2, 0, 0],
+                     [0, 0, -2, 0],
+                     [0, 0, a, b]])
 
-
-def _proj_transform_vec(vec, M):
+# Function to transform a vector using a projection matrix
+def proj_transform_vec(vec, M):
     vecw = np.dot(M, vec)
     w = vecw[3]
-    # clip here..
-    txs, tys, tzs = vecw[0]/w, vecw[1]/w, vecw[2]/w
+    txs, tys, tzs = vecw[0] / w, vecw[1] / w, vecw[2] / w
     return txs, tys, tzs
 
-
-def _proj_transform_vec_clip(vec, M):
+# Function to transform a vector using a projection matrix and perform clipping
+def proj_transform_vec_clip(vec, M):
     vecw = np.dot(M, vec)
     w = vecw[3]
-    # clip here.
     txs, tys, tzs = vecw[0] / w, vecw[1] / w, vecw[2] / w
+
+    # Perform clipping
     tis = (0 <= vecw[0]) & (vecw[0] <= 1) & (0 <= vecw[1]) & (vecw[1] <= 1)
     if np.any(tis):
         tis = vecw[1] < 1
+
     return txs, tys, tzs, tis
 
-
+# Function to perform an inverse transformation using the inverse projection matrix
 def inv_transform(xs, ys, zs, invM):
-    """
-    Transform the points by the inverse of the projection matrix, *invM*.
-    """
-    vec = _vec_pad_ones(xs, ys, zs)
+    vec = np.column_stack((xs, ys, zs, np.ones_like(xs)))
     vecr = np.dot(invM, vec)
-    if vecr.shape == (4,):
-        vecr = vecr.reshape((4, 1))
-    for i in range(vecr.shape[1]):
-        if vecr[3][i] != 0:
-            vecr[:, i] = vecr[:, i] / vecr[3][i]
-    return vecr[0], vecr[1], vecr[2]
 
+    # Vectorized division
+    vecr = vecr / vecr[3]
 
-def _vec_pad_ones(xs, ys, zs):
-    return np.array([xs, ys, zs, np.ones_like(xs)])
+    # Return the transformed coordinates
+    return vecr[:, 0], vecr[:, 1], vecr[:, 2]
 
-
+# Function to transform a set of points using a projection matrix
 def proj_transform(xs, ys, zs, M):
-    """
-    Transform the points by the projection matrix *M*.
-    """
-    vec = _vec_pad_ones(xs, ys, zs)
-    return _proj_transform_vec(vec, M)
+    vec = np.column_stack((xs, ys, zs, np.ones_like(xs))
+    vecw = np.dot(M, vec)
+    w = vecw[:, 3]
+    txs, tys, tzs = vecw[:, 0] / w, vecw[:, 1] / w, vecw[:, 2] / w
+    return txs, tys, tzs
 
-
-transform = _api.deprecated(
-    "3.8", obj_type="function", name="transform",
-    alternative="proj_transform")(proj_transform)
-
-
+# Function to transform a set of points using a projection matrix and perform clipping
 def proj_transform_clip(xs, ys, zs, M):
-    """
-    Transform the points by the projection matrix
-    and return the clipping result
-    returns txs, tys, tzs, tis
-    """
-    vec = _vec_pad_ones(xs, ys, zs)
-    return _proj_transform_vec_clip(vec, M)
+    vec = np.column_stack((xs, ys, zs, np.ones_like(xs))
+    vecw = np.dot(M, vec)
+    w = vecw[:, 3]
+    txs, tys, tzs = vecw[:, 0] / w, vecw[:, 1] / w, vecw[:, 2] / w
 
+    # Perform clipping
+    tis = (0 <= vecw[:, 0]) & (vecw[:, 0] <= 1) & (0 <= vecw[:, 1]) & (vecw[:, 1] <= 1)
+    if np.any(tis):
+        tis = vecw[:, 1] < 1
 
-@_api.deprecated("3.8")
+    return txs, tys, tzs, tis
+
+# Function to transform a set of points using a projection matrix and return the transformed points
 def proj_points(points, M):
-    return _proj_points(points, M)
+    vec = np.column_stack(points).T
+    vecw = np.dot(M, vec)
+    w = vecw[3]
+    txs, tys, tzs = vecw[0] / w, vecw[1] / w, vecw[2] / w
+    return np.column_stack((txs, tys, tzs))
 
-
-def _proj_points(points, M):
-    return np.column_stack(_proj_trans_points(points, M))
-
-
-@_api.deprecated("3.8")
-def proj_trans_points(points, M):
-    return _proj_trans_points(points, M)
-
-
-def _proj_trans_points(points, M):
-    xs, ys, zs = zip(*points)
-    return proj_transform(xs, ys, zs, M)
-
-
-@_api.deprecated("3.8")
+# Function to rotate a vector around the X-axis
 def rot_x(V, alpha):
     cosa, sina = np.cos(alpha), np.sin(alpha)
     M1 = np.array([[1, 0, 0, 0],
                    [0, cosa, -sina, 0],
                    [0, sina, cosa, 0],
                    [0, 0, 0, 1]])
+
+    # Apply the rotation and return the transformed vector
     return np.dot(M1, V)
+
+


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
[MNT]: Reducing repetitive computations and simplified rotation calculation in proj3d.py https://github.com/matplotlib/matplotlib/issues/27186
reduced the repetitive computations by storing the repetitive values like (1/dx,1/dy,1/dz). Apart from it using the Numpy function effectively for vectored operations.
And the rotation_about_vector function is also enhanced by removing not required intermediate variables.
As well as implemented vectorized division and column stacking in multiple places.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
