### PR TITLE
MAINT: fix .yml in tag issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tag_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/tag_proposal.yml
@@ -23,4 +23,5 @@ body:
     id: solution
     attributes:
       label: Proposed solution
-      description: What should the tag be? All tags are in the format `subcategory: tag`
+      description: >
+        What should the tag be? All tags are in the format `subcategory: tag`


### PR DESCRIPTION
FIxes the yml for the new tag template by escaping the space after the : https://github.com/actions/runner/issues/1019#issuecomment-1280938515 - am open to other suggestions but yaml really does not like colons.