### PR TITLE
Add dtype/copy args to internal testing class

### DIFF
--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -282,8 +282,16 @@ class Kernel:
     def __init__(self, array):
         self._array = np.asanyarray(array)
 
-    def __array__(self):
-        return self._array
+    def __array__(self, dtype=None, copy=None):
+        if dtype is not None and dtype != self._array.dtype:
+            if copy is not None and not copy:
+                raise ValueError(
+                    f"Converting array from {self._array.dtype} to "
+                    f"{dtype} requires a copy"
+                )
+
+        arr = np.asarray(self._array, dtype=dtype)
+        return (arr if not copy else np.copy(arr))
 
     @property
     def shape(self):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This fixes some test failures in https://github.com/matplotlib/matplotlib/issues/27844 that we're responsible for. I'm guessing the new requirement on copy/dtype args is from numpy 2.0. I'm not sure if there's a way to run the weekly CI on a PR to check this fixes the issue?


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
