### PR TITLE
BLD: Update Qhull location in branch 3.8.x

### DIFF
--- a/setupext.py
+++ b/setupext.py
@@ -195,9 +195,9 @@ LOCAL_FREETYPE_HASH = _freetype_hashes.get(LOCAL_FREETYPE_VERSION, 'unknown')
 
 # Also update the cache path in `.circleci/config.yml`.
 # Also update the docs in `docs/devel/dependencies.rst`.
-LOCAL_QHULL_VERSION = '2020.2'
+LOCAL_QHULL_VERSION = '8.0.2'
 LOCAL_QHULL_HASH = (
-    'b5c2d7eb833278881b952c8a52d20179eab87766b00b865000469a45c1838b7e')
+    '8774e9a12c70b0180b95d6b0b563c5aa4bea8d5960c15e18ae3b6d2521d64f8b')
 
 
 # Matplotlib build options, which can be altered using mplsetup.cfg
@@ -763,7 +763,7 @@ class Qhull(SetupPackage):
             return
 
         toplevel = get_and_extract_tarball(
-            urls=["http://www.qhull.org/download/qhull-2020-src-8.0.2.tgz"],
+            urls=["https://github.com/qhull/qhull/archive/v8.0.2/qhull-8.0.2.tar.gz"],
             sha=LOCAL_QHULL_HASH,
             dirname=f"qhull-{LOCAL_QHULL_VERSION}",
         )


### PR DESCRIPTION
## PR summary

Change similar to #27505 but on the branch 3.8.x as right now the qhull website seems unable to properly deliver the tarball without disconnecting in the middle. Right now I am unable to build matplotlib from `pip install`.

I have no actual ticket for this on branch 3.8, but this is exactly the same issue as in #27159 however with the previous (ie non-meson) build system.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines