### PR TITLE
Correct numpy dtype comparisons in image_resample

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1576,3 +1576,20 @@ def test_non_transdata_image_does_not_touch_aspect():
     assert ax.get_aspect() == 1
     ax.imshow(im, transform=ax.transAxes, aspect=2)
     assert ax.get_aspect() == 2
+
+
+@pytest.mark.parametrize(
+    'dtype',
+    ('float64', 'float32', 'int16', 'uint16', 'int8', 'uint8'),
+)
+@pytest.mark.parametrize('ndim', (2, 3))
+def test_resample_dtypes(dtype, ndim):
+    # Issue 28448, incorrect dtype comparisons in C++ image_resample can raise
+    # ValueError: arrays must be of dtype byte, short, float32 or float64
+    rng = np.random.default_rng(4181)
+    shape = (2, 2) if ndim == 2 else (2, 2, 3)
+    data = rng.uniform(size=shape).astype(np.dtype(dtype, copy=True))
+    fig, ax = plt.subplots()
+    axes_image = ax.imshow(data)
+    # Before fix the following raises ValueError for some dtypes.
+    axes_image.make_image(None)[0]

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -173,20 +173,20 @@ image_resample(py::array input_array,
 
     if (auto resampler =
             (ndim == 2) ? (
-                (dtype.is(py::dtype::of<std::uint8_t>())) ? resample<agg::gray8> :
-                (dtype.is(py::dtype::of<std::int8_t>())) ? resample<agg::gray8> :
-                (dtype.is(py::dtype::of<std::uint16_t>())) ? resample<agg::gray16> :
-                (dtype.is(py::dtype::of<std::int16_t>())) ? resample<agg::gray16> :
-                (dtype.is(py::dtype::of<float>())) ? resample<agg::gray32> :
-                (dtype.is(py::dtype::of<double>())) ? resample<agg::gray64> :
+                (dtype.equal(py::dtype::of<std::uint8_t>())) ? resample<agg::gray8> :
+                (dtype.equal(py::dtype::of<std::int8_t>())) ? resample<agg::gray8> :
+                (dtype.equal(py::dtype::of<std::uint16_t>())) ? resample<agg::gray16> :
+                (dtype.equal(py::dtype::of<std::int16_t>())) ? resample<agg::gray16> :
+                (dtype.equal(py::dtype::of<float>())) ? resample<agg::gray32> :
+                (dtype.equal(py::dtype::of<double>())) ? resample<agg::gray64> :
                 nullptr) : (
             // ndim == 3
-                (dtype.is(py::dtype::of<std::uint8_t>())) ? resample<agg::rgba8> :
-                (dtype.is(py::dtype::of<std::int8_t>())) ? resample<agg::rgba8> :
-                (dtype.is(py::dtype::of<std::uint16_t>())) ? resample<agg::rgba16> :
-                (dtype.is(py::dtype::of<std::int16_t>())) ? resample<agg::rgba16> :
-                (dtype.is(py::dtype::of<float>())) ? resample<agg::rgba32> :
-                (dtype.is(py::dtype::of<double>())) ? resample<agg::rgba64> :
+                (dtype.equal(py::dtype::of<std::uint8_t>())) ? resample<agg::rgba8> :
+                (dtype.equal(py::dtype::of<std::int8_t>())) ? resample<agg::rgba8> :
+                (dtype.equal(py::dtype::of<std::uint16_t>())) ? resample<agg::rgba16> :
+                (dtype.equal(py::dtype::of<std::int16_t>())) ? resample<agg::rgba16> :
+                (dtype.equal(py::dtype::of<float>())) ? resample<agg::rgba32> :
+                (dtype.equal(py::dtype::of<double>())) ? resample<agg::rgba64> :
                 nullptr)) {
         Py_BEGIN_ALLOW_THREADS
         resampler(


### PR DESCRIPTION
## PR summary

Correct numpy dtype comparisons in `image_resample` C++ code.

Previously we were using `dtype1.is(dtype2)` (the pybind11 C++ equivalent of `dtype1 is dtype2` in Python) whereas we should have been using `dtype1.equal(dtype2)` (the pybind11 C++ equivalent of `dtype1 == dtype2` in Python).

## PR checklist

- [x] "closes #28448" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

