### PR TITLE
Fix 3D rotation precession

### DIFF
--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1950,10 +1950,10 @@ def test_rotate():
     for roll, dx, dy, new_elev, new_azim, new_roll in [
             [0, 0.5, 0, 0, -90, 0],
             [30, 0.5, 0, 30, -90, 0],
-            [0, 0, 0.5, -90, 0, 0],
+            [0, 0, 0.5, -90, -180, 180],
             [30, 0, 0.5, -60, -90, 90],
-            [0, 0.5, 0.5, -45, -90, 45],
-            [30, 0.5, 0.5, -15, -90, 45]]:
+            [0, np.sqrt(2)/4, np.sqrt(2)/4, -45, -90, 45],
+            [30, np.sqrt(2)/4, np.sqrt(2)/4, -15, -90, 45]]:
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1, projection='3d')
         ax.view_init(0, 0, roll)
@@ -1967,9 +1967,8 @@ def test_rotate():
                            xdata=dx*ax._pseudo_w, ydata=dy*ax._pseudo_h))
         fig.canvas.draw()
 
-        assert np.isclose(ax.elev, new_elev)
-        assert np.isclose(ax.azim, new_azim)
-        assert np.isclose(ax.roll, new_roll)
+        np.testing.assert_allclose((ax.elev, ax.azim, ax.roll),
+                                   (new_elev, new_azim, new_roll), atol=1e-6)
 
 
 def test_pan():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

https://github.com/matplotlib/matplotlib/pull/28290 introduced "arcball" style rotation to 3D plots, which IMO is a significant enhancement over the previous rotation style. However, there was a change to the original arcball implementation to slow down the speed of rotation, which had the inadvertent side effect that it caused the plot to precess when moving the mouse around. This removed the desirable property that returning the mouse to the same point on the screen restored the original view. See the comments at the end of that issue for some example videos.

This tweaks the math to have the best of both worlds - a 1:1 mapping between screen position and view angle during a single mouse click, and also scaling down the "double angle" high speed rotations to a "single angle" speed.

@MischaMegens2 could you please check the math and weigh in on if you think this makes sense to change for the default?

I think that since this behavior is new for 3.10, it makes sense to prioritize getting it in. The what's new note shouldn't have to change.

See also some more discussion in https://github.com/matplotlib/matplotlib/issues/28408.

Original arcball paper: https://graphicsinterface.org/wp-content/uploads/gi1992-18.pdf

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
