### PR TITLE
DOC: do not posting LLM output as your own work

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -15,7 +15,9 @@ body:
     attributes:
       label: Code for reproduction
       description: >-
-        If possible, please provide a minimum self-contained example.
+        If possible, please provide a minimum self-contained example.  If you
+        have used generative AI as an aid see
+        https://dev.matplotlib.org/devel/contributing.html#generative_ai.
       placeholder: Paste your code here. This field is automatically formatted as Python code.
       render: Python
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,6 +13,11 @@ out the development guide https://matplotlib.org/devdocs/devel/index.html
 Additionally, please summarize the changes in the title, for example "Raise ValueError on
 non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
 issue #8576".
+
+If possible, please provide a minimum self-contained example.  If you have used
+generative AI as an aid in preparing this PR, see
+https://dev.matplotlib.org/devel/contributing.html#generative_ai.
+
 -->
 
 

--- a/doc/devel/contribute.rst
+++ b/doc/devel/contribute.rst
@@ -183,6 +183,21 @@ please cite us following the :doc:`/project/citing` guidelines.
 If you have developed an extension to Matplotlib, please consider adding it to our
 `third party package <https://github.com/matplotlib/mpl-third-party>`_  list.
 
+
+.. _generative_ai:
+
+
+Restrictions on Generative AI Usage
+===================================
+
+We expect authentic engagement in our community.  Be wary of posting output
+from Large Language Models or similar generative AI as comments on GitHub or
+our discourse server, as such comments tend to be formulaic and low content.
+If you use generative AI tools as an aid in developing code or documentation
+changes, ensure that you fully understand the proposed changes and can explain
+why they are the correct approach and an improvement to the current state.
+
+
 .. _new_contributors:
 
 New contributors


### PR DESCRIPTION
I am not going to link to the issues or comments that inspired me to write this.  We are starting to see comments that look like the are the output from feeding the OP of an issue in to an ai assitant and at least one bug report that was "chatGPT said this should work but it does not".

I think that users who report bugs with us should expect to get feedaback from an expert human and I do not think we should be spending time doing user support for openAI.


I thought about included a sentence to the effect of "We obviously can't stop you from using them, but please rewrite it in your own words" but did not like any of the formulations I came up with.

I do not think asking people who use LLMs to generate comments/issues to attribute addresses the actual problem and is insufficient. 