### PR TITLE
Add axes.violinplot test from test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -845,21 +845,29 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         result = ax.violinplot(values, positions=[datetime(2023, 1, 10)], widths=[
                                timedelta(days=10)], showmeans=True, showextrema=True)
+        assert isinstance(result, dict), "Failed to create violin plot"
+        assert 'bodies' in result, "Violin plot bodies are missing"
+        assert len(result['bodies']) > 0, "Violin plot bodies are empty"
         result1 = ax.violinplot(values, positions=[datetime(2023, 1, 15)], widths=[
                                 timedelta(days=6)], showmeans=True, showextrema=True)
+        assert isinstance(result1, dict), "Failed to create violin plot"
+        assert 'bodies' in result1, "Violin plot bodies are missing"
+        assert len(result1['bodies']) > 0, "Violin plot bodies are empty"
         result2 = ax.violinplot(values, positions=[datetime(2023, 1, 25)], widths=[
                                 timedelta(days=12)], showmeans=True, showextrema=True)
+        assert isinstance(result2, dict), "Failed to create violin plot"
+        assert 'bodies' in result2, "Violin plot bodies are missing"
+        assert len(result2['bodies']) > 0, "Violin plot bodies are empty"
         result3 = ax.violinplot(values, positions=[datetime(2023, 2, 5)], widths=[
                                 timedelta(days=8)], showmeans=True, showextrema=True)
+        assert isinstance(result3, dict), "Failed to create violin plot"
+        assert 'bodies' in result3, "Violin plot bodies are missing"
+        assert len(result3['bodies']) > 0, "Violin plot bodies are empty"
         ax.set_title(
             'Violin Plot with DateTime Positions and Timedelta Widths')
         ax.set_xlabel('Dates')
         ax.set_ylabel('Values')
         plt.xticks(rotation=90)
-        assert isinstance(result, dict)
-        assert isinstance(result1, dict)
-        assert isinstance(result2, dict)
-        assert isinstance(result3, dict)
         assert result is not None, "Failed to create violin plot"
 
     @mpl.style.context("default")

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -835,12 +835,6 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.violin(...)
 
-    @pytest.mark.xfail(reason="Test for violinplot not written yet")
-    @mpl.style.context("default")
-    def test_violinplot(self):
-        fig, ax = plt.subplots()
-        ax.violinplot(...)
-
     @mpl.style.context("default")
     def test_vlines(self):
         mpl.rcParams["date.converter"] = 'concise'

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -835,6 +835,32 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.violin(...)
 
+    @pytest.mark.xfail(reason="Test for violinplot not written yet")
+    @mpl.style.context("default")
+    def test_violinplot(self):
+        np.random.seed(19680801)
+        n_samples = 100
+        values = np.random.randn(n_samples)
+        fig, ax = plt.subplots()
+        result = ax.violinplot(values, positions=[datetime(2023, 1, 10)], widths=[
+                               timedelta(days=10)], showmeans=True, showextrema=True)
+        result1 = ax.violinplot(values, positions=[datetime(2023, 1, 15)], widths=[
+                                timedelta(days=6)], showmeans=True, showextrema=True)
+        result2 = ax.violinplot(values, positions=[datetime(2023, 1, 25)], widths=[
+                                timedelta(days=12)], showmeans=True, showextrema=True)
+        result3 = ax.violinplot(values, positions=[datetime(2023, 2, 5)], widths=[
+                                timedelta(days=8)], showmeans=True, showextrema=True)
+        ax.set_title(
+            'Violin Plot with DateTime Positions and Timedelta Widths')
+        ax.set_xlabel('Dates')
+        ax.set_ylabel('Values')
+        plt.xticks(rotation=90)
+        assert isinstance(result, dict)
+        assert isinstance(result1, dict)
+        assert isinstance(result2, dict)
+        assert isinstance(result3, dict)
+        assert result is not None, "Failed to create violin plot"
+    
     @mpl.style.context("default")
     def test_vlines(self):
         mpl.rcParams["date.converter"] = 'concise'

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -861,7 +861,7 @@ class TestDatetimePlotting:
         assert isinstance(result2, dict)
         assert isinstance(result3, dict)
         assert result is not None, "Failed to create violin plot"
-    
+
     @mpl.style.context("default")
     def test_vlines(self):
         mpl.rcParams["date.converter"] = 'concise'

--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -1,4 +1,5 @@
 import datetime
+from datetime import timedelta
 import numpy as np
 
 import pytest


### PR DESCRIPTION
## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR is modeled for #26864 ``Axes.violinplot``.

Image of generated plot:

![image](https://github.com/matplotlib/matplotlib/assets/96572616/b6df0f39-98a7-4c05-bbc6-4b8474c34bcc)
