### PR TITLE
Added DateTime Test for triplot

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -746,11 +746,18 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.tripcolor(...)
 
-    @pytest.mark.xfail(reason="Test for triplot not written yet")
     @mpl.style.context("default")
     def test_triplot(self):
+        mpl.rcParams["date.converter"] = "concise"
         fig, ax = plt.subplots()
-        ax.triplot(...)
+        np.random.seed(19680801)
+
+        limit_value = 30
+        x_dates = np.array([datetime.datetime(2023, 12, n) for n in range(1, limit_value)])
+        x_dates_converted = mpl.dates.date2num(x_dates)
+        y_data = np.random.rand(limit_value - 1)
+
+        ax.triplot(x_dates_converted, y_data)
 
     @pytest.mark.xfail(reason="Test for violin not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Added code to test_datetime.py in order to test Axes.triplot as requested in https://github.com/matplotlib/matplotlib/issues/26864
Based on my testing, it seems that the triplot function does not support the datetime type, therefore I had to first convert it using date2num() to plot it correctly.

I'm new to this repository and GitHub open source contributions in general, I would appreciate if you provide feedback or if you have any suggestions on how I should proceed.

The outputted graph can be seen below:
![image](https://github.com/matplotlib/matplotlib/assets/61854862/bd8dbc14-5f18-47f4-b674-a13122b6f1bb)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
