### PR TITLE
Make mplot3d mouse rotation style adjustable

### DIFF
--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -83,8 +83,9 @@ mouse movement (it is quite noticeable, especially when adjusting roll),
 and it lacks an obvious mechanical equivalent; arguably, the path-independent rotation is unnatural.
 So it is a trade-off.
 
-Shoemake's arcball has an abrupt edge; this is remedied in Holroyd's arcball
-(``mouserotationstyle: Holroyd``).
+Shoemake's arcball has an abrupt edge; this is remedied in Gavin Bell's arcball
+(``mouserotationstyle: Bell``), originally written for OpenGL [Bell1988]_. It is used
+in Blender and Meshlab.
 
 Henriksen et al. [Henriksen2002]_ provide an overview. In summary:
 
@@ -122,7 +123,7 @@ Henriksen et al. [Henriksen2002]_ provide an overview. In summary:
      - ✔️
      - ✔️
      - ❌
-   * - Holroyd
+   * - Bell
      - ❌
      - ✔️
      - ✔️
@@ -142,7 +143,7 @@ You can try out one of the various mouse rotation styles using::
 .. code::
 
     import matplotlib as mpl
-    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Holroyd'
+    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Bell'
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -183,11 +184,14 @@ A size of about 2/3 appears to work reasonably well; this is the default.
   three-dimensional rotation using a mouse", in Proceedings of Graphics
   Interface '92, 1992, pp. 151-156, https://doi.org/10.20380/GI1992.18
 
-.. [Henriksen2002] Knud Henriksen, Jon Sporring, Kasper Hornbæk,
-  "Virtual Trackballs Revisited", in Proceedings of DSAGM'2002
-  `[pdf]`__;
-  and in IEEE Transactions on Visualization and Computer Graphics,
-  Volume 10, Issue 2, March-April 2004, pp. 206-216,
-  https://doi.org/10.1109/TVCG.2004.1260772
 
-__ https://web.archive.org/web/20240607102518/http://hjemmesider.diku.dk/~kash/papers/DSAGM2002_henriksen.pdf
+.. [Bell1988] Gavin Bell, in the examples included with the GLUT (OpenGL
+  Utility Toolkit) library,
+  https://github.com/markkilgard/glut/blob/master/progs/examples/trackball.h
+
+.. [Henriksen2002] Knud Henriksen, Jon Sporring, Kasper Hornbæk,
+  "Virtual Trackballs Revisited", in IEEE Transactions on Visualization
+  and Computer Graphics, Volume 10, Issue 2, March-April 2004, pp. 206-216,
+  https://doi.org/10.1109/TVCG.2004.1260772 `[full-text]`__;
+
+__ https://www.researchgate.net/publication/8329656_Virtual_Trackballs_Revisited#fullTextFileContent

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -70,22 +70,19 @@ move the mouse in circles with a handedness opposite to the desired rotation,
 counterintuitively.
 
 A different variety of trackball rotates along the shortest arc on the virtual
-sphere (``mouserotationstyle: arcball``); it is a variation on Ken Shoemake's
-ARCBALL [Shoemake1992]_. Rotating around the viewing direction is straightforward
-with it (grab the ball near its edge instead of near the center).
+sphere (``mouserotationstyle: sphere``). Rotating around the viewing direction
+is straightforward with it: grab the ball near its edge instead of near the center.
 
-Shoemake's original arcball is also available (``mouserotationstyle: Shoemake``);
-it is free of hysteresis, i.e., returning mouse to the original position
-returns the figure to its original orientation, the rotation is independent
+Ken Shoemake's ARCBALL [Shoemake1992]_ is also available (``mouserotationstyle: Shoemake``);
+it resembles the ``sphere`` style, but is free of hysteresis,
+i.e., returning mouse to the original position
+returns the figure to its original orientation; the rotation is independent
 of the details of the path the mouse took, which could be desirable.
 However, Shoemake's arcball rotates at twice the angular rate of the
 mouse movement (it is quite noticeable, especially when adjusting roll),
-and it lacks an obvious mechanical equivalent; arguably, the path-independent rotation is unnatural.
+and it lacks an obvious mechanical equivalent; arguably, the path-independent
+rotation is not natural (however convenient), it could take some getting used to.
 So it is a trade-off.
-
-Shoemake's arcball has an abrupt edge; this is remedied in Gavin Bell's arcball
-(``mouserotationstyle: Bell``), originally written for OpenGL [Bell1988]_. It is used
-in Blender and Meshlab.
 
 Henriksen et al. [Henriksen2002]_ provide an overview. In summary:
 
@@ -111,19 +108,13 @@ Henriksen et al. [Henriksen2002]_ provide an overview. In summary:
      - ✔️
      - ❌
      - ✔️
+   * - sphere
+     - ❌
+     - ✔️
+     - ✔️
+     - ❌
+     - ✔️
    * - arcball
-     - ❌
-     - ✔️
-     - ✔️
-     - ❌
-     - ✔️
-   * - Shoemake
-     - ❌
-     - ✔️
-     - ✔️
-     - ✔️
-     - ❌
-   * - Bell
      - ❌
      - ✔️
      - ✔️
@@ -134,16 +125,16 @@ Henriksen et al. [Henriksen2002]_ provide an overview. In summary:
 .. [1] The way it was prior to v3.10; this is also MATLAB's style
 .. [2] Mouse controls roll too (not only azimuth and elevation)
 .. [3] Figure reacts the same way to mouse movements, regardless of orientation (no difference between 'poles' and 'equator')
-.. [4] Returning mouse to original position returns figure to original orientation (no hysteresis: rotation is independent of the details of the path the mouse took)
+.. [4] Returning mouse to original position returns figure to original orientation (rotation is independent of the details of the path the mouse took)
 .. [5] The style has a corresponding natural implementation as a mechanical device
-.. [6] While it is possible to control roll with the ``trackball`` style, this is not very intuitive (it requires moving the mouse in large circles) and the resulting roll is in the opposite direction
+.. [6] While it is possible to control roll with the ``trackball`` style, this is not immediately obvious (it requires moving the mouse in large circles) and a bit counterintuitive (the resulting roll is in the opposite direction)
 
 You can try out one of the various mouse rotation styles using::
 
 .. code::
 
     import matplotlib as mpl
-    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Bell'
+    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'sphere', or 'arcball'
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -169,21 +160,36 @@ Alternatively, create a file ``matplotlibrc``, with contents::
 (or any of the other styles, instead of ``arcball``), and then run any of
 the :ref:`mplot3d-examples-index` examples.
 
-The size of the virtual trackball or arcball can be adjusted as well,
+The size of the virtual trackball, sphere, or arcball can be adjusted
 by setting :rc:`axes3d.trackballsize`. This specifies how much
 mouse motion is needed to obtain a given rotation angle (when near the center),
-and it controls where the edge of the arcball is (how far from the center,
-how close to the plot edge).
+and it controls where the edge of the sphere or arcball is (how far from
+the center, hence how close to the plot edge).
 The size is specified in units of the Axes bounding box,
-i.e., to make the trackball span the whole bounding box, set it to 1.
+i.e., to make the arcball span the whole bounding box, set it to 1.
 A size of about 2/3 appears to work reasonably well; this is the default.
 
-----
+Both arcballs (``mouserotationstyle: sphere`` and
+``mouserotationstyle: arcball``) have a noticeable edge; the edge can be made
+less abrupt by specifying a border width, :rc:`axes3d.trackballborder`.
+This works somewhat like Gavin Bell's arcball, which was
+originally written for OpenGL [Bell1988]_, and is used in Blender and Meshlab.
+Bell's arcball extends the arcball's spherical control surface with a hyperbola;
+the two are smoothly joined. However, the hyperbola extends all the way beyond
+the edge of the plot. In the mplot3d sphere and arcball style, the border extends
+to a radius :rc:`axes3d.trackballsize`/2 + :rc:`axes3d.trackballborder`.
+Beyond the border, the style works like the original: it controls roll only.
+A border width of about 0.2 appears to work well; this is the default.
+To obtain the original Shoemake's arcball with a sharp border,
+set the border width to 0.
+For an extended border similar to Bell's arcball, where the transition from
+the arcball to the border occurs at 45°, set the border width to
+$\sqrt 2 \approx 1.414$.
+
 
 .. [Shoemake1992] Ken Shoemake, "ARCBALL: A user interface for specifying
   three-dimensional rotation using a mouse", in Proceedings of Graphics
   Interface '92, 1992, pp. 151-156, https://doi.org/10.20380/GI1992.18
-
 
 .. [Bell1988] Gavin Bell, in the examples included with the GLUT (OpenGL
   Utility Toolkit) library,

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -54,7 +54,7 @@ Originally (prior to v3.10), the 2D mouse position corresponded directly
 to azimuth and elevation; this is also how it is done
 in `MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_.
 To keep it this way, set ``mouserotationstyle: azel``.
-This approach works fine for polar plots, where the *z* axis is special;
+This approach works fine for spherical coordinate plots, where the *z* axis is special;
 however, it leads to a kind of 'gimbal lock' when looking down the *z* axis:
 the plot reacts differently to mouse movement, dependent on the particular
 orientation at hand. Also, 'roll' cannot be controlled.

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -177,7 +177,7 @@ originally written for OpenGL [Bell1988]_, and is used in Blender and Meshlab.
 Bell's arcball extends the arcball's spherical control surface with a hyperbola;
 the two are smoothly joined. However, the hyperbola extends all the way beyond
 the edge of the plot. In the mplot3d sphere and arcball style, the border extends
-to a radius `trackballsize/2 + trackballborder`.
+to a radius ``trackballsize/2 + trackballborder``.
 Beyond the border, the style works like the original: it controls roll only.
 A border width of about 0.2 appears to work well; this is the default.
 To obtain the original Shoemake's arcball with a sharp border,
@@ -185,6 +185,8 @@ set the border width to 0.
 For an extended border similar to Bell's arcball, where the transition from
 the arcball to the border occurs at 45°, set the border width to
 :math:`\sqrt 2 \approx 1.414`.
+The border is a circular arc, wrapped around the arcball sphere cylindrically
+(like a doughnut), joined smoothly to the sphere, much like Bell's hyperbola.
 
 
 .. [Shoemake1992] Ken Shoemake, "ARCBALL: A user interface for specifying

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -47,7 +47,7 @@ Rotation with mouse
 
 3D plots can be reoriented by dragging the mouse.
 There are various ways to accomplish this; the style of mouse rotation
-can be specified by setting ``rcParams.axes3d.mouserotationstyle``, see
+can be specified by setting :rc:`axes3d.mouserotationstyle`, see
 :doc:`/users/explain/customizing`.
 
 Prior to v3.10, the 2D mouse position corresponded directly
@@ -169,7 +169,7 @@ Alternatively, create a file ``matplotlibrc``, with contents::
 the :ref:`mplot3d-examples-index` examples.
 
 The size of the virtual trackball or arcball can be adjusted as well,
-by setting ``rcParams.axes3d.trackballsize``. This specifies how much
+by setting :rc:`axes3d.trackballsize`. This specifies how much
 mouse motion is needed to obtain a given rotation angle (when near the center),
 and it controls where the edge of the arcball is (how far from the center,
 how close to the plot edge).

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -50,7 +50,7 @@ There are various ways to accomplish this; the style of mouse rotation
 can be specified by setting ``rcParams.axes3d.mouserotationstyle``, see
 :doc:`/users/explain/customizing`.
 
-Originally (prior to v3.10), the 2D mouse position corresponded directly
+Prior to v3.10, the 2D mouse position corresponded directly
 to azimuth and elevation; this is also how it is done
 in `MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_.
 To keep it this way, set ``mouserotationstyle: azel``.

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -38,3 +38,119 @@ further documented in the `.mplot3d.axes3d.Axes3D.view_init` API.
 
 .. plot:: gallery/mplot3d/view_planes_3d.py
    :align: center
+
+
+Rotation with mouse
+===================
+
+3D plots can be reoriented by dragging the mouse.
+There are various ways to accomplish this; the style of mouse rotation
+can be specified by setting ``rcParams.axes3d.mouserotationstyle``, see
+:doc:`/users/explain/customizing`.
+
+Originally (with ``mouserotationstyle: azel``), the 2D mouse position
+corresponded directly to azimuth and elevation; this is also how it is done
+in `MATLAB <https://www.mathworks.com/help/matlab/ref/view.html>`_.
+This approach works fine for polar plots, where the *z* axis is special;
+however, it leads to a kind of 'gimbal lock' when looking down the *z* axis:
+the plot reacts differently to mouse movement, dependent on the particular
+orientation at hand. Also, 'roll' cannot be controlled.
+
+As an alternative, there are various mouse rotation styles where the mouse
+manipulates a 'trackball'. In its simplest form (``mouserotationstyle: trackball``),
+the trackball rotates around an in-plane axis perpendicular to the mouse motion
+(it is as if there is a plate laying on the trackball; the plate itself is fixed
+in orientation, but you can drag the plate with the mouse, thus rotating the ball).
+This is more natural to work with than the ``azel`` style; however,
+the plot cannot be easily rotated around the viewing direction - one has to
+drag the mouse in circles with a handedness opposite to the desired rotation.
+
+A different variety of trackball rotates along the shortest arc on the virtual
+sphere (``mouserotationstyle: arcball``); it is a variation on Ken Shoemake's
+ARCBALL [Shoemake1992]_. Rotating around the viewing direction is straightforward
+with it. Shoemake's original arcball is also available
+(``mouserotationstyle: Shoemake``); it is free of hysteresis, i.e.,
+returning mouse to the original position returns the figure to its original
+orientation, the rotation is independent of the details of the path the mouse
+took. However, Shoemake's arcball rotates at twice the angular rate of the
+mouse movement (it is quite noticeable, especially when adjusting roll).
+So it is a trade-off.
+
+Shoemake's arcball has an abrupt edge; this is remedied in Holroyd's arcball
+(``mouserotationstyle: Holroyd``).
+
+Henriksen et al. [Henriksen2002]_ provide an overview.
+
+In summary:
+
+.. list-table::
+   :width: 100%
+   :widths: 30 20 20 20 35
+
+   * - Style
+     - traditional [1]_
+     - incl. roll [2]_
+     - uniform [3]_
+     - path independent [4]_
+   * - azel
+     - ✔️
+     - ❌
+     - ❌
+     - ✔️
+   * - trackball
+     - ❌
+     - ～
+     - ✔️
+     - ❌
+   * - arcball
+     - ❌
+     - ✔️
+     - ✔️
+     - ❌
+   * - Shoemake
+     - ❌
+     - ✔️
+     - ✔️
+     - ✔️
+   * - Holroyd
+     - ❌
+     - ✔️
+     - ✔️
+     - ✔️
+
+
+.. [1] The way it was historically; this is also MATLAB's style
+.. [2] Mouse controls roll too (not only azimuth and elevation)
+.. [3] Figure reacts the same way to mouse movements, regardless of orientation (no difference between 'poles' and 'equator')
+.. [4] Returning mouse to original position returns figure to original orientation (no hysteresis: rotation is independent of the details of the path the mouse took)
+
+Try it out by adding a file ``matplotlibrc`` to folder ``matplotlib\galleries\examples\mplot3d``,
+with contents::
+
+    axes3d.mouserotationstyle: arcball
+
+(or any of the other styles), and run a suitable example, e.g.::
+
+    python surfaced3d.py
+
+(If eternal compatibility with the horrors of the past is less of a consideration
+for you, then it is likely that you would want to go with ``arcball``, ``Shoemake``,
+or ``Holroyd``.)
+
+The size of the trackball or arcball can be adjusted by setting
+``rcParams.axes3d.trackballsize``, in units of the Axes bounding box;
+i.e., to make the trackball span the whole bounding box, set it to 1.
+A size of ca. 2/3 appears to work reasonably well.
+
+----
+
+.. [Shoemake1992] Ken Shoemake, "ARCBALL: A user interface for specifying
+  three-dimensional rotation using a mouse", in Proceedings of Graphics
+  Interface '92, 1992, pp. 151-156, https://doi.org/10.20380/GI1992.18
+
+.. [Henriksen2002] Knud Henriksen, Jon Sporring, Kasper Hornbæk,
+  "Virtual Trackballs Revisited", in Proceedings of DSAGM'2002:
+  http://www.diku.dk/~kash/papers/DSAGM2002_henriksen.pdf;
+  and in IEEE Transactions on Visualization
+  and Computer Graphics, Volume 10, Issue 2, March-April 2004, pp. 206-216,
+  https://doi.org/10.1109/TVCG.2004.1260772

--- a/doc/api/toolkits/mplot3d/view_angles.rst
+++ b/doc/api/toolkits/mplot3d/view_angles.rst
@@ -129,7 +129,7 @@ Henriksen et al. [Henriksen2002]_ provide an overview. In summary:
 .. [5] The style has a corresponding natural implementation as a mechanical device
 .. [6] While it is possible to control roll with the ``trackball`` style, this is not immediately obvious (it requires moving the mouse in large circles) and a bit counterintuitive (the resulting roll is in the opposite direction)
 
-You can try out one of the various mouse rotation styles using::
+You can try out one of the various mouse rotation styles using:
 
 .. code::
 
@@ -155,9 +155,9 @@ You can try out one of the various mouse rotation styles using::
 
 Alternatively, create a file ``matplotlibrc``, with contents::
 
-    axes3d.mouserotationstyle: arcball
+    axes3d.mouserotationstyle: trackball
 
-(or any of the other styles, instead of ``arcball``), and then run any of
+(or any of the other styles, instead of ``trackball``), and then run any of
 the :ref:`mplot3d-examples-index` examples.
 
 The size of the virtual trackball, sphere, or arcball can be adjusted
@@ -177,14 +177,14 @@ originally written for OpenGL [Bell1988]_, and is used in Blender and Meshlab.
 Bell's arcball extends the arcball's spherical control surface with a hyperbola;
 the two are smoothly joined. However, the hyperbola extends all the way beyond
 the edge of the plot. In the mplot3d sphere and arcball style, the border extends
-to a radius :rc:`axes3d.trackballsize`/2 + :rc:`axes3d.trackballborder`.
+to a radius `trackballsize/2 + trackballborder`.
 Beyond the border, the style works like the original: it controls roll only.
 A border width of about 0.2 appears to work well; this is the default.
 To obtain the original Shoemake's arcball with a sharp border,
 set the border width to 0.
 For an extended border similar to Bell's arcball, where the transition from
 the arcball to the border occurs at 45°, set the border width to
-$\sqrt 2 \approx 1.414$.
+:math:`\sqrt 2 \approx 1.414`.
 
 
 .. [Shoemake1992] Ken Shoemake, "ARCBALL: A user interface for specifying

--- a/doc/users/next_whats_new/mouse_rotation.rst
+++ b/doc/users/next_whats_new/mouse_rotation.rst
@@ -20,7 +20,7 @@ To try out one of the various mouse rotation styles:
 .. code::
 
     import matplotlib as mpl
-    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Bell'
+    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'sphere', or 'arcball'
 
     import numpy as np
     import matplotlib.pyplot as plt

--- a/doc/users/next_whats_new/mouse_rotation.rst
+++ b/doc/users/next_whats_new/mouse_rotation.rst
@@ -8,7 +8,37 @@ degrees of freedom (azimuth, elevation, and roll). By default,
 it uses a variation on Ken Shoemake's ARCBALL [1]_.
 The particular style of mouse rotation can be set via
 ``rcParams.axes3d.mouserotationstyle``.
-See also :doc:`/api/toolkits/mplot3d/view_angles`.
+See also :ref:`toolkit_mouse-rotation`.
+
+To revert to the original mouse rotation style,
+create a file ``matplotlibrc`` with contents::
+
+    axes3d.mouserotationstyle: azel
+
+To try out one of the various mouse rotation styles:
+
+.. code::
+
+    import matplotlib as mpl
+    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Holroyd'
+
+    import numpy as np
+    import matplotlib.pyplot as plt
+    from matplotlib import cm
+
+    ax = plt.figure().add_subplot(projection='3d')
+
+    X = np.arange(-5, 5, 0.25)
+    Y = np.arange(-5, 5, 0.25)
+    X, Y = np.meshgrid(X, Y)
+    R = np.sqrt(X**2 + Y**2)
+    Z = np.sin(R)
+
+    surf = ax.plot_surface(X, Y, Z, cmap=cm.coolwarm,
+                           linewidth=0, antialiased=False)
+
+    plt.show()
+
 
 .. [1] Ken Shoemake, "ARCBALL: A user interface for specifying
   three-dimensional rotation using a mouse", in Proceedings of Graphics

--- a/doc/users/next_whats_new/mouse_rotation.rst
+++ b/doc/users/next_whats_new/mouse_rotation.rst
@@ -4,9 +4,12 @@ Rotating 3d plots with the mouse
 Rotating three-dimensional plots with the mouse has been made more intuitive.
 The plot now reacts the same way to mouse movement, independent of the
 particular orientation at hand; and it is possible to control all 3 rotational
-degrees of freedom (azimuth, elevation, and roll). It uses a variation on
-Ken Shoemake's ARCBALL [Shoemake1992]_.
+degrees of freedom (azimuth, elevation, and roll). By default,
+it uses a variation on Ken Shoemake's ARCBALL [1]_.
+The particular style of mouse rotation can be set via
+``rcParams.axes3d.mouserotationstyle``.
+See also :doc:`/api/toolkits/mplot3d/view_angles`.
 
-.. [Shoemake1992] Ken Shoemake, "ARCBALL: A user interface for specifying
-  three-dimensional rotation using a mouse." in Proceedings of Graphics
+.. [1] Ken Shoemake, "ARCBALL: A user interface for specifying
+  three-dimensional rotation using a mouse", in Proceedings of Graphics
   Interface '92, 1992, pp. 151-156, https://doi.org/10.20380/GI1992.18

--- a/doc/users/next_whats_new/mouse_rotation.rst
+++ b/doc/users/next_whats_new/mouse_rotation.rst
@@ -7,7 +7,7 @@ particular orientation at hand; and it is possible to control all 3 rotational
 degrees of freedom (azimuth, elevation, and roll). By default,
 it uses a variation on Ken Shoemake's ARCBALL [1]_.
 The particular style of mouse rotation can be set via
-``rcParams.axes3d.mouserotationstyle``.
+:rc:`axes3d.mouserotationstyle`.
 See also :ref:`toolkit_mouse-rotation`.
 
 To revert to the original mouse rotation style,

--- a/doc/users/next_whats_new/mouse_rotation.rst
+++ b/doc/users/next_whats_new/mouse_rotation.rst
@@ -20,7 +20,7 @@ To try out one of the various mouse rotation styles:
 .. code::
 
     import matplotlib as mpl
