### PR TITLE
BLD: Downgrade FreeType to 2.6.1 on Windows ARM

### DIFF
--- a/doc/api/next_api_changes/development/27676-ES.rst
+++ b/doc/api/next_api_changes/development/27676-ES.rst
@@ -1,0 +1,6 @@
+Windows on ARM64 support
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+Windows on ARM64 bundles FreeType 2.6.1 instead of 2.11.1 when building from source.
+This may cause small changes to text rendering, but should become consistent with all
+other platforms.

--- a/extern/meson.build
+++ b/extern/meson.build
@@ -14,14 +14,7 @@ else
   # must match the value in `lib/matplotlib.__init__.py`. Also update the docs
   # in `docs/devel/dependencies.rst`. Bump the cache key in
   # `.circleci/config.yml` when changing requirements.
-  TESTING_VERSION_OF_FREETYPE = '2.6.1'
-  if host_machine.system() == 'windows' and host_machine.cpu_family() == 'aarch64'
-    # Older versions of freetype are not supported for win/arm64
-    # Matplotlib tests will not pass
-    LOCAL_FREETYPE_VERSION = '2.11.1'
-  else
-    LOCAL_FREETYPE_VERSION = TESTING_VERSION_OF_FREETYPE
-  endif
+  LOCAL_FREETYPE_VERSION = '2.6.1'
 
   freetype_proj = subproject(
     f'freetype-@LOCAL_FREETYPE_VERSION@',

--- a/subprojects/freetype-2.11.1.wrap
+++ b/subprojects/freetype-2.11.1.wrap
@@ -1,7 +1,0 @@
-[wrap-file]
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.11.1.tar.xz
-source_filename = freetype-2.11.1.tar.xz
-source_hash = 3333ae7cfda88429c97a7ae63b7d01ab398076c3b67182e960e5684050f2c5c8
-
-[provide]
-freetype-2.11.1 = freetype_dep


### PR DESCRIPTION
## PR summary

We needed the new version because autotools didn't know about Windows-on-ARM. But we build with Meson now, and overlay a Meson build system for FreeType, so it either works for both of us or it doesn't (and it does).

Dropping down to the older version means that tests pass on Windows ARM without any need to mess with tolerance or generating new images.

Note: we don't build for Windows on ARM because dependencies aren't there, but they're quite close, so we can enable that soon.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines