### PR TITLE
Avoid division-by-zero in Sketch::Sketch

### DIFF
--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -5,6 +5,7 @@
 
 #include <cmath>
 #include <cstdint>
+#include <limits>
 
 #include "agg_clip_liang_barsky.h"
 #include "mplutils.h"
@@ -1019,8 +1020,18 @@ class Sketch
     {
         rewind(0);
         const double d_M_PI = 3.14159265358979323846;
-        m_p_scale = (2.0 * d_M_PI) / (m_length * m_randomness);
-        m_log_randomness = 2.0 * log(m_randomness);
+        // Set derived values to zero if m_length or m_randomness are zero to
+        // avoid divide-by-zero errors when a sketch is created but not used.
+        if (m_length <= std::numeric_limits<double>::epsilon() || m_randomness <= std::numeric_limits<double>::epsilon()) {
+            m_p_scale = 0.0;
+        } else {
+            m_p_scale = (2.0 * d_M_PI) / (m_length * m_randomness);
+        }
+        if (m_randomness <= std::numeric_limits<double>::epsilon()) {
+            m_log_randomness = 0.0;
+        } else {
+            m_log_randomness = 2.0 * log(m_randomness);
+        }
     }
 
     unsigned vertex(double *x, double *y)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

An optimization introduced in #24964 introduced a divide-by-zero error when creating a `Sketch` object in cases where some parameters were set to 0.  This is normally fine as the sketch is not used in these cases and was only detectable when compiled with `-fsanitize=float-divide-by-zero` . Avoid these errors by detecting zero and near-zero values passed in and set derived values to 0 in these cases.

closes #28669

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
