### PR TITLE
[Doc] Updated Hatches API page 

### DIFF
--- a/doc/api/hatch_api.rst
+++ b/doc/api/hatch_api.rst
@@ -2,6 +2,31 @@
 ``matplotlib.hatch``
 ********************
 
+.. plot::
+   :include-source: false
+   :alt: Example image showing hatching patterns with level 1 density.
+   
+   import matplotlib.pyplot as plt
+
+   from matplotlib.patches import Rectangle
+
+   fig, axs = plt.subplots(2, 5, layout='constrained', figsize=(6.4, 3.2))
+   
+   hatches = ['/', '\\', '|', '-', '+', 'x', 'o', 'O', '.', '*']
+   
+   def hatches_plot(ax, h):
+      ax.add_patch(Rectangle((0, 0), 2, 2, fill=False, hatch=h))
+      ax.text(1, -0.5, f"' {h} '", size=15, ha="center")
+      ax.axis('equal')
+      ax.axis('off')
+
+   for ax, h in zip(axs.flat, hatches):
+      hatches_plot(ax, h)
+
+
+For examples using the hatch api refer to: :ref:`sphx_glr_gallery_shapes_and_collections_hatch_style_reference.py`
+
+
 .. automodule:: matplotlib.hatch
    :members:
    :undoc-members:


### PR DESCRIPTION
## PR summary

This proposed change aims to address the sparsity of information on the hatches API landing page requested in issue #27196. Currently, users landing on this page may see a lack of information on supported hatches. By enhancing the content and linking to the supported hatches it will make it easier for individuals to quickly locate the information they are seeking.

Ashhar-24 was made co-author of this current PR as I took inspiration from Ashhar-24's PR #27203. 

closes #27196

## PR checklist
- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

## Additional Information
In issue #27196 it is requested for an image to be embedded at the top of the API reference page (via the .. plot:: path/to/image directive). Through testing I am unsure if one can use this directive with a path to an image file. The .. image:: directive may be a better option. 

Referencing #27357 and https://matplotlib.org/stable/api/sphinxext_plot_directive_api.html I was able to embed the required image using ".. plot::". 

In the review please let me know if .. image:: would have been a better choice, and if not, the reasons behind that decision. Your insights will be invaluable for my future pull requests. Thank you.