### PR TITLE
DOC: Tell sphinx-gallery to link mpl_toolkits from our build

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -276,7 +276,8 @@ sphinx_gallery_conf = {
     'matplotlib_animations': True,
     'min_reported_time': 1,
     'plot_gallery': 'True',  # sphinx-gallery/913
-    'reference_url': {'matplotlib': None},
+    'reference_url': {'matplotlib': None, 'mpl_toolkits': None},
+    'prefer_full_module': {r'mpl_toolkits\.'},
     'remove_config_comments': True,
     'reset_modules': ('matplotlib', clear_basic_units),
     'subsection_order': gallery_order_sectionorder,


### PR DESCRIPTION
## PR summary

Otherwise, it will try to find it with intersphinx, and fail.

Note that this needs https://github.com/sphinx-gallery/sphinx-gallery/pull/1363 in order to work correctly (and that's currently patched in to the CI).

## PR checklist
- [x] "closes #28250" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines