### PR TITLE
Fix docstring style inconsistencies in lines.py

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1541,21 +1541,15 @@ class AxLine(Line2D):
         super().draw(renderer)
 
     def get_xy1(self):
-        """
-        Return the *xy1* value of the line.
-        """
+        """Return the *xy1* value of the line."""
         return self._xy1
 
     def get_xy2(self):
-        """
-        Return the *xy2* value of the line.
-        """
+        """Return the *xy2* value of the line."""
         return self._xy2
 
     def get_slope(self):
-        """
-        Return the *slope* value of the line.
-        """
+        """Return the *slope* value of the line."""
         return self._slope
 
     def set_xy1(self, x, y):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Fixes code style inconsistencies for docstrings in lines.py
Closes [#28630](https://github.com/matplotlib/matplotlib/issues/28630)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
