### PR TITLE
macOS: Check for display availability when looking for backends

### DIFF
--- a/lib/matplotlib/tests/test_backend_macosx.py
+++ b/lib/matplotlib/tests/test_backend_macosx.py
@@ -6,8 +6,15 @@ import pytest
 from unittest import mock
 
 import matplotlib as mpl
+from matplotlib import _c_internal_utils
 import matplotlib.pyplot as plt
 from matplotlib.testing import subprocess_run_helper
+
+
+pytestmark = [
+    pytest.mark.skipif(not _c_internal_utils.display_is_valid(),
+                       reason="Display is unavailable")
+]
 
 
 _test_timeout = 60

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -310,9 +310,8 @@ def _get_testable_qt_backends():
     ]:
         reason = None
         missing = [dep for dep in deps if not importlib.util.find_spec(dep)]
-        if (sys.platform == "linux" and
-                not _c_internal_utils.display_is_valid()):
-            reason = "$DISPLAY and $WAYLAND_DISPLAY are unset"
+        if not _c_internal_utils.display_is_valid():
+            reason = "Display is unavailable"
         elif missing:
             reason = "{} cannot be imported".format(", ".join(missing))
         elif env["MPLBACKEND"] == 'macosx' and os.environ.get('TF_BUILD'):

--- a/lib/matplotlib/tests/test_backend_tk.py
+++ b/lib/matplotlib/tests/test_backend_tk.py
@@ -36,8 +36,8 @@ def _isolated_tk_test(success_count, func=None):
         reason="missing tkinter"
     )
     @pytest.mark.skipif(
-        sys.platform == "linux" and not _c_internal_utils.xdisplay_is_valid(),
-        reason="$DISPLAY is unset"
+        not _c_internal_utils.display_is_valid(),
+        reason="Display is unavailable"
     )
     @functools.wraps(func)
     def test_func():

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -59,6 +59,8 @@ def _get_available_interactive_backends():
                                      not _c_internal_utils.display_is_valid())
     _is_linux_and_xdisplay_invalid = (sys.platform == "linux" and
                                       not _c_internal_utils.xdisplay_is_valid())
+    _is_macos_and_display_invalid = (sys.platform == "darwin" and
+                                     not _c_internal_utils.display_is_valid())
     envs = []
     for deps, env in [
             *[([qt_api],
@@ -85,6 +87,8 @@ def _get_available_interactive_backends():
             reason = "$DISPLAY is unset"
         elif _is_linux_and_display_invalid:
             reason = "$DISPLAY and $WAYLAND_DISPLAY are unset"
+        elif _is_macos_and_display_invalid:
+            reason = "Display is unavailable"
         elif env["MPLBACKEND"] == 'macosx' and os.environ.get('TF_BUILD'):
             reason = "macosx backend fails on Azure"
         elif env["MPLBACKEND"].startswith('gtk'):
@@ -451,9 +455,8 @@ def qt5_and_qt6_pairs():
             yield from ([qt5, qt6], [qt6, qt5])
 
 
-@pytest.mark.skipif(
-    sys.platform == "linux" and not _c_internal_utils.display_is_valid(),
-    reason="$DISPLAY and $WAYLAND_DISPLAY are unset")
+@pytest.mark.skipif(not _c_internal_utils.display_is_valid(),
+                    reason='Display is unavailable')
 @pytest.mark.parametrize('host, mpl', [*qt5_and_qt6_pairs()])
 def test_cross_Qt_imports(host, mpl):
     try:

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -573,9 +573,7 @@ def test_backend_fallback_headless_auto_backend(tmp_path):
     assert backend.strip().lower() == "agg"
 
 
-@pytest.mark.skipif(
-    sys.platform == "linux" and not _c_internal_utils.xdisplay_is_valid(),
-    reason="headless")
+@pytest.mark.skipif(not _c_internal_utils.display_is_valid(), reason="headless")
 def test_backend_fallback_headful(tmp_path):
     if parse_version(pytest.__version__) >= parse_version('8.2.0'):
         pytest_kwargs = dict(exc_type=ImportError)

--- a/src/_c_internal_utils.cpp
+++ b/src/_c_internal_utils.cpp
@@ -28,6 +28,10 @@
 #else
 #define UNUSED_ON_NON_WINDOWS Py_UNUSED
 #endif
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#include <ApplicationServices/ApplicationServices.h>
+#endif
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -90,6 +94,16 @@ mpl_display_is_valid(void)
         }
     }
     return false;
+#elif defined(__APPLE__)
+    CFDictionaryRef session_info;
+
+    session_info = CGSessionCopyCurrentDictionary();
+    if (session_info == NULL) {
+        return false;
+    }
+
+    CFRelease(session_info);
+    return true;
 #else
     return true;
 #endif
@@ -198,6 +212,8 @@ PYBIND11_MODULE(_c_internal_utils, m, py::mod_gil_not_used())
         On Linux, returns True if either $DISPLAY is set and XOpenDisplay(NULL)
         succeeds, or $WAYLAND_DISPLAY is set and wl_display_connect(NULL)
         succeeds.
+
+        On macOS, returns True if CGSessionCopyCurrentDictionary is not NULL.
 
         On other platforms, always returns True.)""");
     m.def(

--- a/src/_c_internal_utils.cpp
+++ b/src/_c_internal_utils.cpp
@@ -31,6 +31,7 @@
 #ifdef __APPLE__
 #include <CoreFoundation/CoreFoundation.h>
 #include <CoreText/CoreText.h>
+#include <ApplicationServices/ApplicationServices.h>
 #endif
 
 namespace py = pybind11;
@@ -94,6 +95,16 @@ mpl_display_is_valid(void)
         }
     }
     return false;
+#elif defined(__APPLE__)
+    CFDictionaryRef session_info;
+
+    session_info = CGSessionCopyCurrentDictionary();
+    if (session_info == NULL) {
+        return false;
+    }
+
+    CFRelease(session_info);
+    return true;
 #else
     return true;
 #endif
@@ -257,6 +268,8 @@ PYBIND11_MODULE(_c_internal_utils, m, py::mod_gil_not_used())
         On Linux, returns True if either $DISPLAY is set and XOpenDisplay(NULL)
         succeeds, or $WAYLAND_DISPLAY is set and wl_display_connect(NULL)
         succeeds.
+
+        On macOS, returns True if CGSessionCopyCurrentDictionary is not NULL.
 
         On other platforms, always returns True.)""");
     m.def(

--- a/src/meson.build
+++ b/src/meson.build
@@ -30,6 +30,12 @@ else
   user32 = []
 endif
 
+if host_machine.system() == 'darwin'
+  coregraphics = dependency('appleframeworks', modules: 'CoreGraphics')
+else
+  coregraphics = []
+endif
+
 extension_data = {
   '_backend_agg': {
     'subdir': 'matplotlib/backends',
@@ -44,7 +50,7 @@ extension_data = {
     'sources': files(
       '_c_internal_utils.cpp',
     ),
-    'dependencies': [pybind11_dep, dl, ole32, shell32, user32],
+    'dependencies': [pybind11_dep, dl, ole32, shell32, user32, coregraphics],
   },
   'ft2font': {
     'subdir': 'matplotlib',

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,9 +31,9 @@ else
 endif
 
 if host_machine.system() == 'darwin'
-  coretext = dependency('appleframeworks', modules: 'CoreText')
+  appleframeworks = dependency('appleframeworks', modules: ['CoreGraphics', 'CoreText'])
 else
-  coretext = []
+  appleframeworks = []
 endif
 
 extension_data = {
@@ -50,7 +50,7 @@ extension_data = {
     'sources': files(
       '_c_internal_utils.cpp',
     ),
-    'dependencies': [pybind11_dep, dl, ole32, shell32, user32, coretext],
+    'dependencies': [pybind11_dep, dl, ole32, shell32, user32, appleframeworks],
   },
   'ft2font': {
     'subdir': 'matplotlib',


### PR DESCRIPTION
## PR summary

This checks `CGSessionCopyCurrentDictionary` similar to checking `$DISPLAY`/`$WAYLAND_DISPLAY` on Linux.

Fixes #26292

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines