### PR TITLE
Fix new flake8 errors from old merge

### DIFF
--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -943,9 +943,8 @@ def test_auto_format_str(fmt, value, result):
 
 
 def test_unpack_to_numpy_from_torch():
-    """Test that torch tensors are converted to numpy arrays.
-    We don't want to create a dependency on torch in the test suite, so we mock it.
-    """
+    # Test that torch tensors are converted to NumPy arrays.
+    # We don't want to create a dependency on torch in the test suite, so we mock it.
     class Tensor:
         def __init__(self, data):
             self.data = data
@@ -963,9 +962,8 @@ def test_unpack_to_numpy_from_torch():
 
 
 def test_unpack_to_numpy_from_jax():
-    """Test that jax arrays are converted to numpy arrays.
-    We don't want to create a dependency on jax in the test suite, so we mock it.
-    """
+    # Test that jax arrays are converted to NumPy arrays.
+    # We don't want to create a dependency on jax in the test suite, so we mock it.
     class Array:
         def __init__(self, data):
             self.data = data


### PR DESCRIPTION
## PR summary

Some flake8-docstring options were changed between a PR being written and it gettig merge, so these errors were not evident.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines