### PR TITLE
TST: Prepare for pytest 9

### DIFF
--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -1,3 +1,5 @@
+import importlib
+
 from matplotlib import path, transforms
 from matplotlib.backend_bases import (
     FigureCanvasBase, KeyEvent, LocationEvent, MouseButton, MouseEvent,
@@ -325,9 +327,7 @@ def test_toolbar_home_restores_autoscale():
 def test_draw(backend):
     from matplotlib.figure import Figure
     from matplotlib.backends.backend_agg import FigureCanvas
-    test_backend = pytest.importorskip(
-        f'matplotlib.backends.backend_{backend}'
-    )
+    test_backend = importlib.import_module(f'matplotlib.backends.backend_{backend}')
     TestCanvas = test_backend.FigureCanvas
     fig_test = Figure(constrained_layout=True)
     TestCanvas(fig_test)

--- a/lib/matplotlib/tests/test_backend_gtk3.py
+++ b/lib/matplotlib/tests/test_backend_gtk3.py
@@ -3,9 +3,6 @@ from matplotlib import pyplot as plt
 import pytest
 
 
-pytest.importorskip("matplotlib.backends.backend_gtk3agg")
-
-
 @pytest.mark.backend("gtk3agg", skip_on_importerror=True)
 def test_correct_key():
     pytest.xfail("test_widget_send_event is not triggering key_press_event")

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -26,9 +26,7 @@ _test_timeout = 60  # A reasonably safe value for slower architectures.
 
 @pytest.fixture
 def qt_core(request):
-    qt_compat = pytest.importorskip('matplotlib.backends.qt_compat')
-    QtCore = qt_compat.QtCore
-
+    from matplotlib.backends.qt_compat import QtCore
     return QtCore
 
 


### PR DESCRIPTION
## PR summary

The current version of pytest is warning that using `importorskip` to catch `ImportError` will start being ignored (and thus raising) with pytest 9.

Fortunately, in all cases, we don't need these calls, as they are:

- already checked for `ImportError` at the top-level of the file
- already checked by the backend switcher
- not actually possible to fail importing

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines