### PR TITLE
FIX macos: Use the agg buffer_rgba rather than private attribute

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1236,7 +1236,7 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     CGContextRef cr = [[NSGraphicsContext currentContext] CGContext];
 
     if (!(renderer = PyObject_CallMethod(canvas, "get_renderer", ""))
-        || !(renderer_buffer = PyObject_GetAttrString(renderer, "_renderer"))) {
+        || !(renderer_buffer = PyObject_CallMethod(renderer, "buffer_rgba", ""))) {
         PyErr_Print();
         goto exit;
     }


### PR DESCRIPTION
## PR summary

I'm getting `copy_agg_buffer failed` and no plots to show up with the macosx backend.

The `_renderer` attribute has changed with the pybind11 update and we aren't able to access it as a buffer anymore. We can use the buffer_rgba method to get the direct memoryview of the buffer instead.

git bisect shows me it is this commit: 96dd843546ee410ea27e2a3e8f61953a1d3cdc6a
ping @QuLogic