### PR TITLE
Addresses issue #23129: Fixed log scale order dependency when using Collections

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -266,12 +266,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
             # No paths to transform
             return transforms.Bbox.null()
 
-        if not transform.is_affine:
-            paths = [transform.transform_path_non_affine(p) for p in paths]
-            # Don't convert transform to transform.get_affine() here because
-            # we may have transform.contains_branch(transData) but not
-            # transforms.get_affine().contains_branch(transData).  But later,
-            # be careful to only apply the affine part that remains.
+        # Don't convert transform to transform.get_affine() here because
+        # we may have transform.contains_branch(transData) but not
+        # transforms.get_affine().contains_branch(transData).  But later,
+        # be careful to only apply the affine part that remains.
 
         offsets = self.get_offsets()
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -358,6 +358,26 @@ def test_collection_log_datalim(fig_test, fig_ref):
     ax_ref.plot(x, y, marker="o", ls="")
 
 
+@mpl.style.context('mpl20')
+@check_figures_equal(extensions=['png'])
+def test_collection_log_datalim_order_dependency(fig_test, fig_ref):
+    xy = np.c_[np.arange(50), np.linspace(1, 100, 50)]
+    lines_test = mpl.collections.LineCollection(segments=[xy])
+    lines_ref = mpl.collections.LineCollection(segments=[xy])
+
+    ax_test = fig_test.subplots()
+    ax_test.set_xscale('log')
+    ax_test.set_yscale('log')
+    ax_test.add_collection(lines_test)
+    ax_test.autoscale_view()
+
+    ax_ref = fig_ref.subplots()
+    ax_ref.add_collection(lines_ref)
+    ax_ref.set_xscale('log')
+    ax_ref.set_yscale('log')
+    ax_ref.autoscale_view()
+
+
 def test_quiver_limits():
     ax = plt.axes()
     x, y = np.arange(8), np.arange(10)


### PR DESCRIPTION
This PR attempts to resolve issue https://github.com/matplotlib/matplotlib/issues/23129, in which there is an order dependency when using logaritmic scales and a `Collection` as data.

## PR summary
### Error Description
The error in axis computation originates from the `add_collection()` method within the `_AxesBase` class (found in lib/matplotlib/axes/_base.py). Specifically, the issue lies in how the axis limits are computed.

```python
datalim = collection.get_datalim(self.transData)
```

### Analysis
Further investigation into the `get_datalim()` method in the `Collection` class (lib/matplotlib/collections.py) reveals that data limits are influenced by a non-affine transformation:
```python
    if not transform.is_affine:
        paths = [transform.transform_path_non_affine(p) for p in paths]
```
In scenarios where the axis scale is set after adding the data collection, and so the log scale is not yet applied, the data limits are computed as if the data were affine, and yet the correct behavior is achieved. In other words, the shape of the data should not impact bounding limit computation. Therefore, the non-affine transformation is not only unnecessary but also detrimental, as it produces inaccurate results, and its removal solves the issue.


### Unit Test
Finnaly, a unit test was added, `test_collection_log_datalim_order_dependency()` (to lib/matplotlib/tests/test_collections.py), which validates the order dependency, ensuring the correctness of the fix.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #23129"
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
