### PR TITLE
TST: Fix minor issues in interactive backend test

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -166,7 +166,8 @@ def _test_interactive_impl():
 
     if backend.endswith("agg") and not backend.startswith(("gtk", "web")):
         # Force interactive framework setup.
-        plt.figure()
+        fig = plt.figure()
+        plt.close(fig)
 
         # Check that we cannot switch to a backend using another interactive
         # framework, but can switch to a backend using cairo instead of agg,
@@ -224,10 +225,7 @@ def _test_interactive_impl():
     result_after = io.BytesIO()
     fig.savefig(result_after, format='png')
 
-    if not backend.startswith('qt5') and sys.platform == 'darwin':
-        # FIXME: This should be enabled everywhere once Qt5 is fixed on macOS
-        # to not resize incorrectly.
-        assert result.getvalue() == result_after.getvalue()
+    assert result.getvalue() == result_after.getvalue()
 
 
 @pytest.mark.parametrize("env", _get_testable_interactive_backends())
@@ -444,8 +442,7 @@ def qt5_and_qt6_pairs():
 
     for qt5 in qt5_bindings:
         for qt6 in qt6_bindings:
-            for pair in ([qt5, qt6], [qt6, qt5]):
-                yield pair
+            yield from ([qt5, qt6], [qt6, qt5])
 
 
 @pytest.mark.parametrize('host, mpl', [*qt5_and_qt6_pairs()])


### PR DESCRIPTION
## PR summary

We noticed this while looking at #28588.

- Close the figure immediately, to avoid the deprecation warning about automatically closing figure when changing backends. This test doesn't intend to test the warning, just the change behaviour itself.
- Enable the post-`show()` result check everywhere. The comment implies it should only be skipped on `(macOS and Qt5)`, but the condition is actually only enabled on `macOS and (not Qt5)`. I'm not sure if this will actually work as it's been disabled for so long unintentionally.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines