### PR TITLE
Use pybind11 string formatter for exception messages

### DIFF
--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -78,8 +78,8 @@ _get_transform_mesh(const py::object& transform, const py::ssize_t *dims)
 
     if (output_mesh_array.ndim() != 2) {
         throw std::runtime_error(
-            "Inverse transformed mesh array should be 2D not " +
-            std::to_string(output_mesh_array.ndim()) + "D");
+            "Inverse transformed mesh array should be 2D not {}D"_s.format(
+                output_mesh_array.ndim()));
     }
 
     return output_mesh_array;
@@ -108,8 +108,8 @@ image_resample(py::array input_array,
 
     if (ndim == 3 && input_array.shape(2) != 4) {
         throw std::invalid_argument(
-            "3D input array must be RGBA with shape (M, N, 4), has trailing dimension of " +
-            std::to_string(input_array.shape(2)));
+            "3D input array must be RGBA with shape (M, N, 4), has trailing dimension of {}"_s.format(
+                input_array.shape(2)));
     }
 
     // Ensure input array is contiguous, regardless of dtype
@@ -120,14 +120,14 @@ image_resample(py::array input_array,
 
     if (out_ndim != ndim) {
         throw std::invalid_argument(
-            "Input (" + std::to_string(ndim) + "D) and output (" + std::to_string(out_ndim) +
-            "D) arrays have different dimensionalities");
+            "Input ({}D) and output ({}D) arrays have different dimensionalities"_s.format(
+                ndim, out_ndim));
     }
 
     if (out_ndim == 3 && output_array.shape(2) != 4) {
         throw std::invalid_argument(
-            "3D output array must be RGBA with shape (M, N, 4), has trailing dimension of " +
-            std::to_string(output_array.shape(2)));
+            "3D output array must be RGBA with shape (M, N, 4), has trailing dimension of {}"_s.format(
+                output_array.shape(2)));
     }
 
     if (!output_array.dtype().is(dtype)) {

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -99,18 +99,19 @@ mpl_tk_blit(py::object interp_obj, const char *photo_name,
 
     auto data_ptr = data.mutable_unchecked<3>();  // Checks ndim and writeable flag.
     if (data.shape(2) != 4) {
-        throw py::value_error("Data pointer must be RGBA; last dimension is " +
-                              std::to_string(data.shape(2)) + ", not 4");
+        throw py::value_error(
+            "Data pointer must be RGBA; last dimension is {}, not 4"_s.format(
+                data.shape(2)));
     }
     if (data.shape(0) > INT_MAX) {  // Limited by Tk_PhotoPutBlock argument type.
         throw std::range_error(
-            "Height (" + std::to_string(data.shape(0)) +
-            ") exceeds maximum allowable size (" + std::to_string(INT_MAX) + ")");
+            "Height ({}) exceeds maximum allowable size ({})"_s.format(
+                data.shape(0), INT_MAX));
     }
     if (data.shape(1) > INT_MAX / 4) {  // Limited by Tk_PhotoImageBlock.pitch field.
         throw std::range_error(
-            "Width (" + std::to_string(data.shape(1)) +
-            ") exceeds maximum allowable size (" + std::to_string(INT_MAX / 4) + ")");
+            "Width ({}) exceeds maximum allowable size ({})"_s.format(
+                data.shape(1), INT_MAX / 4));
     }
     const auto height = static_cast<int>(data.shape(0));
     const auto width = static_cast<int>(data.shape(1));


### PR DESCRIPTION
## PR summary

This can eventually be replaced by `std::format` when we require C++20.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines