### PR TITLE
Resolve configdir so that it's not a symlink when is_dir() is called

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -530,26 +530,27 @@ def _get_config_or_cache_dir(xdg_base_getter):
     configdir = configdir.resolve()
     try:
         configdir.mkdir(parents=True, exist_ok=True)
-    except OSError:
-        pass
+    except OSError as exc:
+        _log.warning("mkdir -p failed for path %s: %s", configdir, exc)
     else:
         if os.access(str(configdir), os.W_OK) and configdir.is_dir():
             return str(configdir)
+        _log.warning("%s is not a writable directory", configdir)
     # If the config or cache directory cannot be created or is not a writable
     # directory, create a temporary one.
     try:
         tmpdir = tempfile.mkdtemp(prefix="matplotlib-")
     except OSError as exc:
         raise OSError(
-            f"Matplotlib requires access to a writable cache directory, but the "
-            f"default path ({configdir}) is not a writable directory, and a temporary "
+            f"Matplotlib requires access to a writable cache directory, but there "
+            f"was an issue with the default path ({configdir}), and a temporary "
             f"directory could not be created; set the MPLCONFIGDIR environment "
             f"variable to a writable directory") from exc
     os.environ["MPLCONFIGDIR"] = tmpdir
     atexit.register(shutil.rmtree, tmpdir)
     _log.warning(
-        "Matplotlib created a temporary cache directory at %s because the default path "
-        "(%s) is not a writable directory; it is highly recommended to set the "
+        "Matplotlib created a temporary cache directory at %s because there was "
+        "an issue with the default path (%s); it is highly recommended to set the "
         "MPLCONFIGDIR environment variable to a writable directory, in particular to "
         "speed up the import of Matplotlib and to better support multiprocessing.",
         tmpdir, configdir)

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -519,13 +519,15 @@ def _get_xdg_cache_dir():
 def _get_config_or_cache_dir(xdg_base_getter):
     configdir = os.environ.get('MPLCONFIGDIR')
     if configdir:
-        configdir = Path(configdir).resolve()
+        configdir = Path(configdir)
     elif sys.platform.startswith(('linux', 'freebsd')):
         # Only call _xdg_base_getter here so that MPLCONFIGDIR is tried first,
         # as _xdg_base_getter can throw.
         configdir = Path(xdg_base_getter(), "matplotlib")
     else:
         configdir = Path.home() / ".matplotlib"
+    # Resolve the path to handle potential issues with inaccessible symlinks.
+    configdir = configdir.resolve()
     try:
         configdir.mkdir(parents=True, exist_ok=True)
     except OSError:


### PR DESCRIPTION
Closes #28817.

There are some use cases where a user might have to make ~/.config a symlink (e.g. if a corporate home directory has limited space, and symlinks are used to offload the storage to a separate storage disk). So resolving configdir beforehand should prevent the is_dir() check from failing, causing a warning to be issued and forcing a temporary directory to be used.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
