### PR TITLE
[TST] Added test_arrow in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -20,11 +20,61 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.annotate(...)
 
-    @pytest.mark.xfail(reason="Test for arrow not written yet")
     @mpl.style.context("default")
     def test_arrow(self):
-        fig, ax = plt.subplots()
-        ax.arrow(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1,
+                                            constrained_layout=True,
+                                            figsize=(10, 12))
+
+        start_date = datetime.datetime(2023, 1, 1)
+        dates = [start_date + datetime.timedelta(days=i) for i in range(31)]
+        y_values = range(31)
+
+        ax1.plot(dates, y_values, marker='o')
+        ax1.arrow(x=dates[10],
+                  y=10,
+                  dx=10,
+                  dy=10,
+                  head_width=1,
+                  head_length=1,
+                  linewidth=3,
+                  facecolor='red',
+                  edgecolor='red',
+                  transform=ax1.transData)
+        ax1.set_title('Datetime vs. Number')
+        ax1.set_xlabel('Date')
+        ax1.set_ylabel('Number')
+
+        ax2.plot(y_values, dates, marker='o')
+        ax2.arrow(x=10,
+                  y=dates[10],
+                  dx=10,
+                  dy=10,
+                  head_width=1,
+                  head_length=1,
+                  linewidth=3,
+                  facecolor='red',
+                  edgecolor='red',
+                  transform=ax2.transData)
+        ax2.set_title('Number vs. Datetime')
+        ax2.set_xlabel('Number')
+        ax2.set_ylabel('Date')
+
+        ax3.plot(dates, dates, marker='o')
+        ax3.arrow(x=dates[10],
+                  y=dates[10],
+                  dx=10,
+                  dy=10,
+                  head_width=1,
+                  head_length=1,
+                  linewidth=3,
+                  facecolor='red',
+                  edgecolor='red',
+                  transform=ax3.transData)
+        ax3.set_title('Datetime vs. Datetime')
+        ax3.set_xlabel('Date')
+        ax3.set_ylabel('Date')
 
     @mpl.style.context("default")
     def test_axhline(self):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR adds a smoke test for Axes.arrow in lib/matplotlib/tests/test_datetime.py. This PR closes one of the items listed in the issue https://github.com/matplotlib/matplotlib/issues/26864.
Smoke test Plot:
![mpl_arrow](https://github.com/matplotlib/matplotlib/assets/96338098/63542e82-8ff0-4a76-9f88-1ed78e979171)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
