### PR TITLE
Clean up some Meson-related leftovers

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.5.0/development.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/development.rst
@@ -77,6 +77,6 @@ In order to avoid conflicting with the use of :file:`setup.cfg` by
 ``setup.cfg`` to ``mplsetup.cfg``.  The :file:`setup.cfg.template` has been
 correspondingly been renamed to :file:`mplsetup.cfg.template`.
 
-Note that the path to this configuration file can still be set via the
-:envvar:`MPLSETUPCFG` environment variable, which allows one to keep using the
-same file before and after this change.
+Note that the path to this configuration file can still be set via the ``MPLSETUPCFG``
+environment variable, which allows one to keep using the same file before and after this
+change.

--- a/doc/install/environment_variables_faq.rst
+++ b/doc/install/environment_variables_faq.rst
@@ -29,13 +29,6 @@ Environment variables
   used to find a base directory in which the :file:`matplotlib` subdirectory is
   created.
 
-.. envvar:: MPLSETUPCFG
-
-   This optional variable can be set to the full path of a :file:`mplsetup.cfg`
-   configuration file used to customize the Matplotlib build.  By default, a
-   :file:`mplsetup.cfg` file in the root of the Matplotlib source tree will be
-   read.  Supported build options are listed in :file:`mplsetup.cfg.template`.
-
 .. envvar:: PATH
 
   The list of directories searched to find executable programs.

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -121,22 +121,20 @@ Before trying to install Matplotlib, please install the :ref:`dependencies`.
 To build from a tarball, download the latest *tar.gz* release
 file from `the PyPI files page <https://pypi.org/project/matplotlib/>`_.
 
-We provide a `mplsetup.cfg`_ file which you can use to customize the build
-process. For example, which default backend to use, whether some of the
-optional libraries that Matplotlib ships with are installed, and so on. This
-file will be particularly useful to those packaging Matplotlib.
-
-.. _mplsetup.cfg: https://raw.githubusercontent.com/matplotlib/matplotlib/main/mplsetup.cfg.template
-
 If you are building your own Matplotlib wheels (or sdists) on Windows, note
 that any DLLs that you copy into the source tree will be packaged too.
-
 
 Configure build and behavior defaults
 =====================================
 
-Aspects of the build and install process and some behaviorial defaults of the
-library can be configured via:
+We provide a `meson.options`_ file containing options with which you can use to
+customize the build process. For example, which default backend to use, whether some of
+the optional libraries that Matplotlib ships with are installed, and so on. These
+options will be particularly useful to those packaging Matplotlib.
+
+.. _meson.options: https://github.com/matplotlib/matplotlib/blob/main/meson.options
+
+Aspects of some behaviorial defaults of the library can be configured via:
 
 .. toctree::
   :maxdepth: 2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,6 @@ install = ['--tags=data,python-runtime,runtime']
 [tool.setuptools_scm]
 version_scheme = "release-branch-semver"
 local_scheme = "node-and-date"
-write_to = "lib/matplotlib/_version.py"
 parentdir_prefix_version = "matplotlib-"
 fallback_version = "0.0+UNKNOWN"
 

--- a/src/checkdep_freetype2.c
+++ b/src/checkdep_freetype2.c
@@ -1,7 +1,7 @@
 #ifdef __has_include
   #if !__has_include(<ft2build.h>)
     #error "FreeType version 2.3 or higher is required. \
-You may unset the system_freetype entry in mplsetup.cfg to let Matplotlib download it."
+You may set the system-freetype Meson build option to false to let Matplotlib download it."
   #endif
 #endif
 
@@ -15,5 +15,5 @@ You may unset the system_freetype entry in mplsetup.cfg to let Matplotlib downlo
   XSTR(FREETYPE_MAJOR) "." XSTR(FREETYPE_MINOR) "." XSTR(FREETYPE_PATCH) ".")
 #if FREETYPE_MAJOR << 16 + FREETYPE_MINOR << 8 + FREETYPE_PATCH < 0x020300
   #error "FreeType version 2.3 or higher is required. \
-You may unset the system_freetype entry in mplsetup.cfg to let Matplotlib download it."
+You may set the system-freetype Meson build option to false to let Matplotlib download it."
 #endif


### PR DESCRIPTION
## PR summary

Meson creates `_version.py` in the build directory, so we shouldn't ask setuptools-scm to do it. I'm not sure why it started creating it again, but taking this option out should stop it.

Also, there's some documentation about `mplsetup.cfg` that is out of date, and should be replaced by Meson build options.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines