### PR TITLE
gtk: Ensure pending draws are done before GTK draw

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .. import cbook, transforms
 from . import backend_agg, backend_gtk3
-from .backend_gtk3 import Gtk, _BackendGTK3
+from .backend_gtk3 import GLib, Gtk, _BackendGTK3
 
 import cairo  # Presence of cairo is already checked by _backend_gtk.
 
@@ -14,6 +14,11 @@ class FigureCanvasGTK3Agg(backend_agg.FigureCanvasAgg,
         self._bbox_queue = []
 
     def on_draw_event(self, widget, ctx):
+        if self._idle_draw_id:
+            GLib.source_remove(self._idle_draw_id)
+            self._idle_draw_id = 0
+            self.draw()
+
         scale = self.device_pixel_ratio
         allocation = self.get_allocation()
         w = allocation.width * scale

--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -1,11 +1,16 @@
 from contextlib import nullcontext
 
 from .backend_cairo import FigureCanvasCairo
-from .backend_gtk3 import Gtk, FigureCanvasGTK3, _BackendGTK3
+from .backend_gtk3 import GLib, Gtk, FigureCanvasGTK3, _BackendGTK3
 
 
 class FigureCanvasGTK3Cairo(FigureCanvasCairo, FigureCanvasGTK3):
     def on_draw_event(self, widget, ctx):
+        if self._idle_draw_id:
+            GLib.source_remove(self._idle_draw_id)
+            self._idle_draw_id = 0
+            self.draw()
+
         with (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
               else nullcontext()):
             self._renderer.set_context(ctx)

--- a/lib/matplotlib/backends/backend_gtk4agg.py
+++ b/lib/matplotlib/backends/backend_gtk4agg.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .. import cbook
 from . import backend_agg, backend_gtk4
-from .backend_gtk4 import Gtk, _BackendGTK4
+from .backend_gtk4 import GLib, Gtk, _BackendGTK4
 
 import cairo  # Presence of cairo is already checked by _backend_gtk.
 
@@ -11,6 +11,11 @@ class FigureCanvasGTK4Agg(backend_agg.FigureCanvasAgg,
                           backend_gtk4.FigureCanvasGTK4):
 
     def on_draw_event(self, widget, ctx):
+        if self._idle_draw_id:
+            GLib.source_remove(self._idle_draw_id)
+            self._idle_draw_id = 0
+            self.draw()
+
         scale = self.device_pixel_ratio
         allocation = self.get_allocation()
 

--- a/lib/matplotlib/backends/backend_gtk4cairo.py
+++ b/lib/matplotlib/backends/backend_gtk4cairo.py
@@ -1,13 +1,18 @@
 from contextlib import nullcontext
 
 from .backend_cairo import FigureCanvasCairo
-from .backend_gtk4 import Gtk, FigureCanvasGTK4, _BackendGTK4
+from .backend_gtk4 import GLib, Gtk, FigureCanvasGTK4, _BackendGTK4
 
 
 class FigureCanvasGTK4Cairo(FigureCanvasCairo, FigureCanvasGTK4):
     _context_is_scaled = True
 
     def on_draw_event(self, widget, ctx):
+        if self._idle_draw_id:
+            GLib.source_remove(self._idle_draw_id)
+            self._idle_draw_id = 0
+            self.draw()
+
         with (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
               else nullcontext()):
             self._renderer.set_context(ctx)


### PR DESCRIPTION
## PR summary

Originally, the resize event happens first, adds an idle draw callback, and then the widget draws itself. Since the draw callback only happens when _idle_, it happens after the widget's draw, so the figure appears blank. After the mouse is released, the idle draw callback fires, and the figure appears again.

This is already done in the Qt backend [1], and doing so ensures the figure remains visible during resizes with the mouse.

This fixes the bug reported at https://github.com/matplotlib/matplotlib/pull/25861#issuecomment-1545750896

[1] https://github.com/matplotlib/matplotlib/blob/0afc5d6ca49cf6e8aa1da76b5bab0faca2f340f2/lib/matplotlib/backends/backend_qtagg.py#L25

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines