### PR TITLE
ci: Avoid setuptools 72.2.0 when installing kiwi on PyPy

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -193,6 +193,14 @@ jobs:
         env:
           CIBW_BUILD: "pp310-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
+          # Work around for https://github.com/pypa/setuptools/issues/4571
+          # This can be removed once kiwisolver has wheels for PyPy 3.10
+          # https://github.com/nucleic/kiwi/pull/182
+          CIBW_BEFORE_TEST: >-
+            export PIP_CONSTRAINT=pypy-constraint.txt &&
+            echo "setuptools!=72.2.0" > $PIP_CONSTRAINT &&
+            pip install kiwisolver &&
+            unset PIP_CONSTRAINT
         if: matrix.cibw_archs != 'aarch64' && matrix.os != 'windows-latest'
 
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## PR summary

Due to https://github.com/pypa/distutils/issues/283, kiwisolver fails to build on PyPy. Until kiwisolver has PyPy 3.10 wheels (https://github.com/nucleic/kiwi/pull/182), we should avoid the buggy setuptools.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines