### PR TITLE
Added datetime smoke test for Axes.hexbin

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -435,6 +435,8 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_hexbin(self):
+
+        mpl.rcParams["date.converter"] = 'concise'
         np.random.seed(19680801)
 
         dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),
@@ -748,6 +750,7 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for tripcolor not written yet")
     @mpl.style.context("default")
     def test_tripcolor(self):
+        mpl.rcParams["date.converter"] = 'concise'
         fig, ax = plt.subplots()
         ax.tripcolor(...)
 

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -436,15 +436,18 @@ class TestDatetimePlotting:
     @mpl.style.context("default")
     def test_hexbin(self):
         np.random.seed(19680801)
+
         dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),
                           np.timedelta64(1, 'D'))
-        fig, (ax0, ax1, ax2) = plt.subplots(3, 1, constrained_layout=True)
+        fig, (ax0, ax1, ax2) = plt.subplots(3, 1)
+        fig.set_size_inches(4, 8)
 
         n = dates.shape
+        x = np.random.standard_normal(n)
         y = np.random.standard_normal(n)
-        ax0.hexbin(dates, y, gridsize=10)
-        ax1.hexbin(dates, y, gridsize=10)
-        ax2.hexbin(dates, y, gridsize=10)
+        ax0.hexbin(dates, y, gridsize=(5, 3))
+        ax1.hexbin(x, dates, gridsize=(5, 3))
+        ax2.hexbin(dates, dates, gridsize=(5, 3))
 
     @mpl.style.context("default")
     def test_hist(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -435,8 +435,7 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_hexbin(self):
-
-        mpl.rcParams["date.converter"] = 'concise'
+        mpl.rcParams["date.converter"] = "concise"
         np.random.seed(19680801)
 
         dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -433,11 +433,16 @@ class TestDatetimePlotting:
         ax2.fill_betweenx(y_dates, x_values1, x_values2)
         ax3.fill_betweenx(y_dates, x_dates1, x_dates2)
 
-    @pytest.mark.xfail(reason="Test for hexbin not written yet")
     @mpl.style.context("default")
     def test_hexbin(self):
+        np.random.seed(19680801)
+        dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),
+                          np.timedelta64(1, 'D'))
         fig, ax = plt.subplots()
-        ax.hexbin(...)
+
+        n = dates.shape
+        y = np.random.standard_normal(n)
+        ax.hexbin(dates, y, gridsize=10)
 
     @mpl.style.context("default")
     def test_hist(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -438,11 +438,13 @@ class TestDatetimePlotting:
         np.random.seed(19680801)
         dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),
                           np.timedelta64(1, 'D'))
-        fig, ax = plt.subplots()
+        fig, (ax0, ax1, ax2) = plt.subplots(3, 1, constrained_layout=True)
 
         n = dates.shape
         y = np.random.standard_normal(n)
-        ax.hexbin(dates, y, gridsize=10)
+        ax0.hexbin(dates, y, gridsize=10)
+        ax1.hexbin(dates, y, gridsize=10)
+        ax2.hexbin(dates, y, gridsize=10)
 
     @mpl.style.context("default")
     def test_hist(self):

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -749,7 +749,6 @@ class TestDatetimePlotting:
     @pytest.mark.xfail(reason="Test for tripcolor not written yet")
     @mpl.style.context("default")
     def test_tripcolor(self):
-        mpl.rcParams["date.converter"] = 'concise'
         fig, ax = plt.subplots()
         ax.tripcolor(...)
 

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -435,7 +435,7 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_hexbin(self):
-        mpl.rcParams["date.converter"] = "concise"
+        mpl.rcParams["date.converter"] = 'concise'
         np.random.seed(19680801)
 
         dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),
@@ -443,12 +443,15 @@ class TestDatetimePlotting:
         fig, (ax0, ax1, ax2) = plt.subplots(3, 1)
         fig.set_size_inches(4, 8)
 
-        n = dates.shape
+        n = dates.shape[0]
         x = np.random.standard_normal(n)
         y = np.random.standard_normal(n)
-        ax0.hexbin(dates, y, gridsize=(5, 3))
-        ax1.hexbin(x, dates, gridsize=(5, 3))
-        ax2.hexbin(dates, dates, gridsize=(5, 3))
+        ax0.hexbin(dates, y, marginals=True, gridsize=(10, 6),
+                   extent=[19030, 19680, min(y), max(y)])
+        ax1.hexbin(x, dates, marginals=True, gridsize=(10, 6),
+                   extent=[min(x), max(x), 19030, 19680])
+        ax2.hexbin(dates, dates, marginals=True, gridsize=(10, 6),
+                   extent=[19030, 19900, 19030, 19680])
 
     @mpl.style.context("default")
     def test_hist(self):


### PR DESCRIPTION
## PR summary


This is part of the task to include additional smoke-tests for Axes.<plottype> as outlined in issue #26864
A simple datetime test added for Axes.hexbin (Issue #26864) as sub-task, using only numpy datetimes and adhering to the use of the random seed 19680801.  Three plots generated, one with datetime as x-axis, another with datetime as y-axis, and datetime for both x- and y-axis.

Plots look like the following:
![Screenshot 2023-12-08 at 2 31 51 PM](https://github.com/matplotlib/matplotlib/assets/3753118/05fc9338-00a7-4165-81bc-dd4480063629)



## PR checklist


- [x] "addresses part of #26864" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
