### PR TITLE
Allow duplicate (name, value) entry points for backends

### DIFF
--- a/lib/matplotlib/backends/registry.py
+++ b/lib/matplotlib/backends/registry.py
@@ -168,8 +168,11 @@ class BackendRegistry:
     def _validate_and_store_entry_points(self, entries):
         # Validate and store entry points so that they can be used via matplotlib.use()
         # in the normal manner. Entry point names cannot be of module:// format, cannot
-        # shadow a built-in backend name, and cannot be duplicated.
-        for name, module in entries:
+        # shadow a built-in backend name, and there cannot be multiple entry points
+        # with the same name but different modules. Multiple entry points with the same
+        # name and value are permitted (it can sometimes happen outside of our control,
+        # see https://github.com/matplotlib/matplotlib/issues/28367).
+        for name, module in set(entries):
             name = name.lower()
             if name.startswith("module://"):
                 raise RuntimeError(

--- a/lib/matplotlib/tests/test_backend_registry.py
+++ b/lib/matplotlib/tests/test_backend_registry.py
@@ -121,6 +121,17 @@ def test_entry_point_name_duplicate(clear_backend_registry):
             [('some_name', 'module1'), ('some_name', 'module2')])
 
 
+def test_entry_point_identical(clear_backend_registry):
+    # Issue https://github.com/matplotlib/matplotlib/issues/28367
+    # Multiple entry points with the same name and value (value is the module)
+    # are acceptable.
+    n = len(backend_registry._name_to_module)
+    backend_registry._validate_and_store_entry_points(
+        [('some_name', 'some.module'), ('some_name', 'some.module')])
+    assert len(backend_registry._name_to_module) == n+1
+    assert backend_registry._name_to_module['some_name'] == 'module://some.module'
+
+
 def test_entry_point_name_is_module(clear_backend_registry):
     with pytest.raises(RuntimeError):
         backend_registry._validate_and_store_entry_points(


### PR DESCRIPTION
## PR summary
Fixes #28367.

This allows duplicate (name, value) entry points for self-registering backends such as `matplotlib-inline`. This should not occur but sometimes a single `entry_points.txt` file can appear as two identical entry points and hence before this fix a `RuntimeError` was raised. With this fix the duplicated entry points are tolerated.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines