### PR TITLE
MNT/ENH: make hist and friends more forgiving of array-like

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1411,13 +1411,17 @@ def _reshape_2D(X, name):
     *name* is used to generate the error message for invalid inputs.
     """
 
-    # Unpack in case of e.g. Pandas or xarray object
-    X = _unpack_to_numpy(X)
-
     # Iterate over columns for ndarrays.
-    if isinstance(X, np.ndarray):
-        X = X.T
+    if hasattr(X, 'iloc'):
+        # probably pandas...
+        # return each column as a separate list element
+        if X.ndim == 1:
+            return [np.array(X)]
+        elif X.ndim == 2:
+            return [np.array(X.iloc[:, i]) for i in range(X.shape[1])]
 
+    if hasattr(X, 'T') and hasattr(X, 'ndim'):
+        X = X.T
         if len(X) == 0:
             return [[]]
         elif X.ndim == 1 and np.ndim(X[0]) == 0:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6751,6 +6751,16 @@ def test_pandas_indexing_hist(pd):
     ax.hist(ser_2)
 
 
+def test_pandas_hist2D(pd):
+    np.random.seed(19680801)
+    x0 = np.random.randn(200, 3)
+    df = pd.DataFrame(x0, columns=["a", "b", "c"])
+    fig, ax = plt.subplots()
+    tops = ax.hist(df)
+    # one list of hist values for each column:
+    assert tops[0].shape[0] == 3
+
+
 def test_pandas_bar_align_center(pd):
     # Tests fix for issue 8767
     df = pd.DataFrame({'a': range(2), 'b': range(2)})


### PR DESCRIPTION
This is an alternate to #25887.  

Not sure it is correct yet, but the idea is 

1) special carve out if `X` has `iloc`.  Basically pandas.
2) Instead of doing array-like logic on `ndarrays`,  it does them if `X` has `ndim`  and `T`, both of which are required.  
   - Tensor satisfies this
   - Jax has `ndim`.  I was a little unclear if it supports `T`, but it has a transpose method, so I expect it does.  
3) rest is the same.  

Still needs testing that these array-like libraries work.  But if a numpy-like array doesn't support `X.T` and `X.ndim`....

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
