### PR TITLE
Expand CI pytest reporting config to ignore xfails

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ environment:
   global:
     PYTHONFAULTHANDLER: 1
     PYTHONIOENCODING: UTF-8
-    PYTEST_ARGS: -raR --numprocesses=auto --timeout=300 --durations=25
+    PYTEST_ARGS: -rfEsXR --numprocesses=auto --timeout=300 --durations=25
                  --cov-report= --cov=lib --log-level=DEBUG
 
   matrix:

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -242,7 +242,7 @@ jobs:
         shell: bash.exe -eo pipefail -o igncr "{0}"
         id: cygwin-run-pytest
         run: |
-          xvfb-run pytest -raR -n auto \
+          xvfb-run pytest -rfEsXR -n auto \
             --maxfail=50 --timeout=300 --durations=25 \
             --cov-report=xml --cov=lib --log-level=DEBUG --color=yes
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -316,7 +316,7 @@ jobs:
 
       - name: Run pytest
         run: |
-          pytest -raR -n auto \
+          pytest -rfEsXR -n auto \
             --maxfail=50 --timeout=300 --durations=25 \
             --cov-report=xml --cov=lib --log-level=DEBUG --color=yes
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -216,7 +216,7 @@ stages:
             fi
             echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
           fi
-          PYTHONFAULTHANDLER=1 pytest -raR -n 2 \
+          PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 2 \
               --maxfail=50 --timeout=300 --durations=25 \
               --junitxml=junit/test-results.xml --cov-report=xml --cov=lib
           if [[ -n $SESSION_ID ]]; then


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Pytest 8 brought with it an expansion of the reporting for xfails (and xpasses)
which with our current config (`-ra`) on CI renders the reports rather difficult to
read. This is because we have quite a lot of xfails, for various reasons:

- We have many that are very intentional and are testing our test fixures and explicitly pass `strict=True`
- We have things like the recent templated out tests for units behavior that introduced many xfails at once

As a result seeing the output on xfails is not particularly useful for us, especially.

As `x` is included in the `a` (all) option, we are left to expand out all of the components that we do want, which is a little messy.

Unfortuntately there is not a toggle that still gets us the one line "this test xfails" without
providing the full output, which I probably would use if available.

I was borderline on whether or not to remove the xpasses (`X`). As there are not _that_ many of them in my experience and output was not present at least for those that xpassed for me locally I decided that keeping the one line summary was useful.
My reading of the discussion around the addition of this feature to pytest indicates that output _would_ be included if present, but since generally xpassing mostly means we are _not_ getting an exception, I think cases where output is produced are likely relatively rare (and honestly most likely on the strict mode tests that would fail the suite and cause us to look in the first place).


I considered moving all of these to `--add-opts` in the `pyproject.toml` config, but opted to just do the minimal change that would not affect dev machines, just CI.


<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
