### PR TITLE
FIX: allow re-shown Qt windows to be re-destroyed

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -602,6 +602,7 @@ class FigureManagerQT(FigureManagerBase):
                 qt_compat._exec(qapp)
 
     def show(self):
+        self.window._destroying = False
         self.window.show()
         if mpl.rcParams['figure.raise_window']:
             self.window.activateWindow()


### PR DESCRIPTION
When a Qt window is closed we do not strip off the Qt components and it is technically possible to re-show it.  However, the latch we use to detect re-entrant destruction does not get reset so the figure can not be re-destroyed.

More subtle behavior details discovered while working on mpl-gui.