### PR TITLE
MNT: Use __init__ parameters of font properties

### DIFF
--- a/galleries/examples/text_labels_and_annotations/fonts_demo.py
+++ b/galleries/examples/text_labels_and_annotations/fonts_demo.py
@@ -21,34 +21,28 @@ heading_font = FontProperties(size='large')
 fig.text(0.1, 0.9, 'family', fontproperties=heading_font, **alignment)
 families = ['serif', 'sans-serif', 'cursive', 'fantasy', 'monospace']
 for k, family in enumerate(families):
-    font = FontProperties()
-    font.set_family(family)
+    font = FontProperties(family=[family])
     fig.text(0.1, yp[k], family, fontproperties=font, **alignment)
 
 # Show style options
 styles = ['normal', 'italic', 'oblique']
 fig.text(0.3, 0.9, 'style', fontproperties=heading_font, **alignment)
 for k, style in enumerate(styles):
-    font = FontProperties()
-    font.set_family('sans-serif')
-    font.set_style(style)
+    font = FontProperties(family='sans-serif', style=style)
     fig.text(0.3, yp[k], style, fontproperties=font, **alignment)
 
 # Show variant options
 variants = ['normal', 'small-caps']
 fig.text(0.5, 0.9, 'variant', fontproperties=heading_font, **alignment)
 for k, variant in enumerate(variants):
-    font = FontProperties()
-    font.set_family('serif')
-    font.set_variant(variant)
+    font = FontProperties(family='serif', variant=variant)
     fig.text(0.5, yp[k], variant, fontproperties=font, **alignment)
 
 # Show weight options
 weights = ['light', 'normal', 'medium', 'semibold', 'bold', 'heavy', 'black']
 fig.text(0.7, 0.9, 'weight', fontproperties=heading_font, **alignment)
 for k, weight in enumerate(weights):
-    font = FontProperties()
-    font.set_weight(weight)
+    font = FontProperties(weight=weight)
     fig.text(0.7, yp[k], weight, fontproperties=font, **alignment)
 
 # Show size options
@@ -56,8 +50,7 @@ sizes = [
     'xx-small', 'x-small', 'small', 'medium', 'large', 'x-large', 'xx-large']
 fig.text(0.9, 0.9, 'size', fontproperties=heading_font, **alignment)
 for k, size in enumerate(sizes):
-    font = FontProperties()
-    font.set_size(size)
+    font = FontProperties(size=size)
     fig.text(0.9, yp[k], size, fontproperties=font, **alignment)
 
 # Show bold italic

--- a/galleries/users_explain/text/text_intro.py
+++ b/galleries/users_explain/text/text_intro.py
@@ -177,10 +177,7 @@ plt.show()
 
 from matplotlib.font_manager import FontProperties
 
-font = FontProperties()
-font.set_family('serif')
-font.set_name('Times New Roman')
-font.set_style('italic')
+font = FontProperties(family='Times New Roman', style='italic')
 
 fig, ax = plt.subplots(figsize=(5, 3))
 fig.subplots_adjust(bottom=0.15, left=0.2)


### PR DESCRIPTION
Replace default initialization immediately followed by setting values by initialization with values, i.e.

```
# before:
fp = FontProperties()
fp.set_[something](val)

# after
fp = FontProperties([something]=val)
```

This is clearer and additionally helps with the possible transition of making FontProperties immutable, see #22495.
