### PR TITLE
Corrected the slider handle styling

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -417,17 +417,18 @@ class Slider(SliderBase):
         handle_style : dict
             Properties of the slider handle. Default values are
 
-            ========= ===== ======= ========================================
-            Key       Value Default Description
-            ========= ===== ======= ========================================
-            facecolor color 'white' The facecolor of the slider handle.
-            edgecolor color '.75'   The edgecolor of the slider handle.
-            size      int   10      The size of the slider handle in points.
-            ========= ===== ======= ========================================
+            =============== ======= ========================================
+            Key             Default Description
+            =============== ======= ========================================
+            marker          'o'     The style of the slider handle.
+            facecolor       'white' The facecolor of the slider handle.
+            edgecolor       '.75'   The edgecolor of the slider handle.
+            size            10      The size of the slider handle in points.
+            =============== ======= ========================================
 
-            Other values will be transformed as marker{foo} and passed to the
-            `~.Line2D` constructor. e.g. ``handle_style = {'style'='x'}`` will
-            result in ``markerstyle = 'x'``.
+            Please refer to:
+            https://matplotlib.org/stable/gallery/lines_bars_and_markers/marker_reference.html
+            for more information on styling.
 
         Notes
         -----
@@ -453,10 +454,12 @@ class Slider(SliderBase):
         self.val = valinit
         self.valinit = valinit
 
-        defaults = {'facecolor': 'white', 'edgecolor': '.75', 'size': 10}
+        defaults = {'marker': 'o', 'facecolor': 'white',
+                    'edgecolor': '.75', 'size': 10}
         handle_style = {} if handle_style is None else handle_style
         marker_props = {
-            f'marker{k}': v for k, v in {**defaults, **handle_style}.items()
+            f'{"marker" * (not k.startswith("marker")) + k}': v \
+                    for k, v in {**defaults, **handle_style}.items()
         }
 
         if orientation == 'vertical':
@@ -485,7 +488,6 @@ class Slider(SliderBase):
             handleXY = [[valinit], [0.5]]
         self._handle, = ax.plot(
             *handleXY,
-            "o",
             **marker_props,
             clip_on=False
         )


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
resolves #27672

The slider handle marker style can now be provided in handle_style dict with `"marker: "^"`.  
It still defaults to `"o"`.



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
