### PR TITLE
DOC: Move bug reports and feature requests to top of contributing index

### DIFF
--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -163,55 +163,6 @@ a new PR; duplicate PRs are subject to being closed.  However, if the existing
 PR is an outline, unlikely to work, or stalled, and the original author is
 unresponsive, feel free to open a new PR referencing the old one.
 
-.. _submitting-a-bug-report:
-
-Submit a bug report
-===================
-
-If you find a bug in the code or documentation, do not hesitate to submit a
-ticket to the
-`Issue Tracker <https://github.com/matplotlib/matplotlib/issues>`_. You are
-also welcome to post feature requests or pull requests.
-
-If you are reporting a bug, please do your best to include the following:
-
-#. A short, top-level summary of the bug. In most cases, this should be 1-2
-   sentences.
-
-#. A short, self-contained code snippet to reproduce the bug, ideally allowing
-   a simple copy and paste to reproduce. Please do your best to reduce the code
-   snippet to the minimum required.
-
-#. The actual outcome of the code snippet.
-
-#. The expected outcome of the code snippet.
-
-#. The Matplotlib version, Python version and platform that you are using. You
-   can grab the version with the following commands::
-
-      >>> import matplotlib
-      >>> matplotlib.__version__
-      '3.4.1'
-      >>> import platform
-      >>> platform.python_version()
-      '3.9.2'
-
-We have preloaded the issue creation page with a Markdown form that you can
-use to organize this information.
-
-Thank you for your help in keeping bug reports complete, targeted and descriptive.
-
-.. _request-a-new-feature:
-
-Request a new feature
-=====================
-
-Please post feature requests to the
-`Issue Tracker <https://github.com/matplotlib/matplotlib/issues>`_.
-
-The Matplotlib developers will give feedback on the feature proposal. Since
-Matplotlib is an open source project with limited resources, we encourage
-users to then also :ref:`participate in the implementation <contribute_code>`.
 
 .. _contribute_code:
 

--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -13,10 +13,52 @@ Contribute
       of this document as it will have the most up to date installation
       instructions, workflow process, and contributing guidelines.
 
-Thank you for your interest in helping to improve Matplotlib! There are various
-ways to contribute: optimizing and refactoring code, detailing unclear
-documentation and writing new examples, reporting and fixing bugs and requesting
-and implementing new features, helping the community...
+:octicon:`heart;1em;sd-text-info` Thank you for your interest in helping to improve
+Matplotlib! :octicon:`heart;1em;sd-text-info`
+
+.. _submitting-a-bug-report:
+.. _request-a-new-feature:
+
+.. grid:: 1 1 2 2
+
+   .. grid-item-card::
+      :class-header: sd-fs-5
+
+      :octicon:`bug;1em;sd-text-info` **Submit a bug report**
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+      We have preloaded the issue creation page with a Markdown form that you can
+      use to provide relevant context. Thank you for your help in keeping bug reports
+      complete, targeted and descriptive.
+
+      .. button-link:: https://github.com/matplotlib/matplotlib/issues/new/choose
+            :expand:
+            :color: primary
+
+            Report a bug
+
+   .. grid-item-card::
+      :class-header: sd-fs-5
+
+      :octicon:`light-bulb;1em;sd-text-info` **Request a new feature**
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+      We will give feedback on the feature proposal. Since
+      Matplotlib is an open source project with limited resources, we encourage
+      users to then also :ref:`participate in the implementation <contribute_code>`.
+
+      .. button-link:: https://github.com/matplotlib/matplotlib/issues/new/choose
+         :expand:
+         :color: primary
+
+         Request a feature
+
+
+We welcome you to get more involved with the Matplotlib project.
+There are various ways to contribute:
+optimizing and refactoring code, detailing unclear documentation and writing new
+examples, helping the community, reporting and fixing bugs and requesting and
+implementing new features...
 
 New contributors
 ================
@@ -48,20 +90,6 @@ New contributors
          :class-row: sd-fs-5
 
          .. grid-item-card::
-            :link: request-a-new-feature
-            :link-type: ref
-            :shadow: none
-
-            :octicon:`light-bulb;1em;sd-text-info` Request new feature
-
-         .. grid-item-card::
-            :link: submitting-a-bug-report
-            :link-type: ref
-            :shadow: none
-
-            :octicon:`bug;1em;sd-text-info` Submit bug report
-
-         .. grid-item-card::
             :link: contribute_code
             :link-type: ref
             :shadow: none
@@ -74,6 +102,14 @@ New contributors
             :shadow: none
 
             :octicon:`note;1em;sd-text-info` Write documentation
+
+         .. grid-item-card::
+            :link: other_ways_to_contribute
+            :link-type: ref
+            :shadow: none
+
+            :octicon:`paper-airplane;1em;sd-text-info` Other ways to contribute
+
 
 If you are new to contributing, we recommend that you first read our
 :ref:`contributing guide<contributing>`. If you are contributing code or


### PR DESCRIPTION
Partially adresses #28005.

The two sections "Report a bug" and "Request a feature" were burried inside of contribute.rst. They were a bit foreign there because all other content is on direct involvement with the project, which needs much more information.

To keep things focussed and directly redirect the "simple" bug report and feature request topics to GitHub, I've deleted the sections and instead created two cards at the top of devel/index.rst with essentially the content of the sections. Note that I've removed the list of things to include in bug reports because that's covered by our issue template on GitHub nowadays and does not need repetition here.
