### PR TITLE
ci: Bump build image on AppVeyor to MSVC 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ skip_commits:
 
 clone_depth: 50
 
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 environment:
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,8 +45,9 @@ cache:
 
 init:
   - ps:
+      # Pinned due to https://github.com/mamba-org/mamba/issues/3467
       Invoke-Webrequest
-      -URI https://micro.mamba.pm/api/micromamba/win-64/latest
+      -URI https://github.com/mamba-org/micromamba-releases/releases/download/1.5.10-0/micromamba-win-64.tar.bz2
       -OutFile C:\projects\micromamba.tar.bz2
   - ps: C:\PROGRA~1\7-Zip\7z.exe x C:\projects\micromamba.tar.bz2 -aoa -oC:\projects\
   - ps: C:\PROGRA~1\7-Zip\7z.exe x C:\projects\micromamba.tar -ttar -aoa -oC:\projects\


### PR DESCRIPTION
## PR summary

According to the SciPy toolchain roadmap [1], we should be supporting at minimum MSVC 2019. The AppVeyor image has been held back to MSVC 2017 (probably just forgotten since it didn't complain), which is starting to cause issues for more modern code. (Namely #28842 does not work even with the flag for new behaviour.)

There are many [other software changes](https://www.appveyor.com/docs/windows-images-software/#visual-studio-2019), so I'm opening this separately from #28842 just to confirm it doesn't break anything.

[1] https://docs.scipy.org/doc/scipy/dev/toolchain.html

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines