### PR TITLE
ci: Don't include API/what's new notes in general doc labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -75,10 +75,14 @@
           - 'lib/matplotlib/backends/backend_wx*.py*'
 
 "Documentation: API":
-  - changed-files:
-      - any-glob-to-any-file:
-          # Also files in lib/**, but we can't be sure those are only documentation.
-          - 'doc/api/**'
+  - all:
+    - changed-files:
+        - any-glob-to-any-file:
+            # Also files in lib/**, but we can't be sure those are only documentation.
+            - 'doc/api/**'
+        - all-globs-all-files:
+            - '!doc/api/next_api_changes/**'
+
 "Documentation: build":
   - changed-files:
       - any-glob-to-any-file:
@@ -102,10 +106,13 @@
       - any-glob-to-any-file:
           - 'galleries/tutorials/**'
 "Documentation: user guide":
-  - changed-files:
-      - any-glob-to-any-file:
-          - 'doc/users/**'
-          - 'galleries/users_explain/**'
+  - all:
+    - changed-files:
+        - any-glob-to-any-file:
+            - 'doc/users/**'
+            - 'galleries/users_explain/**'
+        - all-globs-to-all-files:
+            - '!doc/users/next_whats_new/**'
 
 "topic: animation":
   - changed-files:


### PR DESCRIPTION
## PR summary

PRs that touch `doc/users/next_whats_new/*` because they have a new feature shouldn't be labelled as "user guide" updates, and similar for API notes.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines