### PR TITLE
Fix: [Bug]: Setting norm by string doesn't work for hexbin #28105

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5228,11 +5228,6 @@ class Axes(_AxesBase):
                 vmin = vmax = None
             bins = None
 
-        # autoscale the norm with current accum values if it hasn't been set
-        if norm is not None:
-            if norm.vmin is None and norm.vmax is None:
-                norm.autoscale(accum)
-
         if bins is not None:
             if not np.iterable(bins):
                 minimum, maximum = min(accum), max(accum)
@@ -5247,6 +5242,11 @@ class Axes(_AxesBase):
         collection.set_alpha(alpha)
         collection._internal_update(kwargs)
         collection._scale_norm(norm, vmin, vmax)
+
+        # autoscale the norm with current accum values if it hasn't been set
+        if norm is not None:
+            if collection.norm.vmin is None and collection.norm.vmax is None:
+                collection.norm.autoscale()
 
         corners = ((xmin, ymin), (xmax, ymax))
         self.update_datalim(corners)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -976,13 +976,15 @@ def test_hexbin_bad_extents():
     with pytest.raises(ValueError, match="In extent, ymax must be greater than ymin"):
         ax.hexbin(x, y, extent=(0, 1, 1, 0))
 
+
 def test_hexbin_string_norm():
     fig, ax = plt.subplots()
-    hex = ax.hexbin(np.random.rand(10), np.random.rand(10), norm="log",vmin=2,vmax=5)
-    assert isinstance(hex,matplotlib.collections.PolyCollection)
-    assert isinstance(hex.norm,matplotlib.colors.LogNorm)
+    hex = ax.hexbin(np.random.rand(10), np.random.rand(10), norm="log", vmin=2, vmax=5)
+    assert isinstance(hex, matplotlib.collections.PolyCollection)
+    assert isinstance(hex.norm, matplotlib.colors.LogNorm)
     assert hex.norm.vmin == 2
     assert hex.norm.vmax == 5
+
 
 @image_comparison(['hexbin_empty.png'], remove_text=True)
 def test_hexbin_empty():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -976,6 +976,13 @@ def test_hexbin_bad_extents():
     with pytest.raises(ValueError, match="In extent, ymax must be greater than ymin"):
         ax.hexbin(x, y, extent=(0, 1, 1, 0))
 
+def test_hexbin_string_norm():
+    fig, ax = plt.subplots()
+    hex = ax.hexbin(np.random.rand(10), np.random.rand(10), norm="log",vmin=2,vmax=5)
+    assert isinstance(hex,matplotlib.collections.PolyCollection)
+    assert isinstance(hex.norm,matplotlib.colors.LogNorm)
+    assert hex.norm.vmin == 2
+    assert hex.norm.vmax == 5
 
 @image_comparison(['hexbin_empty.png'], remove_text=True)
 def test_hexbin_empty():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
The problem was that the methods on the norm were called directly on a string instead of the object itself.
So I put this block after `collection.set_norm(norm) in order to call the norm's getter.

```
# autoscale the norm with current accum values if it hasn't been set
        if norm is not None:
            if collection.norm.vmin is None and collection.norm.vmax is None:
                collection.norm.autoscale()
```

Seems to solve the issue.



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
