### PR TITLE
[BLD] Fix WSL build warning

### DIFF
--- a/src/_image_resample.h
+++ b/src/_image_resample.h
@@ -500,7 +500,7 @@ typedef enum {
 
 // T is rgba if and only if it has an T::r field.
 template<typename T, typename = void> struct is_grayscale : std::true_type {};
-template<typename T> struct is_grayscale<T, decltype(T::r, void())> : std::false_type {};
+template<typename T> struct is_grayscale<T, std::void_t<decltype(T::r)>> : std::false_type {};
 
 
 template<typename color_type>


### PR DESCRIPTION
## PR summary
A fresh build off the main branch was raising the following warning on WSL. This fixes that warning while keeping the behavior, and no warnings are raised during build now.

```
  [87/101] Compiling C++ object src/_image.cpython-312-x86_64-linux-gnu.so.p/_image_wrapper.cpp.o
  In file included from ../../src/_image_wrapper.cpp:4:
  ../../src/_image_resample.h: In instantiation of ‘struct is_grayscale<agg::rgba64, void>’:
  ../../src/_image_resample.h:509:11:   required from ‘struct type_mapping<agg::rgba64>’
  ../../src/_image_resample.h:708:11:   required from ‘void resample(const void*, int, int, void*, int, int, resample_params_t&) [with color_type = agg::rgba64]’
  ../../src/_image_wrapper.cpp:190:17:   required from here
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
    503 | template<typename T> struct is_grayscale<T, decltype(T::r, void())> : std::false_type {};
        |                                                         ~^~~~~~~~
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
  ../../src/_image_resample.h: In instantiation of ‘struct is_grayscale<agg::rgba32, void>’:
  ../../src/_image_resample.h:509:11:   required from ‘struct type_mapping<agg::rgba32>’
  ../../src/_image_resample.h:708:11:   required from ‘void resample(const void*, int, int, void*, int, int, resample_params_t&) [with color_type = agg::rgba32]’
  ../../src/_image_wrapper.cpp:190:17:   required from here
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
  ../../src/_image_resample.h: In instantiation of ‘struct is_grayscale<agg::rgba16, void>’:
  ../../src/_image_resample.h:509:11:   required from ‘struct type_mapping<agg::rgba16>’
  ../../src/_image_resample.h:708:11:   required from ‘void resample(const void*, int, int, void*, int, int, resample_params_t&) [with color_type = agg::rgba16]’
  ../../src/_image_wrapper.cpp:190:17:   required from here
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
  ../../src/_image_resample.h: In instantiation of ‘struct is_grayscale<agg::rgba8T<agg::linear>, void>’:
  ../../src/_image_resample.h:509:11:   required from ‘struct type_mapping<agg::rgba8T<agg::linear> >’
  ../../src/_image_resample.h:708:11:   required from ‘void resample(const void*, int, int, void*, int, int, resample_params_t&) [with color_type = agg::rgba8T<agg::linear>]’
  ../../src/_image_wrapper.cpp:190:17:   required from here
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
  ../../src/_image_resample.h:503:58: warning: left operand of comma operator has no effect [-Wunused-value]
```

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
