### PR TITLE
Run delvewheel with path to required msvcp140.dll

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -96,7 +96,7 @@ jobs:
         pip install delvewheel &&
         rm -rf {package}/build
       CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
-        delvewheel repair -w {dest_dir} {wheel}
+        delvewheel repair -vv --add-path C:\\Windows\\system32 -w {dest_dir} {wheel}
       CIBW_AFTER_BUILD: >-
         twine check {wheel} &&
         python {package}/ci/check_wheel_licenses.py {wheel}
@@ -110,16 +110,16 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
-            cibw_archs: "x86_64"
-          - os: ubuntu-20.04
-            cibw_archs: "aarch64"
+          #- os: ubuntu-20.04
+          #  cibw_archs: "x86_64"
+          #- os: ubuntu-20.04
+          #  cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto64"
-          - os: macos-12
-            cibw_archs: "x86_64"
-          - os: macos-14
-            cibw_archs: "arm64"
+          #- os: macos-12
+          #  cibw_archs: "x86_64"
+          #- os: macos-14
+          #  cibw_archs: "arm64"
 
     steps:
       - name: Set up QEMU
@@ -135,6 +135,7 @@ jobs:
           path: dist/
 
       - name: Build wheels for CPython 3.13
+        if: false
         uses: pypa/cibuildwheel@7e5a838a63ac8128d71ab2dfd99e4634dd1bca09  # v2.19.2
         with:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -110,16 +110,16 @@ jobs:
     strategy:
       matrix:
         include:
-          #- os: ubuntu-20.04
-          #  cibw_archs: "x86_64"
-          #- os: ubuntu-20.04
-          #  cibw_archs: "aarch64"
+          - os: ubuntu-20.04
+            cibw_archs: "x86_64"
+          - os: ubuntu-20.04
+            cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto64"
-          #- os: macos-12
-          #  cibw_archs: "x86_64"
-          #- os: macos-14
-          #  cibw_archs: "arm64"
+          - os: macos-12
+            cibw_archs: "x86_64"
+          - os: macos-14
+            cibw_archs: "arm64"
 
     steps:
       - name: Set up QEMU
@@ -135,7 +135,6 @@ jobs:
           path: dist/
 
       - name: Build wheels for CPython 3.13
-        if: false
         uses: pypa/cibuildwheel@7e5a838a63ac8128d71ab2dfd99e4634dd1bca09  # v2.19.2
         with:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}


### PR DESCRIPTION
Following recommendation at https://github.com/adang1345/delvewheel/issues/52#issuecomment-2274244443,  here telling `delvewheel` to use the `msvc140.dll` from the correct directory when building wheels on Windows. The default behaviour without this is to search the `PATH` and as there are so many packages pre-installed on github runners that it finds the following
```
C:\hostedtoolcache\windows\Java_Temurin-Hotspot_jdk\8.0.422-5\x64\bin\msvcp140.dll
C:\Program Files\ImageMagick-7.1.1-Q16-HDRI\msvcp140.dll
C:\Windows\system32\msvcp140.dll
C:\Program Files\Microsoft Service Fabric\bin\Fabric\Fabric.Code\msvcp140.dll
C:\Program Files\LLVM\bin\msvcp140.dll
```
and we do not want it to use the first one.

I am hoping that this will fix issue #28551.