### PR TITLE
Changes for stale GHA v9

### DIFF
--- a/.github/workflows/stale-tidy.yml
+++ b/.github/workflows/stale-tidy.yml
@@ -1,0 +1,23 @@
+name: 'Close inactive issues'
+on:
+  schedule:
+    - cron: '30 1 * * 2,4,6'
+
+jobs:
+  stale:
+    if: github.repository == 'matplotlib/matplotlib'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          operations-per-run: 300
+          days-before-stale: -1
+          stale-pr-label: "status: inactive"
+          days-before-pr-close: -1
+          stale-issue-label: "status: inactive"
+          close-issue-label: "status: closed as inactive"
+          days-before-issue-close: 30
+          ascending: true
+          exempt-issue-labels: "keep"
+          exempt-pr-labels: "keep,status: orphaned PR"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -8,10 +8,10 @@ jobs:
     if: github.repository == 'matplotlib/matplotlib'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v8
+      - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          operations-per-run: 150
+          operations-per-run: 20
           stale-pr-message: 'Since this Pull Request has not been updated in 60 days, it has been marked "inactive." This does not mean that it will be closed, though it may be moved to a "Draft" state.  This helps maintainers prioritize their reviewing efforts. You can pick the PR back up anytime - please ping us if you need a review or guidance to move the PR forward!  If you do not plan on continuing the work, please let us know so that we can either find someone to take the PR over, or close it.'
           stale-pr-label: "status: inactive"
           days-before-pr-stale: 60


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Since nobody objected to my comment at https://github.com/matplotlib/matplotlib/pull/27495#issuecomment-1851841617, I went ahead and implemented that.

For the existing workflow
* reduced `operations-per-run` to 20.  If I've done this right, that means we get a maximum of five issues/PRs labelled as inactive for each run, and so max 15 per week.
* bumped the action version to 9, so supercedes and closes #27495.

Because the existing workflow won't get around to checking the issues it already labelled for a long time, add a new workflow to tidy up after the first one.  The difference between the two workflows is:

```diff
< name: 'Label inactive PRs'
---
> name: 'Close inactive issues'
4c4
<     - cron: '30 1 * * 1,3,5'
---
>     - cron: '30 1 * * 2,4,6'
14,15c14,15
<           operations-per-run: 20
<           stale-pr-message: 'Since this Pull Request has not been updated in 60 days, it has been marked "inactive." This does not mean that it will be closed, though it may be moved to a "Draft" state.  This helps maintainers prioritize their reviewing efforts. You can pick the PR back up anytime - please ping us if you need a review or guidance to move the PR forward!  If you do not plan on continuing the work, please let us know so that we can either find someone to take the PR over, or close it.'
---
>           operations-per-run: 300
>           days-before-stale: -1
17d16
<           days-before-pr-stale: 60
19d17
<           stale-issue-message: 'This issue has been marked "inactive" because it has been 365 days since the last comment. If this issue is still present in recent Matplotlib releases, or the feature request is still wanted, please leave a comment and this label will be removed. If there are no updates in another 30 days, this issue will be automatically closed, but you are free to re-open or create a new issue if needed. We value issue reports, and this procedure is meant to help us resurface and prioritize issues that have not been addressed yet, not make them disappear.  Thanks for your help!'
22d19
<           days-before-issue-stale: 365
```

* Setting `days-before-stale` to a negative number means the new workflow [does not add the label to any issues or PRs](https://github.com/actions/stale#days-before-stale) and therefore does not need the messages.
* I deliberately set the `operations-per-run` high (though the specific choice of 300 is a bit arbitrary) so the workflow will check through all the currently labelled item fairly quickly.  It should only generate notifications when it finds an issue that has had the label for a month, so shouldn't be too noisy regardless of how high we set this number.

I do not really like the copy/paste nature of this change, but can't currently see a better way.  Hopefully we will eventually clear the backlog of old issues, at which point we can just bump up the `operations-per-run` in the original workflow and remove the extra one.

The upside of all this is that I think we should see more steady progress through the issue backlog.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
