### PR TITLE
DOC: Better visualization for the default color cycle example

### DIFF
--- a/galleries/examples/color/color_cycle_default.py
+++ b/galleries/examples/color/color_cycle_default.py
@@ -9,33 +9,28 @@ Display the colors from the default prop_cycle, which is obtained from the
 import matplotlib.pyplot as plt
 import numpy as np
 
+from matplotlib.colors import TABLEAU_COLORS, same_color
+
+
+def f(x, a):
+    """A nice sigmoid-like parametrized curve, ending approximately at *a*."""
+    return 0.85 * a * (1 / (1 + np.exp(-x)) + 0.2)
+
+
+fig, ax = plt.subplots()
+ax.axis('off')
+ax.set_title("Colors in the default property cycle")
+
 prop_cycle = plt.rcParams['axes.prop_cycle']
 colors = prop_cycle.by_key()['color']
+x = np.linspace(-4, 4, 200)
 
-lwbase = plt.rcParams['lines.linewidth']
-thin = lwbase / 2
-thick = lwbase * 3
-
-fig, axs = plt.subplots(nrows=2, ncols=2, sharex=True, sharey=True)
-for icol in range(2):
-    if icol == 0:
-        lwx, lwy = thin, lwbase
-    else:
-        lwx, lwy = lwbase, thick
-    for irow in range(2):
-        for i, color in enumerate(colors):
-            axs[irow, icol].axhline(i, color=color, lw=lwx)
-            axs[irow, icol].axvline(i, color=color, lw=lwy)
-
-    axs[1, icol].set_facecolor('k')
-    axs[1, icol].xaxis.set_ticks(np.arange(0, 10, 2))
-    axs[0, icol].set_title(f'line widths (pts): {lwx:g}, {lwy:g}',
-                           fontsize='medium')
-
-for irow in range(2):
-    axs[irow, 0].yaxis.set_ticks(np.arange(0, 10, 2))
-
-fig.suptitle('Colors in the default prop_cycle', fontsize='large')
+for i, (color, color_name) in enumerate(zip(colors, TABLEAU_COLORS)):
+    assert same_color(color, color_name)
+    pos = 4.5 - i
+    ax.plot(x, f(x, pos))
+    ax.text(4.2, pos, f"'C{i}': '{color_name}'", color=color, va="center")
+    ax.bar(9, 1, width=1.5, bottom=pos-0.5)
 
 plt.show()
 
@@ -46,14 +41,14 @@ plt.show()
 #    The use of the following functions, methods, classes and modules is shown
 #    in this example:
 #
-#    - `matplotlib.axes.Axes.axhline` / `matplotlib.pyplot.axhline`
-#    - `matplotlib.axes.Axes.axvline` / `matplotlib.pyplot.axvline`
-#    - `matplotlib.axes.Axes.set_facecolor`
-#    - `matplotlib.figure.Figure.suptitle`
+#    - `matplotlib.axes.Axes.axis`
+#    - `matplotlib.axes.Axes.text`
+#    - `matplotlib.colors.same_color`
+#    - `cycler.Cycler`
 #
 # .. tags::
 #
 #    styling: color
-#    styling: colormap
+#    purpose: reference
 #    plot-type: line
 #    level: beginner


### PR DESCRIPTION
The current visualization is quite messy (
https://matplotlib.org/stable/gallery/color/color_cycle_default.html).

Let's focus on:
- giving a one clear sequence
- giving the color names as 'CN' notation and named colors
- showing lines and patches (colors appear substantially different in thin lines and filled areas)

And don't bother with:
- multiple line widths - they are only a slight visual variation (compared to patches) and multiple widths clutter the example
- black background: It's enough to show the default color cycle on the default background.


New rendered example:
![grafik](https://github.com/user-attachments/assets/41648e04-c70d-4896-8c7a-710b42ebc315)

