### PR TITLE
Remove idiosyncratic get_tick_iterator API.

### DIFF
--- a/doc/api/next_api_changes/deprecations/27300-AL.rst
+++ b/doc/api/next_api_changes/deprecations/27300-AL.rst
@@ -1,0 +1,3 @@
+``GridHelperCurveLinear.get_tick_iterator``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated with no replacement.


### PR DESCRIPTION
It's only ever used essentially to expose GridHelperCurveLinear._grid_info to FixedAxisArtistHelper.get_tick_iterators; it seems better to access it from the sole caller.  (Note that floating_axes already does the same direct access to the private _grid_info.)

Removing get_tick_iterator also removes the confusion with get_tick_iterators (plural), which is a common API in axisartist. Also note that the "minor" parameter of get_tick_iterator had a rather peculiar meaning (it only switched the labels off).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
