### PR TITLE
MNT: Add missing dependency to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -40,6 +40,7 @@ dependencies:
   - sphinx>=3.0.0,!=6.1.2
   - sphinx-copybutton
   - sphinx-gallery>=0.12.0
+  - joblib  # needed for sphinx-gallery[parallel]
   - sphinx-design
   - sphinx-tags>=0.4.0
   - pip


### PR DESCRIPTION
#28617 introduced parallel gallery builds. This needs joblib as a dependency for sphinx-gallery. `requirements.txt` solves this via `sphinx-gallery[parallel]>=0.12.0`. Unfortunately, conda does not support variants, therefore we have to add the dependency explicitly to `environment.yml`.
