### PR TITLE
CI: Test building docs in parallel on Cirrus CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
               export RELEASE_TAG='-t release'
             fi
             mkdir -p logs
-            make html O="-T $RELEASE_TAG -j1 -w /tmp/sphinxerrorswarnings.log"
+            make html O="-T $RELEASE_TAG -j2 -w /tmp/sphinxerrorswarnings.log"
             rm -r build/html/_sources
           working_directory: doc
       - save_cache:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Just experimenting for now, curious if this speeds things up

For comparison, [this docs build](https://app.circleci.com/pipelines/github/matplotlib/matplotlib/31241/workflows/f21e1371-b92f-40fc-94b9-383d388d51d8/jobs/83189) took 20m 11s as a baseline on a single core.
![image](https://github.com/matplotlib/matplotlib/assets/14363975/e320fe43-d3b0-4fd2-ae6c-0ff38de16141)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
