### PR TITLE
Add option of running stubtest using tox

### DIFF
--- a/.github/workflows/mypy-stubtest.yml
+++ b/.github/workflows/mypy-stubtest.yml
@@ -18,12 +18,6 @@ jobs:
         with:
           python-version: 3.9
 
-      - name: Install mypy
-        run: |
-          pip3 install -r requirements/testing/mypy.txt \
-            -r requirements/testing/all.txt
-          pip3 install .
-
       - name: Set up reviewdog
         run: |
           mkdir -p "$HOME/bin"
@@ -32,13 +26,16 @@ jobs:
               sh -s -- -b "$HOME/bin"
           echo "$HOME/bin" >> $GITHUB_PATH
 
+      - name: Install tox
+        run: python -m pip install tox
+
       - name: Run mypy stubtest
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -o pipefail
-          MPLBACKEND=agg python tools/stubtest.py | \
-              sed -e "s!$pythonLocation/lib/python3.9/site-packages!lib!g" | \
+          tox -e stubtest | \
+              sed -e "s!.tox/stubtest/lib/python3.11/site-packages!lib!g" | \
               reviewdog \
                 -efm '%Eerror: %m' \
                 -efm '%CStub: in file %f:%l' \

--- a/.github/workflows/mypy-stubtest.yml
+++ b/.github/workflows/mypy-stubtest.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -o pipefail
           tox -e stubtest | \
-              sed -e "s!.tox/stubtest/lib/python3.11/site-packages!lib!g" | \
+              sed -e "s!.tox/stubtest/lib/python3.9/site-packages!lib!g" | \
               reviewdog \
                 -efm '%Eerror: %m' \
                 -efm '%CStub: in file %f:%l' \

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 ################
 # meson-python working directory
 build
+.mesonpy*
 
 # meson-python/build frontend dist directory
 dist

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -88,9 +88,8 @@ We generally use `stub files
 the type information for ``colors.py``. A notable exception is ``pyplot.py``,
 which is type hinted inline.
 
-Type hints are checked by the mypy :ref:`pre-commit hook <pre-commit-hooks>`
-and can often be verified using ``tools\stubtest.py`` and occasionally may
-require the use of ``tools\check_typehints.py``.
+Type hints are checked by the mypy :ref:`pre-commit hook <pre-commit-hooks>`,
+can often be verified by running ``tox -e stubtest``.
 
 New modules and files: installation
 ===================================

--- a/environment.yml
+++ b/environment.yml
@@ -46,6 +46,7 @@ dependencies:
       - sphinxcontrib-svg2pdfconverter>=1.1.0
       - pikepdf
   # testing
+  - black<24
   - coverage
   - flake8>=3.8
   - flake8-docstrings>=1.4.0
@@ -64,4 +65,4 @@ dependencies:
   - pytest-xdist
   - tornado
   - pytz
-  - black<24
+  - tox

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py38, py39, py310
+envlist = py38, py39, py310, stubtest
 
 [testenv]
 changedir = /tmp
@@ -25,3 +25,12 @@ commands =
 deps =
     pytest
     pytz
+
+[testenv:stubtest]
+changedir = {tox_root}
+commands =
+    python tools/stubtest.py
+usedevelop = False
+deps =
+    -r requirements/testing/mypy.txt
+    -r requirements/testing/all.txt


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->
This gives developers the option of running stubtests using `tox`. This is useful, because the stubtests can't be run on local editable installs (see https://github.com/matplotlib/matplotlib/issues/27580).

I've added a test commit that breaks stubtest deliberately to show this works - I will leave this here for review purposes, then force push it away once this has one approved review.

~~I can't get this to give me a true negative result locally though 😢 . With the below diff (saved, but unstaged in git), running `tox -e stubtest` still gives me a successful result. I'll investigate a bit further, but I don't suppose anyone has any ideas?~~

Fixes https://github.com/matplotlib/matplotlib/issues/27580.

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
