### PR TITLE
Add test_semilogx and test_semilogy tests to test_datetime

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -474,9 +474,9 @@ class TestDatetimePlotting:
         log_vals = [2 ** i for i in range(5)]
         reg_vals = [i for i in range(5)]
 
-        ax1.semilogy(log_dates, reg_dates, base = 2)
-        ax2.semilogy(log_dates, reg_vals, base = 2)
-        ax3.semilogy(log_vals, reg_dates, base = 2)
+        ax1.semilogy(reg_dates, log_dates, base = 2)
+        ax2.semilogy(reg_dates, log_vals, base = 2)
+        ax3.semilogy(reg_vals, log_dates, base = 2)
 
     @pytest.mark.xfail(reason="Test for spy not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -448,17 +448,35 @@ class TestDatetimePlotting:
             label.set_rotation(40)
             label.set_horizontalalignment('right')
 
-    @pytest.mark.xfail(reason="Test for semilogx not written yet")
     @mpl.style.context("default")
     def test_semilogx(self):
-        fig, ax = plt.subplots()
-        ax.semilogx(...)
+        mpl.rcParams["date.converter"] = "concise"
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, constrained_layout=True)
 
-    @pytest.mark.xfail(reason="Test for semilogy not written yet")
+        base = datetime.datetime(2000, 1, 1)
+        log_dates = [base + datetime.timedelta(days=((2 ** i) * 365)) for i in range(5)]
+        reg_dates = [base + datetime.timedelta(days=(i)) for i in range(5)]
+        log_vals = [2 ** i for i in range(5)]
+        reg_vals = [i for i in range(5)]
+
+        ax1.semilogx(log_dates, reg_dates, base = 2)
+        ax2.semilogx(log_dates, reg_vals, base = 2)
+        ax3.semilogx(log_vals, reg_dates, base = 2)
+
     @mpl.style.context("default")
     def test_semilogy(self):
-        fig, ax = plt.subplots()
-        ax.semilogy(...)
+        mpl.rcParams["date.converter"] = "concise"
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, constrained_layout=True)
+
+        base = datetime.datetime(2000, 1, 1)
+        log_dates = [base + datetime.timedelta(days=((2 ** i) * 365)) for i in range(5)]
+        reg_dates = [base + datetime.timedelta(days=(i)) for i in range(5)]
+        log_vals = [2 ** i for i in range(5)]
+        reg_vals = [i for i in range(5)]
+
+        ax1.semilogy(log_dates, reg_dates, base = 2)
+        ax2.semilogy(log_dates, reg_vals, base = 2)
+        ax3.semilogy(log_vals, reg_dates, base = 2)
 
     @pytest.mark.xfail(reason="Test for spy not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
Adds test_semilogx and test_semilogy tests to test_datetime, resolving `Axes.semilogx` and `Axes.semilogy` in #26864 

semilogx:
<img width="640" alt="image" src="https://github.com/matplotlib/matplotlib/assets/43834310/4d5d8df8-7816-4eef-8f89-de33e9517f6a">
semilogy:
<img width="639" alt="image" src="https://github.com/matplotlib/matplotlib/assets/43834310/7155a92f-9574-4c68-93a2-a9f7d2b78a0e">

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
