### PR TITLE
Omit MOVETO lines from nearest contour logic

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1339,15 +1339,18 @@ class ContourSet(ContourLabeler, mcoll.Collection):
 
         for idx_level in indices:
             path = self._paths[idx_level]
-            if not len(path.vertices):
-                continue
-            lc = self.get_transform().transform(path.vertices)
-            d2, proj, leg = _find_closest_point_on_path(lc, xy)
-            if d2 < d2min:
-                d2min = d2
-                idx_level_min = idx_level
-                idx_vtx_min = leg[1]
-                proj_min = proj
+            idx_vtx_start = 0
+            for subpath in path._iter_connected_components():
+                if not len(subpath.vertices):
+                    continue
+                lc = self.get_transform().transform(subpath.vertices)
+                d2, proj, leg = _find_closest_point_on_path(lc, xy)
+                if d2 < d2min:
+                    d2min = d2
+                    idx_level_min = idx_level
+                    idx_vtx_min = leg[1] + idx_vtx_start
+                    proj_min = proj
+                idx_vtx_start += len(subpath)
 
         return idx_level_min, idx_vtx_min, proj_min
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -125,6 +125,25 @@ def test_contour_manual_labels(split_collections):
     plt.clabel(cs, manual=pts, fontsize='small', colors=('r', 'g'))
 
 
+def test_contour_manual_moveto():
+    x = np.linspace(-10, 10)
+    y = np.linspace(-10, 10)
+
+    X, Y = np.meshgrid(x, y)
+
+    Z = X**2 * 1 / Y**2 - 1
+
+    contours = plt.contour(X, Y, Z, levels=[0, 100])
+
+    # This point lies on the `MOVETO` line for the 100 contour
+    # but is actually closest to the 0 contour
+    point = (1.3, 1)
+    clabels = plt.clabel(contours, manual=[point])
+
+    # Ensure that the 0 contour was chosen, not the 100 contour
+    assert clabels[0].get_text() == "0"
+
+
 @pytest.mark.parametrize("split_collections", [False, True])
 @image_comparison(['contour_disconnected_segments'],
                   remove_text=True, style='mpl20', extensions=['png'])


### PR DESCRIPTION
Closes #27333

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

I would like to simplify down the reproducer further and add a test, but I think the code change itself is largely good.

Just uses `path._iter_connected_components()` to break apart the connected subpaths so that the MOVETO lines don't get considered as close.
There is a small amount of bookkeeping to make sure that the reported index includes all of the subpaths already processed.

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
