### PR TITLE
Added smoke test for Axes.matshow to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -542,11 +542,16 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.loglog(...)
 
-    @pytest.mark.xfail(reason="Test for matshow not written yet")
     @mpl.style.context("default")
     def test_matshow(self):
+        a = np.diag(range(5))
+        dt_start = datetime.datetime(1980, 4, 15)
+        dt_end = datetime.datetime(2020, 11, 11)
+        extent = (dt_start, dt_end, dt_start, dt_end)
         fig, ax = plt.subplots()
-        ax.matshow(...)
+        ax.matshow(a, extent=extent)
+        for label in ax.get_xticklabels():
+                    label.set_rotation(90)
 
     @pytest.mark.xfail(reason="Test for pcolor not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -551,7 +551,7 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.matshow(a, extent=extent)
         for label in ax.get_xticklabels():
-                    label.set_rotation(90)
+            label.set_rotation(90)
 
     @pytest.mark.xfail(reason="Test for pcolor not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
This PR adds a smoke test for `Axes.matshow` in lib/matplotlib/tests/test_datetime.py and addresses task `Axes.matshow` in issue https://github.com/matplotlib/matplotlib/issues/26864.
Below is the image of the generated plot:

![image](https://github.com/matplotlib/matplotlib/assets/38230539/190bf2c2-3806-45f3-932a-7d680df041dd)

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
