### PR TITLE
Update pgf tutorial

### DIFF
--- a/galleries/users_explain/text/pgf.py
+++ b/galleries/users_explain/text/pgf.py
@@ -28,9 +28,9 @@ or by registering it for handling pdf output ::
     from matplotlib.backends.backend_pgf import FigureCanvasPgf
     matplotlib.backend_bases.register_backend('pdf', FigureCanvasPgf)
 
-The last method allows you to keep using regular interactive backends and to
+The lastest methods allows you to keep using regular interactive backends and to
 save xelatex, lualatex or pdflatex compiled PDF files from the graphical user
-interface.  Note that, in that case, the interactive display will still use the
+interface. Note that, in that case, the interactive display will still use the
 standard interactive backends (e.g., QtAgg), and in particular use latex to
 compile relevant text snippets.
 


### PR DESCRIPTION
## PR summary

In #16281 it was missed the fact that the `backend` keyword was also allowing to keep interactive backends without registering the Pgf one for pdf outputs.

## PR checklist

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines