### PR TITLE
Update 3D orientation indication right away

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1348,6 +1348,8 @@ class Axes3D(Axes):
             toolbar = self.figure.canvas.toolbar
             if toolbar and toolbar._nav_stack() is None:
                 toolbar.push_current()
+            if toolbar:
+                toolbar.set_message(toolbar._mouse_event_to_message(event))
 
     def _button_release(self, event):
         self.button_pressed = None
@@ -1356,6 +1358,8 @@ class Axes3D(Axes):
         # push_current, so check the navigation mode so we don't call it twice
         if toolbar and self.get_navigate_mode() is None:
             toolbar.push_current()
+        if toolbar:
+            toolbar.set_message(toolbar._mouse_event_to_message(event))
 
     def _get_view(self):
         # docstring inherited


### PR DESCRIPTION
## PR summary
Immediately update orientation indication in 3d plot when left mouse button is pressed or released (instead of requiring a mouse movement first): Issue #28310

## PR checklist
- [x] "Issue #28310" is in the body of the PR description
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines