### PR TITLE
Backport PR #28164 on branch v3.9.x (CI: Ensure code coverage is always uploaded)

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -245,9 +245,4 @@ jobs:
         run: |
           xvfb-run pytest-3.${{ matrix.python-minor-version }} -rfEsXR -n auto \
             --maxfail=50 --timeout=300 --durations=25 \
-            --cov-report=xml --cov=lib --log-level=DEBUG --color=yes
-
-      - name: Upload code coverage
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+            --cov-report=term --cov=lib --log-level=DEBUG --color=yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -316,6 +316,7 @@ jobs:
             --cov-report=xml --cov=lib --log-level=DEBUG --color=yes
 
       - name: Filter C coverage
+        if: ${{ !cancelled() && github.event_name != 'schedule' }}
         run: |
           if [[ "${{ runner.os }}" != 'macOS' ]]; then
             lcov --rc lcov_branch_coverage=1 --capture --directory . \
@@ -331,7 +332,7 @@ jobs:
               -instr-profile default.profdata > info.lcov
           fi
       - name: Upload code coverage
-        if: ${{ github.event_name != 'schedule' }}
+        if: ${{ !cancelled() && github.event_name != 'schedule' }}
         uses: codecov/codecov-action@v4
         with:
           name: "${{ matrix.python-version }} ${{ matrix.os }} ${{ matrix.name-suffix }}"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -268,11 +268,13 @@ stages:
                 ;;
               esac
             displayName: 'Filter C coverage'
+            condition: succeededOrFailed()
           - bash: |
               bash <(curl -s https://codecov.io/bash) \
                 -n "$PYTHON_VERSION $AGENT_OS" \
                 -f 'coverage.xml' -f 'extensions.xml'
             displayName: 'Upload to codecov.io'
+            condition: succeededOrFailed()
 
           - task: PublishTestResults@2
             inputs:


### PR DESCRIPTION
## PR summary

The conflict was just that the remove-not-failed-images was not backported.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines