### PR TITLE
Added smoke test for Axes.imshow to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -532,43 +532,13 @@ class TestDatetimePlotting:
 
     @mpl.style.context("default")
     def test_imshow(self):
-        mpl.rcParams["date.converter"] = "concise"
+        fig, ax = plt.subplots()
         a = np.diag(range(5))
-        fig, axes = plt.subplots(nrows=2, ncols=2)
-
-        ax = axes[0, 0]
-        dt_start = datetime.datetime(1980, 4, 15)
-        dt_end = datetime.datetime(2010, 11, 11)
-        extent = (dt_start, dt_end, dt_start, dt_end)
-        ax.imshow(a, extent=extent)
-        for label in ax.get_xticklabels():
-            label.set_rotation(90)
-
-        ax = axes[0, 1]
-        dt_start = datetime.datetime(2010, 4, 15)
-        dt_end = datetime.datetime(2010, 11, 11)
-        extent = (dt_start, dt_end, dt_start, dt_end)
-        ax.imshow(a, extent=extent)
-        for label in ax.get_xticklabels():
-            label.set_rotation(90)
-
-        ax = axes[1, 0]
         dt_start = datetime.datetime(2010, 11, 1)
         dt_end = datetime.datetime(2010, 11, 11)
         extent = (dt_start, dt_end, dt_start, dt_end)
         ax.imshow(a, extent=extent)
-        for label in ax.get_xticklabels():
-            label.set_rotation(90)
-
-        ax = axes[1, 1]
-        dt_start = datetime.datetime(2010, 11, 10)
-        dt_end = datetime.datetime(2010, 11, 11)
-        extent = (dt_start, dt_end, dt_start, dt_end)
-        ax.imshow(a, extent=extent)
-        for label in ax.get_xticklabels():
-            label.set_rotation(90)
-
-        fig.tight_layout()
+        ax.tick_params(axis="x", labelrotation=90)
 
     @pytest.mark.xfail(reason="Test for loglog not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -530,11 +530,45 @@ class TestDatetimePlotting:
                          xmin=0.45,
                          xmax=0.65)
 
-    @pytest.mark.xfail(reason="Test for imshow not written yet")
     @mpl.style.context("default")
     def test_imshow(self):
-        fig, ax = plt.subplots()
-        ax.imshow(...)
+        mpl.rcParams["date.converter"] = "concise"
+        a = np.diag(range(5))
+        fig, axes = plt.subplots(nrows=2, ncols=2)
+
+        ax = axes[0, 0]
+        dt_start = datetime.datetime(1980, 4, 15)
+        dt_end = datetime.datetime(2010, 11, 11)
+        extent = (dt_start, dt_end, dt_start, dt_end)
+        ax.imshow(a, extent=extent)
+        for label in ax.get_xticklabels():
+            label.set_rotation(90)
+
+        ax = axes[0, 1]
+        dt_start = datetime.datetime(2010, 4, 15)
+        dt_end = datetime.datetime(2010, 11, 11)
+        extent = (dt_start, dt_end, dt_start, dt_end)
+        ax.imshow(a, extent=extent)
+        for label in ax.get_xticklabels():
+            label.set_rotation(90)
+
+        ax = axes[1, 0]
+        dt_start = datetime.datetime(2010, 11, 1)
+        dt_end = datetime.datetime(2010, 11, 11)
+        extent = (dt_start, dt_end, dt_start, dt_end)
+        ax.imshow(a, extent=extent)
+        for label in ax.get_xticklabels():
+            label.set_rotation(90)
+
+        ax = axes[1, 1]
+        dt_start = datetime.datetime(2010, 11, 10)
+        dt_end = datetime.datetime(2010, 11, 11)
+        extent = (dt_start, dt_end, dt_start, dt_end)
+        ax.imshow(a, extent=extent)
+        for label in ax.get_xticklabels():
+            label.set_rotation(90)
+
+        fig.tight_layout()
 
     @pytest.mark.xfail(reason="Test for loglog not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
## PR summary
This PR adds a smoke test for `Axes.imshow` in lib/matplotlib/tests/test_datetime.py and addresses task `Axes.imshow` in issue https://github.com/matplotlib/matplotlib/issues/26864. Due to the behavior of `Axes.imshow` with the `mpl.rcParams["date.converter"] = "concise"`, I included year, month, day, and time axis scale plots.
Below is the image of the generated plot:

![image](https://github.com/matplotlib/matplotlib/assets/38230539/660d054b-56a1-404a-b871-38f79196b540)


## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
