### PR TITLE
ConciseDateFormatter's offset string is correct on an inverted axis

### DIFF
--- a/doc/api/next_api_changes/behavior/28501-OV.rst
+++ b/doc/api/next_api_changes/behavior/28501-OV.rst
@@ -1,0 +1,5 @@
+The offset string associated with ConciseDateFormatter will now invert when the axis is inverted
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, when the axis was inverted, the offset string associated with ConciseDateFormatter would not change,
+so the offset string indicated the axis was oriented in the wrong direction. Now, when the axis is inverted, the offset
+string is oriented correctly.

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -797,7 +797,7 @@ class ConciseDateFormatter(ticker.Formatter):
         if show_offset:
             # set the offset string:
             if (self._locator.axis and
-                    self._locator.axis.__name__ == ('xaxis' or 'yaxis')
+                    self._locator.axis.__name__ in ('xaxis', 'yaxis')
                     and self._locator.axis.get_inverted()):
                 self.offset_string = tickdatetime[0].strftime(offsetfmts[level])
             else:

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -796,7 +796,7 @@ class ConciseDateFormatter(ticker.Formatter):
 
         if show_offset:
             # set the offset string:
-            if self._locator.axis.get_inverted():
+            if self._locator.axis and self._locator.axis.__name__ == ('xaxis' or 'yaxis') and self._locator.axis.get_inverted():
                 self.offset_string = tickdatetime[0].strftime(offsetfmts[level])
             else:
                 self.offset_string = tickdatetime[-1].strftime(offsetfmts[level])

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -796,7 +796,10 @@ class ConciseDateFormatter(ticker.Formatter):
 
         if show_offset:
             # set the offset string:
-            self.offset_string = tickdatetime[-1].strftime(offsetfmts[level])
+            if self._locator.axis.get_inverted():
+                self.offset_string = tickdatetime[0].strftime(offsetfmts[level])
+            else:
+                self.offset_string = tickdatetime[-1].strftime(offsetfmts[level])
             if self._usetex:
                 self.offset_string = _wrap_in_tex(self.offset_string)
         else:

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -796,7 +796,9 @@ class ConciseDateFormatter(ticker.Formatter):
 
         if show_offset:
             # set the offset string:
-            if self._locator.axis and self._locator.axis.__name__ == ('xaxis' or 'yaxis') and self._locator.axis.get_inverted():
+            if (self._locator.axis and
+                    self._locator.axis.__name__ == ('xaxis' or 'yaxis')
+                    and self._locator.axis.get_inverted()):
                 self.offset_string = tickdatetime[0].strftime(offsetfmts[level])
             else:
                 self.offset_string = tickdatetime[-1].strftime(offsetfmts[level])

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -636,6 +636,23 @@ def test_concise_formatter_show_offset(t_delta, expected):
     assert formatter.get_offset() == expected
 
 
+def test_concise_formatter_show_offset_inverted():
+    # Test for github issue #28481
+    d1 = datetime.datetime(1997, 1, 1)
+    d2 = d1 + datetime.timedelta(days=60)
+
+    fig, ax = plt.subplots()
+    locator = mdates.AutoDateLocator()
+    formatter = mdates.ConciseDateFormatter(locator)
+    ax.xaxis.set_major_locator(locator)
+    ax.xaxis.set_major_formatter(formatter)
+    ax.invert_xaxis()
+
+    ax.plot([d1, d2], [0, 0])
+    fig.canvas.draw()
+    assert formatter.get_offset() == '1997-Jan'
+
+
 def test_concise_converter_stays():
     # This test demonstrates problems introduced by gh-23417 (reverted in gh-25278)
     # In particular, downstream libraries like Pandas had their designated converters


### PR DESCRIPTION
## PR summary
Fixes a bug with ConciseDateFormatter's offset string where the proper label is not shown if the axis is inverted. Closes https://github.com/matplotlib/matplotlib/issues/28481.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines