### PR TITLE
Fixed xlim issue when clearing shared axes

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1233,6 +1233,8 @@ class _AxesBase(martist.Artist):
         x0, x1 = other.get_xlim()
         self.set_xlim(x0, x1, emit=False, auto=other.get_autoscalex_on())
         self.xaxis._scale = other.xaxis._scale
+        other._shared_axes["x"].join(other, self)
+        other._sharex = self
 
     def sharey(self, other):
         """
@@ -1252,6 +1254,8 @@ class _AxesBase(martist.Artist):
         y0, y1 = other.get_ylim()
         self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
         self.yaxis._scale = other.yaxis._scale
+        other._shared_axes["y"].join(other, self)
+        other._sharey = self
 
     def __clear(self):
         """Clear the Axes."""
@@ -1370,6 +1374,7 @@ class _AxesBase(martist.Artist):
             share = getattr(self, f"_share{name}")
             if share is not None:
                 getattr(self, f"share{name}")(share)
+                axis.set_inverted(False)
             else:
                 # Although the scale was set to linear as part of clear,
                 # polar requires that _set_scale is called again


### PR DESCRIPTION
## PR summary

Making sure that when two subplots are sharing an axes, clearing the leader one doesn't also reset the xlim and ylim to [0,1]

```py
import matplotlib.pyplot as plt
import numpy as np

ax0 = plt.subplot(211)
ax1 = plt.subplot(212, sharex=ax0)
ax0.plot(range(100))
ax1.plot(range(100))
ax0.cla()
plt.show()
```
Befor PR:

![Example](https://github.com/matplotlib/matplotlib/assets/118368455/df2513c0-6d10-4aba-8d48-30b85cf8d231)

After PR:
![Example2](https://github.com/matplotlib/matplotlib/assets/118368455/65cd0a21-1ab2-41f4-b1b7-769be9310b2a)



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- Closes https://github.com/matplotlib/matplotlib/issues/27825


<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
