### PR TITLE
FIX: be careful about communicating with subprocess

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -257,7 +257,8 @@ class LatexManager:
         # Open LaTeX process for real work; register it for deletion.  On
         # Windows, we must ensure that the subprocess has quit before being
         # able to delete the tmpdir in which it runs; in order to do so, we
-        # must first `kill()` it, and then `communicate()` with it.
+        # must first `kill()` it, and then `communicate()` with or `wait()` on
+        # it.
         try:
             self.latex = subprocess.Popen(
                 [mpl.rcParams["pgf.texsystem"], "-halt-on-error"],
@@ -274,7 +275,10 @@ class LatexManager:
 
         def finalize_latex(latex):
             latex.kill()
-            latex.communicate()
+            try:
+                latex.communicate()
+            except RuntimeError:
+                latex.wait()
 
         self._finalize_latex = weakref.finalize(
             self, finalize_latex, self.latex)


### PR DESCRIPTION
On windows on py312 we can not use `.communicate` during process shutdown because it internally uses Python threads which can no longer be created during interpreter shutdown.

Closes #27437
