### PR TITLE
Ignore masked values in boxplot

### DIFF
--- a/doc/api/next_api_changes/behavior/27605-DS.rst
+++ b/doc/api/next_api_changes/behavior/27605-DS.rst
@@ -1,0 +1,4 @@
+Boxplots now ignore masked data points
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`~matplotlib.axes.Axes.boxplot` and `~matplotlib.cbook.boxplot_stats` now ignore
+any masked points in the input data.

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1274,7 +1274,8 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None,
             continue
 
         # up-convert to an array, just to be safe
-        x = np.asarray(x)
+        x = np.ma.asarray(x)
+        x = x.data[~x.mask].ravel()
 
         # arithmetic mean
         stats['mean'] = np.mean(x)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3388,6 +3388,20 @@ def test_boxplot():
     ax.set_ylim((-30, 30))
 
 
+@check_figures_equal(extensions=["png"])
+def test_boxplot_masked(fig_test, fig_ref):
+    # Check that masked values are ignored when plotting a boxplot
+    x_orig = np.linspace(-1, 1, 200)
+
+    ax = fig_test.subplots()
+    x = x_orig[x_orig >= 0]
+    ax.boxplot(x)
+
+    x = np.ma.masked_less(x_orig, 0)
+    ax = fig_ref.subplots()
+    ax.boxplot(x)
+
+
 @image_comparison(['boxplot_custom_capwidths.png'],
                   savefig_kwarg={'dpi': 40}, style='default')
 def test_boxplot_custom_capwidths():


### PR DESCRIPTION
## PR summary
Ignore masked data points when plotting boxplots (and calculating boxplot statistics). Fixes https://github.com/matplotlib/matplotlib/issues/13533.

Replaces https://github.com/matplotlib/matplotlib/pull/13651 with a much simpler fix.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
