### PR TITLE
Appease pycodestyle.

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -362,8 +362,7 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
      /PaintProc {{
         pop
         {linewidth:g} setlinewidth
-{self._convert_path(
-    Path.hatch(hatch), Affine2D().scale(sidelen), simplify=False)}
+{self._convert_path(Path.hatch(hatch), Affine2D().scale(sidelen), simplify=False)}
         gsave
         fill
         grestore

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -270,11 +270,7 @@ class ThetaFormatter(mticker.Formatter):
         vmin, vmax = self.axis.get_view_interval()
         d = np.rad2deg(abs(vmax - vmin))
         digits = max(-int(np.log10(d) - 1.5), 0)
-        # Use Unicode rather than mathtext with \circ, so that it will work
-        # correctly with any arbitrary font (assuming it has a degree sign),
-        # whereas $5\circ$ will only work correctly with one of the supported
-        # math fonts (Computer Modern and STIX).
-        return f"{np.rad2deg(x):0.{digits:d}f}\N{DEGREE SIGN}"
+        return f"{np.rad2deg(x):0.{digits}f}\N{DEGREE SIGN}"
 
 
 class _AxisWrapper:


### PR DESCRIPTION
The ":d" conversion in polar.py (which confuses pycodestyle due to the nested f-string) is unnecessary as digits is made an int immediately above.  While at it, also remove the comment above, which is just wrong as all supported mathtext fonts support `\circ` (but unicode still seems to be the better option).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
