### PR TITLE
DOC: Add tags for 3D fill_between examples

### DIFF
--- a/galleries/examples/mplot3d/fillbetween3d.py
+++ b/galleries/examples/mplot3d/fillbetween3d.py
@@ -26,3 +26,9 @@ ax = fig.add_subplot(projection='3d')
 ax.fill_between(x1, y1, z1, x2, y2, z2, alpha=0.5, edgecolor='k')
 
 plt.show()
+
+# %%
+# .. tags::
+#    plot-type: 3D,
+#    plot-type: fill_between,
+#    level: beginner

--- a/galleries/examples/mplot3d/fillunder3d.py
+++ b/galleries/examples/mplot3d/fillunder3d.py
@@ -32,3 +32,9 @@ ax.set(xlim=(0, 10), ylim=(1, 9), zlim=(0, 0.35),
        xlabel='x', ylabel=r'$\lambda$', zlabel='probability')
 
 plt.show()
+
+# %%
+# .. tags::
+#    plot-type: 3D,
+#    plot-type: fill_between,
+#    level: beginner


### PR DESCRIPTION
## PR summary
https://github.com/matplotlib/matplotlib/pull/28568 missed some examples that were merged in after the PR was first opened. The fill_between examples are covered here, and the axlim_clip example is covered in this PR: https://github.com/matplotlib/matplotlib/pull/28984

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines