### PR TITLE
BLD: Use NumPy nightly wheels for non-release builds

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -116,7 +116,7 @@ jobs:
              rm -rf {package}/build'
         }}
       CIBW_BUILD_FRONTEND: >-
-        ${{ (((github.event_name == '' && github.ref == 'refs/heads/main') ||
+        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
               (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
             'pip; args: --no-build-isolation') || 'build' }}
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -101,7 +101,7 @@ jobs:
       # If using all `--pre` releases creates issues, the NumPy wheel can be
       # istalled more targeted.
       CIBW_BUILD_FRONTEND: >-
-        ${{ (((github.event_name == 'main' && github.ref == 'refs/heads/main') ||
+        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
               (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
             'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"') ||
             'build' }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -90,35 +90,21 @@ jobs:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
     env:
-      # The following commands branch based on whether we are on the main
-      # branch or have a PR into main.  For these, we use the NumPy 2.0
-      # nightlies to ensure future C-API/ABI compatibility.
-      # This branching becomes unnecessary when NumPy 2.0 is released.
-      # When using no-build-isolation we need to install all requirements.
-      CIBW_BEFORE_BUILD:
-        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-              (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
-            'pip install meson-python pybind11 setuptools_scm "setuptools>=64" ninja &&
-             pip install "numpy>=2.0.0.dev0" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" &&
-             rm -rf {package}/build'
-          ) ||
-            'pip install "numpy>=1.25" &&
-             rm -rf {package}/build'
-        }}
-      CIBW_BEFORE_BUILD_WINDOWS:
-        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-              (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
-            'pip install delvewheel meson-python pybind11 setuptools_scm "setuptools>=64" ninja &&
-             pip install "numpy>=2.0.0.dev0" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" &&
-             rm -rf {package}/build'
-          ) ||
-            'pip install delvewheel "numpy>=1.25" &&
-             rm -rf {package}/build'
-        }}
+      CIBW_BEFORE_BUILD: >-
+        rm -rf {package}/build
+      CIBW_BEFORE_BUILD_WINDOWS: >-
+        pip install delvewheel &&
+        rm -rf {package}/build
+      # Live on the edge when building on main or a PR against main since
+      # these wheels are also used for nightlies and NumPy 2.0 transition
+      # requires using the NumPy 2.0 nightlies for compatibility.
+      # If using all `--pre` releases creates issues, the NumPy wheel can be
+      # istalled more targeted.
       CIBW_BUILD_FRONTEND: >-
-        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+        ${{ (((github.event_name == 'main' && github.ref == 'refs/heads/main') ||
               (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
-            'pip; args: --no-build-isolation') || 'build' }}
+            'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"') ||
+            'build' }}
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
         delvewheel repair -w {dest_dir} {wheel}
       CIBW_AFTER_BUILD: >-

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -102,7 +102,7 @@ jobs:
       # istalled more targeted.
       CIBW_BUILD_FRONTEND: >-
         ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-              (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
+              (github.event_name == 'pull_request' && github.base_ref == 'main')) &&
             'pip; args: --pre --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"') ||
             'build' }}
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -90,12 +90,35 @@ jobs:
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_archs }}
     runs-on: ${{ matrix.os }}
     env:
-      CIBW_BEFORE_BUILD: >-
-        pip install numpy>=1.25 &&
-        rm -rf {package}/build
-      CIBW_BEFORE_BUILD_WINDOWS: >-
-        pip install delvewheel numpy>=1.25 &&
-        rm -rf {package}/build
+      # The following commands branch based on whether we are on the main
+      # branch or have a PR into main.  For these, we use the NumPy 2.0
+      # nightlies to ensure future C-API/ABI compatibility.
+      # This branching becomes unnecessary when NumPy 2.0 is released.
+      # When using no-build-isolation we need to install all requirements.
+      CIBW_BEFORE_BUILD:
+        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+              (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
+            'pip install meson-python pybind11 setuptools_scm "setuptools>=64" ninja &&
+             pip install "numpy>=2.0.0.dev0" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" &&
+             rm -rf {package}/build'
+          ) ||
+            'pip install "numpy>=1.25" &&
+             rm -rf {package}/build'
+        }}
+      CIBW_BEFORE_BUILD_WINDOWS:
+        ${{ (((github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+              (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
+            'pip install delvewheel meson-python pybind11 setuptools_scm "setuptools>=64" ninja &&
+             pip install "numpy>=2.0.0.dev0" --extra-index-url "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple" &&
+             rm -rf {package}/build'
+          ) ||
+            'pip install delvewheel "numpy>=1.25" &&
+             rm -rf {package}/build'
+        }}
+      CIBW_BUILD_FRONTEND: >-
+        ${{ (((github.event_name == '' && github.ref == 'refs/heads/main') ||
+              (github.event_name == 'pull_request' && github.base_ref == 'refs/heads/main')) &&
+            'pip; args: --no-build-isolation') || 'build' }}
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
         delvewheel repair -w {dest_dir} {wheel}
       CIBW_AFTER_BUILD: >-


### PR DESCRIPTION
This uses the NumPy nightlies for non-release builds to ensure the matplotlib nightlies uploaded are build against the new NumPy version.

These nightlies are not tested, but if they were they should actually still be tested against the release NumPy.  This is necessary to allow NumPy to enforce API changes, it does mean that potential C-API breaks in NumPy need quicker follow-up unfortunately (either in NumPy or in matplotlib).

Closes gh-27174

---

I have tested that it calls with `--no-build-isolation` and installs the right NumPy before that.  I am *not* sure that this is the best approach, it is rather tedious to set up all dependencies manually (and I am not a workflow specialist)!
For example, I don't really understand the `>-` but I removed it because that means that newlines are not included in the `'strings'`, which would otherwise make trouble.