### PR TITLE
[TYP] Fix overload of `pyplot.subplots`

### DIFF
--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -94,34 +94,6 @@ class FigureBase(Artist):
     @overload
     def subplots(
         self,
-        nrows: Literal[1] = ...,
-        ncols: Literal[1] = ...,
-        *,
-        sharex: bool | Literal["none", "all", "row", "col"] = ...,
-        sharey: bool | Literal["none", "all", "row", "col"] = ...,
-        squeeze: Literal[True] = ...,
-        width_ratios: Sequence[float] | None = ...,
-        height_ratios: Sequence[float] | None = ...,
-        subplot_kw: dict[str, Any] | None = ...,
-        gridspec_kw: dict[str, Any] | None = ...,
-    ) -> Axes: ...
-    @overload
-    def subplots(
-        self,
-        nrows: int = ...,
-        ncols: int = ...,
-        *,
-        sharex: bool | Literal["none", "all", "row", "col"] = ...,
-        sharey: bool | Literal["none", "all", "row", "col"] = ...,
-        squeeze: Literal[True],
-        width_ratios: Sequence[float] | None = ...,
-        height_ratios: Sequence[float] | None = ...,
-        subplot_kw: dict[str, Any] | None = ...,
-        gridspec_kw: dict[str, Any] | None = ...,
-    ) -> np.ndarray: ...  # TODO numpy/numpy#24738
-    @overload
-    def subplots(
-        self,
         nrows: int = ...,
         ncols: int = ...,
         *,
@@ -146,7 +118,7 @@ class FigureBase(Artist):
         height_ratios: Sequence[float] | None = ...,
         subplot_kw: dict[str, Any] | None = ...,
         gridspec_kw: dict[str, Any] | None = ...,
-    ) -> Axes | np.ndarray: ...
+    ) -> Any: ...
     def delaxes(self, ax: Axes) -> None: ...
     def clear(self, keep_observers: bool = ...) -> None: ...
     def clf(self, keep_observers: bool = ...) -> None: ...

--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -113,6 +113,20 @@ class FigureBase(Artist):
         *,
         sharex: bool | Literal["none", "all", "row", "col"] = ...,
         sharey: bool | Literal["none", "all", "row", "col"] = ...,
+        squeeze: Literal[True],
+        width_ratios: Sequence[float] | None = ...,
+        height_ratios: Sequence[float] | None = ...,
+        subplot_kw: dict[str, Any] | None = ...,
+        gridspec_kw: dict[str, Any] | None = ...,
+    ) -> np.ndarray: ...  # TODO numpy/numpy#24738
+    @overload
+    def subplots(
+        self,
+        nrows: int = ...,
+        ncols: int = ...,
+        *,
+        sharex: bool | Literal["none", "all", "row", "col"] = ...,
+        sharey: bool | Literal["none", "all", "row", "col"] = ...,
         squeeze: Literal[False],
         width_ratios: Sequence[float] | None = ...,
         height_ratios: Sequence[float] | None = ...,

--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -94,6 +94,20 @@ class FigureBase(Artist):
     @overload
     def subplots(
         self,
+        nrows: Literal[1] = ...,
+        ncols: Literal[1] = ...,
+        *,
+        sharex: bool | Literal["none", "all", "row", "col"] = ...,
+        sharey: bool | Literal["none", "all", "row", "col"] = ...,
+        squeeze: Literal[True] = ...,
+        width_ratios: Sequence[float] | None = ...,
+        height_ratios: Sequence[float] | None = ...,
+        subplot_kw: dict[str, Any] | None = ...,
+        gridspec_kw: dict[str, Any] | None = ...,
+    ) -> Axes: ...
+    @overload
+    def subplots(
+        self,
         nrows: int = ...,
         ncols: int = ...,
         *,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1564,18 +1564,18 @@ def subplot(*args, **kwargs) -> Axes:
 
 @overload
 def subplots(
-    nrows: int = ...,
-    ncols: int = ...,
+    nrows: Literal[1] = ...,
+    ncols: Literal[1] = ...,
     *,
     sharex: bool | Literal["none", "all", "row", "col"] = ...,
     sharey: bool | Literal["none", "all", "row", "col"] = ...,
-    squeeze: Literal[True],
+    squeeze: Literal[True] = ...,
     width_ratios: Sequence[float] | None = ...,
     height_ratios: Sequence[float] | None = ...,
     subplot_kw: dict[str, Any] | None = ...,
     gridspec_kw: dict[str, Any] | None = ...,
     **fig_kw
-) -> tuple[Figure, Any]:
+) -> tuple[Figure, Axes]:
     ...
 
 
@@ -1593,6 +1593,23 @@ def subplots(
     gridspec_kw: dict[str, Any] | None = ...,
     **fig_kw
 ) -> tuple[Figure, np.ndarray]:  # TODO numpy/numpy#24738
+    ...
+
+
+@overload
+def subplots(
+    nrows: int = ...,
+    ncols: int = ...,
+    *,
+    sharex: bool | Literal["none", "all", "row", "col"] = ...,
+    sharey: bool | Literal["none", "all", "row", "col"] = ...,
+    squeeze: bool = ...,
+    width_ratios: Sequence[float] | None = ...,
+    height_ratios: Sequence[float] | None = ...,
+    subplot_kw: dict[str, Any] | None = ...,
+    gridspec_kw: dict[str, Any] | None = ...,
+    **fig_kw
+) -> tuple[Figure, Any]:
     ...
 
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1564,40 +1564,6 @@ def subplot(*args, **kwargs) -> Axes:
 
 @overload
 def subplots(
-    nrows: Literal[1] = ...,
-    ncols: Literal[1] = ...,
-    *,
-    sharex: bool | Literal["none", "all", "row", "col"] = ...,
-    sharey: bool | Literal["none", "all", "row", "col"] = ...,
-    squeeze: Literal[True] = ...,
-    width_ratios: Sequence[float] | None = ...,
-    height_ratios: Sequence[float] | None = ...,
-    subplot_kw: dict[str, Any] | None = ...,
-    gridspec_kw: dict[str, Any] | None = ...,
-    **fig_kw
-) -> tuple[Figure, Axes]:
-    ...
-
-
-@overload
-def subplots(
-    nrows: int = ...,
-    ncols: int = ...,
-    *,
-    sharex: bool | Literal["none", "all", "row", "col"] = ...,
-    sharey: bool | Literal["none", "all", "row", "col"] = ...,
-    squeeze: Literal[True] = ...,
-    width_ratios: Sequence[float] | None = ...,
-    height_ratios: Sequence[float] | None = ...,
-    subplot_kw: dict[str, Any] | None = ...,
-    gridspec_kw: dict[str, Any] | None = ...,
-    **fig_kw
-) -> tuple[Figure, np.ndarray]:  # TODO numpy/numpy#24738
-    ...
-
-
-@overload
-def subplots(
     nrows: int = ...,
     ncols: int = ...,
     *,
@@ -1610,23 +1576,6 @@ def subplots(
     gridspec_kw: dict[str, Any] | None = ...,
     **fig_kw
 ) -> tuple[Figure, np.ndarray]:  # TODO numpy/numpy#24738
-    ...
-
-
-@overload
-def subplots(
-    nrows: int = ...,
-    ncols: int = ...,
-    *,
-    sharex: bool | Literal["none", "all", "row", "col"] = ...,
-    sharey: bool | Literal["none", "all", "row", "col"] = ...,
-    squeeze: bool = ...,
-    width_ratios: Sequence[float] | None = ...,
-    height_ratios: Sequence[float] | None = ...,
-    subplot_kw: dict[str, Any] | None = ...,
-    gridspec_kw: dict[str, Any] | None = ...,
-    **fig_kw
-) -> tuple[Figure, Axes | np.ndarray]:
     ...
 
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1586,6 +1586,23 @@ def subplots(
     *,
     sharex: bool | Literal["none", "all", "row", "col"] = ...,
     sharey: bool | Literal["none", "all", "row", "col"] = ...,
+    squeeze: Literal[True] = ...,
+    width_ratios: Sequence[float] | None = ...,
+    height_ratios: Sequence[float] | None = ...,
+    subplot_kw: dict[str, Any] | None = ...,
+    gridspec_kw: dict[str, Any] | None = ...,
+    **fig_kw
+) -> tuple[Figure, np.ndarray]:  # TODO numpy/numpy#24738
+    ...
+
+
+@overload
+def subplots(
+    nrows: int = ...,
+    ncols: int = ...,
+    *,
+    sharex: bool | Literal["none", "all", "row", "col"] = ...,
+    sharey: bool | Literal["none", "all", "row", "col"] = ...,
     squeeze: Literal[False],
     width_ratios: Sequence[float] | None = ...,
     height_ratios: Sequence[float] | None = ...,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1569,6 +1569,23 @@ def subplots(
     *,
     sharex: bool | Literal["none", "all", "row", "col"] = ...,
     sharey: bool | Literal["none", "all", "row", "col"] = ...,
+    squeeze: Literal[True],
+    width_ratios: Sequence[float] | None = ...,
+    height_ratios: Sequence[float] | None = ...,
+    subplot_kw: dict[str, Any] | None = ...,
+    gridspec_kw: dict[str, Any] | None = ...,
+    **fig_kw
+) -> tuple[Figure, Any]:
+    ...
+
+
+@overload
+def subplots(
+    nrows: int = ...,
+    ncols: int = ...,
+    *,
+    sharex: bool | Literal["none", "all", "row", "col"] = ...,
+    sharey: bool | Literal["none", "all", "row", "col"] = ...,
     squeeze: Literal[False],
     width_ratios: Sequence[float] | None = ...,
     height_ratios: Sequence[float] | None = ...,


### PR DESCRIPTION
## PR summary

Fixes https://github.com/matplotlib/matplotlib/pull/27001#issuecomment-2211785864

My solution is to have 3 possible cases:

1. `squeeze=True`, `nrows=1`, `ncols=1`: `Axes`
2. `squeeze=True`: `np.ndarray`
3. `squeeze=False`: `np.ndarray`

1 and 3 already existed. 2 is _hopefully_ treated as a fallback by mypy for when either `nrows` or `ncols` is not 1. All of my testing with `reveal_type` works as expected, but I would love suggestions for how to formally test this in CI so it doesn't happen again.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines