### PR TITLE
GOV: write up policy on not updating req for CVEs in dependencies

### DIFF
--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -49,6 +49,9 @@ without compiled extensions
 We will only bump these dependencies as we need new features or the old
 versions no longer support our minimum NumPy or Python.
 
+We should work around bugs in our dependencies when practical.
+
+
 Test and documentation dependencies
 ===================================
 
@@ -58,8 +61,10 @@ support for old versions.  However, we need to be careful to not
 over-run what down-stream packagers support (as most of the run the
 tests and build the documentation as part of the packaging process).
 
-We will support at least minor versions of the development
-dependencies released in the 12 months prior to our planned release.
+We will support at least minor versions of the development dependencies
+released in the 12 months prior to our planned release.  Specific versions that
+are known to be buggy may be excluded from support using the finest-grained
+filtering that is practical.
 
 We will only bump these as needed or versions no longer support our
 minimum Python and NumPy.
@@ -75,6 +80,19 @@ possible.  We will bump these on a case-by-case basis.
 In the case of GUI frameworks for which we rely on Python bindings being
 available, we will also drop support for bindings so old that they don't
 support any Python version that we support.
+
+Security Issues in Dependencies
+===============================
+
+In most cases we should not adjust the versions supported based on CVEs to our
+dependencies.  We are a library not an application and the version constraints
+on our dependencies indicate what will work (not what is wise to use).  Users
+and packagers can install newer versions of the dependencies their discretion
+and evaluation of risk and impact.  In contrast, if we were to adjust our
+minimum supported version it is very hard for a user to override our judgment.
+
+If Matplotlib aids in exploiting the underlying vulnerability we should treat
+that as a critical bug in Matplotlib.
 
 .. _list-of-dependency-min-versions:
 

--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -49,7 +49,7 @@ without compiled extensions
 We will only bump these dependencies as we need new features or the old
 versions no longer support our minimum NumPy or Python.
 
-We should work around bugs in our dependencies when practical.
+We will work around bugs in our dependencies when practical.
 
 
 Test and documentation dependencies
@@ -81,15 +81,16 @@ In the case of GUI frameworks for which we rely on Python bindings being
 available, we will also drop support for bindings so old that they don't
 support any Python version that we support.
 
-Security Issues in Dependencies
+Security issues in dependencies
 ===============================
 
-In most cases we should not adjust the versions supported based on CVEs to our
-dependencies.  We are a library not an application and the version constraints
-on our dependencies indicate what will work (not what is wise to use).  Users
-and packagers can install newer versions of the dependencies their discretion
-and evaluation of risk and impact.  In contrast, if we were to adjust our
-minimum supported version it is very hard for a user to override our judgment.
+Generally, we do not adjust the supported versions of dependencies based on
+security vulnerabilities.   We are a library not an application
+and the version constraints on our dependencies indicate what will work (not
+what is wise to use).  Users and packagers can install newer versions of the
+dependencies at their discretion and evaluation of risk and impact.  In
+contrast, if we were to adjust our minimum supported version it is very hard
+for a user to override our judgment.
 
 If Matplotlib aids in exploiting the underlying vulnerability we should treat
 that as a critical bug in Matplotlib.


### PR DESCRIPTION
This comes up about every other month.

inspired by https://github.com/matplotlib/matplotlib/pull/28110

SC should sign off on this @timhoffm @dopplershift @efiring 