### PR TITLE
MNT/TST: remove xcorr and acorr from test_datetime

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1979,6 +1979,8 @@ class Axes(_AxesBase):
         Parameters
         ----------
         x : array-like
+            Not run through Matplotlib's unit conversion, so this should
+            be a unit-less array.
 
         detrend : callable, default: `.mlab.detrend_none` (no detrending)
             A detrending function applied to *x*.  It must have the
@@ -2056,6 +2058,8 @@ class Axes(_AxesBase):
         Parameters
         ----------
         x, y : array-like of length n
+            Neither *x* nor *y* are run through Matplotlib's unit conversion, so
+            these should be unit-less arrays.
 
         detrend : callable, default: `.mlab.detrend_none` (no detrending)
             A detrending function applied to *x* and *y*.  It must have the

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -8,16 +8,6 @@ import matplotlib as mpl
 
 
 class TestDatetimePlotting:
-<<<<<<< HEAD
-    @pytest.mark.xfail(reason="Test for acorr not written yet")
-    @mpl.style.context("default")
-    def test_acorr(self):
-        fig, ax = plt.subplots()
-        ax.acorr(...)
-
-=======
-    @pytest.mark.xfail(reason="Test for annotate not written yet")
->>>>>>> 151199a8ef (MNT: remove xcorr and acorr from test_datetime)
     @mpl.style.context("default")
     def test_annotate(self):
         mpl.rcParams["date.converter"] = 'concise'

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -8,12 +8,16 @@ import matplotlib as mpl
 
 
 class TestDatetimePlotting:
+<<<<<<< HEAD
     @pytest.mark.xfail(reason="Test for acorr not written yet")
     @mpl.style.context("default")
     def test_acorr(self):
         fig, ax = plt.subplots()
         ax.acorr(...)
 
+=======
+    @pytest.mark.xfail(reason="Test for annotate not written yet")
+>>>>>>> 151199a8ef (MNT: remove xcorr and acorr from test_datetime)
     @mpl.style.context("default")
     def test_annotate(self):
         mpl.rcParams["date.converter"] = 'concise'
@@ -738,9 +742,3 @@ class TestDatetimePlotting:
     def test_vlines(self):
         fig, ax = plt.subplots()
         ax.vlines(...)
-
-    @pytest.mark.xfail(reason="Test for xcorr not written yet")
-    @mpl.style.context("default")
-    def test_xcorr(self):
-        fig, ax = plt.subplots()
-        ax.xcorr(...)


### PR DESCRIPTION
Currently `xcorr` and `acorr` are in `test_datetimes.py`.  However, I think it is highly unlikely anyone would want to pass datetimes in as `x` values to either of these methods.  It is also not clear what giving the unit conversion means for these arguments.  Modified the docstrings to make this clear.


