### PR TITLE
Remove "Past versions" section from release notes

### DIFF
--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -75,10 +75,6 @@ Version 3.4
     prev_whats_new/github_stats_3.4.1.rst
     prev_whats_new/github_stats_3.4.0.rst
 
-=============
-Past versions
-=============
-
 Version 3.3
 ^^^^^^^^^^^
 .. toctree::


### PR DESCRIPTION
This came in via #21251 and I vaguely remember it had a purpose (possibly something with navigation / what is rendered in the sidebars?) However, in the
current docs, it looks rather useless: https://matplotlib.org/devdocs/users/release_notes.html

Ping @jklymak do you remember why you added a "Past versions" section?

