### PR TITLE
Correctly set temporary pdf/pgf backends

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2755,8 +2755,7 @@ class PdfPages:
                 raise ValueError(f"No figure {figure}")
             figure = manager.canvas.figure
         # Force use of pdf backend, as PdfPages is tightly coupled with it.
-        with cbook._setattr_cm(figure, canvas=FigureCanvasPdf(figure)):
-            figure.savefig(self, format="pdf", **kwargs)
+        figure.savefig(self, format="pdf", backend="pdf", **kwargs)
 
     def get_pagecount(self):
         """Return the current number of pages in the multipage pdf file."""

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -987,26 +987,25 @@ class PdfPages:
                 raise ValueError(f"No figure {figure}")
             figure = manager.canvas.figure
 
-        with cbook._setattr_cm(figure, canvas=FigureCanvasPgf(figure)):
-            width, height = figure.get_size_inches()
-            if self._n_figures == 0:
-                self._write_header(width, height)
-            else:
-                # \pdfpagewidth and \pdfpageheight exist on pdftex, xetex, and
-                # luatex<0.85; they were renamed to \pagewidth and \pageheight
-                # on luatex>=0.85.
-                self._file.write(
-                    (
-                        r'\newpage'
-                        r'\ifdefined\pdfpagewidth\pdfpagewidth'
-                        fr'\else\pagewidth\fi={width}in'
-                        r'\ifdefined\pdfpageheight\pdfpageheight'
-                        fr'\else\pageheight\fi={height}in'
-                        '%%\n'
-                    ).encode("ascii")
-                )
-            figure.savefig(self._file, format="pgf", **kwargs)
-            self._n_figures += 1
+        width, height = figure.get_size_inches()
+        if self._n_figures == 0:
+            self._write_header(width, height)
+        else:
+            # \pdfpagewidth and \pdfpageheight exist on pdftex, xetex, and
+            # luatex<0.85; they were renamed to \pagewidth and \pageheight
+            # on luatex>=0.85.
+            self._file.write(
+                (
+                    r'\newpage'
+                    r'\ifdefined\pdfpagewidth\pdfpagewidth'
+                    fr'\else\pagewidth\fi={width}in'
+                    r'\ifdefined\pdfpageheight\pdfpageheight'
+                    fr'\else\pageheight\fi={height}in'
+                    '%%\n'
+                ).encode("ascii")
+            )
+        figure.savefig(self._file, format="pgf", backend="pgf", **kwargs)
+        self._n_figures += 1
 
     def get_pagecount(self):
         """Return the current number of pages in the multipage pdf file."""


### PR DESCRIPTION
## PR summary

Calling `FigureCanvasPdf(figure)` will call `figure.set_canvas(self)`, meaning the `cbook._setattr_cm` context manager that wraps this change will see the _new_ canvas, and the old canvas isn't restored.

Instead, just pass the `backend` parameter, as `savefig` already knows how to correctly save and restore the canvas if it needs to change backends.

Fixes #27865

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines