### PR TITLE
Stop relying on dead-reckoning mouse buttons for motion_notify_event.

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -1324,6 +1324,28 @@ class MouseEvent(LocationEvent):
         If this is unset, *name* is "scroll_event", and *step* is nonzero, then
         this will be set to "up" or "down" depending on the sign of *step*.
 
+    buttons : None or frozenset
+        For 'motion_notify_event', the mouse buttons currently being pressed
+        (a set of zero or more MouseButtons);
+        for other events, None.
+
+        .. note::
+           For 'motion_notify_event', this attribute is more accurate than
+           the ``button`` (singular) attribute, which is obtained from the last
+           'button_press_event' or 'button_release_event' that occurred within
+           the canvas (and thus 1. be wrong if the last change in mouse state
+           occurred when the canvas did not have focus, and 2. cannot report
+           when multiple buttons are pressed).
+
+           This attribute is not set for 'button_press_event' and
+           'button_release_event' because GUI toolkits are inconsistent as to
+           whether they report the button state *before* or *after* the
+           press/release occurred.
+
+        .. warning::
+           On macOS, the Tk backends only report a single button even if
+           multiple buttons are pressed.
+
     key : None or str
         The key pressed when the mouse event triggered, e.g. 'shift'.
         See `KeyEvent`.
@@ -1356,7 +1378,8 @@ class MouseEvent(LocationEvent):
     """
 
     def __init__(self, name, canvas, x, y, button=None, key=None,
-                 step=0, dblclick=False, guiEvent=None, *, modifiers=None):
+                 step=0, dblclick=False, guiEvent=None, *,
+                 buttons=None, modifiers=None):
         super().__init__(
             name, canvas, x, y, guiEvent=guiEvent, modifiers=modifiers)
         if button in MouseButton.__members__.values():
@@ -1367,6 +1390,16 @@ class MouseEvent(LocationEvent):
             elif step < 0:
                 button = "down"
         self.button = button
+        if name == "motion_notify_event":
+            self.buttons = frozenset(buttons if buttons is not None else [])
+        else:
+            # We don't support 'buttons' for button_press/release_event because
+            # toolkits are inconsistent as to whether they report the state
+            # before or after the event.
+            if buttons:
+                raise ValueError(
+                    "'buttons' is only supported for 'motion_notify_event'")
+            self.buttons = None
         self.key = key
         self.step = step
         self.dblclick = dblclick

--- a/lib/matplotlib/backend_bases.pyi
+++ b/lib/matplotlib/backend_bases.pyi
@@ -258,6 +258,7 @@ class MouseEvent(LocationEvent):
         dblclick: bool = ...,
         guiEvent: Any | None = ...,
         *,
+        buttons: Iterable[MouseButton] | None = ...,
         modifiers: Iterable[str] | None = ...,
     ) -> None: ...
 

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -19,7 +19,7 @@ import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook, _c_internal_utils
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, NavigationToolbar2,
-    TimerBase, ToolContainerBase, cursors, _Mode,
+    TimerBase, ToolContainerBase, cursors, _Mode, MouseButton,
     CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 from matplotlib._pylab_helpers import Gcf
 from . import _tkagg
@@ -296,6 +296,7 @@ class FigureCanvasTk(FigureCanvasBase):
     def motion_notify_event(self, event):
         MouseEvent("motion_notify_event", self,
                    *self._event_mpl_coords(event),
+                   buttons=self._mpl_buttons(event),
                    modifiers=self._mpl_modifiers(event),
                    guiEvent=event)._process()
 
@@ -358,12 +359,32 @@ class FigureCanvasTk(FigureCanvasBase):
                    guiEvent=event)._process()
 
     @staticmethod
+    def _mpl_buttons(event):  # See _mpl_modifiers.
+        # NOTE: This fails to report multiclicks on macOS; only one button is
+        # reported (multiclicks work correctly on Linux & Windows).
+        modifiers = [
+            # macOS appears to swap right and middle (look for "Swap buttons
+            # 2/3" in tk/macosx/tkMacOSXMouseEvent.c).
+            (MouseButton.LEFT, 1 << 8),
+            (MouseButton.RIGHT, 1 << 9),
+            (MouseButton.MIDDLE, 1 << 10),
+            (MouseButton.BACK, 1 << 11),
+            (MouseButton.FORWARD, 1 << 12),
+        ] if sys.platform == "darwin" else [
+            (MouseButton.LEFT, 1 << 8),
+            (MouseButton.MIDDLE, 1 << 9),
+            (MouseButton.RIGHT, 1 << 10),
+            (MouseButton.BACK, 1 << 11),
+            (MouseButton.FORWARD, 1 << 12),
+        ]
+        # State *before* press/release.
+        return [name for name, mask in modifiers if event.state & mask]
+
+    @staticmethod
     def _mpl_modifiers(event, *, exclude=None):
-        # add modifier keys to the key string. Bit details originate from
-        # http://effbot.org/tkinterbook/tkinter-events-and-bindings.htm
-        # BIT_SHIFT = 0x001; BIT_CAPSLOCK = 0x002; BIT_CONTROL = 0x004;
-        # BIT_LEFT_ALT = 0x008; BIT_NUMLOCK = 0x010; BIT_RIGHT_ALT = 0x080;
-        # BIT_MB_1 = 0x100; BIT_MB_2 = 0x200; BIT_MB_3 = 0x400;
+        # Add modifier keys to the key string. Bit values are inferred from
+        # the implementation of tkinter.Event.__repr__ (1, 2, 4, 8, ... =
+        # Shift, Lock, Control, Mod1, ..., Mod5, Button1, ..., Button5)
         # In general, the modifier key is excluded from the modifier flag,
         # however this is not the case on "darwin", so double check that
         # we aren't adding repeat modifier flags to a modifier key.

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -6,8 +6,8 @@ from pathlib import Path
 import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
 from matplotlib.backend_bases import (
-    ToolContainerBase, CloseEvent, KeyEvent, LocationEvent, MouseEvent,
-    ResizeEvent)
+    ToolContainerBase, MouseButton,
+    CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
 try:
     import gi
@@ -156,6 +156,7 @@ class FigureCanvasGTK3(_FigureCanvasGTK, Gtk.DrawingArea):
 
     def motion_notify_event(self, widget, event):
         MouseEvent("motion_notify_event", self, *self._mpl_coords(event),
+                   buttons=self._mpl_buttons(event.state),
                    modifiers=self._mpl_modifiers(event.state),
                    guiEvent=event)._process()
         return False  # finish event propagation?
@@ -181,6 +182,18 @@ class FigureCanvasGTK3(_FigureCanvasGTK, Gtk.DrawingArea):
         self.figure.set_size_inches(winch, hinch, forward=False)
         ResizeEvent("resize_event", self)._process()
         self.draw_idle()
+
+    @staticmethod
+    def _mpl_buttons(event_state):
+        modifiers = [
+            (MouseButton.LEFT, Gdk.ModifierType.BUTTON1_MASK),
+            (MouseButton.MIDDLE, Gdk.ModifierType.BUTTON2_MASK),
+            (MouseButton.RIGHT, Gdk.ModifierType.BUTTON3_MASK),
+            (MouseButton.BACK, Gdk.ModifierType.BUTTON4_MASK),
+            (MouseButton.FORWARD, Gdk.ModifierType.BUTTON5_MASK),
+        ]
+        # State *before* press/release.
+        return [name for name, mask in modifiers if event_state & mask]
 
     @staticmethod
     def _mpl_modifiers(event_state, *, exclude=None):

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -5,8 +5,8 @@ import os
 import matplotlib as mpl
 from matplotlib import _api, backend_tools, cbook
 from matplotlib.backend_bases import (
-    ToolContainerBase, KeyEvent, LocationEvent, MouseEvent, ResizeEvent,
-    CloseEvent)
+    ToolContainerBase, MouseButton,
+    KeyEvent, LocationEvent, MouseEvent, ResizeEvent, CloseEvent)
 
 try:
     import gi
@@ -155,6 +155,7 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
     def motion_notify_event(self, controller, x, y):
         MouseEvent(
             "motion_notify_event", self, *self._mpl_coords((x, y)),
+            buttons=self._mpl_buttons(controller),
             modifiers=self._mpl_modifiers(controller),
             guiEvent=controller.get_current_event(),
         )._process()
@@ -181,6 +182,26 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
         self.figure.set_size_inches(winch, hinch, forward=False)
         ResizeEvent("resize_event", self)._process()
         self.draw_idle()
+
+    def _mpl_buttons(self, controller):
+        # NOTE: This spews "Broken accounting of active state" warnings on
+        # right click on macOS.
+        surface = self.get_native().get_surface()
+        is_over, x, y, event_state = surface.get_device_position(
+            self.get_display().get_default_seat().get_pointer())
+        # NOTE: alternatively we could use
+        #   event_state = controller.get_current_event_state()
+        # but for button_press/button_release this would report the state
+        # *prior* to the event rather than after it; the above reports the
+        # state *after* it.
+        mod_table = [
+            (MouseButton.LEFT, Gdk.ModifierType.BUTTON1_MASK),
+            (MouseButton.MIDDLE, Gdk.ModifierType.BUTTON2_MASK),
+            (MouseButton.RIGHT, Gdk.ModifierType.BUTTON3_MASK),
+            (MouseButton.BACK, Gdk.ModifierType.BUTTON4_MASK),
+            (MouseButton.FORWARD, Gdk.ModifierType.BUTTON5_MASK),
+        ]
+        return {name for name, mask in mod_table if event_state & mask}
 
     def _mpl_modifiers(self, controller=None):
         if controller is None:

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -329,6 +329,7 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
             return
         MouseEvent("motion_notify_event", self,
                    *self.mouseEventCoords(event),
+                   buttons=self._mpl_buttons(event.buttons()),
                    modifiers=self._mpl_modifiers(),
                    guiEvent=event)._process()
 
@@ -395,6 +396,13 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
 
     def minimumSizeHint(self):
         return QtCore.QSize(10, 10)
+
+    @staticmethod
+    def _mpl_buttons(buttons):
+        buttons = _to_int(buttons)
+        # State *after* press/release.
+        return {button for mask, button in FigureCanvasQT.buttond.items()
+                if _to_int(mask) & buttons}
 
     @staticmethod
     def _mpl_modifiers(modifiers=None, *, exclude=None):

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -22,7 +22,7 @@ from PIL import Image
 from matplotlib import _api, backend_bases, backend_tools
 from matplotlib.backends import backend_agg
 from matplotlib.backend_bases import (
-    _Backend, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
+    _Backend, MouseButton, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
 _log = logging.getLogger(__name__)
 
@@ -283,10 +283,17 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         y = event['y']
         y = self.get_renderer().height - y
         self._last_mouse_xy = x, y
-        # JavaScript button numbers and Matplotlib button numbers are off by 1.
-        button = event['button'] + 1
-
         e_type = event['type']
+        button = event['button'] + 1  # JS numbers off by 1 compared to mpl.
+        buttons = {  # JS ordering different compared to mpl.
+            button for button, mask in [
+                (MouseButton.LEFT, 1),
+                (MouseButton.RIGHT, 2),
+                (MouseButton.MIDDLE, 4),
+                (MouseButton.BACK, 8),
+                (MouseButton.FORWARD, 16),
+            ] if event['buttons'] & mask  # State *after* press/release.
+        }
         modifiers = event['modifiers']
         guiEvent = event.get('guiEvent')
         if e_type in ['button_press', 'button_release']:
@@ -300,10 +307,12 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                        modifiers=modifiers, guiEvent=guiEvent)._process()
         elif e_type == 'motion_notify':
             MouseEvent(e_type + '_event', self, x, y,
-                       modifiers=modifiers, guiEvent=guiEvent)._process()
+                       buttons=buttons, modifiers=modifiers, guiEvent=guiEvent,
+                       )._process()
         elif e_type in ['figure_enter', 'figure_leave']:
             LocationEvent(e_type + '_event', self, x, y,
                           modifiers=modifiers, guiEvent=guiEvent)._process()
+
     handle_button_press = handle_button_release = handle_dblclick = \
         handle_figure_enter = handle_figure_leave = handle_motion_notify = \
         handle_scroll = _handle_mouse

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -686,6 +686,22 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         self.draw_idle()
 
     @staticmethod
+    def _mpl_buttons():
+        state = wx.GetMouseState()
+        # NOTE: Alternatively, we could use event.LeftIsDown() / etc. but this
+        # fails to report multiclick drags on macOS (other OSes have not been
+        # verified).
+        mod_table = [
+            (MouseButton.LEFT, state.LeftIsDown()),
+            (MouseButton.RIGHT, state.RightIsDown()),
+            (MouseButton.MIDDLE, state.MiddleIsDown()),
+            (MouseButton.BACK, state.Aux1IsDown()),
+            (MouseButton.FORWARD, state.Aux2IsDown()),
+        ]
+        # State *after* press/release.
+        return {button for button, flag in mod_table if flag}
+
+    @staticmethod
     def _mpl_modifiers(event=None, *, exclude=None):
         mod_table = [
             ("ctrl", wx.MOD_CONTROL, wx.WXK_CONTROL),
@@ -794,9 +810,8 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
             MouseEvent("button_press_event", self, x, y, button,
                        modifiers=modifiers, guiEvent=event)._process()
         elif event.ButtonDClick():
-            MouseEvent("button_press_event", self, x, y, button,
-                       dblclick=True, modifiers=modifiers,
-                       guiEvent=event)._process()
+            MouseEvent("button_press_event", self, x, y, button, dblclick=True,
+                       modifiers=modifiers, guiEvent=event)._process()
         elif event.ButtonUp():
             MouseEvent("button_release_event", self, x, y, button,
                        modifiers=modifiers, guiEvent=event)._process()
@@ -826,6 +841,7 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         event.Skip()
         MouseEvent("motion_notify_event", self,
                    *self._mpl_coords(event),
+                   buttons=self._mpl_buttons(),
                    modifiers=self._mpl_modifiers(event),
                    guiEvent=event)._process()
 

--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -644,6 +644,7 @@ mpl.figure.prototype.mouse_event = function (event, name) {
         y: y,
         button: event.button,
         step: event.step,
+        buttons: event.buttons,
         modifiers: getModifiers(event),
         guiEvent: simpleKeys(event),
     });


### PR DESCRIPTION
Previously, for motion_notify_event, `event.attribute` was set by checking the last button_press_event/button_release event.  This is brittle for the same reason as to why we introduced `event.modifiers` to improve over `event.key` (#23473), so introduce the more robust `event.buttons` (see detailed discussion in the attribute docstring).

For a concrete example, consider e.g.

    from matplotlib import pyplot as plt
    from matplotlib.backends.qt_compat import QtWidgets

    def on_button_press(event):
        if event.button != 3:  # Right-click.
            return
        menu = QtWidgets.QMenu()
        menu.addAction("Some menu action", lambda: None)
        menu.exec(event.guiEvent.globalPosition().toPoint())

    fig = plt.figure()
    fig.canvas.mpl_connect("button_press_event", on_button_press)
    fig.add_subplot()
    plt.show()

(connecting a contextual menu on right button click) where a right click while having selected zoom mode on the toolbar starts a zoom mode that stays on even after the mouse release (because the mouse release event is received by the menu widget, not by the main canvas).  This PR does not fix the issue, but will allow a followup fix (where the motion_notify_event associated with zoom mode will be able to first check whether the button is indeed still pressed when the motion occurs).

Limitations, on macOS only (everything works on Linux and Windows AFAICT):
- tk only reports a single pressed button even if multiple buttons are pressed.
- gtk4 spams the terminal with Gtk-WARNINGs: "Broken accounting of active state for widget ..." on right-clicks only; similar issues appear to have been reported a while ago to Gtk (https://gitlab.gnome.org/GNOME/gtk/-/issues/3356 and linked issues) but it's unclear whether any action was taken on their side.

(Alternatively, some GUI toolkits have a "permissive" notion of drag events defined as mouse moves with a button pressed, which we could use as well to define event.button{,s} for motion_notify_event, but e.g. Qt attaches quite heavy semantics to drags which we probably don't want to bother with.)

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
