### PR TITLE
Auto-label PRs based on changed files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -3,3 +3,58 @@
   - any-glob-to-any-file: ['.github/workflows/cibuildwheel.yml']
 "CI: Run cygwin":
   - any-glob-to-any-file: ['.github/workflows/cygwin.yml']
+
+"backend: agg":
+  - any-glob-to-any-file:
+      - 'extern/agg24-svn/'
+      - 'lib/matplotlib/backends/_backend_agg.pyi'
+      - 'lib/matplotlib/backends/backend_agg.py*'
+      - 'src/_backend_agg*'
+"backend: cairo":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/backend_*cairo.py*'
+"backend: pdf":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/_backend_pdf_ps.py'
+      - 'lib/matplotlib/backends/backend_pdf.py'
+"backend: pgf":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/backend_pgf.py'
+"backend: ps":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/_backend_pdf_ps.py'
+      - 'lib/matplotlib/backends/backend_ps.py'
+"backend: svg":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/backend_svg.py'
+
+"GUI: gtk":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/_backend_gtk.py*'
+      - 'lib/matplotlib/backends/backend_gtk*'
+"GUI: MacOSX":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/*_macosx.py*'
+      - 'src/_macosx.m'
+"GUI: nbagg":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/*_nbagg*.py*'
+      - 'lib/matplotlib/backends/web_backend/js/nbagg_mpl.js'
+"GUI: Qt":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/backend_qt*'
+      - 'lib/matplotlib/backends/qt_compat.py'
+      - 'lib/matplotlib/backends/qt_editor/**'
+"GUI: tk":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/*backend_tk*'
+      - 'lib/matplotlib/backends/_tkagg.pyi'
+      - 'src/_tkagg.cpp'
+      - 'src/_tkmini.h'
+"GUI: webagg":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/*_webagg*.py*'
+      - 'lib/matplotlib/backends/web_backend/**'
+"GUI: wx":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backends/backend_wx*.py*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -59,6 +59,32 @@
   - any-glob-to-any-file:
       - 'lib/matplotlib/backends/backend_wx*.py*'
 
+"Documentation: API":
+  - any-glob-to-any-file:
+      # Also files in lib/**, but we can't be sure those are only documentation.
+      - 'doc/api/**'
+"Documentation: build":
+  - any-glob-to-any-file:
+      - 'doc/conf.py'
+      - 'doc/Makefile'
+      - 'doc/make.bat'
+"Documentation: devdocs":
+  - any-glob-to-any-file:
+      - 'doc/devel/**'
+"Documentation: examples":
+  - any-glob-to-any-file:
+      - 'galleries/examples/**'
+"Documentation: plot types":
+  - any-glob-to-any-file:
+      - 'galleries/plot_types/**'
+"Documentation: tutorials":
+  - any-glob-to-any-file:
+      - 'galleries/tutorials/**'
+"Documentation: user guide":
+  - any-glob-to-any-file:
+      - 'doc/users/**'
+      - 'galleries/users_explain/**'
+
 "topic: animation":
   - any-glob-to-any-file:
       - 'lib/matplotlib/animation.py*'

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,5 @@
+---
+"CI: Run cibuildwheel":
+  - any-glob-to-any-file: ['.github/workflows/cibuildwheel.yml']
+"CI: Run cygwin":
+  - any-glob-to-any-file: ['.github/workflows/cygwin.yml']

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -58,3 +58,135 @@
 "GUI: wx":
   - any-glob-to-any-file:
       - 'lib/matplotlib/backends/backend_wx*.py*'
+
+"topic: animation":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/animation.py*'
+      - 'lib/matplotlib/_animation_data.py*'
+"topic: axes":
+  - any-glob-to-any-file:
+      # Note, axes.py is not included here because it contains many plotting
+      # methods, for which changes would not be considered on topic.
+      - 'lib/matplotlib/axes/_base.py*'
+"topic: canvas and figure manager":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backend_bases.py*'
+"topic: categorical":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/category.py*'
+"topic: collections and mappables":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/collections.py*'
+"topic: color/color & colormaps":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/colorbar.py*'
+      - 'lib/matplotlib/colors.py*'
+      - 'lib/matplotlib/_color_data.py*'
+      - 'lib/matplotlib/cm.py*'
+      - 'lib/matplotlib/_cm.py*'
+      - 'lib/matplotlib/_cm_listed.py*'
+"topic: contour":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/contour.py*'
+      - 'src/_qhull_wrapper.cpp'
+"topic: date handling":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/dates.py*'
+"topic: figures and subfigures":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/figure.py*'
+"topic: geometry manager":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/_constrained_layout.py*'
+      - 'lib/matplotlib/_layoutgrid.py*'
+      - 'lib/matplotlib/_tight_bbox.py*'
+      - 'lib/matplotlib/_tight_layout.py*'
+      - 'lib/matplotlib/gridspec.py*'
+      - 'lib/matplotlib/layout_engine.py*'
+"topic: hatch":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/hatch.py*'
+"topic: images":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/image.py*'
+      - 'lib/matplotlib/_image.pyi'
+      - 'src/_image_*'
+"topic: legend":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/legend.py*'
+      - 'lib/matplotlib/legend_handler.py*'
+"topic: markers":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/markers.py*'
+"topic: mpl_toolkit":
+  - any-glob-to-any-file:
+      - 'lib/mpl_toolkits/**'
+  - all-globs-to-all-files:
+      - '!lib/mpl_toolkits/mplot3d/**'
+"topic: mplot3d":
+  - any-glob-to-any-file:
+      - 'lib/mpl_toolkits/mplot3d/**'
+"topic: path handling":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/path.py*'
+      - 'lib/matplotlib/patheffects.py*'
+      - 'lib/matplotlib/_path.pyi'
+      - 'src/*path*'
+"topic: polar":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/projections/polar.py*'
+"topic: pyplot API":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/pyplot.py'
+      - 'lib/matplotlib/_pylab_helpers.py*'
+"topic: rcparams":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/rcsetup.py*'
+"topic: sankey":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/sankey.py*'
+"topic: sphinx extension":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/sphinxext/**'
+"topic: styles":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/mpl-data/stylelib/**'
+      - 'lib/matplotlib/style/**'
+"topic: table":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/table.py*'
+"topic: text":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/text.py*'
+      - 'lib/matplotlib/textpath.py*'
+"topic: text/fonts":
+  - any-glob-to-any-file:
+      - 'src/checkdep_freetype2.c'
+      - 'src/ft2font*'
+"topic: text/mathtext":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/mathtext.py*'
+      - 'lib/matplotlib/_mathtext.py*'
+      - 'lib/matplotlib/_mathtext_data.py*'
+"topic: ticks axis labels":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/axis.py*'
+      - 'lib/matplotlib/ticker.py*'
+"topic: toolbar":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/backend_managers.py*'
+      - 'lib/matplotlib/backend_tools.py*'
+"topic: transforms and scales":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/scale.py*'
+      - 'lib/matplotlib/transforms.py*'
+"topic: tri":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/tri/**'
+      - 'src/tri/**'
+"topic: units and array ducktypes":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/units.py*'
+"topic: widgets/UI":
+  - any-glob-to-any-file:
+      - 'lib/matplotlib/widgets.py*'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+---
+name: "Pull Request Labeler"
+on:
+  - pull_request_target
+
+jobs:
+  labeler:
+    permissions:
+      contents: read
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          sync-labels: true


### PR DESCRIPTION
## PR summary

I believe this was not previously usable due to Actions permission changes, but now that the `pull_request_target` trigger exists, it should work again. Unfortunately, because it uses `pull_request_target`, there's no way to test until it's merged.

This is mainly to catch issues like #27628 which should have been labelled with `Run cibuildwheel` to show that it was broken.
Labelling the topics is a bit arbitrary, but I think I've covered enough of them.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines