### PR TITLE
Added test_loglog in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -426,11 +426,15 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.imshow(...)
 
-    @pytest.mark.xfail(reason="Test for loglog not written yet")
     @mpl.style.context("default")
     def test_loglog(self):
-        fig, ax = plt.subplots()
-        ax.loglog(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout='constrained')
+        x = np.arange(np.datetime64('1980-12-01'), np.datetime64('2023-12-06'))
+        y = 10 ** np.linspace(0, 4, len(x))
+        ax1.loglog(x, y)
+        ax2.loglog(y, x)
+        ax3.loglog(x, x)
 
     @pytest.mark.xfail(reason="Test for matshow not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->


## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Added the test_loglog method in test_datetime.py 
This PR is for `Axes.loglog` in #26864

![image](https://github.com/matplotlib/matplotlib/assets/50563098/d5c1b17c-8a8a-4bc2-bb7f-2cceb7db1eda)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
