### PR TITLE
MNT: prevent merging using labels + branch protection rules

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -1,0 +1,30 @@
+---
+name: Do Not Merge
+
+# action to block merging on specific labels
+on:
+  pull_request:
+    types: [synchronize, opened, reopened, labeled, unlabeled]
+
+permissions: {}
+
+jobs:
+  do-not-merge:
+    name: Prevent Merging
+    runs-on: ubuntu-latest
+    env:
+      has_tag: >-
+         ${{contains(github.event.pull_request.labels.*.name, 'status: needs comment/discussion') ||
+            contains(github.event.pull_request.labels.*.name, 'status: waiting for other PR')}}
+    steps:
+      - name: Check for label
+        if: ${{'true' == env.has_tag}}
+        run: |
+          echo "This PR cannot be merged because it has one of the following labels: "
+          echo "* status: needs comment/discussion"
+          echo "* status: waiting for other PR"
+          echo "${{env.has_tag}}"
+          exit 1
+      - name: Allow merging
+        if: ${{'false' == env.has_tag}}
+        run: exit 0


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Kinda been bugging @QuLogic about this for a while... 

This PR + some one w. org access adding a [branch protection rule](https://www.jessesquires.com/blog/2021/08/24/useful-label-based-github-actions-workflows/)  that blocks merges when this status check fails would allow us to grey out merging using a specific set of labels.

As you can see in the workflow, the status check fails b/c this is labeled "status: needs comment/discussion" (and I tried to turn off most of the CI checks so folks can play with adding and removing the label)

The motivation is b/c 'request changes' for reviews can be used in two ways:

1. needs change but will be merged after change is implemented
2. needs meta discussion, may not be merged 

And I think using it for 2. has made folks wary of using it for 1, and instead some maintainers use "leave comment" to communicate what they would need to see changed before they merge.

My hope is that decoupling small comments from requesting technical changes from blocking a PR b/c there isn't consensus (or on some other label b/c it's an or list) can help us better communicate and manage expectations around what needs to happen next in the PR - make small set of changes or wait on discussion - and make maintainers more likely to use 'request changes' instead of 'comment' to communicate what they're waiting on being implemented before approving. If a maintainer disagrees on a "requested change", then they can always add a blocking label. 

Bonus is it also is a way to flag "this is not in draft, but also not ready for merging" for POC type work. 




## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
