### PR TITLE
DOC: Add more 3D plot types

### DIFF
--- a/galleries/plot_types/3D/bar3d_simple.py
+++ b/galleries/plot_types/3D/bar3d_simple.py
@@ -1,0 +1,29 @@
+"""
+==========================
+bar3d(x, y, z, dx, dy, dz)
+==========================
+
+See `~mpl_toolkits.mplot3d.axes3d.Axes3D.bar3d`.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# Make data
+x = [1, 1, 2, 2]
+y = [1, 2, 1, 2]
+z = [0, 0, 0, 0]
+dx = np.ones_like(x)*0.5
+dy = np.ones_like(x)*0.5
+dz = [2, 3, 1, 4]
+
+# Plot
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+ax.bar3d(x, y, z, dx, dy, dz)
+
+ax.set(xticklabels=[],
+       yticklabels=[],
+       zticklabels=[])
+
+plt.show()

--- a/galleries/plot_types/3D/plot3d_simple.py
+++ b/galleries/plot_types/3D/plot3d_simple.py
@@ -1,0 +1,27 @@
+"""
+================
+plot(xs, ys, zs)
+================
+
+See `~mpl_toolkits.mplot3d.axes3d.Axes3D.plot`.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# Make data
+n = 100
+xs = np.linspace(0, 1, n)
+ys = np.sin(xs * 6 * np.pi)
+zs = np.cos(xs * 6 * np.pi)
+
+# Plot
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+ax.plot(xs, ys, zs)
+
+ax.set(xticklabels=[],
+       yticklabels=[],
+       zticklabels=[])
+
+plt.show()

--- a/galleries/plot_types/3D/quiver3d_simple.py
+++ b/galleries/plot_types/3D/quiver3d_simple.py
@@ -1,0 +1,32 @@
+"""
+========================
+quiver(X, Y, Z, U, V, W)
+========================
+
+See `~mpl_toolkits.mplot3d.axes3d.Axes3D.quiver`.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# Make data
+n = 4
+x = np.linspace(-1, 1, n)
+y = np.linspace(-1, 1, n)
+z = np.linspace(-1, 1, n)
+X, Y, Z = np.meshgrid(x, y, z)
+U = (X + Y)/5
+V = (Y - X)/5
+W = Z*0
+
+
+# Plot
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+ax.quiver(X, Y, Z, U, V, W)
+
+ax.set(xticklabels=[],
+       yticklabels=[],
+       zticklabels=[])
+
+plt.show()

--- a/galleries/plot_types/3D/stem3d.py
+++ b/galleries/plot_types/3D/stem3d.py
@@ -1,0 +1,27 @@
+"""
+=============
+stem(x, y, z)
+=============
+
+See `~mpl_toolkits.mplot3d.axes3d.Axes3D.stem`.
+"""
+import matplotlib.pyplot as plt
+import numpy as np
+
+plt.style.use('_mpl-gallery')
+
+# Make data
+n = 20
+x = np.sin(np.linspace(0, 2*np.pi, n))
+y = np.cos(np.linspace(0, 2*np.pi, n))
+z = np.linspace(0, 1, n)
+
+# Plot
+fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
+ax.stem(x, y, z)
+
+ax.set(xticklabels=[],
+       yticklabels=[],
+       zticklabels=[])
+
+plt.show()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
We were missing a good number of 3D plot types on this page: https://matplotlib.org/stable/plot_types/
I added examples for `plot`, `quiver`, `bar3d`, and `stem`.

![image](https://github.com/matplotlib/matplotlib/assets/14363975/9e784eb4-ffcd-4ae2-a14d-2da5a4887cbd)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
