### PR TITLE
Remove 3.7-deprecated APi

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -98,11 +98,7 @@ def parse_fontconfig_pattern(pattern):
     for prop in parse.get("properties", []):
         if len(prop) == 1:
             if prop[0] not in _CONSTANTS:
-                _api.warn_deprecated(
-                    "3.7", message=f"Support for unknown constants "
-                    f"({prop[0]!r}) is deprecated since %(since)s and "
-                    f"will be removed %(removal)s.")
-                continue
+                raise ValueError("Support for unknown constants is not supported.")
             prop = _CONSTANTS[prop[0]]
         k, *v = prop
         props.setdefault(k, []).extend(map(_value_unescape, v))


### PR DESCRIPTION
## PR summary
Removal of old and unused API that were marked as deprecated in 3.7 of Matplotlib
(issue https://github.com/matplotlib/matplotlib/issues/26865)

## Changes Made:

removed _api.warn_deprecated(
                    "3.7", message=f"Support for unknown constants "
                    f"({prop[0]!r}) is deprecated since %(since)s and "
                    f"will be removed %(removal)s.")
added raise ValueError("Support for unknown constants is not supported.")
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
