### PR TITLE
Make sure custom alpha param does not change 'none' colors in a list of colors

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -506,6 +506,11 @@ def to_rgba_array(c, alpha=None):
 
     if alpha is not None:
         rgba[:, 3] = alpha
+        if isinstance(c, Sequence):
+            # ensure that an explicit alpha does not overwrite full transparency
+            # for "none"
+            none_mask = np.array([isinstance(cc, str) and cc == "none" for cc in c])
+            rgba[:, 3][none_mask] = 0
     return rgba
 
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -509,7 +509,7 @@ def to_rgba_array(c, alpha=None):
         if isinstance(c, Sequence):
             # ensure that an explicit alpha does not overwrite full transparency
             # for "none"
-            none_mask = np.array([isinstance(cc, str) and cc == "none" for cc in c])
+            none_mask = [cbook._str_equal(cc, "none") for cc in c]
             rgba[:, 3][none_mask] = 0
     return rgba
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -19,6 +19,7 @@ import matplotlib.pyplot as plt
 import matplotlib.scale as mscale
 from matplotlib.rcsetup import cycler
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
+from matplotlib.colors import to_rgba_array
 
 
 @pytest.mark.parametrize('N, result', [
@@ -1660,3 +1661,13 @@ def test_set_cmap_mismatched_name():
     cmap_returned = plt.get_cmap("wrong-cmap")
     assert cmap_returned == cmap
     assert cmap_returned.name == "wrong-cmap"
+
+
+def test_to_rgba_array_none_color_with_alpha_param():
+    # effective alpha for color "none" must always be 0 to achieve a vanishing color
+    # even explicit alpha must be ignored
+    c = ["blue", "none"]
+    alpha = [1, 1]
+    assert_array_equal(
+        to_rgba_array(c, alpha), [[0., 0., 1., 1.], [0., 0., 0., 0.]]
+    )


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

This change suggests a fix and hopefully closes #27839 by making sure that 'none' colors in a list won't be affected by custom alpha param.

Before the fix, this code:
```
# colors::to_rgba_array()
509 if alpha is not None:
510     rgba[:, 3] = alpha
```
will change rgba array of color list ['blue', 'none'] from:
```
[[0. 0. 1. 1.]       # this is blue
 [0. 0. 0. 0.]]      # this has no color
```
to
```
[[0. 0. 1. 1.]       # this is still blue
 [0. 0. 0. 1.]]      # this becomes black:
```

After the fix, any 'none' color in a list of colors will be kept colorless.

A test is added to make sure the function works as expected.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
