### PR TITLE
DOC: Add version warning banner for docs versions different from stable

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -2,7 +2,8 @@
     {
         "name": "3.9 (stable)",
         "version": "stable",
-        "url": "https://matplotlib.org/stable/"
+        "url": "https://matplotlib.org/stable/",
+        "preferred": true
     },
     {
         "name": "3.10 (dev)",

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -508,6 +508,7 @@ html_theme_options = {
     # this special value indicates the use of the unreleased banner. If we need
     # an actual announcement, then just place the text here as usual.
     "announcement": "unreleased" if not is_release_build else "",
+    "show_version_warning_banner": True,
 }
 include_analytics = is_release_build
 if include_analytics:


### PR DESCRIPTION
Adds a version warning banner to the documentation pages if they are not the "stable" version.

This is how it looks like:
![Captura de imagem_20240603_113811](https://github.com/matplotlib/matplotlib/assets/3949932/168f4a3b-390b-4423-81dc-0b7a074b0727)

cc @QuLogic 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
