### PR TITLE
FIX: Fix text wrapping

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -15,6 +15,7 @@ from matplotlib.figure import Figure
 from matplotlib.font_manager import FontProperties
 import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
+from matplotlib.gridspec import GridSpec
 import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 from matplotlib.testing._markers import needs_usetex
@@ -707,9 +708,13 @@ def test_large_subscript_title():
      (0.3, 0, 'right'),
      (0.3, 185, 'left')])
 def test_wrap(x, rotation, halign):
-    fig = plt.figure(figsize=(6, 6))
+    fig = plt.figure(figsize=(18, 18))
+    gs = GridSpec(nrows=3, ncols=3, figure=fig)
+    subfig = fig.add_subfigure(gs[1, 1])
+    # we only use the central subfigure, which does not align with any
+    # figure boundary, to ensure only subfigure boundaries are relevant
     s = 'This is a very long text that should be wrapped multiple times.'
-    text = fig.text(x, 0.7, s, wrap=True, rotation=rotation, ha=halign)
+    text = subfig.text(x, 0.7, s, wrap=True, rotation=rotation, ha=halign)
     fig.canvas.draw()
     assert text._get_wrapped_text() == ('This is a very long\n'
                                         'text that should be\n'

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -606,9 +606,8 @@ class Text(Artist):
         """
         Set whether the text can be wrapped.
 
-        Wrapping makes sure the text is completely within the figure box, i.e.
-        it does not extend beyond the drawing area. It does not take into
-        account any other artists.
+        Wrapping makes sure the text is confined to the (sub)figure box. It
+        does not take into account any other artists.
 
         Parameters
         ----------
@@ -657,16 +656,16 @@ class Text(Artist):
         """
         if rotation > 270:
             quad = rotation - 270
-            h1 = y0 / math.cos(math.radians(quad))
+            h1 = (y0 - figure_box.y0) / math.cos(math.radians(quad))
             h2 = (figure_box.x1 - x0) / math.cos(math.radians(90 - quad))
         elif rotation > 180:
             quad = rotation - 180
-            h1 = x0 / math.cos(math.radians(quad))
-            h2 = y0 / math.cos(math.radians(90 - quad))
+            h1 = (x0 - figure_box.x0) / math.cos(math.radians(quad))
+            h2 = (y0 - figure_box.y0) / math.cos(math.radians(90 - quad))
         elif rotation > 90:
             quad = rotation - 90
             h1 = (figure_box.y1 - y0) / math.cos(math.radians(quad))
-            h2 = x0 / math.cos(math.radians(90 - quad))
+            h2 = (x0 - figure_box.x0) / math.cos(math.radians(90 - quad))
         else:
             h1 = (figure_box.x1 - x0) / math.cos(math.radians(rotation))
             h2 = (figure_box.y1 - y0) / math.cos(math.radians(90 - rotation))


### PR DESCRIPTION
`_get_dist_to_box()` assumed that the figure box (x0, y0) coordinates are 0, which was correct at the time of writing, but does not hold anymore since the introduction of subfigures.

Closes #28378
Closes #28358

Note that the modified test fails with the original `_get_dist_to_box()` implementation.