### PR TITLE
Add test_axvline to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -44,11 +44,19 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.axline(...)
 
-    @pytest.mark.xfail(reason="Test for axvline not written yet")
     @mpl.style.context("default")
     def test_axvline(self):
-        fig, ax = plt.subplots()
-        ax.axvline(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        ax1.set_xlim(left=datetime.datetime(2020, 4, 1),
+                     right=datetime.datetime(2020, 8, 1))
+        ax2.set_xlim(left=np.datetime64('2005-01-01'),
+                     right=np.datetime64('2005-04-01'))
+        ax3.set_xlim(left=datetime.datetime(2023, 9, 1),
+                     right=datetime.datetime(2023, 11, 1))
+        ax1.axvline(x=datetime.datetime(2020, 6, 3), ymin=0.5, ymax=0.7)
+        ax2.axvline(np.datetime64('2005-02-25T03:30'), ymin=0.1, ymax=0.9)
+        ax3.axvline(x=datetime.datetime(2023, 10, 24), ymin=0.4, ymax=0.7)
 
     @pytest.mark.xfail(reason="Test for axvspan not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I have added a datetime smoke test/example code for `Axes.axvline` in `lib/matplotlib/test/test_datetime.py`. This addresses the `Axes.axvline` task from #26864. This is very similar to #27177, where I added example code for `Axes.axhline`; this is the vertical version of that function.

The image below is the plot generated from my example code.
![axvline](https://github.com/matplotlib/matplotlib/assets/99672198/2bc22da6-ac71-4997-a290-e07c165b1cc1)


<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
