### PR TITLE
FIX: fake out setuptools scm in tox on ci

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,8 @@ setenv =
     MPLCONFIGDIR={envtmpdir}/.matplotlib
     PIP_USER = 0
     PIP_ISOLATED = 1
+    SETUPTOOLS_SCM_PRETEND_VERSION_FOR_MATPLOTLIB = 0.0.0
+
 usedevelop = True
 commands =
     pytest --pyargs matplotlib.tests  {posargs}


### PR DESCRIPTION
The repository in GHA is a shallow checkout (so to tags) so we are going to get the version wrong no matter what.  However, a recent change to our build dependencies (we think meson-python at 0.17) causes setumtools scm to fail to extract any version when installing from a generated sdist.

By setting a pretend version setuptools_scm will never try to look at git.  It is not yet clear if this fixes the sdist itself or just continues to use the pretend version when installing.

Debugged this on a call with @QuLogic and @ksunden 


To generate a checkout in a state that will fail use (in a container):

```bash
/usr/bin/git init /home/runner/work/matplotlib/matplotlib
cd /home/runner/work/matplotlib/matplotlib/
/usr/bin/git remote add origin https://github.com/matplotlib/matplotlib
/usr/bin/git config --local gc.auto 0
/usr/bin/git -c protocol.version=2 fetch --no-tags --prune --no-recurse-submodules --depth=1 origin +0a6dec17eec446fd28a51bae476a12fd09e73492:refs/remotes/pull/28658/merge
/usr/bin/git checkout --progress --force refs/remotes/pull/28658/merge
```