### PR TITLE
doc: fix Patch.contains_point docstring example

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -190,10 +190,10 @@ class Patch(artist.Artist):
         transform them first:
 
         >>> center = 0, 0
-        >>> c = Circle(center, radius=1)
+        >>> c = Circle(center, radius=3)
         >>> plt.gca().add_patch(c)
-        >>> transformed_center = c.get_transform().transform(center)
-        >>> c.contains_point(transformed_center)
+        >>> transformed_interior_point = c.get_data_transform().transform((0, 2))
+        >>> c.contains_point(transformed_interior_point)
         True
 
         """


### PR DESCRIPTION
## PR summary
See the docstring of `Patch.contains_point`: 
https://github.com/matplotlib/matplotlib/blob/09eab5b1c471410d238b449ebbac63f70759fc21/lib/matplotlib/patches.py#L174-L197

It explains that one has to use data coordinates when using `contains_point` but then provides an example that uses `Circle` and `get_transform` which isn't correct. This has lead to confusion in the past, see #23178.

The proposed changes in this PR will move the example to use `get_data_transform` and uses values which would fail if one were to use `get_transform`. 

IMHO this closes #23178.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

