### PR TITLE
Add test_bxp in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -201,7 +201,6 @@ class TestDatetimePlotting:
         ax.bxp(data, vert=False)
         ax.xaxis.set_major_formatter(mpl.dates.DateFormatter("%Y-%m-%d"))
         ax.set_title('Box plot with datetime data')
-        plt.show()
 
     @pytest.mark.xfail(reason="Test for clabel not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -183,11 +183,25 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.broken_barh(...)
 
-    @pytest.mark.xfail(reason="Test for bxp not written yet")
     @mpl.style.context("default")
     def test_bxp(self):
+        mpl.rcParams["date.converter"] = 'concise'
         fig, ax = plt.subplots()
-        ax.bxp(...)
+        to_mpl_date = mpl.dates.date2num
+        data = [{
+            "med": to_mpl_date(datetime.datetime(2020, 1, 15)),
+            "q1": to_mpl_date(datetime.datetime(2020, 1, 10)),
+            "q3": to_mpl_date(datetime.datetime(2020, 1, 20)),
+            "whislo": to_mpl_date(datetime.datetime(2020, 1, 5)),
+            "whishi": to_mpl_date(datetime.datetime(2020, 1, 25)),
+            "fliers": [
+                to_mpl_date(datetime.datetime(2020, 1, 3)),
+                to_mpl_date(datetime.datetime(2020, 1, 27))
+            ]
+        }]
+        ax.bxp(data)
+        ax.yaxis.set_major_formatter(mpl.dates.DateFormatter("%Y-%m-%d"))
+        ax.set_title('Box plot with datetime data')
 
     @pytest.mark.xfail(reason="Test for clabel not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -187,21 +187,21 @@ class TestDatetimePlotting:
     def test_bxp(self):
         mpl.rcParams["date.converter"] = 'concise'
         fig, ax = plt.subplots()
-        to_mpl_date = mpl.dates.date2num
         data = [{
-            "med": to_mpl_date(datetime.datetime(2020, 1, 15)),
-            "q1": to_mpl_date(datetime.datetime(2020, 1, 10)),
-            "q3": to_mpl_date(datetime.datetime(2020, 1, 20)),
-            "whislo": to_mpl_date(datetime.datetime(2020, 1, 5)),
-            "whishi": to_mpl_date(datetime.datetime(2020, 1, 25)),
+            "med": datetime.datetime(2020, 1, 15),
+            "q1": datetime.datetime(2020, 1, 10),
+            "q3": datetime.datetime(2020, 1, 20),
+            "whislo": datetime.datetime(2020, 1, 5),
+            "whishi": datetime.datetime(2020, 1, 25),
             "fliers": [
-                to_mpl_date(datetime.datetime(2020, 1, 3)),
-                to_mpl_date(datetime.datetime(2020, 1, 27))
+                datetime.datetime(2020, 1, 3),
+                datetime.datetime(2020, 1, 27)
             ]
         }]
-        ax.bxp(data)
-        ax.yaxis.set_major_formatter(mpl.dates.DateFormatter("%Y-%m-%d"))
+        ax.bxp(data, vert=False)
+        ax.xaxis.set_major_formatter(mpl.dates.DateFormatter("%Y-%m-%d"))
         ax.set_title('Box plot with datetime data')
+        plt.show()
 
     @pytest.mark.xfail(reason="Test for clabel not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
I have added a datetime/timedelta smoke test for Axes.bxp in lib/matplotlib/tests/test_datetime.py.
This addresses the Axes.bxp task from https://github.com/matplotlib/matplotlib/issues/26864.

The image below is the plot generated from this smoke test/example code. 
![bxp_graph](https://github.com/matplotlib/matplotlib/assets/112187975/7d3567cc-9f2e-4888-a93f-ab60973ce3b2)

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines