### PR TITLE
Add protections against infinite loop in bezier calculations

### DIFF
--- a/lib/matplotlib/bezier.py
+++ b/lib/matplotlib/bezier.py
@@ -171,9 +171,17 @@ def find_bezier_t_intersecting_with_closedpath(
 
         if start_inside ^ middle_inside:
             t1 = middle_t
+            if end == middle:
+                # Edge case where infinite loop is possible
+                # Caused by large numbers relative to tolerance
+                return t0, t1
             end = middle
         else:
             t0 = middle_t
+            if start == middle:
+                # Edge case where infinite loop is possible
+                # Caused by large numbers relative to tolerance
+                return t0, t1
             start = middle
             start_inside = middle_inside
 

--- a/lib/matplotlib/tests/test_bezier.py
+++ b/lib/matplotlib/tests/test_bezier.py
@@ -1,0 +1,17 @@
+"""
+Tests specific to the bezier module.
+"""
+
+from matplotlib.bezier import inside_circle, split_bezier_intersecting_with_closedpath
+
+
+def test_split_bezier_with_large_values():
+    # These numbers come from gh-27753
+    arrow_path = [(96950809781500.0, 804.7503795623779),
+                  (96950809781500.0, 859.6242585800646),
+                  (96950809781500.0, 914.4981375977513)]
+    in_f = inside_circle(96950809781500.0, 804.7503795623779, 0.06)
+    split_bezier_intersecting_with_closedpath(arrow_path, in_f)
+    # All we are testing is that this completes
+    # The failure case is an infinite loop resulting from floating point precision
+    # pytest will timeout if that occurs


### PR DESCRIPTION
Closes #27753

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

This is usually an internal detail of things like `FancyArrowPatch`. The failure mode
is an infinite loop. Since the only case we are changing never worked, no API note is
included

<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.
Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/coding_guide.html#new-features-and-api-changes)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
