### PR TITLE
Remove test_spy from test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -494,15 +494,17 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_spy(self):
+        dates = [datetime.datetime.today() -
+                 datetime.timedelta(days=i) for i in range(10)]
+        formatted_dates = [date.strftime("%Y-%m-%d") for date in dates]
         data = np.random.rand(10, 10)
-        data[data < 0.9] = 0
-        fig, ax = plt.subplots()
-        sp = ax.spy(data)
-        ax.set_title('Spy Plot Test')
-        ax.set_xlabel('Column Index')
-        ax.set_ylabel('Row Index')
-        assert sp is not None, "Failed to create spy plot"
-        plt.close(fig)
+        threshold = 0.7
+        data = np.where(data > threshold, 1, 0)
+        plt.figure()
+        plt.spy(data)
+        plt.xticks(range(10), formatted_dates, rotation=45)
+        plt.show()
+        assert plt.gcf() is not None
 
     @mpl.style.context("default")
     def test_stackplot(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -493,19 +493,6 @@ class TestDatetimePlotting:
         ax.semilogy(...)
 
     @mpl.style.context("default")
-    def test_spy(self):
-        dates = [datetime.datetime.today() -
-                 datetime.timedelta(days=i) for i in range(10)]
-        formatted_dates = [date.strftime("%Y-%m-%d") for date in dates]
-        data = np.random.rand(10, 10)
-        threshold = 0.7
-        data = np.where(data > threshold, 1, 0)
-        plt.figure()
-        plt.spy(data)
-        plt.xticks(range(10), formatted_dates, rotation=45)
-        assert plt.gcf() is not None
-
-    @mpl.style.context("default")
     def test_stackplot(self):
         mpl.rcParams["date.converter"] = 'concise'
         N = 10

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -503,7 +503,6 @@ class TestDatetimePlotting:
         plt.figure()
         plt.spy(data)
         plt.xticks(range(10), formatted_dates, rotation=45)
-        plt.show()
         assert plt.gcf() is not None
 
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -492,11 +492,17 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.semilogy(...)
 
-    @pytest.mark.xfail(reason="Test for spy not written yet")
     @mpl.style.context("default")
     def test_spy(self):
+        data = np.random.rand(10, 10)
+        data[data < 0.9] = 0
         fig, ax = plt.subplots()
-        ax.spy(...)
+        sp = ax.spy(data)
+        ax.set_title('Spy Plot Test')
+        ax.set_xlabel('Column Index')
+        ax.set_ylabel('Row Index')
+        assert sp is not None, "Failed to create spy plot"
+        plt.close(fig)
 
     @mpl.style.context("default")
     def test_stackplot(self):


### PR DESCRIPTION
## PR summary
Removing the test_spy for datetime, since does not make sense for unitful data. Spy is related to plotting at array indices, and provides no way of setting the x and y values to non-integer data.

Therefore, this PR aims to remove test_spy.

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines