### PR TITLE
Add test for fill_between in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -346,8 +346,6 @@ class TestDatetimePlotting:
         ax2.fill_between(x_dates, y_values1, y_values2)
         ax3.fill_between(x_dates, y_dates1, y_dates2)
 
-        plt.savefig("fill_between2.png")
-
     @pytest.mark.xfail(reason="Test for fill_betweenx not written yet")
     @mpl.style.context("default")
     def test_fill_betweenx(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -331,10 +331,12 @@ class TestDatetimePlotting:
 
         y_values1 = np.random.rand(10) * 10
         y_values2 = y_values1 + np.random.rand(10) * 10
+        y_values1.sort()
+        y_values2.sort()
 
         x_base_date = datetime.datetime(2023, 1, 1)
         x_dates = [x_base_date]
-        for _ in range(1, 10):
+        for i in range(1, 10):
             x_base_date += datetime.timedelta(days=np.random.randint(1, 10))
             x_dates.append(x_base_date)
 

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -340,12 +340,13 @@ class TestDatetimePlotting:
             x_base_date += datetime.timedelta(days=np.random.randint(1, 10))
             x_dates.append(x_base_date)
 
-        fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, layout="constrained")
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout="constrained")
 
         ax1.fill_between(x_values, y_dates1, y_dates2)
-        ax2.fill_between(x_values, y_values1, y_values2)
-        ax3.fill_between(x_dates, y_values1, y_values2)
-        ax4.fill_between(x_dates, y_dates1, y_dates2)
+        ax2.fill_between(x_dates, y_values1, y_values2)
+        ax3.fill_between(x_dates, y_dates1, y_dates2)
+
+        plt.savefig("fill_between2.png")
 
     @pytest.mark.xfail(reason="Test for fill_betweenx not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -329,8 +329,8 @@ class TestDatetimePlotting:
         x_values = np.random.rand(10) * 10
         x_values.sort()
 
-        y_values1 = np.random.rand(10) *10
-        y_values2 = y_values1 + np.random.rand(10) *10
+        y_values1 = np.random.rand(10) * 10
+        y_values2 = y_values1 + np.random.rand(10) * 10
 
         x_base_date = datetime.datetime(2023, 1, 1)
         x_dates = [x_base_date]

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -311,11 +311,39 @@ class TestDatetimePlotting:
         ax3.fill(x_values, y_values)
         ax4.fill(x_dates, y_dates)
 
-    @pytest.mark.xfail(reason="Test for fill_between not written yet")
     @mpl.style.context("default")
     def test_fill_between(self):
-        fig, ax = plt.subplots()
-        ax.fill_between(...)
+        mpl.rcParams["date.converter"] = "concise"
+        np.random.seed(19680801)
+
+        y_base_date = datetime.datetime(2023, 1, 1)
+        y_dates1 = [y_base_date]
+        for i in range(1, 10):
+            y_base_date += datetime.timedelta(days=np.random.randint(1, 5))
+            y_dates1.append(y_base_date)
+
+        y_dates2 = [y_base_date]
+        for i in range(1, 10):
+            y_base_date += datetime.timedelta(days=np.random.randint(1, 5))
+            y_dates2.append(y_base_date)
+        x_values = np.random.rand(10) * 10
+        x_values.sort()
+
+        y_values1 = np.random.rand(10) *10
+        y_values2 = y_values1 + np.random.rand(10) *10
+
+        x_base_date = datetime.datetime(2023, 1, 1)
+        x_dates = [x_base_date]
+        for _ in range(1, 10):
+            x_base_date += datetime.timedelta(days=np.random.randint(1, 10))
+            x_dates.append(x_base_date)
+
+        fig, (ax1, ax2, ax3, ax4) = plt.subplots(4, 1, layout="constrained")
+
+        ax1.fill_between(x_values, y_dates1, y_dates2)
+        ax2.fill_between(x_values, y_values1, y_values2)
+        ax3.fill_between(x_dates, y_values1, y_values2)
+        ax4.fill_between(x_dates, y_dates1, y_dates2)
 
     @pytest.mark.xfail(reason="Test for fill_betweenx not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
add code for test_fill_between in test_datetime.py as requested in #26864.

Output image:
![fit_between1](https://github.com/matplotlib/matplotlib/assets/71032637/84c5c853-bf9a-4236-b71a-4eb7f6bae7c9)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x]  resolves part of [ [TST]: increase unit test coverage #26864 ](https://github.com/matplotlib/matplotlib/issues/26864)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
