### PR TITLE
ci: Improve coverage for compiled code

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -94,7 +94,7 @@ artifacts:
 
 on_finish:
   - conda install codecov
-  - codecov -e PYTHON_VERSION PLATFORM
+  - codecov -e PYTHON_VERSION PLATFORM -n "$PYTHON_VERSION Windows"
 
 on_failure:
   # Generate a html for visual tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -328,6 +328,8 @@ jobs:
           fi
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
+        with:
+          name: "${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.name-suffix }}"
 
       - uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -285,7 +285,10 @@ jobs:
 
           # Set flag in a delayed manner to avoid issues with installing other
           # packages
-          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+          if [[ "${{ runner.os }}" == 'macOS' ]]; then
+            export CPPFLAGS='-fprofile-instr-generate=default.%m.profraw'
+            export CPPFLAGS="$CPPFLAGS -fcoverage-mapping"
+          else
             export CPPFLAGS='--coverage -fprofile-abs-path'
           fi
 
@@ -310,12 +313,19 @@ jobs:
 
       - name: Filter C coverage
         run: |
-          lcov --rc lcov_branch_coverage=1 --capture --directory . --output-file coverage.info
-          lcov --rc lcov_branch_coverage=1 --output-file coverage.info \
-            --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
-          lcov --rc lcov_branch_coverage=1 --list coverage.info
-          find . -name '*.gc*' -delete
-        if: ${{ runner.os != 'macOS' }}
+          if [[ "${{ runner.os }}" != 'macOS' ]]; then
+            lcov --rc lcov_branch_coverage=1 --capture --directory . \
+              --output-file coverage.info
+            lcov --rc lcov_branch_coverage=1 --output-file coverage.info \
+              --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
+            lcov --rc lcov_branch_coverage=1 --list coverage.info
+            find . -name '*.gc*' -delete
+          else
+            xcrun llvm-profdata merge -sparse default.*.profraw \
+              -o default.profdata
+            xcrun llvm-cov export -format="lcov" build/*/src/*.so \
+              -instr-profile default.profdata > info.lcov
+          fi
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -286,11 +286,7 @@ jobs:
           # Set flag in a delayed manner to avoid issues with installing other
           # packages
           if [[ "${{ runner.os }}" != 'macOS' ]]; then
-            if [[ "$(lsb_release -r -s)" == "20.04" ]]; then
-              export CPPFLAGS='--coverage -fprofile-abs-path'
-            else
-              export CPPFLAGS='--coverage'
-            fi
+            export CPPFLAGS='--coverage -fprofile-abs-path'
           fi
 
           python -m pip install --no-deps --no-build-isolation --verbose \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -157,7 +157,7 @@ stages:
         displayName: 'pytest'
 
       - bash: |
-          bash <(curl -s https://codecov.io/bash)  -f "!*.gcov" -X gcov
+          bash <(curl -s https://codecov.io/bash) -n "$PYTHON_VERSION $AGENT_OS" -f "!*.gcov" -X gcov
         displayName: 'Upload to codecov.io'
 
       - task: PublishTestResults@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -88,8 +88,8 @@ stages:
 
       - bash: |
           set -e
-          case "$(python -c 'import sys; print(sys.platform)')" in
-          linux)
+          case "$AGENT_OS" in
+          Linux)
             echo 'Acquire::Retries "3";' | sudo tee /etc/apt/apt.conf.d/80-retries
             sudo apt update
             sudo apt install --no-install-recommends \
@@ -103,6 +103,7 @@ stages:
               gir1.2-gtk-3.0 \
               graphviz \
               inkscape \
+              lcov \
               libcairo2 \
               libgirepository-1.0-1 \
               lmodern \
@@ -116,13 +117,13 @@ stages:
               texlive-pictures \
               texlive-xetex
             ;;
-          darwin)
+          Darwin)
             brew install --cask xquartz
             brew install ccache ffmpeg imagemagick mplayer ninja pkg-config
             brew tap homebrew/cask-fonts
             brew install font-noto-sans-cjk-sc
             ;;
-          win32)
+          Windows_NT)
             choco install ninja
             ;;
           *)
@@ -139,8 +140,26 @@ stages:
         displayName: 'Install dependencies with pip'
 
       - bash: |
+          case "$AGENT_OS" in
+          Linux)
+            export CPPFLAGS='--coverage -fprofile-abs-path'
+            ;;
+          Darwin)
+            export CPPFLAGS='-fprofile-instr-generate=default.%m.profraw'
+            export CPPFLAGS="$CPPFLAGS -fcoverage-mapping"
+            ;;
+          Windows_NT)
+            CONFIG='--config-settings=setup-args=--vsenv'
+            CONFIG="$CONFIG --config-settings=setup-args=-Dcpp_link_args=-PROFILE"
+            CONFIG="$CONFIG --config-settings=setup-args=-Dbuildtype=debug"
+            ;;
+          *)
+            exit 1
+            ;;
+          esac
+
           python -m pip install \
-            --no-build-isolation --config-settings=setup-args="--vsenv" \
+            --no-build-isolation $CONFIG \
             --verbose --editable .[dev] ||
             [[ "$PYTHON_VERSION" = 'Pre' ]]
         displayName: "Install self"
@@ -152,12 +171,109 @@ stages:
         displayName: 'print pip'
 
       - bash: |
-          PYTHONFAULTHANDLER=1 python -m pytest --junitxml=junit/test-results.xml -raR --maxfail=50 --timeout=300 --durations=25 --cov-report= --cov=lib -n 2 ||
+          set -e
+          if [[ "$AGENT_OS" == 'Windows_NT' ]]; then
+            SESSION_ID=$(python -c "import uuid; print(uuid.uuid4(), end='')")
+            echo "Coverage session ID: ${SESSION_ID}"
+            VS=$(ls -d /c/Program\ Files*/Microsoft\ Visual\ Studio/*/Enterprise)
+            echo "Visual Studio: ${VS}"
+            DIR="$VS/Common7/IDE/Extensions/Microsoft/CodeCoverage.Console"
+            if [[ -d $DIR ]]; then
+              # This is for MSVC 2022 (on windows-latest).
+              TOOL="$DIR/Microsoft.CodeCoverage.Console.exe"
+              for f in build/cp*/src/*.pyd; do
+                echo $f
+                echo "=============================="
+                "$TOOL" instrument $f --session-id $SESSION_ID \
+                  --log-level Verbose --log-file instrument.log
+                cat instrument.log
+                rm instrument.log
+              done
+              echo "Starting $TOOL in server mode"
+              "$TOOL" collect \
+                  --session-id $SESSION_ID --server-mode \
+                  --output-format cobertura --output extensions.xml \
+                  --log-level Verbose --log-file extensions.log &
+              VS_VER=2022
+            else
+            DIR="$VS"/Team\ Tools/Dynamic\ Code\ Coverage\ Tools/amd64
+            if [[ -d $DIR ]]; then
+              # This is for MSVC 2019 (on windows-2019).
+              VSINSTR="$VS"/Team\ Tools/Performance\ Tools/vsinstr.exe
+              for f in build/cp*/src/*.pyd; do
+                "$VSINSTR" $f -Verbose -Coverage
+              done
+              TOOL="$DIR/CodeCoverage.exe"
+              cat > extensions.config << EOF
+          <CodeCoverage>
+            <CollectFromChildProcesses>true</CollectFromChildProcesses>
+            <ModulePaths>
+              <Include>
+                <ModulePath>.*\\.*\.pyd</ModulePath>
+              </Include>
+            </ModulePaths>
+          </CodeCoverage>
+          EOF
+              echo "Starting $TOOL in server mode"
+              "$TOOL" collect \
+                -config:extensions.config -session:$SESSION_ID \
+                -output:extensions.coverage -verbose &
+              echo "Started $TOOL"
+              VS_VER=2019
+            fi
+            fi
+            echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
+          fi
+          PYTHONFAULTHANDLER=1 python -m pytest -raR -n 2 \
+              --maxfail=50 --timeout=300 --durations=25 \
+              --junitxml=junit/test-results.xml --cov-report=xml --cov=lib ||
             [[ "$PYTHON_VERSION" = 'Pre' ]]
+          if [[ -n $SESSION_ID ]]; then
+            if [[ $VS_VER == 2022 ]]; then
+              "$TOOL" shutdown $SESSION_ID
+              echo "Coverage collection log"
+              echo "======================="
+              cat extensions.log
+            else
+              "$TOOL" shutdown -session:$SESSION_ID
+            fi
+          fi
         displayName: 'pytest'
 
       - bash: |
-          bash <(curl -s https://codecov.io/bash) -n "$PYTHON_VERSION $AGENT_OS" -f "!*.gcov" -X gcov
+          case "$AGENT_OS" in
+          Linux)
+            lcov --rc lcov_branch_coverage=1 --capture --directory . \
+              --output-file coverage.info
+            lcov --rc lcov_branch_coverage=1 --output-file coverage.info \
+              --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
+            lcov --rc lcov_branch_coverage=1 --list coverage.info
+            find . -name '*.gc*' -delete
+            ;;
+          Darwin)
+            xcrun llvm-profdata merge -sparse default.*.profraw \
+              -o default.profdata
+            xcrun llvm-cov export -format="lcov" build/*/src/*.so \
+              -instr-profile default.profdata > info.lcov
+            ;;
+          Windows_NT)
+            if [[ -f extensions.coverage ]]; then
+              # For MSVC 2019.
+              "$VS_COVERAGE_TOOL" analyze -output:extensions.xml \
+                -include_skipped_functions -include_skipped_modules \
+                extensions.coverage
+              rm extensions.coverage
+            fi
+            ;;
+          *)
+            exit 1
+            ;;
+          esac
+        displayName: 'Filter C coverage'
+      - bash: |
+          bash <(curl -s https://codecov.io/bash) \
+            -n "$PYTHON_VERSION $AGENT_OS" \
+            -f 'coverage.xml' -f 'extensions.xml'
         displayName: 'Upload to codecov.io'
 
       - task: PublishTestResults@2


### PR DESCRIPTION
## PR summary

This enables coverage for compiled code on macOS GitHub Actions, as well as all platforms on Azure Pipelines.

Unfortunately, I don't see any coverage for the Objective-C macosx backend, even though my testing showed that the flag was passed in there.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines