### PR TITLE
DOC: Fix label type specification in parameter descriptions

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3058,7 +3058,7 @@ class Axes(_AxesBase):
         bottom : float, default: 0
             The y/x-position of the baseline (depending on *orientation*).
 
-        label : str, default: None
+        label : str, optional
             The label to use for the stems in legends.
 
         data : indexable object, optional
@@ -6831,7 +6831,7 @@ class Axes(_AxesBase):
             Color or sequence of colors, one per dataset.  Default (``None``)
             uses the standard line color sequence.
 
-        label : str or None, default: None
+        label : str or list of str, optional
             String, or sequence of strings to match multiple datasets.  Bar
             charts yield multiple patches per dataset, but only the first gets
             the label, so that `~.Axes.legend` will work as expected.

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3610,7 +3610,7 @@ class Axes3D(Axes):
         bottom : float, default: 0
             The position of the baseline, in *orientation*-coordinates.
 
-        label : str, default: None
+        label : str, optional
             The label to use for the stems in legends.
 
         orientation : {'x', 'y', 'z'}, default: 'z'


### PR DESCRIPTION
- add missing "or list of str" in hist() docstring
- Use "optional" instead of "default: None"

  See https://matplotlib.org/devdocs/devel/document.html

  > If None is only used as a sentinel value for "parameter not specified",
  > do not document it as the default. Depending on the context, give the
  > actual default, or mark the parameter as optional if not specifying has
  > no particular effect.

