### PR TITLE
Attempted to add test_pcolorfast in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -5,6 +5,7 @@ import pytest
 
 import matplotlib.pyplot as plt
 import matplotlib as mpl
+import matplotlib.dates as dt
 
 
 class TestDatetimePlotting:
@@ -516,11 +517,28 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.pcolor(...)
 
-    @pytest.mark.xfail(reason="Test for pcolorfast not written yet")
     @mpl.style.context("default")
     def test_pcolorfast(self):
+        np.random.seed(19680801)
+
+        '''
+        Directly inputting either datetime.datetime or numpy.datetime64 without using date2num() seems to always generate compile errors for pcolorfast(). 
+        I have used date2num() to ensure that the graph prints correctly despite that such operations may defy the purpose of conducting such tests.
+        '''
+        basedate_x = datetime.datetime(2023, 12, 6, 1, 30, 30)
+        basedate_y = datetime.datetime(2024, 5, 5, 12, 15, 45)
+        dates_x = [dt.date2num(basedate_x + datetime.timedelta(days=1*i, hours=6*i, minutes=20*i,seconds=0)) for i in range(10)]
+        dates_y = [dt.date2num(basedate_y + datetime.timedelta(days=1*i, hours=8*i, minutes=30*i,seconds=0)) for i in range(10)]
+        data = np.random.rand(0, 100)
+
         fig, ax = plt.subplots()
         ax.pcolorfast(...)
+        pc = ax.pcolorfast(dates_x, dates_y, data)
+
+        ax.set_xlabel('Sample datetime')
+        ax.set_ylabel('Sample data')
+        ax.set_title('Sample test case for pcolorfast()')
+        plt.show()
 
     @pytest.mark.xfail(reason="Test for pcolormesh not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -532,7 +532,6 @@ class TestDatetimePlotting:
         data = np.random.rand(0, 100)
 
         fig, ax = plt.subplots()
-        ax.pcolorfast(...)
         pc = ax.pcolorfast(dates_x, dates_y, data)
 
         ax.set_xlabel('Sample datetime')

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -522,13 +522,15 @@ class TestDatetimePlotting:
         np.random.seed(19680801)
 
         '''
-        Directly inputting either datetime.datetime or numpy.datetime64 without using date2num() seems to always generate compile errors for pcolorfast(). 
-        I have used date2num() to ensure that the graph prints correctly despite that such operations may defy the purpose of conducting such tests.
+        Directly inputting either datetime.datetime or numpy.datetime64
+            without using date2num() seems to always generate compile errors for pcolorfast().
+        I have used date2num() to ensure that the graph prints correctly
+            despite that such operations may defy the purpose of conducting such tests.
         '''
         basedate_x = datetime.datetime(2023, 12, 6, 1, 30, 30)
         basedate_y = datetime.datetime(2024, 5, 5, 12, 15, 45)
-        dates_x = [dt.date2num(basedate_x + datetime.timedelta(days=1*i, hours=6*i, minutes=20*i,seconds=0)) for i in range(10)]
-        dates_y = [dt.date2num(basedate_y + datetime.timedelta(days=1*i, hours=8*i, minutes=30*i,seconds=0)) for i in range(10)]
+        dates_x = [dt.date2num(basedate_x + datetime.timedelta(days=1*i, hours=6*i, minutes=20*i)) for i in range(10)]
+        dates_y = [dt.date2num(basedate_y + datetime.timedelta(days=1*i, hours=8*i, minutes=30*i)) for i in range(10)]
         data = np.random.rand(0, 100)
 
         fig, ax = plt.subplots()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Attempted to add code to `test_pcolorfast` in `test_datetime.py` as requested in #26864
Based on my researches and shallow understandings of the code, the original function `pcolorfast()` does not seem to directly support inputs of type `datetime.datetime` or `numpy.datetime64`; therefore I have used `date2num()` to make the graph print correctly.
I am (almost) new to GitHub and entirely new to OSS contributions so I apologize ahead if I have made mistakes or caused trouble. Please feel free to point out my flaws and mistakes so that I can correct them.

The outputted graph is as follows:
![pcolorfast_plot](https://github.com/matplotlib/matplotlib/assets/144465361/3cb11718-c337-404b-8d37-f5a4fc9605eb)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
