### PR TITLE
Doc: typo fix for #22699

### DIFF
--- a/lib/matplotlib/_docstring.py
+++ b/lib/matplotlib/_docstring.py
@@ -8,14 +8,14 @@ def kwarg_doc(text):
     Decorator for defining the kwdoc documentation of artist properties.
 
     This decorator can be applied to artist property setter methods.
-    The given text is stored in a privat attribute ``_kwarg_doc`` on
+    The given text is stored in a private attribute ``_kwarg_doc`` on
     the method.  It is used to overwrite auto-generated documentation
     in the *kwdoc list* for artists. The kwdoc list is used to document
     ``**kwargs`` when they are properties of an artist. See e.g. the
     ``**kwargs`` section in `.Axes.text`.
 
-    The text should contain the supported types as well as the default value
-    if applicable, e.g.:
+    The text should contain the supported types, as well as the default
+    value if applicable, e.g.:
 
         @_docstring.kwarg_doc("bool, default: :rc:`text.usetex`")
         def set_usetex(self, usetex):


### PR DESCRIPTION
Got merged with small typo in docstring (surprised it wasn't caught by the pre-commit :/) so fixed that. Also added a comma b/c phrase seemed parenthetical.