### PR TITLE
Add GIL Release to flush_events in macosx backend

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -80,6 +80,9 @@ static int wait_for_stdin() {
 
         // continuously run an event loop until the stdin_received flag is set to exit
         while (!stdin_received && !stdin_sigint) {
+            // This loop is similar to the main event loop and flush_events which have
+            // Py_[BEGIN|END]_ALLOW_THREADS surrounding the loop.
+            // This should not be necessary here because PyOS_InputHook releases the GIL for us.
             while (true) {
                 NSEvent *event = [NSApp nextEventMatchingMask: NSEventMaskAny
                                                     untilDate: [NSDate distantPast]
@@ -383,6 +386,9 @@ FigureCanvas_flush_events(FigureCanvas* self)
     // to process, breaking out of the loop when no events remain and
     // displaying the canvas if needed.
     NSEvent *event;
+
+    Py_BEGIN_ALLOW_THREADS
+
     while (true) {
         event = [NSApp nextEventMatchingMask: NSEventMaskAny
                                    untilDate: [NSDate distantPast]
@@ -393,6 +399,9 @@ FigureCanvas_flush_events(FigureCanvas* self)
         }
         [NSApp sendEvent:event];
     }
+
+    Py_END_ALLOW_THREADS
+
     [self->view displayIfNeeded];
     Py_RETURN_NONE;
 }


### PR DESCRIPTION
Closes #28387

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

This ensures that we do not get a deadlock when we try to close tabs.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
