### PR TITLE
Defined the test_clabel function in the test_datetime file

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -275,7 +275,8 @@ class TestDatetimePlotting:
         CS = ax.contour(X, Y, Z)
 
         # Input date object to be used as test
-        dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i) for i in range(len(CS.levels))]
+        dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i)
+            for i in range(len(CS.levels))]
 
         ax.clabel(CS, CS.levels, inline=True, fmt=dict(zip(CS.levels, dates)))
 

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -262,39 +262,31 @@ class TestDatetimePlotting:
     @mpl.style.context("default")
     def test_clabel(self):
         # Sample data for contour plot
-        x_start, x_end, x_step = -10.0, 5.0, 0.5
-        y_start, y_end, y_step = -10.0, 5.0, 0.5
+        dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i)
+                for i in range(10)]
 
-        # Trying to generate a contour using dates will either fail when you
-        # do math or fail when generating the contour
+        x_start, x_end, x_step = -10.0, 5.0, 0.5
+        y_start, y_end, y_step = 0, 10, 1
+
         x = np.arange(x_start, x_end, x_step)
         y = np.arange(y_start, y_end, y_step)
-        X, Y = np.meshgrid(x, y)
-        Z = np.sqrt(X**2 + Y**2)
+
+        # In this case, Y axis has dates
+        X, Y = np.meshgrid(x, dates)
+
+        # In this case, X axis has dates
+        #X, Y = np.meshgrid(dates, y)
+
+        rows = len(X)
+        cols = len(X[0])
+
+        z1D = np.arange(rows * cols)
+        Z = z1D.reshape((rows, cols))
 
         fig, ax = plt.subplots()
         CS = ax.contour(X, Y, Z)
 
-        # Input date object to be used as test
-        dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i)
-            for i in range(len(CS.levels))]
-
-        # Passing dates to label the contours directly works as expected
         ax.clabel(CS, CS.levels, inline=True, fmt=dict(zip(CS.levels, dates)))
-        
-        # Set ticks at regular intervals to manually set x axis via dates
-        xinterval = math.floor(len(x)/len(dates)) + 3
-        numXlabels = math.floor(len(x)/xinterval)
-        ax.set_xticks(x[::xinterval])
-
-        # Works, but not readable
-        #labels = dates[:numXlabels:]
-        str_dates = []
-        for i in range(numXlabels):
-            str_dates.append(dates[i].strftime('%Y-%m-%d'))
-        
-        labels = str_dates
-        ax.set_xticklabels(labels)  # Format labels as dates
 
     @pytest.mark.xfail(reason="Test for contour not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -265,7 +265,8 @@ class TestDatetimePlotting:
         x_start, x_end, x_step = -10.0, 5.0, 0.5
         y_start, y_end, y_step = -10.0, 5.0, 0.5
 
-        # Trying to generate a contour using dates will either 
+        # Trying to generate a contour using dates will either fail when you
+        # do math or fail when generating the contour
         x = np.arange(x_start, x_end, x_step)
         y = np.arange(y_start, y_end, y_step)
         X, Y = np.meshgrid(x, y)
@@ -280,17 +281,18 @@ class TestDatetimePlotting:
 
         # Passing dates to label the contours directly works as expected
         ax.clabel(CS, CS.levels, inline=True, fmt=dict(zip(CS.levels, dates)))
+        
+        # Set ticks at regular intervals to manually set x axis via dates
         xinterval = math.floor(len(x)/len(dates)) + 3
         numXlabels = math.floor(len(x)/xinterval)
-
-        ax.set_xticks(x[::xinterval])  # Set ticks at regular intervals
-        str_dates = []
-
-        for i in range(numXlabels):
-            str_dates.append(dates[i].strftime('%Y-%m-%d'))
+        ax.set_xticks(x[::xinterval])
 
         # Works, but not readable
         #labels = dates[:numXlabels:]
+        str_dates = []
+        for i in range(numXlabels):
+            str_dates.append(dates[i].strftime('%Y-%m-%d'))
+        
         labels = str_dates
         ax.set_xticklabels(labels)  # Format labels as dates
 

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -278,7 +278,6 @@ class TestDatetimePlotting:
         dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i) for i in range(len(CS.levels))]
 
         ax.clabel(CS, CS.levels, inline=True, fmt=dict(zip(CS.levels, dates)))
-        plt.show()
 
     @pytest.mark.xfail(reason="Test for contour not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -1,6 +1,6 @@
 import datetime
+import math
 import numpy as np
-
 import pytest
 
 import matplotlib.pyplot as plt
@@ -265,9 +265,9 @@ class TestDatetimePlotting:
         x_start, x_end, x_step = -10.0, 5.0, 0.5
         y_start, y_end, y_step = -10.0, 5.0, 0.5
 
+        # Trying to generate a contour using dates will either 
         x = np.arange(x_start, x_end, x_step)
         y = np.arange(y_start, y_end, y_step)
-
         X, Y = np.meshgrid(x, y)
         Z = np.sqrt(X**2 + Y**2)
 
@@ -278,7 +278,21 @@ class TestDatetimePlotting:
         dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i)
             for i in range(len(CS.levels))]
 
+        # Passing dates to label the contours directly works as expected
         ax.clabel(CS, CS.levels, inline=True, fmt=dict(zip(CS.levels, dates)))
+        xinterval = math.floor(len(x)/len(dates)) + 3
+        numXlabels = math.floor(len(x)/xinterval)
+
+        ax.set_xticks(x[::xinterval])  # Set ticks at regular intervals
+        str_dates = []
+
+        for i in range(numXlabels):
+            str_dates.append(dates[i].strftime('%Y-%m-%d'))
+
+        # Works, but not readable
+        #labels = dates[:numXlabels:]
+        labels = str_dates
+        ax.set_xticklabels(labels)  # Format labels as dates
 
     @pytest.mark.xfail(reason="Test for contour not written yet")
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -259,11 +259,26 @@ class TestDatetimePlotting:
         ax.xaxis.set_major_formatter(mpl.dates.DateFormatter("%Y-%m-%d"))
         ax.set_title('Box plot with datetime data')
 
-    @pytest.mark.xfail(reason="Test for clabel not written yet")
     @mpl.style.context("default")
     def test_clabel(self):
+        # Sample data for contour plot
+        x_start, x_end, x_step = -10.0, 5.0, 0.5
+        y_start, y_end, y_step = -10.0, 5.0, 0.5
+
+        x = np.arange(x_start, x_end, x_step)
+        y = np.arange(y_start, y_end, y_step)
+
+        X, Y = np.meshgrid(x, y)
+        Z = np.sqrt(X**2 + Y**2)
+
         fig, ax = plt.subplots()
-        ax.clabel(...)
+        CS = ax.contour(X, Y, Z)
+
+        # Input date object to be used as test
+        dates = [datetime.datetime(2023, 10, 1) + datetime.timedelta(days=i) for i in range(len(CS.levels))]
+
+        ax.clabel(CS, CS.levels, inline=True, fmt=dict(zip(CS.levels, dates)))
+        plt.show()
 
     @pytest.mark.xfail(reason="Test for contour not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR is one of the issues identified by the larger issue #26864. These changes add a test for the clabel function. I have tested passing datetimes as input labels to the contours and the axis. ~~I could not think of a way nor do I think it to make sense to pass datetime objects as labels to either axis.~~

### Edit: Attempt 3
This time I correctly generate the contour using datetime objects and directly pass it to the clabel function. Passing a contour that was generated where either X or Y values contain datetime objects functions correctly. I simply avoided doing any math related to the inputs to find Z. The [Hovomoller ](https://en.wikipedia.org/wiki/Hovm%C3%B6ller_diagram) diagram @rcomer mentioned helped me visualize how this kind of contour plot with dates would be used which helped me form an example.

Note: I have NOT been able to specify the locations of the labels using the manual kwarg using datetime objects, please see discussion/comments below

Note: I did not use the example where x-axis was used as a date (commented in the code) because it was quite messy, instead I've provided the plot generated when datetime objects are used to set the y-axis of a contour plot.

![download](https://github.com/matplotlib/matplotlib/assets/62535124/26d4bd2b-2593-4fd3-b370-f829740bd9f6)


### Edit: Attempt 2

1. Passing datetime objects to the clabel function works as expected and labels the contours as seen in both the above and below imgs
2. Trying to generate contours using datetime objects and thus have the axis be labeled naturally as you would with numbers fails (any kind of math you do with numpy will fail).
3. You can, however use ax.set_ticks and the ax.set_xticklabels functions, passing datetime objects directly if you wish, to label the x-axis of a contour plot. I do not know however, if this is what the original issue was attempting to test. In any case, the following is the plot produced:

![download1](https://github.com/matplotlib/matplotlib/assets/62535124/f4998987-6275-4778-83c0-1c08bd777d41)

### Original PR summary (Attempt 1)
Here is the image generated by this code:

![download](https://github.com/matplotlib/matplotlib/assets/62535124/12254c67-6ef9-4e5f-b570-d88cb62766bc)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
I have struggled to run pytest due to a circular import issue. Instead, the image of the plot was generated using a separate script.

- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
