### PR TITLE
ENH: adding suggested names to ColormapRegistry missing key error

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -93,7 +93,7 @@ class ColormapRegistry(Mapping):
             if len(best := difflib.get_close_matches(item, known, cutoff=.1)):
                 msg = f"Did you mean one of {best}?"
             else:
-                msg = "No known keys are close"
+                msg = ""
             raise KeyError(f"{item!r} is not a known colormap name. {msg}") from None
 
     def __iter__(self):

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -15,6 +15,7 @@ Builtin colormaps, colormap handling utilities, and the `ScalarMappable` mixin.
 """
 
 from collections.abc import Mapping
+import difflib
 import functools
 
 import numpy as np
@@ -88,7 +89,12 @@ class ColormapRegistry(Mapping):
         try:
             return self._cmaps[item].copy()
         except KeyError:
-            raise KeyError(f"{item!r} is not a known colormap name") from None
+            known = list(self._cmaps)
+            if len(best := difflib.get_close_matches(item, known, cutoff=.1)):
+                msg = f"Did you mean one of {best}?"
+            else:
+                msg = "No known keys are close"
+            raise KeyError(f"{item!r} is not a known colormap name. {msg}") from None
 
     def __iter__(self):
         return iter(self._cmaps)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1697,3 +1697,14 @@ def test_to_rgba_array_none_color_with_alpha_param():
     assert_array_equal(
         to_rgba_array(c, alpha), [[0., 0., 1., 1.], [0., 0., 0., 0.]]
     )
+
+
+def test_close_error_name():
+    with pytest.raises(KeyError) as exinfo:
+        matplotlib.colormaps["grays"]
+
+    msg = exinfo.value.args[0]
+
+    assert "Grays" in msg
+    assert "gray" in msg
+    assert "gray_r" in msg


### PR DESCRIPTION
difflib.get_close_match has been in the standard library from Python 2.1

## PR summary

Make use of a function in the standard library to give suggestions for missed 


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

I don't think this needs to be called out in the release notes.
