### PR TITLE
DOC: tutorials follow up to guide

### DIFF
--- a/galleries/tutorials/index.rst
+++ b/galleries/tutorials/index.rst
@@ -3,17 +3,32 @@
 Tutorials
 =========
 
-This page contains a few tutorials for using Matplotlib.  For the old tutorials, see :ref:`below <user_guide_tutorials>`.
+Walk-throughs of building visualizations that incorporate multiple features of the
+library.
 
-For shorter examples, see our :ref:`examples page <examples-index>`.
-You can also find :ref:`external resources <resources-index>` and
-a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
+
+.. attention::
+
+   We're re-organizing! Please nominate :ref:`examples <examples-index>` that you think are good
+   tutorials and propose new ones by opening an
+   :ref:`issue or pull request <contribute_documentation>`!
+
+   If you are unsure of what we consider a tutorial, see our
+   :ref:`content guide <content-tutorials>` and ask on our
+   :ref:`communication <communication-channels>`
+
+
+To learn more about Matplotlib, see the :ref:`user guide <users-guide-index>` and
+:ref:`community resources  <resources-index>`. For examples, see the
+:ref:`examples-index` gallery.
+
 
 
 .. raw:: html
 
     <div class="sphx-glr-thumbnails">
 
+.. pyplot tutorial
 
 .. raw:: html
 
@@ -31,6 +46,7 @@ a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
       <div class="sphx-glr-thumbnail-title">Pyplot tutorial</div>
     </div>
 
+.. images
 
 .. raw:: html
 
@@ -49,6 +65,8 @@ a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
     </div>
 
 
+.. lifecycle
+
 .. raw:: html
 
     <div class="sphx-glr-thumbcontainer" tooltip="This tutorial aims to show the beginning, middle, and end of a single visualization using Matpl...">
@@ -65,6 +83,7 @@ a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
       <div class="sphx-glr-thumbnail-title">The Lifecycle of a Plot</div>
     </div>
 
+.. artist
 
 .. raw:: html
 
@@ -83,6 +102,25 @@ a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
     </div>
 
 
+.. annotation
+
+.. raw:: html
+
+    <div class="sphx-glr-thumbcontainer" tooltip="Labeling pie and donut charts.">
+
+.. only:: html
+
+  .. image:: /tutorials/images/thumb/sphx_glr_pie_and_donut_labels_thumb.png
+    :alt: Labeling and annotating pie and donut charts.
+
+  :ref:`sphx_glr_tutorials_pie_and_donut_labels.py`
+
+.. raw:: html
+
+      <div class="sphx-glr-thumbnail-title">Labeling a pie and a donut</div>
+    </div>
+
+
 .. raw:: html
 
     </div>
@@ -95,6 +133,7 @@ a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
    /tutorials/images
    /tutorials/lifecycle
    /tutorials/artists
+   /tutorials/pie_and_donut_labels
 
 .. only:: html
 
@@ -107,53 +146,3 @@ a :ref:`FAQ <faq-index>` in our :ref:`user guide <users-guide-index>`.
     .. container:: sphx-glr-download sphx-glr-download-jupyter
 
       :download:`Download all examples in Jupyter notebooks: tutorials_jupyter.zip </tutorials/tutorials_jupyter.zip>`
-
-
-
-.. _user_guide_tutorials:
-
-User guide tutorials
---------------------
-
-Many of our tutorials were moved from this section to :ref:`users-guide-index`:
-
-Introductory
-^^^^^^^^^^^^
-
-- :ref:`quick_start`
-- :ref:`customizing`
-- :ref:`animations`
-
-Intermediate
-^^^^^^^^^^^^
-
-- :ref:`legend_guide`
-- :ref:`color_cycle`
-- :ref:`constrainedlayout_guide`
-- :ref:`tight_layout_guide`
-- :ref:`arranging_axes`
-- :ref:`autoscale`
-- :ref:`imshow_extent`
-
-Advanced
-^^^^^^^^
-
-- :ref:`blitting`
-- :ref:`paths`
-- :ref:`patheffects_guide`
-- :ref:`transforms_tutorial`
-
-Colors
-^^^^^^
-
-See :ref:`tutorials-colors`.
-
-Text
-^^^^
-
-See :ref:`tutorials-text`.
-
-Toolkits
-^^^^^^^^
-
-See :ref:`tutorials-toolkits`.

--- a/galleries/tutorials/pie_and_donut_labels.py
+++ b/galleries/tutorials/pie_and_donut_labels.py
@@ -1,4 +1,8 @@
 """
+.. redirect-from:: /gallery/pie_and_polar_charts/pie_and_donut_labels
+
+.. _pie_donut_labels:
+
 ==========================
 Labeling a pie and a donut
 ==========================
@@ -122,6 +126,7 @@ plt.show()
 # the ingredients would suffice for around 6 donuts - producing one huge
 # donut is untested and might result in kitchen errors.
 
+# .. tags:: plot-type: pie, component: annotation, level: beginner
 
 # %%
 #


### PR DESCRIPTION
ETA: Following @timhoffm's suggestion, this pulls the tutorial content guidance from #26389 into this PR so it can be evaluated in conjunction with a rework of the index page. 

In summary, this PR:
* provides a content guideline + sample inline with the diátaxis guideline as [tutorial as guided walk through](https://diataxis.fr/tutorials/)
* removes the links to the individual user guide documents because cross listing those documents as user guide pages and tutorials makes it very unclear what we consider a user guide versus a tutorial -> which hurts both:
   * discoverability -> it's unclear what sorta content is supposed to be on a page so hard to build intuition on what should be there
   * contributing -> it's unclear what kinda of contributions would be acceptable because the pages don't have a clear identity
* replaces the custom gallery code with a gallery listing. In theory we can just go back to a readme page, but this (uses an unreleased feature of sphinx so requires a release, am adding dev here just to demo what page would look like)
* moves the donut page to tutorials because it's showing a couple of things: how to make a donut chart and also how to annotate it - in an explanatory linear manner, talking the reader through each stage of the process. That's roughly the delineation between tutorial and example/how-to according to diataxes(https://diataxis.fr/tutorials/)