### PR TITLE
DOC: typo fix in contribute doc

### DIFF
--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -249,7 +249,7 @@ you can:
 - Write or update an :ref:`example plot <gallery>`
 - Write or update a comprehensive :ref:`tutorial <tutorials>`
 
-Our code is documented inline in the source code files in :file:`matplotlib\lib`.
+Our code is documented inline in the source code files in :file:`matplotlib/lib`.
 Our website structure mirrors our folder structure, meaning that a narrative
 document's URL roughly corresponds to its location in our folder structure:
 


### PR DESCRIPTION
Accidentally used \ rather than / for a `` :file:`matplotlib/lib` `` so the \ didn't get rendered.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
