### PR TITLE
Fix: Do not use numeric tolerances for axline special cases

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1506,8 +1506,8 @@ class AxLine(Line2D):
                 points_transform.transform([self._xy1, self._xy2])
             dx = x2 - x1
             dy = y2 - y1
-            if np.allclose(x1, x2):
-                if np.allclose(y1, y2):
+            if dx == 0:
+                if dy == 0:
                     raise ValueError(
                         f"Cannot draw a line through two identical points "
                         f"(x={(x1, x2)}, y={(y1, y2)})")


### PR DESCRIPTION
vertical lines (infinite slope) and two identical points as input need special handling in AxLine. The detection was using numeric tolerances, which lead to false-positive detection in cases that are close to but not exactly those special cases.

This PR removes the tolerances. The argument is the same as for the similar case https://github.com/matplotlib/matplotlib/issues/28386#issuecomment-2314629415

Closes #28870.

