### PR TITLE
Update docs for `FancyArrowPatch` & `Annotation` to make it clear that ShinkA/B parameters are in points and not fractional.

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4189,7 +4189,7 @@ default: 'arc3'
             Head and tail patches, respectively.
 
         shrinkA, shrinkB : float, default: 2
-            Shrinking factor of the tail and head of the arrow respectively.
+            Shrink amount, in points, of the tail and head of the arrow respectively.
 
         mutation_scale : float, default: 1
             Value with which attributes of *arrowstyle* (e.g., *head_length*)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1767,8 +1767,8 @@ or callable, default: value of *xycoords*
             relpos           See below; default is (0.5, 0.5)
             patchA           Default is bounding box of the text
             patchB           Default is None
-            shrinkA          Default is 2 points
-            shrinkB          Default is 2 points
+            shrinkA          In points. Default is 2 points
+            shrinkB          In points. Default is 2 points
             mutation_scale   Default is text size (in points)
             mutation_aspect  Default is 1
             ?                Any `.FancyArrowPatch` property


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

closes #27941 

Updates documentation in two places to make it more clear that `FancyArrowPatch` uses point units for the `shrinkA` & `shrinkB` parameters.

This was particularly unclear when accessing `FancyArrowPatch` via `Axes.annotate()` because there is an alternate "simple" way to specify an arrow that uses `shink` as a fraction rather than as points.
Therefore I have also proposed changes to the `Annotation` class in the text module.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".


## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines