### PR TITLE
Fix setting `_selection_completed` in `SpanSelector` when spanselector is initialised using `extents`

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -974,6 +974,23 @@ def test_span_selector_snap(ax):
     assert tool.extents == (17, 35)
 
 
+def test_span_selector_extents(ax):
+    tool = widgets.SpanSelector(
+        ax, lambda a, b: None, "horizontal", ignore_event_outside=True
+        )
+    tool.extents = (5, 10)
+
+    assert tool.extents == (5, 10)
+    assert tool._selection_completed
+
+    # Since `ignore_event_outside=True`, this event should be ignored
+    press_data = (12, 14)
+    release_data = (20, 14)
+    click_and_drag(tool, start=press_data, end=release_data)
+
+    assert tool.extents == (5, 10)
+
+
 @pytest.mark.parametrize('kwargs', [
     dict(),
     dict(useblit=False, props=dict(color='red')),

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2684,7 +2684,7 @@ class SpanSelector(_SelectorWidget):
             # visibility to False and extents to (v, v)
             # update will be called when setting the extents
             self._visible = False
-            self.extents = v, v
+            self._set_extents((v, v))
             # We need to set the visibility back, so the span selector will be
             # drawn when necessary (span width > 0)
             self._visible = True
@@ -2797,7 +2797,7 @@ class SpanSelector(_SelectorWidget):
             if vmin > vmax:
                 vmin, vmax = vmax, vmin
 
-        self.extents = vmin, vmax
+        self._set_extents((vmin, vmax))
 
         if self.onmove_callback is not None:
             self.onmove_callback(vmin, vmax)
@@ -2866,6 +2866,10 @@ class SpanSelector(_SelectorWidget):
 
     @extents.setter
     def extents(self, extents):
+        self._set_extents(extents)
+        self._selection_completed = True
+
+    def _set_extents(self, extents):
         # Update displayed shape
         if self.snap_values is not None:
             extents = tuple(self._snap(extents, self.snap_values))


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

In the following example, if the first click is outside of the span selector, the span selector will be reset on the press event, while it shouldn't. The reason is that when setting `extents` programmatically after initialisation of the span selector, the attribute `_selection_completed` should be `True`, otherwise the span selector will behave as the selection was incomplete!

```python
import matplotlib.pyplot as plt

from matplotlib.widgets import SpanSelector

fig, ax = plt.subplots()
ax.plot(range(40))

span = SpanSelector(
    ax,
    onselect=lambda a, b:None,
    direction="horizontal",
    interactive=True,
    drag_from_anywhere=True,
    ignore_event_outside=True,
)

span.extents = (10, 20)

```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
