### PR TITLE
DOC: Fix typo in ```ax.transData.inversed()```

### DIFF
--- a/galleries/users_explain/artists/transforms_tutorial.py
+++ b/galleries/users_explain/artists/transforms_tutorial.py
@@ -82,7 +82,7 @@ The transformations also know how to invert themselves (via
 `.Transform.inverted`) to generate a transform from output coordinate system
 back to the input coordinate system.  For example, ``ax.transData`` converts
 values in data coordinates to display coordinates and
-``ax.transData.inversed()`` is a :class:`matplotlib.transforms.Transform` that
+``ax.transData.inverted()`` is a :class:`matplotlib.transforms.Transform` that
 goes from display coordinates to data coordinates. This is particularly useful
 when processing events from the user interface, which typically occur in
 display space, and you want to know where the mouse click or key-press occurred


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Fix a typo in documentation: ```ax.transData.inversed()``` --> ```ax.transData.inverted()```


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
