### PR TITLE
Backport PR #28972 on branch v3.9.x (Switch macOS 12 runner images to macOS 13)

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -124,7 +124,7 @@ jobs:
             cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto64"
-          - os: macos-12
+          - os: macos-13
             cibw_archs: "x86_64"
           - os: macos-14
             cibw_archs: "arm64"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -101,7 +101,7 @@ jobs:
             pyqt6-ver: '!=6.6.0'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
-          - os: macos-12  # This runner is on Intel chips.
+          - os: macos-13  # This runner is on Intel chips.
             python-version: '3.9'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
@@ -192,6 +192,17 @@ jobs:
             ;;
           macOS)
             brew update
+            # Periodically, Homebrew updates Python and fails to overwrite the
+            # existing not-managed-by-Homebrew copy without explicitly being told
+            # to do so. GitHub/Azure continues to avoid fixing their runner images:
+            # https://github.com/actions/runner-images/issues/9966
+            # so force an overwrite even if there are no Python updates.
+            # We don't even care about Homebrew's Python because we use the one
+            # from actions/setup-python.
+            for python_package in $(brew list | grep python@); do
+              brew unlink ${python_package}
+              brew link --overwrite ${python_package}
+            done
             brew install ccache ghostscript gobject-introspection gtk4 ninja
             brew install --cask font-noto-sans-cjk inkscape
             ;;

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,6 +120,17 @@ stages:
                 ;;
               Darwin)
                 brew update
+                # Periodically, Homebrew updates Python and fails to overwrite the
+                # existing not-managed-by-Homebrew copy without explicitly being told
+                # to do so. GitHub/Azure continues to avoid fixing their runner images:
+                # https://github.com/actions/runner-images/issues/9966
+                # so force an overwrite even if there are no Python updates.
+                # We don't even care about Homebrew's Python because we use the one
+                # from UsePythonVersion.
+                for python_package in $(brew list | grep python@); do
+                  brew unlink ${python_package}
+                  brew link --overwrite ${python_package}
+                done
                 brew install --cask xquartz
                 brew install ccache ffmpeg imagemagick mplayer ninja pkg-config
                 brew install --cask font-noto-sans-cjk-sc


### PR DESCRIPTION
## PR summary

Manual backport of #28972.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines