### PR TITLE
wx: Fix file extension for toolmanager-style toolbar

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1152,7 +1152,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
         height = self.canvas.figure.bbox.height
-        sf = 1 if wx.Platform == '__WXMSW__' else self.GetDPIScaleFactor()
+        sf = 1 if wx.Platform == '__WXMSW__' else self.canvas.GetDPIScaleFactor()
         self.canvas._rubberband_rect = (x0/sf, (height - y0)/sf,
                                         x1/sf, (height - y1)/sf)
         self.canvas.Refresh()

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1161,6 +1161,8 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
 # tools for matplotlib.backend_managers.ToolManager:
 
 class ToolbarWx(ToolContainerBase, wx.ToolBar):
+    _icon_extension = '.svg'
+
     def __init__(self, toolmanager, parent=None, style=wx.TB_BOTTOM):
         if parent is None:
             parent = toolmanager.canvas.GetParent()

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -14,6 +14,9 @@ import pathlib
 import sys
 import weakref
 
+import numpy as np
+import PIL.Image
+
 import matplotlib as mpl
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase,
@@ -1071,7 +1074,6 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         *name*, including the extension and relative to Matplotlib's "images"
         data directory.
         """
-        svg = cbook._get_data_path("images", name).read_bytes()
         try:
             dark = wx.SystemSettings.GetAppearance().IsDark()
         except AttributeError:  # wxpython < 4.1
@@ -1082,10 +1084,24 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
             bg_lum = (.299 * bg.red + .587 * bg.green + .114 * bg.blue) / 255
             fg_lum = (.299 * fg.red + .587 * fg.green + .114 * fg.blue) / 255
             dark = fg_lum - bg_lum > .2
-        if dark:
-            svg = svg.replace(b'fill:black;', b'fill:white;')
-        toolbarIconSize = wx.ArtProvider().GetDIPSizeHint(wx.ART_TOOLBAR)
-        return wx.BitmapBundle.FromSVG(svg, toolbarIconSize)
+
+        path = cbook._get_data_path('images', name)
+        if path.suffix == '.svg':
+            svg = path.read_bytes()
+            if dark:
+                svg = svg.replace(b'fill:black;', b'fill:white;')
+            toolbarIconSize = wx.ArtProvider().GetDIPSizeHint(wx.ART_TOOLBAR)
+            return wx.BitmapBundle.FromSVG(svg, toolbarIconSize)
+        else:
+            pilimg = PIL.Image.open(path)
+            # ensure RGBA as wx BitMap expects RGBA format
+            image = np.array(pilimg.convert("RGBA"))
+            if dark:
+                fg = wx.SystemSettings.GetColour(wx.SYS_COLOUR_WINDOWTEXT)
+                black_mask = (image[..., :3] == 0).all(axis=-1)
+                image[black_mask, :3] = (fg.Red(), fg.Green(), fg.Blue())
+            return wx.Bitmap.FromBufferRGBA(
+                image.shape[1], image.shape[0], image.tobytes())
 
     def _update_buttons_checked(self):
         if "Pan" in self.wx_ids:


### PR DESCRIPTION
## PR summary

Fixes AppVeyor failure noted in
https://github.com/matplotlib/matplotlib/pull/26710#issuecomment-2031349546

This was also broken on non-Windows; it just didn't crash, but instead produced empty buttons.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines