### PR TITLE
DOC: Update meson-python intersphinx link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -269,7 +269,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'tornado': ('https://www.tornadoweb.org/en/stable/', None),
     'xarray': ('https://docs.xarray.dev/en/stable/', None),
-    'meson-python': ('https://meson-python.readthedocs.io/en/stable/', None),
+    'meson-python': ('https://mesonbuild.com/meson-python/', None),
     'pip': ('https://pip.pypa.io/en/stable/', None),
 }
 


### PR DESCRIPTION
## PR summary

The old one is getting readthedocs' pseudo-redirect with an HTML page.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines