### PR TITLE
DOC: Fix invalid rcParam references

### DIFF
--- a/doc/api/prev_api_changes/api_changes_2.2.0.rst
+++ b/doc/api/prev_api_changes/api_changes_2.2.0.rst
@@ -61,7 +61,7 @@ the future, only broadcasting (1 column to *n* columns) will be performed.
 rcparams
 ~~~~~~~~
 
-The :rc:`backend.qt4` and :rc:`backend.qt5` rcParams were deprecated
+The ``backend.qt4`` and ``backend.qt5`` rcParams were deprecated
 in version 2.2.  In order to force the use of a specific Qt binding,
 either import that binding first, or set the ``QT_API`` environment
 variable.

--- a/doc/api/prev_api_changes/api_changes_3.1.0.rst
+++ b/doc/api/prev_api_changes/api_changes_3.1.0.rst
@@ -743,8 +743,8 @@ The following signature related behaviours are deprecated:
   `.Axes.annotate()` instead.
 - Passing (n, 1)-shaped error arrays to `.Axes.errorbar()`, which was not
   documented and did not work for ``n = 2``. Pass a 1D array instead.
-- The *frameon* kwarg to `~.Figure.savefig` and the :rc:`savefig.frameon` rcParam.
-  To emulate ``frameon = False``, set *facecolor* to fully
+- The *frameon* keyword argument to `~.Figure.savefig` and the ``savefig.frameon``
+  rcParam. To emulate ``frameon = False``, set *facecolor* to fully
   transparent (``"none"``, or ``(0, 0, 0, 0)``).
 - Passing a non-1D (typically, (n, 1)-shaped) input to `.Axes.pie`.
   Pass a 1D array instead.

--- a/doc/api/prev_api_changes/api_changes_3.2.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.2.0/removals.rst
@@ -61,7 +61,7 @@ The following API elements have been removed:
 - passing ``(verts, 0)`` or ``(..., 3)`` when specifying a marker to specify a
   path or a circle, respectively (instead, use ``verts`` or ``"o"``,
   respectively)
-- :rc:`examples.directory`
+- the ``examples.directory`` rcParam
 
 The following members of ``matplotlib.backends.backend_pdf.PdfFile`` were removed:
 

--- a/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.3.0/deprecations.rst
@@ -83,8 +83,8 @@ Passing both singular and plural *colors*, *linewidths*, *linestyles* to `.Axes.
 Passing e.g. both *linewidth* and *linewidths* will raise a TypeError in the
 future.
 
-Setting :rc:`text.latex.preamble` or :rc:`pdf.preamble` to non-strings
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Setting ``text.latex.preamble`` or ``pdf.preamble`` rcParams to non-strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 These rcParams should be set to string values.  Support for None (meaning the
 empty string) and lists of strings (implicitly joined with newlines) is
 deprecated.
@@ -311,7 +311,7 @@ JPEG options
 ~~~~~~~~~~~~
 The *quality*, *optimize*, and *progressive* keyword arguments to
 `~.Figure.savefig`, which were only used when saving to JPEG, are deprecated.
-:rc:`savefig.jpeg_quality` is likewise deprecated.
+The ``savefig.jpeg_quality`` rcParam is likewise deprecated.
 
 Such options should now be directly passed to Pillow using
 ``savefig(..., pil_kwargs={"quality": ..., "optimize": ..., "progressive": ...})``.

--- a/doc/api/prev_api_changes/api_changes_3.5.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/removals.rst
@@ -359,7 +359,6 @@ rcParams
 
   - :rc:`axes.axisbelow` no longer accepts strings starting with "line"
     (case-insensitive) as "line"; use "line" (case-sensitive) instead.
-  - :rc:`text.latex.preamble` and :rc:`pdf.preamble` no longer accept
-    non-string values.
+  - :rc:`text.latex.preamble` and ``pdf.preamble`` no longer accept non-string values.
   - All ``*.linestyle`` rcParams no longer accept ``offset = None``; set the
     offset to 0 instead.

--- a/doc/api/prev_api_changes/api_changes_3.8.0/behaviour.rst
+++ b/doc/api/prev_api_changes/api_changes_3.8.0/behaviour.rst
@@ -159,10 +159,10 @@ Passing ``None`` as ``rotation_mode`` to `.Text` (the default value) or passing 
 `.Text.set_rotation_mode` will make `.Text.get_rotation_mode` return ``"default"``
 instead of ``None``. The behaviour otherwise is the same.
 
-PostScript paper type adds option to use figure size
+PostScript paper size adds option to use figure size
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :rc:`ps.papertype` rcParam can now be set to ``'figure'``, which will use
+The :rc:`ps.papersize` rcParam can now be set to ``'figure'``, which will use
 a paper size that corresponds exactly with the size of the figure that is being
 saved.
 

--- a/doc/devel/MEP/MEP23.rst
+++ b/doc/devel/MEP/MEP23.rst
@@ -38,8 +38,8 @@ desirable to be able to group these under the same window. See :ghpull:`2194`.
 
 
 The proposed solution modifies `.FigureManagerBase` to contain and manage more
-than one ``Canvas``. The settings parameter :rc:`backend.multifigure` control
-when the **MultiFigure** behaviour is desired.
+than one ``Canvas``. The ``backend.multifigure`` rcParam controls when the
+**MultiFigure** behaviour is desired.
 
 **Note**
 

--- a/doc/users/prev_whats_new/whats_new_1.3.rst
+++ b/doc/users/prev_whats_new/whats_new_1.3.rst
@@ -292,9 +292,9 @@ rcParam has been set, and will not retroactively affect already
 existing text objects.  This brings their behavior in line with most
 other rcParams.
 
-Added :rc:`savefig.jpeg_quality`
-````````````````````````````````
-rcParam value :rc:`savefig.jpeg_quality` was added so that the user can
+Added ``savefig.jpeg_quality`` rcParam
+``````````````````````````````````````
+The ``savefig.jpeg_quality`` rcParam was added so that the user can
 configure the default quality used when a figure is written as a JPEG.
 The default quality is 95; previously, the default quality was 75.
 This change minimizes the artifacting inherent in JPEG images,

--- a/doc/users/prev_whats_new/whats_new_1.5.rst
+++ b/doc/users/prev_whats_new/whats_new_1.5.rst
@@ -190,8 +190,8 @@ Some parameters have been added, others have been improved.
 +---------------------------+--------------------------------------------------+
 | Parameter                 | Description                                      |
 +===========================+==================================================+
-|:rc:`xaxis.labelpad`,      | mplot3d now respects these parameters            |
-|:rc:`yaxis.labelpad`       |                                                  |
+|``xaxis.labelpad``,        | mplot3d now respects these attributes, which     |
+|``yaxis.labelpad``         | default to :rc:`axes.labelpad`                   |
 +---------------------------+--------------------------------------------------+
 |:rc:`axes.labelpad`        | Default space between the axis and the label     |
 +---------------------------+--------------------------------------------------+

--- a/doc/users/prev_whats_new/whats_new_3.1.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.1.0.rst
@@ -260,8 +260,7 @@ Default minor tick spacing was changed from 0.625 to 0.5 for major ticks spaced
 
 A public API has been added to `.EngFormatter` to control how the numbers in
 the ticklabels will be rendered. By default, *useMathText* evaluates to
-:rc:`axes.formatter.use_mathtext'` and *usetex* evaluates to
-:rc:`'text.usetex'`.
+:rc:`axes.formatter.use_mathtext` and *usetex* evaluates to :rc:`text.usetex`.
 
 If either is `True` then the numbers will be encapsulated by ``$``
 signs.  When using ``TeX`` this implies that the numbers will be shown

--- a/doc/users/prev_whats_new/whats_new_3.3.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.3.0.rst
@@ -292,8 +292,8 @@ positioning. For the xlabel, the supported values are 'left', 'center', or
 'right'. For the ylabel, the supported values are 'bottom', 'center', or
 'top'.
 
-The default is controlled via :rc:`xaxis.labelposition` and
-:rc:`yaxis.labelposition`; the Colorbar label takes the rcParam based on its
+The default is controlled via :rc:`xaxis.labellocation` and
+:rc:`yaxis.labellocation`; the Colorbar label takes the rcParam based on its
 orientation.
 
 .. plot::

