### PR TITLE
Added default kwargs values to figure.suptitle() in rcParams and inheritance for function

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -331,8 +331,8 @@ default: %(va)s
     @_docstring.copy(_suplabels)
     def suptitle(self, t, **kwargs):
         # docstring from _suplabels...
-        info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
-                'ha': 'center', 'va': 'top', 'rotation': 0,
+        info = {'name': '_suptitle', 'x0': 'figure.title_locx', 'y0': 'figure.title_locy',
+                'ha': 'figure.title_ha', 'va': 'figure.title_va', 'rotation': 0,
                 'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
         return self._suplabels(t, info, **kwargs)
 

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -557,6 +557,10 @@
 ## * FIGURE                                                                  *
 ## ***************************************************************************
 ## See https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
+#figure.titleloc_x:  0.5
+#figure.titleloc_y:  0.98
+#figure.titleha:     center
+#figure.titleva:     center
 #figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
 #figure.titleweight: normal    # weight of the figure title
 #figure.labelsize:   large     # size of the figure label (``Figure.sup[x|y]label()``)

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1218,6 +1218,10 @@ _validators = {
     # figure title
     "figure.titlesize":   validate_fontsize,
     "figure.titleweight": validate_fontweight,
+    "figure.title_locx":  validate_float,
+    "figure.title_locy":  validate_float,
+    "figure.title_ha":    ["center", "left", "right"],
+    "figure.title_va":    ["top", "center", "bottom", "baseline"],
 
     # figure labels
     "figure.labelsize":   validate_fontsize,

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -446,3 +446,29 @@ def test_polar_log():
 
     n = 100
     ax.plot(np.linspace(0, 2 * np.pi, n), np.logspace(0, 2, n))
+
+
+def test_polar_rc_params():
+    fig = plt.figure(figsize=(9,3))
+    ax = fig.add_subplot(polar=True)
+
+    ax.set_rscale('log')
+    ax.set_rlim(1, 1000)
+
+    n = 100
+    ax.plot(np.linspace(0, 2 * np.pi, n), np.logspace(0, 2, n))
+
+    plt.subplot(132)
+    plt.scatter(["1", "2"], [3,4])
+    
+    # Control
+    fig.suptitle("First Title", x=0.1, y=0.2, ha="right", va="bottom")
+
+    # Test suptitle
+    with mpl.rc_context({'figure.title_x': 0.1,
+                         'figure.title_y': 0.2,
+                         'figure.title_ha': "right",
+                         'figure.title_va': "bottom",
+                        })
+    
+    fig.suptitle("First Title")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
-->
This PR addresses issue #24090 which requests to added default kwargs parameters to use for function figure.suptitle() in rcParams. Basic default parameters have been added and adapted to use in inheritance. PR needs to be reviewed and can closes #24090. 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #24090" is in the body of the PR description to [[link the related issue](https://github.com/matplotlib/matplotlib/issues/24090)](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

