### PR TITLE
Fix CompositeGenericTransform.contains_branch_seperately

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -667,6 +667,13 @@ class TestBasicTransform:
 
         assert not self.stack1.contains_branch(self.tn1 + self.ta2)
 
+        blend = mtransforms.BlendedGenericTransform(self.tn2, self.stack2)
+        x, y = blend.contains_branch_seperately(self.stack2_subset)
+        stack_blend = self.tn3 + blend
+        sx, sy = stack_blend.contains_branch_seperately(self.stack2_subset)
+        assert x is sx is False
+        assert y is sy is True
+
     def test_affine_simplification(self):
         # tests that a transform stack only calls as much is absolutely
         # necessary "non-affine" allowing the best possible optimization with

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -1423,7 +1423,7 @@ class Transform(TransformNode):
                              'transforms with 2 output dimensions')
         # for a non-blended transform each separate dimension is the same, so
         # just return the appropriate shape.
-        return [self.contains_branch(other_transform)] * 2
+        return (self.contains_branch(other_transform), ) * 2
 
     def __sub__(self, other):
         """
@@ -2403,6 +2403,15 @@ class CompositeGenericTransform(Transform):
             yield left, right + self._b
         for left, right in self._b._iter_break_from_left_to_right():
             yield self._a + left, right
+
+    def contains_branch_seperately(self, other_transform):
+        # docstring inherited
+        if self.output_dims != 2:
+            raise ValueError('contains_branch_seperately only supports '
+                             'transforms with 2 output dimensions')
+        if self == other_transform:
+            return (True, True)
+        return self._b.contains_branch_seperately(other_transform)
 
     depth = property(lambda self: self._a.depth + self._b.depth)
     is_affine = property(lambda self: self._a.is_affine and self._b.is_affine)


### PR DESCRIPTION
## PR summary

Formerly, this fell back to the the super-class Transform implementation, which returned `Transform.contains_branch` for both dimensions. This doesn't make sense for blended transforms, which have their own implementation that checks each side. However, it _also_ doesn't make sense for composite transforms, because those may contain blended transforms themselves, so add a specific implementation for it.

Also fix type inconsistency for `Transform.contains_branch_seperately`.

This does fix #28383, though since it has to reach into transform internals to do so might make one a bit wary.

## PR checklist

- [x] "closes #28383" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines