### PR TITLE
Faster title alignment

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7118,6 +7118,18 @@ def test_title_no_move_off_page():
     assert tt.get_position()[1] == 1.0
 
 
+def test_title_inset_ax():
+    # Title should be above any child axes
+    mpl.rcParams['axes.titley'] = None
+    fig, ax = plt.subplots()
+    ax.set_title('Title')
+    fig.draw_without_rendering()
+    assert ax.title.get_position()[1] == 1
+    ax.inset_axes([0, 1, 1, 0.1])
+    fig.draw_without_rendering()
+    assert ax.title.get_position()[1] == 1.1
+
+
 def test_offset_label_color():
     # Tests issue 6440
     fig, ax = plt.subplots()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

1. Part of the calculation of `top` does not depend on `title`, so move it outside the loop.
2. If no titles have been set, skip this logic entirely.

I used `fig_many.savefig(stream, format='svg', bbox_inches='tight')` and `fig_many_sharex.savefig(stream, format='svg', bbox_inches='tight')` from #26150 as benchmarks.  `fig_many.savefig` ran in ~320-330 ms regardless of this change.  For `fig_many_sharex` I got

With `main`:
```
484 ms ± 9.87 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After (1)
```
328 ms ± 8.95 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```
After (2)
```
230 ms ± 9.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
