### PR TITLE
Restore axis title set to the right on a twinx() copied axis when cleared.

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1261,6 +1261,14 @@ class _AxesBase(martist.Artist):
         # deprecation on cla() subclassing expires.
 
         # stash the current visibility state
+
+        # A twinx-copied axis title set to the right will move back the
+        # left if it is cleared.
+        set_right_label_again = False
+        if 'y' in self._axis_map:
+            set_right_label_again = \
+                (self._axis_map['y'].get_label_position() == 'right')
+
         if hasattr(self, 'patch'):
             patch_visible = self.patch.get_visible()
         else:
@@ -1377,6 +1385,9 @@ class _AxesBase(martist.Artist):
                     axis._set_scale("linear")
                 axis._set_lim(0, 1, auto=True)
         self._update_transScale()
+
+        if set_right_label_again:
+            self._axis_map['y'].set_label_position('right')
 
         self.stale = True
 


### PR DESCRIPTION
PR summary
When an axis is copied using twinx() the twin title is set to the right. If that axis is then cleared and its title text is set again,
the title is set back to the left. This PR alters that behaviour to be forced back to the right again.

closes https://github.com/matplotlib/matplotlib/issues/28268.

There was one test warning:
test test_pickle_load_from_subprocess
"This figure was saved with matplotlib version 1.6.0.dev34660+gae23583050.d19700101 and loaded with 1.6.0.dev34660+gae23583050.d20240530 so may not function correctly."

I'm hoping this doesn't appear on matplotlib's test runner.

Result of changes against bug example code:
![Figure_1](https://github.com/matplotlib/matplotlib/assets/2662541/e4d477cf-3ed3-4fb6-b721-53e47dad1f29)
