### PR TITLE
 MNT: Replace _docstring.dedent_interpd by its alias _docstring.interpd

### DIFF
--- a/lib/matplotlib/_docstring.py
+++ b/lib/matplotlib/_docstring.py
@@ -122,4 +122,4 @@ def copy(source):
 
 # Create a decorator that will house the various docstring snippets reused
 # throughout Matplotlib.
-dedent_interpd = interpd = _ArtistPropertiesSubstitution()
+interpd = _ArtistPropertiesSubstitution()

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -220,7 +220,7 @@ class Axes(_AxesBase):
             [self], legend_handler_map)
         return handles, labels
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def legend(self, *args, **kwargs):
         """
         Place a legend on the Axes.
@@ -418,7 +418,7 @@ class Axes(_AxesBase):
 
         return inset_ax
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def indicate_inset(self, bounds, inset_ax=None, *, transform=None,
                        facecolor='none', edgecolor='0.5', alpha=0.5,
                        zorder=4.99, **kwargs):
@@ -572,7 +572,7 @@ class Axes(_AxesBase):
         rect = (xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0])
         return self.indicate_inset(rect, inset_ax, **kwargs)
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def secondary_xaxis(self, location, functions=None, *, transform=None, **kwargs):
         """
         Add a second x-axis to this `~.axes.Axes`.
@@ -626,7 +626,7 @@ class Axes(_AxesBase):
         self.add_child_axes(secondary_ax)
         return secondary_ax
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def secondary_yaxis(self, location, functions=None, *, transform=None, **kwargs):
         """
         Add a second y-axis to this `~.axes.Axes`.
@@ -670,7 +670,7 @@ class Axes(_AxesBase):
         self.add_child_axes(secondary_ax)
         return secondary_ax
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def text(self, x, y, s, fontdict=None, **kwargs):
         """
         Add text to the Axes.
@@ -749,7 +749,7 @@ class Axes(_AxesBase):
         self._add_text(t)
         return t
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def annotate(self, text, xy, xytext=None, xycoords='data', textcoords=None,
                  arrowprops=None, annotation_clip=None, **kwargs):
         # Signature must match Annotation. This is verified in
@@ -765,7 +765,7 @@ class Axes(_AxesBase):
     annotate.__doc__ = mtext.Annotation.__init__.__doc__
     #### Lines and spans
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def axhline(self, y=0, xmin=0, xmax=1, **kwargs):
         """
         Add a horizontal line spanning the whole or fraction of the Axes.
@@ -839,7 +839,7 @@ class Axes(_AxesBase):
             self._request_autoscale_view("y")
         return l
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def axvline(self, x=0, ymin=0, ymax=1, **kwargs):
         """
         Add a vertical line spanning the whole or fraction of the Axes.
@@ -921,7 +921,7 @@ class Axes(_AxesBase):
                 raise ValueError(f"{name} must be a single scalar value, "
                                  f"but got {val}")
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def axline(self, xy1, xy2=None, *, slope=None, **kwargs):
         """
         Add an infinitely long straight line.
@@ -995,7 +995,7 @@ class Axes(_AxesBase):
         self._request_autoscale_view()
         return line
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def axhspan(self, ymin, ymax, xmin=0, xmax=1, **kwargs):
         """
         Add a horizontal span (rectangle) across the Axes.
@@ -1050,7 +1050,7 @@ class Axes(_AxesBase):
         self._request_autoscale_view("y")
         return p
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def axvspan(self, xmin, xmax, ymin=0, ymax=1, **kwargs):
         """
         Add a vertical span (rectangle) across the Axes.
@@ -1301,7 +1301,7 @@ class Axes(_AxesBase):
     @_preprocess_data(replace_names=["positions", "lineoffsets",
                                      "linelengths", "linewidths",
                                      "colors", "linestyles"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def eventplot(self, positions, orientation='horizontal', lineoffsets=1,
                   linelengths=1, linewidths=None, colors=None, alpha=None,
                   linestyles='solid', **kwargs):
@@ -1547,7 +1547,7 @@ class Axes(_AxesBase):
 
     # Uses a custom implementation of data-kwarg handling in
     # _process_plot_var_args.
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def plot(self, *args, scalex=True, scaley=True, data=None, **kwargs):
         """
         Plot y versus x as lines and/or markers.
@@ -1803,7 +1803,7 @@ class Axes(_AxesBase):
 
     @_api.deprecated("3.9", alternative="plot")
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def plot_date(self, x, y, fmt='o', tz=None, xdate=True, ydate=False,
                   **kwargs):
         """
@@ -1883,7 +1883,7 @@ class Axes(_AxesBase):
         return self.plot(x, y, fmt, **kwargs)
 
     # @_preprocess_data() # let 'plot' do the unpacking..
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def loglog(self, *args, **kwargs):
         """
         Make a plot with log scaling on both the x- and y-axis.
@@ -1937,7 +1937,7 @@ class Axes(_AxesBase):
             *args, **{k: v for k, v in kwargs.items() if k not in {*dx, *dy}})
 
     # @_preprocess_data() # let 'plot' do the unpacking..
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def semilogx(self, *args, **kwargs):
         """
         Make a plot with log scaling on the x-axis.
@@ -1984,7 +1984,7 @@ class Axes(_AxesBase):
             *args, **{k: v for k, v in kwargs.items() if k not in d})
 
     # @_preprocess_data() # let 'plot' do the unpacking..
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def semilogy(self, *args, **kwargs):
         """
         Make a plot with log scaling on the y-axis.
@@ -2340,7 +2340,7 @@ class Axes(_AxesBase):
         return dx
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def bar(self, x, height, width=0.8, bottom=None, *, align="center",
             **kwargs):
         r"""
@@ -2652,7 +2652,7 @@ class Axes(_AxesBase):
         return bar_container
 
     # @_preprocess_data() # let 'bar' do the unpacking..
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def barh(self, y, width, height=0.8, left=None, *, align="center",
              data=None, **kwargs):
         r"""
@@ -2946,7 +2946,7 @@ class Axes(_AxesBase):
         return annotations
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def broken_barh(self, xranges, yrange, **kwargs):
         """
         Plot a horizontal sequence of rectangles.
@@ -3455,7 +3455,7 @@ class Axes(_AxesBase):
     @_api.make_keyword_only("3.9", "ecolor")
     @_preprocess_data(replace_names=["x", "y", "xerr", "yerr"],
                       label_namer="y")
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def errorbar(self, x, y, yerr=None, xerr=None,
                  fmt='', ecolor=None, elinewidth=None, capsize=None,
                  barsabove=False, lolims=False, uplims=False,
@@ -4985,7 +4985,7 @@ class Axes(_AxesBase):
 
     @_api.make_keyword_only("3.9", "gridsize")
     @_preprocess_data(replace_names=["x", "y", "C"], label_namer="y")
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def hexbin(self, x, y, C=None, gridsize=100, bins=None,
                xscale='linear', yscale='linear', extent=None,
                cmap=None, norm=None, vmin=None, vmax=None,
@@ -5380,7 +5380,7 @@ class Axes(_AxesBase):
 
         return collection
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def arrow(self, x, y, dx, dy, **kwargs):
         """
         Add an arrow to the Axes.
@@ -5435,7 +5435,7 @@ class Axes(_AxesBase):
 
     # args can be a combination of X, Y, U, V, C and all should be replaced
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def quiver(self, *args, **kwargs):
         """%(quiver_doc)s"""
         # Make sure units are handled for x and y values
@@ -5447,7 +5447,7 @@ class Axes(_AxesBase):
 
     # args can be some combination of X, Y, U, V, C and all should be replaced
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def barbs(self, *args, **kwargs):
         """%(barbs_doc)s"""
         # Make sure units are handled for x and y values
@@ -5718,7 +5718,7 @@ class Axes(_AxesBase):
             dir="horizontal", ind="x", dep="y"
         )
     fill_between = _preprocess_data(
-        _docstring.dedent_interpd(fill_between),
+        _docstring.interpd(fill_between),
         replace_names=["x", "y1", "y2", "where"])
 
     def fill_betweenx(self, y, x1, x2=0, where=None,
@@ -5732,7 +5732,7 @@ class Axes(_AxesBase):
             dir="vertical", ind="y", dep="x"
         )
     fill_betweenx = _preprocess_data(
-        _docstring.dedent_interpd(fill_betweenx),
+        _docstring.interpd(fill_betweenx),
         replace_names=["y", "x1", "x2", "where"])
 
     #### plotting z(x, y): imshow, pcolor and relatives, contour
@@ -6093,7 +6093,7 @@ class Axes(_AxesBase):
         return X, Y, C, shading
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def pcolor(self, *args, shading=None, alpha=None, norm=None, cmap=None,
                vmin=None, vmax=None, **kwargs):
         r"""
@@ -6310,7 +6310,7 @@ class Axes(_AxesBase):
         return collection
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def pcolormesh(self, *args, alpha=None, norm=None, cmap=None, vmin=None,
                    vmax=None, shading=None, antialiased=False, **kwargs):
         """
@@ -6537,7 +6537,7 @@ class Axes(_AxesBase):
         return collection
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def pcolorfast(self, *args, alpha=None, norm=None, cmap=None, vmin=None,
                    vmax=None, **kwargs):
         """
@@ -6724,7 +6724,7 @@ class Axes(_AxesBase):
         return ret
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def contour(self, *args, **kwargs):
         """
         Plot contour lines.
@@ -6742,7 +6742,7 @@ class Axes(_AxesBase):
         return contours
 
     @_preprocess_data()
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def contourf(self, *args, **kwargs):
         """
         Plot filled contours.
@@ -7374,7 +7374,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "range")
     @_preprocess_data(replace_names=["x", "y", "weights"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def hist2d(self, x, y, bins=10, range=None, density=False, weights=None,
                cmin=None, cmax=None, **kwargs):
         """
@@ -7481,7 +7481,7 @@ such objects
         return h, xedges, yedges, pc
 
     @_preprocess_data(replace_names=["x", "weights"], label_namer="x")
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def ecdf(self, x, weights=None, *, complementary=False,
              orientation="vertical", compress=False, **kwargs):
         """
@@ -7584,7 +7584,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "NFFT")
     @_preprocess_data(replace_names=["x"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
             sides=None, scale_by_freq=None, return_line=None, **kwargs):
@@ -7696,7 +7696,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "NFFT")
     @_preprocess_data(replace_names=["x", "y"], label_namer="y")
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def csd(self, x, y, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
             sides=None, scale_by_freq=None, return_line=None, **kwargs):
@@ -7799,7 +7799,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "Fs")
     @_preprocess_data(replace_names=["x"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def magnitude_spectrum(self, x, Fs=None, Fc=None, window=None,
                            pad_to=None, sides=None, scale=None,
                            **kwargs):
@@ -7886,7 +7886,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "Fs")
     @_preprocess_data(replace_names=["x"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def angle_spectrum(self, x, Fs=None, Fc=None, window=None,
                        pad_to=None, sides=None, **kwargs):
         """
@@ -7956,7 +7956,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "Fs")
     @_preprocess_data(replace_names=["x"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def phase_spectrum(self, x, Fs=None, Fc=None, window=None,
                        pad_to=None, sides=None, **kwargs):
         """
@@ -8026,7 +8026,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "NFFT")
     @_preprocess_data(replace_names=["x", "y"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def cohere(self, x, y, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,
                window=mlab.window_hanning, noverlap=0, pad_to=None,
                sides='default', scale_by_freq=None, **kwargs):
@@ -8091,7 +8091,7 @@ such objects
 
     @_api.make_keyword_only("3.9", "NFFT")
     @_preprocess_data(replace_names=["x"])
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
                  window=None, noverlap=None,
                  cmap=None, xextent=None, pad_to=None, sides=None,
@@ -8252,7 +8252,7 @@ such objects
         return spec, freqs, t, im
 
     @_api.make_keyword_only("3.9", "precision")
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def spy(self, Z, precision=0, marker=None, markersize=None,
             aspect='equal', origin="upper", **kwargs):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3242,7 +3242,7 @@ class _AxesBase(martist.Artist):
             axis.set_zorder(zorder)
         self.stale = True
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def grid(self, visible=None, which='major', axis='both', **kwargs):
         """
         Configure the grid lines.

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -555,7 +555,7 @@ layers : array
 """)
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 class ContourSet(ContourLabeler, mcoll.Collection):
     """
     Store a set of contour lines or filled regions.
@@ -1269,7 +1269,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
                 super().draw(renderer)
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 class QuadContourSet(ContourSet):
     """
     Create and store a set of contour lines or filled regions.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -527,7 +527,7 @@ default: %(va)s
         self.stale = True
         return artist
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def add_axes(self, *args, **kwargs):
         """
         Add an `~.axes.Axes` to the figure.
@@ -645,7 +645,7 @@ default: %(va)s
                 addendum="Any additional positional arguments are currently ignored.")
         return self._add_axes_internal(a, key)
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def add_subplot(self, *args, **kwargs):
         """
         Add an `~.axes.Axes` to the figure as part of a subplot arrangement.
@@ -1024,7 +1024,7 @@ default: %(va)s
     #    " legend(" -> " figlegend(" for the signatures
     #    "fig.legend(" -> "plt.figlegend" for the code examples
     #    "ax.plot" -> "plt.plot" for consistency in using pyplot when able
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def legend(self, *args, **kwargs):
         """
         Place a legend on the figure.
@@ -1144,7 +1144,7 @@ default: %(va)s
         self.stale = True
         return l
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def text(self, x, y, s, fontdict=None, **kwargs):
         """
         Add text to figure.
@@ -1194,7 +1194,7 @@ default: %(va)s
         self.stale = True
         return text
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def colorbar(
             self, mappable, cax=None, ax=None, use_gridspec=True, **kwargs):
         """

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -351,7 +351,7 @@ class Legend(Artist):
     def __str__(self):
         return "Legend"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(
         self, parent, handles, labels,
         *,
@@ -643,7 +643,7 @@ class Legend(Artist):
 
         a.set_transform(self.get_transform())
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def set_loc(self, loc=None):
         """
         Set the location of the legend.

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -458,7 +458,7 @@ scale_by_freq : bool, default: True
     MATLAB compatibility.""")
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def psd(x, NFFT=None, Fs=None, detrend=None, window=None,
         noverlap=None, pad_to=None, sides=None, scale_by_freq=None):
     r"""
@@ -514,7 +514,7 @@ def psd(x, NFFT=None, Fs=None, detrend=None, window=None,
     return Pxx.real, freqs
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def csd(x, y, NFFT=None, Fs=None, detrend=None, window=None,
         noverlap=None, pad_to=None, sides=None, scale_by_freq=None):
     """
@@ -634,7 +634,7 @@ phase_spectrum.__doc__ = _single_spectrum_docs.format(
     **_docstring.interpd.params)
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
              noverlap=None, pad_to=None, sides=None, scale_by_freq=None,
              mode=None):
