### PR TITLE
MNT: add the running version to pickle warning message

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3168,8 +3168,8 @@ None}, default: None
         if version != mpl.__version__:
             _api.warn_external(
                 f"This figure was saved with matplotlib version {version} and "
-                f"is unlikely to function correctly.")
-
+                f"loaded with {mpl.__version__} so is unlikely to function correctly."
+            )
         self.__dict__ = state
 
         # re-initialise some of the unstored state information

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3168,7 +3168,7 @@ None}, default: None
         if version != mpl.__version__:
             _api.warn_external(
                 f"This figure was saved with matplotlib version {version} and "
-                f"loaded with {mpl.__version__} so is unlikely to function correctly."
+                f"loaded with {mpl.__version__} so may not function correctly."
             )
         self.__dict__ = state
 


### PR DESCRIPTION
Added the version of the currently running Matplotlib to the user warning when loading a pickle from a different of Matplotlib.
