### PR TITLE
Simplify GridSpec setup in make_axes_gridspec.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1518,45 +1518,30 @@ def make_axes_gridspec(parent, *, location=None, orientation=None,
     wh_space = 2 * pad / (1 - pad)
 
     if location in ('left', 'right'):
-        # for shrinking
-        height_ratios = [
-                (1-anchor[1])*(1-shrink), shrink, anchor[1]*(1-shrink)]
-
+        gs = parent.get_subplotspec().subgridspec(
+            3, 2, wspace=wh_space, hspace=0,
+            height_ratios=[(1-anchor[1])*(1-shrink), shrink, anchor[1]*(1-shrink)])
         if location == 'left':
-            gs = parent.get_subplotspec().subgridspec(
-                    1, 2, wspace=wh_space,
-                    width_ratios=[fraction, 1-fraction-pad])
-            ss_main = gs[1]
-            ss_cb = gs[0].subgridspec(
-                    3, 1, hspace=0, height_ratios=height_ratios)[1]
+            gs.set_width_ratios([fraction, 1 - fraction - pad])
+            ss_main = gs[:, 1]
+            ss_cb = gs[1, 0]
         else:
-            gs = parent.get_subplotspec().subgridspec(
-                    1, 2, wspace=wh_space,
-                    width_ratios=[1-fraction-pad, fraction])
-            ss_main = gs[0]
-            ss_cb = gs[1].subgridspec(
-                    3, 1, hspace=0, height_ratios=height_ratios)[1]
+            gs.set_width_ratios([1 - fraction - pad, fraction])
+            ss_main = gs[:, 0]
+            ss_cb = gs[1, 1]
     else:
-        # for shrinking
-        width_ratios = [
-                anchor[0]*(1-shrink), shrink, (1-anchor[0])*(1-shrink)]
-
-        if location == 'bottom':
-            gs = parent.get_subplotspec().subgridspec(
-                    2, 1, hspace=wh_space,
-                    height_ratios=[1-fraction-pad, fraction])
-            ss_main = gs[0]
-            ss_cb = gs[1].subgridspec(
-                    1, 3, wspace=0, width_ratios=width_ratios)[1]
-            aspect = 1 / aspect
+        gs = parent.get_subplotspec().subgridspec(
+            2, 3, hspace=wh_space, wspace=0,
+            width_ratios=[anchor[0]*(1-shrink), shrink, (1-anchor[0])*(1-shrink)])
+        if location == 'top':
+            gs.set_height_ratios([fraction, 1 - fraction - pad])
+            ss_main = gs[1, :]
+            ss_cb = gs[0, 1]
         else:
-            gs = parent.get_subplotspec().subgridspec(
-                    2, 1, hspace=wh_space,
-                    height_ratios=[fraction, 1-fraction-pad])
-            ss_main = gs[1]
-            ss_cb = gs[0].subgridspec(
-                    1, 3, wspace=0, width_ratios=width_ratios)[1]
-            aspect = 1 / aspect
+            gs.set_height_ratios([1 - fraction - pad, fraction])
+            ss_main = gs[0, :]
+            ss_cb = gs[1, 1]
+        aspect = 1 / aspect
 
     parent.set_subplotspec(ss_main)
     if panchor is not False:


### PR DESCRIPTION
Currently, make_axes_gridspec uses two nested gridspecs, first a horizontal (1, 2) gridspec and second a vertical (3, 1) gridspec to position an axes A and the associated left-colorbar C as
```
A.
AC
A.
```
(and similarly for colorbars on other sides of the main axes).  Instead, this can be done with a single (3, 2) gridspec to position both A and C.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