@@ -717,7 +717,7 @@ def specgram(x, NFFT=None, Fs=None, detrend=None, window=None,
     return spec, freqs, t
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def cohere(x, y, NFFT=256, Fs=2, detrend=detrend_none, window=window_hanning,
            noverlap=0, pad_to=None, sides='default', scale_by_freq=None):
     r"""

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1191,7 +1191,7 @@ class AnnotationBbox(martist.Artist, mtext._AnnotationBase):
     def __str__(self):
         return f"AnnotationBbox({self.xy[0]:g},{self.xy[1]:g})"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, offsetbox, xy, xybox=None, xycoords='data', boxcoords=None, *,
                  frameon=True, pad=0.4,  # FancyBboxPatch boxstyle.
                  annotation_clip=None,

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -655,7 +655,7 @@ class Shadow(Patch):
     def __str__(self):
         return f"Shadow({self.patch})"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, patch, ox, oy, *, shade=0.7, **kwargs):
         """
         Create a shadow of the given *patch*.
@@ -735,7 +735,7 @@ class Rectangle(Patch):
         fmt = "Rectangle(xy=(%g, %g), width=%g, height=%g, angle=%g)"
         return fmt % pars
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, width, height, *,
                  angle=0.0, rotation_point='xy', **kwargs):
         """
@@ -936,7 +936,7 @@ class RegularPolygon(Patch):
         return s % (self.xy[0], self.xy[1], self.numvertices, self.radius,
                     self.orientation)
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, numVertices, *,
                  radius=5, orientation=0, **kwargs):
         """
@@ -986,7 +986,7 @@ class PathPatch(Patch):
         s = "PathPatch%d((%g, %g) ...)"
         return s % (len(self._path.vertices), *tuple(self._path.vertices[0]))
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, path, **kwargs):
         """
         *path* is a `.Path` object.
@@ -1015,7 +1015,7 @@ class StepPatch(PathPatch):
 
     _edge_default = False
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, values, edges, *,
                  orientation='vertical', baseline=0, **kwargs):
         """
@@ -1124,7 +1124,7 @@ class Polygon(Patch):
         else:
             return "Polygon0()"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, *, closed=True, **kwargs):
         """
         Parameters
@@ -1222,7 +1222,7 @@ class Wedge(Patch):
         fmt = "Wedge(center=(%g, %g), r=%g, theta1=%g, theta2=%g, width=%s)"
         return fmt % pars
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, center, r, theta1, theta2, *, width=None, **kwargs):
         """
         A wedge centered at *x*, *y* center with radius *r* that
@@ -1310,7 +1310,7 @@ class Arrow(Patch):
         [0.0, 0.1], [0.0, -0.1], [0.8, -0.1], [0.8, -0.3], [1.0, 0.0],
         [0.8, 0.3], [0.8, 0.1]])
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, x, y, dx, dy, *, width=1.0, **kwargs):
         """
         Draws an arrow from (*x*, *y*) to (*x* + *dx*, *y* + *dy*).
@@ -1393,7 +1393,7 @@ class FancyArrow(Polygon):
     def __str__(self):
         return "FancyArrow()"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, x, y, dx, dy, *,
                  width=0.001, length_includes_head=False, head_width=None,
                  head_length=None, shape='full', overhang=0,
@@ -1564,7 +1564,7 @@ class CirclePolygon(RegularPolygon):
         s = "CirclePolygon((%g, %g), radius=%g, resolution=%d)"
         return s % (self.xy[0], self.xy[1], self.radius, self.numvertices)
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, radius=5, *,
                  resolution=20,  # the number of vertices
                  ** kwargs):
@@ -1591,7 +1591,7 @@ class Ellipse(Patch):
         fmt = "Ellipse(xy=(%s, %s), width=%s, height=%s, angle=%s)"
         return fmt % pars
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, width, height, *, angle=0, **kwargs):
         """
         Parameters
@@ -1767,7 +1767,7 @@ class Annulus(Patch):
     An elliptical annulus.
     """
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, r, width, angle=0.0, **kwargs):
         """
         Parameters
@@ -1958,7 +1958,7 @@ class Circle(Ellipse):
         fmt = "Circle(xy=(%g, %g), radius=%g)"
         return fmt % pars
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, radius=5, **kwargs):
         """
         Create a true circle at center *xy* = (*x*, *y*) with given *radius*.
@@ -2005,7 +2005,7 @@ class Arc(Ellipse):
                "height=%g, angle=%g, theta1=%g, theta2=%g)")
         return fmt % pars
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, width, height, *,
                  angle=0.0, theta1=0.0, theta2=360.0, **kwargs):
         """