-    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Holroyd'
+    mpl.rcParams['axes3d.mouserotationstyle'] = 'trackball'  # 'azel', 'trackball', 'arcball', 'Shoemake', or 'Bell'
 
     import numpy as np
     import matplotlib.pyplot as plt

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -433,7 +433,7 @@
 #axes3d.yaxis.panecolor:    (0.90, 0.90, 0.90, 0.5)  # background pane on 3D axes
 #axes3d.zaxis.panecolor:    (0.925, 0.925, 0.925, 0.5)  # background pane on 3D axes
 
-#axes3d.mouserotationstyle: trackball  # {azel, trackball, sphere, arcball}
+#axes3d.mouserotationstyle: arcball  # {azel, trackball, sphere, arcball}
                             # See also https://matplotlib.org/stable/api/toolkits/mplot3d/view_angles.html#rotation-with-mouse
 #axes3d.trackballsize: 0.667  # trackball diameter, in units of the Axes bbox
 #axes3d.trackballborder: 0.2  # trackball border width, in units of the Axes bbox (only for 'sphere' and 'arcball' style)

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -433,6 +433,10 @@
 #axes3d.yaxis.panecolor:    (0.90, 0.90, 0.90, 0.5)  # background pane on 3D axes
 #axes3d.zaxis.panecolor:    (0.925, 0.925, 0.925, 0.5)  # background pane on 3D axes
 
+#axes3d.mouserotationstyle: arcball  # {azel, trackball, arcball, Shoemake, Holroyd}
+                            # See also https://matplotlib.org/stable/api/toolkits/mplot3d/view_angles.html#rotation-with-mouse
+#axes3d.trackballsize: 0.667  # trackball diameter, in units of the Axes bbox
+
 ## ***************************************************************************
 ## * AXIS                                                                    *
 ## ***************************************************************************

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -433,7 +433,7 @@
 #axes3d.yaxis.panecolor:    (0.90, 0.90, 0.90, 0.5)  # background pane on 3D axes
 #axes3d.zaxis.panecolor:    (0.925, 0.925, 0.925, 0.5)  # background pane on 3D axes
 
-#axes3d.mouserotationstyle: arcball  # {azel, trackball, arcball, Shoemake, Holroyd}
+#axes3d.mouserotationstyle: arcball  # {azel, trackball, arcball, Shoemake, Bell}
                             # See also https://matplotlib.org/stable/api/toolkits/mplot3d/view_angles.html#rotation-with-mouse
 #axes3d.trackballsize: 0.667  # trackball diameter, in units of the Axes bbox
 

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -433,7 +433,7 @@
 #axes3d.yaxis.panecolor:    (0.90, 0.90, 0.90, 0.5)  # background pane on 3D axes
 #axes3d.zaxis.panecolor:    (0.925, 0.925, 0.925, 0.5)  # background pane on 3D axes
 
-#axes3d.mouserotationstyle: arcball  # {azel, trackball, sphere, arcball}
+#axes3d.mouserotationstyle: trackball  # {azel, trackball, sphere, arcball}
                             # See also https://matplotlib.org/stable/api/toolkits/mplot3d/view_angles.html#rotation-with-mouse
 #axes3d.trackballsize: 0.667  # trackball diameter, in units of the Axes bbox
 #axes3d.trackballborder: 0.2  # trackball border width, in units of the Axes bbox (only for 'sphere' and 'arcball' style)

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -433,9 +433,10 @@
 #axes3d.yaxis.panecolor:    (0.90, 0.90, 0.90, 0.5)  # background pane on 3D axes
 #axes3d.zaxis.panecolor:    (0.925, 0.925, 0.925, 0.5)  # background pane on 3D axes
 
-#axes3d.mouserotationstyle: arcball  # {azel, trackball, arcball, Shoemake, Bell}
+#axes3d.mouserotationstyle: arcball  # {azel, trackball, sphere, arcball}
                             # See also https://matplotlib.org/stable/api/toolkits/mplot3d/view_angles.html#rotation-with-mouse
 #axes3d.trackballsize: 0.667  # trackball diameter, in units of the Axes bbox
