### PR TITLE
bugfix for `PathSimplifier`

### DIFF
--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -541,35 +541,3 @@ def test_cleanup_closepoly():
         cleaned = p.cleaned(remove_nans=True)
         assert len(cleaned) == 1
         assert cleaned.codes[0] == Path.STOP
-
-
-def test_simplify_closepoly():
-    # The values of the vertices in a CLOSEPOLY should always be ignored,
-    # in favor of the most recent MOVETO's vertex values
-    paths = [Path([(1, 1), (2, 1), (2, 2), (np.nan, np.nan)],
-                  [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
-             Path([(1, 1), (2, 1), (2, 2), (40, 50)],
-                  [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])]
-    expected_path = Path([(1, 1), (2, 1), (2, 2), (1, 1), (1, 1), (0, 0)],
-                         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
-                          Path.LINETO, Path.STOP])
-
-    for path in paths:
-        simplified_path = path.cleaned(simplify=True)
-        assert_array_equal(expected_path.vertices, simplified_path.vertices)
-        assert_array_equal(expected_path.codes, simplified_path.codes)
-
-    # test that a compound path also works
-    path = Path([(1, 1), (2, 1), (2, 2), (np.nan, np.nan),
-                 (-1, 0), (-2, 0), (-2, 1), (np.nan, np.nan)],
-                [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY,
-                 Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
-    expected_path = Path([(1, 1), (2, 1), (2, 2), (1, 1),
-                          (-1, 0), (-2, 0), (-2, 1), (-1, 0), (-1, 0), (0, 0)],
-                         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
-                          Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
-                          Path.LINETO, Path.STOP])
-
-    simplified_path = path.cleaned(simplify=True)
-    assert_array_equal(expected_path.vertices, simplified_path.vertices)
-    assert_array_equal(expected_path.codes, simplified_path.codes)

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -546,27 +546,13 @@ def test_cleanup_closepoly():
 def test_simplify_closepoly():
     # The values of the vertices in a CLOSEPOLY should always be ignored,
     # in favor of the most recent MOVETO's vertex values
-    paths = [
-        Path([(0, 0), (1, 0), (1, 1), (0, 0)],
-             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
-        Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
-             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
-        Path([(0, 0), (1, 0), (1, 1), (40, 50)],
-             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
-        Path([(0, 0), (0.5, 0), (1, 0), (1, 0.5),
-              (1, 1), (0.5, 0.5), (0, 0)],
-             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
-              Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
-    ]
+    path_ref = Path([(0, 0), (1, 0), (1, 1), (40, 50)],
+                    [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
+    path_test = Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
+                     [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
 
-    first_segments = list(paths[0].cleaned(simplify=True).iter_segments())
-    for path in paths[1:]:
-        simplified_segments = list(path.cleaned(simplify=True).iter_segments())
-        for seg1, seg2 in zip(simplified_segments, first_segments):
-            vertex1, code1 = seg1
-            vertex2, code2 = seg2
+    path_ref_simplified = path_ref.cleaned(simplify=True)
+    path_test_simplified = path_test.cleaned(simplify=True)
 
-            # Check whether the vertices are equal
-            assert_array_equal(vertex1, vertex2)
-            # Check whether the codes are equal
-            assert code1 == code2
+    assert_array_equal(path_ref_simplified.vertices, path_test_simplified.vertices)
+    assert_array_equal(path_ref_simplified.codes, path_test_simplified.codes)

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -546,22 +546,27 @@ def test_cleanup_closepoly():
 def test_simplify_closepoly():
     # The values of the vertices in a CLOSEPOLY should always be ignored,
     # in favor of the most recent MOVETO's vertex values
-    paths = (
-            Path([(0, 0), (1, 0), (1, 1), (0, 0)],
-                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY],),
-            Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
-                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY],),
-            Path([(0, 0), (1, 0), (1, 1), (40, 50)],
-                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY],),
-            Path([(0, 0), (0.5, 0), (1, 0), (1, 0.5),
-                  (1, 1), (0.5, 0.5), (0, 0)],
-                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
-                  Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
-    )
+    paths = [
+        Path([(0, 0), (1, 0), (1, 1), (0, 0)],
+             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+        Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
+             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+        Path([(0, 0), (1, 0), (1, 1), (40, 50)],
+             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+        Path([(0, 0), (0.5, 0), (1, 0), (1, 0.5),
+              (1, 1), (0.5, 0.5), (0, 0)],
+             [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+              Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+    ]
 
-    first_segment = list(paths[0].cleaned(simplify=True).iter_segments())
-    for p in paths[1:]:
-        simplified = list(p.cleaned(simplify=True).iter_segments())
+    first_segments = list(paths[0].cleaned(simplify=True).iter_segments())
+    for path in paths[1:]:
+        simplified_segments = list(path.cleaned(simplify=True).iter_segments())
+        for seg1, seg2 in zip(simplified_segments, first_segments):
+            vertex1, code1 = seg1
+            vertex2, code2 = seg2
 
-        assert all([np.array_equal(a[0], b[0]) and a[1] == b[1]
-                    for a, b in zip(simplified, first_segment)])
+            # Check whether the vertices are equal
+            assert_array_equal(vertex1, vertex2)
+            # Check whether the codes are equal
+            assert code1 == code2

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -546,13 +546,30 @@ def test_cleanup_closepoly():
 def test_simplify_closepoly():
     # The values of the vertices in a CLOSEPOLY should always be ignored,
     # in favor of the most recent MOVETO's vertex values
-    path_ref = Path([(0, 0), (1, 0), (1, 1), (40, 50)],
-                    [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
-    path_test = Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
-                     [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
+    paths = [Path([(1, 1), (2, 1), (2, 2), (np.nan, np.nan)],
+                  [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+             Path([(1, 1), (2, 1), (2, 2), (40, 50)],
+                  [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])]
+    expected_path = Path([(1, 1), (2, 1), (2, 2), (1, 1), (1, 1), (0, 0)],
+                         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.LINETO, Path.STOP])
 
-    path_ref_simplified = path_ref.cleaned(simplify=True)
-    path_test_simplified = path_test.cleaned(simplify=True)
+    for path in paths:
+        simplified_path = path.cleaned(simplify=True)
+        assert_array_equal(expected_path.vertices, simplified_path.vertices)
+        assert_array_equal(expected_path.codes, simplified_path.codes)
 
-    assert_array_equal(path_ref_simplified.vertices, path_test_simplified.vertices)
-    assert_array_equal(path_ref_simplified.codes, path_test_simplified.codes)
+    # test that a compound path also works
+    path = Path([(1, 1), (2, 1), (2, 2), (np.nan, np.nan),
+                 (-1, 0), (-2, 0), (-2, 1), (np.nan, np.nan)],
+                [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY,
+                 Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
+    expected_path = Path([(1, 1), (2, 1), (2, 2), (1, 1),
+                          (-1, 0), (-2, 0), (-2, 1), (-1, 0), (-1, 0), (0, 0)],
+                         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.LINETO, Path.STOP])
+
+    simplified_path = path.cleaned(simplify=True)
+    assert_array_equal(expected_path.vertices, simplified_path.vertices)
+    assert_array_equal(expected_path.codes, simplified_path.codes)

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -541,3 +541,27 @@ def test_cleanup_closepoly():
         cleaned = p.cleaned(remove_nans=True)
         assert len(cleaned) == 1
         assert cleaned.codes[0] == Path.STOP
+
+
+def test_simplify_closepoly():
+    # The values of the vertices in a CLOSEPOLY should always be ignored,
+    # in favor of the most recent MOVETO's vertex values
+    paths = (
+            Path([(0, 0), (1, 0), (1, 1), (0, 0)],
+                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY],),
+            Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
+                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY],),
+            Path([(0, 0), (1, 0), (1, 1), (40, 50)],
+                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY],),
+            Path([(0, 0), (0.5, 0), (1, 0), (1, 0.5),
+                  (1, 1), (0.5, 0.5), (0, 0)],
+                 [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                  Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+    )
+
+    first_segment = list(paths[0].cleaned(simplify=True).iter_segments())
+    for p in paths[1:]:
+        simplified = list(p.cleaned(simplify=True).iter_segments())
+
+        assert all([np.array_equal(a[0], b[0]) and a[1] == b[1]
+                    for a, b in zip(simplified, first_segment)])

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -518,3 +518,35 @@ def test_clipping_full():
     simplified = list(p.iter_segments(clip=[0, 0, 100, 100]))
     assert ([(list(x), y) for x, y in simplified] ==
             [([50, 40], 1)])
+
+
+def test_simplify_closepoly():
+    # The values of the vertices in a CLOSEPOLY should always be ignored,
+    # in favor of the most recent MOVETO's vertex values
+    paths = [Path([(1, 1), (2, 1), (2, 2), (np.nan, np.nan)],
+                  [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY]),
+             Path([(1, 1), (2, 1), (2, 2), (40, 50)],
+                  [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])]
+    expected_path = Path([(1, 1), (2, 1), (2, 2), (1, 1), (1, 1), (0, 0)],
+                         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.LINETO, Path.STOP])
+
+    for path in paths:
+        simplified_path = path.cleaned(simplify=True)
+        assert_array_equal(expected_path.vertices, simplified_path.vertices)
+        assert_array_equal(expected_path.codes, simplified_path.codes)
+
+    # test that a compound path also works
+    path = Path([(1, 1), (2, 1), (2, 2), (np.nan, np.nan),
+                 (-1, 0), (-2, 0), (-2, 1), (np.nan, np.nan)],
+                [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY,
+                 Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])
+    expected_path = Path([(1, 1), (2, 1), (2, 2), (1, 1),
+                          (-1, 0), (-2, 0), (-2, 1), (-1, 0), (-1, 0), (0, 0)],
+                         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.LINETO, Path.STOP])
+
+    simplified_path = path.cleaned(simplify=True)
+    assert_array_equal(expected_path.vertices, simplified_path.vertices)
+    assert_array_equal(expected_path.codes, simplified_path.codes)

--- a/lib/matplotlib/tests/test_simplification.py
+++ b/lib/matplotlib/tests/test_simplification.py
@@ -550,3 +550,22 @@ def test_simplify_closepoly():
     simplified_path = path.cleaned(simplify=True)
     assert_array_equal(expected_path.vertices, simplified_path.vertices)
     assert_array_equal(expected_path.codes, simplified_path.codes)
+
+    # test for a path with an invalid MOVETO
+    # CLOSEPOLY with an invalid MOVETO should be ignored
+    path = Path([(1, 0), (1, -1), (2, -1),
+                 (np.nan, np.nan), (-1, -1), (-2, 1), (-1, 1),
+                 (2, 2), (0, -1)],
+                [Path.MOVETO, Path.LINETO, Path.LINETO,
+                 Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                 Path.CLOSEPOLY, Path.LINETO])
+    expected_path = Path([(1, 0), (1, -1), (2, -1),
+                          (np.nan, np.nan), (-1, -1), (-2, 1), (-1, 1),
+                          (0, -1), (0, -1), (0, 0)],
+                         [Path.MOVETO, Path.LINETO, Path.LINETO,
+                          Path.MOVETO, Path.LINETO, Path.LINETO, Path.LINETO,
+                          Path.LINETO, Path.LINETO, Path.STOP])
+
+    simplified_path = path.cleaned(simplify=True)
+    assert_array_equal(expected_path.vertices, simplified_path.vertices)
+    assert_array_equal(expected_path.codes, simplified_path.codes)

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -644,6 +644,9 @@ class PathSimplifier : protected EmbeddedQueue<9>
           m_after_moveto(false),
           m_clipped(false),
 
+          m_laststartx(0.0),
+          m_laststarty(0.0),
+
           // the x, y values from last iteration
           m_lastx(0.0),
           m_lasty(0.0),
@@ -754,6 +757,8 @@ class PathSimplifier : protected EmbeddedQueue<9>
                     _push(x, y);
                 }
                 m_after_moveto = true;
+                m_laststartx = *x;
+                m_laststarty = *y;
                 m_lastx = *x;
                 m_lasty = *y;
                 m_moveto = false;
@@ -767,6 +772,13 @@ class PathSimplifier : protected EmbeddedQueue<9>
                 continue;
             }
             m_after_moveto = false;
+
+            if(agg::is_close(cmd)) {
+                /* If we have to close the polygon, replace
+                   the vertex with the starting vertex */
+                *x = m_laststartx;
+                *y = m_laststarty;
+            }
 
             /* NOTE: We used to skip this very short segments, but if
                you have a lot of them cumulatively, you can miss
@@ -919,6 +931,7 @@ class PathSimplifier : protected EmbeddedQueue<9>
     bool m_moveto;
     bool m_after_moveto;
     bool m_clipped;
+    double m_laststartx, m_laststarty;
     double m_lastx, m_lasty;
 
     double m_origdx;

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -644,8 +644,8 @@ class PathSimplifier : protected EmbeddedQueue<9>
           m_after_moveto(false),
           m_clipped(false),
 
-          m_laststartx(0.0),
-          m_laststarty(0.0),
+          m_last_startx(0.0),
+          m_last_starty(0.0),
 
           // the x, y values from last iteration
           m_lastx(0.0),
@@ -757,8 +757,8 @@ class PathSimplifier : protected EmbeddedQueue<9>
                     _push(x, y);
                 }
                 m_after_moveto = true;
-                m_laststartx = *x;
-                m_laststarty = *y;
+                m_last_startx = *x;
+                m_last_starty = *y;
                 m_lastx = *x;
                 m_lasty = *y;
                 m_moveto = false;
@@ -776,8 +776,8 @@ class PathSimplifier : protected EmbeddedQueue<9>
             if(agg::is_close(cmd)) {
                 /* If we have to close the polygon, replace
                    the vertex with the starting vertex */
-                *x = m_laststartx;
-                *y = m_laststarty;
+                *x = m_last_startx;
+                *y = m_last_starty;
             }
 
             /* NOTE: We used to skip this very short segments, but if
@@ -931,7 +931,7 @@ class PathSimplifier : protected EmbeddedQueue<9>
     bool m_moveto;
     bool m_after_moveto;
     bool m_clipped;
-    double m_laststartx, m_laststarty;
+    double m_last_startx, m_last_starty;
     double m_lastx, m_lasty;
 
     double m_origdx;


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
closes #17914

`PathSimplifier` should ignore vertices corresponding to `Path.CLOSEPOLY`, and rather replace them with the most recent `Path.MOVETO` vertex.

### Code for reproducing the bug / Actual outcome

```
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.path import Path
from matplotlib.patches import PathPatch

p = Path([(0, 0), (1, 0), (1, 1), (np.nan, np.nan)],
         [Path.MOVETO, Path.LINETO, Path.LINETO, Path.CLOSEPOLY])

# Remove this to see expected output
p = p.cleaned(simplify=True)

fig, ax = plt.subplots()
patch = PathPatch(p, facecolor="none", edgecolor="blue")
ax.add_patch(patch)
ax.set_xlim(-1, 2)
ax.set_ylim(-1, 2)

plt.show()
```

#### Expected Outcome
The Path should be closed.

<img src="https://github.com/matplotlib/matplotlib/assets/138380708/93487b36-8cd5-4dfa-bef1-78f7ac30e50d" width="400" />

#### Actual Outcome

<img src="https://github.com/matplotlib/matplotlib/assets/138380708/c0d8848b-7fc4-4c4f-82fe-b7bb4510376b" width="400" />


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
