### PR TITLE
TST: Remove superfluous chdir from tests

### DIFF
--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -81,43 +81,47 @@ def test_multipage_properfinalize():
 
 
 def test_multipage_keep_empty(tmp_path):
-    os.chdir(tmp_path)
-
     # test empty pdf files
 
     # an empty pdf is left behind with keep_empty unset
-    with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:
+    fn = tmp_path / "a.pdf"
+    with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages(fn) as pdf:
         pass
-    assert os.path.exists("a.pdf")
+    assert fn.exists()
 
     # an empty pdf is left behind with keep_empty=True
+    fn = tmp_path / "b.pdf"
     with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-            PdfPages("b.pdf", keep_empty=True) as pdf:
+            PdfPages(fn, keep_empty=True) as pdf:
         pass
-    assert os.path.exists("b.pdf")
+    assert fn.exists()
 
     # an empty pdf deletes itself afterwards with keep_empty=False
-    with PdfPages("c.pdf", keep_empty=False) as pdf:
+    fn = tmp_path / "c.pdf"
+    with PdfPages(fn, keep_empty=False) as pdf:
         pass
-    assert not os.path.exists("c.pdf")
+    assert not fn.exists()
 
     # test pdf files with content, they should never be deleted
 
     # a non-empty pdf is left behind with keep_empty unset
-    with PdfPages("d.pdf") as pdf:
+    fn = tmp_path / "d.pdf"
+    with PdfPages(fn) as pdf:
         pdf.savefig(plt.figure())
-    assert os.path.exists("d.pdf")
+    assert fn.exists()
 
     # a non-empty pdf is left behind with keep_empty=True
+    fn = tmp_path / "e.pdf"
     with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-            PdfPages("e.pdf", keep_empty=True) as pdf:
+            PdfPages(fn, keep_empty=True) as pdf:
         pdf.savefig(plt.figure())
-    assert os.path.exists("e.pdf")
+    assert fn.exists()
 
     # a non-empty pdf is left behind with keep_empty=False
-    with PdfPages("f.pdf", keep_empty=False) as pdf:
+    fn = tmp_path / "f.pdf"
+    with PdfPages(fn, keep_empty=False) as pdf:
         pdf.savefig(plt.figure())
-    assert os.path.exists("f.pdf")
+    assert fn.exists()
 
 
 def test_composite_image():

--- a/lib/matplotlib/tests/test_backend_pgf.py
+++ b/lib/matplotlib/tests/test_backend_pgf.py
@@ -288,43 +288,47 @@ def test_pdf_pages_metadata_check(monkeypatch, system):
 
 @needs_pgf_xelatex
 def test_multipage_keep_empty(tmp_path):
-    os.chdir(tmp_path)
-
     # test empty pdf files
 
     # an empty pdf is left behind with keep_empty unset
-    with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages("a.pdf") as pdf:
+    fn = tmp_path / "a.pdf"
+    with pytest.warns(mpl.MatplotlibDeprecationWarning), PdfPages(fn) as pdf:
         pass
-    assert os.path.exists("a.pdf")
+    assert fn.exists()
 
     # an empty pdf is left behind with keep_empty=True
+    fn = tmp_path / "b.pdf"
     with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-            PdfPages("b.pdf", keep_empty=True) as pdf:
+            PdfPages(fn, keep_empty=True) as pdf:
         pass
-    assert os.path.exists("b.pdf")
+    assert fn.exists()
 
     # an empty pdf deletes itself afterwards with keep_empty=False
-    with PdfPages("c.pdf", keep_empty=False) as pdf:
+    fn = tmp_path / "c.pdf"
+    with PdfPages(fn, keep_empty=False) as pdf:
         pass
-    assert not os.path.exists("c.pdf")
+    assert not fn.exists()
 
     # test pdf files with content, they should never be deleted
 
     # a non-empty pdf is left behind with keep_empty unset
-    with PdfPages("d.pdf") as pdf:
+    fn = tmp_path / "d.pdf"
+    with PdfPages(fn) as pdf:
         pdf.savefig(plt.figure())
-    assert os.path.exists("d.pdf")
+    assert fn.exists()
 
     # a non-empty pdf is left behind with keep_empty=True
+    fn = tmp_path / "e.pdf"
     with pytest.warns(mpl.MatplotlibDeprecationWarning), \
-            PdfPages("e.pdf", keep_empty=True) as pdf:
+            PdfPages(fn, keep_empty=True) as pdf:
         pdf.savefig(plt.figure())
-    assert os.path.exists("e.pdf")
+    assert fn.exists()
 
     # a non-empty pdf is left behind with keep_empty=False
-    with PdfPages("f.pdf", keep_empty=False) as pdf:
+    fn = tmp_path / "f.pdf"
+    with PdfPages(fn, keep_empty=False) as pdf:
         pdf.savefig(plt.figure())
-    assert os.path.exists("f.pdf")
+    assert fn.exists()
 
 
 @needs_pgf_xelatex


### PR DESCRIPTION
## PR summary

These tests don't chdir back to the original directory on exit, so anything using the current directory would be in the temporary directory of this test.

Most notably, any image comparison results would be dumped in that temporary directory instead of the usual `result_images` in the current directory.

I noticed this while debugging #27723, as the failing test images were not in the artifacts, and logs showed them saved in a temporary directory: https://github.com/matplotlib/matplotlib/actions/runs/8458560380/job/23173084420#step:13:183

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines