### PR TITLE
Stop disabling FH4 Exception Handling on MSVC

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -160,21 +160,12 @@ extension_data = {
   },
 }
 
-cpp_special_arguments = []
-if cpp.get_id() == 'msvc' and get_option('buildtype') != 'plain'
-  # Disable FH4 Exception Handling implementation so that we don't require
-  # VCRUNTIME140_1.dll. For more details, see:
-  # https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/
-  # https://github.com/joerick/cibuildwheel/issues/423#issuecomment-677763904
-  cpp_special_arguments += ['/d2FH4-']
-endif
-
 foreach ext, kwargs : extension_data
   # Ensure that PY_ARRAY_UNIQUE_SYMBOL is uniquely defined for each extension.
   unique_array_api = '-DPY_ARRAY_UNIQUE_SYMBOL=MPL_@0@_ARRAY_API'.format(ext.replace('.', '_'))
   additions = {
     'c_args': [unique_array_api] + kwargs.get('c_args', []),
-    'cpp_args': cpp_special_arguments + [unique_array_api] + kwargs.get('cpp_args', []),
+    'cpp_args': [unique_array_api] + kwargs.get('cpp_args', []),
   }
   py3.extension_module(
     ext,


### PR DESCRIPTION
## PR summary

As of #28687, our extensions depend on `VCRUNTIME140_1.dll`, and this was allowed because Python 3.8+ started shipping that file. The original report in #18292 was for Python 3.7, which didn't ship the DLL, but we require Python 3.10 now, so it's safe again.

Since we can use that dependency, there's no need to disable the option that started requiring it in the first place. As noted in the original blog post [1], this will make our extensions smaller, and slightly faster.

[1] https://devblogs.microsoft.com/cppblog/making-cpp-exception-handling-smaller-x64/

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
