### PR TITLE
Parent tk StringVar to the canvas widget, not to the toolbar.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -843,7 +843,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
 
         default_extension = self.canvas.get_default_filetype()
         default_filetype = self.canvas.get_supported_filetypes()[default_extension]
-        filetype_variable = tk.StringVar(self, default_filetype)
+        filetype_variable = tk.StringVar(self.canvas.get_tk_widget(), default_filetype)
 
         # adding a default extension seems to break the
         # asksaveasfilename dialog when you choose various save types


### PR DESCRIPTION
... because the toolbar may be a fake object (when using rcParams["toolbar"] = "toolmanager").

Try with `rcParams["toolbar"] = "toolmanager; use("tkagg")` and interactively saving the picture.  No automated tests, sorry.

Closes #28069 (I chose not to parent to None as suggested in the original issue because I'm not 100% sure this won't lead to variables being progressively leaked into tk's global namespace.)

Looks like a regression in 3.8 (#24531), so let's try to get this in 3.9.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
