### PR TITLE
Fix build on older macOS deployment targets

### DIFF
--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -301,7 +301,7 @@ Py_cleanup_path(mpl::PathIterator path, agg::trans_affine trans, bool remove_nan
     std::vector<npy_uint8> codes;
 
     cleanup_path(path, trans, remove_nans, do_clip, clip_rect, snap_mode, stroke_width,
-                 simplify.value(), return_curves, sketch, vertices, codes);
+                 *simplify, return_curves, sketch, vertices, codes);
 
     auto length = static_cast<py::ssize_t>(codes.size());
 
@@ -360,8 +360,8 @@ Py_convert_to_string(mpl::PathIterator path, agg::trans_affine trans,
         simplify = path.should_simplify();
     }
 
-    status = convert_to_string(path, trans, cliprect, simplify.value(), sketch,
-                               precision, codes, postfix, buffer);
+    status = convert_to_string(path, trans, cliprect, *simplify, sketch, precision,
+                               codes, postfix, buffer);
 
     if (!status) {
         throw py::value_error("Malformed path codes");


### PR DESCRIPTION
## PR summary

Apparently, macOS incorrectly hides this `std::optional.value` method behind the deployment target, even though it's a header-only implementation, so it shouldn't have any runtime requirement.

Instead of fiddling with deployment targets, use an alternate method for getting the `std::optional` value.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines