### PR TITLE
Closed open div tag in color.ColorMap._repr_html_

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -960,6 +960,7 @@ class Colormap:
                 '</div>'
                 '<div style="float: right;">'
                 f'over {color_block(self.get_over())}'
+                '</div>'
                 '</div>')
 
     def copy(self):


### PR DESCRIPTION
## PR summary
ColorMap._repr_html_ produces html that doesn't properly close all div tags.  It was simple fix to add a closing div to the method.

- There wasn't an open issue for this.

