### PR TITLE
Add marker-only and line+marker visuals to the plot() plot types

### DIFF
--- a/galleries/plot_types/basic/plot.py
+++ b/galleries/plot_types/basic/plot.py
@@ -13,12 +13,16 @@ plt.style.use('_mpl-gallery')
 
 # make data
 x = np.linspace(0, 10, 100)
-y = 4 + 2 * np.sin(2 * x)
+y = 4 + 1 * np.sin(2 * x)
+x2 = np.linspace(0, 10, 25)
+y2 = 4 + 1 * np.sin(2 * x2)
 
 # plot
 fig, ax = plt.subplots()
 
+ax.plot(x2, y2 + 2.5, 'x', markeredgewidth=2)
 ax.plot(x, y, linewidth=2.0)
+ax.plot(x2, y2 - 2.5, 'o-', linewidth=2)
 
 ax.set(xlim=(0, 8), xticks=np.arange(1, 8),
        ylim=(0, 8), yticks=np.arange(1, 8))


### PR DESCRIPTION
Inspired from the discussion in #27765: We should visually communicate that `plot()` covers all three variants: markers only, line+markers, line-only. They are visually distinct enough that it's not possible to infer the variants if you see only one.

In particular, it's important to communicate that you can draw markers only. We don't want to automatically drive people who want markers (e.g. some discrete measurements of a dependent variable y (x)) to scatter because that's the only one showing discrete markers in the overview.

