### PR TITLE
Update requirements to add PyStemmer to doc-requirements and environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -43,13 +43,13 @@ dependencies:
   - joblib  # needed for sphinx-gallery[parallel]
   - sphinx-design
   - sphinx-tags>=0.4.0
+  - pystemmer
   - pip
   - pip:
       - mpl-sphinx-theme~=3.8.0
       - sphinxcontrib-svg2pdfconverter>=1.1.0
       - sphinxcontrib-video>=0.2.1
       - pikepdf
-      - PyStemmer
   # testing
   - black<24
   - coverage

--- a/environment.yml
+++ b/environment.yml
@@ -49,6 +49,7 @@ dependencies:
       - sphinxcontrib-svg2pdfconverter>=1.1.0
       - sphinxcontrib-video>=0.2.1
       - pikepdf
+      - PyStemmer
   # testing
   - black<24
   - coverage

--- a/requirements/doc/doc-requirements.txt
+++ b/requirements/doc/doc-requirements.txt
@@ -17,6 +17,7 @@ packaging>=20
 pydata-sphinx-theme~=0.15.0
 mpl-sphinx-theme~=3.9.0
 pyyaml
+PyStemmer
 sphinxcontrib-svg2pdfconverter>=1.1.0
 sphinxcontrib-video>=0.2.1
 sphinx-copybutton


### PR DESCRIPTION


## PR summary
This pull request updates the dependencies for building the documentation by adding PyStemmer to requirements/doc/doc-requirements.txt and environment.yml. The addition of PyStemmer is intended to improve the efficiency of Sphinx documentation builds by enabling stemming for search indexing. This change addresses the need for better search functionality in the generated documentation and may result in a performance improvement during the build process.

Relevant files updated:

requirements/doc/doc-requirements.txt
environment.yml

closes #28570

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines


