### PR TITLE
DOC: Mark subfigures as no longer provisional

### DIFF
--- a/doc/users/next_whats_new/subfigures_change_order.rst
+++ b/doc/users/next_whats_new/subfigures_change_order.rst
@@ -1,3 +1,9 @@
+Subfigures no longer provisional
+--------------------------------
+
+The API on `.Figure.subfigures` and `.SubFigure` are now considered stable.
+
+
 Subfigures are now added in row-major order
 -------------------------------------------
 

--- a/galleries/examples/subplots_axes_and_figures/subfigures.py
+++ b/galleries/examples/subplots_axes_and_figures/subfigures.py
@@ -13,9 +13,6 @@ Matplotlib also has "subfigures", accessed by calling
 `matplotlib.figure.Figure.subfigures` to make an array of subfigures.  Note
 that subfigures can also have their own child subfigures.
 
-.. note::
-    The *subfigure* concept is new in v3.4, and the API is still provisional.
-
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -6,9 +6,8 @@
     Many methods are implemented in `FigureBase`.
 
 `SubFigure`
-    A logical figure inside a figure, usually added to a figure (or parent
-    `SubFigure`) with `Figure.add_subfigure` or `Figure.subfigures` methods
-    (provisional API v3.4).
+    A logical figure inside a figure, usually added to a figure (or parent `SubFigure`)
+    with `Figure.add_subfigure` or `Figure.subfigures` methods.
 
 Figures are typically created using pyplot methods `~.pyplot.figure`,
 `~.pyplot.subplots`, and `~.pyplot.subplot_mosaic`.
@@ -1608,9 +1607,6 @@ default: %(va)s
         the same as a figure, but cannot print itself.
         See :doc:`/gallery/subplots_axes_and_figures/subfigures`.
 
-        .. note::
-            The *subfigure* concept is new in v3.4, and the API is still provisional.
-
         .. versionchanged:: 3.10
             subfigures are now added in row-major order.
 
@@ -2229,9 +2225,6 @@ class SubFigure(FigureBase):
         axsR = sfigs[1].subplots(2, 1)
 
     See :doc:`/gallery/subplots_axes_and_figures/subfigures`
-
-    .. note::
-        The *subfigure* concept is new in v3.4, and the API is still provisional.
     """
 
     def __init__(self, parent, subplotspec, *,


### PR DESCRIPTION
## PR summary

Fixes #25947

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines