### PR TITLE
[DOC] Fix description in CapStyle example

### DIFF
--- a/galleries/examples/lines_bars_and_markers/capstyle.py
+++ b/galleries/examples/lines_bars_and_markers/capstyle.py
@@ -3,8 +3,8 @@
 CapStyle
 =========
 
-The `matplotlib._enums.CapStyle` controls how Matplotlib draws the corners
-where two different line segments meet. For more details, see the
+The `matplotlib._enums.CapStyle` controls how Matplotlib draws the two
+endpoints (caps) of an unclosed line. For more details, see the
 `~matplotlib._enums.CapStyle` docs.
 """
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

The current [CapStyle example](https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/capstyle.html) partially uses text from the [JoinStyle example](https://matplotlib.org/devdocs/gallery/lines_bars_and_markers/joinstyle.html). I've updated the text with the appropriate description.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
