### PR TITLE
Convert remaining code to pybind11

### DIFF
--- a/src/_backend_agg_basic_types.h
+++ b/src/_backend_agg_basic_types.h
@@ -4,6 +4,9 @@
 /* Contains some simple types from the Agg backend that are also used
    by other modules */
 
+#include <pybind11/pybind11.h>
+
+#include <unordered_map>
 #include <vector>
 
 #include "agg_color_rgba.h"
@@ -12,6 +15,8 @@
 #include "path_converters.h"
 
 #include "py_adaptors.h"
+
+namespace py = pybind11;
 
 struct ClipPath
 {
@@ -120,5 +125,136 @@ class GCAgg
     GCAgg(const GCAgg &);
     GCAgg &operator=(const GCAgg &);
 };
+
+namespace PYBIND11_NAMESPACE { namespace detail {
+    template <> struct type_caster<agg::line_cap_e> {
+    public:
+        PYBIND11_TYPE_CASTER(agg::line_cap_e, const_name("line_cap_e"));
+
+        bool load(handle src, bool) {
+            const std::unordered_map<std::string, agg::line_cap_e> enum_values = {
+                {"butt", agg::butt_cap},
+                {"round", agg::round_cap},
+                {"projecting", agg::square_cap},
+            };
+            value = enum_values.at(src.cast<std::string>());
+            return true;
+        }
+    };
+
+    template <> struct type_caster<agg::line_join_e> {
+    public:
+        PYBIND11_TYPE_CASTER(agg::line_join_e, const_name("line_join_e"));
+
+        bool load(handle src, bool) {
+            const std::unordered_map<std::string, agg::line_join_e> enum_values = {
+                {"miter", agg::miter_join_revert},
+                {"round", agg::round_join},
+                {"bevel", agg::bevel_join},
+            };
+            value = agg::miter_join_revert;
+            value = enum_values.at(src.cast<std::string>());
+            return true;
+        }
+    };
+
+    template <> struct type_caster<ClipPath> {
+    public:
+        PYBIND11_TYPE_CASTER(ClipPath, const_name("ClipPath"));
+
+        bool load(handle src, bool) {
+            if (src.is_none()) {
+                return true;
+            }
+
+            auto clippath_tuple = src.cast<py::tuple>();
+
+            auto path = clippath_tuple[0];
+            if (!path.is_none()) {
+                value.path = path.cast<mpl::PathIterator>();
+            }
+            value.trans = clippath_tuple[1].cast<agg::trans_affine>();
+
+            return true;
+        }
+    };
+
+    template <> struct type_caster<Dashes> {
+    public:
+        PYBIND11_TYPE_CASTER(Dashes, const_name("Dashes"));
+
+        bool load(handle src, bool) {
+            auto dash_tuple = src.cast<py::tuple>();
+            auto dash_offset = dash_tuple[0].cast<double>();
+            auto dashes_seq_or_none = dash_tuple[1];
+
+            if (dashes_seq_or_none.is_none()) {
+                return true;
+            }
+
+            auto dashes_seq = dashes_seq_or_none.cast<py::sequence>();
+
+            auto nentries = dashes_seq.size();
+            // If the dashpattern has odd length, iterate through it twice (in
+            // accordance with the pdf/ps/svg specs).
+            auto dash_pattern_length = (nentries % 2) ? 2 * nentries : nentries;
+
+            for (py::size_t i = 0; i < dash_pattern_length; i += 2) {
+                auto length = dashes_seq[i % nentries].cast<double>();
+                auto skip = dashes_seq[(i + 1) % nentries].cast<double>();
+
+                value.add_dash_pair(length, skip);
+            }
+
+            value.set_dash_offset(dash_offset);
+
+            return true;
+        }
+    };
+
+    template <> struct type_caster<SketchParams> {
+    public:
+        PYBIND11_TYPE_CASTER(SketchParams, const_name("SketchParams"));
+
+        bool load(handle src, bool) {
+            if (src.is_none()) {
+                value.scale = 0.0;
+                value.length = 0.0;
+                value.randomness = 0.0;
+                return true;
+            }
+
+            auto params = src.cast<std::tuple<double, double, double>>();
+            std::tie(value.scale, value.length, value.randomness) = params;
+
+            return true;
+        }
+    };
+
+    template <> struct type_caster<GCAgg> {
+    public:
+        PYBIND11_TYPE_CASTER(GCAgg, const_name("GCAgg"));
+
+        bool load(handle src, bool) {
+            value.linewidth = src.attr("_linewidth").cast<double>();
+            value.alpha = src.attr("_alpha").cast<double>();
+            value.forced_alpha = src.attr("_forced_alpha").cast<bool>();
+            value.color = src.attr("_rgb").cast<agg::rgba>();
+            value.isaa = src.attr("_antialiased").cast<bool>();
+            value.cap = src.attr("_capstyle").cast<agg::line_cap_e>();
+            value.join = src.attr("_joinstyle").cast<agg::line_join_e>();
+            value.dashes = src.attr("get_dashes")().cast<Dashes>();
+            value.cliprect = src.attr("_cliprect").cast<agg::rect_d>();
+            value.clippath = src.attr("get_clip_path")().cast<ClipPath>();
+            value.snap_mode = src.attr("get_snap")().cast<e_snap_mode>();
+            value.hatchpath = src.attr("get_hatch_path")().cast<mpl::PathIterator>();
+            value.hatch_color = src.attr("get_hatch_color")().cast<agg::rgba>();
+            value.hatch_linewidth = src.attr("get_hatch_linewidth")().cast<double>();
+            value.sketch = src.attr("get_sketch_params")().cast<SketchParams>();
+
+            return true;
+        }
+    };
+}} // namespace PYBIND11_NAMESPACE::detail
 
 #endif

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -112,43 +112,24 @@ PyRendererAgg_draw_path_collection(RendererAgg *self,
                                    GCAgg &gc,
                                    agg::trans_affine master_transform,
                                    mpl::PathGenerator paths,
-                                   py::object transforms_obj,
-                                   py::object offsets_obj,
+                                   py::array_t<double> transforms_obj,
+                                   py::array_t<double> offsets_obj,
                                    agg::trans_affine offset_trans,
-                                   py::object facecolors_obj,
-                                   py::object edgecolors_obj,
-                                   py::object linewidths_obj,
+                                   py::array_t<double> facecolors_obj,
+                                   py::array_t<double> edgecolors_obj,
+                                   py::array_t<double> linewidths_obj,
                                    DashesVector dashes,
-                                   py::object antialiaseds_obj,
+                                   py::array_t<uint8_t> antialiaseds_obj,
                                    py::object Py_UNUSED(ignored_obj),
                                    // offset position is no longer used
                                    py::object Py_UNUSED(offset_position_obj))
 {
-    numpy::array_view<const double, 3> transforms;
-    numpy::array_view<const double, 2> offsets;
-    numpy::array_view<const double, 2> facecolors;
-    numpy::array_view<const double, 2> edgecolors;
-    numpy::array_view<const double, 1> linewidths;
-    numpy::array_view<const uint8_t, 1> antialiaseds;
-
-    if (!convert_transforms(transforms_obj.ptr(), &transforms)) {
-        throw py::error_already_set();
-    }
-    if (!convert_points(offsets_obj.ptr(), &offsets)) {
-        throw py::error_already_set();
-    }
-    if (!convert_colors(facecolors_obj.ptr(), &facecolors)) {
-        throw py::error_already_set();
-    }
-    if (!convert_colors(edgecolors_obj.ptr(), &edgecolors)) {
-        throw py::error_already_set();
-    }
-    if (!linewidths.converter(linewidths_obj.ptr(), &linewidths)) {
-        throw py::error_already_set();
-    }
-    if (!antialiaseds.converter(antialiaseds_obj.ptr(), &antialiaseds)) {
-        throw py::error_already_set();
-    }
+    auto transforms = convert_transforms(transforms_obj);
+    auto offsets = convert_points(offsets_obj);
+    auto facecolors = convert_colors(facecolors_obj);
+    auto edgecolors = convert_colors(edgecolors_obj);
+    auto linewidths = linewidths_obj.unchecked<1>();
+    auto antialiaseds = antialiaseds_obj.unchecked<1>();
 
     self->draw_path_collection(gc,
             master_transform,
@@ -170,26 +151,16 @@ PyRendererAgg_draw_quad_mesh(RendererAgg *self,
                              unsigned int mesh_width,
                              unsigned int mesh_height,
                              py::array_t<double, py::array::c_style | py::array::forcecast> coordinates_obj,
-                             py::object offsets_obj,
+                             py::array_t<double> offsets_obj,
                              agg::trans_affine offset_trans,
-                             py::object facecolors_obj,
+                             py::array_t<double> facecolors_obj,
                              bool antialiased,
-                             py::object edgecolors_obj)
+                             py::array_t<double> edgecolors_obj)
 {
-    numpy::array_view<const double, 2> offsets;
-    numpy::array_view<const double, 2> facecolors;
-    numpy::array_view<const double, 2> edgecolors;
-
     auto coordinates = coordinates_obj.mutable_unchecked<3>();
-    if (!convert_points(offsets_obj.ptr(), &offsets)) {
-        throw py::error_already_set();
-    }
-    if (!convert_colors(facecolors_obj.ptr(), &facecolors)) {
-        throw py::error_already_set();
-    }
-    if (!convert_colors(edgecolors_obj.ptr(), &edgecolors)) {
-        throw py::error_already_set();
-    }
+    auto offsets = convert_points(offsets_obj);
+    auto facecolors = convert_colors(facecolors_obj);
+    auto edgecolors = convert_colors(edgecolors_obj);
 
     self->draw_quad_mesh(gc,
             master_transform,

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -111,7 +111,7 @@ static void
 PyRendererAgg_draw_path_collection(RendererAgg *self,
                                    GCAgg &gc,
                                    agg::trans_affine master_transform,
-                                   py::object paths_obj,
+                                   mpl::PathGenerator paths,
                                    py::object transforms_obj,
                                    py::object offsets_obj,
                                    agg::trans_affine offset_trans,
@@ -124,7 +124,6 @@ PyRendererAgg_draw_path_collection(RendererAgg *self,
                                    // offset position is no longer used
                                    py::object Py_UNUSED(offset_position_obj))
 {
-    mpl::PathGenerator paths;
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     numpy::array_view<const double, 2> facecolors;
@@ -132,9 +131,6 @@ PyRendererAgg_draw_path_collection(RendererAgg *self,
     numpy::array_view<const double, 1> linewidths;
     numpy::array_view<const uint8_t, 1> antialiaseds;
 
-    if (!convert_pathgen(paths_obj.ptr(), &paths)) {
-        throw py::error_already_set();
-    }
     if (!convert_transforms(transforms_obj.ptr(), &transforms)) {
         throw py::error_already_set();
     }

--- a/src/_path.h
+++ b/src/_path.h
@@ -1223,17 +1223,15 @@ bool convert_to_string(PathIterator &path,
 }
 
 template<class T>
-bool is_sorted_and_has_non_nan(PyArrayObject *array)
+bool is_sorted_and_has_non_nan(py::array_t<T> array)
 {
-    char* ptr = PyArray_BYTES(array);
-    npy_intp size = PyArray_DIM(array, 0),
-             stride = PyArray_STRIDE(array, 0);
+    auto size = array.shape(0);
     using limits = std::numeric_limits<T>;
     T last = limits::has_infinity ? -limits::infinity() : limits::min();
     bool found_non_nan = false;
 
-    for (npy_intp i = 0; i < size; ++i, ptr += stride) {
-        T current = *(T*)ptr;
+    for (auto i = 0; i < size; ++i) {
+        T current = *array.data(i);
         // The following tests !isnan(current), but also works for integral
         // types.  (The isnan(IntegralType) overload is absent on MSVC.)
         if (current == current) {

--- a/src/_path.h
+++ b/src/_path.h
@@ -245,8 +245,7 @@ inline void points_in_path(PointArray &points,
     typedef agg::conv_curve<no_nans_t> curve_t;
     typedef agg::conv_contour<curve_t> contour_t;
 
-    size_t i;
-    for (i = 0; i < safe_first_shape(points); ++i) {
+    for (auto i = 0; i < safe_first_shape(points); ++i) {
         result[i] = false;
     }
 
@@ -270,10 +269,11 @@ template <class PathIterator>
 inline bool point_in_path(
     double x, double y, const double r, PathIterator &path, agg::trans_affine &trans)
 {
-    npy_intp shape[] = {1, 2};
-    numpy::array_view<double, 2> points(shape);
-    points(0, 0) = x;
-    points(0, 1) = y;
+    py::ssize_t shape[] = {1, 2};
+    py::array_t<double> points_arr(shape);
+    *points_arr.mutable_data(0, 0) = x;
+    *points_arr.mutable_data(0, 1) = y;
+    auto points = points_arr.mutable_unchecked<2>();
 
     int result[1];
     result[0] = 0;
@@ -292,10 +292,11 @@ inline bool point_on_path(
     typedef agg::conv_curve<no_nans_t> curve_t;
     typedef agg::conv_stroke<curve_t> stroke_t;
 
-    npy_intp shape[] = {1, 2};
-    numpy::array_view<double, 2> points(shape);
-    points(0, 0) = x;
-    points(0, 1) = y;
+    py::ssize_t shape[] = {1, 2};
+    py::array_t<double> points_arr(shape);
+    *points_arr.mutable_data(0, 0) = x;
+    *points_arr.mutable_data(0, 1) = y;
+    auto points = points_arr.mutable_unchecked<2>();
 
     int result[1];
     result[0] = 0;
@@ -382,20 +383,19 @@ void get_path_collection_extents(agg::trans_affine &master_transform,
         throw std::runtime_error("Offsets array must have shape (N, 2)");
     }
 
-    size_t Npaths = paths.size();
-    size_t Noffsets = safe_first_shape(offsets);
-    size_t N = std::max(Npaths, Noffsets);
-    size_t Ntransforms = std::min(safe_first_shape(transforms), N);
-    size_t i;
+    auto Npaths = paths.size();
+    auto Noffsets = safe_first_shape(offsets);
+    auto N = std::max(Npaths, Noffsets);
+    auto Ntransforms = std::min(safe_first_shape(transforms), N);
 
     agg::trans_affine trans;
 
     reset_limits(extent);
 
-    for (i = 0; i < N; ++i) {
+    for (auto i = 0; i < N; ++i) {
         typename PathGenerator::path_iterator path(paths(i % Npaths));
         if (Ntransforms) {
-            size_t ti = i % Ntransforms;
+            py::ssize_t ti = i % Ntransforms;
             trans = agg::trans_affine(transforms(ti, 0, 0),
                                       transforms(ti, 1, 0),
                                       transforms(ti, 0, 1),
@@ -429,24 +429,23 @@ void point_in_path_collection(double x,
                               bool filled,
                               std::vector<int> &result)
 {
-    size_t Npaths = paths.size();
+    auto Npaths = paths.size();
 
     if (Npaths == 0) {
         return;
     }
 
-    size_t Noffsets = safe_first_shape(offsets);
-    size_t N = std::max(Npaths, Noffsets);
-    size_t Ntransforms = std::min(safe_first_shape(transforms), N);
-    size_t i;
+    auto Noffsets = safe_first_shape(offsets);
+    auto N = std::max(Npaths, Noffsets);
+    auto Ntransforms = std::min(safe_first_shape(transforms), N);
 
     agg::trans_affine trans;
 
-    for (i = 0; i < N; ++i) {
+    for (auto i = 0; i < N; ++i) {
         typename PathGenerator::path_iterator path = paths(i % Npaths);
 
         if (Ntransforms) {
-            size_t ti = i % Ntransforms;
+            auto ti = i % Ntransforms;
             trans = agg::trans_affine(transforms(ti, 0, 0),
                                       transforms(ti, 1, 0),
                                       transforms(ti, 0, 1),

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -44,17 +44,9 @@ static py::array_t<double>
 Py_points_in_path(py::array_t<double> points_obj, double r, mpl::PathIterator path,
                   agg::trans_affine trans)
 {
-    numpy::array_view<double, 2> points;
+    auto points = convert_points(points_obj);
 
-    if (!convert_points(points_obj.ptr(), &points)) {
-        throw py::error_already_set();
-    }
-
-    if (!check_trailing_shape(points, "points", 2)) {
-        throw py::error_already_set();
-    }
-
-    py::ssize_t dims[] = { static_cast<py::ssize_t>(points.size()) };
+    py::ssize_t dims[] = { points.shape(0) };
     py::array_t<uint8_t> results(dims);
     auto results_mutable = results.mutable_unchecked<1>();
 
@@ -123,19 +115,14 @@ Py_update_path_extents(mpl::PathIterator path, agg::trans_affine trans,
 
 static py::tuple
 Py_get_path_collection_extents(agg::trans_affine master_transform,
-                               mpl::PathGenerator paths, py::object transforms_obj,
-                               py::object offsets_obj, agg::trans_affine offset_trans)
+                               mpl::PathGenerator paths,
+                               py::array_t<double> transforms_obj,
+                               py::array_t<double> offsets_obj,
+                               agg::trans_affine offset_trans)
 {
-    numpy::array_view<const double, 3> transforms;
-    numpy::array_view<const double, 2> offsets;
+    auto transforms = convert_transforms(transforms_obj);
+    auto offsets = convert_points(offsets_obj);
     extent_limits e;
-
-    if (!convert_transforms(transforms_obj.ptr(), &transforms)) {
-        throw py::error_already_set();
-    }
-    if (!convert_points(offsets_obj.ptr(), &offsets)) {
-        throw py::error_already_set();
-    }
 
     get_path_collection_extents(
         master_transform, paths, transforms, offsets, offset_trans, e);
@@ -158,19 +145,13 @@ Py_get_path_collection_extents(agg::trans_affine master_transform,
 static py::object
 Py_point_in_path_collection(double x, double y, double radius,
                             agg::trans_affine master_transform, mpl::PathGenerator paths,
-                            py::object transforms_obj, py::object offsets_obj,
+                            py::array_t<double> transforms_obj,
+                            py::array_t<double> offsets_obj,
                             agg::trans_affine offset_trans, bool filled)
 {
-    numpy::array_view<const double, 3> transforms;
-    numpy::array_view<const double, 2> offsets;
+    auto transforms = convert_transforms(transforms_obj);
+    auto offsets = convert_points(offsets_obj);
     std::vector<int> result;
-
-    if (!convert_transforms(transforms_obj.ptr(), &transforms)) {
-        throw py::error_already_set();
-    }
-    if (!convert_points(offsets_obj.ptr(), &offsets)) {
-        throw py::error_already_set();
-    }
 
     point_in_path_collection(x, y, radius, master_transform, paths, transforms, offsets,
                              offset_trans, filled, result);
@@ -229,13 +210,9 @@ Py_affine_transform(py::array_t<double, py::array::c_style | py::array::forcecas
 }
 
 static int
-Py_count_bboxes_overlapping_bbox(agg::rect_d bbox, py::object bboxes_obj)
+Py_count_bboxes_overlapping_bbox(agg::rect_d bbox, py::array_t<double> bboxes_obj)
 {
-    numpy::array_view<const double, 3> bboxes;
-
-    if (!convert_bboxes(bboxes_obj.ptr(), &bboxes)) {
-        throw py::error_already_set();
-    }
+    auto bboxes = convert_bboxes(bboxes_obj);
 
     return count_bboxes_overlapping_bbox(bbox, bboxes);
 }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -123,17 +123,13 @@ Py_update_path_extents(mpl::PathIterator path, agg::trans_affine trans,
 
 static py::tuple
 Py_get_path_collection_extents(agg::trans_affine master_transform,
-                               py::object paths_obj, py::object transforms_obj,
+                               mpl::PathGenerator paths, py::object transforms_obj,
                                py::object offsets_obj, agg::trans_affine offset_trans)
 {
-    mpl::PathGenerator paths;
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     extent_limits e;
 
-    if (!convert_pathgen(paths_obj.ptr(), &paths)) {
-        throw py::error_already_set();
-    }
     if (!convert_transforms(transforms_obj.ptr(), &transforms)) {
         throw py::error_already_set();
     }
@@ -161,18 +157,14 @@ Py_get_path_collection_extents(agg::trans_affine master_transform,
 
 static py::object
 Py_point_in_path_collection(double x, double y, double radius,
-                            agg::trans_affine master_transform, py::object paths_obj,
+                            agg::trans_affine master_transform, mpl::PathGenerator paths,
                             py::object transforms_obj, py::object offsets_obj,
                             agg::trans_affine offset_trans, bool filled)
 {
-    mpl::PathGenerator paths;
     numpy::array_view<const double, 3> transforms;
     numpy::array_view<const double, 2> offsets;
     std::vector<int> result;
 
-    if (!convert_pathgen(paths_obj.ptr(), &paths)) {
-        throw py::error_already_set();
-    }
     if (!convert_transforms(transforms_obj.ptr(), &transforms)) {
         throw py::error_already_set();
     }

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -77,6 +77,11 @@ inline bool check_trailing_shape(T array, char const* name, long d1)
                      array.ndim());
         return false;
     }
+    if (array.size() == 0) {
+        // Sometimes things come through as atleast_2d, etc., but they're empty, so
+        // don't bother enforcing the trailing shape.
+        return true;
+    }
     if (array.shape(1) != d1) {
         PyErr_Format(PyExc_ValueError,
                      "%s must have shape (N, %ld), got (%ld, %ld)",
@@ -94,6 +99,11 @@ inline bool check_trailing_shape(T array, char const* name, long d1, long d2)
                      "Expected 3-dimensional array, got %ld",
                      array.ndim());
         return false;
+    }
+    if (array.size() == 0) {
+        // Sometimes things come through as atleast_3d, etc., but they're empty, so
+        // don't bother enforcing the trailing shape.
+        return true;
     }
     if (array.shape(1) != d1 || array.shape(2) != d2) {
         PyErr_Format(PyExc_ValueError,

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -71,6 +71,12 @@ inline int prepare_and_add_type(PyTypeObject *type, PyObject *module)
 template<typename T>
 inline bool check_trailing_shape(T array, char const* name, long d1)
 {
+    if (array.ndim() != 2) {
+        PyErr_Format(PyExc_ValueError,
+                     "Expected 2-dimensional array, got %ld",
+                     array.ndim());
+        return false;
+    }
     if (array.shape(1) != d1) {
         PyErr_Format(PyExc_ValueError,
                      "%s must have shape (N, %ld), got (%ld, %ld)",
@@ -83,6 +89,12 @@ inline bool check_trailing_shape(T array, char const* name, long d1)
 template<typename T>
 inline bool check_trailing_shape(T array, char const* name, long d1, long d2)
 {
+    if (array.ndim() != 3) {
+        PyErr_Format(PyExc_ValueError,
+                     "Expected 3-dimensional array, got %ld",
+                     array.ndim());
+        return false;
+    }
     if (array.shape(1) != d1 || array.shape(2) != d2) {
         PyErr_Format(PyExc_ValueError,
                      "%s must have shape (N, %ld, %ld), got (%ld, %ld, %ld)",

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -67,6 +67,10 @@ inline int prepare_and_add_type(PyTypeObject *type, PyObject *module)
 #ifdef __cplusplus  // not for macosx.m
 // Check that array has shape (N, d1) or (N, d1, d2).  We cast d1, d2 to longs
 // so that we don't need to access the NPY_INTP_FMT macro here.
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
 
 template<typename T>
 inline bool check_trailing_shape(T array, char const* name, long d1)
@@ -112,6 +116,25 @@ inline bool check_trailing_shape(T array, char const* name, long d1, long d2)
         return false;
     }
     return true;
+}
+
+/* In most cases, code should use safe_first_shape(obj) instead of obj.shape(0), since
+   safe_first_shape(obj) == 0 when any dimension is 0. */
+template <typename T, py::ssize_t ND>
+py::ssize_t
+safe_first_shape(const py::detail::unchecked_reference<T, ND> &a)
+{
+    bool empty = (ND == 0);
+    for (py::ssize_t i = 0; i < ND; i++) {
+        if (a.shape(i) == 0) {
+            empty = true;
+        }
+    }
+    if (empty) {
+        return 0;
+    } else {
+        return a.shape(0);
+    }
 }
 #endif
 

--- a/src/numpy_cpp.h
+++ b/src/numpy_cpp.h
@@ -365,10 +365,6 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
   public:
     typedef T value_type;
 
-    enum {
-        ndim = ND
-    };
-
     array_view() : m_arr(NULL), m_data(NULL)
     {
         m_shape = zeros;
@@ -490,6 +486,10 @@ class array_view : public detail::array_view_accessors<array_view, T, ND>
         }
 
         return true;
+    }
+
+    npy_intp ndim() const {
+        return ND;
     }
 
     npy_intp shape(size_t i) const

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -3,6 +3,8 @@
 #ifndef MPL_PATH_CONVERTERS_H
 #define MPL_PATH_CONVERTERS_H
 
+#include <pybind11/pybind11.h>
+
 #include <cmath>
 #include <cstdint>
 #include <limits>
@@ -529,6 +531,24 @@ enum e_snap_mode {
     SNAP_FALSE,
     SNAP_TRUE
 };
+
+namespace PYBIND11_NAMESPACE { namespace detail {
+    template <> struct type_caster<e_snap_mode> {
+    public:
+        PYBIND11_TYPE_CASTER(e_snap_mode, const_name("e_snap_mode"));
+
+        bool load(handle src, bool) {
+            if (src.is_none()) {
+                value = SNAP_AUTO;
+                return true;
+            }
+
+            value = src.cast<bool>() ? SNAP_TRUE : SNAP_FALSE;
+
+            return true;
+        }
+    };
+}} // namespace PYBIND11_NAMESPACE::detail
 
 template <class VertexSource>
 class PathSnapper

--- a/src/py_converters_11.h
+++ b/src/py_converters_11.h
@@ -294,8 +294,7 @@ namespace PYBIND11_NAMESPACE { namespace detail {
             value.join = src.attr("_joinstyle").cast<agg::line_join_e>();
             value.dashes = src.attr("get_dashes")().cast<Dashes>();
             value.cliprect = src.attr("_cliprect").cast<agg::rect_d>();
-            /* value.clippath = src.attr("get_clip_path")().cast<ClipPath>(); */
-            convert_clippath(src.attr("get_clip_path")().ptr(), &value.clippath);
+            value.clippath = src.attr("get_clip_path")().cast<ClipPath>();
             value.snap_mode = src.attr("get_snap")().cast<e_snap_mode>();
             value.hatchpath = src.attr("get_hatch_path")().cast<mpl::PathIterator>();
             value.hatch_color = src.attr("get_hatch_color")().cast<agg::rgba>();

--- a/src/py_converters_11.h
+++ b/src/py_converters_11.h
@@ -8,12 +8,10 @@
 
 namespace py = pybind11;
 
-#include <unordered_map>
-
 #include "agg_basics.h"
 #include "agg_color_rgba.h"
 #include "agg_trans_affine.h"
-#include "path_converters.h"
+#include "mplutils.h"
 
 void convert_trans_affine(const py::object& transform, agg::trans_affine& affine);
 
@@ -150,161 +148,6 @@ namespace PYBIND11_NAMESPACE { namespace detail {
             return true;
         }
     };
-
-    template <> struct type_caster<e_snap_mode> {
-    public:
-        PYBIND11_TYPE_CASTER(e_snap_mode, const_name("e_snap_mode"));
-
-        bool load(handle src, bool) {
-            if (src.is_none()) {
-                value = SNAP_AUTO;
-                return true;
-            }
-
-            value = src.cast<bool>() ? SNAP_TRUE : SNAP_FALSE;
-
-            return true;
-        }
-    };
-
-/* Remove all this macro magic after dropping NumPy usage and just include `py_adaptors.h`. */
-#ifdef MPL_PY_ADAPTORS_H
-    template <> struct type_caster<agg::line_cap_e> {
-    public:
-        PYBIND11_TYPE_CASTER(agg::line_cap_e, const_name("line_cap_e"));
-
-        bool load(handle src, bool) {
-            const std::unordered_map<std::string, agg::line_cap_e> enum_values = {
-                {"butt", agg::butt_cap},
-                {"round", agg::round_cap},
-                {"projecting", agg::square_cap},
-            };
-            value = enum_values.at(src.cast<std::string>());
-            return true;
-        }
-    };
-
-    template <> struct type_caster<agg::line_join_e> {
-    public:
-        PYBIND11_TYPE_CASTER(agg::line_join_e, const_name("line_join_e"));
-
-        bool load(handle src, bool) {
-            const std::unordered_map<std::string, agg::line_join_e> enum_values = {
-                {"miter", agg::miter_join_revert},
-                {"round", agg::round_join},
-                {"bevel", agg::bevel_join},
-            };
-            value = agg::miter_join_revert;
-            value = enum_values.at(src.cast<std::string>());
-            return true;
-        }
-    };
-#endif
-
-/* Remove all this macro magic after dropping NumPy usage and just include `_backend_agg_basic_types.h`. */
-#ifdef MPL_BACKEND_AGG_BASIC_TYPES_H
-#  ifndef MPL_PY_ADAPTORS_H
-#    error "py_adaptors.h must be included to get Agg type casters"
-#  endif
-
-    template <> struct type_caster<ClipPath> {
-    public:
-        PYBIND11_TYPE_CASTER(ClipPath, const_name("ClipPath"));
-
-        bool load(handle src, bool) {
-            if (src.is_none()) {
-                return true;
-            }
-
-            auto clippath_tuple = src.cast<py::tuple>();
-
-            auto path = clippath_tuple[0];
-            if (!path.is_none()) {
-                value.path = path.cast<mpl::PathIterator>();
-            }
-            value.trans = clippath_tuple[1].cast<agg::trans_affine>();
-
-            return true;
-        }
-    };
-
-    template <> struct type_caster<Dashes> {
-    public:
-        PYBIND11_TYPE_CASTER(Dashes, const_name("Dashes"));
-
-        bool load(handle src, bool) {
-            auto dash_tuple = src.cast<py::tuple>();
-            auto dash_offset = dash_tuple[0].cast<double>();
-            auto dashes_seq_or_none = dash_tuple[1];
-
-            if (dashes_seq_or_none.is_none()) {
-                return true;
-            }
-
-            auto dashes_seq = dashes_seq_or_none.cast<py::sequence>();
-
-            auto nentries = dashes_seq.size();
-            // If the dashpattern has odd length, iterate through it twice (in
-            // accordance with the pdf/ps/svg specs).
-            auto dash_pattern_length = (nentries % 2) ? 2 * nentries : nentries;
-
-            for (py::size_t i = 0; i < dash_pattern_length; i += 2) {
-                auto length = dashes_seq[i % nentries].cast<double>();
-                auto skip = dashes_seq[(i + 1) % nentries].cast<double>();
-
-                value.add_dash_pair(length, skip);
-            }
-
-            value.set_dash_offset(dash_offset);
-
-            return true;
-        }
-    };
-
-    template <> struct type_caster<SketchParams> {
-    public:
-        PYBIND11_TYPE_CASTER(SketchParams, const_name("SketchParams"));
-
-        bool load(handle src, bool) {
-            if (src.is_none()) {
-                value.scale = 0.0;
-                value.length = 0.0;
-                value.randomness = 0.0;
-                return true;
-            }
-
-            auto params = src.cast<std::tuple<double, double, double>>();
-            std::tie(value.scale, value.length, value.randomness) = params;
-
-            return true;
-        }
-    };
-
-    template <> struct type_caster<GCAgg> {
-    public:
-        PYBIND11_TYPE_CASTER(GCAgg, const_name("GCAgg"));
-
-        bool load(handle src, bool) {
-            value.linewidth = src.attr("_linewidth").cast<double>();
-            value.alpha = src.attr("_alpha").cast<double>();
-            value.forced_alpha = src.attr("_forced_alpha").cast<bool>();
-            value.color = src.attr("_rgb").cast<agg::rgba>();
-            value.isaa = src.attr("_antialiased").cast<bool>();
-            value.cap = src.attr("_capstyle").cast<agg::line_cap_e>();
-            value.join = src.attr("_joinstyle").cast<agg::line_join_e>();
-            value.dashes = src.attr("get_dashes")().cast<Dashes>();
-            value.cliprect = src.attr("_cliprect").cast<agg::rect_d>();
-            value.clippath = src.attr("get_clip_path")().cast<ClipPath>();
-            value.snap_mode = src.attr("get_snap")().cast<e_snap_mode>();
-            value.hatchpath = src.attr("get_hatch_path")().cast<mpl::PathIterator>();
-            value.hatch_color = src.attr("get_hatch_color")().cast<agg::rgba>();
-            value.hatch_linewidth = src.attr("get_hatch_linewidth")().cast<double>();
-            value.sketch = src.attr("get_sketch_params")().cast<SketchParams>();
-
-            return true;
-        }
-    };
-#endif
 }} // namespace PYBIND11_NAMESPACE::detail
 
 #endif /* MPL_PY_CONVERTERS_11_H */

--- a/src/py_converters_11.h
+++ b/src/py_converters_11.h
@@ -17,6 +17,38 @@ namespace py = pybind11;
 
 void convert_trans_affine(const py::object& transform, agg::trans_affine& affine);
 
+inline auto convert_points(py::array_t<double> obj)
+{
+    if (!check_trailing_shape(obj, "points", 2)) {
+        throw py::error_already_set();
+    }
+    return obj.unchecked<2>();
+}
+
+inline auto convert_transforms(py::array_t<double> obj)
+{
+    if (!check_trailing_shape(obj, "transforms", 3, 3)) {
+        throw py::error_already_set();
+    }
+    return obj.unchecked<3>();
+}
+
+inline auto convert_bboxes(py::array_t<double> obj)
+{
+    if (!check_trailing_shape(obj, "bbox array", 2, 2)) {
+        throw py::error_already_set();
+    }
+    return obj.unchecked<3>();
+}
+
+inline auto convert_colors(py::array_t<double> obj)
+{
+    if (!check_trailing_shape(obj, "colors", 4)) {
+        throw py::error_already_set();
+    }
+    return obj.unchecked<2>();
+}
+
 namespace PYBIND11_NAMESPACE { namespace detail {
     template <> struct type_caster<agg::rect_d> {
     public:

--- a/src/py_converters_11.h
+++ b/src/py_converters_11.h
@@ -167,29 +167,6 @@ namespace PYBIND11_NAMESPACE { namespace detail {
             return true;
         }
     };
-
-    template <> struct type_caster<mpl::PathIterator> {
-    public:
-        PYBIND11_TYPE_CASTER(mpl::PathIterator, const_name("PathIterator"));
-
-        bool load(handle src, bool) {
-            if (src.is_none()) {
-                return true;
-            }
-
-            py::object vertices = src.attr("vertices");
-            py::object codes = src.attr("codes");
-            auto should_simplify = src.attr("should_simplify").cast<bool>();
-            auto simplify_threshold = src.attr("simplify_threshold").cast<double>();
-
-            if (!value.set(vertices.inc_ref().ptr(), codes.inc_ref().ptr(),
-                           should_simplify, simplify_threshold)) {
-                throw py::error_already_set();
-            }
-
-            return true;
-        }
-    };
 #endif
 
 /* Remove all this macro magic after dropping NumPy usage and just include `_backend_agg_basic_types.h`. */


### PR DESCRIPTION
## PR summary

Now that we are building with pybind11 in all extensions, we can drop/convert several items that were used across extensions. Namely, everything in `py_adaptors` (which was shared between `_path` and `_backend_agg`) can now get a type caster, all the remaining `array_view` can be moved to `py::array_t`, and the `ClipPath` converter issue from #27011 has been fixed.

Additionally, I moved the pybind11 type casters from `py_converters_11.h` to the files that define the related types. This keeps things a bit more consolidated, and avoids the weird `#ifdef` macro magic that was needed before.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines