### PR TITLE
DOC: Add role for custom informal types like color

### DIFF
--- a/doc/sphinxext/custom_roles.py
+++ b/doc/sphinxext/custom_roles.py
@@ -64,8 +64,23 @@ def rcparam_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
     return node_list, messages
 
 
+def mpltype_role(name, rawtext, text, lineno, inliner, options={}, content=[]):
+    mpltype = text
+    type_to_link_target = {
+        'color': 'colors_def',
+    }
+    if mpltype not in type_to_link_target:
+        raise ValueError(f"Unknown mpltype: {mpltype!r}")
+
+    ref_nodes, messages = inliner.interpreted(
+        mpltype, f'{mpltype} <{type_to_link_target[mpltype]}>', 'ref', lineno)
+    node_list = [ref_nodes]
+    return node_list, messages
+
+
 def setup(app):
     app.add_role("rc", rcparam_role)
+    app.add_role("mpltype", mpltype_role)
     app.add_node(
         QueryReference,
         html=(visit_query_reference_node, depart_query_reference_node),

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -191,7 +191,7 @@ class Button(AxesWidget):
         image : array-like or PIL Image
             The image to place in the button, if not *None*.  The parameter is
             directly forwarded to `~.axes.Axes.imshow`.
-        color : color
+        color : :mpltype:`color`
             The color of the button when not activated.
         hovercolor : color
             The color of the button when the mouse is over it.


### PR DESCRIPTION
The role is intended to be used for type references in docstrings like
```
Parameters
----------
    color : :mpltype:`color`
```

It is easily extendable to other types.

The naming `:mpltype:` was a quick choice. I'm open to other names. (Note that `:type:` seem to be available, but I'm inclinded to say it's too generic: People will find it in the code and have a hard time figuring out where it comes from.)

This PR contains one example usage in `widgets.Button` so that one can see the effect in the built docs. Systematic application throughout the codebase should be deferred to a separate PR.

Closes #24859.
Formalizes #27164.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

