### PR TITLE
Simplify some code in dviread

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -132,20 +132,20 @@ _arg_mapping = dict(
     # raw: Return delta as is.
     raw=lambda dvi, delta: delta,
     # u1: Read 1 byte as an unsigned number.
-    u1=lambda dvi, delta: dvi._arg(1, signed=False),
+    u1=lambda dvi, delta: dvi._read_arg(1, signed=False),
     # u4: Read 4 bytes as an unsigned number.
-    u4=lambda dvi, delta: dvi._arg(4, signed=False),
+    u4=lambda dvi, delta: dvi._read_arg(4, signed=False),
     # s4: Read 4 bytes as a signed number.
-    s4=lambda dvi, delta: dvi._arg(4, signed=True),
+    s4=lambda dvi, delta: dvi._read_arg(4, signed=True),
     # slen: Read delta bytes as a signed number, or None if delta is None.
-    slen=lambda dvi, delta: dvi._arg(delta, signed=True) if delta else None,
+    slen=lambda dvi, delta: dvi._read_arg(delta, signed=True) if delta else None,
     # slen1: Read (delta + 1) bytes as a signed number.
-    slen1=lambda dvi, delta: dvi._arg(delta + 1, signed=True),
+    slen1=lambda dvi, delta: dvi._read_arg(delta + 1, signed=True),
     # ulen1: Read (delta + 1) bytes as an unsigned number.
-    ulen1=lambda dvi, delta: dvi._arg(delta + 1, signed=False),
+    ulen1=lambda dvi, delta: dvi._read_arg(delta + 1, signed=False),
     # olen1: Read (delta + 1) bytes as an unsigned number if less than 4 bytes,
     # as a signed number if 4 bytes.
-    olen1=lambda dvi, delta: dvi._arg(delta + 1, signed=(delta == 3)),
+    olen1=lambda dvi, delta: dvi._read_arg(delta + 1, signed=(delta == 3)),
 )
 
 
@@ -358,7 +358,7 @@ class Dvi:
                 self.close()
                 return False
 
-    def _arg(self, nbytes, signed=False):
+    def _read_arg(self, nbytes, signed=False):
         """
         Read and return a big-endian integer *nbytes* long.
         Signedness is determined by the *signed* keyword.
@@ -701,31 +701,31 @@ class Vf(Dvi):
             # We are outside a packet
             if byte < 242:          # a short packet (length given by byte)
                 packet_len = byte
-                packet_char = self._arg(1)
-                packet_width = self._arg(3)
+                packet_char = self._read_arg(1)
+                packet_width = self._read_arg(3)
                 packet_ends = self._init_packet(byte)
                 self.state = _dvistate.inpage
             elif byte == 242:       # a long packet
-                packet_len = self._arg(4)
-                packet_char = self._arg(4)
-                packet_width = self._arg(4)
+                packet_len = self._read_arg(4)
+                packet_char = self._read_arg(4)
+                packet_width = self._read_arg(4)
                 self._init_packet(packet_len)
             elif 243 <= byte <= 246:
-                k = self._arg(byte - 242, byte == 246)
-                c = self._arg(4)
-                s = self._arg(4)
-                d = self._arg(4)
-                a = self._arg(1)
-                l = self._arg(1)
+                k = self._read_arg(byte - 242, byte == 246)
+                c = self._read_arg(4)
+                s = self._read_arg(4)
+                d = self._read_arg(4)
+                a = self._read_arg(1)
+                l = self._read_arg(1)
                 self._fnt_def_real(k, c, s, d, a, l)
                 if self._first_font is None:
                     self._first_font = k
             elif byte == 247:       # preamble
-                i = self._arg(1)
-                k = self._arg(1)
+                i = self._read_arg(1)
+                k = self._read_arg(1)
                 x = self.file.read(k)
-                cs = self._arg(4)
-                ds = self._arg(4)
+                cs = self._read_arg(4)
+                ds = self._read_arg(4)
                 self._pre(i, x, cs, ds)
             elif byte == 248:       # postamble (just some number of 248s)
                 break

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -507,7 +507,7 @@ class Dvi:
             self.fonts[k] = exc
             return
         if c != 0 and tfm.checksum != 0 and c != tfm.checksum:
-            raise ValueError('tfm checksum mismatch: %s' % n)
+            raise ValueError(f'tfm checksum mismatch: {n}')
         try:
             vf = _vffile(fontname)
         except FileNotFoundError:
@@ -518,7 +518,7 @@ class Dvi:
     def _pre(self, i, num, den, mag, k):
         self.file.read(k)  # comment in the dvi file
         if i != 2:
-            raise ValueError("Unknown dvi format %d" % i)
+            raise ValueError(f"Unknown dvi format {i}")
         if num != 25400000 or den != 7227 * 2**16:
             raise ValueError("Nonstandard units in dvi file")
             # meaning: TeX always uses those exact values, so it
@@ -694,8 +694,7 @@ class Vf(Dvi):
                     raise ValueError("Packet length mismatch in vf file")
                 else:
                     if byte in (139, 140) or byte >= 243:
-                        raise ValueError(
-                            "Inappropriate opcode %d in vf file" % byte)
+                        raise ValueError(f"Inappropriate opcode {byte} in vf file")
                     Dvi._dtable[byte](self, byte)
                     continue
 
@@ -731,7 +730,7 @@ class Vf(Dvi):
             elif byte == 248:       # postamble (just some number of 248s)
                 break
             else:
-                raise ValueError("Unknown vf opcode %d" % byte)
+                raise ValueError(f"Unknown vf opcode {byte}")
 
     def _init_packet(self, pl):
         if self.state != _dvistate.outer:
@@ -755,7 +754,7 @@ class Vf(Dvi):
         if self.state is not _dvistate.pre:
             raise ValueError("pre command in middle of vf file")
         if i != 202:
-            raise ValueError("Unknown vf format %d" % i)
+            raise ValueError(f"Unknown vf format {i}")
         if len(x):
             _log.debug('vf file comment: %s', x)
         self.state = _dvistate.outer


### PR DESCRIPTION
## PR summary

Admittedly, this is a bit of a stylistic preference, but I find it a bit confusing to do stuff like:
```
w, x, y, z = foo, bar, baz, quux
```
when the RHS parts are more complex than a simple value.

And with simple values like `None`, that can be simplified to:
```
w = x = y = z = None
```
but with things like `[]`, then we _don't_ want to do that, so it's simpler to make those separate lines.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines