### PR TITLE
Adjusting Rotation

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3766,17 +3766,23 @@ class Axes(_AxesBase):
                     caplines[dep_axis].append(mlines.Line2D(
                         x_masked, y_masked, marker=marker, **eb_cap_style))
         if self.name == 'polar':
+            # Get theta direction and theta offset for proper cap alignment
+            theta_direction = self.get_theta_direction()
+            theta_offset = self.get_theta_offset()
+
             for axis in caplines:
                 for l in caplines[axis]:
                     # Rotate caps to be perpendicular to the error bars
                     for theta, r in zip(l.get_xdata(), l.get_ydata()):
-                        rotation = mtransforms.Affine2D().rotate(theta)
+                        # Adjust rotation using theta direction and offset
+                        rotation = mtransforms.Affine2D().rotate((theta * theta_direction) + theta_offset)
+                        
                         if axis == 'y':
                             rotation.rotate(-np.pi / 2)
-                        ms = mmarkers.MarkerStyle(marker=marker,
-                                                  transform=rotation)
-                        self.add_line(mlines.Line2D([theta], [r], marker=ms,
-                                                    **eb_cap_style))
+
+                        ms = mmarkers.MarkerStyle(marker=marker, transform=rotation)
+                        self.add_line(mlines.Line2D([theta], [r], marker=ms, **eb_cap_style))
+
         else:
             for axis in caplines:
                 for l in caplines[axis]:


### PR DESCRIPTION
…offset, you ensure that the error bar caps are properly aligned when the polar plot has non-default settings for theta direction or zero location.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail (Why is this change required? What problem does it solve?) and link to relevant issues and PRs. Also please summarize the changes in the title, for example "Raise ValueError on non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses issue #8576". -->
This pull request fixes the misalignment of error bar caps in polar plots when non-default theta direction or theta zero location is used. The issue caused the error bar caps to not rotate correctly, resulting in them not being perpendicular to the error bars. The changes ensure that the error bar caps respect the theta direction and zero location, keeping them aligned properly.

Closes #28885.
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes ##28885" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] N/A *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
