### PR TITLE
Backport fixes from #28711

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ requires-python = ">=3.9"
 dev = [
     "meson-python>=0.13.1",
     "numpy>=1.25",
-    "pybind11>=2.6",
+    "pybind11>=2.6,!=2.13.3",
     "setuptools_scm>=7",
     # Not required by us but setuptools_scm without a version, cso _if_
     # installed, then setuptools_scm 8 requires at least this version.
@@ -73,7 +73,7 @@ build-backend = "mesonpy"
 # Also keep in sync with optional dependencies above.
 requires = [
     "meson-python>=0.13.1",
-    "pybind11>=2.6",
+    "pybind11>=2.6,!=2.13.3",
     "setuptools_scm>=7",
 
     # Comments on numpy build requirement range:


### PR DESCRIPTION
## PR summary

These are the minimal changes, but if necessary, we can backport the CI changes to drop GTK4 and pin homebrew more.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines