### PR TITLE
flip subfigures axes to match subplots

### DIFF
--- a/doc/api/next_api_changes/behavior/28363-TS.rst
+++ b/doc/api/next_api_changes/behavior/28363-TS.rst
@@ -1,0 +1,6 @@
+Subfigures
+~~~~~~~~~~
+
+`.Figure.subfigures` are now added in row-major order to be consistent with
+`.Figure.subplots`.  The return value of `~.Figure.subfigures` is not changed,
+but the order of ``fig.subfigs`` is.

--- a/doc/users/next_whats_new/subfigures_change_order.rst
+++ b/doc/users/next_whats_new/subfigures_change_order.rst
@@ -1,0 +1,23 @@
+Subfigures are now added in row-major order
+-------------------------------------------
+
+``Figure.subfigures`` are now added in row-major order for API consistency.
+
+
+.. plot::
+    :include-source: true
+    :alt: Example of creating 3 by 3 subfigures.
+
+    import matplotlib.pyplot as plt
+
+    fig = plt.figure()
+    subfigs = fig.subfigures(3, 3)
+    x = np.linspace(0, 10, 100)
+
+    for i, sf in enumerate(fig.subfigs):
+        ax = sf.subplots()
+        ax.plot(x, np.sin(x + i), label=f'Subfigure {i+1}')
+        sf.suptitle(f'Subfigure {i+1}')
+        ax.set_xticks([])
+        ax.set_yticks([])
+    plt.show()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1583,9 +1583,9 @@ default: %(va)s
                       left=0, right=1, bottom=0, top=1)
 
         sfarr = np.empty((nrows, ncols), dtype=object)
-        for i in range(ncols):
-            for j in range(nrows):
-                sfarr[j, i] = self.add_subfigure(gs[j, i], **kwargs)
+        for i in range(nrows):
+            for j in range(ncols):
+                sfarr[i, j] = self.add_subfigure(gs[i, j], **kwargs)
 
         if self.get_layout_engine() is None and (wspace is not None or
                                                  hspace is not None):

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1550,6 +1550,9 @@ default: %(va)s
         .. note::
             The *subfigure* concept is new in v3.4, and the API is still provisional.
 
+        .. versionchanged:: 3.10
+            subfigures are now added in row-major order.
+
         Parameters
         ----------
         nrows, ncols : int, default: 1

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1733,3 +1733,14 @@ def test_warn_colorbar_mismatch():
     subfig3_1.colorbar(im3_2)   # should not warn
     with pytest.warns(UserWarning, match="different Figure"):
         subfig3_1.colorbar(im4_1)
+
+
+@check_figures_equal(extensions=['png'])
+def test_subfigure_row_order(fig_test, fig_ref):
+    # Test that subfigures are drawn in row major order.
+    sf_arr_ref = fig_ref.subfigures(4, 3)
+    for i, sf in enumerate(sf_arr_ref.ravel()):
+        sf.suptitle(i)
+    fig_test.subfigures(4, 3)
+    for i, sf in enumerate(fig_test.subfigs):
+        sf.suptitle(i)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1735,12 +1735,9 @@ def test_warn_colorbar_mismatch():
         subfig3_1.colorbar(im4_1)
 
 
-@check_figures_equal(extensions=['png'])
-def test_subfigure_row_order(fig_test, fig_ref):
-    # Test that subfigures are drawn in row major order.
-    sf_arr_ref = fig_ref.subfigures(4, 3)
-    for i, sf in enumerate(sf_arr_ref.ravel()):
-        sf.suptitle(i)
-    fig_test.subfigures(4, 3)
-    for i, sf in enumerate(fig_test.subfigs):
-        sf.suptitle(i)
+def test_subfigure_row_order():
+    # Test that subfigures are drawn in row-major order.
+    fig = plt.figure()
+    sf_arr = fig.subfigures(4, 3)
+    for a, b in zip(sf_arr.ravel(), fig.subfigs):
+        assert a is b


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.


Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #28344. Change the iteration order on the rows and columns of `subfigure` to draw them in row-major order.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
