### PR TITLE
DOC / BUG: Better example for 3D axlim_clip argument

### DIFF
--- a/doc/users/next_whats_new/3d_clip_to_axis_limits.rst
+++ b/doc/users/next_whats_new/3d_clip_to_axis_limits.rst
@@ -13,18 +13,22 @@ view box is a limitation of the current renderer.
 
 .. plot::
     :include-source: true
-    :alt: Example of default behavior (left) and axlim_clip=True (right)
+    :alt: Example of default behavior (blue) and axlim_clip=True (orange)
 
     import matplotlib.pyplot as plt
     import numpy as np
 
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
-    np.random.seed(1)
-    xyz = np.random.rand(25, 3)
+    X = np.arange(-5, 5, 0.5)
+    Y = np.arange(-5, 5, 0.5)
+    X, Y = np.meshgrid(X, Y)
+    R = np.sqrt(X**2 + Y**2)
+    Z = np.sin(R)
 
     # Note that when a line has one vertex outside the view limits, the entire
     # line is hidden. The same is true for 3D patches (not shown).
-    ax.plot(xyz[:, 0], xyz[:, 1], xyz[:, 2], '-o')
-    ax.plot(xyz[:, 0], xyz[:, 1], xyz[:, 2], '--*', axlim_clip=True)
-    ax.set(xlim=(0.25, 0.75), ylim=(0, 1), zlim=(0, 1))
+    # In this example, data where x < 0 or z > 0.5 will be clipped.
+    ax.plot_wireframe(X, Y, Z, color='C0')
+    ax.plot_wireframe(X, Y, Z, color='C1', axlim_clip=True)
+    ax.set(xlim=(0, 10), ylim=(-5, 5), zlim=(-1, 0.5))
     ax.legend(['axlim_clip=False (default)', 'axlim_clip=True'])

--- a/doc/users/next_whats_new/3d_clip_to_axis_limits.rst
+++ b/doc/users/next_whats_new/3d_clip_to_axis_limits.rst
@@ -19,15 +19,15 @@ view box is a limitation of the current renderer.
     import numpy as np
 
     fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
-    X = np.arange(-5, 5, 0.5)
-    Y = np.arange(-5, 5, 0.5)
-    X, Y = np.meshgrid(X, Y)
+    x = np.arange(-5, 5, 0.5)
+    y = np.arange(-5, 5, 0.5)
+    X, Y = np.meshgrid(x, y)
     R = np.sqrt(X**2 + Y**2)
     Z = np.sin(R)
 
     # Note that when a line has one vertex outside the view limits, the entire
     # line is hidden. The same is true for 3D patches (not shown).
-    # In this example, data where x < 0 or z > 0.5 will be clipped.
+    # In this example, data where x < 0 or z > 0.5 is clipped.
     ax.plot_wireframe(X, Y, Z, color='C0')
     ax.plot_wireframe(X, Y, Z, color='C1', axlim_clip=True)
     ax.set(xlim=(0, 10), ylim=(-5, 5), zlim=(-1, 0.5))

--- a/galleries/examples/mplot3d/axlim_clip.py
+++ b/galleries/examples/mplot3d/axlim_clip.py
@@ -13,19 +13,28 @@ import numpy as np
 
 fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
-# Generate the random data
-np.random.seed(1)
-xyz = np.random.rand(25, 3)
+# Make the data
+X = np.arange(-5, 5, 0.5)
+Y = np.arange(-5, 5, 0.5)
+X, Y = np.meshgrid(X, Y)
+R = np.sqrt(X**2 + Y**2)
+Z = np.sin(R)
 
 # Default behavior is axlim_clip=False
-ax.plot(xyz[:, 0], xyz[:, 1], xyz[:, 2], '-o')
+ax.plot_wireframe(X, Y, Z, color='C0')
 
 # When axlim_clip=True, note that when a line segment has one vertex outside
 # the view limits, the entire line is hidden. The same is true for 3D patches
 # if one of their vertices is outside the limits (not shown).
-ax.plot(xyz[:, 0], xyz[:, 1], xyz[:, 2], '--*', axlim_clip=True)
+ax.plot_wireframe(X, Y, Z, color='C1', axlim_clip=True)
 
-ax.set(xlim=(0.25, 0.75), ylim=(0, 1), zlim=(-1, 1))
+# In this example, data where x < 0 or z > 0.5 will be clipped.
+ax.set(xlim=(0, 10), ylim=(-5, 5), zlim=(-1, 0.5))
 ax.legend(['axlim_clip=False (default)', 'axlim_clip=True'])
 
 plt.show()
+
+# %%
+# .. tags::
+#    plot-type: 3D,
+#    level: beginner

--- a/galleries/examples/mplot3d/axlim_clip.py
+++ b/galleries/examples/mplot3d/axlim_clip.py
@@ -14,9 +14,9 @@ import numpy as np
 fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
 # Make the data
-X = np.arange(-5, 5, 0.5)
-Y = np.arange(-5, 5, 0.5)
-X, Y = np.meshgrid(X, Y)
+x = np.arange(-5, 5, 0.5)
+y = np.arange(-5, 5, 0.5)
+X, Y = np.meshgrid(x, y)
 R = np.sqrt(X**2 + Y**2)
 Z = np.sin(R)
 
@@ -28,7 +28,7 @@ ax.plot_wireframe(X, Y, Z, color='C0')
 # if one of their vertices is outside the limits (not shown).
 ax.plot_wireframe(X, Y, Z, color='C1', axlim_clip=True)
 
-# In this example, data where x < 0 or z > 0.5 will be clipped.
+# In this example, data where x < 0 or z > 0.5 is clipped
 ax.set(xlim=(0, 10), ylim=(-5, 5), zlim=(-1, 0.5))
 ax.legend(['axlim_clip=False (default)', 'axlim_clip=True'])
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -455,7 +455,7 @@ class Line3DCollection(LineCollection):
             all_points = np.ma.vstack(segments)
             masked_points = np.ma.column_stack([*_viewlim_mask(*all_points.T,
                                                                self.axes)])
-            segment_lengths = [segment.shape[0] for segment in segments]
+            segment_lengths = [np.shape(segment)[0] for segment in segments]
             segments = np.split(masked_points, np.cumsum(segment_lengths[:-1]))
         xyslist = [proj3d._proj_trans_points(points, self.axes.M)
                    for points in segments]


### PR DESCRIPTION
## PR summary
I don't like the example I made that shows clipping to 3D axis limits in https://github.com/matplotlib/matplotlib/pull/27349. It's not clear which of the random points are actually supposed to be outside the axis limits. Switched the gallery example and what's new plot to a continuous function, which I think is easier to interpret.

Before:
![image](https://github.com/user-attachments/assets/a5689dce-55bf-4fd1-bbd4-20a96f25f092)

After:
![sphx_glr_axlim_clip_001_2_00x](https://github.com/user-attachments/assets/dc5cb568-e871-4300-98c2-7a1c5c78344f)

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines