### PR TITLE
Make `functions` param to secondary_x/yaxis not keyword-only.

### DIFF
--- a/galleries/users_explain/quick_start.py
+++ b/galleries/users_explain/quick_start.py
@@ -496,7 +496,7 @@ ax2.legend([l1, l2], ['Sine (left)', 'Straight (right)'])
 
 ax3.plot(t, s)
 ax3.set_xlabel('Angle [rad]')
-ax4 = ax3.secondary_xaxis('top', functions=(np.rad2deg, np.deg2rad))
+ax4 = ax3.secondary_xaxis('top', (np.rad2deg, np.deg2rad))
 ax4.set_xlabel('Angle [°]')
 
 # %%

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -570,7 +570,7 @@ class Axes(_AxesBase):
         return self.indicate_inset(rect, inset_ax, **kwargs)
 
     @_docstring.dedent_interpd
-    def secondary_xaxis(self, location, *, functions=None, transform=None, **kwargs):
+    def secondary_xaxis(self, location, functions=None, *, transform=None, **kwargs):
         """
         Add a second x-axis to this `~.axes.Axes`.
 
@@ -624,7 +624,7 @@ class Axes(_AxesBase):
         return secondary_ax
 
     @_docstring.dedent_interpd
-    def secondary_yaxis(self, location, *, functions=None, transform=None, **kwargs):
+    def secondary_yaxis(self, location, functions=None, *, transform=None, **kwargs):
         """
         Add a second y-axis to this `~.axes.Axes`.
 

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -88,24 +88,24 @@ class Axes(_AxesBase):
     def secondary_xaxis(
         self,
         location: Literal["top", "bottom"] | float,
-        *,
         functions: tuple[
             Callable[[ArrayLike], ArrayLike], Callable[[ArrayLike], ArrayLike]
         ]
         | Transform
         | None = ...,
+        *,
         transform: Transform | None = ...,
         **kwargs
     ) -> SecondaryAxis: ...
     def secondary_yaxis(
         self,
         location: Literal["left", "right"] | float,
-        *,
         functions: tuple[
             Callable[[ArrayLike], ArrayLike], Callable[[ArrayLike], ArrayLike]
         ]
         | Transform
         | None = ...,
+        *,
         transform: Transform | None = ...,
         **kwargs
     ) -> SecondaryAxis: ...


### PR DESCRIPTION
I suspect the parameter was made keyword-only because the originally planned signature (#11859) was `secondary_xaxis(location, forward=..., inverse=...)` where the keywords actually add some semantics (though that signature overall seems worse); however, for a single `functions` parameter, having to type an extra `functions=` in the call doesn't help the reader much (either they know what secondary_x/yaxis does, in which case the explicit kwarg doesn't matter, or they don't, in which case the kwarg name hardly helps)... and is a bit annoying.  See the modified gallery entry, for example.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
