### PR TITLE
Resolving: Add setter/getter methods for all keyword parameters to Figure.__init__ (Issue: #24617)

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2435,7 +2435,7 @@ class SubFigure(FigureBase):
 
 
 @_docstring.interpd
-@_api._define_aliases({
+@_api.define_aliases({
     "size_inches": ["figsize"],
     "layout_engine": ["layout"]
 })

--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -244,6 +244,13 @@ class FigureBase(Artist):
         gridspec_kw: dict[str, Any] | None = ...,
     ) -> dict[Hashable, Axes]: ...
 
+    def set_subplotparams(
+            self,
+            subplotparams: SubplotParams | dict[str, Any] = ...,
+    ) -> None: ...
+
+    def get_subplotparams(self) -> SubplotParams: ...
+
 class SubFigure(FigureBase):
     figure: Figure
     subplotpars: SubplotParams

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1652,6 +1652,45 @@ def test_get_constrained_layout_pads():
         assert fig.get_constrained_layout_pads() == expected
 
 
+def test_get_subplot_params():
+    fig = plt.figure()
+    subplotparams_keys = ["left", "bottom", "right", "top", "wspace", "hspace"]
+    subplotparams = fig.get_subplotparams()
+    test_dict = {}
+    for key in subplotparams_keys:
+        attr = getattr(subplotparams, key)
+        assert attr == mpl.rcParams[f"figure.subplot.{key}"]
+        test_dict[key] = attr * 2
+
+    fig.set_subplotparams(test_dict)
+    for key, value in test_dict.items():
+        assert getattr(fig.get_subplotparams(), key) == value
+
+    test_dict['foo'] = 'bar'
+    with pytest.warns(UserWarning,
+                      match="'foo' is not a valid key for set_subplotparams;"
+                      " this key was ignored"):
+        fig.set_subplotparams(test_dict)
+
+    with pytest.raises(TypeError,
+                       match="subplotparams must be a dictionary of "
+                       "keyword-argument pairs or "
+                       "an instance of SubplotParams()"):
+        fig.set_subplotparams(['foo'])
+
+    assert fig.subplotpars == fig.get_subplotparams()
+
+
+def test_fig_get_set():
+    varnames = filter(lambda var: var not in ['self', 'kwargs', 'args'],
+                      Figure.__init__.__code__.co_varnames)
+    fig = plt.figure()
+    for var in varnames:
+        # if getattr fails then the getter and setter does not exist
+        getfunc = getattr(fig, f"get_{var}")
+        setfunc = getattr(fig, f"set_{var}")
+
+
 def test_not_visible_figure():
     fig = Figure()
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

This PR adds aliasing for layout, figsize and adds getter and setter methods for subplotparams. 
It resolves #24617. The PR utilized #21549 and #25901. 

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

