### PR TITLE
DOC: Fix matching for version switcher

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -514,10 +514,9 @@ html_theme_options = {
             f"https://matplotlib.org/devdocs/_static/switcher.json?{SHA}"
         ),
         "version_match": (
-            # The start version to show. This must be in switcher.json.
-            # We either go to 'stable' or to 'devdocs'
-            'stable' if matplotlib.__version_info__.releaselevel == 'final'
-            else 'devdocs')
+            matplotlib.__version__
+            if matplotlib.__version_info__.releaselevel == 'final'
+            else 'dev')
     },
     "navbar_end": ["theme-switcher", "version-switcher", "mpl_icon_links"],
     "navbar_persistent": ["search-button"],


### PR DESCRIPTION
## PR summary

A released version should point to its version, not 'stable', since that doesn't appear in the version switcher. And devdocs should point to 'dev', since that's what it's called in the JSON.

Note that in our JSON, we only list up to meso versions, though the version is noted in full. This means that older micro versions will not have an entry in the switcher, and the switcher will not be set to anything if you go there, but that's probably fine.

## PR checklist

- [x] "closes #28639" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines