### PR TITLE
MNT: Fix double evaluation of _LazyTickList

### DIFF
--- a/doc/users/next_whats_new/axes_creation_speedup.rst
+++ b/doc/users/next_whats_new/axes_creation_speedup.rst
@@ -1,0 +1,4 @@
+Axes creation speedup
+~~~~~~~~~~~~~~~~~~~~~
+
+Creating an Axes is now 20-25% faster due to internal optimizations.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -538,17 +538,19 @@ class _LazyTickList:
             # instance._get_tick() can itself try to access the majorTicks
             # attribute (e.g. in certain projection classes which override
             # e.g. get_xaxis_text1_transform).  In order to avoid infinite
-            # recursion, first set the majorTicks on the instance to an empty
-            # list, then create the tick and append it.
+            # recursion, first set the majorTicks on the instance temporarily
+            # to an empty lis. Then create the tick; note that _get_tick()
+            # may call reset_ticks(). Therefore, the final tick list is
+            # created and assigned afterwards.
             if self._major:
                 instance.majorTicks = []
                 tick = instance._get_tick(major=True)
-                instance.majorTicks.append(tick)
+                instance.majorTicks = [tick]
                 return instance.majorTicks
             else:
                 instance.minorTicks = []
                 tick = instance._get_tick(major=False)
-                instance.minorTicks.append(tick)
+                instance.minorTicks = [tick]
                 return instance.minorTicks
 
 


### PR DESCRIPTION
Closes #28908.

It seems the read-access to `instance.majorTicks` per `instance .majorTicks.append()` still triggers the descriptor, even though `instance.majorTicks = []` previously should have rebound the name. For details see #28908.

