### PR TITLE
Ignore np.nan values in Normalize.autoscale()

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1447,9 +1447,9 @@ class Normalize:
                 A = A.data
 
         if self.vmin is None and A.size:
-            self.vmin = A.min()
+            self.vmin = np.nanmin(A)
         if self.vmax is None and A.size:
-            self.vmax = A.max()
+            self.vmax = np.nanmax(A)
 
     def scaled(self):
         """Return whether *vmin* and *vmax* are both set."""


### PR DESCRIPTION
## PR summary
When using colormaps to map scalars to colors, it is necessary to normalize the values into the range [0,1] beforehand. The `Normalize` class offers this functionality and includes the method `autoscale` to determine a sensible value `vmin` and `vmax` for scaling automatically. However, in its current state, `autoscale` will set `vmin` and `vmax` to `nan` when presented with the input `np.array([1, 2, np.nan])`. Because of this, calling an Normalize instance on this will transform the entire array to `nan`.

Example pre-PR:

```python
>>> x = np.array([1, 2, 3, np.nan])
>>> n = Normalize()
>>> n.autoscale(x)
>>> n(x)
masked_array(data=[nan, nan, nan, nan],
             mask=False,
       fill_value=1e+20)
```

Example post-PR:

```python
>>> x = np.array([1, 2, 3, np.nan])
>>> n = Normalize()
>>> n.autoscale(x)
>>> n(x)
masked_array(data=[ 0.,  0.5, 1., nan],
             mask=False,
       fill_value=1e+20)
```

This PR closes #28405.

Additonal comment: the values `np.inf` and `-np.inf` currently also break the `autoscale` function. It is not obvious how the autoscaler should behave when presented with such values. I'd be open to modify this PR in such a way that they also get ignored.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
