### PR TITLE
Fix Annulus width check

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1840,7 +1840,7 @@ class Annulus(Patch):
         ----------
         width : float
         """
-        if min(self.a, self.b) <= width:
+        if width <= min(self.a, self.b) is False:
             raise ValueError(
                 'Width of annulus must be less than or equal semi-minor axis')
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1840,7 +1840,7 @@ class Annulus(Patch):
         ----------
         width : float
         """
-        if width <= min(self.a, self.b) is False:
+        if width > min(self.a, self.b):
             raise ValueError(
                 'Width of annulus must be less than or equal semi-minor axis')
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -1842,7 +1842,7 @@ class Annulus(Patch):
         """
         if width > min(self.a, self.b):
             raise ValueError(
-                'Width of annulus must be less than or equal semi-minor axis')
+                'Width of annulus must be less than or equal to semi-minor axis')
 
         self._width = width
         self._path = None


### PR DESCRIPTION
Fix check on annulus width to reflect the error message printed. The logic is presented in this (slightly) convoluted form to better conform with the error message. Obviously, the more concise `if min(self.a, self.b) < width:` works just as well.

This fix will allow annuli to be equivalent to Circles (in terms of area plotted, not underlying object structure). This means plotting (`_recompute_path`, I believe) could be improved by checking for `if w==a or w==b: PLOT WITHOUT HOLE`. Not sure how that would work, but everything does seem to work even without that change.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