+#axes3d.trackballborder: 0.2  # trackball border width, in units of the Axes bbox (only for 'sphere' and 'arcball' style)
 
 ## ***************************************************************************
 ## * AXIS                                                                    *

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1133,7 +1133,7 @@ _validators = {
     "axes3d.zaxis.panecolor":    validate_color,  # 3d background pane
 
     "axes3d.mouserotationstyle": ["azel", "trackball", "arcball",
-                                  "Shoemake", "Holroyd"],
+                                  "Shoemake", "Bell"],
     "axes3d.trackballsize": validate_float,
 
     # scatter props

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1132,9 +1132,9 @@ _validators = {
     "axes3d.yaxis.panecolor":    validate_color,  # 3d background pane
     "axes3d.zaxis.panecolor":    validate_color,  # 3d background pane
 
-    "axes3d.mouserotationstyle": ["azel", "trackball", "arcball",
-                                  "Shoemake", "Bell"],
+    "axes3d.mouserotationstyle": ["azel", "trackball", "sphere", "arcball"],
     "axes3d.trackballsize": validate_float,
+    "axes3d.trackballborder": validate_float,
 
     # scatter props
     "scatter.marker":     _validate_marker,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1132,6 +1132,10 @@ _validators = {
     "axes3d.yaxis.panecolor":    validate_color,  # 3d background pane
     "axes3d.zaxis.panecolor":    validate_color,  # 3d background pane
 
+    "axes3d.mouserotationstyle": ["azel", "trackball", "arcball",
+                                  "Shoemake", "Holroyd"],
+    "axes3d.trackballsize": validate_float,
+
     # scatter props
     "scatter.marker":     _validate_marker,
     "scatter.edgecolors": validate_string,

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -4053,6 +4053,6 @@ class _Quaternion:
         qw = self.scalar
         qx, qy, qz = self.vector[..., :]
         azim = np.arctan2(2*(-qw*qz+qx*qy), qw*qw+qx*qx-qy*qy-qz*qz)
-        elev = np.arcsin( 2*( qw*qy+qz*qx)/(qw*qw+qx*qx+qy*qy+qz*qz))  # noqa E201
-        roll = np.arctan2(2*( qw*qx-qy*qz), qw*qw-qx*qx-qy*qy+qz*qz)   # noqa E201
+        elev = np.arcsin(np.clip(2*(qw*qy+qz*qx)/(qw*qw+qx*qx+qy*qy+qz*qz)), -1, 1)
+        roll = np.arctan2(2*(qw*qx-qy*qz), qw*qw-qx*qx-qy*qy+qz*qz)
         return elev, azim, roll

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1510,8 +1510,9 @@ class Axes3D(Axes):
 
     def _arcball(self, x: float, y: float, style: str) -> np.ndarray:
         """
-        Convert a point (x, y) to a point on a virtual trackball
-        either Ken Shoemake's arcball (a sphere) or
+        Convert a point (x, y) to a point on a virtual trackball.
+
+        This is either Ken Shoemake's arcball (a sphere) or
         Tom Holroyd's (a sphere combined with a hyperbola).
         See: Ken Shoemake, "ARCBALL: A user interface for specifying
         three-dimensional rotation using a mouse." in

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -4053,6 +4053,6 @@ class _Quaternion:
         qw = self.scalar
         qx, qy, qz = self.vector[..., :]
         azim = np.arctan2(2*(-qw*qz+qx*qy), qw*qw+qx*qx-qy*qy-qz*qz)
-        elev = np.arcsin(np.clip(2*(qw*qy+qz*qx)/(qw*qw+qx*qx+qy*qy+qz*qz)), -1, 1)
+        elev = np.arcsin(np.clip(2*(qw*qy+qz*qx)/(qw*qw+qx*qx+qy*qy+qz*qz), -1, 1))
         roll = np.arctan2(2*(qw*qx-qy*qz), qw*qw-qx*qx-qy*qy+qz*qz)
         return elev, azim, roll

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1513,7 +1513,7 @@ class Axes3D(Axes):
         Convert a point (x, y) to a point on a virtual trackball.
 
         This is either Ken Shoemake's arcball (a sphere) or
-        Tom Holroyd's (a sphere combined with a hyperbola).
+        Gavin Bell's (a sphere combined with a hyperbola).
         See: Ken Shoemake, "ARCBALL: A user interface for specifying
         three-dimensional rotation using a mouse." in
         Proceedings of Graphics Interface '92, 1992, pp. 151-156,
@@ -1523,7 +1523,7 @@ class Axes3D(Axes):
         x /= s
         y /= s
         r2 = x*x + y*y
-        if style == 'Holroyd':
+        if style == 'Bell':
             if r2 > 0.5:
                 p = np.array([1/(2*math.sqrt(r2)), x, y])/math.sqrt(1/(4*r2)+r2)
             else:
@@ -1587,12 +1587,12 @@ class Axes3D(Axes):
                     nk = np.linalg.norm(k)
                     th = nk / mpl.rcParams['axes3d.trackballsize']
                     dq = _Quaternion(np.cos(th), k*np.sin(th)/nk)
-                else:  # 'arcball', 'Shoemake', 'Holroyd'
+                else:  # 'arcball', 'Shoemake', 'Bell'
                     current_vec = self._arcball(self._sx/w, self._sy/h, style)
                     new_vec = self._arcball(x/w, y/h, style)
                     if style == 'arcball':
                         dq = _Quaternion.rotate_from_to(current_vec, new_vec)
-                    else:  # 'Shoemake', 'Holroyd'
+                    else:  # 'Shoemake', 'Bell'
                         dq = _Quaternion(0, new_vec) * _Quaternion(0, -current_vec)
 
                 q = dq * q

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1971,7 +1971,7 @@ def test_rotate(style):
                 mock_event(ax, button=MouseButton.LEFT, xdata=0, ydata=0))
             ax._on_move(
                 mock_event(ax, button=MouseButton.LEFT,
-                               xdata=s*dx*ax._pseudo_w, ydata=s*dy*ax._pseudo_h))
+                           xdata=s*dx*ax._pseudo_w, ydata=s*dy*ax._pseudo_h))
             ax.figure.canvas.draw()
 
             c = np.sqrt(3)/2

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1944,7 +1944,7 @@ def test_quaternion():
 
 
 @pytest.mark.parametrize('style',
-                         ('azel', 'trackball', 'arcball', 'Shoemake', 'Bell'))
+                         ('azel', 'trackball', 'sphere', 'arcball'))
 def test_rotate(style):
     """Test rotating using the left mouse button."""
     if style == 'azel':
@@ -1952,6 +1952,7 @@ def test_rotate(style):
     else:
         s = mpl.rcParams['axes3d.trackballsize'] / 2
     s *= 0.5
+    mpl.rcParams['axes3d.trackballborder'] = 0
     with mpl.rc_context({'axes3d.mouserotationstyle': style}):
         for roll, dx, dy in [
                 [0, 1, 0],
@@ -1992,29 +1993,21 @@ def test_rotate(style):
                 ('trackball', 30, 0, 1): (-24.531578, -15.277726, 33.340403),
                 ('trackball', 30, 0.5, c): (-13.869588, -25.319385, 33.129920),
 
-                ('arcball', 0, 1, 0): (0, -30, 0),
-                ('arcball', 0, 0, 1): (-30, 0, 0),
-                ('arcball', 0, 0.5, c): (-25.658906, -16.102114, 3.690068),
-                ('arcball', 0, 2, 0): (0, -90, 0),
-                ('arcball', 30, 1, 0): (14.477512, -26.565051, 26.565051),
-                ('arcball', 30, 0, 1): (-25.658906, -16.102114, 33.690068),
-                ('arcball', 30, 0.5, c): (-14.477512, -26.565051, 33.434949),
+                ('sphere', 0, 1, 0): (0, -30, 0),
+                ('sphere', 0, 0, 1): (-30, 0, 0),
+                ('sphere', 0, 0.5, c): (-25.658906, -16.102114, 3.690068),
+                ('sphere', 0, 2, 0): (0, -90, 0),
+                ('sphere', 30, 1, 0): (14.477512, -26.565051, 26.565051),
+                ('sphere', 30, 0, 1): (-25.658906, -16.102114, 33.690068),
+                ('sphere', 30, 0.5, c): (-14.477512, -26.565051, 33.434949),
 
-                ('Shoemake', 0, 1, 0): (0, -60, 0),
-                ('Shoemake', 0, 0, 1): (-60, 0, 0),
-                ('Shoemake', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
-                ('Shoemake', 0, 2, 0): (0, 180, 0),
-                ('Shoemake', 30, 1, 0): (25.658906, -56.309932, 16.102114),
-                ('Shoemake', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
-                ('Shoemake', 30, 0.5, c): (-25.658906, -56.309932, 43.897886),
-
-                ('Bell', 0, 1, 0): (0, -60, 0),
-                ('Bell', 0, 0, 1): (-60, 0, 0),
-                ('Bell', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
-                ('Bell', 0, 2, 0): (0, -126.869898, 0),
-                ('Bell', 30, 1, 0):  (25.658906, -56.309932, 16.102114),
-                ('Bell', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
-                ('Bell', 30, 0.5, c): (-25.658906, -56.309932, 43.897886)}
+                ('arcball', 0, 1, 0): (0, -60, 0),
+                ('arcball', 0, 0, 1): (-60, 0, 0),
+                ('arcball', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
+                ('arcball', 0, 2, 0): (0, 180, 0),
+                ('arcball', 30, 1, 0): (25.658906, -56.309932, 16.102114),
+                ('arcball', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
+                ('arcball', 30, 0.5, c): (-25.658906, -56.309932, 43.897886)}
             new_elev, new_azim, new_roll = expectations[(style, roll, dx, dy)]
             np.testing.assert_allclose((ax.elev, ax.azim, ax.roll),
                                        (new_elev, new_azim, new_roll), atol=1e-6)

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1939,37 +1939,85 @@ def test_quaternion():
                 np.deg2rad(elev), np.deg2rad(azim), np.deg2rad(roll))
             assert np.isclose(q.norm, 1)
             q = Quaternion(mag * q.scalar, mag * q.vector)
-            e, a, r = np.rad2deg(Quaternion.as_cardan_angles(q))
-            assert np.isclose(e, elev)
-            assert np.isclose(a, azim)
-            assert np.isclose(r, roll)
+            np.testing.assert_allclose(np.rad2deg(Quaternion.as_cardan_angles(q)),
+                                       (elev, azim, roll), atol=1e-6)
 
 
-def test_rotate():
+@pytest.mark.parametrize('style',
+                         ('azel', 'trackball', 'arcball', 'Shoemake', 'Holroyd'))
+def test_rotate(style):
     """Test rotating using the left mouse button."""
-    for roll, dx, dy, new_elev, new_azim, new_roll in [
-            [0, 0.5, 0, 0, -90, 0],
-            [30, 0.5, 0, 30, -90, 0],
-            [0, 0, 0.5, -90, 0, 0],
-            [30, 0, 0.5, -60, -90, 90],
-            [0, 0.5, 0.5, -45, -90, 45],
-            [30, 0.5, 0.5, -15, -90, 45]]:
-        fig = plt.figure()
-        ax = fig.add_subplot(1, 1, 1, projection='3d')
-        ax.view_init(0, 0, roll)
-        fig.canvas.draw()
+    if style == 'azel':
+        s = 0.5
+    else:
+        s = mpl.rcParams['axes3d.trackballsize'] / 2
+    s *= 0.5
+    with mpl.rc_context({'axes3d.mouserotationstyle': style}):
+        for roll, dx, dy in [
+                [0, 1, 0],
+                [30, 1, 0],
+                [0, 0, 1],
+                [30, 0, 1],
+                [0, 0.5, np.sqrt(3)/2],
+                [30, 0.5, np.sqrt(3)/2],
+                [0, 2, 0]]:
+            fig = plt.figure()
+            ax = fig.add_subplot(1, 1, 1, projection='3d')
+            ax.view_init(0, 0, roll)
+            ax.figure.canvas.draw()
 
-        # drag mouse to change orientation
-        ax._button_press(
-            mock_event(ax, button=MouseButton.LEFT, xdata=0, ydata=0))
-        ax._on_move(
-            mock_event(ax, button=MouseButton.LEFT,
-                           xdata=dx*ax._pseudo_w, ydata=dy*ax._pseudo_h))
-        fig.canvas.draw()
+            # drag mouse to change orientation
+            ax._button_press(
+                mock_event(ax, button=MouseButton.LEFT, xdata=0, ydata=0))
+            ax._on_move(
+                mock_event(ax, button=MouseButton.LEFT,
+                               xdata=s*dx*ax._pseudo_w, ydata=s*dy*ax._pseudo_h))
+            ax.figure.canvas.draw()
 
-        assert np.isclose(ax.elev, new_elev)
-        assert np.isclose(ax.azim, new_azim)
-        assert np.isclose(ax.roll, new_roll)
+            c = np.sqrt(3)/2
+            expectations = {
+                ('azel', 0, 1, 0): (0,  -45, 0),
+                ('azel', 0, 0, 1): (-45, 0, 0),
+                ('azel', 0, 0.5, c): (-38.971143, -22.5, 0),
+                ('azel', 0, 2, 0): (0, -90, 0),
+                ('azel', 30, 1, 0): (22.5, -38.971143, 30),
+                ('azel', 30, 0, 1): (-38.971143, -22.5, 30),
+                ('azel', 30, 0.5, c): (-22.5, -38.971143, 30),
+
+                ('trackball', 0, 1, 0): (0, -28.64789, 0),
+                ('trackball', 0, 0, 1): (-28.64789, 0, 0),
+                ('trackball', 0, 0.5, c): (-24.531578, -15.277726, 3.340403),
+                ('trackball', 0, 2, 0): (0, -180/np.pi, 0),
+                ('trackball', 30, 1, 0): (13.869588, -25.319385, 26.87008),
+                ('trackball', 30, 0, 1): (-24.531578, -15.277726, 33.340403),
+                ('trackball', 30, 0.5, c): (-13.869588, -25.319385, 33.129920),
+
+                ('arcball', 0, 1, 0): (0, -30, 0),
+                ('arcball', 0, 0, 1): (-30, 0, 0),
+                ('arcball', 0, 0.5, c): (-25.658906, -16.102114, 3.690068),
+                ('arcball', 0, 2, 0): (0, -90, 0),
+                ('arcball', 30, 1, 0): (14.477512, -26.565051, 26.565051),
+                ('arcball', 30, 0, 1): (-25.658906, -16.102114, 33.690068),
+                ('arcball', 30, 0.5, c): (-14.477512, -26.565051, 33.434949),
+
+                ('Shoemake', 0, 1, 0): (0, -60, 0),
+                ('Shoemake', 0, 0, 1): (-60, 0, 0),
+                ('Shoemake', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
+                ('Shoemake', 0, 2, 0): (0, 180, 0),
+                ('Shoemake', 30, 1, 0): (25.658906, -56.309932, 16.102114),
+                ('Shoemake', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
+                ('Shoemake', 30, 0.5, c): (-25.658906, -56.309932, 43.897886),
+
+                ('Holroyd', 0, 1, 0): (0, -60, 0),
+                ('Holroyd', 0, 0, 1): (-60, 0, 0),
+                ('Holroyd', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
+                ('Holroyd', 0, 2, 0): (0, -126.869898, 0),
+                ('Holroyd', 30, 1, 0):  (25.658906, -56.309932, 16.102114),
+                ('Holroyd', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
+                ('Holroyd', 30, 0.5, c): (-25.658906, -56.309932, 43.897886)}
+            new_elev, new_azim, new_roll = expectations[(style, roll, dx, dy)]
+            np.testing.assert_allclose((ax.elev, ax.azim, ax.roll),
+                                       (new_elev, new_azim, new_roll), atol=1e-6)
 
 
 def test_pan():

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1944,7 +1944,7 @@ def test_quaternion():
 
 
 @pytest.mark.parametrize('style',
-                         ('azel', 'trackball', 'arcball', 'Shoemake', 'Holroyd'))
+                         ('azel', 'trackball', 'arcball', 'Shoemake', 'Bell'))
 def test_rotate(style):
     """Test rotating using the left mouse button."""
     if style == 'azel':
@@ -2008,13 +2008,13 @@ def test_rotate(style):
                 ('Shoemake', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
                 ('Shoemake', 30, 0.5, c): (-25.658906, -56.309932, 43.897886),
 
-                ('Holroyd', 0, 1, 0): (0, -60, 0),
-                ('Holroyd', 0, 0, 1): (-60, 0, 0),
-                ('Holroyd', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
-                ('Holroyd', 0, 2, 0): (0, -126.869898, 0),
-                ('Holroyd', 30, 1, 0):  (25.658906, -56.309932, 16.102114),
-                ('Holroyd', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
-                ('Holroyd', 30, 0.5, c): (-25.658906, -56.309932, 43.897886)}
+                ('Bell', 0, 1, 0): (0, -60, 0),
+                ('Bell', 0, 0, 1): (-60, 0, 0),
+                ('Bell', 0, 0.5, c): (-48.590378, -40.893395, 19.106605),
+                ('Bell', 0, 2, 0): (0, -126.869898, 0),
+                ('Bell', 30, 1, 0):  (25.658906, -56.309932, 16.102114),
+                ('Bell', 30, 0, 1): (-48.590378, -40.893395, 49.106605),
+                ('Bell', 30, 0.5, c): (-25.658906, -56.309932, 43.897886)}
             new_elev, new_azim, new_roll = expectations[(style, roll, dx, dy)]
             np.testing.assert_allclose((ax.elev, ax.azim, ax.roll),
                                        (new_elev, new_azim, new_roll), atol=1e-6)


### PR DESCRIPTION
## PR summary
Makes the plot3d mouse rotation style adjustable (various styles); 
addresses Issue #28408; an attempt to improve on PR #28236.
- matplotlibrc: add axes3d.mouserotationstyle and axes3d.trackballsize
- lib/matplotlib/rcsetup.py: add validation for axes3d.mouserotationstyle and axes3d.trackballsize
- axes3d.py: implement various mouse rotation styles
- update test_axes3d.py::test_rotate()
- view_angles.rst: add documentation for the mouse rotation styles
- update next_whats_new/mouse_rotation.rst

It also incorporates some of the improvements proposed in PR #28236; what it does not include (yet) is the introduction of `np.clip()` to circumvent [floating point round-off errors on the macos github CI runners](https://github.com/matplotlib/matplotlib/pull/28823#discussion_r1761351324).

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

