### PR TITLE
Remove versions from sidebar in docs

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -547,7 +547,6 @@ html_index = 'index.html'
 html_sidebars = {
     "index": [
         # 'sidebar_announcement.html',
-        "sidebar_versions.html",
         "cheatsheet_sidebar.html",
         "donate_sidebar.html",
     ],

--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -443,7 +443,6 @@ which will copy the built docs over.  If this is a final release, link the
   rm stable
   ln -s 3.7.0 stable
 
-You will need to manually edit :file:`versions.html` to show the released version.
 You will also need to edit :file:`sitemap.xml` to include
 the newly released version.  Now commit and push everything to GitHub ::
 


### PR DESCRIPTION
My reasoning here is:

- There is now a version switcher in the top right, as part of the pyadata-sphinx-theme.
- The only other thing the versions in the sidebar adds is a note about the last supported version for Python 2, but Python 2 is long end of life, so I think fine to remove this.
- Removing the versions from the sidebar removes a location where the version has to be manually updated every time a new release is done (e.g., https://github.com/matplotlib/matplotlib/issues/27863).