### PR TITLE
Fix Hatch Color

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -80,8 +80,8 @@ class Patch(artist.Artist):
                     "the edgecolor or facecolor properties.")
             self.set_color(color)
         else:
-            self.set_edgecolor(edgecolor)
             self.set_facecolor(facecolor)
+            self.set_edgecolor(edgecolor)
 
         self._linewidth = 0
         self._unscaled_dash_pattern = (0, None)  # offset, dash
@@ -369,7 +369,7 @@ class Patch(artist.Artist):
                 set_hatch_color = False
 
         self._edgecolor = colors.to_rgba(color, self._alpha)
-        if set_hatch_color:
+        if set_hatch_color and not self._facecolor == self._edgecolor:
             self._hatch_color = self._edgecolor
         self.stale = True
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #8865
Simple fix by checking if face-color is the same as edge-color for a patch, If yes, do not update hatch-color 

Gives the needed output:

<img width="407" alt="image" src="https://github.com/matplotlib/matplotlib/assets/73378019/0a76f54b-503e-4874-9a03-8706265628d2">


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
