### PR TITLE
Improved error message for malformed colors

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -243,7 +243,14 @@ def _check_color_like(**kwargs):
     """
     for k, v in kwargs.items():
         if not is_color_like(v):
-            raise ValueError(f"{v!r} is not a valid value for {k}")
+            raise ValueError(
+                f"{v!r} is not a valid value for {k}: supported inputs are "
+                f"(r, g, b) and (r, g, b, a) 0-1 float tuples; "
+                f"'#rrggbb', '#rrggbbaa', '#rgb', '#rgba' strings; "
+                f"named color strings; "
+                f"string reprs of 0-1 floats for grayscale values; "
+                f"'C0', 'C1', ... strings for colors of the color cycle; "
+                f"and pairs combining one of the above with an alpha value")
 
 
 def same_color(c1, c2):


### PR DESCRIPTION
Implements the suggestion https://github.com/matplotlib/matplotlib/issues/27378#issuecomment-1830271599.

Closes #27378.
