### PR TITLE
Don't cache exception with traceback reference loop in dviread.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -504,7 +504,7 @@ class Dvi:
             # and throw that error in Dvi._read.  For Vf, _finalize_packet
             # checks whether a missing glyph has been used, and in that case
             # skips the glyph definition.
-            self.fonts[k] = exc
+            self.fonts[k] = exc.with_traceback(None)
             return
         if c != 0 and tfm.checksum != 0 and c != tfm.checksum:
             raise ValueError(f'tfm checksum mismatch: {n}')


### PR DESCRIPTION
Rather, preemptively cache the reference loop by explicitly dropping the traceback.

See also db0c7c3 (#25470) for a longer description of the problem in another context.

(@tacaswell: I wonder whether using with_traceback(None) would have been a cleaner solution in #25470?)

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
