### PR TITLE
FIX: Add macos timers to the main thread

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1726,11 +1726,15 @@ Timer__timer_start(Timer* self, PyObject* args)
     }
 
     // hold a reference to the timer so we can invalidate/stop it later
-    self->timer = [NSTimer scheduledTimerWithTimeInterval: interval
-                                            repeats: !single
-                                              block: ^(NSTimer *timer) {
+    self->timer = [NSTimer timerWithTimeInterval: interval
+                                         repeats: !single
+                                           block: ^(NSTimer *timer) {
         gil_call_method((PyObject*)self, "_on_timer");
     }];
+    // Schedule the timer on the main run loop which is needed
+    // when updating the UI from a background thread
+    [[NSRunLoop mainRunLoop] addTimer: self->timer forMode: NSRunLoopCommonModes];
+
 exit:
     Py_XDECREF(py_interval);
     Py_XDECREF(py_single);


### PR DESCRIPTION
## PR summary
The macos timers need to be explicitly added to the main runloop so the drawing takes place there. This causes issues if updating data from other threads and wanting the plot to update.

Fixed previously in: https://github.com/matplotlib/matplotlib/pull/25553
Which then had a regression via: https://github.com/matplotlib/matplotlib/pull/26022 which apparently uses a method that puts the timer onto the currently active thread rather than the main one. So, we need to explicitly add the timer to the main runloop.

I tried adding this as an interactive test, but couldn't get it to trigger the draws properly from the subprocess (not sure if it is because we need to set something up differently when running as `python -i` from a subprocess?). Any thoughts folks have for how to test this so we don't regress again would be welcome.

Same example to manually test with. Save to file, and run with `python -i testfile.py`. I get a segfault currently trying to draw from a separate thread, and this updates as expected now.

```python
import random
import time
import threading
import matplotlib as mpl
import matplotlib.pyplot as plt


class Plot:

    def __init__(self):
        plt.ion()
        self.start = time.time()
        self.xdata = []
        self.ydata = []
        self.running = None
        fig = plt.figure()
        mpl.rcParams["figure.raise_window"] = True
        plt.show()
        self.axis = fig.add_subplot(111)
        self.line, = self.axis.plot([])
        threading.Thread(target=self.worker).start()

    def worker(self):
        for _ in range(50):
            self.xdata.append(len(self.xdata))
            self.ydata.append(random.random())
            self.axis.set_xlim(0, len(self.xdata))
            self.axis.set_ylim(0, max(self.ydata))
            self.line.set_data(self.xdata, self.ydata)
            time.sleep(0.1)
        print(time.time() - self.start)


if __name__ == '__main__':
    Plot()
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [thoughts welcome] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
