### PR TITLE
DOC: State approximate documentation build time

### DIFF
--- a/doc/devel/document.rst
+++ b/doc/devel/document.rst
@@ -64,6 +64,11 @@ used. To build the documentation in html format, cd into :file:`doc/` and run:
 
    make html
 
+.. note::
+
+   Since the documentation is very large, the first build may take 10-20 minutes,
+   depending on your machine.  Subsequent builds will be faster.
+
 Other useful invocations include
 
 .. code-block:: sh


### PR DESCRIPTION
Since the doc build takes very long, an order-of-magnitude estimate is helpful to manage expectations.

I'm not wedded to the actual numbers, if somebody has better suggestions. A quick test on an old i7 6700 (from 2015) yielded

- `O=-j1`: 23min
- `O=-j4`: 15min

Doc build on CI is around 18min.