### PR TITLE
TST: handle change in pytest.importorskip behavior

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -5,6 +5,7 @@ import sys
 from unittest import mock
 
 from cycler import cycler, Cycler
+from packaging.version import parse as parse_version
 import pytest
 
 import matplotlib as mpl
@@ -539,7 +540,12 @@ def test_backend_fallback_headless(tmp_path):
     sys.platform == "linux" and not _c_internal_utils.xdisplay_is_valid(),
     reason="headless")
 def test_backend_fallback_headful(tmp_path):
-    pytest.importorskip("tkinter")
+    if parse_version(pytest.__version__) >= parse_version('8.2.0'):
+        pytest_kwargs = dict(exc_type=ImportError)
+    else:
+        pytest_kwargs = {}
+
+    pytest.importorskip("tkinter", **pytest_kwargs)
     env = {**os.environ, "MPLBACKEND": "", "MPLCONFIGDIR": str(tmp_path)}
     backend = subprocess_run_for_testing(
         [sys.executable, "-c",

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1,6 +1,7 @@
 import functools
 import itertools
 import platform
+import sys
 
 import pytest
 
@@ -115,7 +116,7 @@ def test_axes3d_repr():
 
 
 @mpl3d_image_comparison(['axes3d_primary_views.png'], style='mpl20',
-                        tol=0.05 if platform.machine() == "arm64" else 0)
+                        tol=0.05 if sys.platform == "darwin" else 0)
 def test_axes3d_primary_views():
     # (elev, azim, roll)
     views = [(90, -90, 0),  # XY


### PR DESCRIPTION
It now warns if the module is found, but fails to import (rather than not existing and raising ModuleNotFound).

