### PR TITLE
MNT: Re-add matplotlib.cm.get_cmap

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -239,6 +239,44 @@ _colormaps = ColormapRegistry(_gen_cmap_registry())
 globals().update(_colormaps)
 
 
+# This is an exact copy of pyplot.get_cmap(). It was removed in 3.9, but apparently
+# caused more user trouble than expected. Re-added for 3.9.1 and extended the
+# deprecation period for two additional minor releases.
+@_api.deprecated(
+    '3.7',
+    removal='3.11',
+    alternative="``matplotlib.colormaps[name]`` or ``matplotlib.colormaps.get_cmap()``"
+                " or ``pyplot.get_cmap()``"
+    )
+def get_cmap(name=None, lut=None):
+    """
+    Get a colormap instance, defaulting to rc values if *name* is None.
+
+    Parameters
+    ----------
+    name : `~matplotlib.colors.Colormap` or str or None, default: None
+        If a `.Colormap` instance, it will be returned. Otherwise, the name of
+        a colormap known to Matplotlib, which will be resampled by *lut*. The
+        default, None, means :rc:`image.cmap`.
+    lut : int or None, default: None
+        If *name* is not already a Colormap instance and *lut* is not None, the
+        colormap will be resampled to have *lut* entries in the lookup table.
+
+    Returns
+    -------
+    Colormap
+    """
+    if name is None:
+        name = mpl.rcParams['image.cmap']
+    if isinstance(name, colors.Colormap):
+        return name
+    _api.check_in_list(sorted(_colormaps), name=name)
+    if lut is None:
+        return _colormaps[name]
+    else:
+        return _colormaps[name].resampled(lut)
+
+
 def _auto_norm_from_scale(scale_cls):
     """
     Automatically generate a norm class from *scale_cls*.

--- a/lib/matplotlib/cm.pyi
+++ b/lib/matplotlib/cm.pyi
@@ -19,6 +19,8 @@ class ColormapRegistry(Mapping[str, colors.Colormap]):
 
 _colormaps: ColormapRegistry = ...
 
+def get_cmap(name: str | colors.Colormap | None = ..., lut: int | None = ...) -> colors.Colormap: ...
+
 class ScalarMappable:
     cmap: colors.Colormap | None
     colorbar: Colorbar | None


### PR DESCRIPTION
Addresses https://github.com/matplotlib/matplotlib/issues/28349#issuecomment-2152758163

> We are seeing multiple reports that the warnings in 3.8 were not seen. We should sort out why and consider putting the API in a micro release with a more visible warning (at maybe a custom AttributeError that gives more context?).

This was removed in 3.9, but apparently caused more user trouble than expected. Re-added for 3.9.1 and extended the deprecation period for two additional minor releases.

I did not find a technical reason why people may not see it. My wild guess is that this was quite commonly used and there are enough cases where people jump more than 2 minor versions. Hopefully extending for 2 additional minor releases will be good enough. - I question whether this was too common and should not have been removed at all, but now that we've started IMHO we should eventually remove.