### PR TITLE
Fix mutation_aspect incorrectly scaling FancyBbox

### DIFF
--- a/galleries/examples/shapes_and_collections/fancybox_demo.py
+++ b/galleries/examples/shapes_and_collections/fancybox_demo.py
@@ -92,7 +92,7 @@ ax.set(xlim=(0, 1), ylim=(0, 1), aspect=1,
 ax = axs[1, 1]
 # When the aspect ratio of the Axes is not 1, the fancy box may not be what you
 # expected (green).
-fancy = add_fancy_patch_around(ax, bb, boxstyle="round,pad=0.2")
+fancy = add_fancy_patch_around(ax, bb, boxstyle="round,pad=0.3")
 fancy.set(facecolor="none", edgecolor="green")
 # You can compensate this by setting the mutation_aspect (pink).
 fancy = add_fancy_patch_around(

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4021,12 +4021,14 @@ class FancyBboxPatch(Patch):
     def get_path(self):
         """Return the mutated path of the rectangle."""
         boxstyle = self.get_boxstyle()
-        m_aspect = self.get_mutation_aspect()
+        m_aspect = math.sqrt(self.get_mutation_aspect())
         # Call boxstyle with y, height squeezed by aspect_ratio.
-        path = boxstyle(self._x, self._y / m_aspect,
-                        self._width, self._height / m_aspect,
+        path = boxstyle(self._x * m_aspect,
+                        self._y / m_aspect,
+                        self._width * m_aspect,
+                        self._height / m_aspect,
                         self.get_mutation_scale())
-        return Path(path.vertices * [1, m_aspect], path.codes)  # Unsqueeze y.
+        return Path(path.vertices * [1 / m_aspect, m_aspect], path.codes)  # Unsqueeze y.
 
     # Following methods are borrowed from the Rectangle class.
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4028,7 +4028,7 @@ class FancyBboxPatch(Patch):
                         self._width * m_aspect,
                         self._height / m_aspect,
                         self.get_mutation_scale())
-        return Path(path.vertices * [1 / m_aspect, m_aspect], path.codes)  # Unsqueeze y.
+        return Path(path.vertices * [1 / m_aspect, m_aspect], path.codes)
 
     # Following methods are borrowed from the Rectangle class.
 


### PR DESCRIPTION
This commit changes the mutation_aspect from only affecting the y axis to affecting x and y axis in the correct ratio.

A demonstration is in the linked issue.

closes #28876

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
