### PR TITLE
 test_tripcolor (Issue #26864) plots with datetime on x-axis only , y-axis only, and both x- and y-axis

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -735,11 +735,40 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.tricontourf(...)
 
-    @pytest.mark.xfail(reason="Test for tripcolor not written yet")
     @mpl.style.context("default")
     def test_tripcolor(self):
-        fig, ax = plt.subplots()
-        ax.tripcolor(...)
+        mpl.rcParams["date.converter"] = 'concise'
+        plt.style.use('_mpl-gallery-nogrid')
+
+        fig, (ax, ax1, ax2) = plt.subplots(3, 1, figsize=(6, 4))
+        dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2023-12-31'),
+                          np.timedelta64(1, 'D'))
+        n = 256
+        np.random.seed(19680801)
+        xz = np.random.uniform(-3, 3, n)
+        yz = np.random.uniform(-3, 3, n)
+        zz = (1 - xz / 2 + xz ** 5 + yz ** 3) * np.exp(-xz ** 2 - yz ** 2)
+
+        # Randomly sample n dates for x-axis and different y values than above
+        x_rand_dates = np.random.choice(dates, n, replace=False)
+        y = np.random.uniform(-3, 3, n)
+
+        # Randomly sample n dates for the y-axis and different x values than above
+        x = np.random.uniform(-3, 3, n)
+        y_rand_dates = np.random.choice(dates, n, replace=False)
+
+        # plot:
+        ax.plot(x_rand_dates, y, 'o', markersize=2, color='grey')
+        ax.tripcolor(x_rand_dates, y, zz)
+        ax1.plot(x, y_rand_dates, 'o', markersize=2, color='grey')
+        ax1.tripcolor(x, y_rand_dates, zz)
+        ax2.plot(x_rand_dates, y_rand_dates, 'o', markersize=2, color='grey')
+        ax2.tripcolor(x_rand_dates, y_rand_dates, zz)
+        ax.set(xlim=(min(x_rand_dates), max(x_rand_dates)), ylim=(min(y), max(y)))
+        ax1.set(xlim=(min(x), max(x)), ylim=(min(y_rand_dates), max(y_rand_dates)))
+        ax2.set(xlim=(min(x_rand_dates), max(x_rand_dates)), ylim=(min(y_rand_dates),
+                                                                   max(y_rand_dates)))
+        fig.tight_layout()
 
     @pytest.mark.xfail(reason="Test for triplot not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION


<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Added code to test the tripcolor plotting with np.datetimes, based on the tripcolor(x,y,z) example in the Matplotlib user documentation.  This is one of the numerous sub-tasks identified for testing various Axes._plottype_ ( where plottype= hist, scatter, violin, etc.) described in issue #26864

Generated plots look like the following:

![Screenshot 2023-12-09 at 8 12 26 PM](https://github.com/matplotlib/matplotlib/assets/3753118/6aaba4be-b7d9-4fc1-9b39-7949774abbb3)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "part of issue #26864" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [NA] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
