### PR TITLE
Fix scaling in Tk on non-Windows systems

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -176,8 +176,7 @@ class FigureCanvasTk(FigureCanvasBase):
         self._tkcanvas_image_region = self._tkcanvas.create_image(
             w//2, h//2, image=self._tkphoto)
         self._tkcanvas.bind("<Configure>", self.resize)
-        if sys.platform == 'win32':
-            self._tkcanvas.bind("<Map>", self._update_device_pixel_ratio)
+        self._tkcanvas.bind("<Map>", self._update_device_pixel_ratio)
         self._tkcanvas.bind("<Key>", self.key_press)
         self._tkcanvas.bind("<Motion>", self.motion_notify_event)
         self._tkcanvas.bind("<Enter>", self.enter_notify_event)
@@ -234,11 +233,15 @@ class FigureCanvasTk(FigureCanvasBase):
         self._rubberband_rect_white = None
 
     def _update_device_pixel_ratio(self, event=None):
-        # Tk gives scaling with respect to 72 DPI, but Windows screens are
-        # scaled vs 96 dpi, and pixel ratio settings are given in whole
-        # percentages, so round to 2 digits.
-        ratio = round(self._tkcanvas.tk.call('tk', 'scaling') / (96 / 72), 2)
-        if self._set_device_pixel_ratio(ratio):
+        ratio = None
+        if sys.platform == 'win32':
+            # Tk gives scaling with respect to 72 DPI, but Windows screens are
+            # scaled vs 96 dpi, and pixel ratio settings are given in whole
+            # percentages, so round to 2 digits.
+            ratio = round(self._tkcanvas.tk.call('tk', 'scaling') / (96 / 72), 2)
+        elif sys.platform == "linux":
+            ratio = self._tkcanvas.winfo_fpixels('1i') / 96
+        if ratio is not None and self._set_device_pixel_ratio(ratio):
             # The easiest way to resize the canvas is to resize the canvas
             # widget itself, since we implement all the logic for resizing the
             # canvas backing store on that event.


### PR DESCRIPTION
## PR summary
Fix scaling in Tk on non-Windows systems, closes #10388

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] tested scaling on GNU/Linux (X11)
- [ ] tested scaling on macOS
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

cc: @tacaswell 
