### PR TITLE
Fix get_path for 3d artists

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -448,6 +448,11 @@ class Patch3D(Patch):
                            for ((x, y), z) in zip(verts, zs)]
 
     def get_path(self):
+        # docstring inherited
+        # self._path2d is not initialized until do_3d_projection
+        if not hasattr(self, '_path2d'):
+            self.axes.M = self.axes.get_proj()
+            self.do_3d_projection()
         return self._path2d
 
     def do_3d_projection(self):

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2112,6 +2112,16 @@ def test_scatter_spiral():
     fig.canvas.draw()
 
 
+def test_Poly3DCollection_get_path():
+    # Smoke test to see that get_path does not raise
+    # See GH#27361
+    fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+    p = Circle((0, 0), 1.0)
+    ax.add_patch(p)
+    art3d.pathpatch_2d_to_3d(p)
+    p.get_path()
+
+
 def test_Poly3DCollection_get_facecolor():
     # Smoke test to see that get_facecolor does not raise
     # See GH#4067


### PR DESCRIPTION
closes #27361

## PR summary
The solution is a slightly adapted version of 1868c05e622ad521efd5671e47eef6bd35e0b8c9 as was suggested by the author @oscargus.

I've added a test for the specific test for the issue which now passes.

## PR checklist

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
