### PR TITLE
Fix pickling of make_axes_area_auto_adjustable'd axes.

### DIFF
--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -15,7 +15,7 @@ from matplotlib.lines import VertexSelector
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import matplotlib.figure as mfigure
-from mpl_toolkits.axes_grid1 import parasite_axes  # type: ignore
+from mpl_toolkits.axes_grid1 import axes_divider, parasite_axes  # type: ignore
 
 
 def test_simple():
@@ -274,6 +274,7 @@ def test_unpickle_canvas():
 
 def test_mpl_toolkits():
     ax = parasite_axes.host_axes([0, 0, 1, 1])
+    axes_divider.make_axes_area_auto_adjustable(ax)
     assert type(pickle.loads(pickle.dumps(ax))) == parasite_axes.HostAxes
 
 

--- a/lib/mpl_toolkits/axes_grid1/axes_size.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_size.py
@@ -233,14 +233,14 @@ class _AxesDecorationsSize(_Base):
     }
 
     def __init__(self, ax, direction):
-        self._get_size = _api.check_getitem(
-            self._get_size_map, direction=direction)
+        _api.check_in_list(self._get_size_map, direction=direction)
+        self._direction = direction
         self._ax_list = [ax] if isinstance(ax, Axes) else ax
 
     def get_size(self, renderer):
         sz = max([
-            self._get_size(ax.get_tightbbox(renderer, call_axes_locator=False),
-                           ax.bbox)
+            self._get_size_map[self._direction](
+                ax.get_tightbbox(renderer, call_axes_locator=False), ax.bbox)
             for ax in self._ax_list])
         dpi = renderer.points_to_pixels(72)
         abs_size = sz / dpi


### PR DESCRIPTION
... by not storing a lambda in the _AxesDecorationsSize instance, just a name (the dict lookup cost should be negligible compare to the rest).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
