### PR TITLE
Adding test for axes.streamplot using datetime

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -694,11 +694,23 @@ class TestDatetimePlotting:
         ax2.step(range(1, N), x)
         ax3.step(x, x)
 
-    @pytest.mark.xfail(reason="Test for streamplot not written yet")
     @mpl.style.context("default")
     def test_streamplot(self):
+        mpl.rcParams["date.converter"] = "concise"
         fig, ax = plt.subplots()
-        ax.streamplot(...)
+
+        np.random.seed(19680801)
+        limit_value = 30
+
+        date_array = np.array(
+                    [datetime.datetime(2023, 12, n) for n in range(1, limit_value)]
+                )
+        date_array_converted = mpl.dates.date2num(date_array)
+        X, Y = np.meshgrid(date_array_converted, np.arange(0, limit_value-1))
+        U = np.random.rand(limit_value-1, limit_value-1)
+        V = np.random.rand(limit_value-1, limit_value-1)
+
+        ax.streamplot(X, Y, U, V)
 
     @mpl.style.context("default")
     def test_text(self):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
I've created a test for Axes.streamplot in test_datetime.py as requested in https://github.com/matplotlib/matplotlib/issues/26864
I tried using the normal datetime.datetime data type and passing that into np.meshgrid. However, it looks like np.meshgrid doesn't accept the datetime type and only accepts numerical arrays. I tried doing some research and looking into np.meshgrid further but could not find any way to pass in an array of datetime values. Therefore, I had to convert the datetime values into numerical values using date2num. This allows it to be passed into np.meshgrid to create the X and Y arrays which are then passed into the streamplot function.

Note: I am new to working with matplotlib and also new to open-source contributions so I would really appreciate your support and advice on this PR.

The outputted graph is as follows:
![image](https://github.com/matplotlib/matplotlib/assets/54194957/80496b82-f888-45b7-b612-11d2f4a408af)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
