### PR TITLE
patheffects.SimpleLineShadow calling non-existent get_foreground method from GraphicsContextBase

### DIFF
--- a/lib/matplotlib/patheffects.py
+++ b/lib/matplotlib/patheffects.py
@@ -325,7 +325,7 @@ class SimpleLineShadow(AbstractPathEffect):
         gc0.copy_properties(gc)
 
         if self._shadow_color is None:
-            r, g, b = (gc0.get_foreground() or (1., 1., 1.))[:3]
+            r, g, b = (gc0.get_rgb() or (1., 1., 1.))[:3]
             # Scale the colors by a factor to improve the shadow effect.
             shadow_rgbFace = (r * self._rho, g * self._rho, b * self._rho)
         else:


### PR DESCRIPTION
#28793 : Replaced nonexistent get_foreground() method with get_rgb()