### PR TITLE
Backport PR #27581: CI: install German language packs on ubuntu test …

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -118,6 +118,7 @@ jobs:
               gir1.2-gtk-3.0 \
               graphviz \
               inkscape \
+              language-pack-de \
               lcov \
               libcairo2 \
               libcairo2-dev \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,6 +101,7 @@ stages:
               gir1.2-gtk-3.0 \
               graphviz \
               inkscape \
+              language-pack-de \
               libcairo2 \
               libgirepository-1.0-1 \
               lmodern \


### PR DESCRIPTION
…runners

Merge pull request #27581 from tacaswell/ci/de_locale

CI: install German lanugage packs an ubuntu test runners (cherry picked from commit 4df729a4755a4de6af706f069e23b1b3cdeab839)

This is to see if installing the de lanugage packs on v3.8.x will also break the wxagg memory leak test.

Trying to debug this we noted that runs on main fail regularly and runs on 3.8.x have all passed.