### PR TITLE
Typo in communication guide: extensiblity -> extensibility

### DIFF
--- a/doc/devel/communication_guide.rst
+++ b/doc/devel/communication_guide.rst
@@ -21,7 +21,7 @@ Our approach to community engagement is foremost guided by our :ref:`mission-sta
   who may no longer be active on GitHub, build relationships with potential
   contributors, and connect with other projects and communities who use
   Matplotlib.
-* In prioritizing understandability and extensiblity, we recognize that people
+* In prioritizing understandability and extensibility, we recognize that people
   using Matplotlib, in whatever capacity, are part of our community. Doing so
   empowers our community members to build community with each other, for example
   by creating educational resources, building third party tools, and building


### PR DESCRIPTION

## PR summary

This is an extremely tiny typo correction, changing `extensiblity` to `extensibility` in the development communication guide. I was reading about other development practices for contributing to matplotlib and I noticed this.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines