### PR TITLE
Use class form of data classes 

### DIFF
--- a/doc/api/font_manager_api.rst
+++ b/doc/api/font_manager_api.rst
@@ -4,6 +4,7 @@
 
 .. automodule:: matplotlib.font_manager
    :members:
+   :exclude-members: FontEntry
    :undoc-members:
    :show-inheritance:
 

--- a/galleries/examples/widgets/menu.py
+++ b/galleries/examples/widgets/menu.py
@@ -5,19 +5,22 @@ Menu
 
 Using texts to construct a simple menu.
 """
+
+from dataclasses import dataclass
+
 import matplotlib.pyplot as plt
 
 import matplotlib.artist as artist
 import matplotlib.patches as patches
+from matplotlib.typing import ColorType
 
 
+@dataclass
 class ItemProperties:
-    def __init__(self, fontsize=14, labelcolor='black', bgcolor='yellow',
-                 alpha=1.0):
-        self.fontsize = fontsize
-        self.labelcolor = labelcolor
-        self.bgcolor = bgcolor
-        self.alpha = alpha
+    fontsize: float = 14
+    labelcolor: ColorType = 'black'
+    bgcolor: ColorType = 'yellow'
+    alpha: float = 1.0
 
 
 class MenuItem(artist.Artist):
@@ -130,7 +133,7 @@ hoverprops = ItemProperties(labelcolor='white', bgcolor='blue',
 menuitems = []
 for label in ('open', 'close', 'save', 'save as', 'quit'):
     def on_select(item):
-        print('you selected %s' % item.labelstr)
+        print(f'you selected {item.labelstr}')
     item = MenuItem(fig, label, props=props, hoverprops=hoverprops,
                     on_select=on_select)
     menuitems.append(item)

--- a/lib/matplotlib/_text_helpers.py
+++ b/lib/matplotlib/_text_helpers.py
@@ -2,14 +2,21 @@
 Low-level text helper utilities.
 """
 
+from __future__ import annotations
+
 import dataclasses
 
 from . import _api
-from .ft2font import KERNING_DEFAULT, LOAD_NO_HINTING
+from .ft2font import KERNING_DEFAULT, LOAD_NO_HINTING, FT2Font
 
 
-LayoutItem = dataclasses.make_dataclass(
-    "LayoutItem", ["ft_object", "char", "glyph_idx", "x", "prev_kern"])
+@dataclasses.dataclass(frozen=True)
+class LayoutItem:
+    ft_object: FT2Font
+    char: str
+    glyph_idx: int
+    x: float
+    prev_kern: float
 
 
 def warn_on_missing_glyph(codepoint, fontnames):
@@ -38,9 +45,10 @@ def warn_on_missing_glyph(codepoint, fontnames):
 
 def layout(string, font, *, kern_mode=KERNING_DEFAULT):
     """
-    Render *string* with *font*.  For each character in *string*, yield a
-    (glyph-index, x-position) pair.  When such a pair is yielded, the font's
-    glyph is set to the corresponding character.
+    Render *string* with *font*.
+
+    For each character in *string*, yield a LayoutItem instance. When such an instance
+    is yielded, the font's glyph is set to the corresponding character.
 
     Parameters
     ----------
@@ -53,8 +61,7 @@ def layout(string, font, *, kern_mode=KERNING_DEFAULT):
 
     Yields
     ------
-    glyph_index : int
-    x_position : float
+    LayoutItem
     """
     x = 0
     prev_glyph_idx = None

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2378,8 +2378,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             multibyte_glyphs = []
             prev_was_multibyte = True
             prev_font = font
-            for item in _text_helpers.layout(
-                    s, font, kern_mode=KERNING_UNFITTED):
+            for item in _text_helpers.layout(s, font, kern_mode=KERNING_UNFITTED):
                 if _font_supports_glyph(fonttype, ord(item.char)):
                     if prev_was_multibyte or item.ft_object != prev_font:
                         singlebyte_chunks.append((item.ft_object, item.x, []))
@@ -2389,9 +2388,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                     singlebyte_chunks[-1][2].append(item.char)
                     prev_was_multibyte = False
                 else:
-                    multibyte_glyphs.append(
-                        (item.ft_object, item.x, item.glyph_idx)
-                    )
+                    multibyte_glyphs.append((item.ft_object, item.x, item.glyph_idx))
                     prev_was_multibyte = True
             # Do the rotation and global translation as a single matrix
             # concatenation up front


### PR DESCRIPTION
## PR summary

When these were added in #20118, we had no type annotations, so it made sense to use the functional form. Now that we do, there's no reason not to use the class form.

Also, as `FontEntry` has gained more methods, the functional form looks less clear.

Also, use one in the menu example.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines