### PR TITLE
Call IPython.enable_gui when install repl displayhook

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -304,10 +304,12 @@ def install_repl_displayhook() -> None:
         # This code can be removed when Python 3.12, the latest version supported by
         # IPython < 8.24, reaches end-of-life in late 2028.
         from IPython.core.pylabtools import backend2gui
-        # trigger IPython's eventloop integration, if available
         ipython_gui_name = backend2gui.get(get_backend())
-        if ipython_gui_name:
-            ip.enable_gui(ipython_gui_name)
+    else:
+        _, ipython_gui_name = backend_registry.resolve_backend(get_backend())
+    # trigger IPython's eventloop integration, if available
+    if ipython_gui_name:
+        ip.enable_gui(ipython_gui_name)
 
 
 def uninstall_repl_displayhook() -> None:


### PR DESCRIPTION
Closes #28324.

This fixes the use of `plt.show(block=False)` in `ipython` without specifying a particular backend beforehand. The recent refactor of backend handling in IPython/Matplotlib removed the call to `ip.enable_gui` in `install_repl_displayhook` but in this particular use case it is still needed. If a backend is specified in ipython beforehand (via `ipython --matplotlib` or `%matplotlib` for example) then IPython already knows about the correct event loop, but if not then IPython needs to be explicitly told about it via `ip.enable_gui`.

So really this is putting functionality back in that I erroneously removed in the backend refactor.

On macos the default `macosx` backend needs an extra fix in IPython that I will link to.