### PR TITLE
polar error bar fix

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3770,7 +3770,7 @@ class Axes(_AxesBase):
                 for l in caplines[axis]:
                     # Rotate caps to be perpendicular to the error bars
                     for theta, r in zip(l.get_xdata(), l.get_ydata()):
-                        rotation = mtransforms.Affine2D().rotate(theta + np.pi / 2)
+                        rotation = mtransforms.Affine2D().rotate(theta + np.pi / 2) #changed rotation coefficient
                         if axis == 'y':
                             rotation.rotate(np.pi / 2)#changed sign on "np.pi"
                         ms = mmarkers.MarkerStyle(marker=marker,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3770,9 +3770,9 @@ class Axes(_AxesBase):
                 for l in caplines[axis]:
                     # Rotate caps to be perpendicular to the error bars
                     for theta, r in zip(l.get_xdata(), l.get_ydata()):
-                        rotation = mtransforms.Affine2D().rotate(theta)
+                        rotation = mtransforms.Affine2D().rotate(theta + np.pi / 2)
                         if axis == 'y':
-                            rotation.rotate(-np.pi / 2)
+                            rotation.rotate(np.pi / 2)#changed sign on "np.pi"
                         ms = mmarkers.MarkerStyle(marker=marker,
                                                   transform=rotation)
                         self.add_line(mlines.Line2D([theta], [r], marker=ms,

--- a/test.py
+++ b/test.py
@@ -1,0 +1,14 @@
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+theta = np.arange(0, 2 * np.pi, np.pi / 8)
+r = theta / np.pi / 2 + 0.5
+
+fig = plt.figure(figsize=(10, 10))
+ax = fig.add_subplot(projection='polar')
+ax.set_theta_zero_location("N")
+ax.set_theta_direction(-1)
+ax.errorbar(theta, r, xerr=0.1, yerr=0.1, capsize=7, fmt="o", c="seagreen")
+ax.set_title("Pretty polar error bars")
+plt.show()


### PR DESCRIPTION
Please feel free to review and or test this as I was unable to actually create the plot due to issues with installing python and matplotlib on my local machine here. 
This was supposed to be a bug fix for issue number #28885 linked here : https://github.com/matplotlib/matplotlib/issues/28885
I changed the rotation coefficient in the lines showed in the original post and the sign of the rotate call to match the new coefficient. 

import matplotlib.pyplot as plt
import numpy as np

theta = np.arange(0, 2 * np.pi, np.pi / 8)
r = theta / np.pi / 2 + 0.5

fig = plt.figure(figsize=(10, 10))
ax = fig.add_subplot(projection='polar')
ax.set_theta_zero_location("N")
ax.set_theta_direction(-1)
ax.errorbar(theta, r, xerr=0.1, yerr=0.1, capsize=7, fmt="o", c="seagreen")
ax.set_title("Pretty polar error bars")
plt.show()