### PR TITLE
DOC: Fix syntax for ToolBase.image docstring

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -99,12 +99,12 @@ class ToolBase:
     """
     Icon filename.
 
-    ``str | None``: Filename of the Toolbar icon; either absolute, or
-    relative to the directory containing the Python source file where the
-    ``Tool.image``class attribute is defined (in the latter case, this cannot
-    be defined as an instance attribute).  In either case, the extension is
-    optional; leaving it off lets individual backends select the icon format
-    they prefer.  If None, the *name* is used as a label in the toolbar button.
+    ``str | None``: Filename of the Toolbar icon; either absolute, or relative to the
+    directory containing the Python source file where the ``Tool.image`` class attribute
+    is defined (in the latter case, this cannot be defined as an instance attribute).
+    In either case, the extension is optional; leaving it off lets individual backends
+    select the icon format they prefer.  If None, the *name* is used as a label in the
+    toolbar button.
     """
 
     def __init__(self, toolmanager, name):


### PR DESCRIPTION
## PR summary

Fixes a reST syntax error that slipped in through #27492.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines