### PR TITLE
DOC: Standardize example titles

### DIFF
--- a/galleries/examples/animation/pause_resume.py
+++ b/galleries/examples/animation/pause_resume.py
@@ -1,6 +1,6 @@
 """
 =================================
-Pausing and Resuming an Animation
+Pausing and resuming an animation
 =================================
 
 This example showcases:

--- a/galleries/examples/animation/unchained.py
+++ b/galleries/examples/animation/unchained.py
@@ -1,7 +1,7 @@
 """
-========================
-MATPLOTLIB **UNCHAINED**
-========================
+====================
+Matplotlib unchained
+====================
 
 Comparative path demonstration of frequency from a fake signal of a pulsar
 (mostly known because of the cover for Joy Division's Unknown Pleasures).

--- a/galleries/examples/axes_grid1/scatter_hist_locatable_axes.py
+++ b/galleries/examples/axes_grid1/scatter_hist_locatable_axes.py
@@ -1,7 +1,7 @@
 """
-==================================
-Scatter Histogram (Locatable Axes)
-==================================
+====================================================
+Align histogram to scatter plot using locatable Axes
+====================================================
 
 Show the marginal distributions of a scatter plot as histograms at the sides of
 the plot.

--- a/galleries/examples/axisartist/simple_axis_pad.py
+++ b/galleries/examples/axisartist/simple_axis_pad.py
@@ -1,6 +1,6 @@
 """
 ===============
-Simple Axis Pad
+Simple axis pad
 ===============
 
 """

--- a/galleries/examples/event_handling/close_event.py
+++ b/galleries/examples/event_handling/close_event.py
@@ -1,6 +1,6 @@
 """
 ===========
-Close Event
+Close event
 ===========
 
 Example to show connecting events that occur when the figure closes.

--- a/galleries/examples/event_handling/looking_glass.py
+++ b/galleries/examples/event_handling/looking_glass.py
@@ -1,6 +1,6 @@
 """
 =============
-Looking Glass
+Looking glass
 =============
 
 Example using mouse events to simulate a looking glass for inspecting data.

--- a/galleries/examples/event_handling/poly_editor.py
+++ b/galleries/examples/event_handling/poly_editor.py
@@ -1,7 +1,7 @@
 """
-===========
-Poly Editor
-===========
+==============
+Polygon editor
+==============
 
 This is an example to show how to build cross-GUI applications using
 Matplotlib event handling to interact with objects on the canvas.

--- a/galleries/examples/event_handling/zoom_window.py
+++ b/galleries/examples/event_handling/zoom_window.py
@@ -1,7 +1,7 @@
 """
-===========
-Zoom Window
-===========
+========================
+Zoom modifies other Axes
+========================
 
 This example shows how to connect events in one window, for example, a mouse
 press, to another figure window.

--- a/galleries/examples/images_contours_and_fields/barb_demo.py
+++ b/galleries/examples/images_contours_and_fields/barb_demo.py
@@ -1,6 +1,6 @@
 """
 ==========
-Wind Barbs
+Wind barbs
 ==========
 
 Demonstration of wind barb plots.

--- a/galleries/examples/images_contours_and_fields/colormap_interactive_adjustment.py
+++ b/galleries/examples/images_contours_and_fields/colormap_interactive_adjustment.py
@@ -1,6 +1,6 @@
 """
 ========================================
-Interactive Adjustment of Colormap Range
+Interactive adjustment of colormap range
 ========================================
 
 Demonstration of how a colorbar can be used to interactively adjust the

--- a/galleries/examples/images_contours_and_fields/contour_corner_mask.py
+++ b/galleries/examples/images_contours_and_fields/contour_corner_mask.py
@@ -1,6 +1,6 @@
 """
 ===================
-Contour Corner Mask
+Contour corner mask
 ===================
 
 Illustrate the difference between ``corner_mask=False`` and

--- a/galleries/examples/images_contours_and_fields/contour_image.py
+++ b/galleries/examples/images_contours_and_fields/contour_image.py
@@ -1,6 +1,6 @@
 """
 =============
-Contour Image
+Contour image
 =============
 
 Test combinations of contouring, filled contouring, and image plotting.

--- a/galleries/examples/images_contours_and_fields/contourf_hatching.py
+++ b/galleries/examples/images_contours_and_fields/contourf_hatching.py
@@ -1,6 +1,6 @@
 """
 =================
-Contourf Hatching
+Contourf hatching
 =================
 
 Demo filled contour plots with hatched patterns.

--- a/galleries/examples/images_contours_and_fields/image_masked.py
+++ b/galleries/examples/images_contours_and_fields/image_masked.py
@@ -1,7 +1,7 @@
 """
-============
-Image Masked
-============
+========================
+Image with masked values
+========================
 
 imshow with masked array input and out-of-range colors.
 

--- a/galleries/examples/images_contours_and_fields/layer_images.py
+++ b/galleries/examples/images_contours_and_fields/layer_images.py
@@ -1,7 +1,7 @@
 """
-============
-Layer Images
-============
+================================
+Layer images with alpha blending
+================================
 
 Layer images above one another using alpha blending
 """

--- a/galleries/examples/lines_bars_and_markers/bar_label_demo.py
+++ b/galleries/examples/lines_bars_and_markers/bar_label_demo.py
@@ -1,7 +1,7 @@
 """
-==============
-Bar Label Demo
-==============
+=====================
+Bar chart with labels
+=====================
 
 This example shows how to use the `~.Axes.bar_label` helper function
 to create bar chart labels.

--- a/galleries/examples/lines_bars_and_markers/fill_between_alpha.py
+++ b/galleries/examples/lines_bars_and_markers/fill_between_alpha.py
@@ -1,6 +1,7 @@
 """
-Fill Between and Alpha
-======================
+==============================
+Fill Between with transparency
+==============================
 
 The `~matplotlib.axes.Axes.fill_between` function generates a shaded
 region between a min and max boundary that is useful for illustrating ranges.

--- a/galleries/examples/lines_bars_and_markers/scatter_masked.py
+++ b/galleries/examples/lines_bars_and_markers/scatter_masked.py
@@ -1,7 +1,7 @@
 """
-==============
-Scatter Masked
-==============
+==========================
+Scatter with masked values
+==========================
 
 Mask some data points and add a line demarking
 masked regions.

--- a/galleries/examples/lines_bars_and_markers/simple_plot.py
+++ b/galleries/examples/lines_bars_and_markers/simple_plot.py
@@ -1,9 +1,9 @@
 """
-===========
-Simple Plot
-===========
+=========
+Line plot
+=========
 
-Create a simple plot.
+Create a basic line plot.
 """
 
 import matplotlib.pyplot as plt

--- a/galleries/examples/lines_bars_and_markers/stem_plot.py
+++ b/galleries/examples/lines_bars_and_markers/stem_plot.py
@@ -1,6 +1,6 @@
 """
 =========
-Stem Plot
+Stem plot
 =========
 
 `~.pyplot.stem` plots vertical lines from a baseline to the y-coordinate and

--- a/galleries/examples/misc/image_thumbnail_sgskip.py
+++ b/galleries/examples/misc/image_thumbnail_sgskip.py
@@ -1,6 +1,6 @@
 """
 ===============
-Image Thumbnail
+Image thumbnail
 ===============
 
 You can use Matplotlib to generate thumbnails from existing images.

--- a/galleries/examples/misc/print_stdout_sgskip.py
+++ b/galleries/examples/misc/print_stdout_sgskip.py
@@ -1,7 +1,7 @@
 """
-============
-Print Stdout
-============
+=====================
+Print image to stdout
+=====================
 
 print png to standard out
 

--- a/galleries/examples/misc/svg_filter_line.py
+++ b/galleries/examples/misc/svg_filter_line.py
@@ -1,7 +1,7 @@
 """
-===============
-SVG Filter Line
-===============
+==========================
+Apply SVG filter to a line
+==========================
 
 Demonstrate SVG filtering effects which might be used with Matplotlib.
 

--- a/galleries/examples/scales/aspect_loglog.py
+++ b/galleries/examples/scales/aspect_loglog.py
@@ -1,6 +1,6 @@
 """
 =============
-Loglog Aspect
+Loglog aspect
 =============
 
 """

--- a/galleries/examples/shapes_and_collections/quad_bezier.py
+++ b/galleries/examples/shapes_and_collections/quad_bezier.py
@@ -1,6 +1,6 @@
 """
 ============
-Bezier Curve
+Bezier curve
 ============
 
 This example showcases the `~.patches.PathPatch` object to create a Bezier

--- a/galleries/examples/subplots_axes_and_figures/align_labels_demo.py
+++ b/galleries/examples/subplots_axes_and_figures/align_labels_demo.py
@@ -1,7 +1,7 @@
 """
-==========================
-Aligning Labels and Titles
-==========================
+=======================
+Align labels and titles
+=======================
 
 Aligning xlabel, ylabel, and title using `.Figure.align_xlabels`,
 `.Figure.align_ylabels`, and `.Figure.align_titles`.

--- a/galleries/examples/subplots_axes_and_figures/axes_props.py
+++ b/galleries/examples/subplots_axes_and_figures/axes_props.py
@@ -1,7 +1,7 @@
 """
-==========
-Axes Props
-==========
+===============
+Axes properties
+===============
 
 You can control the axis tick and grid properties
 """

--- a/galleries/examples/subplots_axes_and_figures/axes_zoom_effect.py
+++ b/galleries/examples/subplots_axes_and_figures/axes_zoom_effect.py
@@ -1,6 +1,6 @@
 """
 ================
-Axes Zoom Effect
+Axes zoom effect
 ================
 
 """

--- a/galleries/examples/subplots_axes_and_figures/axis_labels_demo.py
+++ b/galleries/examples/subplots_axes_and_figures/axis_labels_demo.py
@@ -1,6 +1,6 @@
 """
 ===================
-Axis Label Position
+Axis label position
 ===================
 
 Choose axis label position when calling `~.Axes.set_xlabel` and

--- a/galleries/examples/subplots_axes_and_figures/broken_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/broken_axis.py
@@ -1,6 +1,6 @@
 """
 ===========
-Broken Axis
+Broken axis
 ===========
 
 Broken axis example, where the y-axis will have a portion cut out.

--- a/galleries/examples/text_labels_and_annotations/annotate_transform.py
+++ b/galleries/examples/text_labels_and_annotations/annotate_transform.py
@@ -1,6 +1,6 @@
 """
 ==================
-Annotate Transform
+Annotate transform
 ==================
 
 This example shows how to use different coordinate systems for annotations.

--- a/galleries/examples/text_labels_and_annotations/annotation_demo.py
+++ b/galleries/examples/text_labels_and_annotations/annotation_demo.py
@@ -1,7 +1,7 @@
 """
-================
-Annotating Plots
-================
+==============
+Annotate plots
+==============
 
 The following examples show ways to annotate plots in Matplotlib.
 This includes highlighting specific points of interest and using various

--- a/galleries/examples/text_labels_and_annotations/annotation_polar.py
+++ b/galleries/examples/text_labels_and_annotations/annotation_polar.py
@@ -1,7 +1,7 @@
 """
-================
-Annotation Polar
-================
+====================
+Annotate polar plots
+====================
 
 This example shows how to create an annotation on a polar graph.
 

--- a/galleries/examples/text_labels_and_annotations/custom_legends.py
+++ b/galleries/examples/text_labels_and_annotations/custom_legends.py
@@ -1,7 +1,7 @@
 """
-========================
-Composing Custom Legends
-========================
+======================
+Compose custom legends
+======================
 
 Composing custom legends piece-by-piece.
 

--- a/galleries/examples/text_labels_and_annotations/demo_text_rotation_mode.py
+++ b/galleries/examples/text_labels_and_annotations/demo_text_rotation_mode.py
@@ -1,6 +1,6 @@
 r"""
 ==================
-Text Rotation Mode
+Text rotation mode
 ==================
 
 This example illustrates the effect of ``rotation_mode`` on the positioning

--- a/galleries/examples/text_labels_and_annotations/mathtext_examples.py
+++ b/galleries/examples/text_labels_and_annotations/mathtext_examples.py
@@ -1,7 +1,7 @@
 """
-=================
-Mathtext Examples
-=================
+========================
+Mathematical expressions
+========================
 
 Selected features of Matplotlib's math rendering engine.
 """

--- a/galleries/examples/text_labels_and_annotations/text_commands.py
+++ b/galleries/examples/text_labels_and_annotations/text_commands.py
@@ -1,7 +1,7 @@
 """
-=============
-Text Commands
-=============
+===============
+Text properties
+===============
 
 Plotting text of many different kinds.
 

--- a/galleries/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
+++ b/galleries/examples/text_labels_and_annotations/text_rotation_relative_to_line.py
@@ -1,7 +1,7 @@
 """
-==============================
-Text Rotation Relative To Line
-==============================
+=======================================
+Text rotation angle in data coordinates
+=======================================
 
 Text objects in matplotlib are normally rotated with respect to the
 screen coordinate system (i.e., 45 degrees rotation plots text along a

--- a/galleries/examples/text_labels_and_annotations/usetex_baseline_test.py
+++ b/galleries/examples/text_labels_and_annotations/usetex_baseline_test.py
@@ -1,6 +1,6 @@
 """
 ====================
-Usetex Baseline Test
+Usetex text baseline
 ====================
 
 Comparison of text baselines computed for mathtext and usetex.

--- a/galleries/examples/ticks/date_precision_and_epochs.py
+++ b/galleries/examples/ticks/date_precision_and_epochs.py
@@ -1,6 +1,6 @@
 """
 =========================
-Date Precision and Epochs
+Date precision and epochs
 =========================
 
 Matplotlib can handle `.datetime` objects and `numpy.datetime64` objects using

--- a/galleries/examples/units/units_sample.py
+++ b/galleries/examples/units/units_sample.py
@@ -1,6 +1,6 @@
 """
 ======================
-Inches and Centimeters
+Inches and centimeters
 ======================
 
 The example illustrates the ability to override default x and y units (ax1) to

--- a/galleries/examples/widgets/range_slider.py
+++ b/galleries/examples/widgets/range_slider.py
@@ -1,7 +1,7 @@
 """
-======================================
-Thresholding an Image with RangeSlider
-======================================
+=================================
+Image scaling using a RangeSlider
+=================================
 
 Using the RangeSlider widget to control the thresholding of an image.
 


### PR DESCRIPTION
Following recommendatinos from #28527, this improves example titles. Take this as an incremental improvement. I've changed what I saw at a glance when going through the examples once. Certainly, one could do further improvements, but that can be done in follow-ups.
