### PR TITLE
Fix sphinx-gallery CSS

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -85,6 +85,15 @@ html[data-theme="dark"] .sphx-glr-thumbcontainer {
     background-color: rgb(63, 63, 63);
 }
 
+/* Set a fixed height so that lazy loading does not change heights. Without a fixed
+ * height lazy loading of images interferes with anchor links: Clicking a link goes to
+ * a certain position, but then the loaded images add content and move the anchor to a
+ * different position.
+ */
+.sphx-glr-thumbcontainer img {
+    height: 112px;
+}
+
 /* hide download buttons in example headers
  * https://sphinx-gallery.github.io/stable/advanced.html#hide-the-download-buttons-in-the-example-headers
  */

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -85,11 +85,6 @@ html[data-theme="dark"] .sphx-glr-thumbcontainer {
     background-color: rgb(63, 63, 63);
 }
 
-/* workaround: the default padding decenters the image inside the frame */
-.sphx-glr-thumbcontainer .figure {
-    padding: 0;
-}
-
 /* hide download buttons in example headers
  * https://sphinx-gallery.github.io/stable/advanced.html#hide-the-download-buttons-in-the-example-headers
  */


### PR DESCRIPTION
This collects two commits:

---
Remove unused `.sphx-glr-thumbcontainer .figure`. The `.figure` div was removed in
https://github.com/sphinx-gallery/sphinx-gallery/pull/906

The workaround is also not needed anymore because that PR fixes the
centering.

---
Set a fixed height for sphinx gallery images

... so that lazy loading does not change heights. Without a fixed
height lazy loading of images interferes with anchor links: Clicking a
link goes to a certain position, but then the loaded images add content
and move the anchor to a different position.

The position change problem that this addresses can be reproduces as follows:
1. Go to https://matplotlib.org/devdocs/gallery/index.html
2. In the right menu "On this page" click a link (somewhat further down) e.g. "Animation"
3. The page scrolls to that position; then lazy loading of the images in between sets in and move the Animation section off screen. 