### PR TITLE
Reorder Axes3D parameters semantically.

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -58,11 +58,13 @@ class Axes3D(Axes):
     Axes._shared_axes["view"] = cbook.Grouper()
 
     def __init__(
-            self, fig, rect=None, *args,
-            elev=30, azim=-60, roll=0, sharez=None, proj_type='persp',
-            box_aspect=None, computed_zorder=True, focal_length=None,
-            shareview=None,
-            **kwargs):
+        self, fig, rect=None, *args,
+        elev=30, azim=-60, roll=0, shareview=None, sharez=None,
+        proj_type='persp', focal_length=None,
+        box_aspect=None,
+        computed_zorder=True,
+        **kwargs,
+    ):
         """
         Parameters
         ----------
@@ -83,11 +85,21 @@ class Axes3D(Axes):
             The roll angle in degrees rotates the camera about the viewing
             axis. A positive angle spins the camera clockwise, causing the
             scene to rotate counter-clockwise.
+        shareview : Axes3D, optional
+            Other Axes to share view angles with.  Note that it is not possible
+            to unshare axes.
         sharez : Axes3D, optional
             Other Axes to share z-limits with.  Note that it is not possible to
             unshare axes.
         proj_type : {'persp', 'ortho'}
             The projection type, default 'persp'.
+        focal_length : float, default: None
+            For a projection type of 'persp', the focal length of the virtual
+            camera. Must be > 0. If None, defaults to 1.
+            For a projection type of 'ortho', must be set to either None
+            or infinity (numpy.inf). If None, defaults to infinity.
+            The focal length can be computed from a desired Field Of View via
+            the equation: focal_length = 1/tan(FOV/2)
         box_aspect : 3-tuple of floats, default: None
             Changes the physical dimensions of the Axes3D, such that the ratio
             of the axis lengths in display units is x:y:z.
@@ -101,16 +113,6 @@ class Axes3D(Axes):
             does not produce the desired result. Note however, that a manual
             zorder will only be correct for a limited view angle. If the figure
             is rotated by the user, it will look wrong from certain angles.
-        focal_length : float, default: None
-            For a projection type of 'persp', the focal length of the virtual
-            camera. Must be > 0. If None, defaults to 1.
-            For a projection type of 'ortho', must be set to either None
-            or infinity (numpy.inf). If None, defaults to infinity.
-            The focal length can be computed from a desired Field Of View via
-            the equation: focal_length = 1/tan(FOV/2)
-        shareview : Axes3D, optional
-            Other Axes to share view angles with.  Note that it is not possible
-            to unshare axes.
 
         **kwargs
             Other optional keyword arguments:


### PR DESCRIPTION
The parameters changed are keyword-only, so the change is backwards compatible.

Move shareview next to the view angles, and then sharez next to shareview.  Move focal_length next to proj_type.

followup to #28359.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
