### PR TITLE
BLD: Implement PEP639 licensing

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -52,14 +52,6 @@ jobs:
         with:
           python-version: '3.12'
 
-      # Something changed somewhere that prevents the downloaded-at-build-time
-      # licenses from being included in built wheels, so pre-download them so
-      # that they exist before the build and are included.
-      - name: Pre-download bundled licenses
-        run: >
-          curl -Lo LICENSE/LICENSE_QHULL
-          https://github.com/qhull/qhull/raw/2020.2/COPYING.txt
-
       - name: Install dependencies
         run: python -m pip install build twine
 

--- a/ci/check_wheel_licenses.py
+++ b/ci/check_wheel_licenses.py
@@ -25,7 +25,7 @@ for wheel in sys.argv[1:]:
     with zipfile.ZipFile(wheel) as f:
         wheel_license_file_names = {Path(path).name
                                     for path in sorted(f.namelist())
-                                    if '.dist-info/LICENSE' in path}
+                                    if '.dist-info/licenses/LICENSE' in path}
         if not (len(wheel_license_file_names) and
                 wheel_license_file_names.issuperset(license_file_names)):
             sys.exit(f'LICENSE file(s) missing:\n'

--- a/ci/minver-requirements.txt
+++ b/ci/minver-requirements.txt
@@ -5,10 +5,10 @@ cycler==0.10
 fonttools==4.28.2
 importlib-resources==3.2.0
 kiwisolver==1.3.2
-meson-python==0.13.2
-meson==1.1.0
+meson-python==0.18.0
+meson==1.6.0
 numpy==2.0.0
-packaging==20.0
+packaging==23.2
 pillow==9.0.1
 pyparsing==3.0.0
 pytest==7.0.0

--- a/meson.build
+++ b/meson.build
@@ -8,7 +8,7 @@ project(
   # qt_editor backend is MIT
   # STIX, Computer Modern, and Last Resort are OFL
   # DejaVu is Bitstream Vera and Public Domain
-  license: 'PSF-2.0 AND MIT AND CC0-1.0 AND OFL-1.1 AND Bitstream-Vera AND Public-Domain',
+  license: 'PSF-2.0 AND MIT AND CC0-1.0 AND OFL-1.1 AND Bitstream-Vera AND LicenseRef-Public-Domain',
   license_files: [
     'LICENSE/LICENSE',
     'extern/agg24-svn/src/copying',
@@ -26,7 +26,7 @@ project(
     'LICENSE/LICENSE_STIX',
     'LICENSE/LICENSE_YORICK',
   ],
-  meson_version: '>=1.1.0',
+  meson_version: '>=1.6.0',
   default_options: [
     'b_lto=true',
     'cpp_std=c++17',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,14 +6,12 @@ authors = [
 ]
 description = "Python plotting package"
 readme = "README.md"
-license = { file = "LICENSE/LICENSE" }
-dynamic = ["version"]
+dynamic = ["version", "license", "license-files"]
 classifiers=[
     "Development Status :: 5 - Production/Stable",
     "Framework :: Matplotlib",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Education",
-    "License :: OSI Approved :: Python Software Foundation License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.12",
@@ -35,7 +33,7 @@ dependencies = [
     "fonttools >= 4.28.2",
     "kiwisolver >= 1.3.1",
     "numpy >= 2.0",
-    "packaging >= 20.0",
+    "packaging >= 23.2",
     "pillow >= 9",
     "pyparsing >= 3",
     "python-dateutil >= 2.7",
@@ -56,9 +54,7 @@ requires-python = ">=3.12"
 build-backend = "mesonpy"
 # Also keep in sync with dependency groups below.
 requires = [
-    # meson-python 0.17.x breaks symlinks in sdists. You can remove this pin if
-    # you really need it and aren't using an sdist.
-    "meson-python>=0.13.2,!=0.17.*",
+    "meson-python>=0.18.0",
     "pybind11>=3",
     # setuptools_scm 10 breaks versioning in editable installs. You can remove this pin
     # if you're a downstream distributor just building wheels or your equivalent.
@@ -79,7 +75,7 @@ build = [
     "python-dateutil >= 2.7",
 
     # Should be the same as `[build-system] requires` above.
-    "meson-python>=0.13.1,!=0.17.*",
+    "meson-python>=0.18.0",
     "pybind11>=3",
     "setuptools_scm>=7,<10",
     # Not required by us but setuptools_scm without a version, so _if_
@@ -406,7 +402,7 @@ manylinux-x86_64-image = "manylinux2014"
 
 before-build = "rm -rf {package}/build"
 test-command = [
-    # "python {package}/ci/check_wheel_licenses.py {wheel}",
+    "python {package}/ci/check_wheel_licenses.py {wheel}",
     "python {package}/ci/check_version_number.py",
 ]
 test-environment = "PIP_PREFER_BINARY=true"


### PR DESCRIPTION
## PR summary

Note that this would require meson-python 0.18.0, which was only released in May 2025, so we may not want to include this just yet.

It does fix the issue that that wheels do not include all licenses that we have in the sdist. Because of some discussion about the dynamicity of the license(-files) key, it does _not_ automatically include the licenses of subprojects.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines