### PR TITLE
BLD: Include MSVCP140 runtime statically

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -100,7 +100,15 @@ jobs:
       CIBW_AFTER_BUILD: >-
         twine check {wheel} &&
         python {package}/ci/check_wheel_licenses.py {wheel}
-      CIBW_CONFIG_SETTINGS: setup-args="--vsenv"
+      # On Windows, we explicitly request MSVC compilers (as GitHub Action runners have
+      # MinGW on PATH that would be picked otherwise), switch to a static build for
+      # runtimes, but use dynamic linking for `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`,
+      # and the UCRT. This avoids requiring specific versions of `MSVCP140.dll`, while
+      # keeping shared state with the rest of the Python process/extensions.
+      CIBW_CONFIG_SETTINGS_WINDOWS: >-
+        setup-args="--vsenv"
+        setup-args="-Db_vscrt=mt"
+        setup-args="-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']"
       CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
       CIBW_SKIP: "*-musllinux_aarch64"
       CIBW_TEST_COMMAND: >-

--- a/doc/api/next_api_changes/development/28687-ES.rst
+++ b/doc/api/next_api_changes/development/28687-ES.rst
@@ -1,0 +1,10 @@
+Windows wheel runtime bundling made static
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In 3.7.0, the MSVC runtime DLL was bundled in wheels to enable importing Matplotlib on
+systems that do not have it installed. However, this could cause inconsistencies with
+other wheels that did the same, and trigger random crashes depending on import order. See
+`this issue <https://github.com/matplotlib/matplotlib/issues/28551>`_ for further
+details.
+
+Since 3.9.2, wheels now bundle the MSVC runtime DLL statically to avoid such issues.


### PR DESCRIPTION
## PR summary

This may prevent conflicts with other wheels that use the runtime at a different version, and _may_ be an alternative to #28679.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines