### PR TITLE
DOC: Simplify heatmap example

### DIFF
--- a/galleries/examples/images_contours_and_fields/image_annotated_heatmap.py
+++ b/galleries/examples/images_contours_and_fields/image_annotated_heatmap.py
@@ -63,12 +63,9 @@ fig, ax = plt.subplots()
 im = ax.imshow(harvest)
 
 # Show all ticks and label them with the respective list entries
-ax.set_xticks(np.arange(len(farmers)), labels=farmers)
-ax.set_yticks(np.arange(len(vegetables)), labels=vegetables)
-
-# Rotate the tick labels and set their alignment.
-plt.setp(ax.get_xticklabels(), rotation=45, ha="right",
-         rotation_mode="anchor")
+ax.set_xticks(range(len(farmers)), labels=farmers,
+              rotation=45, ha="right", rotation_mode="anchor")
+ax.set_yticks(range(len(vegetables)), labels=vegetables)
 
 # Loop over data dimensions and create text annotations.
 for i in range(len(vegetables)):
@@ -137,16 +134,13 @@ def heatmap(data, row_labels, col_labels, ax=None,
     cbar.ax.set_ylabel(cbarlabel, rotation=-90, va="bottom")
 
     # Show all ticks and label them with the respective list entries.
-    ax.set_xticks(np.arange(data.shape[1]), labels=col_labels)
-    ax.set_yticks(np.arange(data.shape[0]), labels=row_labels)
+    ax.set_xticks(range(data.shape[1]), labels=col_labels,
+                  rotation=-30, ha="right", rotation_mode="anchor")
+    ax.set_yticks(range(data.shape[0]), labels=row_labels)
 
     # Let the horizontal axes labeling appear on top.
     ax.tick_params(top=True, bottom=False,
                    labeltop=True, labelbottom=False)
-
-    # Rotate the tick labels and set their alignment.
-    plt.setp(ax.get_xticklabels(), rotation=-30, ha="right",
-             rotation_mode="anchor")
 
     # Turn spines off and create white grid.
     ax.spines[:].set_visible(False)


### PR DESCRIPTION
Directly rotate ticks in `set_xticks` instead of setting the ticks and then changing them afterwards using `plt.setp(...)`.

Also use the simpler and shorted `range` instead of `np.arange`.