### PR TITLE
Re-fix exception caching in dviread.

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -32,6 +32,29 @@ import matplotlib
 from matplotlib import _api, _c_internal_utils
 
 
+class _ExceptionInfo:
+    """
+    A class to carry exception information around.
+
+    This is used to store and later raise exceptions. It's an alternative to
+    directly storing Exception instances that circumvents traceback-related
+    issues: caching tracebacks can keep user's objects in local namespaces
+    alive indefinitely, which can lead to very surprising memory issues for
+    users and result in incorrect tracebacks.
+    """
+
+    def __init__(self, cls, *args):
+        self._cls = cls
+        self._args = args
+
+    @classmethod
+    def from_exception(cls, exc):
+        return cls(type(exc), *exc.args)
+
+    def to_exception(self):
+        return self._cls(*self._args)
+
+
 def _get_running_interactive_framework():
     """
     Return the interactive framework whose event loop is currently running, if

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -340,7 +340,7 @@ class Dvi:
             byte = self.file.read(1)[0]
             self._dtable[byte](self, byte)
             if self._missing_font:
-                raise self._missing_font
+                raise self._missing_font.to_exception()
             name = self._dtable[byte].__name__
             if name == "_push":
                 down_stack.append(down_stack[-1])
@@ -368,14 +368,14 @@ class Dvi:
     @_dispatch(min=0, max=127, state=_dvistate.inpage)
     def _set_char_immediate(self, char):
         self._put_char_real(char)
-        if isinstance(self.fonts[self.f], FileNotFoundError):
+        if isinstance(self.fonts[self.f], cbook._ExceptionInfo):
             return
         self.h += self.fonts[self.f]._width_of(char)
 
     @_dispatch(min=128, max=131, state=_dvistate.inpage, args=('olen1',))
     def _set_char(self, char):
         self._put_char_real(char)
-        if isinstance(self.fonts[self.f], FileNotFoundError):
+        if isinstance(self.fonts[self.f], cbook._ExceptionInfo):
             return
         self.h += self.fonts[self.f]._width_of(char)
 
@@ -390,7 +390,7 @@ class Dvi:
 
     def _put_char_real(self, char):
         font = self.fonts[self.f]
-        if isinstance(font, FileNotFoundError):
+        if isinstance(font, cbook._ExceptionInfo):
             self._missing_font = font
         elif font._vf is None:
             self.text.append(Text(self.h, self.v, font, char,
@@ -504,7 +504,7 @@ class Dvi:
             # and throw that error in Dvi._read.  For Vf, _finalize_packet
             # checks whether a missing glyph has been used, and in that case
             # skips the glyph definition.
-            self.fonts[k] = exc.with_traceback(None)
+            self.fonts[k] = cbook._ExceptionInfo.from_exception(exc)
             return
         if c != 0 and tfm.checksum != 0 and c != tfm.checksum:
             raise ValueError(f'tfm checksum mismatch: {n}')

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -28,7 +28,6 @@ Future versions may implement the Level 2 or 2.1 specifications.
 from __future__ import annotations
 
 from base64 import b64encode
-from collections import namedtuple
 import copy
 import dataclasses
 from functools import lru_cache
@@ -132,8 +131,6 @@ font_family_aliases = {
     'monospace',
     'sans',
 }
-
-_ExceptionProxy = namedtuple('_ExceptionProxy', ['klass', 'message'])
 
 # OS Font paths
 try:
@@ -1355,8 +1352,8 @@ class FontManager:
         ret = self._findfont_cached(
             prop, fontext, directory, fallback_to_default, rebuild_if_missing,
             rc_params)
-        if isinstance(ret, _ExceptionProxy):
-            raise ret.klass(ret.message)
+        if isinstance(ret, cbook._ExceptionInfo):
+            raise ret.to_exception()
         return ret
 
     def get_font_names(self):
@@ -1509,7 +1506,7 @@ class FontManager:
                 # This return instead of raise is intentional, as we wish to
                 # cache that it was not found, which will not occur if it was
                 # actually raised.
-                return _ExceptionProxy(
+                return cbook._ExceptionInfo(
                     ValueError,
                     f"Failed to find font {prop}, and fallback to the default font was "
                     f"disabled"
@@ -1535,7 +1532,7 @@ class FontManager:
                 # This return instead of raise is intentional, as we wish to
                 # cache that it was not found, which will not occur if it was
                 # actually raised.
-                return _ExceptionProxy(ValueError, "No valid font could be found")
+                return cbook._ExceptionInfo(ValueError, "No valid font could be found")
 
         return _cached_realpath(result)
 


### PR DESCRIPTION
The original solution using with_traceback didn't actually work because with_traceback doesn't return a new exception instance but rather modifies the original one in place, and the traceback will then be attached to it by the raise statement.

Instead, we actually need to build a new instance, so reuse the _ExceptionProxy machinery from font_manager (slightly expanded).

Redo of #28899; sorry about that...

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
