### PR TITLE
API: deprecate unused helper in patch._Styles

### DIFF
--- a/doc/api/next_api_changes/deprecations/28670-TAC.rst
+++ b/doc/api/next_api_changes/deprecations/28670-TAC.rst
@@ -1,5 +1,5 @@
-Drerecated ``matplotlib.patches._Styles`` and subclasses
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Deprecated ``register`` on ``matplotlib.patches._Styles`` and subclasses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This class method is never used internally.  Due to the internal check in the
 method it only accepts subclasses of a private baseclass embedded in the host

--- a/doc/api/next_api_changes/deprecations/28670-TAC.rst
+++ b/doc/api/next_api_changes/deprecations/28670-TAC.rst
@@ -1,0 +1,6 @@
+Drerecated ``matplotlib.patches._Styles`` and subclasses
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This class method is never used internally.  Due to the internal check in the
+method it only accepts subclasses of a private baseclass embedded in the host
+class which makes it unlikely that it has been used externally.

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2347,6 +2347,11 @@ class _Style:
         return textwrap.indent(rst_table, prefix=' ' * 4)
 
     @classmethod
+    @_api.deprecated(
+        '3.10.0',
+        message="This method is never used internally.",
+        alternative="No replacement.  Please open an issue if you use this."
+    )
     def register(cls, name, style):
         """Register a new style."""
         if not issubclass(style, cls._Base):


### PR DESCRIPTION

## PR summary
Remove unused (and untested) helper function.

Noted this while reviewing the existing patch code with @ksunden 

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [/] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [/] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [/] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [/] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
