### PR TITLE
Add test_eventplot to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -260,11 +260,36 @@ class TestDatetimePlotting:
                      uplims=True, xuplims=True,
                      label='Data')
 
-    @pytest.mark.xfail(reason="Test for eventplot not written yet")
     @mpl.style.context("default")
     def test_eventplot(self):
-        fig, ax = plt.subplots()
-        ax.eventplot(...)
+        mpl.rcParams["date.converter"] = "concise"
+
+        fig, (ax1, ax2) = plt.subplots(2, 1, layout="constrained")
+
+        x_dates1 = np.array([
+            datetime.datetime(2020, 6, 30),
+            datetime.datetime(2020, 7, 22),
+            datetime.datetime(2020, 8, 3),
+            datetime.datetime(2020, 9, 14),
+        ], dtype=np.datetime64)
+
+        ax1.eventplot(x_dates1)
+
+        x_dates2 = np.array([
+            [datetime.datetime(2020, 6, 30), datetime.datetime(2020, 7, 22),
+             datetime.datetime(2020, 8, 3), datetime.datetime(2020, 9, 14)],
+            [datetime.datetime(2020, 7, 18), datetime.datetime(2020, 7, 21),
+             datetime.datetime(2020, 8, 3), datetime.datetime(2020, 10, 14)]
+        ], dtype=np.datetime64)
+
+        colors = ['C{}'.format(i) for i in range(2)]
+        lineoffsets = np.array([1, 6])
+        linelengths = [5, 2]
+
+        ax2.eventplot(x_dates2,
+                      colors=colors,
+                      lineoffsets=lineoffsets,
+                      linelengths=linelengths)
 
     @pytest.mark.xfail(reason="Test for fill not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -275,6 +275,8 @@ class TestDatetimePlotting:
 
         ax1.eventplot(x_dates1)
 
+        np.random.seed(19680801)
+
         start_date = datetime.datetime(2020, 7, 1)
         end_date = datetime.datetime(2020, 10, 15)
         date_range = end_date - start_date

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -266,30 +266,31 @@ class TestDatetimePlotting:
 
         fig, (ax1, ax2) = plt.subplots(2, 1, layout="constrained")
 
-        x_dates1 = np.array([
-            datetime.datetime(2020, 6, 30),
-            datetime.datetime(2020, 7, 22),
-            datetime.datetime(2020, 8, 3),
-            datetime.datetime(2020, 9, 14),
-        ], dtype=np.datetime64)
+        x_dates1 = np.array([datetime.datetime(2020, 6, 30),
+                             datetime.datetime(2020, 7, 22),
+                             datetime.datetime(2020, 8, 3),
+                             datetime.datetime(2020, 9, 14),],
+                            dtype=np.datetime64,
+                            )
 
         ax1.eventplot(x_dates1)
 
-        x_dates2 = np.array([
-            [datetime.datetime(2020, 6, 30), datetime.datetime(2020, 7, 22),
-             datetime.datetime(2020, 8, 3), datetime.datetime(2020, 9, 14)],
-            [datetime.datetime(2020, 7, 18), datetime.datetime(2020, 7, 21),
-             datetime.datetime(2020, 8, 3), datetime.datetime(2020, 10, 14)]
-        ], dtype=np.datetime64)
+        start_date = datetime.datetime(2020, 7, 1)
+        end_date = datetime.datetime(2020, 10, 15)
+        date_range = end_date - start_date
 
-        colors = ['C{}'.format(i) for i in range(2)]
-        lineoffsets = np.array([1, 6])
-        linelengths = [5, 2]
+        dates1 = start_date + np.random.rand(30) * date_range
+        dates2 = start_date + np.random.rand(10) * date_range
+        dates3 = start_date + np.random.rand(50) * date_range
 
-        ax2.eventplot(x_dates2,
-                      colors=colors,
-                      lineoffsets=lineoffsets,
-                      linelengths=linelengths)
+        colors1 = ['C1', 'C2', 'C3']
+        lineoffsets1 = np.array([1, 6, 8])
+        linelengths1 = [5, 2, 3]
+
+        ax2.eventplot([dates1, dates2, dates3],
+                      colors=colors1,
+                      lineoffsets=lineoffsets1,
+                      linelengths=linelengths1)
 
     @pytest.mark.xfail(reason="Test for fill not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -264,7 +264,7 @@ class TestDatetimePlotting:
     def test_eventplot(self):
         mpl.rcParams["date.converter"] = "concise"
 
-        fig, (ax1, ax2) = plt.subplots(2, 1, layout="constrained")
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout="constrained")
 
         x_dates1 = np.array([datetime.datetime(2020, 6, 30),
                              datetime.datetime(2020, 7, 22),
@@ -292,6 +292,17 @@ class TestDatetimePlotting:
         ax2.eventplot([dates1, dates2, dates3],
                       colors=colors1,
                       lineoffsets=lineoffsets1,
+                      linelengths=linelengths1)
+
+        lineoffsets2 = np.array([
+            datetime.datetime(2020, 7, 1),
+            datetime.datetime(2020, 7, 15),
+            datetime.datetime(2020, 8, 1)
+        ], dtype=np.datetime64)
+
+        ax3.eventplot([dates1, dates2, dates3],
+                      colors=colors1,
+                      lineoffsets=lineoffsets2,
                       linelengths=linelengths1)
 
     @pytest.mark.xfail(reason="Test for fill not written yet")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
I have added a datetime smoke test/example code under the test_eventplot method in lib/matplotlib/test/test_datetime.py. This addresses the Axes.eventplot task from https://github.com/matplotlib/matplotlib/issues/26864. 

(edited) The plots generated from the latest test code:
![eventplot](https://github.com/matplotlib/matplotlib/assets/87483933/3c0914d8-21b5-4a8d-99d6-16f8564aa0a6)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes task Axes.eventplot in #26864" [link the related issue]
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
