### PR TITLE
Convert TensorFlow to numpy for plots

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2388,7 +2388,7 @@ def _is_tensorflow_array(x):
         # has created a TensorFlow array, TensorFlow should already be in sys.modules
         # we use `is_tensor` to not depend on the class structure of TensorFlow
         # arrays, as `tf.Variables` are not instances of `tf.Tensor`
-        # (but convert the same way)
+        # (they both convert the same way)
         return isinstance(x, sys.modules['tensorflow'].is_tensor(x))
     except Exception:  # TypeError, KeyError, AttributeError, maybe others?
         # we're attempting to access attributes on imported modules which

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2381,6 +2381,7 @@ def _is_jax_array(x):
         # may have arbitrary user code, so we deliberately catch all exceptions
         return False
 
+
 def _is_tensorflow_array(x):
     """Check if 'x' is a TensorFlow Tensor or Variable."""
     try:

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -996,6 +996,7 @@ def test_unpack_to_numpy_from_jax():
     # is the same Python object, just the same values.
     assert_array_equal(result, data)
 
+
 def test_unpack_to_numpy_from_tensorflow():
     """
     Test that tensorflow arrays are converted to NumPy arrays.

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -963,7 +963,10 @@ def test_unpack_to_numpy_from_torch():
     torch_tensor = torch.Tensor(data)
 
     result = cbook._unpack_to_numpy(torch_tensor)
-    assert result is torch_tensor.__array__()
+    # compare results, do not check for identity: the latter would fail
+    # if not mocked, and the implementation does not guarantee it
+    # is the same Python object, just the same values.
+    assert_array_equal(result, data)
 
 
 def test_unpack_to_numpy_from_jax():
@@ -988,4 +991,35 @@ def test_unpack_to_numpy_from_jax():
     jax_array = jax.Array(data)
 
     result = cbook._unpack_to_numpy(jax_array)
-    assert result is jax_array.__array__()
+    # compare results, do not check for identity: the latter would fail
+    # if not mocked, and the implementation does not guarantee it
+    # is the same Python object, just the same values.
+    assert_array_equal(result, data)
+
+def test_unpack_to_numpy_from_tensorflow():
+    """
+    Test that tensorflow arrays are converted to NumPy arrays.
+
+    We don't want to create a dependency on tensorflow in the test suite, so we mock it.
+    """
+    class Tensor:
+        def __init__(self, data):
+            self.data = data
+
+        def __array__(self):
+            return self.data
+
+    tensorflow = ModuleType('tensorflow')
+    tensorflow.is_tensor = lambda x: isinstance(x, Tensor)
+    tensorflow.Tensor = Tensor
+
+    sys.modules['tensorflow'] = tensorflow
+
+    data = np.arange(10)
+    tf_tensor = tensorflow.Tensor(data)
+
+    result = cbook._unpack_to_numpy(tf_tensor)
+    # compare results, do not check for identity: the latter would fail
+    # if not mocked, and the implementation does not guarantee it
+    # is the same Python object, just the same values.
+    assert_array_equal(result, data)


### PR DESCRIPTION
## PR summary
as mentioned in https://github.com/matplotlib/matplotlib/issues/22879#issuecomment-2056729839, adding support for TensorFlow tensors to be converted to numpy (equivalent to what was done for JAX and torch in https://github.com/matplotlib/matplotlib/pull/25887)

Also improved previous handling by using `np.asarray` and allow _the specific subset of arrays (JAX, torch, TF)_ to also use more efficient methods if desired (see also https://numpy.org/devdocs/user/basics.interoperability.html#using-arbitrary-objects-in-numpy).


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] no explicit issue, but discussed
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

