### PR TITLE
Simplify the qt backend by using buffers to construct the image to be restored

### DIFF
--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -75,6 +75,14 @@ static PyObject *PyBufferRegion_get_extents(PyBufferRegion *self, PyObject *args
     return Py_BuildValue("IIII", rect.x1, rect.y1, rect.x2, rect.y2);
 }
 
+static PyObject *PyBufferRegion_get_bounds(PyBufferRegion *self, PyObject *args)
+{
+    agg::rect_i rect = self->x->get_rect();
+
+    return Py_BuildValue("IIII", rect.x1, rect.y1, rect.x2 - rect.x1, rect.y2 - rect.y1);
+}
+
+
 int PyBufferRegion_get_buffer(PyBufferRegion *self, Py_buffer *buf, int flags)
 {
     Py_INCREF(self);
@@ -105,6 +113,7 @@ static PyTypeObject *PyBufferRegion_init_type()
         { "set_x", (PyCFunction)PyBufferRegion_set_x, METH_VARARGS, NULL },
         { "set_y", (PyCFunction)PyBufferRegion_set_y, METH_VARARGS, NULL },
         { "get_extents", (PyCFunction)PyBufferRegion_get_extents, METH_NOARGS, NULL },
+        { "get_bounds", (PyCFunction)PyBufferRegion_get_bounds, METH_NOARGS, NULL },
         { NULL }
     };
 


### PR DESCRIPTION
## PR summary

Pass a numpy array when constructing a QImage in the qt backend(s), instead of dealing with pointers.

**Motivation**:
I'm fiddling with a new renderer (more on that at a not-too-distant future date :wink:), and it would be *super* convenient if I was able to implement a ``copy_from_bbox`` and ``restore_region`` in pure Python which is usable by the ``backend_qtagg`` machinery (at least during my prototyping phase). Unfortunately, the way this was done before this change it was impossible to create such a renderer in pure python... but now it is simply using the array interface and one additional method, it is easy for me to do that.  


Note that in future, it is plausible that we remove ``PyBufferRegion`` entirely, and simply have a common (non-Agg specific) region representation (containing image & bounding box). Such a standardisation would take us a step closer to backends being separated from renderers (rasterising ones) - this is something that would dramatically simplify the backend machinery, IMO (plus is a motivation for me if I end up producing a new type of rasterising renderer). 


In an earlier draft of this MR, I had removed the bounding box from the ``copy_from_bbox`` response (reflecting the fact that the response should be an image for the given bbox), but there are a number of places in which it is convenient to have the opaque response actually represent an image + a bounding box (e.g. in the widgets code). As a result, I pivotted on what we see in this MR - essentially, that means that a renderer is free to return a response from ``copy_from_bbox`` which is not actually representative of the given bbox (bigger, smaller, whatever).

Obvious reviewers of this PR are @QuLogic and @anntzer - of course, happy for others to review too :wink: