### PR TITLE
Don't clip PowerNorm inputs < vmin

### DIFF
--- a/doc/api/next_api_changes/behavior/27589-DS.rst
+++ b/doc/api/next_api_changes/behavior/27589-DS.rst
@@ -1,0 +1,5 @@
+PowerNorm no longer clips values below vmin
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When ``clip=False`` is set (the default) on `~matplotlib.colors.PowerNorm`,
+values below ``vmin`` are now linearly normalised. Previously they were clipped
+to zero. This fixes issues with the display of colorbars associated with a power norm.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1970,7 +1970,7 @@ class PowerNorm(Normalize):
 
         \left ( \frac{x - v_{min}}{v_{max}  - v_{min}} \right )^{\gamma}
 
-    For input values below *vmin*, gamma is set to zero.
+    For input values below *vmin*, gamma is set to one.
     """
     def __init__(self, gamma, vmin=None, vmax=None, clip=False):
         super().__init__(vmin, vmax, clip)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1953,10 +1953,10 @@ class PowerNorm(Normalize):
         Determines the behavior for mapping values outside the range
         ``[vmin, vmax]``.
 
-        If clipping is off, values outside the range ``[vmin, vmax]`` are also
-        transformed by the power function, resulting in values outside ``[0, 1]``.
-        This behavior is usually desirable, as colormaps can mark these *under*
-        and *over* values with specific colors.
+        If clipping is off, values above *vmax* are transformed by the power
+        function, resulting in values above 1, and values below *vmin* are linearly
+        transformed resulting in values below 0. This behavior is usually desirable, as
+        colormaps can mark these *under* and *over* values with specific colors.
 
         If clipping is on, values below *vmin* are mapped to 0 and values above
         *vmax* are mapped to 1. Such values become indistinguishable from
@@ -1969,6 +1969,8 @@ class PowerNorm(Normalize):
     .. math::
 
         \left ( \frac{x - v_{min}}{v_{max}  - v_{min}} \right )^{\gamma}
+
+    For input values below *vmin*, gamma is set to zero.
     """
     def __init__(self, gamma, vmin=None, vmax=None, clip=False):
         super().__init__(vmin, vmax, clip)
@@ -1994,9 +1996,8 @@ class PowerNorm(Normalize):
                                      mask=mask)
             resdat = result.data
             resdat -= vmin
-            resdat[resdat < 0] = 0
-            np.power(resdat, gamma, resdat)
-            resdat /= (vmax - vmin) ** gamma
+            resdat /= (vmax - vmin)
+            resdat[resdat > 0] = np.power(resdat[resdat > 0], gamma)
 
             result = np.ma.array(resdat, mask=result.mask, copy=False)
         if is_scalar:
@@ -2006,14 +2007,21 @@ class PowerNorm(Normalize):
     def inverse(self, value):
         if not self.scaled():
             raise ValueError("Not invertible until scaled")
+
+        result, is_scalar = self.process_value(value)
+
         gamma = self.gamma
         vmin, vmax = self.vmin, self.vmax
 
-        if np.iterable(value):
-            val = np.ma.asarray(value)
-            return np.ma.power(val, 1. / gamma) * (vmax - vmin) + vmin
-        else:
-            return pow(value, 1. / gamma) * (vmax - vmin) + vmin
+        resdat = result.data
+        resdat[resdat > 0] = np.power(resdat[resdat > 0], 1 / gamma)
+        resdat *= (vmax - vmin)
+        resdat += vmin
+
+        result = np.ma.array(resdat, mask=result.mask, copy=False)
+        if is_scalar:
+            result = result[0]
+        return result
 
 
 class BoundaryNorm(Normalize):

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -552,10 +552,10 @@ def test_colorbar_lognorm_extension(extend):
 
 def test_colorbar_powernorm_extension():
     # Test that colorbar with powernorm is extended correctly
-    f, ax = plt.subplots()
-    cb = Colorbar(ax, norm=PowerNorm(gamma=0.5, vmin=0.0, vmax=1.0),
-                  orientation='vertical', extend='both')
-    assert cb._values[0] >= 0.0
+    # Just a smoke test that adding the colorbar doesn't raise an error or warning
+    fig, ax = plt.subplots()
+    Colorbar(ax, norm=PowerNorm(gamma=0.5, vmin=0.0, vmax=1.0),
+             orientation='vertical', extend='both')
 
 
 def test_colorbar_axes_kw():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -555,12 +555,16 @@ def test_PowerNorm():
     assert_array_almost_equal(norm(a), pnorm(a))
 
     a = np.array([-0.5, 0, 2, 4, 8], dtype=float)
-    expected = [0, 0, 1/16, 1/4, 1]
+    expected = [-1/16, 0, 1/16, 1/4, 1]
     pnorm = mcolors.PowerNorm(2, vmin=0, vmax=8)
     assert_array_almost_equal(pnorm(a), expected)
     assert pnorm(a[0]) == expected[0]
     assert pnorm(a[2]) == expected[2]
-    assert_array_almost_equal(a[1:], pnorm.inverse(pnorm(a))[1:])
+    # Check inverse
+    a_roundtrip = pnorm.inverse(pnorm(a))
+    assert_array_almost_equal(a, a_roundtrip)
+    # PowerNorm inverse adds a mask, so check that is correct too
+    assert_array_equal(a_roundtrip.mask, np.zeros(a.shape, dtype=bool))
 
     # Clip = True
     a = np.array([-0.5, 0, 1, 8, 16], dtype=float)
@@ -589,6 +593,15 @@ def test_PowerNorm_translation_invariance():
     assert_array_almost_equal(pnorm(a), expected)
     pnorm = mcolors.PowerNorm(vmin=-2, vmax=-1, gamma=3)
     assert_array_almost_equal(pnorm(a - 2), expected)
+
+
+def test_powernorm_cbar_limits():
+    fig, ax = plt.subplots()
+    vmin, vmax = 300, 1000
+    data = np.arange(100*100).reshape(100, 100) + vmin
+    im = ax.imshow(data, norm=mcolors.PowerNorm(gamma=0.2, vmin=vmin, vmax=vmax))
+    cbar = fig.colorbar(im)
+    assert cbar.ax.get_ylim() == (vmin, vmax)
 
 
 def test_Normalize():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -598,7 +598,7 @@ def test_PowerNorm_translation_invariance():
 def test_powernorm_cbar_limits():
     fig, ax = plt.subplots()
     vmin, vmax = 300, 1000
-    data = np.arange(100*100).reshape(100, 100) + vmin
+    data = np.arange(10*10).reshape(10, 10) + vmin
     im = ax.imshow(data, norm=mcolors.PowerNorm(gamma=0.2, vmin=vmin, vmax=vmax))
     cbar = fig.colorbar(im)
     assert cbar.ax.get_ylim() == (vmin, vmax)


### PR DESCRIPTION
## PR summary
This updates the behaviour of `PowerNorm` to linearly normalize input values < vmin, instead of clipping them.

Fixes https://github.com/matplotlib/matplotlib/issues/25239; replaces https://github.com/matplotlib/matplotlib/pull/25256. See discussion at https://github.com/matplotlib/matplotlib/pull/25256 for more context on this.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
