### PR TITLE
Add `@QtCore.Slot()` decorations to `NavigationToolbar2QT`

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -642,8 +642,13 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             if text is None:
                 self.addSeparator()
             else:
+                slot = getattr(self, callback)
+                # https://bugreports.qt.io/browse/PYSIDE-2512
+                slot = lambda slot=slot, *args: slot(*args)
+                slot = QtCore.Slot()(slot)
+
                 a = self.addAction(self._icon(image_file + '.png'),
-                                   text, getattr(self, callback))
+                                   text, slot)
                 self._actions[callback] = a
                 if callback in ['zoom', 'pan']:
                     a.setCheckable(True)

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -644,7 +644,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             else:
                 slot = getattr(self, callback)
                 # https://bugreports.qt.io/browse/PYSIDE-2512
-                slot = lambda slot=slot, *args: slot(*args)
+                slot = functools.partial(slot)
                 slot = QtCore.Slot()(slot)
 
                 a = self.addAction(self._icon(image_file + '.png'),

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -644,7 +644,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             else:
                 slot = getattr(self, callback)
                 # https://bugreports.qt.io/browse/PYSIDE-2512
-                slot = functools.partial(slot)
+                slot = functools.wraps(slot)(functools.partial(slot))
                 slot = QtCore.Slot()(slot)
 
                 a = self.addAction(self._icon(image_file + '.png'),


### PR DESCRIPTION
## PR summary
Add `@QtCore.Slot()` decorations to `NavigationToolbar2QT` to suppress "Registering dynamic slot" warnings. Closes #27214.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
