### PR TITLE
Added documentation for parameters vmin and vmax inside specgram function.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8136,6 +8136,13 @@ such objects
         data : indexable object, optional
             DATA_PARAMETER_PLACEHOLDER
 
+        vmin, vmax : float, optional
+            vmin and vmax define the data range that the colormap covers.
+            By default, the colormap covers the complete value range of the
+            data. It is an error to use vmin/vmax when a norm instance is
+            given (but using a str norm name together with vmin/vmax is
+            acceptable). This parameter is ignored if X is RGB(A).
+
         **kwargs
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`
             which makes the specgram image. The origin keyword argument

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8139,9 +8139,7 @@ such objects
         vmin, vmax : float, optional
             vmin and vmax define the data range that the colormap covers.
             By default, the colormap covers the complete value range of the
-            data. It is an error to use vmin/vmax when a norm instance is
-            given (but using a str norm name together with vmin/vmax is
-            acceptable). This parameter is ignored if X is RGB(A).
+            data.
 
         **kwargs
             Additional keyword arguments are passed on to `~.axes.Axes.imshow`


### PR DESCRIPTION
## PR summary
Parameters vmin and vmax are not documented inside specgram function.
Issue: https://github.com/matplotlib/matplotlib/issues/28548

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
