### PR TITLE
MNT: Update label for Tag proposal issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/tag_proposal.yml
+++ b/.github/ISSUE_TEMPLATE/tag_proposal.yml
@@ -2,7 +2,7 @@
 name: Tag Proposal
 description: Suggest a new tag or subcategory for the gallery of examples
 title: "[Tag]: "
-labels: [Tag proposal]
+labels: ["Documentation: tags"]
 body:
   - type: markdown
     attributes:


### PR DESCRIPTION
## PR summary

Noticed there was no automatic label added on #28565. We don't have a "Tag proposal" label.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines