### PR TITLE
Added test for Axes.bar_label

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -7,7 +7,6 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 
 
-
 class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for acorr not written yet")
     @mpl.style.context("default")
@@ -143,13 +142,10 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_bar_label(self):
-        """
-        import matplotlib.pyplot as plt
-        import matplotlib.dates as mdates
-        from datetime import datetime, timedelta
-        """
+       
         # Generate some example data with dateTime inputs
-        date_list = [datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i) for i in range(5)]
+        date_list = [datetime.datetime(2023, 1, 1) +
+                      datetime.timedelta(days=i) for i in range(5)]
         values = [10, 20, 15, 25, 30]
 
         # Create a bar plot
@@ -166,28 +162,28 @@ class TestDatetimePlotting:
         axs[0, 1].bar(date_list, values)
         axs[0, 1].xaxis_date()
         axs[0, 1].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[0, 1].bar_label(axs[0, 1].containers[0], fmt='%.1f%%', label_type='center', color='blue')
+        axs[0, 1].bar_label(axs[0, 1].containers[0],
+                             fmt='%.1f%%', label_type='center', color='blue')
 
         # Variation 3: Label inside, with custom formatting
         axs[1, 0].bar(date_list, values)
         axs[1, 0].xaxis_date()
         axs[1, 0].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[1, 0].bar_label(axs[1, 0].containers[0], fmt='%d', label_type='center', color='white')
+        axs[1, 0].bar_label(axs[1, 0].containers[0], fmt='%d',
+                             label_type='center', color='white')
 
         # Variation 4: Label outside, with rotated text
         axs[1, 1].bar(date_list, values)
         axs[1, 1].xaxis_date()
         axs[1, 1].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[1, 1].bar_label(axs[1, 1].containers[0], fmt='%d', label_type='edge', color='red', rotation=45)
+        axs[1, 1].bar_label(axs[1, 1].containers[0], fmt='%d',
+                             label_type='edge', color='red', rotation=45)
 
         # Adjust layout
         plt.tight_layout(rect=[0, 0.03, 1, 0.95])
 
         # Show the plot
         plt.show()
-
-            
-
 
     @mpl.style.context("default")
     def test_barbs(self): 

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -148,11 +148,12 @@ class TestDatetimePlotting:
         values = [10, 20, 15, 25, 30]
 
         # Creating the plot
-        fig, axs = plt.subplots(1,1, figsize=(10, 8), layout='constrained')
+        fig, axs = plt.subplots(1, 1, figsize=(10, 8), layout='constrained')
         bars = axs.bar(date_list, values)
 
         # Add labels to the bars using bar_label
-        axs.bar_label(bars, labels=[f'{val}%' for val in values], label_type='edge', color='black')
+        axs.bar_label(bars, labels=[f'{val}%' for val in values],
+                       label_type='edge', color='black')
 
     @mpl.style.context("default")
     def test_barbs(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -144,14 +144,15 @@ class TestDatetimePlotting:
     def test_bar_label(self):
         # Generate some example data with dateTime inputs
         date_list = [datetime.datetime(2023, 1, 1) +
-                    datetime.timedelta(days=i) for i in range(5)]
+                     datetime.timedelta(days=i) for i in range(5)]
         values = [10, 20, 15, 25, 30]
 
         # Creating the plot
         fig, axs = plt.subplots(1,1, figsize=(10, 8), layout='constrained')
-        axs.bar(date_list, values)
+        bars = axs.bar(date_list, values)
 
