### PR TITLE
MNT: be more careful about disk I/O failures when writing font cache

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -965,11 +965,11 @@ def json_dump(data, filename):
     This function temporarily locks the output file to prevent multiple
     processes from overwriting one another's output.
     """
-    with cbook._lock_path(filename), open(filename, 'w') as fh:
-        try:
+    try:
+        with cbook._lock_path(filename), open(filename, 'w') as fh:
             json.dump(data, fh, cls=_JSONEncoder, indent=2)
-        except OSError as e:
-            _log.warning('Could not save font_manager cache %s', e)
+    except OSError as e:
+        _log.warning('Could not save font_manager cache %s', e)
 
 
 def json_load(filename):

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -16,7 +16,7 @@ from matplotlib.font_manager import (
     json_dump, json_load, get_font, is_opentype_cff_font,
     MSUserFontDirectories, _get_fontconfig_fonts, ttfFontProperty)
 from matplotlib import cbook, ft2font, pyplot as plt, rc_context, figure as mfigure
-from matplotlib.testing import subprocess_run_helper
+from matplotlib.testing import subprocess_run_helper, subprocess_run_for_testing
 
 
 has_fclist = shutil.which('fc-list') is not None
@@ -285,6 +285,28 @@ def test_fontcache_thread_safe():
     pytest.importorskip('threading')
 
     subprocess_run_helper(_test_threading, timeout=10)
+
+
+def test_lockfilefailure(tmp_path):
+    # The logic here:
+    # 1. get a temp directory from pytest
+    # 2. import matplotlib which makes sure it exists
+    # 3. get the cache dir (where we check it is writable)
+    # 4. make it not writable
+    # 5. try to write into it via font manager
+    proc = subprocess_run_for_testing(
+        [
+            sys.executable,
+            "-c",
+            "import matplotlib;"
+            "import os;"
+            "p = matplotlib.get_cachedir();"
+            "os.chmod(p, 0o555);"
+            "import matplotlib.font_manager;"
+        ],
+        env={**os.environ, 'MPLCONFIGDIR': str(tmp_path)},
+        check=True
+    )
 
 
 def test_fontentry_dataclass():


### PR DESCRIPTION
The locker works by writing a file to disk.  This can also fail so make sure we can still import in that case.

Closes #28538

The only way I could think to test this is very synthetic and requires messing with the file system at in between importing the top level module and font_manager.  Still not sure how the OP drove their system to expose this issue.   I think it has not come up before because if the directory is not writable we detect that and bail to asking for a temporary directory to work with.



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [-] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [-] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [-] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

