### PR TITLE
svg: Ensure marker-only lines get URLs

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -715,6 +715,8 @@ class RendererSVG(RendererBase):
             self._markers[dictkey] = oid
 
         writer.start('g', **self._get_clip_attrs(gc))
+        if gc.get_url() is not None:
+            self.writer.start('a', {'xlink:href': gc.get_url()})
         trans_and_flip = self._make_flip_transform(trans)
         attrib = {'xlink:href': f'#{oid}'}
         clip = (0, 0, self.width*72, self.height*72)
@@ -726,6 +728,8 @@ class RendererSVG(RendererBase):
                 attrib['y'] = _short_float_fmt(y)
                 attrib['style'] = self._get_style(gc, rgbFace)
                 writer.element('use', attrib=attrib)
+        if gc.get_url() is not None:
+            self.writer.end('a')
         writer.end('g')
 
     def draw_path_collection(self, gc, master_transform, paths, all_transforms,

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -343,13 +343,17 @@ def test_url():
     s.set_urls(['https://example.com/foo', 'https://example.com/bar', None])
 
     # Line2D
-    p, = plt.plot([1, 3], [6, 5])
+    p, = plt.plot([2, 3, 4], [4, 5, 6])
     p.set_url('https://example.com/baz')
+
+    # Line2D markers-only
+    p, = plt.plot([3, 4, 5], [4, 5, 6], linestyle='none', marker='x')
+    p.set_url('https://example.com/quux')
 
     b = BytesIO()
     fig.savefig(b, format='svg')
     b = b.getvalue()
-    for v in [b'foo', b'bar', b'baz']:
+    for v in [b'foo', b'bar', b'baz', b'quux']:
         assert b'https://example.com/' + v in b
 
 


### PR DESCRIPTION

## PR summary

Fixes #28595

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines