### PR TITLE
Added test_hist2d

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -355,12 +355,47 @@ class TestDatetimePlotting:
             weights=values3
         )
 
-    @pytest.mark.xfail(reason="Test for hist2d not written yet")
     @mpl.style.context("default")
     def test_hist2d(self):
-        fig, ax = plt.subplots()
-        ax.hist2d(...)
+        mpl.rcParams["date.converter"] = 'concise'
 
+        start_date = datetime.datetime(2023, 10, 1)
+        time_delta = datetime.timedelta(days=1)
+
+        values1 = np.random.randint(1, 10, 30)
+        values2 = np.random.randint(1, 10, 30)
+        values3 = np.random.randint(1, 10, 30)
+
+        x_values = mpl.dates.date2num([start_date + i * time_delta for i in range(30)])
+
+        # Using Axes.hist2d
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, constrained_layout=True)
+
+        # Testing with Axes.hist2d
+        hist2d1 = ax1.hist2d(
+            x_values,
+            values1,
+            bins=10,
+            cmap='Blues'
+        )
+        ax1.set_title('Axes.hist2d - Data 1')
+
+        hist2d2 = ax2.hist2d(
+            x_values,
+            values2,
+            bins=10,
+            cmap='Greens'
+        )
+        ax2.set_title('Axes.hist2d - Data 2')
+
+        hist2d3 = ax3.hist2d(
+            x_values,
+            values3,
+            bins=10,
+            cmap='Reds'
+        )
+        ax3.set_title('Axes.hist2d - Data 3')
+        
     @mpl.style.context("default")
     def test_hlines(self):
         mpl.rcParams["date.converter"] = 'concise'


### PR DESCRIPTION
## PR summary

I have added a test for Axes.hist2d in lib/matplotlib/tests/test_datetime.py that tests with randomly created data if the data correctly plots. It is similar to the Axes.hist method of testing, as it uses similar generated data and methods.

This addresses the Axes.hist2d task from https://github.com/matplotlib/matplotlib/issues/26864.

Below is a picture of the generated plots.
![image](https://github.com/matplotlib/matplotlib/assets/66811124/a6fca0ff-46c0-4402-983a-71e9f4cc00f6)

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines