### PR TITLE
FIX: auto_fmtxdate for constrained layout

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -194,14 +194,15 @@ class FigureBase(Artist):
             Selects which ticklabels to rotate.
         """
         _api.check_in_list(['major', 'minor', 'both'], which=which)
-        allsubplots = all(ax.get_subplotspec() for ax in self.axes)
-        if len(self.axes) == 1:
+        axes = [ax for ax in self.axes if ax._label != '<colorbar>']
+        allsubplots = all(ax.get_subplotspec() for ax in axes)
+        if len(axes) == 1:
             for label in self.axes[0].get_xticklabels(which=which):
                 label.set_ha(ha)
                 label.set_rotation(rotation)
         else:
             if allsubplots:
-                for ax in self.get_axes():
+                for ax in axes:
                     if ax.get_subplotspec().is_last_row():
                         for label in ax.get_xticklabels(which=which):
                             label.set_ha(ha)
@@ -211,7 +212,8 @@ class FigureBase(Artist):
                             label.set_visible(False)
                         ax.set_xlabel('')
 
-        if allsubplots:
+        engine = self.get_layout_engine()
+        if allsubplots and (engine is None or engine.adjust_compatible):
             self.subplots_adjust(bottom=bottom)
         self.stale = True
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -496,6 +496,20 @@ def test_autofmt_xdate(which):
             assert int(label.get_rotation()) == angle
 
 
+def test_autofmt_xdate_colorbar_constrained():
+    # check works with a colorbar.
+    # with constrained layout, colorbars do not have a gridspec,
+    # but autofmt_xdate checks if all axes have a gridspec before being
+    # applied.
+    fig, ax = plt.subplots(layout="constrained")
+    im = ax.imshow([[1, 4, 6], [2, 3, 5]])
+    plt.colorbar(im)
+    fig.autofmt_xdate()
+    fig.draw_without_rendering()
+    label = ax.get_xticklabels(which='major')[1]
+    assert label.get_rotation() == 30.0
+
+
 @mpl.style.context('default')
 def test_change_dpi():
     fig = plt.figure(figsize=(4, 4))


### PR DESCRIPTION
Closes #29011

`figure.automft_xdate` is a bit of a weird method, that labels outer labels on a subplotgrid in a figure and turns the labels 30 degrees (or more). 

However, before this PR it only did so if all the axes on the figure had a subplotspec. 

By default, colorbars have a subplotspec, so old layout managers worked fine.  However, colorbars in constrained layout are _not_ created with a subplotspec (`colorbar(usegridspec=False)`), so autofmt_xdate would not do anything.

This just checks if an axes is labeled with '<colorbar>' or not, and if so, ignores if for the sake of determining if autofmt_xdate can work or not.  It also doesn't try to do suplots_adjust if the engine is constrained layout as that is incompatible.  