### PR TITLE
Fix PolygonSelector cursor to temporarily hide during active zoom/pan

### DIFF
--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4000,11 +4000,18 @@ class PolygonSelector(_SelectorWidget):
         # needs to process the move callback even if there is no button press.
         # _SelectorWidget.onmove include logic to ignore move event if
         # _eventpress is None.
-        if not self.ignore(event):
+
+        # Hide the cursor when interactive zoom/pan is active
+        if self.ignore(event):
+            if not self.canvas.widgetlock.available(self) and self._xys:
+                self._xys[-1] = (np.nan, np.nan)
+                self._draw_polygon()
+            return False
+
+        else:
             event = self._clean_event(event)
             self._onmove(event)
             return True
-        return False
 
     def _onmove(self, event):
         """Cursor move event handler."""

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4000,9 +4000,8 @@ class PolygonSelector(_SelectorWidget):
         # needs to process the move callback even if there is no button press.
         # _SelectorWidget.onmove include logic to ignore move event if
         # _eventpress is None.
-
-        # Hide the cursor when interactive zoom/pan is active
         if self.ignore(event):
+            # Hide the cursor when interactive zoom/pan is active
             if not self.canvas.widgetlock.available(self) and self._xys:
                 self._xys[-1] = (np.nan, np.nan)
                 self._draw_polygon()


### PR DESCRIPTION
Issue: #28165

The PolygonSelector now correctly hide the cursor when another widget is active, such as the zoom/pan functionality, ensuring a smooth user experience.. This fix ensures that the cursor is temporarily hidden when another interaction is active.