### PR TITLE
DOC/TST: lock numpy < 2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
     parameters:
       numpy_version:
         type: string
-        default: "!=2.1.0"
+        default: "<2.1.0"
     steps:
       - run:
           name: Install Python dependencies

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
     parameters:
       numpy_version:
         type: string
-        default: "<2.1.0"
+        default: "~=2.0.0"
     steps:
       - run:
           name: Install Python dependencies

--- a/requirements/dev/build-requirements.txt
+++ b/requirements/dev/build-requirements.txt
@@ -1,4 +1,4 @@
 pybind11!=2.13.3
 meson-python
-numpy
+numpy<2.1.0
 setuptools-scm


### PR DESCRIPTION
recent numpy breaks `basic_units.py`, which breaks the doc build. 

Someone should fix `basic_units.py`, but for now, force version to be smaller than numpy 2.1
