### PR TITLE
Improve legend picking example

### DIFF
--- a/galleries/examples/event_handling/legend_picking.py
+++ b/galleries/examples/event_handling/legend_picking.py
@@ -18,33 +18,46 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 t = np.linspace(0, 1)
-y1 = 2 * np.sin(2*np.pi*t)
-y2 = 4 * np.sin(2*np.pi*2*t)
+y1 = 2 * np.sin(2 * np.pi * t)
+y2 = 4 * np.sin(2 * np.pi * 2 * t)
 
 fig, ax = plt.subplots()
 ax.set_title('Click on legend line to toggle line on/off')
-line1, = ax.plot(t, y1, lw=2, label='1 Hz')
-line2, = ax.plot(t, y2, lw=2, label='2 Hz')
+(line1, ) = ax.plot(t, y1, lw=2, label='1 Hz')
+(line2, ) = ax.plot(t, y2, lw=2, label='2 Hz')
 leg = ax.legend(fancybox=True, shadow=True)
 
 lines = [line1, line2]
-lined = {}  # Will map legend lines to original lines.
-for legline, origline in zip(leg.get_lines(), lines):
-    legline.set_picker(True)  # Enable picking on the legend line.
-    lined[legline] = origline
+map_legend_to_ax = {}  # Will map legend lines to original lines.
+
+pickradius = 5  # Points (Pt). How close the click needs to be to trigger an event.
+
+for legend_line, ax_line in zip(leg.get_lines(), lines):
+    legend_line.set_picker(pickradius)  # Enable picking on the legend line.
+    map_legend_to_ax[legend_line] = ax_line
 
 
 def on_pick(event):
     # On the pick event, find the original line corresponding to the legend
     # proxy line, and toggle its visibility.
-    legline = event.artist
-    origline = lined[legline]
-    visible = not origline.get_visible()
-    origline.set_visible(visible)
+    legend_line = event.artist
+
+    # Do nothing if the source of the event is not a legend line.
+    if legend_line not in map_legend_to_ax:
+        return
+
+    ax_line = map_legend_to_ax[legend_line]
+    visible = not ax_line.get_visible()
+    ax_line.set_visible(visible)
     # Change the alpha on the line in the legend, so we can see what lines
     # have been toggled.
-    legline.set_alpha(1.0 if visible else 0.2)
+    legend_line.set_alpha(1.0 if visible else 0.2)
     fig.canvas.draw()
 
+
 fig.canvas.mpl_connect('pick_event', on_pick)
+
+# Works even if the legend is draggable. This is independent from picking legend lines.
+leg.set_draggable(True)
+
 plt.show()


### PR DESCRIPTION
## PR summary
* Pass an actual pickradius instead of `True`. `True` (`1`) is a bad user experience.
* Fix `on_pick` to work when the legend is draggable. (Early exit)
* For good measure, show that it works with draggable legends.
* Use higher visability syntax for single element destrturing for higher readability.
* Refactor varible names. (`lined` -> `map_legend_to_ax`)
* (Formatted with autopep8)

Live version: https://matplotlib.org/stable/gallery/event_handling/legend_picking.html

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->


<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" 
- [N/A] (?) new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
