### PR TITLE
DOC: Add note about simplification of to_polygons

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -697,6 +697,9 @@ class Path:
         be simplified so that vertices outside of (0, 0), (width,
         height) will be clipped.
 
+        The resulting polygons will be simplified if the
+        :attr:`Path.should_simplify` attribute of the path is `True`.
+
         If *closed_only* is `True` (default), only closed polygons,
         with the last point being the same as the first point, will be
         returned.  Any unclosed polylines in the path will be


### PR DESCRIPTION
## PR summary

During a review in Cartopy, it was noted that it was non-obvious that `Path.to_polygons` would also simplify the path.
https://github.com/SciTools/cartopy/pull/2362#issuecomment-2179511074
This adds an explicit note that it will simplify the path according to the `should_simplify` attribute.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
