### PR TITLE
DOC: Add a few more notes to release guide

### DIFF
--- a/doc/devel/release_guide.rst
+++ b/doc/devel/release_guide.rst
@@ -143,7 +143,8 @@ prepare this list:
            --project 'matplotlib/matplotlib' --links > doc/users/github_stats.rst
 
 3. Review and commit changes. Some issue/PR titles may not be valid reST (the most
-   common issue is ``*`` which is interpreted as unclosed markup).
+   common issue is ``*`` which is interpreted as unclosed markup). Also confirm that
+   ``codespell`` does not find any issues.
 
 .. note::
 
@@ -450,7 +451,7 @@ which will copy the built docs over.  If this is a final release, link the
   rm stable
   ln -s 3.7.0 stable
 
-You will also need to edit :file:`sitemap.xml` to include
+You will also need to edit :file:`sitemap.xml` and :file:`versions.html` to include
 the newly released version.  Now commit and push everything to GitHub ::
 
   git add *


### PR DESCRIPTION
## PR summary

I make releases in a new worktree, so it doesn't always have pre-commit setup, so I always forget to check `codespell`, and so making a release can introduce issues from the Issue/PR titles in the GitHub stats.

Also, note another file to update in the documentation repo.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines