### PR TITLE
Compressed layout moves suptitle

### DIFF
--- a/doc/api/next_api_changes/behavior/28734-REC.rst
+++ b/doc/api/next_api_changes/behavior/28734-REC.rst
@@ -1,0 +1,7 @@
+``suptitle`` in compressed layout
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Compressed layout now automatically positions the `~.Figure.suptitle` just
+above the top row of axes.  To keep this title in its previous position,
+either pass ``in_layout=False`` or explicitly set ``y=0.98`` in the
+`~.Figure.suptitle` call.

--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -140,6 +140,13 @@ def do_constrained_layout(fig, h_pad, w_pad,
                                     w_pad=w_pad, hspace=hspace, wspace=wspace)
                 else:
                     _api.warn_external(warn_collapsed)
+
+                if ((suptitle := fig._suptitle) is not None and
+                        suptitle.get_in_layout() and suptitle._autopos):
+                    x, _ = suptitle.get_position()
+                    suptitle.set_position(
+                        (x, layoutgrids[fig].get_inner_bbox().y1 + h_pad))
+                    suptitle.set_verticalalignment('bottom')
         else:
             _api.warn_external(warn_collapsed)
         reset_margins(layoutgrids, fig)

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -662,6 +662,30 @@ def test_compressed1():
     np.testing.assert_allclose(pos.y0, 0.1934, atol=1e-3)
 
 
+def test_compressed_suptitle():
+    fig, (ax0, ax1) = plt.subplots(
+        nrows=2, figsize=(4, 10), layout="compressed",
+        gridspec_kw={"height_ratios": (1 / 4, 3 / 4), "hspace": 0})
+
+    ax0.axis("equal")
+    ax0.set_box_aspect(1/3)
+
+    ax1.axis("equal")
+    ax1.set_box_aspect(1)
+
+    title = fig.suptitle("Title")
+    fig.draw_without_rendering()
+    assert title.get_position()[1] == pytest.approx(0.7457, abs=1e-3)
+
+    title = fig.suptitle("Title", y=0.98)
+    fig.draw_without_rendering()
+    assert title.get_position()[1] == 0.98
+
+    title = fig.suptitle("Title", in_layout=False)
+    fig.draw_without_rendering()
+    assert title.get_position()[1] == 0.98
+
+
 @pytest.mark.parametrize('arg, state', [
     (True, True),
     (False, False),


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
Closes #27866.  I found myself wanting this today.  The code from the issue now produces

![test](https://github.com/user-attachments/assets/15df475d-5d06-4b33-9a83-5aa59be85313)

I am at a loss how to provide a deprecation path for this.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
