### PR TITLE
DOC: consolidated coding guide and added naming conventions table

### DIFF
--- a/doc/api/next_api_changes/README.rst
+++ b/doc/api/next_api_changes/README.rst
@@ -22,11 +22,17 @@ author's initials. Typically, each change will get its own file, but you may
 also amend existing files when suitable. The overall goal is a comprehensible
 documentation of the changes.
 
-Please avoid using references in section titles, as it causes links to be
-confusing in the table of contents. Instead, ensure that a reference is
-included in the descriptive text. A typical entry could look like this::
+A typical entry could look like this::
 
    Locators
    ~~~~~~~~
    The unused `Locator.autoscale()` method is deprecated (pass the axis
    limits to `Locator.view_limits()` instead).
+
+Please avoid using references in section titles, as it causes links to be
+confusing in the table of contents. Instead, ensure that a reference is
+included in the descriptive text.
+
+.. NOTE
+   Lines 5-30 of this file are include in :ref:`api_whats_new`;
+   therefore, please check the doc build after changing this file.

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -8,144 +8,82 @@ Pull request guidelines
 <https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests>`__
 are the mechanism for contributing to Matplotlib's code and documentation.
 
-It is recommended to check that your contribution complies with the following
-rules before submitting a pull request:
+We value contributions from people with all levels of experience. In particular,
+if this is your first PR not everything has to be perfect. We'll guide you
+through the PR process. Nevertheless, please try to follow our guidelines as well
+as you can to help make the PR process quick and smooth. If your pull request is
+incomplete or a work-in-progress, please mark it as a `draft pull requests <https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests>`_
+on GitHub and specify what feedback from the developers would be helpful.
 
-* If your pull request addresses an issue, please use the title to describe the
-  issue (e.g. "Add ability to plot timedeltas") and mention the issue number
-  in the pull request description to ensure that a link is created to the
-  original issue (e.g. "Closes #8869" or "Fixes #8869"). This will ensure the
-  original issue mentioned is automatically closed when your PR is merged. See
-  `the GitHub documentation
-  <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>`__
-  for more details.
-
-* Formatting should follow the recommendations of PEP8_, as enforced by
-  flake8_. Matplotlib modifies PEP8 to extend the maximum line length to 88
-  characters. You can check flake8 compliance from the command line with ::
-
-    python -m pip install flake8
-    flake8 /path/to/module.py
-
-  or your editor may provide integration with it.  Note that Matplotlib
-  intentionally does not use the black_ auto-formatter (1__), in particular due
-  to its inability to understand the semantics of mathematical expressions
-  (2__, 3__).
-
-  .. _PEP8: https://www.python.org/dev/peps/pep-0008/
-  .. _flake8: https://flake8.pycqa.org/
-  .. _black: https://black.readthedocs.io/
-  .. __: https://github.com/matplotlib/matplotlib/issues/18796
-  .. __: https://github.com/psf/black/issues/148
-  .. __: https://github.com/psf/black/issues/1984
-
-* All public methods should have informative docstrings with sample usage when
-  appropriate. Use the :ref:`docstring standards <writing-docstrings>`.
-
-* For high-level plotting functions, consider adding a simple example either in
-  the ``Example`` section of the docstring or the
-  :ref:`examples gallery <gallery>`.
-
-* Changes (both new features and bugfixes) should have good test coverage. See
-  :ref:`testing` for more details.
-
-* Import the following modules using the standard scipy conventions::
-
-     import numpy as np
-     import numpy.ma as ma
-     import matplotlib as mpl
-     import matplotlib.pyplot as plt
-     import matplotlib.cbook as cbook
-     import matplotlib.patches as mpatches
-
-  In general, Matplotlib modules should **not** import `.rcParams` using ``from
-  matplotlib import rcParams``, but rather access it as ``mpl.rcParams``.  This
-  is because some modules are imported very early, before the `.rcParams`
-  singleton is constructed.
-
-* If your change is a major new feature, add an entry to the ``What's new``
-  section by adding a new file in ``doc/users/next_whats_new`` (see
-  :file:`doc/users/next_whats_new/README.rst` for more information).
-
-* If you change the API in a backward-incompatible way, please document it in
-  :file:`doc/api/next_api_changes/behavior`, by adding a new file with the
-  naming convention ``99999-ABC.rst`` where the pull request number is followed
-  by the contributor's initials. (see :file:`doc/api/api_changes.rst` for more
-  information)
-
-* If you add new public API or change public API, update or add the
-  corresponding type hints. Most often this is found in the corresponding
-  ``.pyi`` file for the ``.py`` file which was edited. Changes in ``pyplot.py``
-  are type hinted inline.
-
-* See below for additional points about :ref:`keyword-argument-processing`, if
-  applicable for your pull request.
-
-.. note::
-
-    The current state of the Matplotlib code base is not compliant with all
-    of these guidelines, but we expect that enforcing these constraints on all
-    new contributions will move the overall code base quality in the right
-    direction.
-
-
-.. seealso::
-
-  * :ref:`coding_guidelines`
-  * :ref:`testing`
-  * :ref:`documenting-matplotlib`
-
+Please be patient with reviewers. We try our best to respond quickly, but we have
+limited bandwidth. If there is no feedback within a couple of days, please ping
+us by posting a comment to your PR or reaching out on a :ref:`communication channel <communication-channels>`
 
 
 Summary for pull request authors
 ================================
 
-.. note::
-
-   * We value contributions from people with all levels of experience. In
-     particular if this is your first PR not everything has to be perfect.
-     We'll guide you through the PR process.
-   * Nevertheless, please try to follow the guidelines below as well as you can to
-     help make the PR process quick and smooth.
-   * Be patient with reviewers. We try our best to respond quickly, but we
-     have limited bandwidth. If there is no feedback within a couple of days,
-     please ping us by posting a comment to your PR.
-
-When making a PR, pay attention to:
+We recommend that you check that your contribution complies with the following
+guidelines before submitting a pull request:
 
 .. rst-class:: checklist
 
-* :ref:`Target the main branch <pr-branch-selection>`.
-* Adhere to the :ref:`coding_guidelines`.
+* Changes, both new features and bugfixes, should have good test coverage. See
+  :ref:`testing` for more details.
+
 * Update the :ref:`documentation <pr-documentation>` if necessary.
-* Aim at making the PR as "ready-to-go" as you can. This helps to speed up
-  the review process.
-* It is ok to open incomplete or work-in-progress PRs if you need help or
-  feedback from the developers. You may mark these as
-  `draft pull requests <https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests#draft-pull-requests>`_
-  on GitHub.
-* When updating your PR, instead of adding new commits to fix something, please
-  consider amending your initial commit(s) to keep the history clean.
-  You can achieve this by using
 
-  .. code-block:: bash
+* All public methods should have informative docstrings with sample usage when
+  appropriate. Use the :ref:`docstring standards <writing-docstrings>`.
 
-     git commit --amend --no-edit
-     git push [your-remote-repo] [your-branch] --force-with-lease
+* For high-level plotting functions, consider adding a small example to the
+  :ref:`examples gallery <gallery>`.
 
-See also :ref:`contributing` for how to make a PR.
+* If you add a major new feature or change the API in a backward-incompatible
+  way, please document it as described in :ref:`new-changed-api`
+
+* Code should follow our conventions as documented in our :ref:`coding_guidelines`
+
+* When adding or changing public function signatures, add :ref:`type hints <type-hints>`
+
+* When adding keyword arguments, see our guide to :ref:`keyword-argument-processing`.
+
+When opening a pull request on Github, please ensure that:
+
+.. rst-class:: checklist
+
+* Changes were made on a :ref:`feature branch <make-feature-branch>`.
+
+* :ref:`pre-commit <pre-commit-hooks>` checks for spelling, formatting, etc pass
+
+* The pull request targets the :ref:`main branch <pr-branch-selection>`
+
+* If your pull request addresses an issue, please use the title to describe the
+  issue (e.g. "Add ability to plot timedeltas") and mention the issue number
+  in the pull request description to ensure that a link is created to the
+  original issue (e.g. "Closes #8869" or "Fixes #8869"). This will ensure the
+  original issue mentioned is automatically closed when your PR is merged. For more
+  details, see `linking an issue and pull request <https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue>`__.
+
+* :ref:`pr-automated-tests` pass
+
+For guidance on creating and managing a pull request, please see our
+:ref:`contributing <contributing>` and :ref:`pull request workflow <edit-flow>`
+guides.
+
 
 Summary for pull request reviewers
 ==================================
 
 .. redirect-from:: /devel/maintainer_workflow
 
-.. note::
+**Please help review and merge PRs!**
 
-   * If you have commit rights, then you are trusted to use them.
-     **Please help review and merge PRs!**
-   * Be patient and `kind <https://youtu.be/tzFWz5fiVKU?t=49m30s>`__ with
-     contributors.
+If you have commit rights, then you are trusted to use them. Please be patient
+and `kind <https://youtu.be/tzFWz5fiVKU?t=49m30s>`__ with contributors.
+
+When reviewing, please ensure that the pull request satisfies the following
+requirements before merging it:
 
 Content topics:
 
@@ -195,61 +133,6 @@ Documentation
 * Build the docs and make sure all formatting warnings are addressed.
 
 * See :ref:`documenting-matplotlib` for our documentation style guide.
-
-.. _release_notes:
-
-New features and API changes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When adding a major new feature or changing the API in a backward incompatible
-way, please document it by including a versioning directive in the docstring
-and adding an entry to the folder for either the what's new or API change notes.
-
-+-------------------+-----------------------------+----------------------------------+
-| for this addition | include this directive      | create entry in this folder      |
-+===================+=============================+==================================+
-| new feature       | ``.. versionadded:: 3.N``   | :file:`doc/users/next_whats_new/`|
-+-------------------+-----------------------------+----------------------------------+
-| API change        | ``.. versionchanged:: 3.N`` | :file:`doc/api/next_api_changes/`|
-|                   |                             |                                  |
-|                   |                             | probably in ``behavior/``        |
-+-------------------+-----------------------------+----------------------------------+
-
-The directives should be placed at the end of a description block. For example::
-
-  class Foo:
-      """
-      This is the summary.
-
-      Followed by a longer description block.
-
-      Consisting of multiple lines and paragraphs.
-
-      .. versionadded:: 3.5
-
-      Parameters
-      ----------
-      a : int
-          The first parameter.
-      b: bool, default: False
-          This was added later.
-
-          .. versionadded:: 3.6
-      """
-
-      def set_b(b):
-          """
-          Set b.
-
-          .. versionadded:: 3.6
-
-          Parameters
-          ----------
-          b: bool
-
-For classes and functions, the directive should be placed before the
-*Parameters* section. For parameters, the directive should be placed at the
-end of the parameter description. The patch release version is omitted and
-the directive should not be added to entire modules.
 
 .. _pr-labels:
 
@@ -330,7 +213,8 @@ Merging
 
 Automated tests
 ---------------
-Before being merged, a PR should pass the :ref:`automated-tests`. If you are unsure why a test is failing, ask on the PR or in our `chat space <https://gitter.im/matplotlib/matplotlib>`_
+Before being merged, a PR should pass the :ref:`automated-tests`. If you are
+unsure why a test is failing, ask on the PR or in our :ref:`communication-channels`
 
 .. _pr-squashing:
 

--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -212,6 +212,8 @@ you are aware of the existing issues beforehand.
 * Run test cases to verify installation :ref:`testing`
 * Verify documentation build :ref:`documenting-matplotlib`
 
+.. _pre-commit-hooks:
+
 Install pre-commit hooks
 ========================
 `pre-commit <https://pre-commit.com/>`_ hooks save time in the review process by

--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -151,6 +151,23 @@ If you don't think your request is ready to be merged, just say so in your pull
 request message and use the "Draft PR" feature of GitHub. This is a good way of
 getting some preliminary code review.
 
+.. _update-pull-request:
+
+Update a pull request
+=====================
+
+When updating your pull request after making revisions, instead of adding new
+commits, please consider amending your initial commit(s) to keep the commit
+history clean.
+
+You can achieve this by using
+
+  .. code-block:: bash
+
+     git commit -a --amend --no-edit
+     git push [your-remote-repo] [your-branch] --force-with-lease
+
+
 Manage commit history
 =====================
 

--- a/doc/users/next_whats_new/README.rst
+++ b/doc/users/next_whats_new/README.rst
@@ -11,9 +11,7 @@ something like :file:`cool_new_feature.rst` if you have added a brand new
 feature or something like :file:`updated_feature.rst` for extensions of
 existing features.
 
-Please avoid using references in section titles, as it causes links to be
-confusing in the table of contents.  Instead, ensure that a reference is
-included in the descriptive text.  Include contents of the form: ::
+Include contents of the form::
 
     Section title for feature
     -------------------------
@@ -23,3 +21,11 @@ included in the descriptive text.  Include contents of the form: ::
 
     A sub-section
     ~~~~~~~~~~~~~
+
+Please avoid using references in section titles, as it causes links to be
+confusing in the table of contents. Instead, ensure that a reference is
+included in the descriptive text.
+
+.. NOTE
+   Lines 5-24 of this file are include in :ref:`api_whats_new`;
+   therefore, please check the doc build after changing this file.


### PR DESCRIPTION
This started as an attempt to document variable naming conventions to address #22156 and well trying to put a table into a bullet list didn't work well and that had me thinking that a bullet list is the wrong structure when tables are involved so 😅 this PR:

- moves a lot of text out of notes and turns it into the preambles they were functionally acting as
- consolidates the contributor checklists sections, mostly by removing content and instead linking out to where it's discussed/described
- better distinguish contributor content checklist from github checklist
- move the checklist .css into the mpl.css file
- moved info on updating a pull request to the workflow-> as with #26998, this is to better scope the PR guidelines doc to being about the content of the PR and the git workflow doc to be about git/github specific workflow. 
- moved bulkier bullet points into coding guidelines as subsections to avoid having two coding guides b/c   #26095
- moved all the what's new/API changes stuff out to the coding guidelines too and reworked that section a drop b/c #26095
     - the changes to the API/What's new readmes just moves the duplicated part to the bottom so that it can get cropped in the include. 
     - I would like to also remove the very large item bulleted lists here (I think most of them are really tables), but I'd like to move all the "new/changed/deprecated API" info out into its own page because it is a lot of content.
   
While it may not seem like it, I have tried to avoid rewording/rewriting except to remove redundancy. In particularly, I'm trying to remove duplicate sets of detailed instructions b/c I think that creates space for deviation in those instructions/confusion. 

### Next Steps
I think merging this should be good enough to close #26095 cause it'll at least put everything in one place (mostly). I don't want to overwhelm this PR w/ changes since it's already doing a lot more than I planned, but once this is merged I'd like to clean up the code section of the policy and guidelines page so that it can just be a TOC. To do so, I think a sensible swapping would be to 

1. move the contents of code_guidelines in contribute into the file called code guidelines
2. move the API changes content into its own file
3. move the pull request checklists out of coding_guidelines into their own file:
      * alt: contributor checklist -> coding guide, maintainer checklist -> pr triage file
5. move the information that has to do with pull request triage into a pull_request_triage file and move that under triage

Basically proposing that the code section of policies & guidelines changes: 

| current | proposed|
|---------|-----------|
| <ul> <li>coding guidelines </li> <li>pull request guidelines</li> <li> testing </li></ul> | <ul> <li>coding style guide </li> <li>API changes and new features</li> <li> testing </li></ul>|

and the triage section changes to

| current | proposed|
|---------|-----------|
| <ul> <li>bug triaging and issue curation </li> <li>triage team</li> <li> a typical workflow for triaging issues</li></ul> | <ul> <li>triage team </li> <li>bug triaging and issue curation</li> <li> pull request triage</li></ul>|

or the pull request triage document gets moved to maintenance, but technically I think anyone w/ triage rights can do most of the triage stuff discussed in the pull request guide. 