### PR TITLE
Remove 3.7-deprecated fontconfig api

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -96,7 +96,7 @@ def parse_fontconfig_pattern(pattern):
     for prop in parse.get("properties", []):
         if len(prop) == 1:
             if prop[0] not in _CONSTANTS:
-                raise ValueError("Support for unknown constants is not supported.")
+                raise ValueError(f"Unknown constants ({prop[0]!r}) are not supported.")
             prop = _CONSTANTS[prop[0]]
         k, *v = prop
         props.setdefault(k, []).extend(map(_value_unescape, v))

--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -98,11 +98,7 @@ def parse_fontconfig_pattern(pattern):
     for prop in parse.get("properties", []):
         if len(prop) == 1:
             if prop[0] not in _CONSTANTS:
-                _api.warn_deprecated(
-                    "3.7", message=f"Support for unknown constants "
-                    f"({prop[0]!r}) is deprecated since %(since)s and "
-                    f"will be removed %(removal)s.")
-                continue
+                raise ValueError("Support for unknown constants is not supported.")
             prop = _CONSTANTS[prop[0]]
         k, *v = prop
         props.setdefault(k, []).extend(map(_value_unescape, v))

--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -15,8 +15,6 @@ import re
 from pyparsing import (
     Group, Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore)
 
-from matplotlib import _api
-
 
 _family_punc = r'\\\-:,'
 _family_unescape = partial(re.compile(r'\\(?=[%s])' % _family_punc).sub, '')

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -1,4 +1,3 @@
-import pytest
 
 from matplotlib.font_manager import FontProperties
 
@@ -70,4 +69,3 @@ def test_fontconfig_str():
                            stretch="expanded")
     for k in keys:
         assert getattr(font, k)() == getattr(right, k)(), test + k
-

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -1,6 +1,7 @@
 
 from matplotlib.font_manager import FontProperties
 
+import pytest
 
 # Attributes on FontProperties object to check for consistency
 keys = [
@@ -69,3 +70,7 @@ def test_fontconfig_str():
                            stretch="expanded")
     for k in keys:
         assert getattr(font, k)() == getattr(right, k)(), test + k
+
+def test_fontconfig_unknown_constant():
+    with pytest.raises(ValueError, match="Support for unknown constants is not supported."):
+        FontProperties(":unknown")

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -71,7 +71,3 @@ def test_fontconfig_str():
     for k in keys:
         assert getattr(font, k)() == getattr(right, k)(), test + k
 
-
-def test_fontconfig_unknown_constant():
-    with pytest.warns(DeprecationWarning):
-        FontProperties(":unknown")

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -71,6 +71,7 @@ def test_fontconfig_str():
     for k in keys:
         assert getattr(font, k)() == getattr(right, k)(), test + k
 
+
 def test_fontconfig_unknown_constant():
     with pytest.raises(ValueError):
         FontProperties(":unknown")

--- a/lib/matplotlib/tests/test_fontconfig_pattern.py
+++ b/lib/matplotlib/tests/test_fontconfig_pattern.py
@@ -72,5 +72,5 @@ def test_fontconfig_str():
         assert getattr(font, k)() == getattr(right, k)(), test + k
 
 def test_fontconfig_unknown_constant():
-    with pytest.raises(ValueError, match="Support for unknown constants is not supported."):
+    with pytest.raises(ValueError):
         FontProperties(":unknown")


### PR DESCRIPTION
## PR summary
Removal of old and unused API that were marked as deprecated in 3.7 of Matplotlib and the corresponding test.
(issue https://github.com/matplotlib/matplotlib/issues/26865)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
