### PR TITLE
Bump required pybind11 to 2.13

### DIFF
--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -232,7 +232,7 @@ means that the dependencies must be explicitly installed, either by :ref:`creati
 - `ninja <https://ninja-build.org/>`_ (>= 1.8.2). This may be available in your package
   manager or bundled with Meson, but may be installed via ``pip`` if otherwise not
   available.
-- `PyBind11 <https://pypi.org/project/pybind11/>`_ (>= 2.6). Used to connect C/C++ code
+- `PyBind11 <https://pypi.org/project/pybind11/>`_ (>= 2.13). Used to connect C/C++ code
   with Python.
 - `setuptools_scm <https://pypi.org/project/setuptools-scm/>`_ (>= 7).  Used to
   update the reported ``mpl.__version__`` based on the current git commit.

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - fonttools>=4.22.0
   - importlib-resources>=3.2.0
   - kiwisolver>=1.3.1
-  - pybind11>=2.6.0
+  - pybind11>=2.13.0
   - meson-python>=0.13.1
   - numpy>=1.23
   - pillow>=8

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
 py3_dep = py3.dependency()
 
-pybind11_dep = dependency('pybind11', version: '>=2.6')
+pybind11_dep = dependency('pybind11', version: '>=2.13')
 
 subdir('extern')
 subdir('src')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires-python = ">=3.10"
 # Should be a copy of the build dependencies below.
 dev = [
     "meson-python>=0.13.1",
-    "pybind11>=2.6,!=2.13.3",
+    "pybind11>=2.13,!=2.13.3",
     "setuptools_scm>=7",
     # Not required by us but setuptools_scm without a version, cso _if_
     # installed, then setuptools_scm 8 requires at least this version.
@@ -71,7 +71,7 @@ build-backend = "mesonpy"
 # Also keep in sync with optional dependencies above.
 requires = [
     "meson-python>=0.13.1",
-    "pybind11>=2.6,!=2.13.3",
+    "pybind11>=2.13,!=2.13.3",
     "setuptools_scm>=7",
 ]
 


### PR DESCRIPTION
## PR summary

This is necessary for the `py::mod_gil_not_used` tag. Note that this if fairly new, so we could go the other route and `#if` the tag.

See https://matrix.to/#/!BXmyZMTnRjWJldDRLV:gitter.im/$Bsyuv1YBdUjtHnJLP1jE7KjYdk5O6DVBzfG6giPd-D0?via=gitter.im&via=matrix.org&via=aria-net.org

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines