### PR TITLE
Override open_group, close_group methods in PathEffectRenderer

### DIFF
--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -152,6 +152,12 @@ class PathEffectRenderer(RendererBase):
         else:
             return object.__getattribute__(self, name)
 
+    def open_group(self, s, gid=None):
+        return self._renderer.open_group(s, gid)
+
+    def close_group(self, s):
+        return self._renderer.close_group(s)
+
 
 class Normal(AbstractPathEffect):
     """

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -5,6 +5,8 @@ import matplotlib.pyplot as plt
 import matplotlib.patheffects as path_effects
 from matplotlib.path import Path
 import matplotlib.patches as patches
+from matplotlib.backend_bases import RendererBase
+from matplotlib.patheffects import PathEffectRenderer
 
 
 @image_comparison(['patheffect1'], remove_text=True)
@@ -192,3 +194,20 @@ def test_patheffects_spaces_and_newlines():
                     bbox={'color': 'thistle'})
     text1.set_path_effects([path_effects.Normal()])
     text2.set_path_effects([path_effects.Normal()])
+
+
+def test_patheffects_overridden_methods_open_close_group():
+    class CustomRenderer(RendererBase):
+        def __init__(self):
+            super().__init__()
+
+        def open_group(self, s, gid=None):
+            return "open_group overridden"
+
+        def close_group(self, s):
+            return "close_group overridden"
+
+    renderer = PathEffectRenderer([path_effects.Normal()], CustomRenderer())
+
+    assert renderer.open_group('s') == "open_group overridden"
+    assert renderer.close_group('s') == "close_group overridden"


### PR DESCRIPTION
## PR summary

This code change is to ensure that methods like `open_group` and `close_group` are overridden in `PathEffectRenderer`.

This pull request addresses and hopefully closes #27843. 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
