### PR TITLE
Fix #25032 by reading gallery ordering from a txt file in galleries folder

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -8,7 +8,7 @@ import os
 
 
 # Utility functions
-def get_ordering(dir):
+def get_ordering(dir, include_directory_path=False):
     """Read gallery_order.txt in dir and return content of the file as a List"""
     file_path = os.path.join(dir, 'gallery_order.txt')
     f = open(file_path, "r")
@@ -18,7 +18,10 @@ def get_ordering(dir):
         if line == "unsorted":
             ordered_list.append(UNSORTED)
         else:
-            ordered_list.append(line)
+            if include_directory_path:
+                ordered_list.append(os.path.join(dir, line))
+            else:
+                ordered_list.append(line)
 
     return ordered_list
 
@@ -69,9 +72,9 @@ tutorials_order = [
 #     UNSORTED
 # ]
 
-plot_types_directory = "../galleries/plot_types/"
-plot_types_order = get_ordering(plot_types_directory)
 
+plot_types_directory = "../galleries/plot_types/"
+plot_types_order = get_ordering(plot_types_directory, include_directory_path=True)
 
 folder_lists = [examples_order, tutorials_order, plot_types_order]
 explicit_order_folders = [fd for folders in folder_lists
@@ -133,7 +136,7 @@ list_all = [
 
 for dir in list_directory(plot_types_directory):
     try:
-        ordered_subdirs = get_ordering(dir)
+        ordered_subdirs = get_ordering(dir, include_directory_path=False)
         list_all.extend(ordered_subdirs)
     except FileNotFoundError:
         # Fallback to ordering already defined in list_all

--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -37,46 +37,13 @@ def list_directory(parent_dir):
 UNSORTED = "unsorted"
 
 
-examples_order = [
-    '../galleries/examples/lines_bars_and_markers',
-    '../galleries/examples/images_contours_and_fields',
-    '../galleries/examples/subplots_axes_and_figures',
-    '../galleries/examples/statistics',
-    '../galleries/examples/pie_and_polar_charts',
-    '../galleries/examples/text_labels_and_annotations',
-    '../galleries/examples/color',
-    '../galleries/examples/shapes_and_collections',
-    '../galleries/examples/style_sheets',
-    '../galleries/examples/pyplots',
-    '../galleries/examples/axes_grid1',
-    '../galleries/examples/axisartist',
-    '../galleries/examples/showcase',
-    UNSORTED,
-    '../galleries/examples/userdemo',
-]
-
-tutorials_order = [
-    '../galleries/tutorials/introductory',
-    '../galleries/tutorials/intermediate',
-    '../galleries/tutorials/advanced',
-    UNSORTED,
-    '../galleries/tutorials/provisional'
-]
-
-# plot_types_order = [
-#     '../galleries/plot_types/basic',
-#     '../galleries/plot_types/stats',
-#     '../galleries/plot_types/arrays',
-#     '../galleries/plot_types/unstructured',
-#     '../galleries/plot_types/3D',
-#     UNSORTED
-# ]
-
-
 plot_types_directory = "../galleries/plot_types/"
 plot_types_order = get_ordering(plot_types_directory, include_directory_path=True)
 
-folder_lists = [examples_order, tutorials_order, plot_types_order]
+examples_directory = "../galleries/examples/"
+examples_order = get_ordering(examples_directory, include_directory_path=True)
+
+folder_lists = [examples_order, plot_types_order]
 explicit_order_folders = [fd for folders in folder_lists
                           for fd in folders[:folders.index(UNSORTED)]]
 explicit_order_folders.append(UNSORTED)
@@ -99,39 +66,9 @@ class MplExplicitOrder(ExplicitOrder):
 # Examples/tutorials that do not appear in a list will be appended.
 
 list_all = [
-    #  **Tutorials**
-    #  introductory
-    "quick_start", "pyplot", "images", "lifecycle", "customizing",
-    #  intermediate
-    "artists", "legend_guide", "color_cycle",
-    "constrainedlayout_guide", "tight_layout_guide",
-    #  advanced
-    #  text
-    "text_intro", "text_props",
-    #  colors
-    "colors",
-
-    #  **Examples**
-    #  color
-    "color_demo",
-    #  pies
-    "pie_features", "pie_demo2",
-
-    # **Plot Types
-    # Basic
-    # "plot", "scatter_plot", "bar", "stem", "step", "fill_between",
-    # Arrays
-    # "imshow", "pcolormesh", "contour", "contourf",
-    # "barbs", "quiver", "streamplot",
-    # Stats
-    # "hist_plot", "boxplot_plot", "errorbar_plot", "violin",
-    # "eventplot", "hist2d", "hexbin", "pie",
-    # Unstructured
-    # "tricontour", "tricontourf", "tripcolor", "triplot",
-    # Spines
-    "spines", "spine_placement_demo", "spines_dropped",
-    "multiple_yaxis_with_spines", "centered_spines_with_arrows",
-    ]
+    # folders that don't contain gallery_order.txt file can  
+    # list their file orderings here 
+]
 
 
 for dir in list_directory(plot_types_directory):

--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -4,11 +4,35 @@ Paths are relative to the conf.py file.
 """
 
 from sphinx_gallery.sorting import ExplicitOrder
+import os
+
+
+# Utility functions
+def get_ordering(dir):
+    """Read gallery_order.txt in dir and return content of the file as a List"""
+    file_path = os.path.join(dir, 'gallery_order.txt')
+    f = open(file_path, "r")
+    lines = [line.replace('\n', '') for line in f.readlines()]
+    ordered_list = []
+    for line in lines:
+        if line == "unsorted":
+            ordered_list.append(UNSORTED)
+        else:
+            ordered_list.append(line)
+
+    return ordered_list
+
+
+def list_directory(parent_dir):
+    """Return list of sub directories at a directory"""
+    root, dirs, files = next(os.walk(parent_dir))
+    return [os.path.join(root, dir) for dir in dirs]
 
 # Gallery sections shall be displayed in the following order.
 # Non-matching sections are inserted at the unsorted position
 
 UNSORTED = "unsorted"
+
 
 examples_order = [
     '../galleries/examples/lines_bars_and_markers',
@@ -36,17 +60,20 @@ tutorials_order = [
     '../galleries/tutorials/provisional'
 ]
 
-plot_types_order = [
-    '../galleries/plot_types/basic',
-    '../galleries/plot_types/stats',
-    '../galleries/plot_types/arrays',
-    '../galleries/plot_types/unstructured',
-    '../galleries/plot_types/3D',
-    UNSORTED
-]
+# plot_types_order = [
+#     '../galleries/plot_types/basic',
+#     '../galleries/plot_types/stats',
+#     '../galleries/plot_types/arrays',
+#     '../galleries/plot_types/unstructured',
+#     '../galleries/plot_types/3D',
+#     UNSORTED
+# ]
+
+plot_types_directory = "../galleries/plot_types/"
+plot_types_order = get_ordering(plot_types_directory)
+
 
 folder_lists = [examples_order, tutorials_order, plot_types_order]
-
 explicit_order_folders = [fd for folders in folder_lists
                           for fd in folders[:folders.index(UNSORTED)]]
 explicit_order_folders.append(UNSORTED)
@@ -89,19 +116,30 @@ list_all = [
 
     # **Plot Types
     # Basic
-    "plot", "scatter_plot", "bar", "stem", "step", "fill_between",
+    # "plot", "scatter_plot", "bar", "stem", "step", "fill_between",
     # Arrays
-    "imshow", "pcolormesh", "contour", "contourf",
-    "barbs", "quiver", "streamplot",
+    # "imshow", "pcolormesh", "contour", "contourf",
+    # "barbs", "quiver", "streamplot",
     # Stats
-    "hist_plot", "boxplot_plot", "errorbar_plot", "violin",
-    "eventplot", "hist2d", "hexbin", "pie",
+    # "hist_plot", "boxplot_plot", "errorbar_plot", "violin",
+    # "eventplot", "hist2d", "hexbin", "pie",
     # Unstructured
-    "tricontour", "tricontourf", "tripcolor", "triplot",
+    # "tricontour", "tricontourf", "tripcolor", "triplot",
     # Spines
     "spines", "spine_placement_demo", "spines_dropped",
     "multiple_yaxis_with_spines", "centered_spines_with_arrows",
     ]
+
+
+for dir in list_directory(plot_types_directory):
+    try:
+        ordered_subdirs = get_ordering(dir)
+        list_all.extend(ordered_subdirs)
+    except FileNotFoundError:
+        # Fallback to ordering already defined in list_all
+        pass
+
+
 explicit_subsection_order = [item + ".py" for item in list_all]
 
 

--- a/galleries/examples/color/gallery_order.txt
+++ b/galleries/examples/color/gallery_order.txt
@@ -1,0 +1,2 @@
+color_demo
+unsorted

--- a/galleries/examples/gallery_order.txt
+++ b/galleries/examples/gallery_order.txt
@@ -1,0 +1,15 @@
+lines_bars_and_markers
+images_contours_and_fields
+subplots_axes_and_figures
+statistics
+pie_and_polar_charts
+text_labels_and_annotations
+color
+shapes_and_collections
+style_sheets
+pyplots
+axes_grid1
+axisartist
+showcase
+unsorted
+userdemo

--- a/galleries/examples/pie_and_polar_charts/gallery_order.txt
+++ b/galleries/examples/pie_and_polar_charts/gallery_order.txt
@@ -1,0 +1,2 @@
+pie_features
+unsorted

--- a/galleries/examples/spines/gallery_order.txt
+++ b/galleries/examples/spines/gallery_order.txt
@@ -1,0 +1,5 @@
+spines
+spine_placement_demo
+spines_dropped
+multiple_yaxis_with_spines
+centered_spines_with_arrows

--- a/galleries/plot_types/arrays/gallery_order.txt
+++ b/galleries/plot_types/arrays/gallery_order.txt
@@ -1,0 +1,6 @@
+imshow
+pcolormesh
+contourcontourf
+barbs
+quiver
+streamplot

--- a/galleries/plot_types/basic/gallery_order.txt
+++ b/galleries/plot_types/basic/gallery_order.txt
@@ -1,0 +1,6 @@
+plot
+scatter_plot
+bar
+stem
+step
+fill_between

--- a/galleries/plot_types/gallery_order.txt
+++ b/galleries/plot_types/gallery_order.txt
@@ -1,0 +1,6 @@
+basic
+stats
+arrays
+unstructured
+3D
+unsorted

--- a/galleries/plot_types/stats/gallery_order.txt
+++ b/galleries/plot_types/stats/gallery_order.txt
@@ -1,0 +1,8 @@
+hist_plot
+boxplot_plot
+errorbar_plot
+violin
+eventplot
+hist2d
+hexbin
+pie

--- a/galleries/plot_types/unstructured/gallery_order.txt
+++ b/galleries/plot_types/unstructured/gallery_order.txt
@@ -1,0 +1,4 @@
+tricontour
+tricontourf
+tripcolor
+triplot


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Addresses #25032. Requires review for closing #25032 

Modified `gallery_order.py` to read ordering of examples from `galleries/plot_types` and its subdirectories. It adresses the issue described in #25032 but instead of reading the ordering from readme it's currently fetching ordering from `gallery_order.txt` as described in the comments by [ @timhoffm ]( https://github.com/matplotlib/matplotlib/pull/27442#issuecomment-1842767658 ) and [@story645]( https://github.com/matplotlib/matplotlib/pull/27442#issuecomment-1843630464 ).

I only added the functionality for `galleries/plot_types` as a draft to gather feedback on the approach. After iterations if the implementation approach is finalized I can work on integrating with other galleries and also add the devel documentation as asked in #25032


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #25032" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
