### PR TITLE
DOC: Synchronize LICENSE_STIX files

### DIFF
--- a/LICENSE/LICENSE_STIX
+++ b/LICENSE/LICENSE_STIX
@@ -1,71 +1,124 @@
-TERMS AND CONDITIONS
+The STIX fonts distributed with matplotlib have been modified from
+their canonical form.  They have been converted from OTF to TTF format
+using Fontforge and this script:
 
-   1. Permission is hereby granted, free of charge, to any person 
-obtaining a copy of the STIX Fonts-TM set accompanying this license 
-(collectively, the "Fonts") and the associated documentation files 
-(collectively with the Fonts, the "Font Software"), to reproduce and 
-distribute the Font Software, including the rights to use, copy, merge 
-and publish copies of the Font Software, and to permit persons to whom 
-the Font Software is furnished to do so same, subject to the following 
-terms and conditions (the "License").
+  #!/usr/bin/env fontforge
+  i=1
+  while ( i<$argc )
+    Open($argv[i])
+    Generate($argv[i]:r + ".ttf")
+    i = i+1
+  endloop
 
-   2. The following copyright and trademark notice and these Terms and 
-Conditions shall be included in all copies of one or more of the Font 
-typefaces and any derivative work created as permitted under this 
-License:
+The original STIX Font License begins below.
 
-	Copyright (c) 2001-2005 by the STI Pub Companies, consisting of 
-the American Institute of Physics, the American Chemical Society, the 
-American Mathematical Society, the American Physical Society, Elsevier, 
-Inc., and The Institute of Electrical and Electronic Engineers, Inc. 
-Portions copyright (c) 1998-2003 by MicroPress, Inc. Portions copyright 
-(c) 1990 by Elsevier, Inc. All rights reserved. STIX Fonts-TM is a 
-trademark of The Institute of Electrical and Electronics Engineers, Inc.
+-----------------------------------------------------------
 
-   3. You may (a) convert the Fonts from one format to another (e.g., 
-from TrueType to PostScript), in which case the normal and reasonable 
-distortion that occurs during such conversion shall be permitted and (b) 
-embed or include a subset of the Fonts in a document for the purposes of 
-allowing users to read text in the document that utilizes the Fonts. In 
-each case, you may use the STIX Fonts-TM mark to designate the resulting 
-Fonts or subset of the Fonts.
+STIX Font License
 
-   4. You may also (a) add glyphs or characters to the Fonts, or modify 
-the shape of existing glyphs, so long as the base set of glyphs is not 
-removed and (b) delete glyphs or characters from the Fonts, provided 
-that the resulting font set is distributed with the following 
-disclaimer: "This [name] font does not include all the Unicode points 
-covered in the STIX Fonts-TM set but may include others." In each case, 
-the name used to denote the resulting font set shall not include the 
-term "STIX" or any similar term.
+24 May 2010
 
-   5. You may charge a fee in connection with the distribution of the 
-Font Software, provided that no copy of one or more of the individual 
-Font typefaces that form the STIX Fonts-TM set may be sold by itself.
+Copyright (c) 2001-2010 by the STI Pub Companies, consisting of the American
+Institute of Physics, the American Chemical Society, the American Mathematical
+Society, the American Physical Society, Elsevier, Inc., and The Institute of
+Electrical and Electronic Engineers, Inc. (www.stixfonts.org), with Reserved
+Font Name STIX Fonts, STIX Fonts (TM) is a  trademark of The Institute of
+Electrical and Electronics Engineers, Inc.
 
-   6. THE FONT SOFTWARE IS PROVIDED "AS IS," WITHOUT WARRANTY OF ANY 
-KIND, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, ANY WARRANTIES 
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT 
-OF COPYRIGHT, PATENT, TRADEMARK OR OTHER RIGHT. IN NO EVENT SHALL 
-MICROPRESS OR ANY OF THE STI PUB COMPANIES BE LIABLE FOR ANY CLAIM, 
-DAMAGES OR OTHER LIABILITY, INCLUDING, BUT NOT LIMITED TO, ANY GENERAL, 
-SPECIAL, INDIRECT, INCIDENTAL OR CONSEQUENTIAL DAMAGES, WHETHER IN AN 
-ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM OR OUT OF THE USE OR 
-INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT 
-SOFTWARE.
+Portions copyright (c) 1998-2003 by MicroPress, Inc. (www.micropress-inc.com),
+with Reserved Font Name TM Math. To obtain additional mathematical fonts, please
+contact MicroPress, Inc., 68-30 Harrow Street, Forest Hills, NY 11375, USA,
+Phone: (718) 575-1816.
 
-   7. Except as contained in the notice set forth in Section 2, the 
-names MicroPress Inc. and STI Pub Companies, as well as the names of the 
-companies/organizations that compose the STI Pub Companies, shall not be 
-used in advertising or otherwise to promote the sale, use or other 
-dealings in the Font Software without the prior written consent of the 
-respective company or organization.
+Portions copyright (c) 1990 by Elsevier, Inc.
 
-   8. This License shall become null and void in the event of any 
-material breach of the Terms and Conditions herein by licensee.
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+https://scripts.sil.org/OFL
 
-   9. A substantial portion of the STIX Fonts set was developed by 
-MicroPress Inc. for the STI Pub Companies. To obtain additional 
-mathematical fonts, please contact MicroPress, Inc., 68-30 Harrow 
-Street, Forest Hills, NY 11375, USA - Phone: (718) 575-1816.
+-----------------------------------------------------------
+SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+-----------------------------------------------------------
 
+PREAMBLE
+The goals of the Open Font License (OFL) are to stimulate worldwide
+development of collaborative font projects, to support the font creation
+efforts of academic and linguistic communities, and to provide a free and
+open framework in which fonts may be shared and improved in partnership
+with others.
+
+The OFL allows the licensed fonts to be used, studied, modified and
+redistributed freely as long as they are not sold by themselves. The
+fonts, including any derivative works, can be bundled, embedded,
+redistributed and/or sold with any software provided that any reserved
+names are not used by derivative works. The fonts and derivatives,
+however, cannot be released under any other type of license. The
+requirement for fonts to remain under this license does not apply
+to any document created using the fonts or their derivatives.
+
+DEFINITIONS
+"Font Software" refers to the set of files released by the Copyright
+Holder(s) under this license and clearly marked as such. This may
+include source files, build scripts and documentation.
+
+"Reserved Font Name" refers to any names specified as such after the
+copyright statement(s).
+
+"Original Version" refers to the collection of Font Software components as
+distributed by the Copyright Holder(s).
+
+"Modified Version" refers to any derivative made by adding to, deleting,
+or substituting -- in part or in whole -- any of the components of the
+Original Version, by changing formats or by porting the Font Software to a
+new environment.
+
+"Author" refers to any designer, engineer, programmer, technical
+writer or other person who contributed to the Font Software.
+
+PERMISSION & CONDITIONS
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of the Font Software, to use, study, copy, merge, embed, modify,
+redistribute, and sell modified and unmodified copies of the Font
+Software, subject to the following conditions:
+
+1) Neither the Font Software nor any of its individual components,
+in Original or Modified Versions, may be sold by itself.
+
+2) Original or Modified Versions of the Font Software may be bundled,
+redistributed and/or sold with any software, provided that each copy
+contains the above copyright notice and this license. These can be
+included either as stand-alone text files, human-readable headers or
+in the appropriate machine-readable metadata fields within text or
+binary files as long as those fields can be easily viewed by the user.
+
+3) No Modified Version of the Font Software may use the Reserved Font
+Name(s) unless explicit written permission is granted by the corresponding
+Copyright Holder. This restriction only applies to the primary font name as
+presented to the users.
+
+4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+Software shall not be used to promote, endorse or advertise any
+Modified Version, except to acknowledge the contribution(s) of the
+Copyright Holder(s) and the Author(s) or with their explicit written
+permission.
+
+5) The Font Software, modified or unmodified, in part or in whole,
+must be distributed entirely under this license, and must not be
+distributed under any other license. The requirement for fonts to
+remain under this license does not apply to any document created
+using the Font Software.
+
+TERMINATION
+This license becomes null and void if any of the above conditions are
+not met.
+
+DISCLAIMER
+THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+OTHER DEALINGS IN THE FONT SOFTWARE.


### PR DESCRIPTION
## PR summary

The `LICENSE_STIX` files have been out of sync and provided two different terms. This PR synchronizes them by using the more recent version of both.

https://github.com/matplotlib/matplotlib/blob/main/LICENSE/LICENSE_STIX has been created in 2007 and never modified, while https://github.com/matplotlib/matplotlib/blob/main/lib/matplotlib/mpl-data/fonts/ttf/LICENSE_STIX has been updated in 2010 with new licensing terms: https://github.com/matplotlib/matplotlib/commit/fda682ed211ce7d3e473a3ad733e143389ede712. This made it confusing which actually is the correct license text.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
