### PR TITLE
Resolve MaxNLocator IndexError when no large steps

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -130,6 +130,14 @@ class TestMultipleLocator:
             loc = mticker.MultipleLocator(base=3.147, offset=1.3)
             assert_almost_equal(loc.view_limits(-4, 4), (-4.994, 4.447))
 
+    def test_view_limits_single_bin(self):
+        """
+        Test that 'round_numbers' works properly with a single bin.
+        """
+        with mpl.rc_context({'axes.autolimit_mode': 'round_numbers'}):
+            loc = mticker.MaxNLocator(nbins=1)
+            assert_almost_equal(loc.view_limits(-2.3, 2.3), (-4, 4))
+
     def test_set_params(self):
         """
         Create multiple locator with 0.7 base, and change it to something else.

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2137,7 +2137,10 @@ class MaxNLocator(Locator):
             large_steps = large_steps & (floored_vmaxs >= _vmax)
 
         # Find index of smallest large step
-        istep = np.nonzero(large_steps)[0][0]
+        if any(large_steps):
+            istep = np.nonzero(large_steps)[0][0]
+        else:
+            istep = len(steps) - 1
 
         # Start at smallest of the steps greater than the raw step, and check
         # if it provides enough ticks. If not, work backwards through


### PR DESCRIPTION
## PR summary
Resolves IndexError in `MaxNLocator._raw_ticks()`.

The IndexError occurred under the following conditions:
- nbins=1
- rcParams['axes.autolimit_mode'] == 'round_numbers'
- the input parameters for vmin and vmax resulted in no large_steps (all are False)

closes #27603 


## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

