### PR TITLE
FIX: also exclude np.nan in RGB(A) in color mapping

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -487,9 +487,12 @@ class ScalarMappable:
                 else:
                     raise ValueError("Third dimension must be 3 or 4")
                 if xx.dtype.kind == 'f':
-                    if norm and (xx.max() > 1 or xx.min() < 0):
+                    if norm and (
+                            np.any(np.isnan(xx)) or (xx.max() > 1 or xx.min() < 0)
+                    ):
                         raise ValueError("Floating point image RGB values "
                                          "must be in the 0..1 range.")
+
                     if bytes:
                         xx = (xx * 255).astype(np.uint8)
                 elif xx.dtype == np.uint8:

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1400,6 +1400,23 @@ def test_scalarmappable_to_rgba(bytes):
     np.testing.assert_array_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
 
 
+@pytest.mark.parametrize("inp", (
+    [[[2, .5, 1], [.5, .5, .5]]],
+    [[[np.nan, .5, 1], [.5, .5, .5]]],
+    [[[-1, .5, 1], [.5, .5, .5]]],
+    [[[np.inf, .5, 1], [.5, .5, .5]]],
+    [[[-np.inf, .5, 1], [.5, .5, .5]]]
+   )
+)
+def test_scalarmappable_to_rgba_invalid(inp):
+    sm = cm.ScalarMappable()
+    with pytest.raises(
+            ValueError,
+            match="Floating point image RGB values must be in the 0..1 range."
+    ):
+        sm.to_rgba(np.asarray(inp))
+
+
 def test_failed_conversions():
     with pytest.raises(ValueError):
         mcolors.to_rgba('5')


### PR DESCRIPTION
closes #27301


## PR summary

The docstring says "values must be on [0, 1] gamut" as is our standard encoding for float RGB(A) arrays.  We check that the min and max are not outside of this range, but due to the way comparisons work with `np.nan` our test erroneously passed.

This adds an explict check for `np.nan`

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
