### PR TITLE
In colorbar docs, add ref from 'boundaries' doc to 'spacing' doc.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -86,11 +86,6 @@ extendrect : bool
     If *False* the minimum and maximum colorbar extensions will be triangular
     (the default).  If *True* the extensions will be rectangular.
 
-spacing : {'uniform', 'proportional'}
-    For discrete colorbars (`.BoundaryNorm` or contours), 'uniform' gives each
-    color the same space; 'proportional' makes the space proportional to the
-    data interval.
-
 ticks : None or list of ticks or Locator
     If None, ticks are determined automatically from the input.
 
@@ -109,9 +104,15 @@ boundaries, values : None or a sequence
     If unset, the colormap will be displayed on a 0-1 scale.
     If sequences, *values* must have a length 1 less than *boundaries*.  For
     each region delimited by adjacent entries in *boundaries*, the color mapped
-    to the corresponding value in values will be used.
+    to the corresponding value in *values* will be used.  The size of each
+    region is determined by the *spacing* parameter.
     Normally only useful for indexed colors (i.e. ``norm=NoNorm()``) or other
-    unusual circumstances.""")
+    unusual circumstances.
+
+spacing : {'uniform', 'proportional'}
+    For discrete colorbars (`.BoundaryNorm` or contours), 'uniform' gives each
+    color the same space; 'proportional' makes the space proportional to the
+    data interval.""")
 
 
 def _set_ticks_on_axis_warn(*args, **kwargs):


### PR DESCRIPTION
The `spacing` kwarg only makes sense in relation to `boundaries`, so put the docs for them next to one another and add an explicit reference from `boundaries` to `spacing`.  (The order of the kwargs in the signature did not change, because it already doesn't match the docs anyways; reordering them could be done separately.)

Closes #12312 (by documenting the behavior rather than trying to change anything).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
