### PR TITLE
macosx: Clean up single-shot timers correctly

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -67,13 +67,9 @@ class FigureCanvasMac(FigureCanvasAgg, _macosx.FigureCanvas, FigureCanvasBase):
 
     def _single_shot_timer(self, callback):
         """Add a single shot timer with the given callback"""
-        # We need to explicitly stop and remove the timer after
-        # firing, otherwise segfaults will occur when trying to deallocate
-        # the singleshot timers.
         def callback_func(callback, timer):
             callback()
             self._timers.remove(timer)
-            timer.stop()
         timer = self.new_timer(interval=0)
         timer.single_shot = True
         timer.add_callback(callback_func, callback, timer)

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1741,6 +1741,11 @@ Timer__timer_start(Timer* self, PyObject* args)
                                          repeats: !single
                                            block: ^(NSTimer *timer) {
         gil_call_method((PyObject*)self, "_on_timer");
+        if (single) {
+            // A single-shot timer will be automatically invalidated when it fires, so
+            // we shouldn't do it ourselves when the object is deleted.
+            self->timer = NULL;
+        }
     }];
     // Schedule the timer on the main run loop which is needed
     // when updating the UI from a background thread


### PR DESCRIPTION
## PR summary

The `NSTimer` docs state that a non-repeating (aka single-shot in our terms) timer is invalidated after if fires. This means that we should not do it ourselves, and in fact it appears that the pointer itself is no longer valid, so we would be passing an `invalidate` message to a random object or segfault.

~~I believe this is why `test_other_signal_before_sigint` is marked as flaky as well, as it uses a single-shot timer and a segfault is recorded in the XPASS log.~~

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines