### PR TITLE
Remove old reference to 72 DPI in figure_size_units.py

### DIFF
--- a/galleries/examples/subplots_axes_and_figures/figure_size_units.py
+++ b/galleries/examples/subplots_axes_and_figures/figure_size_units.py
@@ -57,18 +57,11 @@ plt.show()
 # tedious for quick iterations.
 #
 # Because of the default ``rcParams['figure.dpi'] = 100``, one can mentally
-# divide the needed pixel value by 100 [#]_:
+# divide the needed pixel value by 100:
 #
 plt.subplots(figsize=(6, 2))
 plt.text(0.5, 0.5, '600px x 200px', **text_kwargs)
 plt.show()
-
-# %%
-# .. [#] Unfortunately, this does not work well for the ``matplotlib inline``
-#        backend in Jupyter because that backend uses a different default of
-#        ``rcParams['figure.dpi'] = 72``. Additionally, it saves the figure
-#        with ``bbox_inches='tight'``, which crops the figure and makes the
-#        actual size unpredictable.
 
 # %%
 #

--- a/galleries/examples/subplots_axes_and_figures/figure_size_units.py
+++ b/galleries/examples/subplots_axes_and_figures/figure_size_units.py
@@ -57,11 +57,17 @@ plt.show()
 # tedious for quick iterations.
 #
 # Because of the default ``rcParams['figure.dpi'] = 100``, one can mentally
-# divide the needed pixel value by 100:
+# divide the needed pixel value by 100 [#]_:
 #
 plt.subplots(figsize=(6, 2))
 plt.text(0.5, 0.5, '600px x 200px', **text_kwargs)
 plt.show()
+
+# %%
+# .. [#] Unfortunately, this does not work well for the ``matplotlib inline``
+#        backend in Jupyter because that backend saves the figure
+#        with ``bbox_inches='tight'``, which crops the figure and makes the
+#        actual size unpredictable.
 
 # %%
 #


### PR DESCRIPTION
Remove old reference to 72 DPI

Page for reference: https://matplotlib.org/stable/gallery/subplots_axes_and_figures/figure_size_units.html

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Removed the outdated note about DPI.

The default DPI for `matplotlib inline` has been 100 [for a while](https://github.com/ipython/matplotlib-inline/pull/14/files), and with the below test in Jupyter, the saved image is 1000 x 1000 pixels as expected.

```py
%matplotlib inline
import matplotlib.pyplot as plt

fig, ax = plt.subplots(figsize=(10, 10))

ax.plot([1, 2, 3, 2, 3])

fig.savefig('testing.png')
```

Let me know if this change is a bit aggressive and maybe the text could just be updated to indicate which older versions its a problem in. Or are these guides meant to reflect the current version anyway?

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
