### PR TITLE
Pin black version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -64,4 +64,4 @@ dependencies:
   - pytest-xdist
   - tornado
   - pytz
-  - black
+  - black~=23.0

--- a/environment.yml
+++ b/environment.yml
@@ -64,4 +64,4 @@ dependencies:
   - pytest-xdist
   - tornado
   - pytz
-  - black~=23.0
+  - black<24

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -1,6 +1,6 @@
 # pip requirements for all the CI builds
 
-black~=23.0
+black<24
 certifi
 coverage!=6.3
 psutil

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -1,6 +1,6 @@
 # pip requirements for all the CI builds
 
-black
+black~=23.0
 certifi
 coverage!=6.3
 psutil


### PR DESCRIPTION
## PR summary
Each calendar year black can make updates/changes to how they format code (see the [black stability policy](https://black.readthedocs.io/en/stable/the_black_code_style/index.html#stability-policy)). To make sure our autogenerated `pyplot.py` corresponds to a particular version of `black`, add a pin to the version. When we want to update we can then bump the major version of black and regenerate `pyplot.py` in sync. 

Fixes partially https://github.com/matplotlib/matplotlib/issues/27529 - I'm not sure if there's a way to run the weekly GH actions workflows on a PR to check this works?

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
