### PR TITLE
MNT: deprecate draw method args and kwargs

### DIFF
--- a/doc/api/next_api_changes/deprecations/27768-REC.rst
+++ b/doc/api/next_api_changes/deprecations/27768-REC.rst
@@ -1,0 +1,5 @@
+``[XYZ]Axis.draw``, ``*Image.draw`` *args* and *kwargs*...
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... are deprecated because they have no effect.  This will make the calling sequence
+consistent with the ``draw`` method of other artists.

--- a/galleries/examples/misc/demo_ribbon_box.py
+++ b/galleries/examples/misc/demo_ribbon_box.py
@@ -49,7 +49,7 @@ class RibbonBoxImage(AxesImage):
         self._ribbonbox = RibbonBox(color)
         self.set_transform(BboxTransformTo(bbox))
 
-    def draw(self, renderer, *args, **kwargs):
+    def draw(self, renderer):
         stretch_factor = self._bbox.height / self._bbox.width
 
         ny = int(stretch_factor*self._ribbonbox.nx)
@@ -57,7 +57,7 @@ class RibbonBoxImage(AxesImage):
             arr = self._ribbonbox.get_stretched_image(stretch_factor)
             self.set_array(arr)
 
-        super().draw(renderer, *args, **kwargs)
+        super().draw(renderer)
 
 
 def main():

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1373,6 +1373,8 @@ class Axis(martist.Artist):
             values.append(self.minorTicks[0].get_tick_padding())
         return max(values, default=0)
 
+    @_api.delete_parameter('3.9', 'args')
+    @_api.delete_parameter('3.9', 'kwargs')
     @martist.allow_rasterization
     def draw(self, renderer, *args, **kwargs):
         # docstring inherited

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -626,6 +626,8 @@ class _ImageBase(martist.Artist, cm.ScalarMappable):
         """
         return False
 
+    @_api.delete_parameter('3.9', 'args')
+    @_api.delete_parameter('3.9', 'kwargs')
     @martist.allow_rasterization
     def draw(self, renderer, *args, **kwargs):
         # if not visible, declare victory and return


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #27745

I am very much appreciating how easy the deprecation module makes this :+1:

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
