### PR TITLE
Remove direct pydata-sphinx-theme dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,7 +33,6 @@ dependencies:
   - ipywidgets
   - numpydoc>=1.0
   - packaging>=20
-  - pydata-sphinx-theme~=0.13.1
   - pyyaml
   - sphinx>=3.0.0,!=6.1.2
   - sphinx-copybutton

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -14,7 +14,6 @@ ipywidgets
 ipykernel
 numpydoc>=1.0
 packaging>=20
-pydata-sphinx-theme~=0.13.1
 mpl-sphinx-theme~=3.8.0
 pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0


### PR DESCRIPTION
## PR summary
It (probably naively...) seems that we should be depending on `pydata-sphinx-theme` indirectly via `mpl-sphinx-theme`, and letting any pinnning happen there.

This PR should have the side effect of updating the version of `pydata-sphinx-theme` that is used to build the docs, which I'm hoping will fix https://github.com/matplotlib/matplotlib/issues/27652


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
