### PR TITLE
TST: Fix test_pickle_load_from_subprocess in a dirty tree

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -225,6 +225,7 @@ def _get_version():
         else:
             return setuptools_scm.get_version(
                 root=root,
+                dist_name="matplotlib",
                 version_scheme="release-branch-semver",
                 local_scheme="node-and-date",
                 fallback_version=_version.version,

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -150,7 +150,15 @@ def test_pickle_load_from_subprocess(fig_test, fig_ref, tmp_path):
     proc = subprocess_run_helper(
         _pickle_load_subprocess,
         timeout=60,
-        extra_env={'PICKLE_FILE_PATH': str(fp), 'MPLBACKEND': 'Agg'}
+        extra_env={
+            "PICKLE_FILE_PATH": str(fp),
+            "MPLBACKEND": "Agg",
+            # subprocess_run_helper will set SOURCE_DATE_EPOCH=0, so for a dirty tree,
+            # the version will have the date 19700101. As we aren't trying to test the
+            # version compatibility warning, force setuptools-scm to use the same
+            # version as us.
+            "SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MATPLOTLIB": mpl.__version__,
+        },
     )
 
     loaded_fig = pickle.loads(ast.literal_eval(proc.stdout))


### PR DESCRIPTION
## PR summary

For a ditry tree, `setuptools-scm` adds the date to the end of the version. This test runs a subprocess and `subprocess_run_helper` will set `SOURCE_DATE_EPOCH=0`, which forces the date to be 1970-01-01, triggering a mismatched version warning on unpickle.

Since we aren't testing the version-compatibility warning, set `SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MATPLOTLIB` in the subprocess call so that versions match.

We also need to set the `dist_name` parameter when querying setuptools-scm or it won't check that environment variable.

This is something I've long seen, but never investigated.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines