### PR TITLE
Add legend support for boxplots

### DIFF
--- a/doc/users/next_whats_new/boxplot_legend_support.rst
+++ b/doc/users/next_whats_new/boxplot_legend_support.rst
@@ -3,7 +3,7 @@ Legend support for Boxplot
 Boxplots now support a *label* parameter to create legend entries.
 
 Legend labels can be passed as a list of strings to label multiple boxes in a single
-`.boxplot` call:
+`.Axes.boxplot` call:
 
 
 .. plot::
@@ -37,7 +37,7 @@ Legend labels can be passed as a list of strings to label multiple boxes in a si
     ax.legend()
 
 
-Or as a single string to each individual `.boxplot`:
+Or as a single string to each individual `.Axes.boxplot`:
 
 .. plot::
     :include-source: true

--- a/doc/users/next_whats_new/boxplot_legend_support.rst
+++ b/doc/users/next_whats_new/boxplot_legend_support.rst
@@ -1,0 +1,60 @@
+Legend support for Boxplot
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Boxplots now support a *label* parameter to create legend entries.
+
+Legend labels can be passed as a list of strings to label multiple boxes in a single
+boxplot call:
+
+
+.. plot::
+    :include-source: true
+    :alt: Example of creating 3 boxplots and assigning legend labels as a sequence.
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    np.random.seed(19680801)
+    fruit_weights = [
+        np.random.normal(130, 10, size=100),
+        np.random.normal(125, 20, size=100),
+        np.random.normal(120, 30, size=100),
+    ]
+    labels = ['peaches', 'oranges', 'tomatoes']
+    colors = ['peachpuff', 'orange', 'tomato']
+
+    fig, ax = plt.subplots()
+    ax.set_ylabel('fruit weight (g)')
+
+    bplot = ax.boxplot(fruit_weights,
+                       patch_artist=True,  # fill with color
+                       label=labels)
+
+    # fill with colors
+    for patch, color in zip(bplot['boxes'], colors):
+        patch.set_facecolor(color)
+
+    ax.set_xticks([])
+    ax.legend()
+
+
+Or as a single string to each individual boxplot:
+
+.. plot::
+    :include-source: true
+    :alt: Example of creating 2 boxplots and assigning each legend label as a string.
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    fig, ax = plt.subplots()
+
+    data_A = np.random.random((100, 3))
+    data_B = np.random.random((100, 3)) + 0.2
+    pos = np.arange(3)
+
+    ax.boxplot(data_A, positions=pos - 0.2, patch_artist=True, label='Box A',
+               boxprops={'facecolor': 'steelblue'})
+    ax.boxplot(data_B, positions=pos + 0.2, patch_artist=True, label='Box B',
+               boxprops={'facecolor': 'lightblue'})
+
+    ax.legend()

--- a/doc/users/next_whats_new/boxplot_legend_support.rst
+++ b/doc/users/next_whats_new/boxplot_legend_support.rst
@@ -3,7 +3,7 @@ Legend support for Boxplot
 Boxplots now support a *label* parameter to create legend entries.
 
 Legend labels can be passed as a list of strings to label multiple boxes in a single
-boxplot call:
+`.boxplot` call:
 
 
 .. plot::
@@ -37,7 +37,7 @@ boxplot call:
     ax.legend()
 
 
-Or as a single string to each individual boxplot:
+Or as a single string to each individual `.boxplot`:
 
 .. plot::
     :include-source: true

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3997,6 +3997,8 @@ class Axes(_AxesBase):
             median line (``result["medians"]``); if *patch_artist* is True, the legend
             will show the box `.Patch` artists (``result["boxes"]``) instead.
 
+            .. versionadded:: 3.9
+
         data : indexable object, optional
             DATA_PARAMETER_PLACEHOLDER
 
@@ -4221,6 +4223,8 @@ class Axes(_AxesBase):
             median line (``result["medians"]``); if *patch_artist* is True, the legend
             will show the box `.Patch` artists (``result["boxes"]``) instead.
 
+            .. versionadded:: 3.9
+
         zorder : float, default: ``Line2D.zorder = 2``
           The zorder of the resulting boxplot.
 
@@ -4421,8 +4425,7 @@ class Axes(_AxesBase):
                 box_or_med[0].set_label(label)
             else:  # label is a sequence
                 if len(box_or_med) != len(label):
-                    raise ValueError("There must be an equal number of legend"
-                                     " labels and boxplots.")
+                    raise ValueError(datashape_message.format("label"))
                 for artist, lbl in zip(box_or_med, label):
                     artist.set_label(lbl)
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3995,7 +3995,7 @@ class Axes(_AxesBase):
             In the case of a single string, the legend entry will technically be
             associated with the first box only. By default, the legend will show the
             median line (``result["medians"]``); if *patch_artist* is True, the legend
-            will show the box `Patch` artists (``result["boxes"]``) instead.
+            will show the box `.Patch` artists (``result["boxes"]``) instead.
 
         data : indexable object, optional
             DATA_PARAMETER_PLACEHOLDER
@@ -4219,7 +4219,7 @@ class Axes(_AxesBase):
             In the case of a single string, the legend entry will technically be
             associated with the first box only. By default, the legend will show the
             median line (``result["medians"]``); if *patch_artist* is True, the legend
-            will show the box `Patch` artists (``result["boxes"]``) instead.
+            will show the box `.Patch` artists (``result["boxes"]``) instead.
 
         zorder : float, default: ``Line2D.zorder = 2``
           The zorder of the resulting boxplot.

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -372,7 +372,7 @@ class Axes(_AxesBase):
         autorange: bool = ...,
         zorder: float | None = ...,
         capwidths: float | ArrayLike | None = ...,
-		label: Sequence[str] | None = ...,
+        label: Sequence[str] | None = ...,
         *,
         data=...,
     ) -> dict[str, Any]: ...
@@ -398,7 +398,7 @@ class Axes(_AxesBase):
         manage_ticks: bool = ...,
         zorder: float | None = ...,
         capwidths: float | ArrayLike | None = ...,
-		label: Sequence[str] | None = ...,
+        label: Sequence[str] | None = ...,
     ) -> dict[str, Any]: ...
     def scatter(
         self,

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -372,6 +372,7 @@ class Axes(_AxesBase):
         autorange: bool = ...,
         zorder: float | None = ...,
         capwidths: float | ArrayLike | None = ...,
+		label: Sequence[str] | None = ...,
         *,
         data=...,
     ) -> dict[str, Any]: ...
@@ -397,6 +398,7 @@ class Axes(_AxesBase):
         manage_ticks: bool = ...,
         zorder: float | None = ...,
         capwidths: float | ArrayLike | None = ...,
