### PR TITLE
add test_axlines

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -5,6 +5,7 @@ import pytest
 
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+from matplotlib.dates import date2num, DateFormatter
 
 
 class TestDatetimePlotting:
@@ -77,11 +78,38 @@ class TestDatetimePlotting:
         ax3.set_xlabel('Date')
         ax3.set_ylabel('Date')
 
-    @pytest.mark.xfail(reason="Test for axline not written yet")
     @mpl.style.context("default")
     def test_axline(self):
-        fig, ax = plt.subplots()
-        ax.axline(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1,
+                                            constrained_layout=True,
+                                            figsize=(10, 12))
+
+        start_date = datetime.datetime(2023, 1, 1)
+        dates = [start_date + datetime.timedelta(days=i) for i in range(31)]
+        values = list(range(1, 32))
+
+        ax1.plot(dates, values, 'ro')
+        ax1.axline((date2num(dates[0]), values[0]), (date2num(dates[-1]), values[-1]),
+                   color='blue', linewidth=2)
+        ax1.set_title('Datetime vs. Number')
+        date_format = DateFormatter('%b%d')
+        ax1.xaxis.set_major_formatter(date_format)
+
+        ax2.plot(values, dates, 'ro')
+        ax2.axline((values[0], date2num(dates[0])), (values[-1], date2num(dates[-1])),
+                   color='blue', linewidth=2)
+        ax2.set_title('Number vs. Datetime')
+        ax2.yaxis.set_major_formatter(date_format)
+
+        dates2 = [start_date + datetime.timedelta(days=2*i) for i in range(31)]
+        ax3.plot(dates, dates2, 'ro')
+        ax3.axline((date2num(dates[0]), date2num(dates2[0])),
+                   (date2num(dates[-1]), date2num(dates2[-1])),
+                   color='blue', linewidth=2)
+        ax3.set_title('Datetime vs. Datetime')
+        ax3.xaxis.set_major_formatter(date_format)
+        ax3.yaxis.set_major_formatter(date_format)
 
     @mpl.style.context("default")
     def test_axvline(self):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR adds a smoke test for Axes.axlines in lib/matplotlib/tests/test_datetime.py. This PR closes one of the items listed in the issue https://github.com/matplotlib/matplotlib/issues/26864.
Smoke test Plot:
<img width="1383" alt="result" src="https://github.com/matplotlib/matplotlib/assets/96338098/30ec9e6b-c06f-47e3-9599-c753945f1bbe">

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
