### PR TITLE
Fix color sequence data for Set2 and Set3

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -127,8 +127,8 @@ class ColorSequenceRegistry(Mapping):
         'Accent': _cm._Accent_data,
         'Dark2': _cm._Dark2_data,
         'Set1': _cm._Set1_data,
-        'Set2': _cm._Set1_data,
-        'Set3': _cm._Set1_data,
+        'Set2': _cm._Set2_data,
+        'Set3': _cm._Set3_data,
     }
 
     def __init__(self):


### PR DESCRIPTION
## PR summary

This PR fixes the color sequence data for the `Set2` and `Set3` qualitative colormaps in the `matplotlib.color_sequences` object. They were errorneously assigned to the `Set1` sequence data.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