@@ -2367,7 +2367,7 @@ def _register_style(style_list, cls=None, *, name=None):
     return cls
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 class BoxStyle(_Style):
     """
     `BoxStyle` is a container class which defines several
@@ -2732,7 +2732,7 @@ class BoxStyle(_Style):
             return Path(saw_vertices, codes)
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 class ConnectionStyle(_Style):
     """
     `ConnectionStyle` is a container class which defines
@@ -3154,7 +3154,7 @@ def _point_along_a_line(x0, y0, x1, y1, d):
     return x2, y2
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 class ArrowStyle(_Style):
     """
     `ArrowStyle` is a container class which defines several
@@ -3891,7 +3891,7 @@ class FancyBboxPatch(Patch):
         s = self.__class__.__name__ + "((%g, %g), width=%g, height=%g)"
         return s % (self._x, self._y, self._width, self._height)
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xy, width, height, boxstyle="round", *,
                  mutation_scale=1, mutation_aspect=1, **kwargs):
         """
@@ -3943,7 +3943,7 @@ class FancyBboxPatch(Patch):
         self._mutation_aspect = mutation_aspect
         self.stale = True
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def set_boxstyle(self, boxstyle=None, **kwargs):
         """
         Set the box style, possibly with further attributes.
@@ -4143,7 +4143,7 @@ class FancyArrowPatch(Patch):
         else:
             return f"{type(self).__name__}({self._path_original})"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, posA=None, posB=None, *,
                  path=None, arrowstyle="simple", connectionstyle="arc3",
                  patchA=None, patchB=None, shrinkA=2, shrinkB=2,
@@ -4282,7 +4282,7 @@ default: 'arc3'
         self.patchB = patchB
         self.stale = True
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def set_connectionstyle(self, connectionstyle=None, **kwargs):
         """
         Set the connection style, possibly with further attributes.
@@ -4326,7 +4326,7 @@ default: 'arc3'
         """Return the `ConnectionStyle` used."""
         return self._connector
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def set_arrowstyle(self, arrowstyle=None, **kwargs):
         """
         Set the arrow style, possibly with further attributes.
@@ -4470,7 +4470,7 @@ class ConnectionPatch(FancyArrowPatch):
         return "ConnectionPatch((%g, %g), (%g, %g))" % \
                (self.xy1[0], self.xy1[1], self.xy2[0], self.xy2[1])
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, xyA, xyB, coordsA, coordsB=None, *,
                  axesA=None, axesB=None,
                  arrowstyle="-",

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1257,7 +1257,7 @@ if Figure.legend.__doc__:
 
 ## Axes ##
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def axes(
     arg: None | tuple[float, float, float, float] = None,
     **kwargs
@@ -1376,7 +1376,7 @@ def cla() -> None:
 
 ## More ways of creating Axes ##
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def subplot(*args, **kwargs) -> Axes:
     """
     Add an Axes to the current figure or retrieve an existing Axes.

--- a/lib/matplotlib/sankey.py
+++ b/lib/matplotlib/sankey.py
@@ -347,7 +347,7 @@ class Sankey:
         # path[2] = path[2][::-1]
         # return path
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def add(self, patchlabel='', flows=None, orientations=None, labels='',
             trunklength=1.0, pathlengths=0.25, prior=None, connect=(0, 0),
             rotation=0, **kwargs):

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -32,7 +32,7 @@ class Spine(mpatches.Patch):
     def __str__(self):
         return "Spine"
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, axes, spine_type, path, **kwargs):
         """
         Parameters

--- a/lib/matplotlib/table.py
+++ b/lib/matplotlib/table.py
@@ -175,7 +175,7 @@ substring of 'BRTL'
         l, b, w, h = self.get_text_bounds(renderer)
         return w * (1.0 + (2.0 * self.PAD))
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def set_text_props(self, **kwargs):
         """
         Update the text properties.
@@ -649,7 +649,7 @@ class Table(Artist):
         return self._cells
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def table(ax,
           cellText=None, cellColours=None,
           cellLoc='right', colWidths=None,

--- a/lib/matplotlib/tri/_tricontour.py
+++ b/lib/matplotlib/tri/_tricontour.py
@@ -5,7 +5,7 @@ from matplotlib.contour import ContourSet
 from matplotlib.tri._triangulation import Triangulation
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 class TriContourSet(ContourSet):
     """
     Create and store a set of contour lines or filled regions for
@@ -218,7 +218,7 @@ antialiased : bool, optional
 
 
 @_docstring.Substitution(func='tricontour', type='lines')
-@_docstring.dedent_interpd
+@_docstring.interpd
 def tricontour(ax, *args, **kwargs):
     """
     %(_tricontour_doc)s
@@ -247,7 +247,7 @@ def tricontour(ax, *args, **kwargs):
 
 
 @_docstring.Substitution(func='tricontourf', type='regions')
-@_docstring.dedent_interpd
+@_docstring.interpd
 def tricontourf(ax, *args, **kwargs):
     """
     %(_tricontour_doc)s

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -15,7 +15,7 @@ from .parasite_axes import HostAxes
 
 @_api.deprecated("3.8", alternative="Axes.inset_axes")
 class InsetPosition:
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, parent, lbwh):
         """
         An object for positioning an inset axes.
@@ -131,7 +131,7 @@ class AnchoredZoomLocator(AnchoredLocatorBase):
 
 
 class BboxPatch(Patch):
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, bbox, **kwargs):
         """
         Patch showing the shape bounded by a Bbox.
@@ -193,7 +193,7 @@ class BboxConnector(Patch):
         x2, y2 = BboxConnector.get_bbox_edge_pos(bbox2, loc2)
         return Path([[x1, y1], [x2, y2]])
 
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, bbox1, bbox2, loc1, loc2=None, **kwargs):
         """
         Connect two bboxes with a straight line.
@@ -237,7 +237,7 @@ class BboxConnector(Patch):
 
 
 class BboxConnectorPatch(BboxConnector):
-    @_docstring.dedent_interpd
+    @_docstring.interpd
     def __init__(self, bbox1, bbox2, loc1a, loc2a, loc1b, loc2b, **kwargs):
         """
         Connect two bboxes with a quadrilateral.
@@ -295,7 +295,7 @@ def _add_inset_axes(parent_axes, axes_class, axes_kwargs, axes_locator):
     return fig.add_axes(inset_axes)
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def inset_axes(parent_axes, width, height, loc='upper right',
                bbox_to_anchor=None, bbox_transform=None,
                axes_class=None, axes_kwargs=None,
@@ -419,7 +419,7 @@ def inset_axes(parent_axes, width, height, loc='upper right',
             bbox_transform=bbox_transform, borderpad=borderpad))
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def zoomed_inset_axes(parent_axes, zoom, loc='upper right',
                       bbox_to_anchor=None, bbox_transform=None,
                       axes_class=None, axes_kwargs=None,
@@ -512,7 +512,7 @@ class _TransformedBboxWithCallback(TransformedBbox):
         return super().get_points()
 
 
-@_docstring.dedent_interpd
+@_docstring.interpd
 def mark_inset(parent_axes, inset_axes, loc1, loc2, **kwargs):
     """
     Draw a box to mark the location of an area represented by an inset axes.


### PR DESCRIPTION
 Historically, they were the different, but are the same for
 several years. Since the whole `_docstring` module has become private,
 we can simply remove the alias `dedent_interpd`. Note that `interpd`
 nowadays also handles indentation smartly, so we don't have to care
 about "dedenting".
