### PR TITLE
DOC: Fix non-working code object references

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -28,6 +28,17 @@ The Axes class
 
    Axes
 
+Attributes
+----------
+
+.. autosummary::
+   :toctree: _as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   Axes.viewLim
+   Axes.dataLim
+
 Plotting
 ========
 

--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -338,10 +338,6 @@
     "Artist.stale_callback": [
       "doc/users/explain/figure/interactive_guide.rst:323"
     ],
-    "Axes.dataLim": [
-      "doc/api/axes_api.rst:293:<autosummary>:1",
-      "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes._base._AxesBase.update_datalim:2"
-    ],
     "AxesBase": [
       "doc/api/axes_api.rst:448:<autosummary>:1",
       "lib/matplotlib/axes/_base.py:docstring of matplotlib.axes._base._AxesBase.add_child_axes:2"

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -85,13 +85,6 @@ class Axes(_AxesBase):
         methods instead; e.g. from `.pyplot` or `.Figure`:
         `~.pyplot.subplots`, `~.pyplot.subplot_mosaic` or `.Figure.add_axes`.
 
-    Attributes
-    ----------
-    dataLim : `.Bbox`
-        The bounding box enclosing all data displayed in the Axes.
-    viewLim : `.Bbox`
-        The view limits in data coordinates.
-
     """
     ### Labelling, legend and texts
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -551,6 +551,9 @@ class _AxesBase(martist.Artist):
 
     _subclass_uses_cla = False
 
+    dataLim: mtransforms.Bbox
+    """The bounding `.Bbox` enclosing all data displayed in the Axes."""
+
     @property
     def _axis_map(self):
         """A mapping of axis names, e.g. 'x', to `Axis` instances."""
@@ -849,6 +852,7 @@ class _AxesBase(martist.Artist):
 
     @property
     def viewLim(self):
+        """The view limits as `.Bbox` in data coordinates."""
         self._unstale_viewLim()
         return self._viewLim
 
@@ -2265,7 +2269,7 @@ class _AxesBase(martist.Artist):
 
     def add_child_axes(self, ax):
         """
-        Add an `.AxesBase` to the Axes' children; return the child Axes.
+        Add an `.Axes` to the Axes' children; return the child Axes.
 
         This is the lowlevel version.  See `.axes.Axes.inset_axes`.
         """


### PR DESCRIPTION
These were not rendered as links in the current docs, because the
associated code objects do not exist as targets in the docs. For some
reason, sphinx did not complain about it. But it does in some recent
PRs (extracted from #28560) - I'm unclear why, but anyway the correct
solution is to change to explicitly listing the attributes.