### PR TITLE
SpanSelector widget: Improve doc for `extents`

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2695,7 +2695,7 @@ class SpanSelector(_SelectorWidget):
 
     @property
     def direction(self):
-        """Direction of the span selector: 'vertical' or 'horizontal'."""
+        """Direction of the span selector: 'vertical' or 'horizontal'. Writable."""
         return self._direction
 
     @direction.setter
@@ -2855,7 +2855,12 @@ class SpanSelector(_SelectorWidget):
 
     @property
     def extents(self):
-        """Return extents of the span selector."""
+        """
+        (float, float)
+            The axis values for the start and end points of the current selection.
+            If there is no selection then the start and end values will be the same.
+            Writable.
+        """
         if self.direction == 'horizontal':
             vmin = self._selection_artist.get_x()
             vmax = vmin + self._selection_artist.get_width()


### PR DESCRIPTION


## PR summary
Explains what the extents are. Addresses my problem here https://discourse.matplotlib.org/t/spanselector-how-to-set-selection-with-code/24114/4

Old:

https://matplotlib.org/stable/api/widgets_api.html#matplotlib.widgets.SpanSelector.extents

New rendering:

![image](https://github.com/matplotlib/matplotlib/assets/39133604/898bed7a-419b-4c07-a4cf-283f0a2b576d)



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines


