### PR TITLE
Add test_vlines to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -750,8 +750,24 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.violinplot(...)
 
-    @pytest.mark.xfail(reason="Test for vlines not written yet")
     @mpl.style.context("default")
     def test_vlines(self):
-        fig, ax = plt.subplots()
-        ax.vlines(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        ax1.set_xlim(left=datetime.datetime(2023, 1, 1),
+                     right=datetime.datetime(2023, 6, 30))
+        ax1.vlines(x=[datetime.datetime(2023, 2, 10),
+                      datetime.datetime(2023, 5, 18),
+                      datetime.datetime(2023, 6, 6)],
+                   ymin=[0, 0.25, 0.5],
+                   ymax=[0.25, 0.5, 0.75])
+        ax2.set_xlim(left=0,
+                     right=0.5)
+        ax2.vlines(x=[0.3, 0.35],
+                   ymin=[np.datetime64('2023-03-20'), np.datetime64('2023-03-31')],
+                   ymax=[np.datetime64('2023-05-01'), np.datetime64('2023-05-16')])
+        ax3.set_xlim(left=datetime.datetime(2023, 7, 1),
+                     right=datetime.datetime(2023, 12, 31))
+        ax3.vlines(x=[datetime.datetime(2023, 9, 1), datetime.datetime(2023, 12, 10)],
+                   ymin=datetime.datetime(2023, 1, 15),
+                   ymax=datetime.datetime(2023, 1, 30))


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
I have added a datetime smoke test for `Axes.vlines` in `lib/matplotlib/tests/test_datetime.py`. It includes a combination of dates and floats for the axes as well as scalars and arrays for ymin and ymax.
This addresses the `Axes.vlines` task from #26864.

Here is an image of the plots:
<img width="657" alt="Screenshot 2023-12-01 at 12 34 48 PM" src="https://github.com/matplotlib/matplotlib/assets/58918746/a7a40e35-3a9b-42f0-9929-63a20156c175">

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
