### PR TITLE
API: warn if stairs used in way that is likely not desired

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7200,8 +7200,8 @@ such objects
             Whether the area under the step curve should be filled.
 
             Passing both ``fill=True` and ``baseline=None`` will likely result in
-            undesired filling as the first and last points will be connected
-            with a straight line with the fill between the line and the stairs.
+            undesired filling: the first and last points will be connected
+            with a straight line and the fill will be between this line and the stairs.
 
 
         Returns

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7245,7 +7245,7 @@ such objects
             _api.warn_external(
                 f"Both {baseline=} and {fill=} have been passed. "
                 "baseline=None is only intended for unfilled stair plots. "
-                "Because baseline in None, the Path used to draw the stairs will "
+                "Because baseline is None, the Path used to draw the stairs will "
                 "not be closed, thus because fill is True the polygon will be closed "
                 "by drawing an (unstroked) edge from the first to last point.  It is "
                 "very likely that the resulting fill patterns is not the desired "

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7201,7 +7201,7 @@ such objects
 
             Passing both ``fill=True` and ``baseline=None`` will likely result in
             undesired filling as the first and last points will be connected
-            with a straight line with the fill between and the stairs.
+            with a straight line with the fill between the line and the stairs.
 
 
         Returns
@@ -7244,6 +7244,7 @@ such objects
         if baseline is None and fill:
             _api.warn_external(
                 f"Both {baseline=} and {fill=} have been passed. "
+                "baseline=None is only intended for unfilled stair plots. "
                 "Because baseline in None, the Path used to draw the stairs will "
                 "not be closed, thus because fill is True the polygon will be closed "
                 "by drawing an (unstroked) edge from the first to last point.  It is "

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7194,8 +7194,15 @@ such objects
             True or an array is passed to *baseline*, a closed
             path is drawn.
 
+            If None, then drawn as an unclosed Path.
+
         fill : bool, default: False
             Whether the area under the step curve should be filled.
+
+            Passing both ``fill=True` and ``baseline=None`` will likely result in
+            undesired filling as the first and last points will be connected
+            with a straight line with the fill between and the stairs.
+
 
         Returns
         -------
@@ -7234,6 +7241,15 @@ such objects
                                    fill=fill,
                                    **kwargs)
         self.add_patch(patch)
+        if baseline is None and fill:
+            _api.warn_external(
+                f"Both {baseline=} and {fill=} have been passed. "
+                "Because baseline in None, the Path used to draw the stairs will "
+                "not be closed, thus because fill is True the polygon will be closed "
+                "by drawing an (unstroked) edge from the first to last point.  It is "
+                "very likely that the resulting fill patterns is not the desired "
+                "result."
+            )
         if baseline is None:
             baseline = 0
         if orientation == 'vertical':

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2342,6 +2342,23 @@ def test_hist_zorder(histtype, zorder):
         assert patch.get_zorder() == zorder
 
 
+def test_stairs_no_baseline_fill_warns():
+    fig, ax = plt.subplots()
+    baseline = None
+    fill = True
+    warn_match = (
+        "Because baseline in None, the Path used to draw the stairs will "
+    )
+    with pytest.warns(UserWarning, match=warn_match):
+        ax.stairs(
+            [4, 5, 1, 0, 2],
+            [1, 2, 3, 4, 5, 6],
+            facecolor="blue",
+            baseline=baseline,
+            fill=fill
+        )
+
+
 @check_figures_equal(extensions=['png'])
 def test_stairs(fig_test, fig_ref):
     import matplotlib.lines as mlines

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2344,18 +2344,13 @@ def test_hist_zorder(histtype, zorder):
 
 def test_stairs_no_baseline_fill_warns():
     fig, ax = plt.subplots()
-    baseline = None
-    fill = True
-    warn_match = (
-        "Because baseline in None, the Path used to draw the stairs will "
-    )
-    with pytest.warns(UserWarning, match=warn_match):
+    with pytest.warns(UserWarning, match="baseline=None and fill=True"):
         ax.stairs(
             [4, 5, 1, 0, 2],
             [1, 2, 3, 4, 5, 6],
             facecolor="blue",
-            baseline=baseline,
-            fill=fill
+            baseline=None,
+            fill=True
         )
 
 


### PR DESCRIPTION
Closes #26752

I think the best we can do here is warn the user they are about to do something silly.  Raising on this combination seems too harsh.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

