### PR TITLE
Qt embedding example: Separate drawing and data retrieval timers

### DIFF
--- a/galleries/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -44,18 +44,34 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self._static_ax.plot(t, np.tan(t), ".")
 
         self._dynamic_ax = dynamic_canvas.figure.subplots()
-        t = np.linspace(0, 10, 101)
         # Set up a Line2D.
-        self._line, = self._dynamic_ax.plot(t, np.sin(t + time.time()))
-        self._timer = dynamic_canvas.new_timer(50)
-        self._timer.add_callback(self._update_canvas)
-        self._timer.start()
+        self.xdata = np.linspace(0, 10, 101)
+        self._update_data()
+        self._line, = self._dynamic_ax.plot(self.xdata, self.ydata)
+        # The below two timers must be attributes of self, so that the garbage
+        # collector won't clean them after we finish with __init__...
+
+        # The data retrieval may be fast as possible (Using QRunnable could be
+        # even faster).
+        self.data_timer = dynamic_canvas.new_timer(1)
+        self.data_timer.add_callback(self._update_data)
+        self.data_timer.start()
+        # Drawing at 50Hz should be fast enough for the GUI to feel smooth, and
+        # not too fast for the GUI to be overloaded with events that need to be
+        # processed while the GUI element is changed.
+        self.drawing_timer = dynamic_canvas.new_timer(20)
+        self.drawing_timer.add_callback(self._update_canvas)
+        self.drawing_timer.start()
+
+    def _update_data(self):
+        # Shift the sinusoid as a function of time.
+        self.ydata = np.sin(self.xdata + time.time())
 
     def _update_canvas(self):
-        t = np.linspace(0, 10, 101)
-        # Shift the sinusoid as a function of time.
-        self._line.set_data(t, np.sin(t + time.time()))
-        self._line.figure.canvas.draw()
+        self._line.set_data(self.xdata, self.ydata)
+        # It should be safe to use the synchronous draw() method for most drawing
+        # frequencies, but it is safer to use draw_idle().
+        self._line.figure.canvas.draw_idle()
 
 
 if __name__ == "__main__":

--- a/galleries/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -46,7 +46,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self._dynamic_ax = dynamic_canvas.figure.subplots()
         # Set up a Line2D.
         self.xdata = np.linspace(0, 10, 101)
-        self._update_data()
+        self._update_ydata()
         self._line, = self._dynamic_ax.plot(self.xdata, self.ydata)
         # The below two timers must be attributes of self, so that the garbage
         # collector won't clean them after we finish with __init__...
@@ -54,7 +54,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         # The data retrieval may be fast as possible (Using QRunnable could be
         # even faster).
         self.data_timer = dynamic_canvas.new_timer(1)
-        self.data_timer.add_callback(self._update_data)
+        self.data_timer.add_callback(self._update_ydata)
         self.data_timer.start()
         # Drawing at 50Hz should be fast enough for the GUI to feel smooth, and
         # not too fast for the GUI to be overloaded with events that need to be
@@ -63,7 +63,7 @@ class ApplicationWindow(QtWidgets.QMainWindow):
         self.drawing_timer.add_callback(self._update_canvas)
         self.drawing_timer.start()
 
-    def _update_data(self):
+    def _update_ydata(self):
         # Shift the sinusoid as a function of time.
         self.ydata = np.sin(self.xdata + time.time())
 


### PR DESCRIPTION
## PR summary

While developing a Qt application that had to retrieve data as quickly as possible from a measurement instrument, and display that in multiple plots, I encountered an issue with my 1ms timers causing the application to not respond to events, and essentially making the app stuck and unusable. [ChatGPT helped me](https://chatgpt.com/share/2f110cad-77ee-4442-9b66-e773dec678e3) to figure out I need to process the events in my timer timeout function. This has bugged me for a week or so, and this is not trivial to figure out by oneself IMO. Hence this PR. See also https://github.com/pyqtgraph/pyqtgraph/issues/3092.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) - it is hard to test this, as the issue is present mostly on Windows and on slow desktops.
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines