### PR TITLE
Fixing Pylab documentation in API interface overview

### DIFF
--- a/galleries/users_explain/figure/api_interfaces.rst
+++ b/galleries/users_explain/figure/api_interfaces.rst
@@ -285,6 +285,11 @@ Appendix: "pylab" interface
 ---------------------------
 
 There is one further interface that is highly discouraged, and that is to
-basically do ``from matplotlib.pyplot import *``.  This allows users to simply
-call ``plot(x, y)``.  While convenient, this can lead to obvious problems if the
-user unwittingly names a variable the same name as a pyplot method.
+basically do ``from matplotlib.pylab import *``. This imports all the
+functions from ``matplotlib.pyplot``, ``numpy``, ``numpy.fft``, ``numpy.linalg``, and
+``numpy.random``, and some additional functions into the global namespace.
+
+Such a pattern is considered bad practice in modern python, as it clutters
+the global namespace. Even more severely, in the case of ``pylab``, this will
+overwrite some builtin functions (e.g. the builtin ``sum`` will be replaced by
+``numpy.sum``), which can lead to unexpected behavior.


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

The Pylab import statement was incorrectly given as `matplotlib.pyplot import *` in the description of the pylab interface  in the Matplotlib API overview, https://matplotlib.org/stable/users/explain/figure/api_interfaces.html#appendix-pylab-interface. 

Replaced `pyplot` with `pylab` and replaced the description accordingly using https://matplotlib.org/stable/api/pylab.html.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #27461"  [link the related issue](https://github.com/matplotlib/matplotlib/issues/27461)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
