### PR TITLE
BLD: Add a fallback URL for FreeType

### DIFF
--- a/subprojects/freetype-2.6.1.wrap
+++ b/subprojects/freetype-2.6.1.wrap
@@ -1,5 +1,6 @@
 [wrap-file]
 source_url = https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
+source_fallback_url = https://downloads.sourceforge.net/project/freetype/freetype2/2.6.1/freetype-2.6.1.tar.gz
 source_filename = freetype-2.6.1.tar.gz
 source_hash = 0a3c7dfbda6da1e8fce29232e8e96d987ababbbf71ebc8c75659e4132c367014
 


### PR DESCRIPTION
## PR summary

FreeType is available from both Savannah and SourceForge, and sometimes AppVeyor seems to have trouble downloading from Savannah, so perhaps this fallback will help. We used to try both these URLs in the pre-Meson build system.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines