### PR TITLE
DOC: Use video files for saving animations

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -195,6 +195,11 @@ else:
         subsectionorder as gallery_order_subsectionorder)
     from sphinxext.util import clear_basic_units, matplotlib_reduced_latex_scraper
 
+if parse_version(sphinx_gallery.__version__) >= parse_version('0.17.0'):
+    sg_matplotlib_animations = (True, 'mp4')
+else:
+    sg_matplotlib_animations = True
+
 # The following import is only necessary to monkey patch the signature later on
 from sphinx_gallery import gen_rst
 
@@ -273,7 +278,7 @@ sphinx_gallery_conf = {
     'image_scrapers': (matplotlib_reduced_latex_scraper, ),
     'image_srcset': ["2x"],
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
-    'matplotlib_animations': True,
+    'matplotlib_animations': sg_matplotlib_animations,
     'min_reported_time': 1,
     'plot_gallery': 'True',  # sphinx-gallery/913
     'reference_url': {'matplotlib': None},

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -18,6 +18,7 @@ pydata-sphinx-theme~=0.15.0
 mpl-sphinx-theme~=3.9.0
 pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0
+sphinxcontrib-video>=0.2.1
 sphinx-copybutton
 sphinx-design
 sphinx-gallery>=0.12.0


### PR DESCRIPTION
## PR summary

Because the default is Base64-encoded frames of PNGs, this should save a substantial amount of space in the resulting docs. We may want to increase the bitrate slightly, though most of the videos seem clear enough to me.

This currently depends on sphinx-gallery/sphinx-gallery#1243 and sphinx-contrib/video#36.

These results are probably on the upper end, depending on if we change the bitrate, but disk usage is reduced substantially:
```
485M	html/
377M	doc/build/html/
```
That's 108M of savings, or 22% of the original disk usage.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines