### PR TITLE
FIX: Made AffineDeltaTransform pass-through properly

### DIFF
--- a/doc/api/next_api_changes/behavior/28375-MP.rst
+++ b/doc/api/next_api_changes/behavior/28375-MP.rst
@@ -1,0 +1,5 @@
+``transforms.AffineDeltaTransform`` updates correctly on axis limit changes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Before this change, transform sub-graphs with ``AffineDeltaTransform`` did not update correctly.
+This PR ensures that changes to the child transform are passed through correctly.

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -341,6 +341,31 @@ class TestAffine2D:
         assert_array_equal(s.get_matrix(), a.get_matrix())
 
 
+class TestAffineDeltaTransform:
+    def test_invalidate(self):
+        before = np.array([[1.0, 4.0, 0.0],
+                           [5.0, 1.0, 0.0],
+                           [0.0, 0.0, 1.0]])
+        after = np.array([[1.0, 3.0, 0.0],
+                          [5.0, 1.0, 0.0],
+                          [0.0, 0.0, 1.0]])
+
+        # Translation and skew present
+        base = mtransforms.Affine2D.from_values(1, 5, 4, 1, 2, 3)
+        t = mtransforms.AffineDeltaTransform(base)
+        assert_array_equal(t.get_matrix(), before)
+
+        # Mess with the internal structure of `base` without invalidating
+        # This should not affect this transform because it's a passthrough:
+        # it's always invalid
+        base.get_matrix()[0, 1:] = 3
+        assert_array_equal(t.get_matrix(), after)
+
+        # Invalidate the base
+        base.invalidate()
+        assert_array_equal(t.get_matrix(), after)
+
+
 def test_non_affine_caching():
     class AssertingNonAffineTransform(mtransforms.Transform):
         """

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2711,9 +2711,12 @@ class AffineDeltaTransform(Affine2DBase):
     This class is experimental as of 3.3, and the API may change.
     """
 
+    pass_through = True
+
     def __init__(self, transform, **kwargs):
         super().__init__(**kwargs)
         self._base_transform = transform
+        self.set_children(transform)
 
     __str__ = _make_str_method("_base_transform")
 


### PR DESCRIPTION
## PR summary
Makes `mtrans.AffineDeltaTransform` update correctly when axis bounds change. Change made by @anntzer 

closes #28372 

enables the proposed example in #28364 to work correctly

### Testing
A combination of manual and unit tests.

Manually verified that the example above works as expected now:

Before:

![image](https://github.com/matplotlib/matplotlib/assets/156837150/6b7230f8-52ed-4d5f-8808-18bc00988158)

After:

![image](https://github.com/matplotlib/matplotlib/assets/156837150/1b7cb2b7-b2f6-425f-a2f9-2437c5e363e5)

Unit test shows that the parent transform is invalidated when the child is now.

## PR checklist
- [x] "closes #28372" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines