### PR TITLE
circle: Make deploy stage into a normal step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 # Circle CI configuration file
 # https://circleci.com/docs/
-
+---
 version: 2.1
 
 
@@ -199,6 +199,12 @@ commands:
       - store_artifacts:
           path: doc/build/sphinx-gallery-files.tar.gz
 
+  deploy-docs:
+    steps:
+      - run:
+          name: "Deploy new docs"
+          command: ./.circleci/deploy-docs.sh
+
 
 ##########################################
 # Here is where the real jobs are defined.
@@ -236,9 +242,7 @@ jobs:
           fingerprints:
             - "be:c3:c1:d8:fb:a1:0e:37:71:72:d7:a3:40:13:8f:14"
 
-      - deploy:
-          name: "Deploy new docs"
-          command: ./.circleci/deploy-docs.sh
+      - deploy-docs
 
 #########################################
 # Defining workflows gets us parallelism.


### PR DESCRIPTION
## PR summary

Circle is warning about this being deprecated:
https://circleci.com/docs/migrate-from-deploy-to-run/
![image](https://github.com/matplotlib/matplotlib/assets/302469/62fe7b20-8faf-4904-b0c1-c2d6acf18014)

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines