### PR TITLE
Expand ticklabels_rotation example to cover rotating default ticklabels.

### DIFF
--- a/galleries/examples/ticks/ticklabels_rotation.py
+++ b/galleries/examples/ticks/ticklabels_rotation.py
@@ -1,9 +1,7 @@
 """
-===========================
-Rotating custom tick labels
-===========================
-
-Demo of custom tick-labels with user-defined rotation.
+====================
+Rotating tick labels
+====================
 """
 
 import matplotlib.pyplot as plt
@@ -14,7 +12,22 @@ labels = ['Frogs', 'Hogs', 'Bogs', 'Slogs']
 
 fig, ax = plt.subplots()
 ax.plot(x, y)
-# You can specify a rotation for the tick labels in degrees or with keywords.
+# A tick label rotation can be set using Axes.tick_params.
+ax.tick_params("y", rotation=45)
+# Alternatively, if setting custom labels with set_xticks/set_yticks, it can
+# be set at the same time as the labels.
+# For both APIs, the rotation can be an angle in degrees, or one of the strings
+# "horizontal" or "vertical".
 ax.set_xticks(x, labels, rotation='vertical')
 
 plt.show()
+
+# %%
+#
+# .. admonition:: References
+#
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.axes.Axes.tick_params` / `matplotlib.pyplot.tick_params`
+#    - `matplotlib.axes.Axes.set_xticks` / `matplotlib.pyplot.xticks`


### PR DESCRIPTION
set_xticks only works if redefining the ticks at the same time; tick_params works in all cases.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
