### PR TITLE
Work around pyparsing diagnostic warnings

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -13,7 +13,7 @@ from functools import lru_cache, partial
 import re
 
 from pyparsing import (
-    Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore, oneOf)
+    Group, Optional, ParseException, Regex, StringEnd, Suppress, ZeroOrMore, oneOf)
 
 
 _family_punc = r'\\\-:,'
@@ -61,7 +61,7 @@ def _make_fontconfig_parser():
     size = Regex(r"([0-9]+\.?[0-9]*|\.[0-9]+)")
     name = Regex(r"[a-z]+")
     value = Regex(fr"([^{_value_punc}]|(\\[{_value_punc}]))*")
-    prop = (name + Suppress("=") + comma_separated(value)) | oneOf(_CONSTANTS)
+    prop = Group((name + Suppress("=") + comma_separated(value)) | oneOf(_CONSTANTS))
     return (
         Optional(comma_separated(family)("families"))
         + Optional("-" + comma_separated(size)("sizes"))


### PR DESCRIPTION
Closes #25204

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


This feels a bit more "workaround" than I'd _really_ like, but it seems to work.

- Pyparsing warns when you try to name a forward reference before it is defined
  - As far as I can tell, it actually _does_ work currently, but discussion on pyparsing/pyparsing#95
    leads me to believe that we are relying on something that could change
  - When names are given, a _copy_ is produced, and thus in theory the forward references won't get their definitions
     - In practice, they appear to
  - There is a warning which is disabled by default for this behavior.
    - Enabled with `python -Wdefault`, but not enabled in our test suite
  - The solution I came up with was to wrap it in another layer of forward reference
    - This feels like a hack, but the reference the outer forward holds gets filled out and a copy to that reference is transmitted to the copies.
  - I also considered
    - defining early
      - Can't do completely due to cycles, redefining is _possible_, but likely to be more fragile
    - Supressing warnings
      - Works for now, but seems not by design
    - Removing names
      - Would require (at least) more extensive code changes, as many test failures result.
    - Not using a `Forward`
      - Was unable to find something that did not obstruct values used by parsing functions (tried e.g. `Group`, ` + Empty()`, etc)

The `_fontconfig_pattern.py` is a compatibility change adding a `Group` which was suggested by a similar warning.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