+		label: Sequence[str] | None = ...,
     ) -> dict[str, Any]: ...
     def scatter(
         self,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2871,6 +2871,7 @@ def boxplot(
     autorange: bool = False,
     zorder: float | None = None,
     capwidths: float | ArrayLike | None = None,
+    label: Sequence[str] | None = None,
     *,
     data=None,
 ) -> dict[str, Any]:
@@ -2902,6 +2903,7 @@ def boxplot(
         autorange=autorange,
         zorder=zorder,
         capwidths=capwidths,
+        label=label,
         **({"data": data} if data is not None else {}),
     )
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1460,7 +1460,7 @@ def test_boxplot_legend_labels():
     assert all(isinstance(h, mpl.lines.Line2D) for h in handles)
 
     # Testing legend with number of labels different from number of boxes.
-    with pytest.raises(ValueError, match='There must be an equal number'):
+    with pytest.raises(ValueError, match='values must have same the length'):
         bp3 = axs[2].boxplot(data, label=legend_labels[:-1])
 
     # Test that for a string label, only the first box gets a label.

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1437,21 +1437,6 @@ def test_legend_text():
     assert_allclose(leg_bboxes[1].bounds, leg_bboxes[0].bounds)
 
 
-def test_boxplot_labels():
-    # Test that boxplot(..., labels=) sets the tick labels but not legend entries
-    # This is not consistent with other plot types but is the current behavior.
-    fig, ax = plt.subplots()
-    np.random.seed(19680801)
-    data = np.random.random((10, 3))
-    bp = ax.boxplot(data, labels=['A', 'B', 'C'])
-    # Check that labels set the tick labels ...
-    assert [l.get_text() for l in ax.get_xticklabels()] == ['A', 'B', 'C']
-    # ... but not legend entries
-    handles, labels = ax.get_legend_handles_labels()
-    assert len(handles) == 0
-    assert len(labels) == 0
-
-
 def test_boxplot_legend_labels():
     # Test that legend entries are generated when passing `label`.
     np.random.seed(19680801)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1435,3 +1435,50 @@ def test_legend_text():
         leg_bboxes.append(
             leg.get_window_extent().transformed(ax.transAxes.inverted()))
     assert_allclose(leg_bboxes[1].bounds, leg_bboxes[0].bounds)
+
+
+def test_boxplot_labels():
+    # Test that boxplot(..., labels=) sets the tick labels but not legend entries
+    # This is not consistent with other plot types but is the current behavior.
+    fig, ax = plt.subplots()
+    np.random.seed(19680801)
+    data = np.random.random((10, 3))
+    bp = ax.boxplot(data, labels=['A', 'B', 'C'])
+    # Check that labels set the tick labels ...
+    assert [l.get_text() for l in ax.get_xticklabels()] == ['A', 'B', 'C']
+    # ... but not legend entries
+    handles, labels = ax.get_legend_handles_labels()
+    assert len(handles) == 0
+    assert len(labels) == 0
+
+
+def test_boxplot_legend_labels():
+    # Test that legend entries are generated when passing `label`.
+    np.random.seed(19680801)
+    data = np.random.random((10, 4))
+    fig, axs = plt.subplots(nrows=1, ncols=4)
+    legend_labels = ['box A', 'box B', 'box C', 'box D']
+
+    # Testing legend labels and patch passed to legend.
+    bp1 = axs[0].boxplot(data, patch_artist=True, label=legend_labels)
+    assert [v.get_label() for v in bp1['boxes']] == legend_labels
+    handles, labels = axs[0].get_legend_handles_labels()
+    assert labels == legend_labels
+    assert all(isinstance(h, mpl.patches.PathPatch) for h in handles)
+
+    # Testing legend without `box`.
+    bp2 = axs[1].boxplot(data, label=legend_labels, showbox=False)
+    # Without a box, The legend entries should be passed from the medians.
+    assert [v.get_label() for v in bp2['medians']] == legend_labels
+    handles, labels = axs[1].get_legend_handles_labels()
+    assert labels == legend_labels
+    assert all(isinstance(h, mpl.lines.Line2D) for h in handles)
+
+    # Testing legend with number of labels different from number of boxes.
+    with pytest.raises(ValueError, match='There must be an equal number'):
+        bp3 = axs[2].boxplot(data, label=legend_labels[:-1])
+
+    # Test that for a string label, only the first box gets a label.
+    bp4 = axs[3].boxplot(data, label='box A')
+    assert bp4['medians'][0].get_label() == 'box A'
+    assert all(x.get_label().startswith("_") for x in bp4['medians'][1:])


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Closes #27792. Boxplots now get legend entries.
This was previously attempted on  #27711 and then reverted #27780 because it used the same parameter for tick labels and didn't generalize well. These 2 issues have been addressed in this PR.

A new `label` parameter has been added to `Axes.boxplot` and `Axes.bxp`. If called via `ax.boxplot()`, label is passed to the bxp function, otherwise bxp can be directly called with the label parameter.

The label is passed to the `boxes` object if `showbox=True`, otherwise it will be passed to the `medians` object is `showbox=False`. Attaching the label to the boxes makes sure that the legend handles will get a patch which will be displayed on the legend.
If the box is turned off, the legend handles will get a Line2D object from the median line which will be displayed as a line in the legend. This has 2 advantages:
- It suits the aesthetics of a boxless plot
- Unlike the `box`, `caps`, `flyers` and `means`, the `medians` cannot be turned off so they're a good vehicle for the legend label and will ensure that the labels always get set.

<details>
  <summary>Click to old test cases</summary>

![new_test](https://github.com/matplotlib/matplotlib/assets/9763064/7b7cf482-28cd-4199-ba78-77039c0b1af8)
</details>

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
