### PR TITLE
DOC: Fix missing cross-reference checks for sphinx-tags

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -89,6 +89,7 @@
           - 'doc/conf.py'
           - 'doc/Makefile'
           - 'doc/make.bat'
+          - 'doc/sphinxext/**'
 "Documentation: devdocs":
   - changed-files:
       - any-glob-to-any-file:

--- a/doc/sphinxext/missing_references.py
+++ b/doc/sphinxext/missing_references.py
@@ -100,10 +100,11 @@ def handle_missing_reference(app, domain, node):
     #. record missing references for saving/comparing with ignored list.
     #. prevent Sphinx from raising a warning on ignored references.
     """
-    typ = node["reftype"]
+    refdomain = node["refdomain"]
+    reftype = node["reftype"]
     target = node["reftarget"]
     location = get_location(node, app)
-    domain_type = f"{domain.name}:{typ}"
+    domain_type = f"{refdomain}:{reftype}"
 
     app.env.missing_references_events[(domain_type, target)].add(location)
 


### PR DESCRIPTION
## PR summary

In cda437289b0cf41a01571904b6a13bedf8f037a4, I "simplified" from `node['refdomain']` to the existing `domain` argument. With `sphinx-tags`, the `warn-missing-reference` event occurs for a `None` domain, and we crash trying to access `domain.name`. But `node['refdomain']` is still an empty string, so revert back to that.

Noticed this as part of #27302.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines