### PR TITLE
Fix flaky labelcolor tests

### DIFF
--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -868,8 +868,8 @@ def test_legend_pathcollection_labelcolor_linecolor_iterable():
     # test the labelcolor for labelcolor='linecolor' on PathCollection
     # with iterable colors
     fig, ax = plt.subplots()
-    colors = np.random.default_rng().choice(['r', 'g', 'b'], 10)
-    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', c=colors)
+    colors = np.array(['r', 'g', 'b', 'c', 'm'] * 2)
+    ax.scatter(np.arange(10), np.arange(10), label='#1', c=colors)
 
     leg = ax.legend(labelcolor='linecolor')
     text, = leg.get_texts()
@@ -915,8 +915,8 @@ def test_legend_pathcollection_labelcolor_markeredgecolor_iterable():
     # test the labelcolor for labelcolor='markeredgecolor' on PathCollection
     # with iterable colors
     fig, ax = plt.subplots()
-    colors = np.random.default_rng().choice(['r', 'g', 'b'], 10)
-    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', edgecolor=colors)
+    colors = np.array(['r', 'g', 'b', 'c', 'm'] * 2)
+    ax.scatter(np.arange(10), np.arange(10), label='#1', edgecolor=colors)
 
     leg = ax.legend(labelcolor='markeredgecolor')
     for text, color in zip(leg.get_texts(), ['k']):
@@ -970,8 +970,8 @@ def test_legend_pathcollection_labelcolor_markerfacecolor_iterable():
     # test the labelcolor for labelcolor='markerfacecolor' on PathCollection
     # with iterable colors
     fig, ax = plt.subplots()
-    colors = np.random.default_rng().choice(['r', 'g', 'b'], 10)
-    ax.scatter(np.arange(10), np.arange(10)*1, label='#1', facecolor=colors)
+    colors = np.array(['r', 'g', 'b', 'c', 'm'] * 2)
+    ax.scatter(np.arange(10), np.arange(10), label='#1', facecolor=colors)
 
     leg = ax.legend(labelcolor='markerfacecolor')
     for text, color in zip(leg.get_texts(), ['k']):


### PR DESCRIPTION
## PR summary

For labelcolor={linecolor,markeredgecolor,markerfacecolor}, text will match the specified attribute if consistent, but fall back to black if they differ within a single labeled artist.

These tests use 10 random colours out of the ['r', 'g', 'b'] set, so 3 (all red, all green, all blue) out of 3**10 will result in the text _not_ being black. This is rare (0.0051%), but does happen once in a while (e.g., https://github.com/matplotlib/matplotlib/actions/runs/10967975776/job/30458622005).

Instead, just hard-code some different colours in the test.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines