### PR TITLE
DOC: changed tag `plot type` to `plot-type`

### DIFF
--- a/doc/devel/tag_glossary.rst
+++ b/doc/devel/tag_glossary.rst
@@ -94,21 +94,21 @@ API tags: what content from the API reference is in the example?
 +-----------------------------------+---------------------------------------------+
 |**Plot Type**                                                                    |
 +-----------------------------------+---------------------------------------------+
-|``plot type: bar``                 |example contains a bar plot                  |
+|``plot-type: bar``                 |example contains a bar plot                  |
 +-----------------------------------+---------------------------------------------+
-|``plot type: line``                |example contains a line plot                 |
+|``plot-type: line``                |example contains a line plot                 |
 +-----------------------------------+---------------------------------------------+
-|``plot type: pie``                 |example contains a pie plot                  |
+|``plot-type: pie``                 |example contains a pie plot                  |
 +-----------------------------------+---------------------------------------------+
-|``plot type: polar``               |example contains a polar plot                |
+|``plot-type: polar``               |example contains a polar plot                |
 +-----------------------------------+---------------------------------------------+
-|``plot type: 3D``                  |example contains a 3D plot                   |
+|``plot-type: 3D``                  |example contains a 3D plot                   |
 +-----------------------------------+---------------------------------------------+
-|``plot type: histogram``           |example contains a histogram                 |
+|``plot-type: histogram``           |example contains a histogram                 |
 +-----------------------------------+---------------------------------------------+
-|``plot type: specialty``           |                                             |
+|``plot-type: specialty``           |                                             |
 +-----------------------------------+---------------------------------------------+
-|``plot type: scatter``             |                                             |
+|``plot-type: scatter``             |                                             |
 +-----------------------------------+---------------------------------------------+
 
 
@@ -166,7 +166,7 @@ Internal tags: what information is helpful for maintainers or contributors?
 +-------------------------------+-----------------------------------------------------------------------+
 |``tag``                        | use case                                                              |
 +===============================+=======================================================================+
-|``internal: low bandwidth``    |allows users to filter out bandwidth-intensive examples like animations|
+|``internal: high-bandwidth``   |allows users to filter out bandwidth-intensive examples like animations|
 +-------------------------------+-----------------------------------------------------------------------+
 |``internal: untagged``         |allows docs contributors to easily find untagged examples              |
 +-------------------------------+-----------------------------------------------------------------------+

--- a/galleries/examples/subplots_axes_and_figures/multiple_figs_demo.py
+++ b/galleries/examples/subplots_axes_and_figures/multiple_figs_demo.py
@@ -51,4 +51,4 @@ ax.set_xticklabels([])
 plt.show()
 
 # %%
-# .. tags:: component: figure, plot type: line
+# .. tags:: component: figure, plot-type: line


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Changed `plot type` to `plot-type` cause the space is already being tripped over https://matplotlib.org/devdocs/_tags/tagsindex.html#tagoverview and it's easier to git grep `plot-type` attn: @esibinga 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
