### PR TITLE
Fixed _has_alpha_channel function to work with hex and tuple colors

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -231,10 +231,64 @@ def is_color_like(c):
         return True
 
 
+def is_hex_color(c):
+    """
+    (Helper function) Determines if the input string is a
+    hexadecimal number in color format. String must start
+    with # or 0x and have 8 bytes following, 2 for each color
+    and alpha channel.
+    """
+    if not isinstance(c, str):
+        return False
+    if c.startswith('#'):
+        if len(c) != 9:
+            return False
+        c = c[1:]
+    elif c.startswith('0x'):
+        if len(c) != 10:
+            return False
+        c = c[2:]
+    else:
+        return False
+
+    for x in c:
+        if x not in '0123456789abcdefABCDEF':
+            return False
+
+    return True
+
+
+def is_tuple_color(c):
+    """
+    (Helper function) Determines if the input string is a
+    tuple in color format. Tuple must have two values: the
+    first representing the color and the second representing
+    the alpha value.
+    """
+    if not isinstance(c, tuple):
+        return False
+    if len(c) != 2:
+        return False
+
+    color = c[0]
+    if not isinstance(color, str):
+        return False
+    if c != 'r' and c != 'g' and c != 'b':
+        return False
+
+    alpha = c[1]
+    if not isinstance(alpha, float):
+        return False
+    if alpha < 0 or alpha > 1:
+        return False
+
+    return True
+
+
 def _has_alpha_channel(c):
     """Return whether *c* is a color with an alpha channel."""
-    # 4-element sequences are interpreted as r, g, b, a
-    return not isinstance(c, str) and len(c) == 4
+    is_color = not isinstance(c, str) and len(c) == 4
+    return is_color or is_hex_color(c) or is_tuple_color(c)
 
 
 def _check_color_like(**kwargs):


### PR DESCRIPTION
## PR summary
This PR fixes bug #27321. The _has_alpha_channel function didn't work for hex strings and tuples because it just checked for decimal strings of length 4 (RGBA). The new implementation cases on the three different possible inputs (decimal, hex, and tuple) and determines if the input is a valid color that has an alpha channel. For checking hex colors, the function checks if all the symbols are hex values (0-9, A-F), and if the string is the correct length. Since hex values can be represented with the prefix "#" or "0x", the input strings have to be of length 9 or 10 (prefix + 4 bytes or 8 hex values for all channels).

## PR checklist
- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

## Note
This PR doesn't pass the MyPy Stubtest, but passes all of the others. I'm not entirely sure how to get it to pass that, although it doesn't seem like too big of an error.