### PR TITLE
Deleting all images that have passed tests before upload

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -339,8 +339,8 @@ jobs:
                       fi
                       if [[ -e "${base}.$extension" ]]; then
                           rm "${base}.$extension"
+                          echo " Removed ${base}.$extension"
                       fi
-                      echo "Removed $file"
                   fi
               done
           }

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -347,6 +347,10 @@ jobs:
 
           remove_files "png"; remove_files "svg"; remove_files "pdf"; remove_files "eps";
 
+          if [ "$(find ./result_images -mindepth 1 -type d)" ]; then
+              find ./result_images/* -type d -empty -delete
+          fi
+
       - name: Filter C coverage
         run: |
           if [[ "${{ runner.os }}" != 'macOS' ]]; then

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -318,6 +318,35 @@ jobs:
             --maxfail=50 --timeout=300 --durations=25 \
             --cov-report=xml --cov=lib --log-level=DEBUG --color=yes
 
+      - name: Cleanup non-failed image files
+        run: |
+          function remove_files() {
+              local extension=$1
+              find ./result_images -type f -name "*-expected*.$extension" | while read file; do
+                  if [[ $file == *"-expected_pdf"* ]]; then
+                      base=${file%-expected_pdf.$extension}_pdf
+                  elif [[ $file == *"-expected_eps"* ]]; then
+                      base=${file%-expected_eps.$extension}_eps
+                  elif [[ $file == *"-expected_svg"* ]]; then
+                      base=${file%-expected_svg.$extension}_svg
+                  else
+                      base=${file%-expected.$extension}
+                  fi
+                  if [[ ! -e "${base}-failed-diff.$extension" ]]; then
+                      if [[ -e "$file" ]]; then
+                          rm "$file"
+                          echo "Removed $file"
+                      fi
+                      if [[ -e "${base}.$extension" ]]; then
+                          rm "${base}.$extension"
+                      fi
+                      echo "Removed $file"
+                  fi
+              done
+          }
+
+          remove_files "png"; remove_files "svg"; remove_files "pdf"; remove_files "eps";
+
       - name: Filter C coverage
         run: |
           if [[ "${{ runner.os }}" != 'macOS' ]]; then


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example, "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Supersedes PR #27881 (I'm so sorry for creating unnecessary traffic on this repo.)
Attempts to close #23400 and potentially complete what PR #19466 intended to do
Included a bash script right before the uploading part of the code in the *tests.yml* file to delete all files(.png, .svg, .eps, .pdf) that have not failed in the *result_images* directory. Have tested this using a dummy bash file and the downloaded result_images folder. Please let me know if this approach seems correct, or is blatantly wrong :).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
