### PR TITLE
Fix Numpy 2.0 related test failures

### DIFF
--- a/lib/matplotlib/pylab.py
+++ b/lib/matplotlib/pylab.py
@@ -60,6 +60,8 @@ import datetime
 bytes = __import__("builtins").bytes
 # We also don't want the numpy version of these functions
 abs = __import__("builtins").abs
+bool = __import__("builtins").bool
 max = __import__("builtins").max
 min = __import__("builtins").min
+pow = __import__("builtins").pow
 round = __import__("builtins").round

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5743,7 +5743,12 @@ def test_text_labelsize():
     ax.tick_params(direction='out')
 
 
-@image_comparison(['pie_default.png'])
+# Note: The `pie` image tests were affected by Numpy 2.0 changing promotions
+# (NEP 50). While the changes were only marginal, tolerances were introduced.
+# These tolerances could likely go away when numpy 2.0 is the minimum supported
+# numpy and the images are regenerated.
+
+@image_comparison(['pie_default.png'], tol=0.01)
 def test_pie_default():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -5756,7 +5761,7 @@ def test_pie_default():
 
 
 @image_comparison(['pie_linewidth_0', 'pie_linewidth_0', 'pie_linewidth_0'],
-                  extensions=['png'], style='mpl20')
+                  extensions=['png'], style='mpl20', tol=0.01)
 def test_pie_linewidth_0():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -5788,7 +5793,7 @@ def test_pie_linewidth_0():
     plt.axis('equal')
 
 
-@image_comparison(['pie_center_radius.png'], style='mpl20')
+@image_comparison(['pie_center_radius.png'], style='mpl20', tol=0.005)
 def test_pie_center_radius():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -5808,7 +5813,7 @@ def test_pie_center_radius():
     plt.axis('equal')
 
 
-@image_comparison(['pie_linewidth_2.png'], style='mpl20')
+@image_comparison(['pie_linewidth_2.png'], style='mpl20', tol=0.01)
 def test_pie_linewidth_2():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -5823,7 +5828,7 @@ def test_pie_linewidth_2():
     plt.axis('equal')
 
 
-@image_comparison(['pie_ccw_true.png'], style='mpl20')
+@image_comparison(['pie_ccw_true.png'], style='mpl20', tol=0.01)
 def test_pie_ccw_true():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -5838,7 +5843,7 @@ def test_pie_ccw_true():
     plt.axis('equal')
 
 
-@image_comparison(['pie_frame_grid.png'], style='mpl20')
+@image_comparison(['pie_frame_grid.png'], style='mpl20', tol=0.002)
 def test_pie_frame_grid():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -5865,7 +5870,7 @@ def test_pie_frame_grid():
     plt.axis('equal')
 
 
-@image_comparison(['pie_rotatelabels_true.png'], style='mpl20')
+@image_comparison(['pie_rotatelabels_true.png'], style='mpl20', tol=0.009)
 def test_pie_rotatelabels_true():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
@@ -5880,7 +5885,7 @@ def test_pie_rotatelabels_true():
     plt.axis('equal')
 
 
-@image_comparison(['pie_no_label.png'])
+@image_comparison(['pie_no_label.png'], tol=0.01)
 def test_pie_nolabel_but_legend():
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
     sizes = [15, 30, 45, 10]
@@ -5894,7 +5899,7 @@ def test_pie_nolabel_but_legend():
     plt.legend()
 
 
-@image_comparison(['pie_shadow.png'], style='mpl20')
+@image_comparison(['pie_shadow.png'], style='mpl20', tol=0.002)
 def test_pie_shadow():
     # Also acts as a test for the shade argument of Shadow
     sizes = [15, 30, 45, 10]

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1379,38 +1379,38 @@ def test_scalarmappable_to_rgba(bytes):
     # uint8 RGBA
     x = np.ones((2, 3, 4), dtype=np.uint8)
     expected = x.copy() if bytes else x.astype(np.float32)/255
-    np.testing.assert_array_equal(sm.to_rgba(x, bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(x, bytes=bytes), expected)
     # uint8 RGB
     expected[..., 3] = alpha_1
-    np.testing.assert_array_equal(sm.to_rgba(x[..., :3], bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(x[..., :3], bytes=bytes), expected)
     # uint8 masked RGBA
     xm = np.ma.masked_array(x, mask=np.zeros_like(x))
     xm.mask[0, 0, 0] = True
     expected = x.copy() if bytes else x.astype(np.float32)/255
     expected[0, 0, 3] = 0
-    np.testing.assert_array_equal(sm.to_rgba(xm, bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(xm, bytes=bytes), expected)
     # uint8 masked RGB
     expected[..., 3] = alpha_1
     expected[0, 0, 3] = 0
-    np.testing.assert_array_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
 
     # float RGBA
     x = np.ones((2, 3, 4), dtype=float) * 0.5
     expected = (x * 255).astype(np.uint8) if bytes else x.copy()
-    np.testing.assert_array_equal(sm.to_rgba(x, bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(x, bytes=bytes), expected)
     # float RGB
     expected[..., 3] = alpha_1
-    np.testing.assert_array_equal(sm.to_rgba(x[..., :3], bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(x[..., :3], bytes=bytes), expected)
     # float masked RGBA
     xm = np.ma.masked_array(x, mask=np.zeros_like(x))
     xm.mask[0, 0, 0] = True
     expected = (x * 255).astype(np.uint8) if bytes else x.copy()
     expected[0, 0, 3] = 0
-    np.testing.assert_array_equal(sm.to_rgba(xm, bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(xm, bytes=bytes), expected)
     # float masked RGB
     expected[..., 3] = alpha_1
     expected[0, 0, 3] = 0
-    np.testing.assert_array_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
+    np.testing.assert_almost_equal(sm.to_rgba(xm[..., :3], bytes=bytes), expected)
 
 
 def test_failed_conversions():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Closes #27645 (technically combination of this and #27624, but the comments I've left on there have all been about this part)

Numpy made tweaks to dtype promotions that affected some computation (but only at the limits of floating point precision)

This PR counter acts these:

- `pie` image tests have a tolerance introduced
   - could perhaps tweak some of the exact values down a bit, but none were more than (0.01 RMS)
   - All differences were imperceptable as a human, and _some_ tolerance would be required regardless, so I did not replace the images
   - Technically could be changed by setting the env var `NPY_PROMOTION_state=legacy`, but that is changing intendid numpy 2.0 behavior
- `pylab` updated to ensure builtins are used for two more functions now included in numpy's namespace that occlude builtints
   - `pow` and `bool`
- Assertions in `test_scalarmappable_to_rgba` changed to `np.testing.assert_almost_equal`
   - Since some values are close to `0`, some of the `assert_almost_equal_nulp` and similar options proved insufficient. 
   - Could use `assert_allclose` instead, but would have to specify tolerances.

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
