### PR TITLE
Fix draggable annotations on subfigures.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -537,7 +537,8 @@ class Artist:
         for a in self.get_children():
             # make sure the event happened in the same Axes
             ax = getattr(a, 'axes', None)
-            if (mouseevent.inaxes is None or ax is None
+            if (isinstance(a, mpl.figure.SubFigure)
+                    or mouseevent.inaxes is None or ax is None
                     or mouseevent.inaxes == ax):
                 # we need to check if mouseevent.inaxes is None
                 # because some objects associated with an Axes (e.g., a

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1458,7 +1458,7 @@ class DraggableBase:
             ref_artist.set_picker(True)
         self.got_artist = False
         self._use_blit = use_blit and self.canvas.supports_blit
-        callbacks = ref_artist.figure._canvas_callbacks
+        callbacks = self.canvas.callbacks
         self._disconnectors = [
             functools.partial(
                 callbacks.disconnect, callbacks._connect_picklable(name, func))
@@ -1471,7 +1471,6 @@ class DraggableBase:
 
     # A property, not an attribute, to maintain picklability.
     canvas = property(lambda self: self.ref_artist.figure.canvas)
-
     cids = property(lambda self: [
         disconnect.args[0] for disconnect in self._disconnectors[:2]])
 

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -450,3 +450,13 @@ def test_remove_draggable():
     an.draggable(True)
     an.remove()
     MouseEvent("button_release_event", fig.canvas, 1, 1)._process()
+
+
+def test_draggable_in_subfigure():
+    fig = plt.figure()
+    # Put annotation at lower left corner to make it easily pickable below.
+    ann = fig.subfigures().add_axes([0, 0, 1, 1]).annotate("foo", (0, 0))
+    ann.draggable(True)
+    fig.canvas.draw()  # Texts are non-pickable until the first draw.
+    MouseEvent("button_press_event", fig.canvas, 1, 1)._process()
+    assert ann._draggable.got_artist


### PR DESCRIPTION
- Picking on subfigures was broken because `ax = getattr(a, 'axes', None)` would return the SubFigure.axes *list* when `a` is a subfigure, so the axes identity test would just be completely wrong.  Fix that by special-casing subfigures.  (Ideally I would entirely remove the axes equality test because that also breaks in the case of overlapping axes, but that's a much bigger change.)
- `ref_artist.figure._canvas_callbacks` would fail when the ref_artist is on a subfigure because subfigures don't have a _canvas_callbacks attribute; instead use `ref_artist.figure.canvas.callbacks` where accessing the canvas attribute correctly goes back to the toplevel figure first.

See test for an example (which would previously fail with an AttributeError).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
