### PR TITLE
Don't fail if we can't query system fonts on macOS

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -266,8 +266,11 @@ def _get_fontconfig_fonts():
 @lru_cache
 def _get_macos_fonts():
     """Cache and list the font paths known to ``system_profiler SPFontsDataType``."""
-    d, = plistlib.loads(
-        subprocess.check_output(["system_profiler", "-xml", "SPFontsDataType"]))
+    try:
+        d, = plistlib.loads(
+            subprocess.check_output(["system_profiler", "-xml", "SPFontsDataType"]))
+    except (OSError, subprocess.CalledProcessError, plistlib.InvalidFileException):
+        return []
     return [Path(entry["path"]) for entry in d["_items"]]
 
 


### PR DESCRIPTION

## PR summary
The query can fail in some environments where system_profiler is not available on PATH, but we don't want it to just crash the entire thing.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
