### PR TITLE
DOC: Remove hint on PRs from origin/main

### DIFF
--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -79,13 +79,6 @@ default, git will have a link to your fork of the GitHub repo, called
 
    git push origin my-new-feature
 
-.. hint::
-
-    If you first opened the pull request from your ``main`` branch and then
-    converted it to a feature branch, you will need to close the original pull
-    request and open a new pull request from the renamed branch. See
-    `GitHub: working with branches
-    <https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#working-with-branches>`_.
 
 .. _edit-flow:
 


### PR DESCRIPTION
As poposed in https://github.com/matplotlib/matplotlib/pull/28575#pullrequestreview-2204672811, I propose we don't need this. If developers have followed above instructions, they won't end up having changes on origin/main. But if they do, it's not really a problem on our side. We're still able to handle that. - As this PR shows, which I've intentionally made from my origin/main :smile:  ping @story645 

For an inexperienced user, it is simpler to continue with a PR from main rather than roll everything back and create a new PR.

The only problem exists on the user side in that they can't handle multiple concurrent changes when they only use main. But that's on them. And if they are inexperienced, they likely won't do that anyway.