### PR TITLE
DOC: fixed code for testing check figures equal example

### DIFF
--- a/doc/devel/testing.rst
+++ b/doc/devel/testing.rst
@@ -182,17 +182,28 @@ circle: plotting a circle using a `matplotlib.patches.Circle` patch
 vs plotting the circle using the parametric equation of a circle ::
 
    from matplotlib.testing.decorators import check_figures_equal
-   import matplotib.patches as mpatches
+   import matplotlib.patches as mpatches
    import matplotlib.pyplot as plt
    import numpy as np
 
-   @check_figures_equal(extensions=['png'], tol=100)
+   @check_figures_equal()
    def test_parametric_circle_plot(fig_test, fig_ref):
-       red_circle_ref = mpatches.Circle((0, 0), 0.2, color='r', clip_on=False)
-       fig_ref.add_artist(red_circle_ref)
-       theta = np.linspace(0, 2 * np.pi, 150)
+
+       xo, yo= (.5, .5)
        radius = 0.4
-       fig_test.plot(radius * np.cos(theta), radius * np.sin(theta), color='r')
+
+       ax_test = fig_test.subplots()
+       theta = np.linspace(0, 2 * np.pi, 150)
+       l, = ax_test.plot(xo + (radius * np.cos(theta)),
+                         yo + (radius * np.sin(theta)), c='r')
+
+       ax_ref = fig_ref.subplots()
+       red_circle_ref = mpatches.Circle((xo, yo), radius, ec='r', fc='none',
+                                        lw=l.get_linewidth())
+       ax_ref.add_artist(red_circle_ref)
+
+       for ax in [ax_ref, ax_test]:
+           ax.set(xlim=(0,1), ylim=(0,1), aspect='equal')
 
 Both comparison decorators have a tolerance argument ``tol`` that is used to specify the
 tolerance for difference in color value between the two images, where 255 is the maximal


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Fixed the code in the [check figures equal](https://matplotlib.org/devdocs/devel/testing.html#compare-two-methods-of-creating-an-image) example in contribute/testing so that it works and creates two equal figures. 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
