### PR TITLE
DOC: Show _CollectionWithSizes in the docs

### DIFF
--- a/doc/api/collections_api.rst
+++ b/doc/api/collections_api.rst
@@ -11,3 +11,9 @@
    :undoc-members:
    :show-inheritance:
    :inherited-members:
+   :private-members: set_sizes, get_sizes
+
+.. set_sizes and get_sizes are defined in the private base class
+   _CollectionWithSizes. These are public for child classes and
+   thus should be listed there.
+

--- a/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
+++ b/lib/matplotlib/backends/web_backend/nbagg_uat.ipynb
@@ -4,10 +4,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "from imp import reload"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -22,7 +22,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import matplotlib\n",
     "reload(matplotlib)\n",
@@ -31,7 +30,8 @@
     "\n",
     "import matplotlib.backends.backend_nbagg\n",
     "reload(matplotlib.backends.backend_nbagg)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -46,7 +46,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import matplotlib.backends.backend_webagg_core\n",
     "reload(matplotlib.backends.backend_webagg_core)\n",
@@ -58,7 +57,8 @@
     "plt.plot(range(10))\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -73,11 +73,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.plot([3, 2, 1])\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -92,10 +92,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "print(matplotlib.backends.backend_nbagg.connection_info())"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -110,11 +110,11 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.close(fig1)\n",
     "plt.close('all')"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -130,10 +130,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.plot(range(10))"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -148,10 +148,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "print(matplotlib.backends.backend_nbagg.connection_info())"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -166,13 +166,13 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.show()\n",
     "plt.figure()\n",
     "plt.plot(range(5))\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -187,12 +187,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.interactive(True)\n",
     "plt.figure()\n",
     "plt.plot([3, 2, 1])"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -205,10 +205,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.plot(range(3))"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -221,10 +221,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "print(matplotlib.backends.backend_nbagg.connection_info())"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -237,10 +237,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.interactive(False)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -255,10 +255,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "plt.gcf().canvas.manager.reshow()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -284,7 +284,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fig = plt.figure()\n",
     "plt.axes()\n",
@@ -292,7 +291,8 @@
     "\n",
     "plt.plot([1, 2, 3])\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -307,7 +307,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "from matplotlib.backends.backend_nbagg import new_figure_manager,show\n",
     "\n",
@@ -316,7 +315,8 @@
     "ax = fig.add_subplot(1,1,1)\n",
     "ax.plot([1,2,3])\n",
     "fig.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -331,7 +331,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import matplotlib.animation as animation\n",
     "import numpy as np\n",
@@ -353,7 +352,8 @@
     "ani = animation.FuncAnimation(fig, animate, np.arange(1, 200), init_func=init,\n",
     "                              interval=100., blit=True)\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -372,7 +372,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import matplotlib\n",
     "matplotlib.rcParams.update({'figure.facecolor': 'red',\n",
@@ -381,7 +380,8 @@
     "plt.plot([3, 2, 1])\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -396,7 +396,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import itertools\n",
     "fig, ax = plt.subplots()\n",
@@ -424,7 +423,8 @@
     "fig.canvas.mpl_connect('key_release_event', on_event)\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -441,7 +441,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import time\n",
     "\n",
@@ -455,7 +454,8 @@
     "timer = fig.canvas.new_timer(500, [(update, [text], {})])\n",
     "timer.start()\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -468,7 +468,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
     "text = ax.text(0.5, 0.5, '', ha='center') \n",
@@ -478,7 +477,8 @@
     "timer.start()\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -491,7 +491,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
     "text = ax.text(0.5, 0.5, '', ha='center')\n",
@@ -501,13 +500,13 @@
     "timer.stop()\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
     "text = ax.text(0.5, 0.5, '', ha='center')\n",
@@ -518,7 +517,8 @@
     "timer.stop()\n",
     "\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -533,12 +533,12 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fig, ax = plt.subplots()\n",
     "ax.plot(range(5))\n",
     "plt.show()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -551,10 +551,10 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "fig.canvas.manager.reshow()"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "markdown",
@@ -571,7 +571,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
    "source": [
     "import itertools\n",
     "\n",
@@ -597,14 +596,15 @@
     "ax.figure.canvas.draw()\n",
     "\n",
     "ax.figure.canvas.mpl_connect('button_press_event', onclick_handle)"
-   ]
+   ],
+   "outputs": []
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [],
+   "outputs": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
From a documentation perspective, it's not quite ideal to have a private base class. Maybe we have to rearchitect at some point. But for now, just document `_CollectionWithSizes`. This also fixes the problem that `set_sizes` couldn't be referenced because it did not show up in the documentation.
