### PR TITLE
Change order of mplot3d view angles to match order of rotations

### DIFF
--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -8,7 +8,7 @@ How to define the view angle
 ============================
 
 The position of the viewport "camera" in a 3D plot is defined by three angles:
-*elevation*, *azimuth*, and *roll*. From the resulting position, it always
+*azimuth*, *elevation*, and *roll*. From the resulting position, it always
 points towards the center of the plot box volume. The angle direction is a
 common convention, and is shared with
 `PyVista <https://docs.pyvista.org/api/core/camera.html>`_ and
@@ -32,7 +32,7 @@ as well as roll, and all three angles can be set programmatically::
 Primary view planes
 ===================
 
-To look directly at the primary view planes, the required elevation, azimuth,
+To look directly at the primary view planes, the required azimuth, elevation,
 and roll angles are shown in the diagram of an "unfolded" plot below. These are
 further documented in the `.mplot3d.axes3d.Axes3D.view_init` API.
 

--- a/galleries/examples/mplot3d/2dcollections3d.py
+++ b/galleries/examples/mplot3d/2dcollections3d.py
@@ -43,6 +43,6 @@ ax.set_zlabel('Z')
 
 # Customize the view angle so it's easier to see that the scatter points lie
 # on the plane y=0
-ax.view_init(elev=20., azim=-35, roll=0)
+ax.view_init(elev=20, azim=-35, roll=0)
 
 plt.show()

--- a/galleries/examples/mplot3d/box3d.py
+++ b/galleries/examples/mplot3d/box3d.py
@@ -68,7 +68,7 @@ ax.set(
 )
 
 # Set zoom and angle view
-ax.view_init(40, -30, 0)
+ax.view_init(elev=40, azim=-30, roll=0)
 ax.set_box_aspect(None, zoom=0.9)
 
 # Colorbar

--- a/galleries/examples/mplot3d/rotate_axes3d_sgskip.py
+++ b/galleries/examples/mplot3d/rotate_axes3d_sgskip.py
@@ -33,7 +33,7 @@ for angle in range(0, 360*4 + 1):
     angle_norm = (angle + 180) % 360 - 180
 
     # Cycle through a full rotation of elevation, then azimuth, roll, and all
-    elev = azim = roll = 0
+    azim = elev = roll = 0
     if angle <= 360:
         elev = angle_norm
     elif angle <= 360*2:
@@ -41,11 +41,11 @@ for angle in range(0, 360*4 + 1):
     elif angle <= 360*3:
         roll = angle_norm
     else:
-        elev = azim = roll = angle_norm
+        azim = elev = roll = angle_norm
 
     # Update the axis view and title
-    ax.view_init(elev, azim, roll)
-    plt.title('Elevation: %d°, Azimuth: %d°, Roll: %d°' % (elev, azim, roll))
+    ax.view_init(elev=elev, azim=azim, roll=roll)
+    plt.title('Azimuth: %d°, Elevation: %d°, Roll: %d°' % (azim, elev, roll))
 
     plt.draw()
     plt.pause(.001)

--- a/galleries/examples/mplot3d/view_planes_3d.py
+++ b/galleries/examples/mplot3d/view_planes_3d.py
@@ -4,7 +4,7 @@ Primary 3D view planes
 ======================
 
 This example generates an "unfolded" 3D plot that shows each of the primary 3D
-view planes. The elevation, azimuth, and roll angles required for each view are
+view planes. The azimuth, elevation, and roll angles required for each view are
 labeled. You could print out this image and fold it into a box where each plane
 forms a side of the box.
 """
@@ -16,13 +16,13 @@ def annotate_axes(ax, text, fontsize=18):
     ax.text(x=0.5, y=0.5, z=0.5, s=text,
             va="center", ha="center", fontsize=fontsize, color="black")
 
-# (plane, (elev, azim, roll))
-views = [('XY',   (90, -90, 0)),
-         ('XZ',    (0, -90, 0)),
-         ('YZ',    (0,   0, 0)),
-         ('-XY', (-90,  90, 0)),
-         ('-XZ',   (0,  90, 0)),
-         ('-YZ',   (0, 180, 0))]
+# (plane, (azim, elev, roll))
+views = [('XY',   (-90,  90, 0)),
+         ('XZ',   (-90,   0, 0)),
+         ('YZ',     (0,   0, 0)),
+         ('-XY',   (90, -90, 0)),
+         ('-XZ',   (90,   0, 0)),
+         ('-YZ',   (180,  0, 0))]
 
 layout = [['XY',  '.',   'L',   '.'],
           ['XZ', 'YZ', '-XZ', '-YZ'],
@@ -34,10 +34,10 @@ for plane, angles in views:
     axd[plane].set_ylabel('y')
     axd[plane].set_zlabel('z')
     axd[plane].set_proj_type('ortho')
-    axd[plane].view_init(elev=angles[0], azim=angles[1], roll=angles[2])
+    axd[plane].view_init(elev=angles[1], azim=angles[0], roll=angles[2])
     axd[plane].set_box_aspect(None, zoom=1.25)
 
-    label = f'{plane}\n{angles}'
+    label = f'{plane}\nazim={angles[0]}\nelev={angles[1]}\nroll={angles[2]}'
     annotate_axes(axd[plane], label, fontsize=14)
 
 for plane in ('XY', '-XY'):

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -10,9 +10,9 @@ def test_scatter_3d_projection_conservation():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     # fix axes3d projection
-    ax.roll = 0
-    ax.elev = 0
     ax.azim = -45
+    ax.elev = 0
+    ax.roll = 0
     ax.stale = True
 
     x = [0, 1, 2, 3, 4]


### PR DESCRIPTION
## PR summary
Changes the order of the view angles to azim-elev-roll, since:
- azim-elev(-roll) appears to be a much more common order, the elev-azim(-roll) that we had is unusual 
- it corresponds to the order in which the 3 rotations take place
- it is consistent with the ordering in matplotlib's colors.py

The proposed changes (to the documentation of view_init() in particular) suggest to use keyword arguments 
in this order, but the historical positional arguments are still accepted without change, so the interface does not actually change with this PR.
Resolves #28353.

Summary of changes:
- Change order of mplot3d view angles to azim-elev-roll, the order in which rotations occur:
  - in axes3d.py
  - in tests
  - in documentation
  - in examples
- Add description of rotation to view_angles.rst
- Put in ref. to https://github.com/moble/quaternion/wiki/Euler-angles-are-horrible
- Update view_init() documentation
- Add doc\api\next_api_changes\deprecations warning that Axes3D.view_init preferably should be used with keyword arguments
- Add next_whats_new\view_angles_order.rst explaining the new view angles order


## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [(please review)] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
