### PR TITLE
Ensure SketchParams is always fully initialized

### DIFF
--- a/src/py_converters.cpp
+++ b/src/py_converters.cpp
@@ -453,6 +453,8 @@ int convert_sketch_params(PyObject *obj, void *sketchp)
 
     if (obj == NULL || obj == Py_None) {
         sketch->scale = 0.0;
+        sketch->length = 0.0;
+        sketch->randomness = 0.0;
     } else if (!PyArg_ParseTuple(obj,
                                  "ddd:sketch_params",
                                  &sketch->scale,


### PR DESCRIPTION
## PR summary

This fixes the following errors from valgrind:
```
Conditional jump or move depends on uninitialised value(s)
   at 0x377C3EE4: UnknownInlinedFun (path_converters.h:1025)
   by 0x377C3EE4: UnknownInlinedFun (_backend_agg.h:477)
   by 0x377C3EE4: PyRendererAgg_draw_path(PyRendererAgg*, _object*) [clone .lto_priv.0] (_backend_agg_wrapper.cpp:197)
   by 0x49E8705: method_vectorcall_VARARGS (descrobject.c:331)
   by 0x4A03B7B: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A03B7B: PyObject_Vectorcall (call.c:325)
   by 0x49ECEA4: _PyEval_EvalFrameDefault (bytecodes.c:2714)
   by 0x4A2B684: UnknownInlinedFun (call.c:419)
   by 0x4A2B684: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A2B684: method_vectorcall (classobject.c:91)
   by 0x49F1E44: UnknownInlinedFun (call.c:387)
   by 0x49F1E44: _PyEval_EvalFrameDefault (bytecodes.c:3262)
   by 0x4A2B684: UnknownInlinedFun (call.c:419)
   by 0x4A2B684: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A2B684: method_vectorcall (classobject.c:91)
   by 0x49F1E44: UnknownInlinedFun (call.c:387)
   by 0x49F1E44: _PyEval_EvalFrameDefault (bytecodes.c:3262)
   by 0x4A2B737: UnknownInlinedFun (call.c:419)
   by 0x4A2B737: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A2B737: method_vectorcall (classobject.c:61)
   by 0x4A19144: _PyVectorcall_Call (call.c:283)
   by 0x49F1E44: UnknownInlinedFun (call.c:387)
   by 0x49F1E44: _PyEval_EvalFrameDefault (bytecodes.c:3262)
   by 0x49E6CBA: _PyObject_FastCallDictTstate (call.c:144)

Conditional jump or move depends on uninitialised value(s)
   at 0x377C3F4F: UnknownInlinedFun (path_converters.h:1030)
   by 0x377C3F4F: UnknownInlinedFun (_backend_agg.h:477)
   by 0x377C3F4F: PyRendererAgg_draw_path(PyRendererAgg*, _object*) [clone .lto_priv.0] (_backend_agg_wrapper.cpp:197)
   by 0x49E8705: method_vectorcall_VARARGS (descrobject.c:331)
   by 0x4A03B7B: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A03B7B: PyObject_Vectorcall (call.c:325)
   by 0x49ECEA4: _PyEval_EvalFrameDefault (bytecodes.c:2714)
   by 0x4A2B684: UnknownInlinedFun (call.c:419)
   by 0x4A2B684: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A2B684: method_vectorcall (classobject.c:91)
   by 0x49F1E44: UnknownInlinedFun (call.c:387)
   by 0x49F1E44: _PyEval_EvalFrameDefault (bytecodes.c:3262)
   by 0x4A2B684: UnknownInlinedFun (call.c:419)
   by 0x4A2B684: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A2B684: method_vectorcall (classobject.c:91)
   by 0x49F1E44: UnknownInlinedFun (call.c:387)
   by 0x49F1E44: _PyEval_EvalFrameDefault (bytecodes.c:3262)
   by 0x4A2B737: UnknownInlinedFun (call.c:419)
   by 0x4A2B737: UnknownInlinedFun (pycore_call.h:92)
   by 0x4A2B737: method_vectorcall (classobject.c:61)
   by 0x4A19144: _PyVectorcall_Call (call.c:283)
   by 0x49F1E44: UnknownInlinedFun (call.c:387)
   by 0x49F1E44: _PyEval_EvalFrameDefault (bytecodes.c:3262)
   by 0x49E6CBA: _PyObject_FastCallDictTstate (call.c:144)
```

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines