### PR TITLE
MNT: Update basic units example to work with numpy 2.0

### DIFF
--- a/galleries/examples/units/basic_units.py
+++ b/galleries/examples/units/basic_units.py
@@ -146,10 +146,10 @@ class TaggedValue(metaclass=TaggedValueMeta):
             return getattr(variable, name)
         return object.__getattribute__(self, name)
 
-    def __array__(self, dtype=object):
+    def __array__(self, dtype=object, copy=False):
         return np.asarray(self.value, dtype)
 
-    def __array_wrap__(self, array, context):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         return TaggedValue(array, self.unit)
 
     def __repr__(self):
@@ -222,10 +222,10 @@ class BasicUnit:
     def __rmul__(self, lhs):
         return self*lhs
 
-    def __array_wrap__(self, array, context):
+    def __array_wrap__(self, array, context=None, return_scalar=False):
         return TaggedValue(array, self)
 
-    def __array__(self, t=None, context=None):
+    def __array__(self, t=None, context=None, copy=False):
         ret = np.array(1)
         if t is not None:
             return ret.astype(t)


### PR DESCRIPTION
## PR summary

We are getting reviewdog failures in the galleries/examples tests with numpy 2.0. There are new keyword arguments required for __array__ and __array_wrap__ that are expected in numpy 2.0.

From the release notes https://numpy.org/devdocs/release/2.0.0-notes.html
> __array_wrap__ is now passed arr, context, return_scalar and support for implementations not accepting all three are deprecated. Its signature should be __array_wrap__(self, arr, context=None, return_scalar=False)

https://numpy.org/devdocs/release/2.0.0-notes.html#the-array-special-method-now-takes-a-copy-keyword-argument
> NumPy will pass copy to the __array__ special method in situations where it would be set to a non-default value (e.g. in a call to np.asarray(some_object, copy=False)). Currently, if an unexpected keyword argument error is raised after this, NumPy will print a warning and re-try without the copy keyword argument. Implementations of objects implementing the __array__ protocol should accept a copy keyword argument with the same meaning as when passed to [numpy.array](https://numpy.org/devdocs/reference/generated/numpy.array.html#numpy.array) or [numpy.asarray](https://numpy.org/devdocs/reference/generated/numpy.asarray.html#numpy.asarray).


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
