### PR TITLE
Fix specifying number of levels with log contour

### DIFF
--- a/doc/users/next_whats_new/log_contour_levels.rst
+++ b/doc/users/next_whats_new/log_contour_levels.rst
@@ -1,0 +1,4 @@
+Maximum levels on log-scaled contour plots are now respected
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When plotting contours with a log norm, passing an integer value to the ``levels``
+argument to cap the maximum number of contour levels now works as intended.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -964,7 +964,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
             label.set_color(self.labelMappable.to_rgba(cv))
         super().changed()
 
-    def _autolev(self, N):
+    def _autolev(self, N, *, using_default):
         """
         Select contour levels to span the data.
 
@@ -981,7 +981,12 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator(numticks=N)
+                if using_default:
+                    # Let log locator choose instead of using hard coded value
+                    # set in self._process_contour_level_args()
+                    self.locator = ticker.LogLocator()
+                else:
+                    self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 
@@ -1024,8 +1029,9 @@ class ContourSet(ContourLabeler, mcoll.Collection):
                 levels_arg = 7  # Default, hard-wired.
         else:
             levels_arg = self.levels
+
         if isinstance(levels_arg, Integral):
-            self.levels = self._autolev(levels_arg)
+            self.levels = self._autolev(levels_arg, using_default=self.levels is None)
         else:
             self.levels = np.asarray(levels_arg, np.float64)
         if self.filled and len(self.levels) < 2:

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -968,14 +968,13 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         """
         Set a locator on this ContourSet if it's not already set.
 
-        If *N* is an int, it is used as the target number of levels.
-        Otherwise when *N* is None, a reasonable default is chosen;
-        for logscales the LogLocator chooses, N=7 is the default
-        otherwise.
-
         Parameters
         ----------
         N : int or None
+            If *N* is an int, it is used as the target number of levels.
+            Otherwise when *N* is None, a reasonable default is chosen;
+            for logscales the LogLocator chooses, N=7 is the default
+            otherwise.
         """
         if self.locator is None:
             if self.logscale:

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -964,7 +964,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
             label.set_color(self.labelMappable.to_rgba(cv))
         super().changed()
 
-    def _set_locator_if_none(self, N):
+    def _ensure_locator_exists(self, N):
         """
         Set a locator on this ContourSet if it's not already set.
 
@@ -1033,7 +1033,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
                 levels_arg = [0, .5, 1] if self.filled else [.5]
 
         if isinstance(levels_arg, Integral) or levels_arg is None:
-            self._set_locator_if_none(levels_arg)
+            self._ensure_locator_exists(levels_arg)
             self.levels = self._autolev()
         else:
             self.levels = np.asarray(levels_arg, np.float64)

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -969,7 +969,8 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         Select contour levels to span the data.
 
         The target number of levels, *N*, is used only when the
-        scale is not log and default locator is used.
+        locator is not set and the scale is log or the default
+        locator is used.
 
         We need two more levels for filled contours than for
         line contours, because for the latter we need to specify
@@ -980,7 +981,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator()
+                self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -214,6 +214,24 @@ def test_log_locator_levels():
     assert_array_almost_equal(cb.ax.get_yticks(), c.levels)
 
 
+
+@pytest.mark.parametrize("n_levels", [2, 3, 4, 5, 6])
+def test_lognorm_levels(n_levels):
+    x = np.arange(100) + 1
+    y = np.arange(100) + 1
+    x, y = np.meshgrid(x, y)
+    data = x**2 + y**2
+
+    fig, ax = plt.subplots()
+    im = ax.contour(x, y, data, norm=LogNorm(), levels=n_levels)
+    cbar = fig.colorbar(im, ax=ax)
+
+    levels = im.levels
+    visible_levels = levels[(levels <= data.max()) & (levels >= data.min())]
+    # levels parameter promises "no more than n+1 "nice" contour levels "
+    assert len(visible_levels) <= n_levels + 1
+
+
 @image_comparison(['contour_datetime_axis.png'], style='mpl20')
 def test_contour_datetime_axis():
     fig = plt.figure()

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -217,14 +217,12 @@ def test_log_locator_levels():
 
 @pytest.mark.parametrize("n_levels", [2, 3, 4, 5, 6])
 def test_lognorm_levels(n_levels):
-    x = np.arange(100) + 1
-    y = np.arange(100) + 1
-    x, y = np.meshgrid(x, y)
-    data = x**2 + y**2
+    x, y = np.mgrid[1:10:0.1, 1:10:0.1]
+    data = np.abs(np.sin(x)*np.exp(y))
 
     fig, ax = plt.subplots()
     im = ax.contour(x, y, data, norm=LogNorm(), levels=n_levels)
-    cbar = fig.colorbar(im, ax=ax)
+    fig.colorbar(im, ax=ax)
 
     levels = im.levels
     visible_levels = levels[(levels <= data.max()) & (levels >= data.min())]

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -214,7 +214,6 @@ def test_log_locator_levels():
     assert_array_almost_equal(cb.ax.get_yticks(), c.levels)
 
 
-
 @pytest.mark.parametrize("n_levels", [2, 3, 4, 5, 6])
 def test_lognorm_levels(n_levels):
     x, y = np.mgrid[1:10:0.1, 1:10:0.1]


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

When plotting contours with a log norm, passing an integer value to the ``levels`` argument to cap the maximum number of contour levels now works as intended.  Partially addresses https://github.com/matplotlib/matplotlib/issues/19856 and replaces https://github.com/matplotlib/matplotlib/pull/25149.

I've maually checked that the added test fails before this fix. Testing with the following script:

```python
import matplotlib.pyplot as plt
from matplotlib.colors import LogNorm
import numpy as np

x, y = np.mgrid[1:10:0.1, 1:10:0.1]
data = np.abs(np.sin(x)*np.exp(y))

for n_levels in range(2, 20):
    fig, ax = plt.subplots()
    im = ax.contourf(x, y, data, norm=LogNorm(), levels=n_levels)
    cbar = fig.colorbar(im, ax=ax)
    n_ticks = len(cbar.ax.get_yticklabels())
    print(f"Requested max {n_levels + 1}, got {n_ticks - 1}")
```

Gives on current `main`:
```
Requested max 3, got 7
Requested max 4, got 7
Requested max 5, got 7
Requested max 6, got 7
Requested max 7, got 7
Requested max 8, got 7
Requested max 9, got 7
Requested max 10, got 7
Requested max 11, got 7
Requested max 12, got 7
Requested max 13, got 7
Requested max 14, got 7
Requested max 15, got 7
Requested max 16, got 7
Requested max 17, got 7
Requested max 18, got 7
Requested max 19, got 7
Requested max 20, got 7
```
and with this PR:

```
Requested max 3, got 3
Requested max 4, got 4
Requested max 5, got 4
Requested max 6, got 4
Requested max 7, got 7
Requested max 8, got 7
Requested max 9, got 7
Requested max 10, got 7
Requested max 11, got 7
Requested max 12, got 7
Requested max 13, got 7
Requested max 14, got 7
Requested max 15, got 7
Requested max 16, got 7
Requested max 17, got 7
Requested max 18, got 7
Requested max 19, got 7
Requested max 20, got 7
```
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
