### PR TITLE
FIX: scale norm of collections when first array is set

### DIFF
--- a/doc/api/next_api_changes/behavior/27347-GL.rst
+++ b/doc/api/next_api_changes/behavior/27347-GL.rst
@@ -1,0 +1,7 @@
+ScalarMappables auto-scale their norm when an array is set
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Collections previously deferred auto-scaling of the norm until draw time.
+This has been changed to scale the norm whenever the first array is set
+to align with the docstring and reduce unexpected behavior when
+accessing the norm before drawing.

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -536,6 +536,8 @@ class ScalarMappable:
                             "converted to float")
 
         self._A = A
+        if not self.norm.scaled():
+            self.norm.autoscale_None(A)
 
     def get_array(self):
         """

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -292,6 +292,16 @@ def check_segments(coll, positions, linelength, lineoffset, orientation):
         assert segment[1, pos2] == positions[i]
 
 
+def test_collection_norm_autoscale():
+    # norm should be autoscaled when array is set, not deferred to draw time
+    lines = np.arange(24).reshape((4, 3, 2))
+    coll = mcollections.LineCollection(lines, array=np.arange(4))
+    assert coll.norm(2) == 2 / 3
+    # setting a new array shouldn't update the already scaled limits
+    coll.set_array(np.arange(4) + 5)
+    assert coll.norm(2) == 2 / 3
+
+
 def test_null_collection_datalim():
     col = mcollections.PathCollection([])
     col_data_lim = col.get_datalim(mtransforms.IdentityTransform())


### PR DESCRIPTION
Previously, Collections would defer auto-scaling the norm until draw time. Now the collection is scaled anytime an array is set and hasn't already been scaled previously.

closes #13887
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
