### PR TITLE
Agg: Remove 16-bit limits

### DIFF
--- a/doc/users/next_whats_new/increased_figure_limits.rst
+++ b/doc/users/next_whats_new/increased_figure_limits.rst
@@ -1,0 +1,9 @@
+Increased Figure limits with Agg renderer
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Figures using the Agg renderer are now limited to 2**23 pixels in each
+direction, instead of 2**16. Additionally, bugs that caused artists to not
+render past 2**15 pixels horizontally have been fixed.
+
+Note that if you are using a GUI backend, it may have its own smaller limits
+(which may themselves depend on screen size.)

--- a/extern/agg24-svn/include/agg_rasterizer_cells_aa.h
+++ b/extern/agg24-svn/include/agg_rasterizer_cells_aa.h
@@ -325,8 +325,10 @@ namespace agg
 
         if(dx >= dx_limit || dx <= -dx_limit)
         {
-            int cx = (x1 + x2) >> 1;
-            int cy = (y1 + y2) >> 1;
+            // These are overflow safe versions of (x1 + x2) >> 1; divide each by 2
+            // first, then add 1 if both were odd.
+            int cx = (x1 >> 1) + (x2 >> 1) + ((x1 & 1) & (x2 & 1));
+            int cy = (y1 >> 1) + (y2 >> 1) + ((y1 & 1) & (y2 & 1));
             line(x1, y1, cx, cy);
             line(cx, cy, x2, y2);
             return;

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -199,7 +199,7 @@ def test_agg_filter():
 
 
 def test_too_large_image():
-    fig = plt.figure(figsize=(300, 1000))
+    fig = plt.figure(figsize=(300, 2**25))
     buff = io.BytesIO()
     with pytest.raises(ValueError):
         fig.savefig(buff)

--- a/src/_backend_agg.cpp
+++ b/src/_backend_agg.cpp
@@ -33,10 +33,10 @@ RendererAgg::RendererAgg(unsigned int width, unsigned int height, double dpi)
         throw std::range_error("dpi must be positive");
     }
 
-    if (width >= 1 << 16 || height >= 1 << 16) {
+    if (width >= 1 << 23 || height >= 1 << 23) {
         throw std::range_error(
             "Image size of " + std::to_string(width) + "x" + std::to_string(height) +
-            " pixels is too large. It must be less than 2^16 in each direction.");
+            " pixels is too large. It must be less than 2^23 in each direction.");
     }
 
     unsigned stride(width * 4);

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -117,10 +117,10 @@ class RendererAgg
     typedef agg::renderer_scanline_bin_solid<renderer_base> renderer_bin;
     typedef agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip_dbl> rasterizer;
 
-    typedef agg::scanline_p8 scanline_p8;
-    typedef agg::scanline_bin scanline_bin;
+    typedef agg::scanline32_p8 scanline_p8;
+    typedef agg::scanline32_bin scanline_bin;
     typedef agg::amask_no_clip_gray8 alpha_mask_type;
-    typedef agg::scanline_u8_am<alpha_mask_type> scanline_am;
+    typedef agg::scanline32_u8_am<alpha_mask_type> scanline_am;
 
     typedef agg::renderer_base<agg::pixfmt_gray8> renderer_base_alpha_mask_type;
     typedef agg::renderer_scanline_aa_solid<renderer_base_alpha_mask_type> renderer_alpha_mask_type;

--- a/src/_image_resample.h
+++ b/src/_image_resample.h
@@ -712,6 +712,7 @@ void resample(
 
     using renderer_t = agg::renderer_base<output_pixfmt_t>;
     using rasterizer_t = agg::rasterizer_scanline_aa<agg::rasterizer_sl_clip_dbl>;
+    using scanline_t = agg::scanline32_u8;
 
     using reflect_t = agg::wrap_mode_reflect;
     using image_accessor_t = agg::image_accessor_wrap<input_pixfmt_t, reflect_t, reflect_t>;
@@ -739,7 +740,7 @@ void resample(
 
     span_alloc_t span_alloc;
     rasterizer_t rasterizer;
-    agg::scanline_u8 scanline;
+    scanline_t scanline;
 
     span_conv_alpha_t conv_alpha(params.alpha);
 


### PR DESCRIPTION
## PR summary

When rendering objects, Agg rasterizes them into scan line objects (an x/y point, horizontal length, and colour), and the renderer class writes those to the pixels in the final buffer. Though we have determined that Agg buffers cannot be larger than 2**16, the scan line classes that we use contain 16-bit _signed_ integers internally, cutting off positive values at half the maximum.

Since the renderer uses 32-bit integers, this can cause odd behaviour where any horizontal span that _starts_ before 2**15 (such as a horizontal spine) is rendered correctly even if it cross that point, but those that start after (such as a vertical spine or any portion of an angled line) end up clipped. For example, see how the spines and lines break in #28893.

![image](https://github.com/user-attachments/assets/bd30b8fa-4335-4dd7-a48e-b7a8757dfaa9)

A similar problem occurs for resampled images, which also uses Agg scanlines internally. See the breakage in #26368 for an example.

![image](https://github.com/user-attachments/assets/1f59ce0f-47e4-4355-846d-ea2faec642bf)

The example in that issue also contains horizontal spines that are wider than 2**15, which also exhibit strange behaviour.

![image](https://github.com/user-attachments/assets/50078eb6-7afe-4ac5-b3a3-0c757fb6eb07)

By moving to 32-bit scan lines, positions and lengths of the lines will no longer be clipped, and this fixes rendering on very large figures.

Now, this does mean that internal bookkeeping will use double the memory. I have not yet benchmarked the memory usage to see what effect that would have. But I have implemented this two ways to show how it might work:
1. In `_image_resample.h`, the larger scan lines are used if the output image is >=2**15 in either dimension.
2. In `_backend_agg.h`, the larger scan lines are always used. While this is unfortunately the more common case, it's also the harder one to conditionalize as the type is in the class, and the template is used everywhere.

That being said, having the scan lines be conditional means that double the code is emitted instead. For the Agg backend, it increases by 4096 bytes (after stripping debug info), whereas for the image extension, it increased by 65536 bytes vs no increase for just using the larger one.

However, given the breakage in #23826, it may be necessary to _always_ use the 32-bit scan lines.

Fixes #23826
Fixes #26368
Fixes #28893

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines