### PR TITLE
DOC: clean up links under table formatting docs

### DIFF
--- a/doc/devel/document.rst
+++ b/doc/devel/document.rst
@@ -176,6 +176,7 @@ Given the size of the table and length of each entry, use:
 +-------------+-------------------------------+--------------------+
 
 For more information, see `rst tables <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#tables>`_.
+
 .. _sg: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#tables
 .. _lt: https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
 .. _csv: https://docutils.sourceforge.io/docs/ref/rst/directives.html#toc-entry-22

--- a/doc/devel/document.rst
+++ b/doc/devel/document.rst
@@ -170,16 +170,17 @@ Given the size of the table and length of each entry, use:
 +-------------+-------------------------------+--------------------+
 |             | small table                   | large table        |
 +-------------+-------------------------------+--------------------+
-| short entry | `simple or grid table <sg>`_  | `grid table <sg>`_ |
+| short entry | `simple or grid table`_       | `grid table`_      |
 +-------------+-------------------------------+--------------------+
-| long entry  | `list table <lt>`_            | `csv table <csv>`_ |
+| long entry  | `list table`_                 | `csv table`_       |
 +-------------+-------------------------------+--------------------+
 
 For more information, see `rst tables <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#tables>`_.
 
-.. _sg: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#tables
-.. _lt: https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
-.. _csv: https://docutils.sourceforge.io/docs/ref/rst/directives.html#toc-entry-22
+.. _`simple or grid table`: https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#tables
+.. _`grid table`: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#grid-tables
+.. _`list table`: https://docutils.sourceforge.io/docs/ref/rst/directives.html#list-table
+.. _`csv table`: https://docutils.sourceforge.io/docs/ref/rst/directives.html#csv-table-1
 
 Function arguments
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I guess I forgot to add a line and nobody checked the final build - currently all the urls in the table are batched underneath 😬 

![image](https://github.com/matplotlib/matplotlib/assets/1300499/19200c5a-8d35-46dd-b68b-59675ad4ec55)

this PR also fixes the links 🤦‍♀️ 
