### PR TITLE
BLD: Fetch version from setuptools_scm at build time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
       - run:
           name: Install Python dependencies
           command: |
-            python -m pip install --user meson-python pybind11
+            python -m pip install --user meson-python numpy pybind11 setuptools-scm
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> \
                 -r requirements/doc/doc-requirements.txt

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -135,7 +135,7 @@ stages:
 
           - bash: |
               python -m pip install --upgrade pip
-              python -m pip install --upgrade meson-python pybind11
+              python -m pip install --upgrade meson-python numpy pybind11 setuptools-scm
               python -m pip install -r requirements/testing/all.txt -r requirements/testing/extra.txt
             displayName: 'Install dependencies with pip'
 

--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'matplotlib',
   'c', 'cpp',
-  version: '3.9.0.dev0',
+  version: run_command(find_program('python3'), '-m', 'setuptools_scm', check: true).stdout().strip(),
   # qt_editor backend is MIT
   # ResizeObserver at end of lib/matplotlib/backends/web_backend/js/mpl.js is CC0
   # Carlogo, STIX and Computer Modern is OFL


### PR DESCRIPTION
## PR summary

This should ensure we get the right version when tagging, etc., without having to do manual changes.

We had incorrect sdist/wheel names when building rc1 due to this: https://github.com/matplotlib/matplotlib/actions/runs/8566515999/job/23476414949#step:6:89

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines