### PR TITLE
ci: Unpin micromamba again

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -45,9 +45,8 @@ cache:
 
 init:
   - ps:
-      # Pinned due to https://github.com/mamba-org/mamba/issues/3467
       Invoke-Webrequest
-      -URI https://github.com/mamba-org/micromamba-releases/releases/download/1.5.10-0/micromamba-win-64.tar.bz2
+      -URI https://micro.mamba.pm/api/micromamba/win-64/latest
       -OutFile C:\projects\micromamba.tar.bz2
   - ps: C:\PROGRA~1\7-Zip\7z.exe x C:\projects\micromamba.tar.bz2 -aoa -oC:\projects\
   - ps: C:\PROGRA~1\7-Zip\7z.exe x C:\projects\micromamba.tar -ttar -aoa -oC:\projects\
@@ -55,6 +54,7 @@ init:
   - micromamba shell init --shell cmd.exe
   - micromamba config set always_yes true
   - micromamba config prepend channels conda-forge
+  - micromamba info
 
 install:
   - micromamba env create -f environment.yml python=%PYTHON_VERSION% pywin32


### PR DESCRIPTION
## PR summary

Upstream has updated their links, and the latest should have a fix for the error we were seeing.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines