### PR TITLE
Bump pydata-sphinx-theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
               export RELEASE_TAG='-t release'
             fi
             mkdir -p logs
-            make html O="-T $RELEASE_TAG -j4 -w /tmp/sphinxerrorswarnings.log"
+            make html O="-T $RELEASE_TAG -j1 -w /tmp/sphinxerrorswarnings.log"
             rm -r build/html/_sources
           working_directory: doc
       - save_cache:

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -14,29 +14,6 @@
     margin: 0;
 }
 
-/* Make announcement an error colour for unreleased documentation, and sticky. */
-#unreleased-message.bd-header-announcement {
-    border-bottom: solid var(--pst-color-danger-highlight);
-    color: var(--pst-color-danger-text);
-    font-weight: var(--pst-admonition-font-weight-heading);
-    position: sticky;
-    top: 0;
-    z-index: 1050;
-}
-
-#unreleased-message.bd-header-announcement:after {
-    background-color: var(--pst-color-danger);
-    opacity: 1;
-}
-
-#unreleased-message.bd-header-announcement a {
-    color: var(--pst-color-danger-text);
-}
-
-#unreleased-message.bd-header-announcement + .bd-navbar {
-    top: 3rem;  /* Minimum height of announcement header. */
-}
-
 /* multi column TOC */
 .contents ul {
     list-style-type: none;

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -484,7 +484,13 @@ html_theme_options = {
         # the server, but will be used as part of the key for caching by browsers
         # so when we do a new meso release the switcher will update "promptly" on
         # the stable and devdocs.
-        "json_url": f"https://matplotlib.org/devdocs/_static/switcher.json?{SHA}",
+        "json_url": (
+            "https://output.circle-artifacts.com/output/job/"
+            f"{os.environ['CIRCLE_WORKFLOW_JOB_ID']}/artifacts/"
+            f"{os.environ['CIRCLE_NODE_INDEX']}"
+            "/doc/build/html/_static/switcher.json" if CIRCLECI else
+            f"https://matplotlib.org/devdocs/_static/switcher.json?{SHA}"
+        ),
         "version_match": (
             # The start version to show. This must be in switcher.json.
             # We either go to 'stable' or to 'devdocs'

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -492,6 +492,7 @@ html_theme_options = {
             else 'devdocs')
     },
     "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"],
+    "navbar_persistent": ["search-button"],
     "secondary_sidebar_items": "page-toc.html",
     "footer_start": ["copyright", "sphinx-version", "doc_version"],
     # We override the announcement template from pydata-sphinx-theme, where

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -200,6 +200,7 @@ nitpicky = True
 missing_references_write_json = False
 missing_references_warn_unused_ignores = False
 
+
 intersphinx_mapping = {
     'Pillow': ('https://pillow.readthedocs.io/en/stable/', None),
     'cycler': ('https://matplotlib.org/cycler/', None),
@@ -548,6 +549,9 @@ html_sidebars = {
     "users/release_notes": ["empty_sidebar.html"],
     # '**': ['localtoc.html', 'pagesource.html']
 }
+
+# Don't include link to doc source files
+html_show_sourcelink = False
 
 # Copies only relevant code, not the '>>>' prompt
 copybutton_prompt_text = r'>>> |\.\.\. '

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -493,7 +493,6 @@ html_theme_options = {
     },
     "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"],
     "navbar_persistent": ["search-button"],
-    "secondary_sidebar_items": "page-toc.html",
     "footer_start": ["copyright", "sphinx-version", "doc_version"],
     # We override the announcement template from pydata-sphinx-theme, where
     # this special value indicates the use of the unreleased banner. If we need

--- a/environment.yml
+++ b/environment.yml
@@ -34,7 +34,7 @@ dependencies:
   - ipywidgets
   - numpydoc>=1.0
   - packaging>=20
-  - pydata-sphinx-theme~=0.13.1
+  - pydata-sphinx-theme~=0.15.0
   - pyyaml
   - sphinx>=3.0.0,!=6.1.2
   - sphinx-copybutton

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -14,7 +14,7 @@ ipywidgets
 ipykernel
 numpydoc>=1.0
 packaging>=20
-pydata-sphinx-theme~=0.13.1
+pydata-sphinx-theme~=0.15.0
 mpl-sphinx-theme~=3.8.0
 pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
The goal of this PR is to bump `pydata-shpinx-theme`, so we can take advantage of improvements/bug fixes that have happened since version 0.13.

Things that are ~currently broken~ now fixed:

- [x] Light/dark theme button
- [x] Search button - working fine in a build of `mpl-sphinx-theme`, so there must be something funny going on in `matplotlib` itself that is stopping this from working... update 1: it's `version-switcher.html` that's breaking this somehow. update 2: I think https://github.com/pydata/pydata-sphinx-theme/issues/1654 is the upstream issue here
- [x] Version switcher doesn't say "devdocs"
- [x] Section navigation missing

Fixes https://github.com/matplotlib/matplotlib/issues/27652
Fixes https://github.com/matplotlib/mpl-sphinx-theme/issues/80

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
