### PR TITLE
FIX: remove __array__ method on BasicUnit

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -356,7 +356,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.gci:4"
     ],
     "Line2D.pick": [
-      "doc/users/explain/figure/event_handling.rst:568"
+      "doc/users/explain/figure/event_handling.rst:571"
     ],
     "QuadContourSet.changed()": [
       "lib/matplotlib/axes/_axes.py:docstring of matplotlib.axes._axes.Axes.contour:156",
@@ -365,7 +365,7 @@
       "lib/matplotlib/pyplot.py:docstring of matplotlib.pyplot.contourf:156"
     ],
     "Rectangle.contains": [
-      "doc/users/explain/figure/event_handling.rst:280"
+      "doc/users/explain/figure/event_handling.rst:285"
     ],
     "Size.from_any": [
       "lib/mpl_toolkits/axes_grid1/axes_grid.py:docstring of mpl_toolkits.axes_grid1.axes_grid.ImageGrid:87",

--- a/galleries/examples/units/basic_units.py
+++ b/galleries/examples/units/basic_units.py
@@ -223,13 +223,6 @@ class BasicUnit:
     def __array_wrap__(self, array, context=None, return_scalar=False):
         return TaggedValue(array, self)
 
-    def __array__(self, t=None, context=None, copy=False):
-        ret = np.array(1)
-        if t is not None:
-            return ret.astype(t)
-        else:
-            return ret
-
     def add_conversion_factor(self, unit, factor):
         def convert(x):
             return x*factor

--- a/galleries/examples/units/basic_units.py
+++ b/galleries/examples/units/basic_units.py
@@ -147,9 +147,6 @@ class TaggedValue(metaclass=TaggedValueMeta):
             return getattr(variable, name)
         return object.__getattribute__(self, name)
 
-    def __array__(self, dtype=object, copy=False):
-        return np.asarray(self.value, dtype)
-
     def __array_wrap__(self, array, context=None, return_scalar=False):
         return TaggedValue(array, self.unit)
 


### PR DESCRIPTION
The presence of this method causes the numpy float __mul__ to use it in numpy 2.1 which results in the units not being tagged as expected and the example failing.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
