### PR TITLE
fix default image format in gtk4 savefig dialog

### DIFF
--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -361,7 +361,7 @@ class NavigationToolbar2GTK4(_NavigationToolbar2GTK, Gtk.Box):
         formats = [formats[default_format], *formats[:default_format],
                    *formats[default_format+1:]]
         dialog.add_choice('format', 'File format', formats, formats)
-        dialog.set_choice('format', formats[default_format])
+        dialog.set_choice('format', formats[0])
 
         dialog.set_current_folder(Gio.File.new_for_path(
             os.path.expanduser(mpl.rcParams['savefig.directory'])))


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

When I try to save a figure using the gtk4 file chooser the default format is `PGF code for LaTeX`, but it should be "png" because I set  `rcParams["savefig.format"] = 'png'` . The default file extension is still `.png` , confusingly. This only started happening after I recently upgraded my system to gtk4. 

Looking at the code, I see an indexing bug when choosing the default format: The previous lines to my diff reorganized the format order so that the default format is the first in the list, therefore to get the default one should use index 0, not the old index before reordering.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

I manually tested that the dialog works as expected after this PR. I did not run the unit tests, nor create a unit test, but I can run them if requested. I hope that CI can be enough for such a small change as I haven't set up a dev env for matplotlib. 

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
