### PR TITLE
FIX: intersphinx URL changed for meson-python

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -269,7 +269,7 @@ intersphinx_mapping = {
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'tornado': ('https://www.tornadoweb.org/en/stable/', None),
     'xarray': ('https://docs.xarray.dev/en/stable/', None),
-    'meson-python': ('https://meson-python.readthedocs.io/en/stable/', None),
+    'meson-python': ('https://mesonbuild.com/meson-python/', None),
     'pip': ('https://pip.pypa.io/en/stable/', None),
 }
 


### PR DESCRIPTION
Closes #29008.

