### PR TITLE
FIX: Remove runloop execution while waiting for stdin

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -89,9 +89,6 @@ static int wait_for_stdin() {
                 if (!event) { break; }
                 [NSApp sendEvent: event];
             }
-            // We need to run the run loop for a short time to allow the
-            // events to be processed and keep flushing them while we wait for stdin
-            [[NSRunLoop currentRunLoop] runUntilDate: [NSDate dateWithTimeIntervalSinceNow: 0.01]];
         }
         // Remove the input handler as an observer
         [[NSNotificationCenter defaultCenter] removeObserver: stdinHandle];


### PR DESCRIPTION
## PR summary

This would slow down the typing at a command prompt while waiting for stdin from the programs because each character would bounce for 0.01 seconds adding up to a noticeable slowdown when piping in characters from an external source. I _thought_ this was needed while I was testing which is why I added that comment, but I just went through a few interactive test cases including the one from https://github.com/matplotlib/matplotlib/issues/26869 which all still worked interactively, and updated the display as expected. So I think we can safely remove it, but I'm not 100% on that.

The only way I could get this to fail was to interactively from my IDE "shift+enter" on the code blocks so that input was piped in. Is there a way to get that same effect in the interactive tests so we could add it there? Some quick tests with `p.communicate()` didn't slow it down for me in a script.

closes #27515

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [open to suggestions] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
