### PR TITLE
CI: Resolve mypy stubtest build errors

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -33,7 +33,7 @@ import matplotlib.pyplot as plt
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
-import mpl_toolkits.axisartist as AA  # type: ignore
+import mpl_toolkits.axisartist as AA  # type: ignore[import]
 from numpy.testing import (
     assert_allclose, assert_array_equal, assert_array_almost_equal)
 from matplotlib.testing.decorators import (
@@ -2976,7 +2976,7 @@ class TestScatter:
 
 
 def _params(c=None, xsize=2, *, edgecolors=None, **kwargs):
-    return (c, edgecolors, kwargs if kwargs is not None else {}, xsize)
+    return (c, edgecolors, kwargs, xsize)
 _result = namedtuple('_result', 'c, colors')
 
 

--- a/lib/matplotlib/tests/test_backend_gtk3.py
+++ b/lib/matplotlib/tests/test_backend_gtk3.py
@@ -7,7 +7,7 @@ import pytest
 def test_correct_key():
     pytest.xfail("test_widget_send_event is not triggering key_press_event")
 
-    from gi.repository import Gdk, Gtk  # type: ignore
+    from gi.repository import Gdk, Gtk  # type: ignore[import]
     fig = plt.figure()
     buf = []
 

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -15,7 +15,8 @@ from matplotlib._pylab_helpers import Gcf
 from matplotlib import _c_internal_utils
 
 try:
-    from matplotlib.backends.qt_compat import QtGui, QtWidgets  # type: ignore # noqa
+    from matplotlib.backends.qt_compat import QtGui  # type: ignore[attr-defined]  # noqa: E501, F401
+    from matplotlib.backends.qt_compat import QtWidgets  # type: ignore[attr-defined]
     from matplotlib.backends.qt_editor import _formlayout
 except ImportError:
     pytestmark = pytest.mark.skip('No usable Qt bindings')

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -86,7 +86,7 @@ def _get_available_interactive_backends():
             reason = "macosx backend fails on Azure"
         elif env["MPLBACKEND"].startswith('gtk'):
             try:
-                import gi  # type: ignore
+                import gi  # type: ignore[import]
             except ImportError:
                 # Though we check that `gi` exists above, it is possible that its
                 # C-level dependencies are not available, and then it still raises an

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -11,7 +11,7 @@ def test_simple():
 
 
 def test_override_builtins():
-    import pylab  # type: ignore
+    import pylab  # type: ignore[import]
     ok_to_override = {
         '__name__',
         '__doc__',

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -186,7 +186,7 @@ class Hashable:
 
 
 class Unhashable:
-    __hash__ = None  # type: ignore
+    __hash__ = None  # type: ignore[assignment]
     def dummy(self): pass
 
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -456,7 +456,7 @@ def test_EllipseCollection_setter_getter():
 
 @image_comparison(['polycollection_close.png'], remove_text=True, style='mpl20')
 def test_polycollection_close():
-    from mpl_toolkits.mplot3d import Axes3D  # type: ignore
+    from mpl_toolkits.mplot3d import Axes3D  # type: ignore[import]
     plt.rcParams['axes3d.automargin'] = True
 
     vertsQuad = [

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1415,7 +1415,7 @@ def test_ndarray_subclass_norm():
     # which objects when adding or subtracting with other
     # arrays. See #6622 and #8696
     class MyArray(np.ndarray):
-        def __isub__(self, other):  # type: ignore
+        def __isub__(self, other):  # type: ignore[misc]
             raise RuntimeError
 
         def __add__(self, other):

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -402,7 +402,7 @@ class TestLegendFunction:
             "be discarded.")
 
     def test_parasite(self):
-        from mpl_toolkits.axes_grid1 import host_subplot  # type: ignore
+        from mpl_toolkits.axes_grid1 import host_subplot  # type: ignore[import]
 
         host = host_subplot(111)
         par = host.twinx()

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -17,7 +17,7 @@ from matplotlib.lines import VertexSelector
 import matplotlib.pyplot as plt
 import matplotlib.transforms as mtransforms
 import matplotlib.figure as mfigure
-from mpl_toolkits.axes_grid1 import axes_divider, parasite_axes  # type: ignore
+from mpl_toolkits.axes_grid1 import axes_divider, parasite_axes  # type: ignore[import]
 
 
 def test_simple():


### PR DESCRIPTION
## PR summary
I believe there must have been a dependency update in the last day or two that made mypy checks more strict, as Mypy Stubtest CI began failing with the below errors:
```
error: not checking stubs due to mypy build errors:
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_basic.py:14: error: "type: ignore" comment without error code  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_cbook.py:189: error: "type: ignore" comment without error code (consider "type: ignore[assignment]" instead)  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_pickle.py:20: error: "type: ignore" comment without error code  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_legend.py:405: error: "type: ignore" comment without error code  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_colors.py:1418: error: "type: ignore" comment without error code (consider "type: ignore[explicit-override, misc]" instead)  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_collections.py:459: error: "type: ignore" comment without error code  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_backend_gtk3.py:10: error: "type: ignore" comment without error code  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_axes.py:36: error: "type: ignore" comment without error code  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_axes.py:2979: error: If condition is always true  [redundant-expr]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_backend_qt.py:18: error: "type: ignore" comment without error code (consider "type: ignore[attr-defined]" instead)  [ignore-without-code]
.tox/stubtest/lib/python3.12/site-packages/matplotlib/tests/test_backends_interactive.py:89: error: "type: ignore" comment without error code  [ignore-without-code]
```

This resolves those with more specific ignore comments. Note that running `mypy` was not broken, this specifically came up when running `tox -e stubtest`. I did not check each one to see if the `#ignore` comments were still necessary.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines