### PR TITLE
Handle GetForegroundWindow() returning NULL.

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -44,7 +44,7 @@ def _restore_foreground_window_at_end():
     try:
         yield
     finally:
-        if mpl.rcParams['tk.window_focus']:
+        if foreground and mpl.rcParams['tk.window_focus']:
             _c_internal_utils.Win32_SetForegroundWindow(foreground)
 
 

--- a/src/_c_internal_utils.cpp
+++ b/src/_c_internal_utils.cpp
@@ -111,7 +111,11 @@ static py::object
 mpl_GetForegroundWindow(void)
 {
 #ifdef _WIN32
-  return py::capsule(GetForegroundWindow(), "HWND");
+  if (HWND hwnd = GetForegroundWindow()) {
+    return py::capsule(hwnd, "HWND");
+  } else {
+    return py::none();
+  }
 #else
   return py::none();
 #endif


### PR DESCRIPTION
GetForegroundWindow() is documented as sometimes returning NULL (https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getforegroundwindow), which is not a valid argument to PyCapsule_New.  Use None to cover that case, instead.

Closes #28267 (in all likelihood...).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
