### PR TITLE
CI: Build docs on latest Python

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,9 +216,9 @@ commands:
 #
 
 jobs:
-  docs-python310:
+  docs-python3:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.12
     resource_class: large
     steps:
       - checkout
@@ -259,4 +259,4 @@ workflows:
     jobs:
       # NOTE: If you rename this job, then you must update the `if` condition
       # and `circleci-jobs` option in `.github/workflows/circleci.yml`.
-      - docs-python310
+      - docs-python3

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -3,7 +3,7 @@ name: "CircleCI artifact handling"
 on: [status]
 jobs:
   circleci_artifacts_redirector_job:
-    if: "${{ github.event.context == 'ci/circleci: docs-python310' }}"
+    if: "${{ github.event.context == 'ci/circleci: docs-python3' }}"
     permissions:
       statuses: write
     runs-on: ubuntu-latest
@@ -16,11 +16,11 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           api-token: ${{ secrets.CIRCLECI_TOKEN }}
           artifact-path: 0/doc/build/html/index.html
-          circleci-jobs: docs-python310
+          circleci-jobs: docs-python3
           job-title: View the built docs
 
   post_warnings_as_review:
-    if: "${{ github.event.context == 'ci/circleci: docs-python310' }}"
+    if: "${{ github.event.context == 'ci/circleci: docs-python3' }}"
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
## PR summary

There have been improvements to Python performance in 3.11 and 3.12 thanks to the Faster CPython project, and we hope this might help a little with docs.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines