### PR TITLE
MNT: arghandling subplotspec

### DIFF
--- a/lib/matplotlib/gridspec.py
+++ b/lib/matplotlib/gridspec.py
@@ -484,7 +484,12 @@ class GridSpecFromSubplotSpec(GridSpecBase):
         """
         self._wspace = wspace
         self._hspace = hspace
-        self._subplot_spec = subplot_spec
+        if isinstance(subplot_spec, SubplotSpec):
+            self._subplot_spec = subplot_spec
+        else:
+            raise TypeError(
+                            "subplot_spec must be type SubplotSpec, "
+                            "usually from GridSpec, or axes.get_subplotspec.")
         self.figure = self._subplot_spec.get_gridspec().figure
         super().__init__(nrows, ncols,
                          width_ratios=width_ratios,

--- a/lib/matplotlib/tests/test_gridspec.py
+++ b/lib/matplotlib/tests/test_gridspec.py
@@ -1,4 +1,5 @@
 import matplotlib.gridspec as gridspec
+import matplotlib.pyplot as plt
 import pytest
 
 
@@ -35,3 +36,15 @@ def test_repr():
                            width_ratios=(1, 3))
     assert repr(ss) == \
         "GridSpec(2, 2, height_ratios=(3, 1), width_ratios=(1, 3))"
+
+
+def test_subplotspec_args():
+    fig, axs = plt.subplots(1, 2)
+    # should work:
+    gs = gridspec.GridSpecFromSubplotSpec(2, 1,
+                                          subplot_spec=axs[0].get_subplotspec())
+    assert gs.get_topmost_subplotspec() == axs[0].get_subplotspec()
+    with pytest.raises(TypeError, match="subplot_spec must be type SubplotSpec"):
+        gs = gridspec.GridSpecFromSubplotSpec(2, 1, subplot_spec=axs[0])
+    with pytest.raises(TypeError, match="subplot_spec must be type SubplotSpec"):
+        gs = gridspec.GridSpecFromSubplotSpec(2, 1, subplot_spec=axs)


### PR DESCRIPTION
In https://stackoverflow.com/questions/77710768/getting-constrained-layout-to-work-with-nested-subplots-in-matplotlib
the user did 

```python
    fig, axs = plt.subplots(1, 2)
    gs = mpl.gridspec.GridSpecFromSubplotSpec(2, 1, subplot_spec=axs[0])
```

which isn't crazy, though `subplot_spec` should really be of type `SubplotSpec`.  Indeed it works fine if the user doesn't call `constrained_layout`.  

This PR makes the argument a bit more forgiving and will do `axs[0].get_subplotspec` for the user without complaining, and will check for any other inputs not being type `SubplotSpec`. 
