### PR TITLE
Add EffVer badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![Azure pipelines status](https://dev.azure.com/matplotlib/matplotlib/_apis/build/status/matplotlib.matplotlib?branchName=main)](https://dev.azure.com/matplotlib/matplotlib/_build/latest?definitionId=1&branchName=main)
 [![AppVeyor status](https://ci.appveyor.com/api/projects/status/github/matplotlib/matplotlib?branch=main&svg=true)](https://ci.appveyor.com/project/matplotlib/matplotlib)
 [![Codecov status](https://codecov.io/github/matplotlib/matplotlib/badge.svg?branch=main&service=github)](https://app.codecov.io/gh/matplotlib/matplotlib)
+[![EffVer Versioning](https://img.shields.io/badge/version_scheme-EffVer-0097a7)](https://jacobtomlinson.dev/effver)
 
 ![Matplotlib logotype](https://matplotlib.org/_static/logo2.svg)
 


### PR DESCRIPTION
This is a follow on to https://github.com/matplotlib/matplotlib/pull/27702. 

Given EffVer has been adopted here I wanted to see if folks had an appetite to add the EffVer badge to the README? It would really help raise awareness of the version scheme and hopefully increase adoption in other projects.

Totally understand if you don't want to, but thought I'd ask 😄.

cc @tacaswell @timhoffm @efiring 