### PR TITLE
DOC: Flip the imshow plot types example to match the other examples

### DIFF
--- a/galleries/plot_types/arrays/imshow.py
+++ b/galleries/plot_types/arrays/imshow.py
@@ -19,6 +19,6 @@ Z = (1 - X/2 + X**5 + Y**3) * np.exp(-X**2 - Y**2)
 # plot
 fig, ax = plt.subplots()
 
-ax.imshow(Z)
+ax.imshow(Z, origin='lower')
 
 plt.show()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Flips the imshow plot types example to put the origin at the lower left instead of the default upper left. This allows for direct comparison with the 6 other examples that use the same data.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
