### PR TITLE
Suptitle swapping order of updates between defaults and fontdict

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1121,8 +1121,8 @@ default: %(va)s
         """
         effective_kwargs = {
             'transform': self.transSubfigure,
-            **(fontdict if fontdict is not None else {}),
             **kwargs,
+            **(fontdict if fontdict is not None else {}),
         }
         text = Text(x=x, y=y, text=s, **effective_kwargs)
         text.set_figure(self)


### PR DESCRIPTION
Closes #27630

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Issue #27630 highlighted how passing a `size`  value inside `fontdict` was being ignored within `figure.suptitle`. This was happening because the default kwargs sent to Text were being updated with the defaults last (i.e. highest priority). Switching the order of the dictionary update fixes this, giving highest priority to arguments specified in `fontdict` by the user.

Test code by @boffi:
```
import matplotlib.pyplot as plt

fig = plt.figure(figsize=(8, 3), layout='constrained')
f0, f1 = fig.subfigures(1, 2)
f0.suptitle('xxxXXX', fontdict=dict(family='Candara', size=30))
f0.add_subplot().set_title('xxxXXX', fontdict=dict(family='Candara', size=20))
f1.suptitle('xxxXXX', size=30, fontdict=dict(family='Candara'))
f1.add_subplot().set_title('xxxXXX', size=20, fontdict=dict(family='Candara'))
plt.show()
```

Broken behavior:
![Figure_0](https://github.com/matplotlib/matplotlib/assets/15110959/92d7b836-0f3f-48a0-a47e-98c27f4b9763)

Fixed behavior:
![Figure_1](https://github.com/matplotlib/matplotlib/assets/15110959/1a42ea80-f735-49b1-b235-8e442b8c5bc1)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] N/A *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] N/A *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] N/A Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines


Note: This is my first PR. Please let me know if I messed up anything here.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
