### PR TITLE
Fix error that occurs when minorticks are on multi-Axes Figure with more than one boxplot

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -12,6 +12,8 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
+import random
+
 
 class TestMaxNLocator:
     basic_data = [
@@ -1796,3 +1798,31 @@ def test_set_offset_string(formatter):
     assert formatter.get_offset() == ''
     formatter.set_offset_string('mpl')
     assert formatter.get_offset() == 'mpl'
+
+
+def test_minorticks_on_multi_fig():
+    """
+    Turning on minor gridlines in a multi-Axes Figure
+    that contains more than one boxplot and shares the x-axis
+    should not raise an exception.
+    """
+    fig, ax = plt.subplots(sharex=True, ncols=2, nrows=2)
+
+    def values():
+        return [random.random() for _ in range(9)]
+
+    for x in range(3):
+        ax[0, 0].boxplot(values(), positions=[x])
+        ax[0, 1].boxplot(values(), positions=[x])
+        ax[1, 0].boxplot(values(), positions=[x])
+        ax[1, 1].boxplot(values(), positions=[x])
+
+    for a in ax.flatten():
+        a.grid(which="major")
+        a.grid(which="minor", linestyle="--")
+        a.minorticks_on()
+    fig.canvas.draw()
+
+    assert all(a.get_xgridlines() for a in ax.flatten())
+    assert all((isinstance(a.xaxis.get_minor_locator(), mpl.ticker.AutoMinorLocator)
+                for a in ax.flatten()))

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -12,8 +12,6 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 
-import random
-
 
 class TestMaxNLocator:
     basic_data = [
@@ -1806,23 +1804,16 @@ def test_minorticks_on_multi_fig():
     that contains more than one boxplot and shares the x-axis
     should not raise an exception.
     """
-    fig, ax = plt.subplots(sharex=True, ncols=2, nrows=2)
+    fig, ax = plt.subplots()
 
-    def values():
-        return [random.random() for _ in range(9)]
+    ax.boxplot(np.arange(10), positions=[0])
+    ax.boxplot(np.arange(10), positions=[0])
+    ax.boxplot(np.arange(10), positions=[1])
 
-    for x in range(3):
-        ax[0, 0].boxplot(values(), positions=[x])
-        ax[0, 1].boxplot(values(), positions=[x])
-        ax[1, 0].boxplot(values(), positions=[x])
-        ax[1, 1].boxplot(values(), positions=[x])
+    ax.grid(which="major")
+    ax.grid(which="minor")
+    ax.minorticks_on()
+    fig.draw_without_rendering()
 
-    for a in ax.flatten():
-        a.grid(which="major")
-        a.grid(which="minor", linestyle="--")
-        a.minorticks_on()
-    fig.canvas.draw()
-
-    assert all(a.get_xgridlines() for a in ax.flatten())
-    assert all((isinstance(a.xaxis.get_minor_locator(), mpl.ticker.AutoMinorLocator)
-                for a in ax.flatten()))
+    assert ax.get_xgridlines()
+    assert isinstance(ax.xaxis.get_minor_locator(), mpl.ticker.AutoMinorLocator)

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2903,7 +2903,7 @@ class AutoMinorLocator(Locator):
             _api.warn_external('AutoMinorLocator does not work on logarithmic scales')
             return []
 
-        majorlocs = self.axis.get_majorticklocs()
+        majorlocs = np.unique(self.axis.get_majorticklocs())
         if len(majorlocs) < 2:
             # Need at least two major ticks to find minor tick locations.
             # TODO: Figure out a way to still be able to display minor ticks with less


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Closes https://github.com/matplotlib/matplotlib/issues/26484. Having `minorticks_on()`  in a multi-Axes Figure that contains more than one boxplot and shares the x-axis was raising an OverflowError. 

As @ksunden pointed out in https://github.com/matplotlib/matplotlib/issues/26484#issuecomment-1674018344, the boxplots set the Locator and Formatter of one axis to be FixedLocator/FixedFormatter, without handling repeated values. This leads to multiple repeated values for the Major ticks, which then the `AutoMinorLocator` does major[1] - major[0] to get the spacing of the major, which returns zero and then divides by 0, leading to the error.

I've implemented the option on the first bullet point of the above comment to call `np.unique` on the `majorticklocs` in `AutoMinorLocator`. This fix remove repeated values from `majorticklocs` to avoid the zero division that was causing the error.  

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
