### PR TITLE
DOC: Use released mpl-sphinx-theme on v3.9.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,6 @@ commands:
             python -m pip install --user \
                 numpy<< parameters.numpy_version >> \
                 -r requirements/doc/doc-requirements.txt
-            python -m pip install --no-deps --user \
-                git+https://github.com/matplotlib/mpl-sphinx-theme.git
 
   mpl-install:
     steps:


### PR DESCRIPTION
## PR summary

We don't need to use in-development versions here, just as in the `v3.8.x` branch.

(Side note, this shouldn't be merged back to `main`, so one should be a bit careful doing that merge back up.)

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines