### PR TITLE
Fix draggable legend disappearing when picking while use_blit=True

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1506,6 +1506,7 @@ class DraggableBase:
             self.finalize_offset()
             self.got_artist = False
             if self._use_blit:
+                self.canvas.restore_region(self.background)
                 self.ref_artist.draw(
                     self.ref_artist.figure._get_renderer())
                 self.canvas.blit()

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1486,11 +1486,13 @@ class DraggableBase:
                 self.canvas.draw()
 
     def on_pick(self, evt):
-        if self._check_still_parented() and evt.artist == self.ref_artist:
-            self.mouse_x = evt.mouseevent.x
-            self.mouse_y = evt.mouseevent.y
-            self.got_artist = True
-            if self._use_blit:
+        if self._check_still_parented():
+            if evt.artist == self.ref_artist:
+                self.mouse_x = evt.mouseevent.x
+                self.mouse_y = evt.mouseevent.y
+                self.save_offset()
+                self.got_artist = True
+            if self.got_artist and self._use_blit:
                 self.ref_artist.set_animated(True)
                 self.canvas.draw()
                 self.background = \
@@ -1498,7 +1500,6 @@ class DraggableBase:
                 self.ref_artist.draw(
                     self.ref_artist.figure._get_renderer())
                 self.canvas.blit()
-            self.save_offset()
 
     def on_release(self, event):
         if self._check_still_parented() and self.got_artist:

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1506,6 +1506,9 @@ class DraggableBase:
             self.finalize_offset()
             self.got_artist = False
             if self._use_blit:
+                self.ref_artist.draw(
+                    self.ref_artist.figure._get_renderer())
+                self.canvas.blit()
                 self.ref_artist.set_animated(False)
 
     def _check_still_parented(self):

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1507,8 +1507,7 @@ class DraggableBase:
             self.got_artist = False
             if self._use_blit:
                 self.canvas.restore_region(self.background)
-                self.ref_artist.draw(
-                    self.ref_artist.figure._get_renderer())
+                self.ref_artist.draw(self.ref_artist.figure._get_renderer())
                 self.canvas.blit()
                 self.ref_artist.set_animated(False)
 


### PR DESCRIPTION
Fix for the issue #28129. When using a draggable legend with use_blit=True and picking enabled, the bug caused the whole legend to disappear once a line in the legend was clicked.