### PR TITLE
Fix #28016: wrong lower ylim when baseline=None on stairs

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7272,14 +7272,14 @@ such objects
                 "very likely that the resulting fill patterns is not the desired "
                 "result."
             )
-        if baseline is None:
-            baseline = 0
-        if orientation == 'vertical':
-            patch.sticky_edges.y.append(np.min(baseline))
-            self.update_datalim([(edges[0], np.min(baseline))])
-        else:
-            patch.sticky_edges.x.append(np.min(baseline))
-            self.update_datalim([(np.min(baseline), edges[0])])
+
+        if baseline is not None:
+            if orientation == 'vertical':
+                patch.sticky_edges.y.append(np.min(baseline))
+                self.update_datalim([(edges[0], np.min(baseline))])
+            else:
+                patch.sticky_edges.x.append(np.min(baseline))
+                self.update_datalim([(np.min(baseline), edges[0])])
         self._request_autoscale_view()
         return patch
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2449,16 +2449,17 @@ def test_stairs_update(fig_test, fig_ref):
 
 
 @check_figures_equal(extensions=['png'])
-def test_stairs_baseline_0(fig_test, fig_ref):
-    # Test
-    test_ax = fig_test.add_subplot()
-    test_ax.stairs([5, 6, 7], baseline=None)
+def test_stairs_baseline_None(fig_test, fig_ref):
+    x = np.array([0, 2, 3, 5, 10])
+    y = np.array([1.148, 1.231, 1.248, 1.25])
 
-    # Ref
-    ref_ax = fig_ref.add_subplot()
+    test_axes = fig_test.add_subplot()
+    test_axes.stairs(y, x, baseline=None)
+
     style = {'solid_joinstyle': 'miter', 'solid_capstyle': 'butt'}
-    ref_ax.plot(range(4), [5, 6, 7, 7], drawstyle='steps-post', **style)
-    ref_ax.set_ylim(0, None)
+
+    ref_axes = fig_ref.add_subplot()
+    ref_axes.plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
 
 
 def test_stairs_empty():


### PR DESCRIPTION
Instead of assuming that lower ylim=0 when baseline=None, it now takes into account the imputed values. Also, it no longer uses sticky_edges in these cases. Changed the unit test that tested baseline=None.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
### Error Description

The error occured when calling the function stairs() with baseline=None. In these cases, the function would assume a value of 0 for the baseline.
```python
plt.stairs(x, edges=bins, baseline=None
```

### Changes to the code

The issue lies in the following lines of code:
```python
if baseline is None:
    baseline = 0
```
I changed it so the baseline now takes into account the values imputed and does not utilize sticky_edges:
```python
if baseline is None:
            baseline = values
            if orientation == 'vertical':
                self.update_datalim([(edges[0], np.min(baseline))])
            else:
                self.update_datalim([(np.min(baseline), edges[0])])
```

### Unit test

Finnaly, I changed the unit test that tested the use of baseline=None, test_stairs_baseline_None() (in lib\matplotlib\tests\test_axes.py) so it tests correctly according to the changes made.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes [Bug]: Unexpected ylim of stairs with baseline=None #28016" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
