### PR TITLE
DOC: we do not need the blit call in on_draw

### DIFF
--- a/galleries/examples/event_handling/path_editor.py
+++ b/galleries/examples/event_handling/path_editor.py
@@ -94,7 +94,6 @@ class PathInteractor:
         self.background = self.canvas.copy_from_bbox(self.ax.bbox)
         self.ax.draw_artist(self.pathpatch)
         self.ax.draw_artist(self.line)
-        self.canvas.blit(self.ax.bbox)
 
     def on_button_press(self, event):
         """Callback for mouse button presses."""


### PR DESCRIPTION
on_draw is triggered via the draw_event callback which is processed after the rest of the rendering in finished, but before the buffer is painted to the screen so the `blit` call was at best redundent (causing two copies of the buffer from our side to the GUI side) and at worst causes segfaults in some versions of Qt.

Closes #28002
