### PR TITLE
Deactivate sidebar for release notes

### DIFF
--- a/doc/_templates/empty_sidebar.html
+++ b/doc/_templates/empty_sidebar.html
@@ -1,0 +1,1 @@
+<div class="sidebar-empty"></div>

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -536,6 +536,10 @@ html_sidebars = {
         "cheatsheet_sidebar.html",
         "donate_sidebar.html",
     ],
+    # no sidebar for release notes, because that page is only a collection of links
+    # to sub-pages. The sidebar would repeat all the titles of the sub-pages and
+    # thus basically repeat all the content of the page.
+    "users/release_notes": ["empty_sidebar.html"],
     # '**': ['localtoc.html', 'pagesource.html']
 }
 


### PR DESCRIPTION
The [release note page](https://matplotlib.org/3.8.0/users/release_notes) is only a structured collection of links to sub-pages. The sidebar would repeat all the titles of the sub-pages and thus basically repeat all the content of the page. Even worse, it does not contain the version sectioning structure of the release notes page itself.

![image](https://github.com/matplotlib/matplotlib/assets/2836374/9cff4781-e1d0-4e70-85d3-8f046f5eb1f3)

It's thus best to deactivate the sidebar here.

Related to https://github.com/matplotlib/matplotlib/pull/27690#issuecomment-1907277251
