### PR TITLE
TST: always set a (long) timeout for subprocess and always use our wrapper

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -50,7 +50,7 @@ def setup():
     set_reproducibility_for_testing()
 
 
-def subprocess_run_for_testing(command, env=None, timeout=None, stdout=None,
+def subprocess_run_for_testing(command, env=None, timeout=60, stdout=None,
                                stderr=None, check=False, text=True,
                                capture_output=False):
     """

--- a/lib/matplotlib/tests/test_backend_nbagg.py
+++ b/lib/matplotlib/tests/test_backend_nbagg.py
@@ -1,9 +1,11 @@
 import os
 from pathlib import Path
-import subprocess
+
 from tempfile import TemporaryDirectory
 
 import pytest
+
+from matplotlib.testing import subprocess_run_for_testing
 
 nbformat = pytest.importorskip('nbformat')
 pytest.importorskip('nbconvert')
@@ -17,11 +19,12 @@ def test_ipynb():
 
     with TemporaryDirectory() as tmpdir:
         out_path = Path(tmpdir, "out.ipynb")
-        subprocess.check_call(
+        subprocess_run_for_testing(
             ["jupyter", "nbconvert", "--to", "notebook",
              "--execute", "--ExecutePreprocessor.timeout=500",
              "--output", str(out_path), str(nb_path)],
-            env={**os.environ, "IPYTHONDIR": tmpdir})
+            env={**os.environ, "IPYTHONDIR": tmpdir},
+            check=True)
         with out_path.open() as out:
             nb = nbformat.read(out, nbformat.current_nbformat)
 

--- a/lib/matplotlib/tests/test_backend_nbagg.py
+++ b/lib/matplotlib/tests/test_backend_nbagg.py
@@ -1,6 +1,5 @@
 import os
 from pathlib import Path
-
 from tempfile import TemporaryDirectory
 
 import pytest

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -1,8 +1,8 @@
 import os
 import sys
 import pytest
-import matplotlib.backends.backend_webagg_core
 
+import matplotlib.backends.backend_webagg_core
 from matplotlib.testing import subprocess_run_for_testing
 
 
@@ -24,9 +24,7 @@ def test_webagg_fallback(backend):
         + "print(plt.get_backend());"
         f"assert '{backend}' == plt.get_backend().lower();"
     )
-    subprocess_run_for_testing(
-        [sys.executable, "-c", test_code], env=env, check=True
-    )
+    subprocess_run_for_testing([sys.executable, "-c", test_code], env=env, check=True)
 
 
 def test_webagg_core_no_toolbar():

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -1,8 +1,9 @@
-import subprocess
 import os
 import sys
 import pytest
 import matplotlib.backends.backend_webagg_core
+
+from matplotlib.testing import subprocess_run_for_testing
 
 
 @pytest.mark.parametrize("backend", ["webagg", "nbagg"])
@@ -23,9 +24,9 @@ def test_webagg_fallback(backend):
         + "print(plt.get_backend());"
         f"assert '{backend}' == plt.get_backend().lower();"
     )
-    ret = subprocess.call([sys.executable, "-c", test_code], env=env)
-
-    assert ret == 0
+    subprocess_run_for_testing(
+        [sys.executable, "-c", test_code], env=env, check=True
+    )
 
 
 def test_webagg_core_no_toolbar():

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -1,8 +1,9 @@
 import builtins
 import os
-import subprocess
 import sys
 import textwrap
+
+from matplotlib.testing import subprocess_run_for_testing
 
 
 def test_simple():
@@ -41,6 +42,7 @@ def test_lazy_imports():
     assert 'urllib.request' not in sys.modules
     """)
 
-    subprocess.check_call(
+    subprocess_run_for_testing(
         [sys.executable, '-c', source],
-        env={**os.environ, "MPLBACKEND": "", "MATPLOTLIBRC": os.devnull})
+        env={**os.environ, "MPLBACKEND": "", "MATPLOTLIBRC": os.devnull},
+        check=True)

--- a/lib/matplotlib/tests/test_determinism.py
+++ b/lib/matplotlib/tests/test_determinism.py
@@ -3,7 +3,6 @@ Test output reproducibility.
 """
 
 import os
-import subprocess
 import sys
 
 import pytest

--- a/lib/matplotlib/tests/test_determinism.py
+++ b/lib/matplotlib/tests/test_determinism.py
@@ -12,6 +12,7 @@ import matplotlib as mpl
 import matplotlib.testing.compare
 from matplotlib import pyplot as plt
 from matplotlib.testing._markers import needs_ghostscript, needs_usetex
+from matplotlib.testing import subprocess_run_for_testing
 
 
 def _save_figure(objects='mhi', fmt="pdf", usetex=False):
@@ -89,12 +90,13 @@ def test_determinism_check(objects, fmt, usetex):
         Output format.
     """
     plots = [
-        subprocess.check_output(
+        subprocess_run_for_testing(
             [sys.executable, "-R", "-c",
              f"from matplotlib.tests.test_determinism import _save_figure;"
              f"_save_figure({objects!r}, {fmt!r}, {usetex})"],
             env={**os.environ, "SOURCE_DATE_EPOCH": "946684800",
-                 "MPLBACKEND": "Agg"})
+                 "MPLBACKEND": "Agg"},
+            text=False, capture_output=True, check=True).stdout
         for _ in range(3)
     ]
     for p in plots[1:]:
@@ -129,10 +131,10 @@ def test_determinism_source_date_epoch(fmt, string):
     string : bytes
         Timestamp string for 2000-01-01 00:00 UTC.
     """
-    buf = subprocess.check_output(
+    buf = subprocess_run_for_testing(
         [sys.executable, "-R", "-c",
          f"from matplotlib.tests.test_determinism import _save_figure; "
          f"_save_figure('', {fmt!r})"],
         env={**os.environ, "SOURCE_DATE_EPOCH": "946684800",
-             "MPLBACKEND": "Agg"})
+             "MPLBACKEND": "Agg"}, capture_output=True, text=False, check=True).stdout
     assert string in buf

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -5,7 +5,6 @@ import os
 from pathlib import Path
 from PIL import Image
 import shutil
-import subprocess
 import sys
 import warnings
 
@@ -17,6 +16,8 @@ from matplotlib.font_manager import (
     json_dump, json_load, get_font, is_opentype_cff_font,
     MSUserFontDirectories, _get_fontconfig_fonts, ttfFontProperty)
 from matplotlib import cbook, ft2font, pyplot as plt, rc_context, figure as mfigure
+from matplotlib.testing import subprocess_run_helper
+
 
 has_fclist = shutil.which('fc-list') is not None
 
@@ -275,11 +276,10 @@ def _test_threading():
 
 def test_fontcache_thread_safe():
     pytest.importorskip('threading')
-    import inspect
 
-    proc = subprocess.run(
-        [sys.executable, "-c",
-         inspect.getsource(_test_threading) + '\n_test_threading()']
+    proc = subprocess_run_helper(
+        _test_threading,
+        timeout=10
     )
     if proc.returncode:
         pytest.fail("The subprocess returned with non-zero exit status "

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -277,13 +277,7 @@ def _test_threading():
 def test_fontcache_thread_safe():
     pytest.importorskip('threading')
 
-    proc = subprocess_run_helper(
-        _test_threading,
-        timeout=10
-    )
-    if proc.returncode:
-        pytest.fail("The subprocess returned with non-zero exit status "
-                    f"{proc.returncode}.")
+    subprocess_run_helper(_test_threading, timeout=10)
 
 
 def test_fontentry_dataclass():

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -74,7 +74,7 @@ def test_importable_with__OO():
         "import matplotlib.cbook as cbook; "
         "import matplotlib.patches as mpatches"
     )
-    cmd = [sys.executable, "-OO", "-c", program]
     subprocess_run_for_testing(
-        cmd, env={**os.environ, "MPLBACKEND": ""}, check=True
+        [sys.executable, "-OO", "-c", program],
+        env={**os.environ, "MPLBACKEND": ""}, check=True
         )

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -5,6 +5,7 @@ import sys
 import pytest
 
 import matplotlib
+from matplotlib.testing import subprocess_run_for_testing
 
 
 @pytest.mark.parametrize('version_str, version_tuple', [
@@ -26,7 +27,7 @@ def test_tmpconfigdir_warning(tmp_path):
     mode = os.stat(tmp_path).st_mode
     try:
         os.chmod(tmp_path, 0)
-        proc = subprocess.run(
+        proc = subprocess_run_for_testing(
             [sys.executable, "-c", "import matplotlib"],
             env={**os.environ, "MPLCONFIGDIR": str(tmp_path)},
             stderr=subprocess.PIPE, text=True, check=True)
@@ -36,7 +37,7 @@ def test_tmpconfigdir_warning(tmp_path):
 
 
 def test_importable_with_no_home(tmp_path):
-    subprocess.run(
+    subprocess_run_for_testing(
         [sys.executable, "-c",
          "import pathlib; pathlib.Path.home = lambda *args: 1/0; "
          "import matplotlib.pyplot"],
@@ -74,4 +75,6 @@ def test_importable_with__OO():
         "import matplotlib.patches as mpatches"
     )
     cmd = [sys.executable, "-OO", "-c", program]
-    assert subprocess.call(cmd, env={**os.environ, "MPLBACKEND": ""}) == 0
+    subprocess_run_for_testing(
+        cmd, env={**os.environ, "MPLBACKEND": ""}, check=True
+        )

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -29,6 +29,7 @@ from matplotlib.rcsetup import (
     validate_sketch,
     _validate_linestyle,
     _listify_validator)
+from matplotlib.testing import subprocess_run_for_testing
 
 
 def test_rcparams(tmp_path):
@@ -524,7 +525,7 @@ def test_backend_fallback_headless(tmp_path):
            "DISPLAY": "", "WAYLAND_DISPLAY": "",
            "MPLBACKEND": "", "MPLCONFIGDIR": str(tmp_path)}
     with pytest.raises(subprocess.CalledProcessError):
-        subprocess.run(
+        subprocess_run_for_testing(
             [sys.executable, "-c",
              "import matplotlib;"
              "matplotlib.use('tkagg');"
@@ -540,7 +541,7 @@ def test_backend_fallback_headless(tmp_path):
 def test_backend_fallback_headful(tmp_path):
     pytest.importorskip("tkinter")
     env = {**os.environ, "MPLBACKEND": "", "MPLCONFIGDIR": str(tmp_path)}
-    backend = subprocess.check_output(
+    backend = subprocess_run_for_testing(
         [sys.executable, "-c",
          "import matplotlib as mpl; "
          "sentinel = mpl.rcsetup._auto_backend_sentinel; "
@@ -549,7 +550,7 @@ def test_backend_fallback_headful(tmp_path):
          "assert mpl.rcParams._get('backend') == sentinel; "
          "import matplotlib.pyplot; "
          "print(matplotlib.get_backend())"],
-        env=env, text=True)
+        env=env, text=True, check=True, capture_output=True).stdout
     # The actual backend will depend on what's installed, but at least tkagg is
     # present.
     assert backend.strip().lower() != "agg"

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,13 +1,15 @@
 import os
 from pathlib import Path
 import re
-import subprocess
+
 import sys
 
 import matplotlib.pyplot as plt
 from matplotlib.texmanager import TexManager
 from matplotlib.testing._markers import needs_usetex
 import pytest
+
+from matplotlib.testing import subprocess_run_for_testing
 
 
 def test_fontconfig_preamble():
@@ -64,11 +66,11 @@ def test_unicode_characters():
 
 @needs_usetex
 def test_openin_any_paranoid():
-    completed = subprocess.run(
+    completed = subprocess_run_for_testing(
         [sys.executable, "-c",
          'import matplotlib.pyplot as plt;'
          'plt.rcParams.update({"text.usetex": True});'
          'plt.title("paranoid");'
          'plt.show(block=False);'],
         env={**os.environ, 'openin_any': 'p'}, check=True, capture_output=True)
-    assert completed.stderr == b""
+    assert completed.stderr == ""

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -1,15 +1,14 @@
 import os
 from pathlib import Path
 import re
-
 import sys
 
-import matplotlib.pyplot as plt
-from matplotlib.texmanager import TexManager
-from matplotlib.testing._markers import needs_usetex
 import pytest
 
+import matplotlib.pyplot as plt
 from matplotlib.testing import subprocess_run_for_testing
+from matplotlib.testing._markers import needs_usetex
+from matplotlib.texmanager import TexManager
 
 
 def test_fontconfig_preamble():


### PR DESCRIPTION
If you are using this and really need unbounded timeouts, explicitly pass `timeout=None`

This is an attempt to avoid azure from hanging and then timing out.