### PR TITLE
Inform tool-manager that wx backend wants icons in svg format

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1165,6 +1165,7 @@ class ToolbarWx(ToolContainerBase, wx.ToolBar):
         if parent is None:
             parent = toolmanager.canvas.GetParent()
         ToolContainerBase.__init__(self, toolmanager)
+        self._icon_extension = '.svg' # wx backend wants 'svg' tool icons
         wx.ToolBar.__init__(self, parent, -1, style=style)
         self._space = self.AddStretchableSpace()
         self._label_text = wx.StaticText(self, style=wx.ALIGN_RIGHT)


### PR DESCRIPTION
The refactoring in PR #26710 modified the wx backend to use resolution-independent tool icons in `svg` format. But informing tool-manager of this change was not done. So toolbar icons do not work when using tool-manager in conjunction with the wx backend. This in particular triggered issue #28007 

This PR addresses this problem by informing tool-manager that the wx backend wants icons in svg format.
