### PR TITLE
Change return type of `ion` and `ioff` to fix unbound variable errors with Pyright

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -556,6 +556,9 @@ def isinteractive() -> bool:
     return matplotlib.is_interactive()
 
 
+# Note: The return type of ioff being AbstractContextManager instead of ExitStack is deliberate.
+# See https://github.com/matplotlib/matplotlib/issues/27659 
+# and https://github.com/matplotlib/matplotlib/pull/27667 for more info.
 def ioff() -> AbstractContextManager:
     """
     Disable interactive mode.
@@ -596,6 +599,9 @@ def ioff() -> AbstractContextManager:
     return stack
 
 
+# Note: The return type of ion being AbstractContextManager instead of ExitStack is deliberate.
+# See https://github.com/matplotlib/matplotlib/issues/27659 
+# and https://github.com/matplotlib/matplotlib/pull/27667 for more info.
 def ion() -> AbstractContextManager:
     """
     Enable interactive mode.

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -556,7 +556,7 @@ def isinteractive() -> bool:
     return matplotlib.is_interactive()
 
 
-def ioff() -> ExitStack:
+def ioff() -> AbstractContextManager:
     """
     Disable interactive mode.
 
@@ -586,7 +586,7 @@ def ioff() -> ExitStack:
             # ...
 
     To enable optional usage as a context manager, this function returns a
-    `~contextlib.ExitStack` object, which is not intended to be stored or
+    context manager object, which is not intended to be stored or
     accessed by the user.
     """
     stack = ExitStack()
@@ -596,7 +596,7 @@ def ioff() -> ExitStack:
     return stack
 
 
-def ion() -> ExitStack:
+def ion() -> AbstractContextManager:
     """
     Enable interactive mode.
 
@@ -626,7 +626,7 @@ def ion() -> ExitStack:
             # ...
 
     To enable optional usage as a context manager, this function returns a
-    `~contextlib.ExitStack` object, which is not intended to be stored or
+    context manager object, which is not intended to be stored or
     accessed by the user.
     """
     stack = ExitStack()

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -556,9 +556,9 @@ def isinteractive() -> bool:
     return matplotlib.is_interactive()
 
 
-# Note: The return type of ioff being AbstractContextManager 
+# Note: The return type of ioff being AbstractContextManager
 # instead of ExitStack is deliberate.
-# See https://github.com/matplotlib/matplotlib/issues/27659 
+# See https://github.com/matplotlib/matplotlib/issues/27659
 # and https://github.com/matplotlib/matplotlib/pull/27667 for more info.
 def ioff() -> AbstractContextManager:
     """
@@ -600,9 +600,9 @@ def ioff() -> AbstractContextManager:
     return stack
 
 
-# Note: The return type of ion being AbstractContextManager 
+# Note: The return type of ion being AbstractContextManager
 # instead of ExitStack is deliberate.
-# See https://github.com/matplotlib/matplotlib/issues/27659 
+# See https://github.com/matplotlib/matplotlib/issues/27659
 # and https://github.com/matplotlib/matplotlib/pull/27667 for more info.
 def ion() -> AbstractContextManager:
     """

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -556,7 +556,8 @@ def isinteractive() -> bool:
     return matplotlib.is_interactive()
 
 
-# Note: The return type of ioff being AbstractContextManager instead of ExitStack is deliberate.
+# Note: The return type of ioff being AbstractContextManager 
+# instead of ExitStack is deliberate.
 # See https://github.com/matplotlib/matplotlib/issues/27659 
 # and https://github.com/matplotlib/matplotlib/pull/27667 for more info.
 def ioff() -> AbstractContextManager:
@@ -599,7 +600,8 @@ def ioff() -> AbstractContextManager:
     return stack
 
 
-# Note: The return type of ion being AbstractContextManager instead of ExitStack is deliberate.
+# Note: The return type of ion being AbstractContextManager 
+# instead of ExitStack is deliberate.
 # See https://github.com/matplotlib/matplotlib/issues/27659 
 # and https://github.com/matplotlib/matplotlib/pull/27667 for more info.
 def ion() -> AbstractContextManager:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Closes https://github.com/matplotlib/matplotlib/issues/27659.

By changing the return type annotation to `AbstractContextManager`, Pyright considers the context managers returned by `ion` and `ioff` as not supressing errors and does not give warnings about possibly unbound variables after the `with` block.

This change has absolutely no effect on runtime behavior.

It might cause type errors for users who store the return value of `ion` or `ioff` and attempt to call `ExitStack`-specific methods on it. However, the runtime behavior of such usage has not changed and the number of users who actually do this should be very small, given that the documentation explicitly forbids "storing or accessing" the returned context manager.


## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

PS: I couldn't figure out from the developer documentation if changing a type hint constitutes an API change. Let me know if I need to add something to release notes.