### PR TITLE
TST: Followup corrections to #28205

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -210,4 +210,4 @@ def ipython_in_subprocess(requested_backend_or_gui_framework, all_expected_backe
         capture_output=True,
     )
 
-    assert proc.stdout.strip() == f"Out[1]: '{expected_backend}'"
+    assert proc.stdout.strip().endswith(f"'{expected_backend}'")

--- a/lib/matplotlib/tests/test_backend_inline.py
+++ b/lib/matplotlib/tests/test_backend_inline.py
@@ -1,6 +1,7 @@
 import os
 from pathlib import Path
 from tempfile import TemporaryDirectory
+import sys
 
 import pytest
 
@@ -12,6 +13,7 @@ pytest.importorskip('ipykernel')
 pytest.importorskip('matplotlib_inline')
 
 
+@pytest.mark.skipif(sys.version_info[:2] <= (3, 9), reason="Requires Python 3.10+")
 def test_ipynb():
     nb_path = Path(__file__).parent / 'test_inline_01.ipynb'
 

--- a/lib/matplotlib/tests/test_backend_macosx.py
+++ b/lib/matplotlib/tests/test_backend_macosx.py
@@ -46,6 +46,7 @@ def test_savefig_rcparam(monkeypatch, tmp_path):
         assert mpl.rcParams["savefig.directory"] == f"{tmp_path}/test"
 
 
+@pytest.mark.backend('macosx')
 def test_ipython():
     from matplotlib.testing import ipython_in_subprocess
     ipython_in_subprocess("osx", {(8, 24): "macosx", (7, 0): "MacOSX"})

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -376,6 +376,7 @@ def test_fig_sigint_override(qt_core):
         signal.signal(signal.SIGINT, original_handler)
 
 
+@pytest.mark.backend('QtAgg', skip_on_importerror=True)
 def test_ipython():
     from matplotlib.testing import ipython_in_subprocess
     ipython_in_subprocess("qt", {(8, 24): "qtagg", (8, 15): "QtAgg", (7, 0): "Qt5Agg"})


### PR DESCRIPTION
## PR summary

Make the changes suggested by @ianthomas23 in #28205, and also mark the ipython tests as using their backend. While the backend is already checked for availability at the top of the respective files, that only checks whether it can be imported, not whether it can be set as the Matplotlib backend. Adding the marker causes our pytest configuration to actually check and skip the test if unavailable (e.g., on Linux without `(WAYLAND_)DISPLAY` set fails to set an interactive backend).

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines