### PR TITLE
Fix warnings from mingw compilers

### DIFF
--- a/src/_c_internal_utils.cpp
+++ b/src/_c_internal_utils.cpp
@@ -165,7 +165,7 @@ mpl_SetProcessDpiAwareness_max(void)
         DPI_AWARENESS_CONTEXT_SYSTEM_AWARE};         // Win10
     if (IsValidDpiAwarenessContextPtr != NULL
             && SetProcessDpiAwarenessContextPtr != NULL) {
-        for (int i = 0; i < sizeof(ctxs) / sizeof(DPI_AWARENESS_CONTEXT); ++i) {
+        for (size_t i = 0; i < sizeof(ctxs) / sizeof(DPI_AWARENESS_CONTEXT); ++i) {
             if (IsValidDpiAwarenessContextPtr(ctxs[i])) {
                 SetProcessDpiAwarenessContextPtr(ctxs[i]);
                 break;

--- a/src/_c_internal_utils.cpp
+++ b/src/_c_internal_utils.cpp
@@ -125,7 +125,7 @@ static void
 mpl_SetForegroundWindow(py::capsule UNUSED_ON_NON_WINDOWS(handle_p))
 {
 #ifdef _WIN32
-    if (handle_p.name() != "HWND") {
+    if (strcmp(handle_p.name(), "HWND") != 0) {
         throw std::runtime_error("Handle must be a value returned from Win32_GetForegroundWindow");
     }
     HWND handle = static_cast<HWND>(handle_p.get_pointer());

--- a/src/_c_internal_utils.cpp
+++ b/src/_c_internal_utils.cpp
@@ -7,7 +7,14 @@
 #define WIN32_LEAN_AND_MEAN
 // Windows 10, for latest HiDPI API support.
 #define WINVER 0x0A00
-#define _WIN32_WINNT 0x0A00
+#if defined(_WIN32_WINNT)
+#if _WIN32_WINNT < WINVER
+#undef _WIN32_WINNT
+#define _WIN32_WINNT WINVER
+#endif
+#else
+#define _WIN32_WINNT WINVER
+#endif
 #endif
 #include <pybind11/pybind11.h>
 #ifdef __linux__

--- a/src/_tkagg.cpp
+++ b/src/_tkagg.cpp
@@ -19,7 +19,14 @@
 #define WIN32_LEAN_AND_MEAN
 // Windows 8.1
 #define WINVER 0x0603
-#define _WIN32_WINNT 0x0603
+#if defined(_WIN32_WINNT)
+#if _WIN32_WINNT < WINVER
+#undef _WIN32_WINNT
+#define _WIN32_WINNT WINVER
+#endif
+#else
+#define _WIN32_WINNT WINVER
+#endif
 #endif
 
 #include <pybind11/pybind11.h>


### PR DESCRIPTION
## PR summary

This fixes several [warnings I noticed](https://github.com/QuLogic/mplpb11/actions/runs/10280477342/job/28447908104#step:4:347) while debugging source builds for #28551.

Most are harmless, but I think the capsule change in `_c_internal_utils` may have hidden a real error (and possibly MSVC just "did the right thing" for us).

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines