### PR TITLE
Simplify example: Box plots with custom fill colors

### DIFF
--- a/galleries/examples/statistics/boxplot_color.py
+++ b/galleries/examples/statistics/boxplot_color.py
@@ -3,52 +3,34 @@
 Box plots with custom fill colors
 =================================
 
-This plot illustrates how to create two types of box plots
-(rectangular and notched), and how to fill them with custom
-colors by accessing the properties of the artists of the
-box plots. Additionally, the ``labels`` parameter is used to
-provide x-tick labels for each sample.
+To color each box of a box plot individually:
 
-A good general reference on boxplots and their history can be found
-here: http://vita.had.co.nz/papers/boxplots.pdf
+1) use the keyword argument ``patch_artist=True`` to create filled boxes.
+2) loop through the created boxes and adapt their color.
 """
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-# Random test data
 np.random.seed(19680801)
-all_data = [np.random.normal(0, std, size=100) for std in range(1, 4)]
-labels = ['x1', 'x2', 'x3']
+fruit_weights = [
+    np.random.normal(130, 10, size=100),
+    np.random.normal(125, 20, size=100),
+    np.random.normal(120, 30, size=100),
+]
+labels = ['peaches', 'oranges', 'tomatos']
+colors = ['peachpuff', 'orange', 'tomato']
 
-fig, (ax1, ax2) = plt.subplots(nrows=1, ncols=2, figsize=(9, 4))
+fig, ax = plt.subplots()
+ax.set_ylabel('fruit weight (g)')
 
-# rectangular box plot
-bplot1 = ax1.boxplot(all_data,
-                     vert=True,  # vertical box alignment
-                     patch_artist=True,  # fill with color
-                     labels=labels)  # will be used to label x-ticks
-ax1.set_title('Rectangular box plot')
-
-# notch shape box plot
-bplot2 = ax2.boxplot(all_data,
-                     notch=True,  # notch shape
-                     vert=True,  # vertical box alignment
-                     patch_artist=True,  # fill with color
-                     labels=labels)  # will be used to label x-ticks
-ax2.set_title('Notched box plot')
+bplot = ax.boxplot(fruit_weights,
+                   patch_artist=True,  # fill with color
+                   labels=labels)  # will be used to label x-ticks
 
 # fill with colors
-colors = ['pink', 'lightblue', 'lightgreen']
-for bplot in (bplot1, bplot2):
-    for patch, color in zip(bplot['boxes'], colors):
-        patch.set_facecolor(color)
-
-# adding horizontal grid lines
-for ax in [ax1, ax2]:
-    ax.yaxis.grid(True)
-    ax.set_xlabel('Three separate samples')
-    ax.set_ylabel('Observed values')
+for patch, color in zip(bplot['boxes'], colors):
+    patch.set_facecolor(color)
 
 plt.show()
 

--- a/galleries/examples/statistics/boxplot_color.py
+++ b/galleries/examples/statistics/boxplot_color.py
@@ -18,7 +18,7 @@ fruit_weights = [
     np.random.normal(125, 20, size=100),
     np.random.normal(120, 30, size=100),
 ]
-labels = ['peaches', 'oranges', 'tomatos']
+labels = ['peaches', 'oranges', 'tomatoes']
 colors = ['peachpuff', 'orange', 'tomato']
 
 fig, ax = plt.subplots()


### PR DESCRIPTION
The [original example](https://matplotlib.org/3.8.0/gallery/statistics/boxplot_color.html) was more complex than need be:

- The two plots only differed in the `notch=True` parameter, which is irrelevant for custom fill colors -> reduce to one
- rework to a more realistic-like plot
