### PR TITLE
Prepare for Pytest v8

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2708,6 +2708,7 @@ class PdfPages:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        print(f"Closing file {self._filename}")
         self.close()
 
     def _ensure_file(self):
@@ -2728,7 +2729,7 @@ class PdfPages:
             _api.warn_deprecated("3.8", message=(
                 "Keeping empty pdf files is deprecated since %(since)s and support "
                 "will be removed %(removal)s."))
-            PdfFile(self._filename, metadata=self._metadata)  # touch the file.
+            PdfFile(self._filename, metadata=self._metadata).close()  # touch the file.
 
     def infodict(self):
         """

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2708,7 +2708,6 @@ class PdfPages:
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        print(f"Closing file {self._filename}")
         self.close()
 
     def _ensure_file(self):

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -87,41 +87,42 @@ def test_multipage_keep_empty(tmp_path):
     # test empty pdf files
     # Due to order of `with` block execution, a warning for unclosed file is raised
     # but the pytest.warns must happen before the PdfPages is created
-    warnings.filterwarnings("ignore", category=ResourceWarning)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-    # an empty pdf is left behind with keep_empty unset
-    with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:
-        pass
-    assert os.path.exists("a.pdf")
+        # an empty pdf is left behind with keep_empty unset
+        with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:
+            pass
+        assert os.path.exists("a.pdf")
 
-    # an empty pdf is left behind with keep_empty=True
-    with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-            PdfPages("b.pdf", keep_empty=True) as pdf:
-        pass
-    assert os.path.exists("b.pdf")
+        # an empty pdf is left behind with keep_empty=True
+        with pytest.warns(mpl.MatplotlibDeprecationWarning), \
+                PdfPages("b.pdf", keep_empty=True) as pdf:
+            pass
+        assert os.path.exists("b.pdf")
 
-    # an empty pdf deletes itself afterwards with keep_empty=False
-    with PdfPages("c.pdf", keep_empty=False) as pdf:
-        pass
-    assert not os.path.exists("c.pdf")
+        # an empty pdf deletes itself afterwards with keep_empty=False
+        with PdfPages("c.pdf", keep_empty=False) as pdf:
+            pass
+        assert not os.path.exists("c.pdf")
 
-    # test pdf files with content, they should never be deleted
+        # test pdf files with content, they should never be deleted
 
-    # a non-empty pdf is left behind with keep_empty unset
-    with PdfPages("d.pdf") as pdf:
-        pdf.savefig(plt.figure())
-    assert os.path.exists("d.pdf")
+        # a non-empty pdf is left behind with keep_empty unset
+        with PdfPages("d.pdf") as pdf:
+            pdf.savefig(plt.figure())
+        assert os.path.exists("d.pdf")
 
-    # a non-empty pdf is left behind with keep_empty=True
-    with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-            PdfPages("e.pdf", keep_empty=True) as pdf:
-        pdf.savefig(plt.figure())
-    assert os.path.exists("e.pdf")
+        # a non-empty pdf is left behind with keep_empty=True
+        with pytest.warns(mpl.MatplotlibDeprecationWarning), \
+                PdfPages("e.pdf", keep_empty=True) as pdf:
+            pdf.savefig(plt.figure())
+        assert os.path.exists("e.pdf")
 
-    # a non-empty pdf is left behind with keep_empty=False
-    with PdfPages("f.pdf", keep_empty=False) as pdf:
-        pdf.savefig(plt.figure())
-    assert os.path.exists("f.pdf")
+        # a non-empty pdf is left behind with keep_empty=False
+        with PdfPages("f.pdf", keep_empty=False) as pdf:
+            pdf.savefig(plt.figure())
+        assert os.path.exists("f.pdf")
 
 
 def test_composite_image():

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -3,6 +3,7 @@ import decimal
 import io
 import os
 from pathlib import Path
+import warnings
 
 import numpy as np
 import pytest
@@ -84,6 +85,9 @@ def test_multipage_keep_empty(tmp_path):
     os.chdir(tmp_path)
 
     # test empty pdf files
+    # Due to order of `with` block execution, a warning for unclosed file is raised
+    # but the pytest.warns must happen before the PdfPages is created
+    warnings.filterwarnings("ignore", category=ResourceWarning)
 
     # an empty pdf is left behind with keep_empty unset
     with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -3,7 +3,6 @@ import decimal
 import io
 import os
 from pathlib import Path
-import warnings
 
 import numpy as np
 import pytest
@@ -85,44 +84,40 @@ def test_multipage_keep_empty(tmp_path):
     os.chdir(tmp_path)
 
     # test empty pdf files
-    # Due to order of `with` block execution, a warning for unclosed file is raised
-    # but the pytest.warns must happen before the PdfPages is created
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=ResourceWarning)
 
-        # an empty pdf is left behind with keep_empty unset
-        with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:
-            pass
-        assert os.path.exists("a.pdf")
+    # an empty pdf is left behind with keep_empty unset
+    with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:
+        pass
+    assert os.path.exists("a.pdf")
 
-        # an empty pdf is left behind with keep_empty=True
-        with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-                PdfPages("b.pdf", keep_empty=True) as pdf:
-            pass
-        assert os.path.exists("b.pdf")
+    # an empty pdf is left behind with keep_empty=True
+    with pytest.warns(mpl.MatplotlibDeprecationWarning), \
+            PdfPages("b.pdf", keep_empty=True) as pdf:
+        pass
+    assert os.path.exists("b.pdf")
 
-        # an empty pdf deletes itself afterwards with keep_empty=False
-        with PdfPages("c.pdf", keep_empty=False) as pdf:
-            pass
-        assert not os.path.exists("c.pdf")
+    # an empty pdf deletes itself afterwards with keep_empty=False
+    with PdfPages("c.pdf", keep_empty=False) as pdf:
+        pass
+    assert not os.path.exists("c.pdf")
 
-        # test pdf files with content, they should never be deleted
+    # test pdf files with content, they should never be deleted
 
-        # a non-empty pdf is left behind with keep_empty unset
-        with PdfPages("d.pdf") as pdf:
-            pdf.savefig(plt.figure())
-        assert os.path.exists("d.pdf")
+    # a non-empty pdf is left behind with keep_empty unset
+    with PdfPages("d.pdf") as pdf:
+        pdf.savefig(plt.figure())
+    assert os.path.exists("d.pdf")
 
-        # a non-empty pdf is left behind with keep_empty=True
-        with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-                PdfPages("e.pdf", keep_empty=True) as pdf:
-            pdf.savefig(plt.figure())
-        assert os.path.exists("e.pdf")
+    # a non-empty pdf is left behind with keep_empty=True
+    with pytest.warns(mpl.MatplotlibDeprecationWarning), \
+            PdfPages("e.pdf", keep_empty=True) as pdf:
+        pdf.savefig(plt.figure())
+    assert os.path.exists("e.pdf")
 
-        # a non-empty pdf is left behind with keep_empty=False
-        with PdfPages("f.pdf", keep_empty=False) as pdf:
-            pdf.savefig(plt.figure())
-        assert os.path.exists("f.pdf")
+    # a non-empty pdf is left behind with keep_empty=False
+    with PdfPages("f.pdf", keep_empty=False) as pdf:
+        pdf.savefig(plt.figure())
+    assert os.path.exists("f.pdf")
 
 
 def test_composite_image():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1,6 +1,7 @@
 import copy
 import itertools
 import unittest.mock
+import warnings
 
 from io import BytesIO
 import numpy as np
@@ -147,8 +148,11 @@ def test_double_register_builtin_cmap():
     with pytest.raises(ValueError, match='A colormap named "viridis"'):
         with pytest.warns(mpl.MatplotlibDeprecationWarning):
             cm.register_cmap(name, mpl.colormaps[name])
-    with pytest.warns(UserWarning), pytest.warns(mpl.MatplotlibDeprecationWarning):
-        cm.register_cmap(name, mpl.colormaps[name], override_builtin=True)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+        with pytest.warns(UserWarning):
+            cm.register_cmap(name, mpl.colormaps[name], override_builtin=True)
 
 
 def test_unregister_builtin_cmap():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1,7 +1,7 @@
 import copy
 import itertools
 import unittest.mock
-import warnings
+from packaging.version import parse as parse_version
 
 from io import BytesIO
 import numpy as np
@@ -149,9 +149,11 @@ def test_double_register_builtin_cmap():
         with pytest.warns(mpl.MatplotlibDeprecationWarning):
             cm.register_cmap(name, mpl.colormaps[name])
 
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", category=mpl.MatplotlibDeprecationWarning)
+    if parse_version(pytest.__version__).major < 8:
         with pytest.warns(UserWarning):
+            cm.register_cmap(name, mpl.colormaps[name], override_builtin=True)
+    else:
+        with pytest.warns(UserWarning), pytest.warns(mpl.MatplotlibDeprecationWarning):
             cm.register_cmap(name, mpl.colormaps[name], override_builtin=True)
 
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -147,8 +147,7 @@ def test_double_register_builtin_cmap():
     with pytest.raises(ValueError, match='A colormap named "viridis"'):
         with pytest.warns(mpl.MatplotlibDeprecationWarning):
             cm.register_cmap(name, mpl.colormaps[name])
-    with pytest.warns(UserWarning):
-        # TODO is warning more than once!
+    with pytest.warns(UserWarning), pytest.warns(mpl.MatplotlibDeprecationWarning):
         cm.register_cmap(name, mpl.colormaps[name], override_builtin=True)
 
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -106,14 +106,12 @@ def test_rcparams_update():
     rc = mpl.RcParams({'figure.figsize': (3.5, 42)})
     bad_dict = {'figure.figsize': (3.5, 42, 1)}
     # make sure validation happens on input
-    with pytest.raises(ValueError), \
-         pytest.warns(UserWarning, match="validate"):
+    with pytest.raises(ValueError):
         rc.update(bad_dict)
 
 
 def test_rcparams_init():
-    with pytest.raises(ValueError), \
-         pytest.warns(UserWarning, match="validate"):
+    with pytest.raises(ValueError):
         mpl.RcParams({'figure.figsize': (3.5, 42, 1)})
 
 

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -3,7 +3,7 @@ import itertools
 import locale
 import logging
 import re
-import warnings
+from packaging.version import parse as parse_version
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -915,13 +915,14 @@ class TestScalarFormatter:
             'axes.formatter.use_mathtext': False
         })
 
-        # Glyph warning unrelated
-        with warnings.catch_warnings():
-            warnings.filterwarnings(
-                "ignore", category=UserWarning, message="Glyph 8722"
-            )
-
+        if parse_version(pytest.__version__).major < 8:
             with pytest.warns(UserWarning, match='cmr10 font should ideally'):
+                fig, ax = plt.subplots()
+                ax.set_xticks([-1, 0, 1])
+                fig.canvas.draw()
+        else:
+            with (pytest.warns(UserWarning, match="Glyph 8722"),
+                  pytest.warns(UserWarning, match='cmr10 font should ideally')):
                 fig, ax = plt.subplots()
                 ax.set_xticks([-1, 0, 1])
                 fig.canvas.draw()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -3,6 +3,7 @@ import itertools
 import locale
 import logging
 import re
+import warnings
 
 import numpy as np
 from numpy.testing import assert_almost_equal, assert_array_equal
@@ -913,6 +914,9 @@ class TestScalarFormatter:
             'font.serif': 'cmr10',
             'axes.formatter.use_mathtext': False
         })
+
+        # Glyph warning unrelated
+        warnings.filterwarnings("ignore", category=UserWarning, message="Glyph 8722")
 
         with pytest.warns(UserWarning, match='cmr10 font should ideally'):
             fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -916,12 +916,15 @@ class TestScalarFormatter:
         })
 
         # Glyph warning unrelated
-        warnings.filterwarnings("ignore", category=UserWarning, message="Glyph 8722")
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=UserWarning, message="Glyph 8722"
+            )
 
-        with pytest.warns(UserWarning, match='cmr10 font should ideally'):
-            fig, ax = plt.subplots()
-            ax.set_xticks([-1, 0, 1])
-            fig.canvas.draw()
+            with pytest.warns(UserWarning, match='cmr10 font should ideally'):
+                fig, ax = plt.subplots()
+                ax.set_xticks([-1, 0, 1])
+                fig.canvas.draw()
 
     def test_cmr10_substitutions(self, caplog):
         mpl.rcParams.update({


### PR DESCRIPTION

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

The behavior of pytest.warns has changed, particularly with regards to handling of additional warnings

When additional warnings that were not tested for are raised, I simply add a `filterwarnings` (some are artifacts of `with` blocks).

And there are a couple that seem are not actually currently warning at all, but had been occluded by a `pytest.errors`.

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
