### PR TITLE
Pass AbstractMovieWriter.setup kwargs through Animation.save

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -209,7 +209,7 @@ class AbstractMovieWriter(abc.ABC):
         """
         Context manager to facilitate writing the movie file.
 
-        ``*args, **kw`` are any parameters that should be passed to `setup`.
+        ``*args, **kwargs`` are any parameters that should be passed to `setup`.
         """
         if mpl.rcParams['savefig.bbox'] == 'tight':
             _log.info("Disabling savefig.bbox = 'tight', as it may cause "
@@ -906,7 +906,7 @@ class Animation:
 
     def save(self, filename, writer=None, fps=None, dpi=None, codec=None,
              bitrate=None, extra_args=None, metadata=None, extra_anim=None,
-             savefig_kwargs=None, *, progress_callback=None):
+             savefig_kwargs=None, *, progress_callback=None, **kwargs):
         """
         Save the animation as a movie file by drawing every frame.
 
@@ -972,6 +972,9 @@ class Animation:
             Example code to write the progress to stdout::
 
                 progress_callback = lambda i, n: print(f'Saving frame {i}/{n}')
+
+        **kwargs :
+            Additional keyword arguments are passed to `AbstractMovieWriter.setup`.
 
         Notes
         -----
@@ -1066,7 +1069,7 @@ class Animation:
         # canvas._is_saving = True makes the draw_event animation-starting
         # callback a no-op; canvas.manager = None prevents resizing the GUI
         # widget (both are likewise done in savefig()).
-        with (writer.saving(self._fig, filename, dpi),
+        with (writer.saving(self._fig, filename, dpi, **kwargs),
               cbook._setattr_cm(self._fig.canvas, _is_saving=True, manager=None)):
             for anim in all_anim:
                 anim._init_draw()  # Clear the initial frame


### PR DESCRIPTION
## PR summary

This is a rebase of #11863 with the addition of a test. That PR was closed because #16082 defaulted animations to save intermediate files to a temporary directory. However, that didn't actually fix the ability to pass arguments to `setup`, which means the idea from #16082 to "just pass `frame_prefix` if you want to save the temporary files" was never possible.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines