### PR TITLE
Remove one indirection layer in ToolSetCursor.

### DIFF
--- a/lib/matplotlib/backend_tools.py
+++ b/lib/matplotlib/backend_tools.py
@@ -261,9 +261,9 @@ class ToolSetCursor(ToolBase):
         self._last_cursor = self._default_cursor
         self.toolmanager.toolmanager_connect('tool_added_event',
                                              self._add_tool_cbk)
-        # process current tools
-        for tool in self.toolmanager.tools.values():
-            self._add_tool(tool)
+        for tool in self.toolmanager.tools.values():  # process current tools
+            self._add_tool_cbk(mpl.backend_managers.ToolEvent(
+                'tool_added_event', self.toolmanager, tool))
 
     def set_figure(self, figure):
         if self._id_drag:
@@ -273,24 +273,15 @@ class ToolSetCursor(ToolBase):
             self._id_drag = self.canvas.mpl_connect(
                 'motion_notify_event', self._set_cursor_cbk)
 
-    def _tool_trigger_cbk(self, event):
-        if event.tool.toggled:
-            self._current_tool = event.tool
-        else:
-            self._current_tool = None
-        self._set_cursor_cbk(event.canvasevent)
-
-    def _add_tool(self, tool):
-        """Set the cursor when the tool is triggered."""
-        if getattr(tool, 'cursor', None) is not None:
-            self.toolmanager.toolmanager_connect('tool_trigger_%s' % tool.name,
-                                                 self._tool_trigger_cbk)
-
     def _add_tool_cbk(self, event):
         """Process every newly added tool."""
-        if event.tool is self:
-            return
-        self._add_tool(event.tool)
+        if getattr(event.tool, 'cursor', None) is not None:
+            self.toolmanager.toolmanager_connect(
+                f'tool_trigger_{event.tool.name}', self._tool_trigger_cbk)
+
+    def _tool_trigger_cbk(self, event):
+        self._current_tool = event.tool if event.tool.toggled else None
+        self._set_cursor_cbk(event.canvasevent)
 
     def _set_cursor_cbk(self, event):
         if not event or not self.canvas:


### PR DESCRIPTION
Instead of having both _add_tool_cbk (the main callback that handles addition of new tools) and _add_tool (which does the same but for pre-existing tools), we can just always use _add_tool_cbk, sending synthetic tool_added_events for the initialization step).

Also move _tool_trigger_cbk down, next to _set_cursor_cbk, with which it is semantically associated.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
