### PR TITLE
ticker.py: always use np.round

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -983,8 +983,8 @@ class LogFormatter(Formatter):
         # only label the decades
         fx = math.log(x) / math.log(b)
         is_x_decade = _is_close_to_int(fx)
-        exponent = round(fx) if is_x_decade else np.floor(fx)
-        coeff = round(b ** (fx - exponent))
+        exponent = np.round(fx) if is_x_decade else np.floor(fx)
+        coeff = np.round(b ** (fx - exponent))
 
         if self.labelOnlyBase and not is_x_decade:
             return ''
@@ -1064,8 +1064,8 @@ class LogFormatterMathtext(LogFormatter):
         # only label the decades
         fx = math.log(x) / math.log(b)
         is_x_decade = _is_close_to_int(fx)
-        exponent = round(fx) if is_x_decade else np.floor(fx)
-        coeff = round(b ** (fx - exponent))
+        exponent = np.round(fx) if is_x_decade else np.floor(fx)
+        coeff = np.round(b ** (fx - exponent))
 
         if self.labelOnlyBase and not is_x_decade:
             return ''
@@ -1073,7 +1073,7 @@ class LogFormatterMathtext(LogFormatter):
             return ''
 
         if is_x_decade:
-            fx = round(fx)
+            fx = np.round(fx)
 
         # use string formatting of the base if it is not an integer
         if b % 1 == 0.0:
@@ -1101,7 +1101,7 @@ class LogFormatterSciNotation(LogFormatterMathtext):
         exponent = math.floor(fx)
         coeff = b ** (fx - exponent)
         if _is_close_to_int(coeff):
-            coeff = round(coeff)
+            coeff = np.round(coeff)
         return r'$\mathdefault{%s%g\times%s^{%d}}$' \
             % (sign_string, coeff, base, exponent)
 
@@ -1276,13 +1276,13 @@ class LogitFormatter(Formatter):
             return ""
         if x <= 0 or x >= 1:
             return ""
-        if _is_close_to_int(2 * x) and round(2 * x) == 1:
+        if _is_close_to_int(2 * x) and np.round(2 * x) == 1:
             s = self._one_half
         elif x < 0.5 and _is_decade(x, rtol=1e-7):
-            exponent = round(math.log10(x))
+            exponent = np.round(math.log10(x))
             s = "10^{%d}" % exponent
         elif x > 0.5 and _is_decade(1 - x, rtol=1e-7):
-            exponent = round(math.log10(1 - x))
+            exponent = np.round(math.log10(1 - x))
             s = self._one_minus("10^{%d}" % exponent)
         elif x < 0.1:
             s = self._format_value(x, self.locs)
@@ -2239,7 +2239,7 @@ def _decade_greater(x, base):
 
 
 def _is_close_to_int(x):
-    return math.isclose(x, round(x))
+    return math.isclose(x, np.round(x))
 
 
 class LogLocator(Locator):
@@ -2904,8 +2904,8 @@ class AutoMinorLocator(Locator):
 
         vmin, vmax = sorted(self.axis.get_view_interval())
         t0 = majorlocs[0]
-        tmin = round((vmin - t0) / minorstep)
-        tmax = round((vmax - t0) / minorstep) + 1
+        tmin = np.round((vmin - t0) / minorstep)
+        tmax = np.round((vmax - t0) / minorstep) + 1
         locs = (np.arange(tmin, tmax) * minorstep) + t0
 
         return self.raise_if_exceeds(locs)


### PR DESCRIPTION
## PR summary

I encountered the following error when using a logarithmic `yscale` in a graph:

```
Traceback (most recent call last):
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/backends/backend_gtk3.py", line 277, in idle_draw
    self.draw()
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/backends/backend_agg.py", line 388, in draw
    self.figure.draw(self.renderer)
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 95, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 72, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/figure.py", line 3154, in draw
    mimage._draw_list_compositing_images(
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/image.py", line 132, in _draw_list_compositing_images
    a.draw(renderer)
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 72, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/axes/_base.py", line 3070, in draw
    mimage._draw_list_compositing_images(
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/image.py", line 132, in _draw_list_compositing_images
    a.draw(renderer)
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 72, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/axis.py", line 1387, in draw
    ticks_to_draw = self._update_ticks()
                    ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/axis.py", line 1276, in _update_ticks
    major_labels = self.major.formatter.format_ticks(major_locs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 216, in format_ticks
    return [self(value, i) for i, value in enumerate(values)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 216, in <listcomp>
    return [self(value, i) for i, value in enumerate(values)]
            ^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 1066, in __call__
    is_x_decade = _is_close_to_int(fx)
                  ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 2239, in _is_close_to_int
    return math.isclose(x, round(x))
                           ^^^^^^^^
OverflowError: cannot convert float infinity to integer
```

Where the above is printed repeatedly, for ever, and the GUI is stuck. With this patch applied, I get this graph in a logarithmic scale:

![image](https://github.com/matplotlib/matplotlib/assets/10998835/f0a2e271-c0b7-4bea-85e6-e65af517f7ff)

The orange line goes upwards to huge values - which proves that the fit I tried to perform was wrong, but still matplotlib shouldn't almost crash due to such scientific error. Without this patch, I managed to fix one instance of the above error, using the following code:

```
import matplotlib.ticker as ticker
import math
def my_is_close_to_int(x):
    return math.isclose(x, np.round(x))
ticker._is_close_to_int = my_is_close_to_int
```

But then I encountered this error:

```
Traceback (most recent call last):
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/backends/backend_gtk3.py", line 277, in idle_draw
    self.draw()
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/backends/backend_agg.py", line 388, in draw
    self.figure.draw(self.renderer)
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 95, in draw_wrapper
    result = draw(artist, renderer, *args, **kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 72, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/figure.py", line 3154, in draw
    mimage._draw_list_compositing_images(
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/image.py", line 132, in _draw_list_compositing_images
    a.draw(renderer)
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 72, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/axes/_base.py", line 3070, in draw
    mimage._draw_list_compositing_images(
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/image.py", line 132, in _draw_list_compositing_images
    a.draw(renderer)
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/artist.py", line 72, in draw_wrapper
    return draw(artist, renderer)
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/axis.py", line 1387, in draw
    ticks_to_draw = self._update_ticks()
                    ^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/axis.py", line 1276, in _update_ticks
    major_labels = self.major.formatter.format_ticks(major_locs)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 216, in format_ticks
    return [self(value, i) for i, value in enumerate(values)]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 216, in <listcomp>
    return [self(value, i) for i, value in enumerate(values)]
            ^^^^^^^^^^^^^^
  File "/nix/store/40yp1y2hd4l9pajlclp8nhzxpv5hksgm-python3-3.11.6-env/lib/python3.11/site-packages/matplotlib/ticker.py", line 1067, in __call__
    exponent = round(fx) if is_x_decade else np.floor(fx)
               ^^^^^^^^^
OverflowError: cannot convert float infinity to integer
```

So I decided to discuss with you about the simple suggestion of replacing all of Python's builtin usages of `round`, with `numpy`'s implementation, that can handle `NaN` or `Inf` easily.

It was very hard to debug it, as I couldn't use even a `try - except` clause to catch the error. I'm sorry, but I also currently haven't yet generated a reproducible example, due to the structure that my data is currently held at. I'd like to hear what you think first before I'll write tests to this PR.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) - **It'd be nice to write a test that will prove the issue and that will be fixed in a commit afterwards**.
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines