### PR TITLE
Fixed PolarAxes not using format_data (#4568)

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1447,12 +1447,23 @@ class PolarAxes(Axes):
                     cbook._g_sig_digits(value, delta))
             return f"{value:-{opt}.{prec}{fmt}}"
 
-        return ('\N{GREEK SMALL LETTER THETA}={}\N{GREEK SMALL LETTER PI} '
-                '({}\N{DEGREE SIGN}), r={}').format(
+        # In case fmt_xdata was not specified, resort to default
+        if self.fmt_xdata is None:
+            return ('\N{GREEK SMALL LETTER THETA}={}\N{GREEK SMALL LETTER PI} '
+                    '({}\N{DEGREE SIGN}), r={}').format(
                     format_sig(theta_halfturns, delta_t_halfturns, "", "f"),
                     format_sig(theta_degrees, delta_t_degrees, "", "f"),
-                    format_sig(r, delta_r, "#", "g"),
+                    format_sig(r, delta_r, "#", "g")
+                    if self.fmt_ydata is None
+                    else self.format_ydata(r)
                 )
+        else:
+            return '\N{GREEK SMALL LETTER THETA}={}, r={}'.format(
+                        self.format_xdata(theta),
+                        format_sig(r, delta_r, "#", "g")
+                        if self.fmt_ydata is None
+                        else self.format_ydata(r)
+                        )
 
     def get_data_ratio(self):
         """

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -436,6 +436,28 @@ def test_cursor_precision():
     assert ax.format_coord(2, 1) == "θ=0.637π (114.6°), r=1.000"
 
 
+def test_custom_fmt_ydata():
+    ax = plt.subplot(projection="polar")
+    def millions(x):
+        return '$%1.1fM' % (x*1e-6)
+
+    ax.fmt_ydata = millions
+    assert ax.format_coord(12, 2e7) == "θ=3.8197186342π (687.54935416°), r=$20.0M"
+    assert ax.format_coord(1234, 2e6) == "θ=392.794399551π (70702.9919191°), r=$2.0M"
+    assert ax.format_coord(3, 100) == "θ=0.95493π (171.887°), r=$0.0M"
+
+
+def test_custom_fmt_xdata():
+    ax = plt.subplot(projection="polar")
+    def millions(x):
+        return '$%1.1fM' % (x*1e-6)
+
+    ax.fmt_xdata = millions
+    assert ax.format_coord(2e5, 1) == "θ=$0.2M, r=1.000"
+    assert ax.format_coord(1, .1) == "θ=$0.0M, r=0.100"
+    assert ax.format_coord(1e6, 0.005) == "θ=$1.0M, r=0.005"
+
+
 @image_comparison(['polar_log.png'], style='default')
 def test_polar_log():
     fig = plt.figure()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Updates `PolarAxes.format_coord` function to use `format_xdata` and `format_ydata` to resolve #4568.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #4568" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/4568)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
