### PR TITLE
DOC: Fix version switcher for stable docs

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "3.9 (stable)",
-        "version": "stable",
+        "version": "3.9.1",
         "url": "https://matplotlib.org/stable/",
         "preferred": true
     },


### PR DESCRIPTION
## PR summary

This should stop the banner from showing up on stable.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines