### PR TITLE
TST: Fix image comparison directory for test_striped_lines

### DIFF
--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -1311,7 +1311,6 @@ def test_check_offsets_dtype():
 
 @pytest.mark.parametrize('gapcolor', ['orange', ['r', 'k']])
 @check_figures_equal(extensions=['png'])
-@mpl.rc_context({'lines.linewidth': 20})
 def test_striped_lines(fig_test, fig_ref, gapcolor):
     ax_test = fig_test.add_subplot(111)
     ax_ref = fig_ref.add_subplot(111)
@@ -1323,11 +1322,12 @@ def test_striped_lines(fig_test, fig_ref, gapcolor):
     x = range(1, 6)
     linestyles = [':', '-', '--']
 
-    ax_test.vlines(x, 0, 1, linestyle=linestyles, gapcolor=gapcolor, alpha=0.5)
+    ax_test.vlines(x, 0, 1, linewidth=20, linestyle=linestyles, gapcolor=gapcolor,
+                   alpha=0.5)
 
     if isinstance(gapcolor, str):
         gapcolor = [gapcolor]
 
     for x, gcol, ls in zip(x, itertools.cycle(gapcolor),
                            itertools.cycle(linestyles)):
-        ax_ref.axvline(x, 0, 1, linestyle=ls, gapcolor=gcol, alpha=0.5)
+        ax_ref.axvline(x, 0, 1, linewidth=20, linestyle=ls, gapcolor=gcol, alpha=0.5)


### PR DESCRIPTION
## PR summary

The image comparison directory is determined by `inspect.getfile(func)`, but when a test is wrapped in `rc_context`, the file returned is `contextlib` since that decorator is `contextlib.contextmanager`. Since this test uses `check_figures_equal`, that doesn't break it, but it does break the `triage_tests.py` tool as it cannot find a corresponding baseline image directory.

Moving the `rc_context` decorator above `check_figures_equal` fixes the determined directory. While in this case, the context doesn't set anything that would affect figures, it also makes sense to set the context before figures are created.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines