### PR TITLE
Added test for tricontour 

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -5,7 +5,7 @@ import pytest
 
 import matplotlib.pyplot as plt
 import matplotlib as mpl
-
+import matplotlib.tri as tri
 
 class TestDatetimePlotting:
     @mpl.style.context("default")
@@ -805,11 +805,42 @@ class TestDatetimePlotting:
         ax3.plot(x_dates, y_dates)
         ax3.text(test_date, test_date, "Inserted Text", **font_properties)
 
-    @pytest.mark.xfail(reason="Test for tricontour not written yet")
     @mpl.style.context("default")
     def test_tricontour(self):
-        fig, ax = plt.subplots()
-        ax.tricontour(...)
+ 
+        # make unequailly distributed data points:
+
+        dates = np.arange(np.datetime64('2022-01-01'), np.datetime64('2022-12-28'),
+                         np.timedelta64(1,'D'))
+        n = len(dates)
+        np.random.seed(19680801)
+        indx  = np.array(np.random.random_sample(n//2)*n, dtype='int')
+        np.random.seed(100)
+        indy  = np.array(np.random.random_sample(n//2)*n, dtype='int')
+        x = indx - n/2.
+        y = indy - n/2.
+        z = x**2 + y**2 - x/4.
+        levels = np.linspace(z.min(), z.max(), 5)
+        dates_x = dates[indx]
+        dates_y = dates[indy]
+        
+        # plot:
+        fig, (ax0, ax1, ax2) = plt.subplots(1,3, figsize=(20, 5))
+        # dates on y axis
+        ax0.plot(x, dates_y, 'o', markersize=2, color='lightgrey')
+        ax0.tricontour(x, dates_y, z, levels=levels)
+        ax0.tick_params('y',labelrotation=45)
+        # dates on x axis         
+        ax1.plot(dates_x, y, 'o', markersize=2, color='lightgrey')
+        ax1.tricontour(dates_x, y, z, levels=levels)
+        ax1.tick_params('x',labelrotation=45)
+        # dates on x and y axes        
+        ax2.plot(dates_x, dates_y, 'o', markersize=2, color='lightgrey')
+        ax2.tricontour(dates_x, dates_y, z, levels=levels)
+        ax2.tick_params(labelrotation=45)
+
+        fig.tight_layout()
+        plt.show()
 
     @pytest.mark.xfail(reason="Test for tricontourf not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Added 3 tests for tricontour (issue <https://github.com/matplotlib/matplotlib/issues/26864>): datetime on y only, on x only and on x and y axes 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
