### PR TITLE
Strip trailing spaces from log-formatter cursor output.

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1177,11 +1177,11 @@ class TestLogFormatter:
         assert label == expected
 
     @pytest.mark.parametrize('value, long, short', [
-        (0.0, "0", "0           "),
-        (0, "0", "0           "),
-        (-1.0, "-10^0", "-1          "),
-        (2e-10, "2x10^-10", "2e-10       "),
-        (1e10, "10^10", "1e+10       "),
+        (0.0, "0", "0"),
+        (0, "0", "0"),
+        (-1.0, "-10^0", "-1"),
+        (2e-10, "2x10^-10", "2e-10"),
+        (1e10, "10^10", "1e+10"),
     ])
     def test_format_data(self, value, long, short):
         fig, ax = plt.subplots()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1024,7 +1024,7 @@ class LogFormatter(Formatter):
 
     def format_data_short(self, value):
         # docstring inherited
-        return '%-12g' % value
+        return ('%-12g' % value).rstrip()
 
     def _pprint_val(self, x, d):
         # If the number is not too big and it's an int, format it as an int.


### PR DESCRIPTION
The trailing spaces were fine when the cursor position was shown as
`x=...    y=...`, but become very ugly now that it's
`(x, y) = (...,    ...)`.  (#25556)

(test e.g. with moving the cursor on a loglog() axes and looking at the coordinates display)

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
