### PR TITLE
[svg] Add rcParam["svg.id"] to add a top-level id attribute to <svg>

### DIFF
--- a/doc/users/next_whats_new/svg_id_rc.rst
+++ b/doc/users/next_whats_new/svg_id_rc.rst
@@ -1,7 +1,8 @@
 ``svg.id`` rcParam
 ~~~~~~~~~~~~~~~~~~
-The value of this new rcParam controls whether the top-level ``<svg>`` tag
-contains an ``id`` attribute and what its value is. When set to ``None`` (the
+:rc:`svg.id` lets you insert an ``id`` attibute into the top-level ``<svg>`` tag.
+
+e.g. ``rcParams["svg.id"] = "svg1"`` results in
 default), no ``id`` tag is included
 
 .. code-block:: XML

--- a/doc/users/next_whats_new/svg_id_rc.rst
+++ b/doc/users/next_whats_new/svg_id_rc.rst
@@ -1,6 +1,6 @@
 ``svg.id`` rcParam
 ~~~~~~~~~~~~~~~~~~
-:rc:`svg.id` lets you insert an ``id`` attibute into the top-level ``<svg>`` tag.
+:rc:`svg.id` lets you insert an ``id`` attribute into the top-level ``<svg>`` tag.
 
 e.g. ``rcParams["svg.id"] = "svg1"`` results in
 default), no ``id`` tag is included

--- a/doc/users/next_whats_new/svg_id_rc.rst
+++ b/doc/users/next_whats_new/svg_id_rc.rst
@@ -1,0 +1,31 @@
+``svg.id`` rcParam
+~~~~~~~~~~~~~~~~~~
+The value of this new rcParam controls whether the top-level ``<svg>`` tag
+contains an ``id`` attribute and what its value is. When set to ``None`` (the
+default), no ``id`` tag is included
+
+.. code-block:: XML
+
+    <svg
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        width="50pt" height="50pt"
+        viewBox="0 0 50 50"
+        xmlns="http://www.w3.org/2000/svg"
+        version="1.1"
+        id="svg1"
+    ></svg>
+
+This is useful if you would like to link the entire matplotlib SVG file within
+another SVG file with the ``<use>`` tag.
+
+.. code-block:: XML
+
+    <svg>
+    <use
+        width="50" height="50"
+        xlink:href="mpl.svg#svg1" id="use1"
+        x="0" y="0"
+    /></svg>
+
+Where the ``#svg1`` indicator will now refer to the top level ``<svg>`` tag, and
+will hence result in the inclusion of the entire file.

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -322,6 +322,7 @@ class RendererSVG(RendererBase):
             viewBox=f'0 0 {str_width} {str_height}',
             xmlns="http://www.w3.org/2000/svg",
             version="1.1",
+            id=mpl.rcParams['svg.id'],
             attrib={'xmlns:xlink': "http://www.w3.org/1999/xlink"})
         self._write_metadata(metadata)
         self._write_default_style()

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -735,6 +735,8 @@
                          #     None: Assume fonts are installed on the
                          #           machine where the SVG will be viewed.
 #svg.hashsalt: None      # If not None, use this string as hash salt instead of uuid4
+#svg.id: None            # If not None, use this string as the value for the `id`
+                         # attribute in the top <svg> tag
 
 ### pgf parameter
 ## See https://matplotlib.org/stable/tutorials/text/pgf.html for more information.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1311,6 +1311,7 @@ _validators = {
     "svg.image_inline": validate_bool,
     "svg.fonttype": ["none", "path"],  # save text as text ("none") or "paths"
     "svg.hashsalt": validate_string_or_None,
+    "svg.id": validate_string_or_None,
 
     # set this when you want to generate hardcopy docstring
     "docstring.hardcopy": validate_bool,

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -669,3 +669,34 @@ def test_annotationbbox_gid():
 
     expected = '<g id="a test for issue 20044">'
     assert expected in buf
+
+
+def test_svgid():
+    """Test that `svg.id` rcparam appears in output svg if not None."""
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [3, 2, 1])
+    fig.canvas.draw()
+
+    # Default: svg.id = None
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg')
+        buf = fd.getvalue().decode()
+
+    tree = xml.etree.ElementTree.fromstring(buf)
+
+    assert plt.rcParams['svg.id'] is None
+    assert not tree.findall('.[@id]')
+
+    # String: svg.id = str
+    svg_id = 'a test for issue 28535'
+    plt.rc('svg', id=svg_id)
+
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg')
+        buf = fd.getvalue().decode()
+
+    tree = xml.etree.ElementTree.fromstring(buf)
+
+    assert plt.rcParams['svg.id'] == svg_id
+    assert tree.findall(f'.[@id="{svg_id}"]')


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Exported SVGs now contain a fixed `id="svg1"` attribute in the top level `<svg>` tag.

```svg
<svg 
    xmlns:xlink="http://www.w3.org/1999/xlink"
    width="50pt" height="50pt"
    viewBox="0 0 50 50"
    xmlns="http://www.w3.org/2000/svg"
    version="1.1"
    id="svg1"
>
```

This is useful if you would like to link the entire matplotlib SVG file within another SVG file with the `<use>` tag.

```svg
<use
    width="50" height="50"
    xlink:href="mpl.svg#svg1" id="use1"
    x="0" y="0"
/>
```

Where the `#svg1` indicator will now refer to the top level `<svg>` tag, and will hence result in the inclusion of the entire file.

Closes issue #28535


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
