### PR TITLE
[DOC]: Fix compatibility with sphinx-gallery 0.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,6 @@ commands:
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> \
                 -r requirements/doc/doc-requirements.txt
-            pip install git+https://github.com/larsoner/sphinx-gallery.git@serial
             python -m pip install --no-deps --user \
                 git+https://github.com/matplotlib/mpl-sphinx-theme.git
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,6 +107,7 @@ commands:
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> \
                 -r requirements/doc/doc-requirements.txt
+            pip install git+https://github.com/larsoner/sphinx-gallery.git@serial
             python -m pip install --no-deps --user \
                 git+https://github.com/matplotlib/mpl-sphinx-theme.git
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -325,7 +325,7 @@ gen_rst.EXAMPLE_HEADER = """
         :class: sphx-glr-download-link-note
 
         :ref:`Go to the end <sphx_glr_download_{1}>`
-        to download the full example code{2}
+        to download the full example code.{2}
 
 .. rst-class:: sphx-glr-example-title
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -180,7 +180,6 @@ _check_dependencies()
 # Import only after checking for dependencies.
 # gallery_order.py from the sphinxext folder provides the classes that
 # allow custom ordering of sections and subsections of the gallery
-import sphinxext.gallery_order as gallery_order
 
 # The following import is only necessary to monkey patch the signature later on
 from sphinx_gallery import gen_rst

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -228,22 +228,6 @@ intersphinx_mapping = {
 }
 
 
-# Sphinx gallery configuration
-
-def matplotlib_reduced_latex_scraper(block, block_vars, gallery_conf,
-                                     **kwargs):
-    """
-    Reduce srcset when creating a PDF.
-
-    Because sphinx-gallery runs *very* early, we cannot modify this even in the
-    earliest builder-inited signal. Thus we do it at scraping time.
-    """
-    from sphinx_gallery.scrapers import matplotlib_scraper
-
-    if gallery_conf['builder_name'] == 'latex':
-        gallery_conf['image_srcset'] = []
-    return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
-
 gallery_dirs = [f'{ed}' for ed in
                 ['gallery', 'tutorials', 'plot_types', 'users/explain']
                 if f'{ed}/*' not in skip_subdirs]
@@ -261,7 +245,7 @@ sphinx_gallery_conf = {
     'examples_dirs': example_dirs,
     'filename_pattern': '^((?!sgskip).)*$',
     'gallery_dirs': gallery_dirs,
-    'image_scrapers': (matplotlib_reduced_latex_scraper, ),
+    'image_scrapers': ("sphinxext.util.matplotlib_reduced_latex_scraper", ),
     'image_srcset': ["2x"],
     'junit': '../test-results/sphinx-gallery/junit.xml' if CIRCLECI else '',
     'matplotlib_animations': True,
@@ -272,11 +256,11 @@ sphinx_gallery_conf = {
     'reset_modules': (
         'matplotlib',
         # clear basic_units module to re-register with unit registry on import
-        lambda gallery_conf, fname: sys.modules.pop('basic_units', None)
+        "sphinxext.util.clear_basic_unit"
     ),
-    'subsection_order': gallery_order.sectionorder,
+    'subsection_order': "sphinxext.gallery_order.sectionorder",
     'thumbnail_size': (320, 224),
-    'within_subsection_order': gallery_order.subsectionorder,
+    'within_subsection_order': "sphinxext.gallery_order.subsectionorder",
     'capture_repr': (),
     'copyfile_regex': r'.*\.rst',
 }

--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -105,7 +105,7 @@ list_all = [
 explicit_subsection_order = [item + ".py" for item in list_all]
 
 
-class MplExplicitSubOrder:
+class MplExplicitSubOrder(ExplicitOrder):
     """For use within the 'within_subsection_order' key."""
     def __init__(self, src_dir):
         self.src_dir = src_dir  # src_dir is unused here
@@ -118,6 +118,9 @@ class MplExplicitSubOrder:
         else:
             # ensure not explicitly listed items come last.
             return "zzz" + item
+
+# from sphinx.confing import is_serializable
+# assert is_serializable(MplExplicitSubOrder)
 
 
 # Provide the above classes for use in conf.py

--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -119,9 +119,6 @@ class MplExplicitSubOrder(ExplicitOrder):
             # ensure not explicitly listed items come last.
             return "zzz" + item
 
-# from sphinx.confing import is_serializable
-# assert is_serializable(MplExplicitSubOrder)
-
 
 # Provide the above classes for use in conf.py
 sectionorder = MplExplicitOrder(explicit_order_folders)

--- a/doc/sphinxext/util.py
+++ b/doc/sphinxext/util.py
@@ -1,0 +1,20 @@
+import sys
+
+# Sphinx gallery configuration
+def matplotlib_reduced_latex_scraper(block, block_vars, gallery_conf,
+                                     **kwargs):
+    """
+    Reduce srcset when creating a PDF.
+
+    Because sphinx-gallery runs *very* early, we cannot modify this even in the
+    earliest builder-inited signal. Thus we do it at scraping time.
+    """
+    from sphinx_gallery.scrapers import matplotlib_scraper
+
+    if gallery_conf['builder_name'] == 'latex':
+        gallery_conf['image_srcset'] = []
+    return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
+
+
+def clear_basic_unit(gallery_conf, fname):
+    return sys.modules.pop('basic_units', None)

--- a/doc/sphinxext/util.py
+++ b/doc/sphinxext/util.py
@@ -1,6 +1,6 @@
 import sys
 
-# Sphinx gallery configuration
+
 def matplotlib_reduced_latex_scraper(block, block_vars, gallery_conf,
                                      **kwargs):
     """

--- a/doc/sphinxext/util.py
+++ b/doc/sphinxext/util.py
@@ -16,5 +16,6 @@ def matplotlib_reduced_latex_scraper(block, block_vars, gallery_conf,
     return matplotlib_scraper(block, block_vars, gallery_conf, **kwargs)
 
 
-def clear_basic_unit(gallery_conf, fname):
+# Clear basic_units module to re-register with unit registry on import.
+def clear_basic_units(gallery_conf, fname):
     return sys.modules.pop('basic_units', None)

--- a/lib/matplotlib/tests/test_doc.py
+++ b/lib/matplotlib/tests/test_doc.py
@@ -9,7 +9,8 @@ def test_sphinx_gallery_example_header():
     EXAMPLE_HEADER, this test will start to fail. In that case, please update
     the monkey-patching of EXAMPLE_HEADER in conf.py.
     """
-    gen_rst = pytest.importorskip('sphinx_gallery.gen_rst')
+    pytest.importorskip('sphinx_gallery', minversion='0.16.0')
+    from sphinx_gallery import gen_rst
 
     EXAMPLE_HEADER = """
 .. DO NOT EDIT.
@@ -24,7 +25,7 @@ def test_sphinx_gallery_example_header():
         :class: sphx-glr-download-link-note
 
         :ref:`Go to the end <sphx_glr_download_{1}>`
-        to download the full example code{2}
+        to download the full example code.{2}
 
 .. rst-class:: sphx-glr-example-title
 

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=3.0.0
+sphinx>=3.0.0,!=6.1.2
 colorspacious
 ipython
 ipywidgets

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -7,7 +7,7 @@
 # Install the documentation requirements with:
 #     pip install -r requirements/doc/doc-requirements.txt
 #
-sphinx>=3.0.0,!=6.1.2,!=7.3.*
+sphinx>=3.0.0
 colorspacious
 ipython
 ipywidgets

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -21,3 +21,4 @@ sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-copybutton
 sphinx-design
 sphinx-tags>=0.3.0
+sphinx-gallery @ git+https://github.com/larsoner/sphinx-gallery.git@serial

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -20,5 +20,5 @@ pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-copybutton
 sphinx-design
+sphinx-gallery>=0.12.0
 sphinx-tags>=0.3.0
-sphinx-gallery @ git+https://github.com/larsoner/sphinx-gallery.git@serial

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -18,7 +18,6 @@ pydata-sphinx-theme~=0.15.0
 mpl-sphinx-theme~=3.8.0
 pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0
-sphinx-gallery>=0.12.0
 sphinx-copybutton
 sphinx-design
 sphinx-tags>=0.3.0


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs. -->

I was following a thread on the same issue in sphinx-gallery [](https://github.com/sphinx-gallery/sphinx-gallery/issues/1286). It seems every callables and classes need to be stringified. There is some work being done on sphinx-gallery side at [1289](https://github.com/sphinx-gallery/sphinx-gallery/pull/1289). But even with this PR the build fails, My assumption is that its because of the callable in  `subsection_order` key which is not being handled on sphinx_gallery side. I was able to get the error for `subsection_order` fixed but had to modify some code within sphinx_gallery. I will ask for the `subsection_order` fix in that [sphinx_gallery PR](https://github.com/sphinx-gallery/sphinx-gallery/pull/1289). but other than that i was able to build the doc without the *not pickleable* warning (using the small change i made in sphinx_gallery code for subsection_order) following the conf.py changes introduced at [that PR](https://github.com/sphinx-gallery/sphinx-gallery/pull/1289).



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
