### PR TITLE
Raise ValueError for RGB values outside the [0, 1] range in rgb_to_hsv function

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3097,7 +3097,7 @@ def rgb_to_hsv(arr):
         dtype=np.promote_types(arr.dtype, np.float32),  # Don't work on ints.
         ndmin=2,  # In case input was 1D.
     )
-    
+
     out = np.zeros_like(arr)
     arr_max = arr.max(-1)
     # Check if input is in the expected range

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3100,10 +3100,20 @@ def rgb_to_hsv(arr):
 
     out = np.zeros_like(arr)
     arr_max = arr.max(-1)
+    arr_min = arr.min(-1)
     # Check if input is in the expected range
-    if np.any(arr_max > 1) or np.any(arr < 0):
-        raise ValueError("Input RGB values must be in the range [0, 1]. "
-                         f"Found values out of range in array: {arr}")
+    if arr_max > 1:
+        raise ValueError(
+            "Input array must be in the range [0, 1]. "
+            f"Found a maximum value of {arr_max}"
+        )
+
+    if arr_min < 0:
+        raise ValueError(
+            "Input array must be in the range [0, 1]. "
+            f"Found a minimum value of {arr_min}"
+        )
+
     ipos = arr_max > 0
     delta = np.ptp(arr, -1)
     s = np.zeros_like(delta)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3100,7 +3100,6 @@ def rgb_to_hsv(arr):
 
     out = np.zeros_like(arr)
     arr_max = arr.max(-1)
-    arr_min = arr.min(-1)
     # Check if input is in the expected range
     if np.any(arr_max > 1):
         raise ValueError(

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3098,14 +3098,15 @@ def rgb_to_hsv(arr):
         ndmin=2,  # In case input was 1D.
     )
     
-    # Calculate arr_max to check if values are in the [0, 1] range
+    out = np.zeros_like(arr)
     arr_max = arr.max(-1)
     
+    # Check if input is in the expected range
     if np.any(arr_max > 1) or np.any(arr < 0):
         raise ValueError("Input RGB values must be in the range [0, 1]. "
                          f"Found values out of range in array: {arr}")
 
-    out = np.zeros_like(arr)
+    
     ipos = arr_max > 0
     delta = np.ptp(arr, -1)
     s = np.zeros_like(delta)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3102,7 +3102,7 @@ def rgb_to_hsv(arr):
     arr_max = arr.max(-1)
     arr_min = arr.min(-1)
     # Check if input is in the expected range
-    if arr_max > 1:
+    if np.any(arr_max > 1):
         raise ValueError(
             "Input array must be in the range [0, 1]. "
             f"Found a maximum value of {arr_max}"

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3100,13 +3100,10 @@ def rgb_to_hsv(arr):
     
     out = np.zeros_like(arr)
     arr_max = arr.max(-1)
-    
     # Check if input is in the expected range
     if np.any(arr_max > 1) or np.any(arr < 0):
         raise ValueError("Input RGB values must be in the range [0, 1]. "
                          f"Found values out of range in array: {arr}")
-
-    
     ipos = arr_max > 0
     delta = np.ptp(arr, -1)
     s = np.zeros_like(delta)

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3108,10 +3108,10 @@ def rgb_to_hsv(arr):
             f"Found a maximum value of {arr_max}"
         )
 
-    if arr_min < 0:
+    if arr.min() < 0:
         raise ValueError(
             "Input array must be in the range [0, 1]. "
-            f"Found a minimum value of {arr_min}"
+            f"Found a minimum value of {arr.min()}"
         )
 
     ipos = arr_max > 0

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3105,7 +3105,7 @@ def rgb_to_hsv(arr):
     if np.any(arr_max > 1):
         raise ValueError(
             "Input array must be in the range [0, 1]. "
-            f"Found a maximum value of {arr_max}"
+            f"Found a maximum value of {arr_max.max()}"
         )
 
     if arr.min() < 0:

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3128,7 +3128,6 @@ def rgb_to_hsv(arr):
     return out.reshape(in_shape)
 
 
-
 def hsv_to_rgb(hsv):
     """
     Convert HSV values to RGB.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3097,8 +3097,15 @@ def rgb_to_hsv(arr):
         dtype=np.promote_types(arr.dtype, np.float32),  # Don't work on ints.
         ndmin=2,  # In case input was 1D.
     )
-    out = np.zeros_like(arr)
+    
+    # Calculate arr_max to check if values are in the [0, 1] range
     arr_max = arr.max(-1)
+    
+    if np.any(arr_max > 1) or np.any(arr < 0):
+        raise ValueError("Input RGB values must be in the range [0, 1]. "
+                         f"Found values out of range in array: {arr}")
+
+    out = np.zeros_like(arr)
     ipos = arr_max > 0
     delta = np.ptp(arr, -1)
     s = np.zeros_like(delta)
@@ -3119,6 +3126,7 @@ def rgb_to_hsv(arr):
     out[..., 2] = arr_max
 
     return out.reshape(in_shape)
+
 
 
 def hsv_to_rgb(hsv):


### PR DESCRIPTION
This change improves the `rgb_to_hsv` function by adding a clear and explicit error message when the input RGB values are outside the valid range [0, 1]. Previously, the error raised by NumPy was not intuitive, making it difficult for users to understand the issue. This update ensures that users are notified of the value range requirements upfront, enhancing usability and debugging experience.
Fix #28941