### PR TITLE
Experiment with defining _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR on Windows

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -112,14 +112,14 @@ jobs:
         include:
           - os: ubuntu-20.04
             cibw_archs: "x86_64"
-          - os: ubuntu-20.04
-            cibw_archs: "aarch64"
+          #- os: ubuntu-20.04
+          #  cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto64"
-          - os: macos-12
-            cibw_archs: "x86_64"
-          - os: macos-14
-            cibw_archs: "arm64"
+          #- os: macos-12
+          #  cibw_archs: "x86_64"
+          #- os: macos-14
+          #  cibw_archs: "arm64"
 
     steps:
       - name: Set up QEMU
@@ -135,6 +135,7 @@ jobs:
           path: dist/
 
       - name: Build wheels for CPython 3.13
+        if: false
         uses: pypa/cibuildwheel@7e5a838a63ac8128d71ab2dfd99e4634dd1bca09  # v2.19.2
         with:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}

--- a/meson.build
+++ b/meson.build
@@ -31,6 +31,11 @@ project(
 cc = meson.get_compiler('c')
 cpp = meson.get_compiler('cpp')
 
+# Try defining _DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR on Windows to see what happens.
+if cpp.get_id() == 'msvc'
+  add_global_arguments('-D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR', language : 'cpp')
+endif
+
 # https://mesonbuild.com/Python-module.html
 py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,9 @@ requires = [
 
 [tool.meson-python.args]
 install = ['--tags=data,python-runtime,runtime']
+compile = [
+    "-v",
+]
 
 [tool.setuptools_scm]
 version_scheme = "release-branch-semver"


### PR DESCRIPTION
Experiment with defining `_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR` on Windows to see what happens to the generated wheels. See https://github.com/matplotlib/matplotlib/issues/28551#issuecomment-2273144251. I've turned off some of the wheel build platforms to minimise use of CI resources.