### PR TITLE
Remove backend 3.7-deprecated API #26962

### DIFF
--- a/doc/api/next_api_changes/removals/26962.rst
+++ b/doc/api/next_api_changes/removals/26962.rst
@@ -1,0 +1,8 @@
+``backend_ps.PsBackendHelper`` and ``backend_webagg.ServerThread``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... are removed .These were mareked as deprecated since 3.7 of Matplpotlib
+
+``PyBufferRegion_to_string`` and ``PyBufferRegion_to_string_argb``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... methods are removed from `src/_backend_agg_wrapper.cpp`.These were mareked as 
+    deprecated since 3.7 Matplpotlib

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -39,17 +39,9 @@ _log = logging.getLogger(__name__)
 debugPS = False
 
 
-@_api.deprecated("3.7")
-class PsBackendHelper:
-    def __init__(self):
-        self._cached = {}
-
-
 @_api.caching_module_getattr
 class __getattr__:
     # module-level deprecations
-    ps_backend_helper = _api.deprecated("3.7", obj_type="")(
-        property(lambda self: PsBackendHelper()))
     psDefs = _api.deprecated("3.8", obj_type="")(property(lambda self: _psDefs))
 
 

--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -37,12 +37,6 @@ from .backend_webagg_core import (  # noqa: F401 # pylint: disable=W0611
     TimerAsyncio, TimerTornado)
 
 
-@mpl._api.deprecated("3.7")
-class ServerThread(threading.Thread):
-    def run(self):
-        tornado.ioloop.IOLoop.instance().start()
-
-
 webagg_server_thread = threading.Thread(
     target=lambda: tornado.ioloop.IOLoop.instance().start())
 

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -5,26 +5,6 @@
 #include "_backend_agg.h"
 #include "mplutils.h"
 
-void BufferRegion::to_string_argb(uint8_t *buf)
-{
-    unsigned char *pix;
-    unsigned char tmp;
-    size_t i, j;
-
-    memcpy(buf, data, (size_t) height * stride);
-
-    for (i = 0; i < (size_t)height; ++i) {
-        pix = buf + i * stride;
-        for (j = 0; j < (size_t)width; ++j) {
-            // Convert rgba to argb
-            tmp = pix[2];
-            pix[2] = pix[0];
-            pix[0] = tmp;
-            pix += 4;
-        }
-    }
-}
-
 RendererAgg::RendererAgg(unsigned int width, unsigned int height, double dpi)
     : width(width),
       height(height),

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -86,8 +86,6 @@ class BufferRegion
         return stride;
     }
 
-    void to_string_argb(uint8_t *buf);
-
   private:
     agg::int8u *data;
     agg::rect_i rect;

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -44,18 +44,6 @@ static void PyBufferRegion_dealloc(PyBufferRegion *self)
     Py_TYPE(self)->tp_free((PyObject *)self);
 }
 
-static PyObject *PyBufferRegion_to_string(PyBufferRegion *self, PyObject *args)
-{
-    char const* msg =
-        "BufferRegion.to_string is deprecated since Matplotlib 3.7 and will "
-        "be removed two minor releases later; use np.asarray(region) instead.";
-    if (PyErr_WarnEx(PyExc_DeprecationWarning, msg, 1)) {
-        return NULL;
-    }
-    return PyBytes_FromStringAndSize((const char *)self->x->get_data(),
-                                     (Py_ssize_t) self->x->get_height() * self->x->get_stride());
-}
-
 /* TODO: This doesn't seem to be used internally.  Remove? */
 
 static PyObject *PyBufferRegion_set_x(PyBufferRegion *self, PyObject *args)
@@ -87,28 +75,6 @@ static PyObject *PyBufferRegion_get_extents(PyBufferRegion *self, PyObject *args
     return Py_BuildValue("IIII", rect.x1, rect.y1, rect.x2, rect.y2);
 }
 
-static PyObject *PyBufferRegion_to_string_argb(PyBufferRegion *self, PyObject *args)
-{
-    char const* msg =
-        "BufferRegion.to_string_argb is deprecated since Matplotlib 3.7 and "
-        "will be removed two minor releases later; use "
-        "np.take(region, [2, 1, 0, 3], axis=2) instead.";
-    if (PyErr_WarnEx(PyExc_DeprecationWarning, msg, 1)) {
-        return NULL;
-    }
-    PyObject *bufobj;
-    uint8_t *buf;
-    Py_ssize_t height, stride;
-    height = self->x->get_height();
-    stride = self->x->get_stride();
-    bufobj = PyBytes_FromStringAndSize(NULL, height * stride);
-    buf = (uint8_t *)PyBytes_AS_STRING(bufobj);
-
-    CALL_CPP_CLEANUP("to_string_argb", (self->x->to_string_argb(buf)), Py_DECREF(bufobj));
-
-    return bufobj;
-}
-
 int PyBufferRegion_get_buffer(PyBufferRegion *self, Py_buffer *buf, int flags)
 {
     Py_INCREF(self);
@@ -136,8 +102,6 @@ int PyBufferRegion_get_buffer(PyBufferRegion *self, Py_buffer *buf, int flags)
 static PyTypeObject *PyBufferRegion_init_type()
 {
     static PyMethodDef methods[] = {
-        { "to_string", (PyCFunction)PyBufferRegion_to_string, METH_NOARGS, NULL },
-        { "to_string_argb", (PyCFunction)PyBufferRegion_to_string_argb, METH_NOARGS, NULL },
         { "set_x", (PyCFunction)PyBufferRegion_set_x, METH_VARARGS, NULL },
         { "set_y", (PyCFunction)PyBufferRegion_set_y, METH_VARARGS, NULL },
         { "get_extents", (PyCFunction)PyBufferRegion_get_extents, METH_NOARGS, NULL },


### PR DESCRIPTION
## PR summary
<!-- -->
Removal of old and unused API that were marked as deprecated in 3.7 of Matplotlib 
(issue #26865)
 
changes made :
Removed PsBackendHelper class and ServerThread class which were deprecated in 3.7 version of Matplotlib
Also removed  PyBufferRegion_to_string and PyBufferRegion_to_string_argb methods from c++ files as they were also deprecated in 3.7 version of Matplotlib.

## PR checklist
<!-- -->

- [ ] "closes Remove backend 3.7-deprecated API  #26962" is in the body of the PR description to issue #26865
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
