### PR TITLE
Add a draw during show for macos backend

### DIFF
--- a/lib/matplotlib/backends/backend_macosx.py
+++ b/lib/matplotlib/backends/backend_macosx.py
@@ -179,6 +179,8 @@ class FigureManagerMac(_macosx.FigureManager, FigureManagerBase):
             _macosx.show()
 
     def show(self):
+        if self.canvas.figure.stale:
+            self.canvas.draw_idle()
         if not self._shown:
             self._show()
             self._shown = True


### PR DESCRIPTION
Without this a stale figure is shown

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

This is basically the same concept as what happens just before show in [`plt.pause`](https://github.com/matplotlib/matplotlib/blob/1174aadafd9ae55818436bd3033b36626dcd3b0d/lib/matplotlib/pyplot.py#L731).

Essentially, there is nothing in the macos backend that actually causes a stale figure to be redrawn on `show`.
Other backends (qt, tk in particular, but likely others) seem to be saved by the fact that a resize event is triggered upon show, but macos does not do the same.


Other ideas considered, would be to do this in `plt.show` (which would perhaps leave out some other mechanisms, such as mpl-gui) or to try and do this in backend_bases (which is hard because most do not call `super`).
Could also leave out the condition and just always call `draw_idle`.

closes #27953

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
