### PR TITLE
[DOC]: Update 3d axis limits whats new

### DIFF
--- a/doc/users/next_whats_new/3d_axis_limits.rst
+++ b/doc/users/next_whats_new/3d_axis_limits.rst
@@ -12,7 +12,9 @@ automatically added.
 
     import matplotlib.pyplot as plt
     fig, axs = plt.subplots(1, 2, subplot_kw={'projection': '3d'})
-    plt.rcParams['axes3d.automargin'] = False  # the default in 3.9.0
-    axs[0].set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1), title='New Behavior')
+
     plt.rcParams['axes3d.automargin'] = True
-    axs[1].set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1), title='Old Behavior')
+    axs[0].set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1), title='Old Behavior')
+
+    plt.rcParams['axes3d.automargin'] = False  # the default in 3.9.0
+    axs[1].set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1), title='New Behavior')


### PR DESCRIPTION
## PR summary
The current what's new shows a poor example of the new exact axis limits introduced in https://github.com/matplotlib/matplotlib/pull/25272/. This is an issue that happens only when the new rc param changes mid-plot-generation, which shouldn't ever happen normally. Workaround is to swap the order the subplots are generated.

Before:
![3d_axis_limits-1](https://github.com/matplotlib/matplotlib/assets/14363975/32dbc5e5-2d7a-4093-95ec-f74fa1641e79)

After:
![3d_axis_limits-1 (2)](https://github.com/matplotlib/matplotlib/assets/14363975/09ff0fb8-6aab-411b-8729-b1c46818b8b1)

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
