### PR TITLE
Better group logging of font handling by texmanager.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -134,18 +134,16 @@ class TexManager:
                 preambles[font_family] = cls._font_preambles[
                     mpl.rcParams['font.family'][0].lower()]
             else:
-                for font in mpl.rcParams['font.' + font_family]:
-                    if font.lower() in cls._font_preambles:
-                        preambles[font_family] = \
-                            cls._font_preambles[font.lower()]
+                rcfonts = mpl.rcParams[f"font.{font_family}"]
+                for i, font in enumerate(map(str.lower, rcfonts)):
+                    if font in cls._font_preambles:
+                        preambles[font_family] = cls._font_preambles[font]
                         _log.debug(
-                            'family: %s, font: %s, info: %s',
-                            font_family, font,
-                            cls._font_preambles[font.lower()])
+                            'family: %s, package: %s, font: %s, skipped: %s',
+                            font_family, cls._font_preambles[font], rcfonts[i],
+                            ', '.join(rcfonts[:i]),
+                        )
                         break
-                    else:
-                        _log.debug('%s font is not compatible with usetex.',
-                                   font)
                 else:
                     _log.info('No LaTeX-compatible font found for the %s font'
                               'family in rcParams. Using default.',


### PR DESCRIPTION
Print all unusable font names together after a usable font has been found, rather than one at a time.  This makes the log easier to read.  Noticed while preparing the debugging instructions at https://github.com/matplotlib/matplotlib/issues/28212#issuecomment-2107655992.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
