### PR TITLE
added test_quiver in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -446,11 +446,20 @@ class TestDatetimePlotting:
         ax2.plot_date(x_dates, y_ranges)
         ax3.plot_date(x_ranges, y_dates)
 
-    @pytest.mark.xfail(reason="Test for quiver not written yet")
     @mpl.style.context("default")
     def test_quiver(self):
-        fig, ax = plt.subplots()
-        ax.quiver(...)
+        dates = [datetime.datetime(2023, 1, 1) +
+                    datetime.timedelta(days=i) for i in range(5)]
+        x = dates
+        y = np.zeros_like(x, dtype=float)
+        u = np.sin(np.arange(len(x)))
+        v = np.cos(np.arange(len(x)))
+        fig, ax = plt.subplots(figsize=(10, 6))
+        ax.quiver(x, y, u, v, scale=20)
+        fig.autofmt_xdate()
+        ax.set_title('Quiver Plot with Datetime Data')
+        ax.set_xlabel('Date')
+        ax.set_ylabel('Y-axis')
 
     @pytest.mark.xfail(reason="Test for quiverkey not written yet")
     @mpl.style.context("default")
@@ -611,3 +620,7 @@ class TestDatetimePlotting:
     def test_xcorr(self):
         fig, ax = plt.subplots()
         ax.xcorr(...)
+
+if __name__ == "__main__":
+    test = TestDatetimePlotting()
+    test.test_quiver()

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -620,7 +620,3 @@ class TestDatetimePlotting:
     def test_xcorr(self):
         fig, ax = plt.subplots()
         ax.xcorr(...)
-
-if __name__ == "__main__":
-    test = TestDatetimePlotting()
-    test.test_quiver()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I have added a datetime smoke test for Axes.quiver in lib/matplotlib/test/test_datetime.py.
This addresses the Axes.quiver task from https://github.com/matplotlib/matplotlib/issues/26864.

The image below is the plot generated from my example code.
![quiver test](https://github.com/matplotlib/matplotlib/assets/112187975/46e81507-0d50-4dac-b38a-2cc3ca5b20de)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
