### PR TITLE
Added test for tricontour in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -734,11 +734,19 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.tricontour(...)
 
-    @pytest.mark.xfail(reason="Test for tricontourf not written yet")
     @mpl.style.context("default")
-    def test_tricontourf(self):
-        fig, ax = plt.subplots()
-        ax.tricontourf(...)
+    def test_tricontour(self):
+        mpl.rcParams["date.converter"] = "concise"
+        fig, ax = plt.subplots()       
+        range_threshold = 10
+        np.random.seed(19680801)
+        x_dates = np.array(
+            [datetime.datetime(2023, 10, n) for n in range(1, range_threshold)]
+        )
+        x_dates_numeric = mpl.dates.date2num(x_dates)
+        y_data = np.random.rand(range_threshold - 1) * range_threshold
+        z_data = np.sin(x_dates_numeric) + y_data**2
+
 
     @pytest.mark.xfail(reason="Test for tripcolor not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
This PR addresses the tricontour task in the Increase Unit Test Coverage Issue: https://github.com/matplotlib/matplotlib/issues/26864. 
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
