### PR TITLE
doc: add description of **kwargs usage to collections

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -151,6 +151,9 @@ class Collection(artist.Artist, cm.ScalarMappable):
         zorder : float, default: 1
             The drawing order, shared by all Patches in the Collection. See
             :doc:`/gallery/misc/zorder_demo` for all defaults and examples.
+        **kwargs
+            Remaining kwargs will be used to set properties as
+             `Collection.set_{key}(val)` for each `key`, `val` kwarg pair.
         """
         artist.Artist.__init__(self)
         cm.ScalarMappable.__init__(self, norm, cmap)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -152,8 +152,8 @@ class Collection(artist.Artist, cm.ScalarMappable):
             The drawing order, shared by all Patches in the Collection. See
             :doc:`/gallery/misc/zorder_demo` for all defaults and examples.
         **kwargs
-            Remaining kwargs will be used to set properties as
-             `Collection.set_{key}(val)` for each `key`, `val` kwarg pair.
+            Remaining keyword arguments will be used to set properties as
+            ``Collection.set_{key}(val)`` for each key-value pair in *kwargs*.
         """
         artist.Artist.__init__(self)
         cm.ScalarMappable.__init__(self, norm, cmap)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Follow up to https://github.com/matplotlib/matplotlib/pull/27871 addressing the missing `**kwargs` in the Collection docstring

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [NA] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [NA] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x?] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
