### PR TITLE
DOC: correct path to mpl_toolkits reference images

### DIFF
--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -315,7 +315,7 @@ The correct target folder can be found using::
 
     python -c "import matplotlib.tests; print(matplotlib.tests.__file__.rsplit('/', 1)[0])"
 
-An analogous copying of :file:`lib/mpl_toolkits/tests/baseline_images`
+An analogous copying of :file:`lib/mpl_toolkits/*/tests/baseline_images`
 is necessary for testing ``mpl_toolkits``.
 
 Run the tests


### PR DESCRIPTION

## PR summary

Tests and references images are stored in subdirectories for each toolkit.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
