### PR TITLE
Doc: add a "please use dev version" to top of contribute docs

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -4,6 +4,15 @@
 Contribute
 ##########
 
+.. ifconfig:: releaselevel != 'dev'
+
+   .. important::
+
+      If you plan to contribute to Matplotlib, please read the
+      `development version <https://matplotlib.org/devdocs/devel/index.html>`_
+      of this document as it will have the most up to date installation
+      instructions, workflow process, and contributing guidelines.
+
 Thank you for your interest in helping to improve Matplotlib! There are various
 ways to contribute: optimizing and refactoring code, detailing unclear
 documentation and writing new examples, reporting and fixing bugs and requesting


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Motivated by a top issue for new contributors being that they're not using the dev docs. xref #18402
So I tried to version guard this so the admonishment will only show on non devel versions but I don't think I can test if this works on non-backports. Aim is it looks like this 

![image](https://github.com/matplotlib/matplotlib/assets/1300499/c681ef46-100f-4ce8-afc7-e8b003bea6c5)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
