### PR TITLE
Avoid plt.xticks/plt.yticks in gallery examples.

### DIFF
--- a/galleries/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/secondary_axis.py
@@ -154,7 +154,7 @@ fig, ax = plt.subplots(layout='constrained')
 
 ax.plot(dates, temperature)
 ax.set_ylabel(r'$T\ [^oC]$')
-plt.xticks(rotation=70)
+ax.xaxis.set_tick_params(rotation=70)
 
 
 def date2yday(x):

--- a/galleries/examples/ticks/ticklabels_rotation.py
+++ b/galleries/examples/ticks/ticklabels_rotation.py
@@ -5,17 +5,16 @@ Rotating custom tick labels
 
 Demo of custom tick-labels with user-defined rotation.
 """
+
 import matplotlib.pyplot as plt
 
 x = [1, 2, 3, 4]
 y = [1, 4, 9, 6]
 labels = ['Frogs', 'Hogs', 'Bogs', 'Slogs']
 
-plt.plot(x, y)
+fig, ax = plt.subplots()
+ax.plot(x, y)
 # You can specify a rotation for the tick labels in degrees or with keywords.
-plt.xticks(x, labels, rotation='vertical')
-# Pad margins so that markers don't get clipped by the Axes
-plt.margins(0.2)
-# Tweak spacing to prevent clipping of tick-labels
-plt.subplots_adjust(bottom=0.15)
+ax.set_xticks(x, labels, rotation='vertical')
+
 plt.show()


### PR DESCRIPTION
In particular, the ticklabels_rotation example is likely the one most easily found by those looking for how to do this; let's not suggest that plt.xticks is "the" way to rotate ticklabels.

Also remove the margins() call (which was really only needed with the old round_numbers autolimits mode) and the subplots_adjust() call (the ticklabels already fit in, and the modern approach would be to use constrained_layout anyways).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
