### PR TITLE
Added test_fill_betweenx in test_datetime.py 

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -336,8 +336,8 @@ class TestDatetimePlotting:
         y_values.sort()
 
         x_values1 = np.random.rand(10) * 10
-        x_values1.sort()
         x_values2 = x_values1 + np.random.rand(10) * 10
+        x_values1.sort()
         x_values2.sort()
 
         y_base_date = datetime.datetime(2023, 1, 1)

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -346,12 +346,11 @@ class TestDatetimePlotting:
             y_base_date += datetime.timedelta(days=np.random.randint(1, 10))
             y_dates.append(y_base_date)
 
-        fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, layout="constrained")
+        fig, (ax1, ax2, ax3) = plt.subplots(1, 3, layout="constrained")
 
         ax1.fill_betweenx(y_values, x_dates1, x_dates2)
-        ax2.fill_betweenx(y_values, x_values1, x_values2)
-        ax3.fill_betweenx(y_dates, x_values1, x_values2)
-        ax4.fill_betweenx(y_dates, x_dates1, x_dates2)
+        ax2.fill_betweenx(y_dates, x_values1, x_values2)
+        ax3.fill_betweenx(y_dates, x_dates1, x_dates2)
 
     @pytest.mark.xfail(reason="Test for hexbin not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -278,11 +278,41 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.fill_between(...)
 
-    @pytest.mark.xfail(reason="Test for fill_betweenx not written yet")
     @mpl.style.context("default")
     def test_fill_betweenx(self):
-        fig, ax = plt.subplots()
-        ax.fill_betweenx(...)
+        mpl.rcParams["date.converter"] = "concise"
+        np.random.seed(19680801)
+
+        x_base_date = datetime.datetime(2023, 1, 1)
+        x_dates1 = [x_base_date]
+        for i in range(1, 10):
+            x_base_date += datetime.timedelta(days=np.random.randint(1, 5))
+            x_dates1.append(x_base_date)
+
+        x_dates2 = [x_base_date]
+        for i in range(1, 10):
+            x_base_date += datetime.timedelta(days=np.random.randint(1, 5))
+            x_dates2.append(x_base_date)
+        y_values = np.random.rand(10) * 10
+        y_values.sort()
+
+        x_values1 = np.random.rand(10) * 10
+        x_values1.sort()
+        x_values2 = x_values1 + np.random.rand(10) * 10
+        x_values2.sort()
+
+        y_base_date = datetime.datetime(2023, 1, 1)
+        y_dates = [y_base_date]
+        for i in range(1, 10):
+            y_base_date += datetime.timedelta(days=np.random.randint(1, 10))
+            y_dates.append(y_base_date)
+
+        fig, (ax1, ax2, ax3, ax4) = plt.subplots(1, 4, layout="constrained")
+
+        ax1.fill_betweenx(y_values, x_dates1, x_dates2)
+        ax2.fill_betweenx(y_values, x_values1, x_values2)
+        ax3.fill_betweenx(y_dates, x_values1, x_values2)
+        ax4.fill_betweenx(y_dates, x_dates1, x_dates2)
 
     @pytest.mark.xfail(reason="Test for hexbin not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
Added code for test_fill_betweenx in test_datetime.py as requested in https://github.com/matplotlib/matplotlib/issues/26864

Image for an output
![image](https://github.com/matplotlib/matplotlib/assets/105222584/4d327402-c92e-45d4-bf5a-898e2c18daf3)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] resolves part of   #26864
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
