### PR TITLE
FIX: macos: Use standard NSApp run loop in our input hook

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -88,6 +88,10 @@ static int wait_for_stdin() {
                 if (!event) { break; }
                 [NSApp sendEvent: event];
             }
+            // We need to run the run loop for a short time to allow the
+            // events to be processed and keep flushing them while we wait for stdin
+            // without this, the CPU usage will be very high constantly polling this loop
+            [[NSRunLoop currentRunLoop] runUntilDate: [NSDate dateWithTimeIntervalSinceNow: 0.01]];
         }
         // Remove the input handler as an observer
         [[NSNotificationCenter defaultCenter] removeObserver: stdinHandle];
@@ -192,16 +196,16 @@ void process_event(char const* cls_name, char const* fmt, ...)
 static bool backend_inited = false;
 
 static void lazy_init(void) {
+    // Run our own event loop while waiting for stdin on the Python side
+    // this is needed to keep the application responsive while waiting for input
+    PyOS_InputHook = wait_for_stdin;
+
     if (backend_inited) { return; }
     backend_inited = true;
 
     NSApp = [NSApplication sharedApplication];
     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
     [NSApp setDelegate: [[[MatplotlibAppDelegate alloc] init] autorelease]];
-
-    // Run our own event loop while waiting for stdin on the Python side
-    // this is needed to keep the application responsive while waiting for input
-    PyOS_InputHook = wait_for_stdin;
 }
 
 static PyObject*
@@ -236,6 +240,8 @@ wake_on_fd_write(PyObject* unused, PyObject* args)
 static PyObject*
 stop(PyObject* self)
 {
+    // Remove our input hook and stop the event loop.
+    PyOS_InputHook = NULL;
     [NSApp stop: nil];
     // Post an event to trigger the actual stopping.
     [NSApp postEvent: [NSEvent otherEventWithType: NSEventTypeApplicationDefined
@@ -1122,10 +1128,13 @@ choose_save_file(PyObject* unused, PyObject* args)
 {
     [super close];
     --FigureWindowCount;
-    if (!FigureWindowCount) [NSApp stop: self];
-    /* This is needed for show(), which should exit from [NSApp run]
-     * after all windows are closed.
-     */
+    if (!FigureWindowCount) {
+        /* This is needed for show(), which should exit from [NSApp run]
+        * after all windows are closed.
+        */
+        PyObject* x = stop(NULL);
+        Py_DECREF(x);
+    }
     // For each new window, we have incremented the manager reference, so
     // we need to bring that down during close and not just dealloc.
     Py_DECREF(manager);


### PR DESCRIPTION
## PR summary

We want to defer back to Python's native input hook handling when we don't have any figures to interact with, otherwise our runloop will continue running unecessarily.

Additionally, we need to add a short runloop burst in our hotloop to avoid saturating the CPU while waiting for input. (i.e. sitting on an idle figure would keep 100% cpu while waiting for an input() event without this runloop trigger).

closes #28960

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
