### PR TITLE
Add test_boxplot to test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -171,11 +171,32 @@ class TestDatetimePlotting:
         ax2.set_ylabel('Order of Birth Dates')
         ax2.barh(np.arange(4), birth_date-year_start, left=year_start)
 
-    @pytest.mark.xfail(reason="Test for boxplot not written yet")
     @mpl.style.context("default")
     def test_boxplot(self):
-        fig, ax = plt.subplots()
-        ax.boxplot(...)
+        mpl.rcParams["date.converter"] = "concise"
+
+        fig, (ax1, ax2) = plt.subplots(2, 1, layout="constrained")
+
+        dates1 = [
+            datetime(2023, 1, 1),
+            datetime(2023, 1, 10),
+            datetime(2023, 1, 15),
+            datetime(2023, 1, 20)
+        ]
+
+        time_diffs = [(date - min(dates1)).total_seconds() for date in dates1]
+
+        ax1.boxplot(time_diffs)
+
+        np.random.seed(19680801)
+
+        dates2 = [datetime(2023, 1, 1) +
+                  datetime.timedelta(days=np.random.randint(1, 365))
+                  for _ in range(100)]
+
+        timestamps = [(date - datetime(1970, 1, 1)).total_seconds() for date in dates2]
+
+        ax2.boxplot(timestamps)
 
     @pytest.mark.xfail(reason="Test for broken_barh not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

I have added a datetime smoke test/example code under the test_boxplot method in lib/matplotlib/test/test_datetime.py. This addresses the Axes.boxplot task from https://github.com/matplotlib/matplotlib/issues/26864.

Here, since the statistical measures in boxplots don't translate well to dates, we convert dates to physical units.
(Using advice from @ksunden 's comment on #27485)

The plots generated from the latest test code:
![boxplot](https://github.com/matplotlib/matplotlib/assets/87483933/e03564df-a00a-4bd8-9da0-2fb271261160)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes task Axes.boxplot in #26864"
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
