### PR TITLE
MNT: Add git blame ignore for docstring parameter indentation fix

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -12,3 +12,6 @@ c1a33a481b9c2df605bcb9bef9c19fe65c3dac21
 
 # chore: pyupgrade --py39-plus
 4d306402bb66d6d4c694d8e3e14b91054417070e
+
+# style: docstring parameter indentation
+68daa962de5634753205cba27f21d6edff7be7a2


### PR DESCRIPTION
from # 28037

