### PR TITLE
Implement macos AppDelegate

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -100,6 +100,9 @@ static int wait_for_stdin() {
 }
 
 /* ---------------------------- Cocoa classes ---------------------------- */
+@interface MatplotlibAppDelegate : NSObject <NSApplicationDelegate>
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app;
+@end
 
 @interface Window : NSWindow
 {   PyObject* manager;
@@ -195,6 +198,7 @@ static void lazy_init(void) {
 
     NSApp = [NSApplication sharedApplication];
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+    [NSApp setDelegate: [[[MatplotlibAppDelegate alloc] init] autorelease]];
 
     // Run our own event loop while waiting for stdin on the Python side
     // this is needed to keep the application responsive while waiting for input
@@ -778,6 +782,12 @@ static PyTypeObject FigureManagerType = {
         {}  // sentinel
     },
 };
+
+@implementation MatplotlibAppDelegate
+- (BOOL)applicationSupportsSecureRestorableState:(NSApplication *)app {
+    return YES;
+}
+@end
 
 @interface NavigationToolbar2Handler : NSObject
 {   PyObject* toolbar;


### PR DESCRIPTION
## PR summary

This suppresses a warning that appears with MacOS 14+. `WARNING: Secure coding is not enabled for restorable state!`

Thanks, @QuLogic and @tacaswell for the pointers on what needed to be done!

Testing: It seems like Python compiled with clang 15+ doesn't produce this warning, but installing Python 3.12 downloaded from python.org uses clang 13 and I do get the warnings locally.
Running a simple script you should see the warnings on main and then they should go away on this branch.
```
import matplotlib.pyplot as plt
plt.plot([1, 2, 3])
plt.show()
```

closes #27389

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
