### PR TITLE
add test_quiver in test_datetime.py

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -464,11 +464,23 @@ class TestDatetimePlotting:
         ax2.plot_date(x_dates, y_ranges)
         ax3.plot_date(x_ranges, y_dates)
 
-    @pytest.mark.xfail(reason="Test for quiver not written yet")
     @mpl.style.context("default")
     def test_quiver(self):
-        fig, ax = plt.subplots()
-        ax.quiver(...)
+        range_threshold = 10
+        fig, (ax1, ax2, ax3) = plt.subplots(3, 1, layout="constrained")
+
+        x_dates = [datetime.datetime(2023, 11, 1) + datetime.timedelta(days=i) for i in range(range_threshold)]
+
+        y_dates = [datetime.datetime(2023, 12, 1) + datetime.timedelta(days=i) for i in range(range_threshold)]
+        x_ranges = np.array(range(range_threshold))
+        y_ranges = np.array(range(range_threshold))
+
+        U = np.sin(np.arange(len(x_dates)))
+        V = np.cos(np.arange(len(y_dates)))
+
+        ax1.quiver(x_dates, y_ranges, U, V, scale=20)
+        ax2.quiver(x_ranges, y_dates, U, V, scale=20)
+        ax3.quiver(x_dates, y_dates, U, V, scale=20)
 
     @pytest.mark.xfail(reason="Test for quiverkey not written yet")
     @mpl.style.context("default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
I have added a datetime smoketest for **Axes.quiver** to lib/matplotlib/tests/test_datetime.py. as requested in [#26864](https://github.com/matplotlib/matplotlib/issues/26864)

It seems like Axes.quiver() allows datatime as the types of parameter X and Y.

I also tested whether U and V can accept the values of the datetime / timedelta, and the answer is no. Firstly, since U and V represent the x and y directional components of the arrow vector, the datetime type seems meaningless. Secondly, after testing, the same bug [#27500 ](https://github.com/matplotlib/matplotlib/issues/27500) will appear, requiring the use of dates.date 2num() for type conversion

(It's my first time actively participating in an open-source project, and I've just opened my first pull request. I've conscientiously adhered to the contributing guidelines throughout the implementation process, and I appreciate your understanding in case of any unintentional mistakes.)

Below is an image of the plot generated from this example code.
![test_quiver](https://github.com/matplotlib/matplotlib/assets/100711005/83188c8c-f086-4a32-8589-4d5af033ff71)




## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
