### PR TITLE
Revert renaming labels to tick_labels in boxplot_stats()

### DIFF
--- a/galleries/examples/statistics/bxp.py
+++ b/galleries/examples/statistics/bxp.py
@@ -25,7 +25,7 @@ data = np.random.lognormal(size=(37, 4), mean=1.5, sigma=1.75)
 labels = list('ABCD')
 
 # compute the boxplot stats
-stats = cbook.boxplot_stats(data, tick_labels=labels, bootstrap=10000)
+stats = cbook.boxplot_stats(data, labels=labels, bootstrap=10000)
 
 # %%
 # After we've computed the stats, we can go through and change anything.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4001,7 +4001,7 @@ class Axes(_AxesBase):
             bootstrap = mpl.rcParams['boxplot.bootstrap']
 
         bxpstats = cbook.boxplot_stats(x, whis=whis, bootstrap=bootstrap,
-                                       tick_labels=tick_labels, autorange=autorange)
+                                       labels=tick_labels, autorange=autorange)
         if notch is None:
             notch = mpl.rcParams['boxplot.notch']
         if vert is None:

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1126,9 +1126,7 @@ def _broadcast_with_masks(*args, compress=False):
     return inputs
 
 
-@_api.rename_parameter("3.9", "labels", "tick_labels")
-def boxplot_stats(X, whis=1.5, bootstrap=None, tick_labels=None,
-                  autorange=False):
+def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None, autorange=False):
     r"""
     Return a list of dictionaries of statistics used to draw a series of box
     and whisker plots using `~.Axes.bxp`.
@@ -1162,13 +1160,9 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, tick_labels=None,
         Number of times the confidence intervals around the median
         should be bootstrapped (percentile method).
 
-    tick_labels : array-like, optional
+    labels : list of str, optional
         Labels for each dataset. Length must be compatible with
         dimensions of *X*.
-
-        .. versionchanged:: 3.9
-            Renamed from *labels*, which is deprecated since 3.9
-            and will be removed in 3.11.
 
     autorange : bool, optional (False)
         When `True` and the data are distributed such that the 25th and 75th
@@ -1245,13 +1239,13 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, tick_labels=None,
     X = _reshape_2D(X, "X")
 
     ncols = len(X)
-    if tick_labels is None:
-        tick_labels = itertools.repeat(None)
-    elif len(tick_labels) != ncols:
-        raise ValueError("Dimensions of tick_labels and X must be compatible")
+    if labels is None:
+        labels = itertools.repeat(None)
+    elif len(labels) != ncols:
+        raise ValueError("Dimensions of labels and X must be compatible")
 
     input_whis = whis
-    for ii, (x, label) in enumerate(zip(X, tick_labels)):
+    for ii, (x, label) in enumerate(zip(X, labels)):
 
         # empty dict
         stats = {}

--- a/lib/matplotlib/cbook.pyi
+++ b/lib/matplotlib/cbook.pyi
@@ -135,7 +135,7 @@ def boxplot_stats(
     X: ArrayLike,
     whis: float | tuple[float, float] = ...,
     bootstrap: int | None = ...,
-    tick_labels: ArrayLike | None = ...,
+    labels: ArrayLike | None = ...,
     autorange: bool = ...,
 ) -> list[dict[str, Any]]: ...
 

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -147,7 +147,7 @@ class Test_boxplot_stats:
 
     def test_results_withlabels(self):
         labels = ['Test1', 2, 'Aardvark', 4]
-        results = cbook.boxplot_stats(self.data, tick_labels=labels)
+        results = cbook.boxplot_stats(self.data, labels=labels)
         for lab, res in zip(labels, results):
             assert res['label'] == lab
 
@@ -158,7 +158,7 @@ class Test_boxplot_stats:
     def test_label_error(self):
         labels = [1, 2]
         with pytest.raises(ValueError):
-            cbook.boxplot_stats(self.data, tick_labels=labels)
+            cbook.boxplot_stats(self.data, labels=labels)
 
     def test_bad_dims(self):
         data = np.random.normal(size=(34, 34, 34))


### PR DESCRIPTION
This is up for debate: I'm only +0.2 here.

The renaming was done in #27901, which renamed the parameter `labels` to `tick_labels` for `boxplot()` and `bxp()`.

One can take two views here:

- If `boxplot_stats()` is specifically for the input of `bxp()`, one can justify the renaming as being consistent with the `bxp()` signature. Note however, that the returned dict still contains the key "label" for back-compatibility (There's no easy migration path for that). So, this brings us an inconsistency between the parameter name and the returned dict key.

- One can alternatively view `boxplot_stats()` as a generic function to define box parameters. Here, we'd only have a general `label` for the boy and no information that this should be used as tick label.

If we could make a clean transition and also rename the dict key, I would tend to go with the first view. But the inevitable inconsistency of the fist view let's me sway towards the second view, so that with the revert, we've effectively not touched `boxplot_stats()`.
