### PR TITLE
[SVG] Introduce sequential ID-generation scheme for clip-paths.

### DIFF
--- a/doc/api/next_api_changes/behavior/27833-JA.rst
+++ b/doc/api/next_api_changes/behavior/27833-JA.rst
@@ -1,0 +1,8 @@
+SVG output: improved reproducibility
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Some SVG-format plots `produced different output on each render <https://github.com/matplotlib/matplotlib/issues/27831>`__, even with a static ``svg.hashsalt`` value configured.
+
+The problem was a non-deterministic ID-generation scheme for clip paths; the fix introduces a repeatable, monotonically increasing integer ID scheme as a replacement.
+
+Provided that plots add clip paths themselves in deterministic order, this enables repeatable (a.k.a. reproducible, deterministic) SVG output.


### PR DESCRIPTION
## PR summary
This pull request is intended to improve the reproducibility of SVG output from `matplotlib`, by removing variability from the ID generation scheme for the identifiers of `<clipPath>` XML elements (and references to them).

In particular, use of the Python built-in `id(...)` function, that retrieves an integer identifier for an object in memory at runtime -- not _necessarily_ a memory address, but often so -- is removed and replaced by a monotonically increasing counter value.

Closes #27831.

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
  - [x] Minimal test coverage has been added.
  - [x] Adding some [previously-recommended test coverage](https://github.com/matplotlib/matplotlib/issues/27831#issuecomment-1968969933) would be an improvement.
- [ ] ~~*Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)~~
- [x] *New Features* ~~and *API Changes*~~ are noted with a [~~directive and~~ release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

Edit: use a more-direct hyperlink to the test coverage recommendation.