### PR TITLE
MNT: pcolormesh robust underflow

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5883,7 +5883,7 @@ default: :rc:`scatter.edgecolors`
                 def _interp_grid(X):
                     # helper for below
                     if np.shape(X)[1] > 1:
-                        dX = np.diff(X, axis=1)/2.
+                        dX = np.diff(X, axis=1) * 0.5
                         if not (np.all(dX >= 0) or np.all(dX <= 0)):
                             _api.warn_external(
                                 f"The input coordinates to {funcname} are "

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1517,6 +1517,19 @@ def test_pcolorargs():
         ax.pcolormesh(X, Y, Z, shading='auto')
 
 
+def test_pcolormesh_underflow_error():
+    """
+    Test that underflow errors don't crop up in pcolormesh.  Probably
+    a numpy bug (https://github.com/numpy/numpy/issues/25810).
+    """
+    with np.errstate(under="raise"):
+        x = np.arange(0, 3, 0.1)
+        y = np.arange(0, 6, 0.1)
+        z = np.random.randn(len(y), len(x))
+        fig, ax = plt.subplots()
+        ax.pcolormesh(x, y, z)
+
+
 def test_pcolorargs_with_read_only():
     x = np.arange(6).reshape(2, 3)
     xmask = np.broadcast_to([False, True, False], x.shape)  # read-only array


### PR DESCRIPTION
Closes #27770

This looks to be a numpy masked array problem, but multiplication doesn't trigger the spurious underflow, and probably is a touch faster as well.  

