### PR TITLE
DOC: Update policy to prefer squash merging

### DIFF
--- a/doc/devel/pr_guide.rst
+++ b/doc/devel/pr_guide.rst
@@ -228,11 +228,14 @@ unsure why a test is failing, ask on the PR or in our :ref:`communication-channe
 Number of commits and squashing
 -------------------------------
 
-* Squashing is case-by-case.  The balance is between burden on the
-  contributor, keeping a relatively clean history, and keeping a
-  history usable for bisecting.  The only time we are really strict
-  about it is to eliminate binary files (ex multiple test image
-  re-generations) and to remove upstream merges.
+* The default and preferred method of merging code into the main branch
+  is to squash merge commits so that a single clean and usable
+  commit is in the git history. The commit message should be cleaned up
+  by the person merging so that the git history has useful messages
+  when going through the history. If the commits are organized and contain
+  useful messages, the PR author can ask the person merging to not squash
+  the commits. This is done on a case-by-case basis and at the discretion
+  of the person merging.
 
 * Do not let perfect be the enemy of the good, particularly for
   documentation or example PRs.  If you find yourself making many


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

On the weekly call, we discussed our squash merging policy. There was a general consensus to update our documentation to default/prefer squash merging commits. This can be on a case-by-case basis and if the PR author has good clean commit messages and history, we do not need to squash commits. This means that maintainers should clean up commit messages when squashing many commits down for the author to tidy up the message history.

This will help avoid contacting PR authors asking them to squash their commits down, going back and forth, and potentially losing new contributors from this sometimes confusing process. It can also help when accepting the GitHub inline code suggestions which create new commits where a maintainer can now accept suggestions and squash those out of the history.

ping @matplotlib/developers for awareness and more open discussion if anyone has strong preferences for/against this update.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
