### PR TITLE
Check if the mappable is in a different Figure than the one fig.color…

### DIFF
--- a/galleries/users_explain/axes/colorbar_placement.py
+++ b/galleries/users_explain/axes/colorbar_placement.py
@@ -53,7 +53,7 @@ for col in range(2):
 fig, axs = plt.subplots(2, 1, figsize=(4, 5), sharex=True)
 X = np.random.randn(20, 20)
 axs[0].plot(np.sum(X, axis=0))
-axs[1].pcolormesh(X)
+pcm = axs[1].pcolormesh(X)
 fig.colorbar(pcm, ax=axs[1], shrink=0.6)
 
 # %%
@@ -63,7 +63,7 @@ fig.colorbar(pcm, ax=axs[1], shrink=0.6)
 
 fig, axs = plt.subplots(2, 1, figsize=(4, 5), sharex=True, layout='constrained')
 axs[0].plot(np.sum(X, axis=0))
-axs[1].pcolormesh(X)
+pcm = axs[1].pcolormesh(X)
 fig.colorbar(pcm, ax=axs[1], shrink=0.6)
 
 # %%

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1248,8 +1248,6 @@ default: %(va)s
             self_host_fig = self.figure
             if isinstance(mappable_host_fig, mpl.figure.SubFigure):
                 mappable_host_fig = mappable_host_fig.figure
-            if isinstance(self_host_fig, mpl.figure.SubFigure):
-                self_host_fig = self_host_fig.figure
             # Warn in case of mismatch
             if mappable_host_fig is not self_host_fig:
                 _api.warn_external(

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1241,13 +1241,22 @@ default: %(va)s
             # make_axes calls add_{axes,subplot} which changes gca; undo that.
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
-
-        if hasattr(mappable, "figure") and mappable.figure is not self.figure:
-            _api.warn_external(
-                    f'Adding colorbar to a different Figure '
-                    f'{repr(mappable.figure)} than '
-                    f'{repr(self.figure)} which '
-                    f'fig.colorbar is called on.')
+        
+        if hasattr(mappable, "figure"):
+            # Get top level artists
+            mappable_host_fig = mappable.figure
+            self_host_fig = self.figure
+            if isinstance(mappable_host_fig, mpl.figure.SubFigure):
+                mappable_host_fig = mappable_host_fig.figure
+            if isinstance(self_host_fig, mpl.figure.SubFigure):
+                self_host_fig = self_host_fig.figure
+            # Warn in case of mismatch
+            if mappable_host_fig is not self_host_fig:
+                _api.warn_external(
+                        f'Adding colorbar to a different Figure '
+                        f'{repr(mappable.figure)} than '
+                        f'{repr(self.figure)} which '
+                        f'fig.colorbar is called on.')
 
         NON_COLORBAR_KEYS = [  # remove kws that cannot be passed to Colorbar
             'fraction', 'pad', 'shrink', 'aspect', 'anchor', 'panchor']

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1213,6 +1213,7 @@ default: %(va)s
         therefore, this workaround is not used by default (see issue #1188).
 
         """
+        infer_ax = (ax is None) and (cax is None)
 
         if ax is None:
             ax = getattr(mappable, "axes", None)
@@ -1242,11 +1243,10 @@ default: %(va)s
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
 
-        if hasattr(mappable, "figure") and mappable.figure is not self.figure:
-            _log.warning(
-                    'Adding colorbar to a different Figure %s'
-                    ' than %s which fig.colorbar is called on.',
-                    repr(mappable.figure), repr(self.figure))
+        if infer_ax and hasattr(mappable, "figure") and mappable.figure is not self.figure:
+            _api.warn_external(
+                    f'Adding colorbar to a different Figure {repr(mappable.figure)} '
+                    'than {repr(self.figure)} which fig.colorbar is called on.')
 
         NON_COLORBAR_KEYS = [  # remove kws that cannot be passed to Colorbar
             'fraction', 'pad', 'shrink', 'aspect', 'anchor', 'panchor']

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1242,7 +1242,6 @@ default: %(va)s
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
 
-
         if hasattr(mappable, "figure") and mappable.figure is not self.figure:
             _api.warn_external(
                     f'Adding colorbar to a different Figure '

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1241,7 +1241,7 @@ default: %(va)s
             # make_axes calls add_{axes,subplot} which changes gca; undo that.
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
-        
+
         if hasattr(mappable, "figure"):
             # Get top level artists
             mappable_host_fig = mappable.figure

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1242,6 +1242,11 @@ default: %(va)s
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
 
+        if hasattr(mappable, "figure") and mappable.figure is not self.figure:
+            _log.warning(
+                    'Trying to add colorbar to a Figure different '
+                    'than the one fig.colorbar is called on.')
+
         NON_COLORBAR_KEYS = [  # remove kws that cannot be passed to Colorbar
             'fraction', 'pad', 'shrink', 'aspect', 'anchor', 'panchor']
         cb = cbar.Colorbar(cax, mappable, **{

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1244,8 +1244,9 @@ default: %(va)s
 
         if hasattr(mappable, "figure") and mappable.figure is not self.figure:
             _log.warning(
-                    'Trying to add colorbar to a Figure different '
-                    'than the one fig.colorbar is called on.')
+                    'Adding colorbar to a different Figure %s'
+                    ' than %s which fig.colorbar is called on.',
+                    repr(mappable.figure), repr(self.figure))
 
         NON_COLORBAR_KEYS = [  # remove kws that cannot be passed to Colorbar
             'fraction', 'pad', 'shrink', 'aspect', 'anchor', 'panchor']

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1245,11 +1245,10 @@ default: %(va)s
         if hasattr(mappable, "figure") and mappable.figure is not None:
             # Get top level artists
             mappable_host_fig = mappable.figure
-            self_host_fig = self.figure
             if isinstance(mappable_host_fig, mpl.figure.SubFigure):
                 mappable_host_fig = mappable_host_fig.figure
             # Warn in case of mismatch
-            if mappable_host_fig is not self_host_fig:
+            if mappable_host_fig is not self.figure:
                 _api.warn_external(
                         f'Adding colorbar to a different Figure '
                         f'{repr(mappable.figure)} than '

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1242,7 +1242,7 @@ default: %(va)s
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
 
-        if hasattr(mappable, "figure"):
+        if hasattr(mappable, "figure") and mappable.figure is not None:
             # Get top level artists
             mappable_host_fig = mappable.figure
             self_host_fig = self.figure

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1213,7 +1213,6 @@ default: %(va)s
         therefore, this workaround is not used by default (see issue #1188).
 
         """
-        infer_ax = (ax is None) and (cax is None)
 
         if ax is None:
             ax = getattr(mappable, "axes", None)
@@ -1243,10 +1242,13 @@ default: %(va)s
             fig.sca(current_ax)
             cax.grid(visible=False, which='both', axis='both')
 
-        if infer_ax and hasattr(mappable, "figure") and mappable.figure is not self.figure:
+
+        if hasattr(mappable, "figure") and mappable.figure is not self.figure:
             _api.warn_external(
-                    f'Adding colorbar to a different Figure {repr(mappable.figure)} '
-                    'than {repr(self.figure)} which fig.colorbar is called on.')
+                    f'Adding colorbar to a different Figure '
+                    f'{repr(mappable.figure)} than '
+                    f'{repr(self.figure)} which '
+                    f'fig.colorbar is called on.')
 
         NON_COLORBAR_KEYS = [  # remove kws that cannot be passed to Colorbar
             'fraction', 'pad', 'shrink', 'aspect', 'anchor', 'panchor']

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1220,19 +1220,6 @@ def test_colorbar_axes_parmeters():
     fig.draw_without_rendering()
 
 
-def test_colorbar_wrong_figure():
-    # If we decide in the future to disallow calling colorbar() on the "wrong" figure,
-    # just delete this test.
-    fig_tl = plt.figure(layout="tight")
-    fig_cl = plt.figure(layout="constrained")
-    im = fig_cl.add_subplot().imshow([[0, 1]])
-    # Make sure this doesn't try to setup a gridspec-controlled colorbar on fig_cl,
-    # which would crash CL.
-    fig_tl.colorbar(im)
-    fig_tl.draw_without_rendering()
-    fig_cl.draw_without_rendering()
-
-
 def test_colorbar_format_string_and_old():
     plt.imshow([[0, 1]])
     cb = plt.colorbar(format="{x}%")

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1034,8 +1034,9 @@ def test_colorbar_contourf_extend_patches():
         for ax, (extend, levels, hatches) in zip(axs, params):
             cs = ax.contourf(x, y, z, levels, hatches=hatches,
                              cmap=cmap, extend=extend)
-            subfig.colorbar(cs, ax=ax, orientation=orientation, fraction=0.4,
-                            extendfrac=0.2, aspect=5)
+            with pytest.warns(UserWarning, match="different Figure"):
+                subfig.colorbar(cs, ax=ax, orientation=orientation, fraction=0.4,
+                                extendfrac=0.2, aspect=5)
 
 
 def test_negative_boundarynorm():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1034,9 +1034,8 @@ def test_colorbar_contourf_extend_patches():
         for ax, (extend, levels, hatches) in zip(axs, params):
             cs = ax.contourf(x, y, z, levels, hatches=hatches,
                              cmap=cmap, extend=extend)
-            with pytest.warns(UserWarning, match="different Figure"):
-                subfig.colorbar(cs, ax=ax, orientation=orientation, fraction=0.4,
-                                extendfrac=0.2, aspect=5)
+            subfig.colorbar(cs, ax=ax, orientation=orientation, fraction=0.4,
+                            extendfrac=0.2, aspect=5)
 
 
 def test_negative_boundarynorm():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1220,6 +1220,20 @@ def test_colorbar_axes_parmeters():
     fig.draw_without_rendering()
 
 
+def test_colorbar_wrong_figure():
+    # If we decide in the future to disallow calling colorbar() on the "wrong" figure,
+    # just delete this test.
+    fig_tl = plt.figure(layout="tight")
+    fig_cl = plt.figure(layout="constrained")
+    im = fig_cl.add_subplot().imshow([[0, 1]])
+    # Make sure this doesn't try to setup a gridspec-controlled colorbar on fig_cl,
+    # which would crash CL.
+    with pytest.warns(UserWarning, match="different Figure"):
+        fig_tl.colorbar(im)
+    fig_tl.draw_without_rendering()
+    fig_cl.draw_without_rendering()
+
+
 def test_colorbar_format_string_and_old():
     plt.imshow([[0, 1]])
     cb = plt.colorbar(format="{x}%")

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1273,8 +1273,7 @@ def test_subfigure():
     axs = sub[0].subplots(2, 2)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
-    with pytest.warns(UserWarning, match="different Figure"):
-        sub[0].colorbar(pc, ax=axs)
+    sub[0].colorbar(pc, ax=axs)
     sub[0].suptitle('Left Side')
     sub[0].set_facecolor('white')
 
@@ -1321,8 +1320,7 @@ def test_subfigure_ss():
     axs = sub.subplots(2, 2)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
-    with pytest.warns(UserWarning, match="different Figure"):
-        sub.colorbar(pc, ax=axs)
+    sub.colorbar(pc, ax=axs)
     sub.suptitle('Left Side')
 
     ax = fig.add_subplot(gs[1])
@@ -1360,8 +1358,7 @@ def test_subfigure_double():
         ax.set_xlabel('x-label', fontsize=fontsize)
         ax.set_ylabel('y-label', fontsize=fontsize)
         ax.set_title('Title', fontsize=fontsize)
-    with pytest.warns(UserWarning, match="different Figure"):
-        subfigsnest[0].colorbar(pc, ax=axsnest0)
+    subfigsnest[0].colorbar(pc, ax=axsnest0)
 
     subfigsnest[1].suptitle('subfigsnest[1]')
     subfigsnest[1].set_facecolor('g')

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1678,6 +1678,6 @@ def test_warn_colorbar_mismatch():
     with pytest.warns(UserWarning, match="different Figure"):
         fig2.colorbar(im, ax=ax)
     with pytest.warns(UserWarning, match="different Figure"):
-        fig2.colorbar(im, ax=axA) 
+        fig2.colorbar(im, ax=axA)
     with pytest.warns(UserWarning, match="different Figure"):
         fig2.colorbar(im, cax=axB)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1666,17 +1666,18 @@ def test_not_visible_figure():
     buf.seek(0)
     assert '<g ' not in buf.read()
 
+
 def test_warn_colorbar_mismatch():
     fig, ax = plt.subplots()
     fig2, (axA, axB) = plt.subplots(2)
     im = ax.imshow([[1, 2], [3, 4]])
 
-    with pytest.warns(UserWarning, match = "different Figure"):
-        fig2.colorbar(im)   # this should warn
-
-    with warnings.catch_warnings() as mismatch_warn:
-        warnings.simplefilter("error")
-        fig2.colorbar(im, ax=ax)   # this is weird, but should not warn
-        fig2.colorbar(im, ax=axA)  # this should not warn
-        fig2.colorbar(im, cax=axB) # also should not warn
-    assert not mismatch_warn
+    with pytest.warns(UserWarning, match="different Figure"):
+        fig2.colorbar(im)
+    # warn even when the host figure is not inferred
+    with pytest.warns(UserWarning, match="different Figure"):
+        fig2.colorbar(im, ax=ax)
+    with pytest.warns(UserWarning, match="different Figure"):
+        fig2.colorbar(im, ax=axA) 
+    with pytest.warns(UserWarning, match="different Figure"):
+        fig2.colorbar(im, cax=axB)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1671,11 +1671,8 @@ def test_warn_colorbar_mismatch():
     fig2, (axA, axB) = plt.subplots(2)
     im = ax.imshow([[1, 2], [3, 4]])
 
-    with pytest.warns() as mismatch_warn:
+    with pytest.warns(UserWarning, match = "different Figure"):
         fig2.colorbar(im)   # this should warn
-    assert len(mismatch_warn) == 1
-    assert mismatch_warn[0].category is UserWarning
-    assert str(mismatch_warn[0].message).startswith("Adding colorbar to a different Figure")
 
     with warnings.catch_warnings() as mismatch_warn:
         warnings.simplefilter("error")

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1281,8 +1281,7 @@ def test_subfigure():
     axs = sub[1].subplots(1, 3)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
-    with pytest.warns(UserWarning, match="different Figure"):
-        sub[1].colorbar(pc, ax=axs, location='bottom')
+    sub[1].colorbar(pc, ax=axs, location='bottom')
     sub[1].suptitle('Right Side')
     sub[1].set_facecolor('white')
 
@@ -1671,19 +1670,36 @@ def test_not_visible_figure():
 
 
 def test_warn_colorbar_mismatch():
-    fig, ax = plt.subplots()
-    fig2, (axA, axB) = plt.subplots(2)
-    im = ax.imshow([[1, 2], [3, 4]])
+    fig1, ax1 = plt.subplots()
+    fig2, (ax2_1, ax2_2) = plt.subplots(2)
+    im = ax1.imshow([[1, 2], [3, 4]])
 
-    # this should not warn
-    fig.colorbar(im)
-    # warn on an inferred mismatch
+    fig1.colorbar(im)  # should not warn
     with pytest.warns(UserWarning, match="different Figure"):
         fig2.colorbar(im)
     # warn mismatch even when the host figure is not inferred
     with pytest.warns(UserWarning, match="different Figure"):
-        fig2.colorbar(im, ax=ax)
+        fig2.colorbar(im, ax=ax1)
     with pytest.warns(UserWarning, match="different Figure"):
-        fig2.colorbar(im, ax=axA)
+        fig2.colorbar(im, ax=ax2_1)
     with pytest.warns(UserWarning, match="different Figure"):
-        fig2.colorbar(im, cax=axB)
+        fig2.colorbar(im, cax=ax2_2)
+
+    # edge case: only compare top level artist in case of subfigure
+    fig3 = plt.figure()
+    fig4 = plt.figure()
+    subfig3_1 = fig3.subfigures()
+    subfig3_2 = fig3.subfigures()
+    subfig4_1 = fig4.subfigures()
+    ax3_1 = subfig3_1.subplots()
+    ax3_2 = subfig3_1.subplots()
+    ax4_1 = subfig4_1.subplots()
+    im3_1 = ax3_1.imshow([[1,2],[3,4]])
+    im3_2 = ax3_2.imshow([[1,2],[3,4]])
+    im4_1 = ax4_1.imshow([[1,2],[3,4]])
+
+    fig3.colorbar(im3_1)   # should not warn
+    subfig3_1.colorbar(im3_1)   # should not warn
+    subfig3_1.colorbar(im3_2)   # should not warn
+    with pytest.warns(UserWarning, match="different Figure"):
+        subfig3_1.colorbar(im4_1)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1280,7 +1280,8 @@ def test_subfigure():
     axs = sub[1].subplots(1, 3)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
-    sub[1].colorbar(pc, ax=axs, location='bottom')
+    with pytest.warns(UserWarning, match="different Figure"):
+        sub[1].colorbar(pc, ax=axs, location='bottom')
     sub[1].suptitle('Right Side')
     sub[1].set_facecolor('white')
 
@@ -1320,7 +1321,8 @@ def test_subfigure_ss():
     axs = sub.subplots(2, 2)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
-    sub.colorbar(pc, ax=axs)
+    with pytest.warns(UserWarning, match="different Figure"):
+        sub.colorbar(pc, ax=axs)
     sub.suptitle('Left Side')
 
     ax = fig.add_subplot(gs[1])
@@ -1358,8 +1360,8 @@ def test_subfigure_double():
         ax.set_xlabel('x-label', fontsize=fontsize)
         ax.set_ylabel('y-label', fontsize=fontsize)
         ax.set_title('Title', fontsize=fontsize)
-
-    subfigsnest[0].colorbar(pc, ax=axsnest0)
+    with pytest.warns(UserWarning, match="different Figure"):
+        subfigsnest[0].colorbar(pc, ax=axsnest0)
 
     subfigsnest[1].suptitle('subfigsnest[1]')
     subfigsnest[1].set_facecolor('g')
@@ -1672,9 +1674,12 @@ def test_warn_colorbar_mismatch():
     fig2, (axA, axB) = plt.subplots(2)
     im = ax.imshow([[1, 2], [3, 4]])
 
+    # this should not warn
+    fig.colorbar(im)
+    # warn on an inferred mismatch
     with pytest.warns(UserWarning, match="different Figure"):
         fig2.colorbar(im)
-    # warn even when the host figure is not inferred
+    # warn mismatch even when the host figure is not inferred
     with pytest.warns(UserWarning, match="different Figure"):
         fig2.colorbar(im, ax=ax)
     with pytest.warns(UserWarning, match="different Figure"):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1694,9 +1694,9 @@ def test_warn_colorbar_mismatch():
     ax3_1 = subfig3_1.subplots()
     ax3_2 = subfig3_1.subplots()
     ax4_1 = subfig4_1.subplots()
-    im3_1 = ax3_1.imshow([[1,2],[3,4]])
-    im3_2 = ax3_2.imshow([[1,2],[3,4]])
-    im4_1 = ax4_1.imshow([[1,2],[3,4]])
+    im3_1 = ax3_1.imshow([[1, 2], [3, 4]])
+    im3_2 = ax3_2.imshow([[1, 2], [3, 4]])
+    im4_1 = ax4_1.imshow([[1, 2], [3, 4]])
 
     fig3.colorbar(im3_1)   # should not warn
     subfig3_1.colorbar(im3_1)   # should not warn

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1273,7 +1273,8 @@ def test_subfigure():
     axs = sub[0].subplots(2, 2)
     for ax in axs.flat:
         pc = ax.pcolormesh(np.random.randn(30, 30), vmin=-2, vmax=2)
-    sub[0].colorbar(pc, ax=axs)
+    with pytest.warns(UserWarning, match="different Figure"):
+        sub[0].colorbar(pc, ax=axs)
     sub[0].suptitle('Left Side')
     sub[0].set_facecolor('white')
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1665,3 +1665,21 @@ def test_not_visible_figure():
     fig.savefig(buf, format='svg')
     buf.seek(0)
     assert '<g ' not in buf.read()
+
+def test_warn_colorbar_mismatch():
+    fig, ax = plt.subplots()
+    fig2, (axA, axB) = plt.subplots(2)
+    im = ax.imshow([[1, 2], [3, 4]])
+
+    with pytest.warns() as mismatch_warn:
+        fig2.colorbar(im)   # this should warn
+    assert len(mismatch_warn) == 1
+    assert mismatch_warn[0].category is UserWarning
+    assert str(mismatch_warn[0].message).startswith("Adding colorbar to a different Figure")
+
+    with warnings.catch_warnings() as mismatch_warn:
+        warnings.simplefilter("error")
+        fig2.colorbar(im, ax=ax)   # this is weird, but should not warn
+        fig2.colorbar(im, ax=axA)  # this should not warn
+        fig2.colorbar(im, cax=axB) # also should not warn
+    assert not mismatch_warn


### PR DESCRIPTION
…bar is being called on.

Ignore this check if the mappable has no host Figure. Warn in case of a mismatch.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
