### PR TITLE
PathEffectsRenderer can plainly inherit RendererBase._draw_text_as_path.

### DIFF
--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -96,6 +96,13 @@ class PathEffectRenderer(RendererBase):
     def copy_with_path_effect(self, path_effects):
         return self.__class__(path_effects, self._renderer)
 
+    def __getattribute__(self, name):
+        if name in ['flipy', 'get_canvas_width_height', 'new_gc',
+                    'points_to_pixels', '_text2path', 'height', 'width']:
+            return getattr(self._renderer, name)
+        else:
+            return object.__getattribute__(self, name)
+
     def draw_path(self, gc, tpath, affine, rgbFace=None):
         for path_effect in self._path_effects:
             path_effect.draw_path(self._renderer, gc, tpath, affine,
@@ -136,21 +143,6 @@ class PathEffectRenderer(RendererBase):
             # one path effect.
             renderer.draw_path_collection(gc, master_transform, paths,
                                           *args, **kwargs)
-
-    def _draw_text_as_path(self, gc, x, y, s, prop, angle, ismath):
-        # Implements the naive text drawing as is found in RendererBase.
-        path, transform = self._get_text_path_transform(x, y, s, prop,
-                                                        angle, ismath)
-        color = gc.get_rgb()
-        gc.set_linewidth(0.0)
-        self.draw_path(gc, path, transform, rgbFace=color)
-
-    def __getattribute__(self, name):
-        if name in ['flipy', 'get_canvas_width_height', 'new_gc',
-                    'points_to_pixels', '_text2path', 'height', 'width']:
-            return getattr(self._renderer, name)
-        else:
-            return object.__getattribute__(self, name)
 
     def open_group(self, s, gid=None):
         return self._renderer.open_group(s, gid)


### PR DESCRIPTION
The current implementation is exactly the same as in the super class.

Also, move the `__getattribute__` definition higher, before all renderer-specific method definitions.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