--- a/doc/users/prev_whats_new/whats_new_3.6.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.6.0.rst
@@ -217,7 +217,7 @@ Linestyles for negative contours may be set individually
 
 The line style of negative contours may be set by passing the
 *negative_linestyles* argument to `.Axes.contour`. Previously, this style could
-only be set globally via :rc:`contour.negative_linestyles`.
+only be set globally via :rc:`contour.negative_linestyle`.
 
 .. plot::
     :alt: Two contour plots, each showing two positive and two negative contours. The positive contours are shown in solid black lines in both plots. In one plot the negative contours are shown in dashed lines, which is the current styling. In the other plot they're shown in dotted lines, which is one of the new options.

--- a/doc/users/prev_whats_new/whats_new_3.8.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.8.0.rst
@@ -496,7 +496,7 @@ Other improvements
 macosx: New figures can be opened in either windows or tabs
 -----------------------------------------------------------
 
-There is a new :rc:`macosx.window_mode`` rcParam to control how
+There is a new :rc:`macosx.window_mode` rcParam to control how
 new figures are opened with the macosx backend. The default is
 **system** which uses the system settings, or one can specify either
 **tab** or **window** to explicitly choose the mode used to open new figures.

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -574,7 +574,7 @@ class Axis(martist.Artist):
         The axis label.
     labelpad : float
         The distance between the axis label and the tick labels.
-        Defaults to :rc:`axes.labelpad` = 4.
+        Defaults to :rc:`axes.labelpad`.
     offsetText : `~matplotlib.text.Text`
         A `.Text` object containing the data offset of the ticks (if any).
     pickradius : float

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -113,10 +113,10 @@ class Collection(artist.Artist, cm.ScalarMappable):
             where *onoffseq* is an even length tuple of on and off ink lengths
             in points. For examples, see
             :doc:`/gallery/lines_bars_and_markers/linestyles`.
-        capstyle : `.CapStyle`-like, default: :rc:`patch.capstyle`
+        capstyle : `.CapStyle`-like, default: 'butt'
             Style to use for capping lines for all paths in the collection.
             Allowed values are %(CapStyle)s.
-        joinstyle : `.JoinStyle`-like, default: :rc:`patch.joinstyle`
+        joinstyle : `.JoinStyle`-like, default: 'round'
             Style to use for joining lines for all paths in the collection.
             Allowed values are %(JoinStyle)s.
         antialiaseds : bool or list of bool, default: :rc:`patch.antialiased`

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1643,7 +1643,7 @@ negative_linestyles : {*None*, 'solid', 'dashed', 'dashdot', 'dotted'}, \
     specifies the line style for negative contours.
 
     If *negative_linestyles* is *None*, the default is taken from
-    :rc:`contour.negative_linestyles`.
+    :rc:`contour.negative_linestyle`.
 
     *negative_linestyles* can also be an iterable of the above strings
     specifying a set of linestyles to be used. If this iterable is shorter than

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -37,7 +37,7 @@ year 0001 and 9999 can be represented.  Microsecond precision
 is achievable for (approximately) 70 years on either side of the epoch, and
 20 microseconds for the rest of the allowable range of dates (year 0001 to
 9999). The epoch can be changed at import time via `.dates.set_epoch` or
-:rc:`dates.epoch` to other dates if necessary; see
+:rc:`date.epoch` to other dates if necessary; see
 :doc:`/gallery/ticks/date_precision_and_epochs` for a discussion.
 
 .. note::
@@ -267,7 +267,7 @@ def set_epoch(epoch):
     """
     Set the epoch (origin for dates) for datetime calculations.
 
-    The default epoch is :rc:`dates.epoch` (by default 1970-01-01T00:00).
+    The default epoch is :rc:`date.epoch`.
 
     If microsecond accuracy is desired, the date being plotted needs to be
     within approximately 70 years of the epoch. Matplotlib internally


### PR DESCRIPTION
## PR summary

These have either been deprecated and removed, or just simple typos. A small few were never rcParams in the first place.

These were surfaced by #28930, but don't need to wait for it to be fixed.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines