### PR TITLE
Don't set savefig.facecolor/edgecolor in dark_background/538 styles.

### DIFF
--- a/doc/api/next_api_changes/behavior/28156-AL.rst
+++ b/doc/api/next_api_changes/behavior/28156-AL.rst
@@ -1,0 +1,12 @@
+dark_background and fivethirtyeight styles no longer set ``savefig.facecolor`` and ``savefig.edgecolor``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+When using these styles, :rc:`savefig.facecolor` and :rc:`savefig.edgecolor`
+now inherit the global default value of "auto", which means that the actual
+figure colors will be used.  Previously, these rcParams were set to the same
+values as :rc:`figure.facecolor` and :rc:`figure.edgecolor`, i.e. a saved
+figure would always use the theme colors even if the user manually overrode
+them; this is no longer the case.
+
+This change should have no impact for users that do not manually set the figure
+face and edge colors.

--- a/lib/matplotlib/mpl-data/stylelib/dark_background.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/dark_background.mplstyle
@@ -18,9 +18,6 @@ grid.color: white
 figure.facecolor: black
 figure.edgecolor: black
 
-savefig.facecolor: black
-savefig.edgecolor: black
-
 ### Boxplots
 boxplot.boxprops.color: white
 boxplot.capprops.color: white

--- a/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/fivethirtyeight.mplstyle
@@ -29,10 +29,7 @@ xtick.minor.size: 0
 ytick.major.size: 0
 ytick.minor.size: 0
 
-font.size:14.0
-
-savefig.edgecolor: f0f0f0
-savefig.facecolor: f0f0f0
+font.size: 14.0
 
 figure.subplot.left: 0.08
 figure.subplot.right: 0.95


### PR DESCRIPTION
Previously, the dark_background and fivethirtyeight styles would set the savefig.facecolor and savefig.edgecolor rcParams to the same values as figure.facecolor and figure.edgecolor; i.e., if a user uses a style but tweaks the figure facecolor, this tweak is lost (overridden) when saving the figure.  A concrete example would be using the dark_background style but wanting a dark gray background instead of a black one, e.g. `mpl.style.use(["dark_background", {"figure.facecolor": ".2"}]); plot(); savefig(...)`.

In all likelihood these values were set because the styles predate the ability to set these savefig rcParams to "auto", which means "don't change the figure facecolor, just use it as is" (a feature introduced in #15111 exactly because this auto-switching of color by savefig was confusing users).  Now we can just remove these rcParams from the two styles (which are the only ones affected by the issue -- the grayscale style also sets savefig.facecolor but to a value different from figure.facecolor) and let them inherit the global default value, "auto".

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
