### PR TITLE
DOC: Add command to install appropriate `requirements.txt` during dev venv setup

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -131,9 +131,13 @@ The simplest way to do this is to use either Python's virtual environment
       On some systems, you may need to type ``python3`` instead of ``python``.
       For a discussion of the technical reasons, see `PEP-394 <https://peps.python.org/pep-0394>`_.
 
+      Install the development dependencies ::
+
+        pip install -r requirements/dev/dev-requirements.txt
+
    .. tab-item:: conda environment
 
-      Create a new `conda`_ environment with ::
+      Create a new `conda`_ environment with the development dependencies installed ::
 
         conda env create -f environment.yml
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
The `venv` tab of the [Create a dedicated environment](https://matplotlib.org/devdocs/devel/development_setup.html#create-a-dedicated-environment) page in the developer docs does not include a step for actually installing the required dependencies in the new environment. This PR adds the line `pip install -r requirements/dev/dev-requirements.txt` and some text for context.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->