### PR TITLE
Fix docs and add tests for transform and deprecate `BboxTransformToMaxOnly`

### DIFF
--- a/doc/api/next_api_changes/deprecations/27513-OG.rst
+++ b/doc/api/next_api_changes/deprecations/27513-OG.rst
@@ -1,0 +1,5 @@
+``BboxTransformToMaxOnly``
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... is deprecated without replacement. If you rely on this, please make a copy of the
+code.

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -1054,3 +1054,21 @@ def test_transformedbbox_contains():
     assert bb.contains(1.25, 1.5)
     assert not bb.fully_contains(1.25, 1.5)
     assert not bb.fully_contains(.1, .1)
+
+
+def test_interval_contains():
+    assert mtransforms.interval_contains((0, 1), 0.5)
+    assert mtransforms.interval_contains((0, 1), 0)
+    assert mtransforms.interval_contains((0, 1), 1)
+    assert not mtransforms.interval_contains((0, 1), -1)
+    assert not mtransforms.interval_contains((0, 1), 2)
+    assert mtransforms.interval_contains((1, 0), 0.5)
+
+
+def test_interval_contains_open():
+    assert mtransforms.interval_contains_open((0, 1), 0.5)
+    assert not mtransforms.interval_contains_open((0, 1), 0)
+    assert not mtransforms.interval_contains_open((0, 1), 1)
+    assert not mtransforms.interval_contains_open((0, 1), -1)
+    assert not mtransforms.interval_contains_open((0, 1), 2)
+    assert mtransforms.interval_contains_open((1, 0), 0.5)

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2617,6 +2617,7 @@ class BboxTransformTo(Affine2DBase):
         return self._mtx
 
 
+@_api.deprecated("3.9")
 class BboxTransformToMaxOnly(BboxTransformTo):
     """
     `BboxTransformToMaxOnly` is a transformation that linearly transforms points from

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2619,7 +2619,7 @@ class BboxTransformTo(Affine2DBase):
 
 class BboxTransformToMaxOnly(BboxTransformTo):
     """
-    `BboxTransformTo` is a transformation that linearly transforms points from
+    `BboxTransformToMaxOnly` is a transformation that linearly transforms points from
     the unit bounding box to a given `Bbox` with a fixed upper left of (0, 0).
     """
     def get_matrix(self):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

One may consider deprecating `BboxTransformToMaxOnly` as it is not used in the code base. But at least the doc-string should be correct.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
