### PR TITLE
Fix GTK cairo backends

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3cairo.py
+++ b/lib/matplotlib/backends/backend_gtk3cairo.py
@@ -13,15 +13,19 @@ class FigureCanvasGTK3Cairo(FigureCanvasCairo, FigureCanvasGTK3):
 
         with (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
               else nullcontext()):
-            self._renderer.set_context(ctx)
+            allocation = self.get_allocation()
+            # Render the background before scaling, as the allocated size here is in
+            # logical pixels.
+            Gtk.render_background(
+                self.get_style_context(), ctx,
+                0, 0, allocation.width, allocation.height)
             scale = self.device_pixel_ratio
             # Scale physical drawing to logical size.
             ctx.scale(1 / scale, 1 / scale)
-            allocation = self.get_allocation()
-            Gtk.render_background(
-                self.get_style_context(), ctx,
-                allocation.x, allocation.y,
-                allocation.width, allocation.height)
+            self._renderer.set_context(ctx)
+            # Set renderer to physical size so it renders in full resolution.
+            self._renderer.width = allocation.width * scale
+            self._renderer.height = allocation.height * scale
             self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -34,7 +34,6 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
     required_interactive_framework = "gtk4"
     supports_blit = False
     manager_class = _api.classproperty(lambda cls: FigureManagerGTK4)
-    _context_is_scaled = False
 
     def __init__(self, figure=None):
         super().__init__(figure=figure)
@@ -228,13 +227,8 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
 
         lw = 1
         dash = 3
-        if not self._context_is_scaled:
-            x0, y0, w, h = (dim / self.device_pixel_ratio
-                            for dim in self._rubberband_rect)
-        else:
-            x0, y0, w, h = self._rubberband_rect
-            lw *= self.device_pixel_ratio
-            dash *= self.device_pixel_ratio
+        x0, y0, w, h = (dim / self.device_pixel_ratio
+                        for dim in self._rubberband_rect)
         x1 = x0 + w
         y1 = y0 + h
 

--- a/lib/matplotlib/backends/backend_gtk4cairo.py
+++ b/lib/matplotlib/backends/backend_gtk4cairo.py
@@ -5,7 +5,10 @@ from .backend_gtk4 import GLib, Gtk, FigureCanvasGTK4, _BackendGTK4
 
 
 class FigureCanvasGTK4Cairo(FigureCanvasCairo, FigureCanvasGTK4):
-    _context_is_scaled = True
+    def _set_device_pixel_ratio(self, ratio):
+        # Cairo in GTK4 always uses logical pixels, so we don't need to do anything for
+        # changes to the device pixel ratio.
+        return False
 
     def on_draw_event(self, widget, ctx):
         if self._idle_draw_id:
@@ -16,15 +19,11 @@ class FigureCanvasGTK4Cairo(FigureCanvasCairo, FigureCanvasGTK4):
         with (self.toolbar._wait_cursor_for_draw_cm() if self.toolbar
               else nullcontext()):
             self._renderer.set_context(ctx)
-            scale = self.device_pixel_ratio
-            # Scale physical drawing to logical size.
-            ctx.scale(1 / scale, 1 / scale)
             allocation = self.get_allocation()
             Gtk.render_background(
                 self.get_style_context(), ctx,
                 allocation.x, allocation.y,
                 allocation.width, allocation.height)
-            self._renderer.dpi = self.figure.dpi
             self.figure.draw(self._renderer)
 
 


### PR DESCRIPTION
## PR summary

For GTK4Cairo, HiDPI displays were broken because we were scaling unnecessarily, as GTK4 takes care of setting up the Cairo context for us with the right scale.

For GTK3Cairo, _all_ displays were broken, as we inferred the size from the backing surface (since #22004), which is the size of the _window_. Then we re-orient the origin using that height, causing everything to be placed incorrectly.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines