### PR TITLE
doc: add pandas and xarray fixtures to testing API docs

### DIFF
--- a/doc/api/testing_api.rst
+++ b/doc/api/testing_api.rst
@@ -37,3 +37,10 @@
    :members:
    :undoc-members:
    :show-inheritance:
+
+
+Data container testing fixtures
+==================================
+
+.. autofunction:: matplotlib.testing.conftest.pd
+.. autofunction:: matplotlib.testing.conftest.xr

--- a/doc/api/testing_api.rst
+++ b/doc/api/testing_api.rst
@@ -39,8 +39,9 @@
    :show-inheritance:
 
 
-Data container testing fixtures
+Testing with optional dependencies
 ==================================
+For more information on fixtures, see :external+pytest:ref:`pytest fixtures <about-fixtures>`.
 
 .. autofunction:: matplotlib.testing.conftest.pd
 .. autofunction:: matplotlib.testing.conftest.xr

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -220,6 +220,7 @@ logger.addFilter(tutorials_download_error)
 
 autosummary_generate = True
 autodoc_typehints = "none"
+autodoc_mock_imports = ["pytest"]
 
 # we should ignore warnings coming from importing deprecated modules for
 # autodoc purposes, as this will disappear automatically when they are removed

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -82,7 +82,20 @@ def mpl_test_settings(request):
 
 @pytest.fixture
 def pd():
-    """Fixture to import and configure pandas."""
+    """
+    Fixture to import and configure pandas. Using this fixture, the test is skipped when
+    pandas is not installed. Use this fixture instead of importing pandas in test files.
+
+    Examples
+    --------
+    Request the pandas fixture by passing in ``pd`` as an argument to the test ::
+
+        def test_matshow_pandas(pd):
+
+            df = pd.DataFrame({'x':[1,2,3], 'y':[4,5,6]})
+            im = plt.figure().subplots().matshow(df)
+            np.testing.assert_array_equal(im.get_array(), df)
+    """
     pd = pytest.importorskip('pandas')
     try:
         from pandas.plotting import (
@@ -95,6 +108,20 @@ def pd():
 
 @pytest.fixture
 def xr():
-    """Fixture to import xarray."""
+    """
+    Fixture to import xarray so that the test is skipped when xarray is not installed.
+    Use this fixture instead of importing xrray in test files.
+
+    Examples
+    --------
+    Request the xarray fixture by passing in ``xr`` as an argument to the test ::
+
+        def test_imshow_xarray(xr):
+
+            ds = xr.DataArray(np.random.randn(2, 3))
+            im = plt.figure().subplots().imshow(ds)
+            np.testing.assert_array_equal(im.get_array(), ds)
+    """
+
     xr = pytest.importorskip('xarray')
     return xr


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

Motivated by #28830, figured it'd be a lot easier for contributors to use/reviewers to suggest if the pandas and xarray fixtures were exposed in the docs. I'm not fond of the subheading title but also can't think of a better one.  

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
