### PR TITLE
Examples/Patheffect Demo: Replaced deprecated QuadContourSet 'set' attribute

### DIFF
--- a/galleries/examples/misc/patheffect_demo.py
+++ b/galleries/examples/misc/patheffect_demo.py
@@ -29,7 +29,8 @@ arr = np.arange(25).reshape((5, 5))
 ax2.imshow(arr)
 cntr = ax2.contour(arr, colors="k")
 
-cntr.set(path_effects=[patheffects.withStroke(linewidth=3, foreground="w")])
+for collection in cntr.collections:
+    collection.set_path_effects([patheffects.withStroke(linewidth=3, foreground="w")])
 
 clbls = ax2.clabel(cntr, fmt="%2.0f", use_clabeltext=True)
 plt.setp(clbls, path_effects=[


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

The existing Patheffect Demo example was broken because the 'set' method for QuadContourSet has been deprecated. This change fixes it, and the demo works on the latest version.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [√] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
