### PR TITLE
Introduce natural 3D rotation with mouse

### DIFF
--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -12,8 +12,7 @@ The position of the viewport "camera" in a 3D plot is defined by three angles:
 points towards the center of the plot box volume. The angle direction is a
 common convention, and is shared with
 `PyVista <https://docs.pyvista.org/api/core/camera.html>`_ and
-`MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_
-(though MATLAB lacks a roll angle). Note that a positive roll angle rotates the
+`MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_. Note that a positive roll angle rotates the
 viewing plane clockwise, so the 3d axes will appear to rotate
 counter-clockwise.
 
@@ -21,8 +20,8 @@ counter-clockwise.
    :align: center
    :scale: 50
 
-Rotating the plot using the mouse will control only the azimuth and elevation,
-but all three angles can be set programmatically::
+Rotating the plot using the mouse will control azimuth, elevation,
+as well as roll, and all three angles can be set programmatically::
 
     import matplotlib.pyplot as plt
     ax = plt.figure().add_subplot(projection='3d')

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -12,7 +12,8 @@ The position of the viewport "camera" in a 3D plot is defined by three angles:
 points towards the center of the plot box volume. The angle direction is a
 common convention, and is shared with
 `PyVista <https://docs.pyvista.org/api/core/camera.html>`_ and
-`MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_. Note that a positive roll angle rotates the
+`MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_.
+Note that a positive roll angle rotates the
 viewing plane clockwise, so the 3d axes will appear to rotate
 counter-clockwise.
 

--- a/doc/users/next_whats_new/mouse_rotation.rst
+++ b/doc/users/next_whats_new/mouse_rotation.rst
@@ -1,0 +1,12 @@
+Rotating 3d plots with the mouse
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Rotating three-dimensional plots with the mouse has been made more intuitive.
+The plot now reacts the same way to mouse movement, independent of the
+particular orientation at hand; and it is possible to control all 3 rotational
+degrees of freedom (azimuth, elevation, and roll). It uses a variation on
+Ken Shoemake's ARCBALL [Shoemake1992]_.
+
+.. [Shoemake1992] Ken Shoemake, "ARCBALL: A user interface for specifying
+  three-dimensional rotation using a mouse." in Proceedings of Graphics
+  Interface '92, 1992, pp. 151-156, https://doi.org/10.20380/GI1992.18

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1503,21 +1503,22 @@ class Axes3D(Axes):
         p2 = p1 - scale*vec
         return p2, pane_idx
 
-    def _arcball(self, p):
+    def _arcball(self, x: float, y: float) -> np.ndarray:
         """
-        Convert a point p = [x, y] to a point on a virtual trackball
+        Convert a point (x, y) to a point on a virtual trackball
         This is Ken Shoemake's arcball
         See: Ken Shoemake, "ARCBALL: A user interface for specifying
         three-dimensional rotation using a mouse." in
         Proceedings of Graphics Interface '92, 1992, pp. 151-156,
         https://doi.org/10.20380/GI1992.18
         """
-        p = 2 * p
-        r = p[0]**2 + p[1]**2
-        if r > 1:
-            p = np.concatenate(([0], p/math.sqrt(r)))
+        x *= 2
+        y *= 2
+        r2 = x*x + y*y
+        if r2 > 1:
+            p = np.array([0, x/math.sqrt(r2), y/math.sqrt(r2)])
         else:
-            p = np.concatenate(([math.sqrt(1-r)], p))
+            p = np.array([math.sqrt(1-r2), x, y])
         return p
 
     def _on_move(self, event):
@@ -1562,12 +1563,10 @@ class Axes3D(Axes):
             q = _Quaternion.from_cardan_angles(elev, azim, roll)
 
             # Update quaternion - a variation on Ken Shoemake's ARCBALL
-            current_point = np.array([self._sx/w, self._sy/h])
-            new_point = np.array([x/w, y/h])
-            current_vec = self._arcball(current_point)
-            new_vec = self._arcball(new_point)
+            current_vec = self._arcball(self._sx/w, self._sy/h)
+            new_vec = self._arcball(x/w, y/h)
             dq = _Quaternion.rotate_from_to(current_vec, new_vec)
-            q = dq*q
+            q = dq * q
 
             # Convert to elev, azim, roll
             elev, azim, roll = q.as_cardan_angles()


### PR DESCRIPTION
## PR summary
- Addresses Issue #28288, i.e.:
  - Makes three-dimensional rotation by mouse independent of the particular orientation at hand, which is natural and intuitive (no 'gimbal lock')
  - Extends the rotation to all three rotational degrees of freedom
- Introduces three-dimensional rotation by mouse using a variation on Ken Shoemake's ARCBALL
- Provides a minimal Quaternion class, to avoid an additional  dependency on a large package like 'numpy-quaternion'

## PR checklist

- [x] "Addresses #28288" is in the body of the PR description
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