-        plt.show()
+        # Add labels to the bars using bar_label
+        axs.bar_label(bars, labels=[f'{val}%' for val in values], label_type='edge', color='black')
 
     @mpl.style.context("default")
     def test_barbs(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -148,12 +148,12 @@ class TestDatetimePlotting:
         values = [10, 20, 15, 25, 30]
 
         # Creating the plot
-        fig, axs = plt.subplots(1, 1, figsize=(10, 8), layout='constrained')
-        bars = axs.bar(date_list, values)
+        fig, ax = plt.subplots(1, 1, figsize=(10, 8), layout='constrained')
+        bars = ax.bar(date_list, values)
 
         # Add labels to the bars using bar_label
-        axs.bar_label(bars, labels=[f'{val}%' for val in values],
-                       label_type='edge', color='black')
+        ax.bar_label(bars, labels=[f'{val}%' for val in values],
+                     label_type='edge', color='black')
 
     @mpl.style.context("default")
     def test_barbs(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -140,11 +140,48 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.bar(...)
 
-    @pytest.mark.xfail(reason="Test for bar_label not written yet")
     @mpl.style.context("default")
     def test_bar_label(self):
-        fig, ax = plt.subplots()
-        ax.bar_label(...)
+        # Generate some example data with dateTime inputs
+        date_list = [datetime(2023, 1, 1) + timedelta(days=i) for i in range(5)]
+        values = [10, 20, 15, 25, 30]
+
+        # Create a bar plot
+        fig, axs = plt.subplots(2, 2, figsize=(10, 8))
+        fig.suptitle('Variations of ax.bar_label', fontsize=16)
+
+        # Variation 1: Default settings
+        axs[0, 0].bar(date_list, values)
+        axs[0, 0].xaxis_date()
+        axs[0, 0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[0, 0].bar_label(axs[0, 0].containers[0])  # Using default settings
+
+        # Variation 2: Label on top, with percentage formatting
+        axs[0, 1].bar(date_list, values)
+        axs[0, 1].xaxis_date()
+        axs[0, 1].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[0, 1].bar_label(axs[0, 1].containers[0], fmt='%.1f%%', label_type='center', color='blue')
+
+        # Variation 3: Label inside, with custom formatting
+        axs[1, 0].bar(date_list, values)
+        axs[1, 0].xaxis_date()
+        axs[1, 0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[1, 0].bar_label(axs[1, 0].containers[0], fmt='%d', label_type='center', color='white')
+
+        # Variation 4: Label outside, with rotated text
+        axs[1, 1].bar(date_list, values)
+        axs[1, 1].xaxis_date()
+        axs[1, 1].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[1, 1].bar_label(axs[1, 1].containers[0], fmt='%d', label_type='edge', color='red', rotation=45)
+
+        # Adjust layout
+        plt.tight_layout(rect=[0, 0.03, 1, 0.95])
+
+        # Show the plot
+        plt.show()
+
+            
+
 
     @mpl.style.context("default")
     def test_barbs(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -142,7 +142,6 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_bar_label(self):
-       
         # Generate some example data with dateTime inputs
         date_list = [datetime.datetime(2023, 1, 1) +
                       datetime.timedelta(days=i) for i in range(5)]
@@ -186,7 +185,7 @@ class TestDatetimePlotting:
         plt.show()
 
     @mpl.style.context("default")
-    def test_barbs(self): 
+    def test_barbs(self):
         plt.rcParams["date.converter"] = 'concise'
 
         start_date = datetime.datetime(2022, 2, 8, 22)

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -144,44 +144,13 @@ class TestDatetimePlotting:
     def test_bar_label(self):
         # Generate some example data with dateTime inputs
         date_list = [datetime.datetime(2023, 1, 1) +
-                      datetime.timedelta(days=i) for i in range(5)]
+                    datetime.timedelta(days=i) for i in range(5)]
         values = [10, 20, 15, 25, 30]
 
-        # Create a bar plot
-        fig, axs = plt.subplots(2, 2, figsize=(10, 8))
-        fig.suptitle('Variations of ax.bar_label', fontsize=16)
+        # Creating the plot
+        fig, axs = plt.subplots(1,1, figsize=(10, 8), layout='constrained')
+        axs.bar(date_list, values)
 
-        # Variation 1: Default settings
-        axs[0, 0].bar(date_list, values)
-        axs[0, 0].xaxis_date()
-        axs[0, 0].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[0, 0].bar_label(axs[0, 0].containers[0])  # Using default settings
-
-        # Variation 2: Label on top, with percentage formatting
-        axs[0, 1].bar(date_list, values)
-        axs[0, 1].xaxis_date()
-        axs[0, 1].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[0, 1].bar_label(axs[0, 1].containers[0],
-                             fmt='%.1f%%', label_type='center', color='blue')
-
-        # Variation 3: Label inside, with custom formatting
-        axs[1, 0].bar(date_list, values)
-        axs[1, 0].xaxis_date()
-        axs[1, 0].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[1, 0].bar_label(axs[1, 0].containers[0], fmt='%d',
-                             label_type='center', color='white')
-
-        # Variation 4: Label outside, with rotated text
-        axs[1, 1].bar(date_list, values)
-        axs[1, 1].xaxis_date()
-        axs[1, 1].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
-        axs[1, 1].bar_label(axs[1, 1].containers[0], fmt='%d',
-                             label_type='edge', color='red', rotation=45)
-
-        # Adjust layout
-        plt.tight_layout(rect=[0, 0.03, 1, 0.95])
-
-        # Show the plot
         plt.show()
 
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -7,6 +7,7 @@ import matplotlib.pyplot as plt
 import matplotlib as mpl
 
 
+
 class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for acorr not written yet")
     @mpl.style.context("default")
@@ -142,8 +143,13 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_bar_label(self):
+        """
+        import matplotlib.pyplot as plt
+        import matplotlib.dates as mdates
+        from datetime import datetime, timedelta
+        """
         # Generate some example data with dateTime inputs
-        date_list = [datetime(2023, 1, 1) + timedelta(days=i) for i in range(5)]
+        date_list = [datetime.datetime(2023, 1, 1) + datetime.timedelta(days=i) for i in range(5)]
         values = [10, 20, 15, 25, 30]
 
         # Create a bar plot
@@ -153,25 +159,25 @@ class TestDatetimePlotting:
         # Variation 1: Default settings
         axs[0, 0].bar(date_list, values)
         axs[0, 0].xaxis_date()
-        axs[0, 0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[0, 0].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
         axs[0, 0].bar_label(axs[0, 0].containers[0])  # Using default settings
 
         # Variation 2: Label on top, with percentage formatting
         axs[0, 1].bar(date_list, values)
         axs[0, 1].xaxis_date()
-        axs[0, 1].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[0, 1].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
         axs[0, 1].bar_label(axs[0, 1].containers[0], fmt='%.1f%%', label_type='center', color='blue')
 
         # Variation 3: Label inside, with custom formatting
         axs[1, 0].bar(date_list, values)
         axs[1, 0].xaxis_date()
-        axs[1, 0].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[1, 0].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
         axs[1, 0].bar_label(axs[1, 0].containers[0], fmt='%d', label_type='center', color='white')
 
         # Variation 4: Label outside, with rotated text
         axs[1, 1].bar(date_list, values)
         axs[1, 1].xaxis_date()
-        axs[1, 1].xaxis.set_major_formatter(mdates.DateFormatter('%Y-%m-%d'))
+        axs[1, 1].xaxis.set_major_formatter(mpl.dates.DateFormatter('%Y-%m-%d'))
         axs[1, 1].bar_label(axs[1, 1].containers[0], fmt='%d', label_type='edge', color='red', rotation=45)
 
         # Adjust layout
@@ -184,7 +190,7 @@ class TestDatetimePlotting:
 
 
     @mpl.style.context("default")
-    def test_barbs(self):
+    def test_barbs(self): 
         plt.rcParams["date.converter"] = 'concise'
 
         start_date = datetime.datetime(2022, 2, 8, 22)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

I have added a datetime/timedelta smoke test for Axes.bar_label in lib/matplotlib/tests/test_datetime.py.
This addresses the Axes.bar_label task from https://github.com/matplotlib/matplotlib/issues/26864.

![image](https://github.com/matplotlib/matplotlib/assets/59756754/7f65ff18-97aa-40b2-a3c6-af6b2c18a775)

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
