### PR TITLE
ci: Fix mpl_toolkits label

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -181,11 +181,12 @@
       - any-glob-to-any-file:
           - 'lib/matplotlib/markers.py*'
 "topic: mpl_toolkit":
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'lib/mpl_toolkits/**'
-      - all-globs-to-all-files:
-          - '!lib/mpl_toolkits/mplot3d/**'
+  - all:
+      - changed-files:
+          - any-glob-to-any-file:
+              - 'lib/mpl_toolkits/**'
+          - all-globs-to-all-files:
+              - '!lib/mpl_toolkits/mplot3d/**'
 "topic: mplot3d":
   - changed-files:
       - any-glob-to-any-file:


### PR DESCRIPTION
## PR summary

The default is `any`, so the negated glob matches almost all PRs accidentally. So we need to wrap this in an `all` so it's just toolkits-but-not-mplot3d.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines