### PR TITLE
Update AppVeyor config

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,12 +29,9 @@ environment:
                  --cov-report= --cov=lib --log-level=DEBUG
 
   matrix:
-    - PYTHON_VERSION: "3.9"
+    - PYTHON_VERSION: "3.11"
       CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
-      TEST_ALL: "no"
-    - PYTHON_VERSION: "3.10"
-      CONDA_INSTALL_LOCN: "C:\\Miniconda3-x64"
-      TEST_ALL: "no"
+      TEST_ALL: "yes"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable
@@ -77,7 +74,8 @@ test_script:
   - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'
 
   # this are optional dependencies so that we don't skip so many tests...
-  - if x%TEST_ALL% == xyes conda install -q ffmpeg inkscape miktex
+  - if x%TEST_ALL% == xyes conda install -q ffmpeg inkscape
+  # miktex is available on conda, but seems to fail with permission errors.
   # missing packages on conda-forge for imagemagick
   # This install sometimes failed randomly :-(
   # - choco install imagemagick

--- a/lib/matplotlib/tests/test_tightlayout.py
+++ b/lib/matplotlib/tests/test_tightlayout.py
@@ -130,7 +130,7 @@ def test_tight_layout7():
     plt.tight_layout()
 
 
-@image_comparison(['tight_layout8'])
+@image_comparison(['tight_layout8'], tol=0.005)
 def test_tight_layout8():
     """Test automatic use of tight_layout."""
     fig = plt.figure()


### PR DESCRIPTION
## PR summary

AppVeyor is quite slow, but is also the only CI to check the conda environment, so cut it down to only one Python version. But also enable a few more things to see if they work.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines