### PR TITLE
Fix build on PyPy

### DIFF
--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -309,8 +309,8 @@ load_tkinter_funcs()
         module = py::module_::import("_tkinter");  // CPython
     }
     auto py_path = module.attr("__file__");
-    py::bytes py_path_b = py_path.attr("encode")(
-        Py_FileSystemDefaultEncoding, Py_FileSystemDefaultEncodeErrors);
+    auto py_path_b = py::reinterpret_steal<py::bytes>(
+        PyUnicode_EncodeFSDefault(py_path.ptr()));
     std::string path = py_path_b;
     auto tkinter_lib = dlopen(path.c_str(), RTLD_LAZY);
     if (!tkinter_lib) {


### PR DESCRIPTION
## PR summary

It appears that `Py_FileSystemDefaultEncodeErrors` is not part of the limited API, and PyPy does not have it. This broke wheel building CI only, as PyPy isn't otherwise built.

Since pybind11 does not have a wrapper for `PyUnicode_EncodeFSDefault` (the main reason I had switched to a `encode` call earlier), we need to call it ourselves manually.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines