### PR TITLE
Update for checking whether colors have an alpha channel

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -238,12 +238,12 @@ def _has_alpha_channel(c):
         return False
 
     # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
-    if isinstance(c, str) and c[0] == '#' and (len(c) == 5 or len(c) == 9):
-        # example: '#fff8' or '#0f0f0f80'
-        return True
-
-    # if c isn't a string, it can be an RGB(A) or a color-alpha tuple
-    if not isinstance(c, str):
+    if isinstance(c, str):
+        if c[0] == '#' and (len(c) == 5 or len(c) == 9):
+            # example: '#fff8' or '#0f0f0f80'
+            return True
+    else:
+        # if c isn't a string, it can be an RGB(A) or a color-alpha tuple
         # if it has length 4, it has an alpha channel
         if len(c) == 4:
             # example: [0.5, 0.5, 0.5, 0.5]

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -233,8 +233,36 @@ def is_color_like(c):
 
 def _has_alpha_channel(c):
     """Return whether *c* is a color with an alpha channel."""
-    # 4-element sequences are interpreted as r, g, b, a
-    return not isinstance(c, str) and len(c) == 4
+    # If c is not a color, it doesn't have an alpha channel
+    if not is_color_like(c):
+        return False
+
+    # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
+    if isinstance(c, str) and c[0] == '#' and (len(c) == 5 or len(c) == 9):
+        # example: '#fff8' or '#0f0f0f80'
+        return True
+
+    # if c isn't a string, it can be an RGB(A) or a color-alpha tuple
+    if not isinstance(c, str):
+        # if it has length 4, it has an alpha channel
+        if len(c) == 4:
+            # example: [0.5, 0.5, 0.5, 0.5]
+            return True
+
+        # if it has length 2, the 2nd element isn't None, and the 1st element has len=3
+        if len(c) == 2 and (c[1] is not None or len(c[0]) == 4):
+            # example: ([0.5, 0.5, 0.5, 0.5], None) or ('r', 0.5)
+            return True
+
+    # otherwise it doesn't have an alpha channel
+    return False
+
+
+def _has_alpha_channel_array(cseq):
+    """Return whether each element in *cseq* is a color with an alpha channel"""
+    if is_color_like(cseq):
+        cseq = [cseq]  # force it to be a sequence
+    return [_has_alpha_channel(c) for c in cseq]
 
 
 def _check_color_like(**kwargs):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -249,7 +249,8 @@ def _has_alpha_channel(c):
             # example: [0.5, 0.5, 0.5, 0.5]
             return True
 
-        # if it has length 2, the 2nd element isn't None, and the 1st element has len=3
+        # if it has length 2, it's a color/alpha tuple
+        # if the second element isn't None or the first element has length = 4
         if len(c) == 2 and (c[1] is not None or len(c[0]) == 4):
             # example: ([0.5, 0.5, 0.5, 0.5], None) or ('r', 0.5)
             return True

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -232,11 +232,7 @@ def is_color_like(c):
 
 
 def _has_alpha_channel(c):
-    """Return whether *c* is a color with an alpha channel."""
-    # If c is not a color, it doesn't have an alpha channel
-    if not is_color_like(c):
-        return False
-
+    """Return whether *c* is a color with an alpha channel"""
     # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
     if isinstance(c, str):
         if c[0] == '#' and (len(c) == 5 or len(c) == 9):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -235,8 +235,7 @@ def _has_alpha_channel(c):
     """
     Return whether *c* is a color with an alpha channel.
 
-    If *c* is not a valid color specifier, then the result is
-    undefined but will return False.
+    If *c* is not a valid color specifier, then the result is undefined.
     """
     # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
     if isinstance(c, str):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -237,7 +237,7 @@ def _has_alpha_channel(c):
 
     If *c* is not a valid color specifier, then the result is undefined.
     """
-    # The following logic is build with the assumption that c is a valid color spec.
+    # The following logic uses the assumption that c is a valid color spec.
     # For speed and simplicity, we intentionally don't care about other inputs.
     # Anything can happen with them.
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -259,7 +259,7 @@ def _has_alpha_channel(c):
             # example: ([0.5, 0.5, 0.5, 0.5], None) or ('r', 0.5)
             return True
 
-    # otherwise it doesn't have an alpha channel (or is not a valid color specifier)
+    # otherwise it doesn't have an alpha channel
     return False
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -232,7 +232,8 @@ def is_color_like(c):
 
 
 def _has_alpha_channel(c):
-    """Return whether *c* is a color with an alpha channel.
+    """
+    Return whether *c* is a color with an alpha channel.
 
     If *c* is not a valid color specifier, then the result is
     undefined but will return False.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -237,7 +237,7 @@ def _has_alpha_channel(c):
 
     If *c* is not a valid color specifier, then the result is undefined.
     """
-    # The following logic is build with the assumtion that c is a valid color spec.
+    # The following logic is build with the assumption that c is a valid color spec.
     # For speed and simplicity, we intentionally don't care about other inputs.
     # Anything can happen with them.
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -237,9 +237,9 @@ def _has_alpha_channel(c):
 
     If *c* is not a valid color specifier, then the result is undefined.
     """
-    # If c isn't a color, this is undefined. Return False instead of raising.
-    if not is_color_like(c):
-        return False
+    # The following logic is build with the assumtion that c is a valid color spec.
+    # For speed and simplicity, we intentionally don't care about other inputs.
+    # Anything can happen with them.
 
     # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
     if isinstance(c, str):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -232,7 +232,11 @@ def is_color_like(c):
 
 
 def _has_alpha_channel(c):
-    """Return whether *c* is a color with an alpha channel"""
+    """Return whether *c* is a color with an alpha channel.
+
+    If *c* is not a valid color specifier, then the result is
+    undefined but will return False.
+    """
     # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
     if isinstance(c, str):
         if c[0] == '#' and (len(c) == 5 or len(c) == 9):
@@ -251,7 +255,7 @@ def _has_alpha_channel(c):
             # example: ([0.5, 0.5, 0.5, 0.5], None) or ('r', 0.5)
             return True
 
-    # otherwise it doesn't have an alpha channel
+    # otherwise it doesn't have an alpha channel (or is not a valid color specifier)
     return False
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -259,6 +259,11 @@ def _has_alpha_channel(c):
     return False
 
 
+@_api.deprecated(
+    '3.11',
+    removal='3.14',
+    alternative="``use matplotlib.colors._has_alpha_channel`` with list comprehension"
+    )
 def _has_alpha_channel_array(cseq):
     """Return whether each element in *cseq* is a color with an alpha channel"""
     if is_color_like(cseq):

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -251,7 +251,7 @@ def _has_alpha_channel(c):
 
         # if it has length 2, it's a color/alpha tuple
         # if the second element isn't None or the first element has length = 4
-        if len(c) == 2 and (c[1] is not None or len(c[0]) == 4):
+        if len(c) == 2 and (c[1] is not None or _has_alpha_channel(c[0]):
             # example: ([0.5, 0.5, 0.5, 0.5], None) or ('r', 0.5)
             return True
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -259,18 +259,6 @@ def _has_alpha_channel(c):
     return False
 
 
-@_api.deprecated(
-    '3.11',
-    removal='3.14',
-    alternative="``use matplotlib.colors._has_alpha_channel`` with list comprehension"
-    )
-def _has_alpha_channel_array(cseq):
-    """Return whether each element in *cseq* is a color with an alpha channel"""
-    if is_color_like(cseq):
-        cseq = [cseq]  # force it to be a sequence
-    return [_has_alpha_channel(c) for c in cseq]
-
-
 def _check_color_like(**kwargs):
     """
     For each *key, value* pair in *kwargs*, check that *value* is color-like.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -237,6 +237,10 @@ def _has_alpha_channel(c):
 
     If *c* is not a valid color specifier, then the result is undefined.
     """
+    # If c isn't a color, this is undefined. Return False instead of raising.
+    if not is_color_like(c):
+        return False
+
     # if c is a hex, it has an alpha channel when it has 4 (or 8) digits after '#'
     if isinstance(c, str):
         if c[0] == '#' and (len(c) == 5 or len(c) == 9):
@@ -251,7 +255,7 @@ def _has_alpha_channel(c):
 
         # if it has length 2, it's a color/alpha tuple
         # if the second element isn't None or the first element has length = 4
-        if len(c) == 2 and (c[1] is not None or _has_alpha_channel(c[0]):
+        if len(c) == 2 and (c[1] is not None or _has_alpha_channel(c[0])):
             # example: ([0.5, 0.5, 0.5, 0.5], None) or ('r', 0.5)
             return True
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1231,10 +1231,19 @@ def test_colormap_reversing(name):
 def test_has_alpha_channel():
     assert mcolors._has_alpha_channel((0, 0, 0, 0))
     assert mcolors._has_alpha_channel([1, 1, 1, 1])
+    assert mcolors._has_alpha_channel('#fff8')
+    assert mcolors._has_alpha_channel('#0f0f0f80')
+    assert mcolors._has_alpha_channel(('r', 0.5))
+    assert mcolors._has_alpha_channel(([1, 1, 1, 1], None))
     assert not mcolors._has_alpha_channel('blue')  # 4-char string!
     assert not mcolors._has_alpha_channel('0.25')
     assert not mcolors._has_alpha_channel('r')
     assert not mcolors._has_alpha_channel((1, 0, 0))
+    assert not mcolors._has_alpha_channel('#fff')
+    assert not mcolors._has_alpha_channel('#0f0f0f')
+    assert not mcolors._has_alpha_channel(('r', None))
+    assert not mcolors._has_alpha_channel(([1, 1, 1], None))
+    assert not mcolors._has_alpha_channel(1)  # non-colors don't have alpha channels
 
 
 def test_cn():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1243,7 +1243,6 @@ def test_has_alpha_channel():
     assert not mcolors._has_alpha_channel('#0f0f0f')
     assert not mcolors._has_alpha_channel(('r', None))
     assert not mcolors._has_alpha_channel(([1, 1, 1], None))
-    assert not mcolors._has_alpha_channel(1)  # non-colors don't have alpha channels
 
 
 def test_cn():


### PR DESCRIPTION
## PR summary
* Update check of whether a color has an alpha channel to include hexadecimal and color/alpha tuple formats.
* Add test of the new formats
* Add method to check whether a sequence of colors has an alpha channel

For more explanation see the matplotlib page on [specifying colors](https://matplotlib.org/stable/users/explain/colors/colors.html).

## PR checklist
- [x] "Closes #27321"
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
