### PR TITLE
MNT: Remove PolyQuadMesh deprecations

### DIFF
--- a/doc/api/next_api_changes/removals/28492-GML.rst
+++ b/doc/api/next_api_changes/removals/28492-GML.rst
@@ -1,0 +1,9 @@
+The ``.PolyQuadMesh`` class requires full 2D arrays of values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously, if a masked array was input, the list of polygons within the collection
+would shrink to the size of valid polygons and users were required to keep track of
+which polygons were drawn and call ``set_array()`` with the smaller "compressed"
+array size. Passing the "compressed" and flattened array values will no longer
+work and the full 2D array of values (including the mask) should be passed
+to `.PolyQuadMesh.set_array`.

--- a/doc/api/next_api_changes/removals/28492-GML.rst
+++ b/doc/api/next_api_changes/removals/28492-GML.rst
@@ -1,4 +1,4 @@
-The ``.PolyQuadMesh`` class requires full 2D arrays of values
+The ``PolyQuadMesh`` class requires full 2D arrays of values
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Previously, if a masked array was input, the list of polygons within the collection

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -965,11 +965,6 @@ def test_polyquadmesh_masked_vertices_array():
     # Poly version should have the same facecolors as the end of the quadmesh
     assert_array_equal(quadmesh_fc, polymesh.get_facecolor())
 
-    # Setting array with 1D compressed values is deprecated
-    with pytest.warns(mpl.MatplotlibDeprecationWarning,
-                      match="Setting a PolyQuadMesh"):
-        polymesh.set_array(np.ones(5))
-
     # We should also be able to call set_array with a new mask and get
     # updated polys
     # Remove mask, should add all polys back


### PR DESCRIPTION
## PR summary

The mask is no longer compressed and full 2D arrays are used for the PolyQuadMesh objects. This removes the deprecation path that began in v3.8.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
