### PR TITLE
DOC: Enable parallel builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
               export RELEASE_TAG='-t release'
             fi
             mkdir -p logs
-            make html O="-T $RELEASE_TAG -j1 -w /tmp/sphinxerrorswarnings.log"
+            make html O="-T $RELEASE_TAG -j4 -w /tmp/sphinxerrorswarnings.log"
             rm -r build/html/_sources
           working_directory: doc
       - save_cache:

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -286,6 +286,11 @@ sphinx_gallery_conf = {
     'copyfile_regex': r'.*\.rst',
 }
 
+if parse_version(sphinx_gallery.__version__) >= parse_version('0.17.0'):
+    sphinx_gallery_conf['parallel'] = True
+    # Any warnings from joblib turned into errors may cause a deadlock.
+    warnings.filterwarnings('default', category=UserWarning, module='joblib')
+
 if 'plot_gallery=0' in sys.argv:
     # Gallery images are not created.  Suppress warnings triggered where other
     # parts of the documentation link to these images.

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -20,5 +20,5 @@ pyyaml
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinx-copybutton
 sphinx-design
-sphinx-gallery>=0.12.0
+sphinx-gallery[parallel]>=0.12.0
 sphinx-tags>=0.4.0


### PR DESCRIPTION
## PR summary

The latest sphinx-gallery 0.17.0 adds support for parallel building of examples, and the issue in pydata-sphinx-theme was fixed in 0.15.4, so we can try enabling it again.

We're on a large docker instance, with 4 cores and 8GB RAM; the RAM tracking shows we use max 43% / average 37%, so I've set parallelism to 2, which hopefully won't OOM.

cf #28244 for the last attempt that was stalled by the pydata-sphinx-theme issue.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines