### PR TITLE
Optimise `Axes.add_patch` to avoid python iteration over bezier segments

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2445,7 +2445,6 @@ class _AxesBase(martist.Artist):
                                       updatex=updatex, updatey=updatey)
         self.ignore_existing_data_limits = False
 
-
     def add_table(self, tab):
         """
         Add a `.Table` to the Axes; return the table.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2429,18 +2429,6 @@ class _AxesBase(martist.Artist):
         if (isinstance(patch, mpatches.Rectangle) and
                 ((not patch.get_width()) and (not patch.get_height()))):
             return
-        p = patch.get_path()
-        # Get all vertices on the path
-        # Loop through each segment to get extrema for Bezier curve sections
-        vertices = []
-        for curve, code in p.iter_bezier(simplify=False):
-            # Get distance along the curve of any extrema
-            _, dzeros = curve.axis_aligned_extrema()
-            # Calculate vertices of start, end and any extrema in between
-            vertices.append(curve([0, *dzeros, 1]))
-
-        if len(vertices):
-            vertices = np.vstack(vertices)
 
         patch_trf = patch.get_transform()
         updatex, updatey = patch_trf.contains_branch_seperately(self.transData)
@@ -2452,9 +2440,11 @@ class _AxesBase(martist.Artist):
                 updatex = False
             if updatey and patch_trf == self.get_xaxis_transform():
                 updatey = False
-        trf_to_data = patch_trf - self.transData
-        xys = trf_to_data.transform(vertices)
-        self.update_datalim(xys, updatex=updatex, updatey=updatey)
+        self.dataLim.update_from_path(patch.get_path(),
+                                      self.ignore_existing_data_limits,
+                                      updatex=updatex, updatey=updatey)
+        self.ignore_existing_data_limits = False
+
 
     def add_table(self, tab):
         """


### PR DESCRIPTION
## PR summary
This aims to optimise calls to `_AxesBase.add_patch`, where the patch might have a path with many bezier segments. This is done by avoiding a long loop in python, and instead delegating to `BBox.update_from_path`, which is used when updating limits from other artists.

This provides a ~5x speedup for a call to `_AxesBase.add_patch` in some of our internal code, with complicated patches with hundreds of bezier segments.

### Implementation notes
The implementation is effectively the same as that in `_AxesBase._update_line_limits` also in this class. It performs the iteration in C++ (in `_path.h::update_path_extents`).
This is the same approach as used for collections of patches; i.e. the rescaling behaviour is now as performant as:

```python
axes.add_collection(PatchCollection([patch]))
```


## PR checklist
**WIP**: trying but so far have failed to get the test suite running locally. I followed steps to create necessary venv and build, but running `pytest` just hangs indefinitely without consuming any resources. I can however import the local build of matplotlib and perform basic tasks with it by hand.

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
