### PR TITLE
Fix is_sorted_and_has_non_nan for byteswapped inputs.

### DIFF
--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -246,6 +246,8 @@ def test_is_sorted_and_has_non_nan():
     assert _path.is_sorted_and_has_non_nan(np.array([1, 2, 3]))
     assert _path.is_sorted_and_has_non_nan(np.array([1, np.nan, 3]))
     assert not _path.is_sorted_and_has_non_nan([3, 5] + [np.nan] * 100 + [0, 2])
+    # [2, 256] byteswapped:
+    assert not _path.is_sorted_and_has_non_nan(np.array([33554432, 65536], ">i4"))
     n = 2 * mlines.Line2D._subslice_optim_min_size
     plt.plot([np.nan] * n, range(n))
 

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -707,8 +707,8 @@ static PyObject *Py_is_sorted_and_has_non_nan(PyObject *self, PyObject *obj)
 {
     bool result;
 
-    PyArrayObject *array = (PyArrayObject *)PyArray_FromAny(
-        obj, NULL, 1, 1, 0, NULL);
+    PyArrayObject *array = (PyArrayObject *)PyArray_CheckFromAny(
+        obj, NULL, 1, 1, NPY_ARRAY_NOTSWAPPED, NULL);
 
     if (array == NULL) {
         return NULL;


### PR DESCRIPTION
Closes #25995.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
