### PR TITLE
MNT: add spaces to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,6 +11,8 @@ Also please summarize the changes in the title, for example "Raise ValueError on
 non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
 issue #8576".
 -->
+
+
 ## PR checklist
 <!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Adds a space between the summary and checklist b/c currently that lack of space makes distinguishing between the two sections really hard. 
