### PR TITLE
Update fonttools used during CI

### DIFF
--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -2,7 +2,7 @@
 
 contourpy==1.0.1
 cycler==0.10
-fonttools==4.22.0
+fonttools==4.43.0
 importlib-resources==3.2.0
 kiwisolver==1.3.1
 meson-python==0.13.1


### PR DESCRIPTION
Update the version of fonttools used to avoid CVE-2023-45139 being reported, although there's no practical security implication as the tests don't operate on untrusted fonts

## PR checklist

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
