### PR TITLE
FIX: macos: Add update capability to interval/singleshot timer properties

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2320,13 +2320,11 @@ class FigureCanvasBase:
         """
         if timeout <= 0:
             timeout = np.inf
-        timestep = 0.01
-        counter = 0
+        t_end = time.perf_counter() + timeout
         self._looping = True
-        while self._looping and counter * timestep < timeout:
+        while self._looping and time.perf_counter() < t_end:
             self.flush_events()
-            time.sleep(timestep)
-            counter += 1
+            time.sleep(0.01)  # Pause for 10ms
 
     def stop_event_loop(self):
         """

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -69,6 +69,10 @@ class TimerWx(TimerBase):
         if self._timer.IsRunning():
             self._timer_start()  # Restart with new interval.
 
+    def _timer_set_single_shot(self):
+        if self._timer.IsRunning():
+            self._timer_start()  # Restart with new interval.
+
 
 @_api.deprecated(
     "2.0", name="wx", obj_type="backend", removal="the future",

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -653,7 +653,8 @@ def _impl_test_interactive_timers():
     assert mock_repeating.call_count > expected_100ms_calls, \
         f"Expected more than {expected_100ms_calls} calls, " \
         f"got {mock_repeating.call_count}"
-    assert mock_single_shot.call_count == 1
+    assert mock_single_shot.call_count == 1, \
+        f"Expected 1 call, got {mock_single_shot.call_count}"
 
     # Test updating the interval updates a running timer
     timer_repeating.interval = 100
@@ -666,7 +667,8 @@ def _impl_test_interactive_timers():
     assert 1 < mock_repeating.call_count <= expected_100ms_calls + 1, \
         f"Expected less than {expected_100ms_calls + 1} calls, " \
         "got {mock.call_count}"
-    assert mock_single_shot.call_count == 2
+    assert mock_single_shot.call_count == 2, \
+        f"Expected 2 calls, got {mock_single_shot.call_count}"
     plt.close("all")
 
 

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -1789,6 +1789,18 @@ Timer__timer_stop(Timer* self)
     Py_RETURN_NONE;
 }
 
+static PyObject*
+Timer__timer_update(Timer* self)
+{
+    // stop and invalidate a timer if it is already running and then create a new one
+    // where the start() method retrieves the updated interval internally
+    if (self->timer) {
+        Timer__timer_stop_impl(self);
+        gil_call_method((PyObject*)self, "_timer_start");
+    }
+    Py_RETURN_NONE;
+}
+
 static void
 Timer_dealloc(Timer* self)
 {
@@ -1814,6 +1826,12 @@ static PyTypeObject TimerType = {
          METH_VARARGS},
         {"_timer_stop",
          (PyCFunction)Timer__timer_stop,
+         METH_NOARGS},
+        {"_timer_set_interval",
+         (PyCFunction)Timer__timer_update,
+         METH_NOARGS},
+        {"_timer_set_single_shot",
+         (PyCFunction)Timer__timer_update,
          METH_NOARGS},
         {}  // sentinel
     },


### PR DESCRIPTION
## PR summary

As noted by @dopplershift here https://github.com/matplotlib/matplotlib/pull/28997#issuecomment-2433662715
The macos timers didn't get updated when a user would update the timer interval `timer.interval = newvalue` (in that example a new timer is created and _then_ an interval is set with the delay).

This adds tests for the timer updates as well.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
