### PR TITLE
Simplify color/marker disambiguation logic in _process_plot_format.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -143,24 +143,16 @@ def _process_plot_format(fmt, *, ambiguous_fmt_datakey=False):
     marker = None
     color = None
 
-    # Is fmt just a colorspec?
-    try:
-        color = mcolors.to_rgba(fmt)
-
-        # We need to differentiate grayscale '1.0' from tri_down marker '1'
+    # First check whether fmt is just a colorspec, but specifically exclude the
+    # grayscale string "1" (not "1.0"), which is interpreted as the tri_down
+    # marker "1".  The grayscale string "0" could be unambiguously understood
+    # as a color (black) but also excluded for consistency.
+    if fmt not in ["0", "1"]:
         try:
-            fmtint = str(int(fmt))
+            color = mcolors.to_rgba(fmt)
+            return linestyle, marker, color
         except ValueError:
-            return linestyle, marker, color  # Yes
-        else:
-            if fmt != fmtint:
-                # user definitely doesn't want tri_down marker
-                return linestyle, marker, color  # Yes
-            else:
-                # ignore converted color
-                color = None
-    except ValueError:
-        pass  # No, not just a color.
+            pass
 
     errfmt = ("{!r} is neither a data key nor a valid format string ({})"
               if ambiguous_fmt_datakey else


### PR DESCRIPTION
There's a bit of code in the parsing of plot() format shorthands to disambiguate the "1" marker and the "1.0" grayscale color string.  It's actually easier to just explicitly check for the bad strings.

This also makes it clearer that we *could* have supported "0" as unambiguous color string (white) as there's no "0" marker (there's a 0 (int) marker, which is not the same...), but let's not bother with changing any semantics.

Noted while looking at #27827 and #27828.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
