### PR TITLE
Fix 3D lines being visible when behind camera

### DIFF
--- a/doc/api/next_api_changes/deprecations/27385-SS.rst
+++ b/doc/api/next_api_changes/deprecations/27385-SS.rst
@@ -1,0 +1,3 @@
+``proj3d.proj_transform_clip``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated with no replacement.

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -129,7 +129,7 @@ class Path:
         vertices = _to_unmasked_float_array(vertices)
         _api.check_shape((None, 2), vertices=vertices)
 
-        if codes is not None:
+        if codes is not None and len(vertices):
             codes = np.asarray(codes, self.code_type)
             if codes.ndim != 1 or len(codes) != len(vertices):
                 raise ValueError("'codes' must be a 1D list or array with the "

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -267,7 +267,9 @@ class Line3D(lines.Line2D):
     @artist.allow_rasterization
     def draw(self, renderer):
         xs3d, ys3d, zs3d = self._verts3d
-        xs, ys, zs = proj3d.proj_transform(xs3d, ys3d, zs3d, self.axes.M)
+        xs, ys, zs, tis = proj3d._proj_transform_clip(xs3d, ys3d, zs3d,
+                                                      self.axes.M,
+                                                      self.axes._focal_length)
         self.set_data(xs, ys)
         super().draw(renderer)
         self.stale = False
@@ -458,8 +460,9 @@ class Patch3D(Patch):
     def do_3d_projection(self):
         s = self._segment3d
         xs, ys, zs = zip(*s)
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
-                                                        self.axes.M)
+        vxs, vys, vzs, vis = proj3d._proj_transform_clip(xs, ys, zs,
+                                                         self.axes.M,
+                                                         self.axes._focal_length)
         self._path2d = mpath.Path(np.column_stack([vxs, vys]))
         return min(vzs)
 
@@ -505,8 +508,9 @@ class PathPatch3D(Patch3D):
     def do_3d_projection(self):
         s = self._segment3d
         xs, ys, zs = zip(*s)
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
-                                                        self.axes.M)
+        vxs, vys, vzs, vis = proj3d._proj_transform_clip(xs, ys, zs,
+                                                         self.axes.M,
+                                                         self.axes._focal_length)
         self._path2d = mpath.Path(np.column_stack([vxs, vys]), self._code3d)
         return min(vzs)
 
@@ -611,8 +615,9 @@ class Patch3DCollection(PatchCollection):
 
     def do_3d_projection(self):
         xs, ys, zs = self._offsets3d
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
-                                                        self.axes.M)
+        vxs, vys, vzs, vis = proj3d._proj_transform_clip(xs, ys, zs,
+                                                         self.axes.M,
+                                                         self.axes._focal_length)
         self._vzs = vzs
         super().set_offsets(np.column_stack([vxs, vys]))
 
@@ -752,8 +757,9 @@ class Path3DCollection(PathCollection):
 
     def do_3d_projection(self):
         xs, ys, zs = self._offsets3d
-        vxs, vys, vzs, vis = proj3d.proj_transform_clip(xs, ys, zs,
-                                                        self.axes.M)
+        vxs, vys, vzs, vis = proj3d._proj_transform_clip(xs, ys, zs,
+                                                         self.axes.M,
+                                                         self.axes._focal_length)
         # Sort the points based on z coordinates
         # Performance optimization: Create a sorted index array and reorder
         # points and point properties according to the index array

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -173,19 +173,21 @@ def _ortho_transformation(zfront, zback):
 def _proj_transform_vec(vec, M):
     vecw = np.dot(M, vec)
     w = vecw[3]
-    # clip here..
     txs, tys, tzs = vecw[0]/w, vecw[1]/w, vecw[2]/w
     return txs, tys, tzs
 
 
-def _proj_transform_vec_clip(vec, M):
+def _proj_transform_vec_clip(vec, M, focal_length):
     vecw = np.dot(M, vec)
     w = vecw[3]
-    # clip here.
     txs, tys, tzs = vecw[0] / w, vecw[1] / w, vecw[2] / w
-    tis = (0 <= vecw[0]) & (vecw[0] <= 1) & (0 <= vecw[1]) & (vecw[1] <= 1)
-    if np.any(tis):
-        tis = vecw[1] < 1
+    if np.isinf(focal_length):  # don't clip orthographic projection
+        tis = np.ones(txs.shape, dtype=bool)
+    else:
+        tis = (-1 <= txs) & (txs <= 1) & (-1 <= tys) & (tys <= 1) & (tzs <= 0)
+    txs = np.ma.masked_array(txs, ~tis)
+    tys = np.ma.masked_array(tys, ~tis)
+    tzs = np.ma.masked_array(tzs, ~tis)
     return txs, tys, tzs, tis
 
 
@@ -220,14 +222,19 @@ transform = _api.deprecated(
     alternative="proj_transform")(proj_transform)
 
 
-def proj_transform_clip(xs, ys, zs, M):
+@_api.deprecated("3.10")
+def proj_transform_clip(xs, ys, zs, M, focal_length=np.inf):
+    return _proj_transform_clip(xs, ys, zs, M, focal_length)
+
+
+def _proj_transform_clip(xs, ys, zs, M, focal_length):
     """
     Transform the points by the projection matrix
     and return the clipping result
     returns txs, tys, tzs, tis
     """
     vec = _vec_pad_ones(xs, ys, zs)
-    return _proj_transform_vec_clip(vec, M)
+    return _proj_transform_vec_clip(vec, M, focal_length)
 
 
 @_api.deprecated("3.8")

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -223,8 +223,8 @@ transform = _api.deprecated(
 
 
 @_api.deprecated("3.10")
-def proj_transform_clip(xs, ys, zs, M, focal_length=np.inf):
-    return _proj_transform_clip(xs, ys, zs, M, focal_length)
+def proj_transform_clip(xs, ys, zs, M):
+    return _proj_transform_clip(xs, ys, zs, M, focal_length=np.inf)
 
 
 def _proj_transform_clip(xs, ys, zs, M, focal_length):

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1325,6 +1325,21 @@ def test_unautoscale(axis, auto):
     np.testing.assert_array_equal(get_lim(), (-0.5, 0.5))
 
 
+@check_figures_equal(extensions=["png"])
+def test_culling(fig_test, fig_ref):
+    xmins = (-100, -50)
+    for fig, xmin in zip((fig_test, fig_ref), xmins):
+        ax = fig.add_subplot(projection='3d')
+        n = abs(xmin) + 1
+        xs = np.linspace(0, xmin, n)
+        ys = np.ones(n)
+        zs = np.zeros(n)
+        ax.plot(xs, ys, zs, 'k')
+
+        ax.set(xlim=(-5, 5), ylim=(-5, 5), zlim=(-5, 5))
+        ax.view_init(5, 180, 0)
+
+
 def test_axes3d_focal_length_checks():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

Closes https://github.com/matplotlib/matplotlib/issues/6305

## PR summary

Lines behind the camera were not being properly culled, and were visible in certain circumstances. Will leave this as a draft until I figure out if this issue applies to all 3D objects and not just lines. Also want to understand what exactly `proj3d.proj_transform_clip` is doing since I would have thought that does exactly this, but swapping to that function didn't solve anything.

Note to self, this is a good reference: https://www.scratchapixel.com/lessons/3d-basic-rendering/perspective-and-orthographic-projection-matrix/opengl-perspective-projection-matrix

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
