### PR TITLE
FIX: improve formatting of image values in cases of singular norms

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1365,7 +1365,9 @@ class Artist:
                     delta = np.diff(
                         self.norm.boundaries[neigh_idx:cur_idx + 2]
                     ).max()
-
+                elif self.norm.vmin == self.norm.vmax:
+                    # singular norms, use delta of 10% of only value
+                    delta = np.abs(self.norm.vmin * .1)
                 else:
                     # Midpoints of neighboring color intervals.
                     neighbors = self.norm.inverse(

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2252,6 +2252,10 @@ def _g_sig_digits(value, delta):
     it is known with an error of *delta*.
     """
     if delta == 0:
+        if value == 0:
+            # if both value and delta are 0, np.spacing below returns 5e-324
+            # which results in rather silly results
+            return 3
         # delta = 0 may occur when trying to format values over a tiny range;
         # in that case, replace it by the distance to the closest float.
         delta = abs(np.spacing(value))

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -390,7 +390,8 @@ def test_cursor_data_nonuniform(xy, data):
         ([[.123, .987]], "[0.123]"),
         ([[np.nan, 1, 2]], "[]"),
         ([[1, 1+1e-15]], "[1.0000000000000000]"),
-        ([[-1, -1]], "[-1.0000000000000000]"),
+        ([[-1, -1]], "[-1.0]"),
+        ([[0, 0]], "[0.00]"),
     ])
 def test_format_cursor_data(data, text):
     from matplotlib.backend_bases import MouseEvent


### PR DESCRIPTION
closes #28648

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Special case singular norms and estimating 0 width ranges at 0


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [/] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [/] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [/] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
