### PR TITLE
Fix deprecation warnings in ft2font extension

### DIFF
--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -73,8 +73,8 @@ static PyObject *PyFT2Image_draw_rect(PyFT2Image *self, PyObject *args)
 {
     char const* msg =
         "FT2Image.draw_rect is deprecated since Matplotlib 3.8 and will be removed "
-        "in Matplotlib 3.10 releases later as it is not used in the library. "
-        "If you rely on it, please let us know.";
+        "in Matplotlib 3.10 as it is not used in the library. If you rely on it, "
+        "please let us know.";
     if (PyErr_WarnEx(PyExc_DeprecationWarning, msg, 1)) {
         return NULL;
     }
@@ -838,8 +838,8 @@ const char *PyFT2Font_get_xys__doc__ =
 static PyObject *PyFT2Font_get_xys(PyFT2Font *self, PyObject *args, PyObject *kwds)
 {
     char const* msg =
-        "FT2Font.get_xys is deprecated since Matplotlib 3.8 and will be removed two "
-        "meso releases later as it is not used in the library. If you rely on it, "
+        "FT2Font.get_xys is deprecated since Matplotlib 3.8 and will be removed in "
+        "Matplotlib 3.10 as it is not used in the library. If you rely on it, "
         "please let us know.";
     if (PyErr_WarnEx(PyExc_DeprecationWarning, msg, 1)) {
         return NULL;


### PR DESCRIPTION
## PR summary

Minor typos introduced in #27702.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines