### PR TITLE
Remove empty user guide tutorials page

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -130,7 +130,10 @@ extensions = [
 ]
 
 exclude_patterns = [
-    'api/prev_api_changes/api_changes_*/*', '**/*inc.rst']
+    'api/prev_api_changes/api_changes_*/*',
+    '**/*inc.rst',
+    'users/explain/index.rst'  # Page has no content, but required by sphinx gallery
+]
 
 exclude_patterns += skip_subdirs
 

--- a/doc/users/index.rst
+++ b/doc/users/index.rst
@@ -101,6 +101,5 @@ Using Matplotlib
 .. toctree::
     :hidden:
 
-    explain/index
     getting_started/index
     installing/index

--- a/galleries/users_explain/index.rst
+++ b/galleries/users_explain/index.rst
@@ -1,4 +1,6 @@
-.. _users-guide-explain:
+..
+    This page is required by sphinx-gallery,
+    but is not rendered in the final doc build.
 
 ====================
 User guide tutorials


### PR DESCRIPTION
Fixes https://github.com/matplotlib/matplotlib/issues/27896.