### PR TITLE
Simplify Figure._suplabels.

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -287,8 +287,6 @@ default: %(va)s
             Additional kwargs are `matplotlib.text.Text` properties.
         """
 
-        suplab = getattr(self, info['name'])
-
         x = kwargs.pop('x', None)
         y = kwargs.pop('y', None)
         if info['name'] in ['_supxlabel', '_suptitle']:
@@ -300,29 +298,24 @@ default: %(va)s
         if y is None:
             y = info['y0']
 
-        if 'horizontalalignment' not in kwargs and 'ha' not in kwargs:
-            kwargs['horizontalalignment'] = info['ha']
-        if 'verticalalignment' not in kwargs and 'va' not in kwargs:
-            kwargs['verticalalignment'] = info['va']
-        if 'rotation' not in kwargs:
-            kwargs['rotation'] = info['rotation']
+        kwargs = cbook.normalize_kwargs(kwargs, Text)
+        kwargs.setdefault('horizontalalignment', info['ha'])
+        kwargs.setdefault('verticalalignment', info['va'])
+        kwargs.setdefault('rotation', info['rotation'])
 
         if 'fontproperties' not in kwargs:
-            if 'fontsize' not in kwargs and 'size' not in kwargs:
-                kwargs['size'] = mpl.rcParams[info['size']]
-            if 'fontweight' not in kwargs and 'weight' not in kwargs:
-                kwargs['weight'] = mpl.rcParams[info['weight']]
+            kwargs.setdefault('fontsize', mpl.rcParams[info['size']])
+            kwargs.setdefault('fontweight', mpl.rcParams[info['weight']])
 
-        sup = self.text(x, y, t, **kwargs)
+        suplab = getattr(self, info['name'])
         if suplab is not None:
             suplab.set_text(t)
             suplab.set_position((x, y))
-            suplab.update_from(sup)
-            sup.remove()
+            suplab.set(**kwargs)
         else:
-            suplab = sup
+            suplab = self.text(x, y, t, **kwargs)
+            setattr(self, info['name'], suplab)
         suplab._autopos = autopos
-        setattr(self, info['name'], suplab)
         self.stale = True
         return suplab
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -80,17 +80,17 @@ def _get_text_metrics_with_cache_impl(
 @_docstring.interpd
 @_api.define_aliases({
     "color": ["c"],
-    "fontfamily": ["family"],
     "fontproperties": ["font", "font_properties"],
-    "horizontalalignment": ["ha"],
-    "multialignment": ["ma"],
+    "fontfamily": ["family"],
     "fontname": ["name"],
     "fontsize": ["size"],
     "fontstretch": ["stretch"],
     "fontstyle": ["style"],
     "fontvariant": ["variant"],
-    "verticalalignment": ["va"],
     "fontweight": ["weight"],
+    "horizontalalignment": ["ha"],
+    "verticalalignment": ["va"],
+    "multialignment": ["ma"],
 })
 class Text(Artist):
     """Handle storing and drawing of text in window or data coordinates."""


### PR DESCRIPTION
Rely on alias normalization machinery to make alias checking simpler and more robust (there are also aliases for fontproperties which were not checked before).

While at it, also slightly reorder Text aliases (this has no actual visible effect) to have the font properties and the alignments grouped.

Noted via #27630 (this should not interfere with the current PR for that issue).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
