### PR TITLE
Update minimum pybind11 to 2.13.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -266,7 +266,7 @@ jobs:
           python -m pip install --upgrade $PRE \
             'contourpy>=1.0.1' cycler fonttools kiwisolver importlib_resources \
             packaging pillow 'pyparsing!=3.1.0' python-dateutil setuptools-scm \
-            'meson-python>=0.13.1' 'pybind11>=2.6' \
+            'meson-python>=0.13.1' 'pybind11>=2.13.2' \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}
 

--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -232,7 +232,7 @@ means that the dependencies must be explicitly installed, either by :ref:`creati
 - `ninja <https://ninja-build.org/>`_ (>= 1.8.2). This may be available in your package
   manager or bundled with Meson, but may be installed via ``pip`` if otherwise not
   available.
-- `PyBind11 <https://pypi.org/project/pybind11/>`_ (>= 2.13). Used to connect C/C++ code
+- `PyBind11 <https://pypi.org/project/pybind11/>`_ (>= 2.13.2). Used to connect C/C++ code
   with Python.
 - `setuptools_scm <https://pypi.org/project/setuptools-scm/>`_ (>= 7).  Used to
   update the reported ``mpl.__version__`` based on the current git commit.

--- a/environment.yml
+++ b/environment.yml
@@ -16,7 +16,7 @@ dependencies:
   - fonttools>=4.22.0
   - importlib-resources>=3.2.0
   - kiwisolver>=1.3.1
-  - pybind11>=2.13.0
+  - pybind11>=2.13.2
   - meson-python>=0.13.1
   - numpy>=1.23
   - pillow>=8

--- a/meson.build
+++ b/meson.build
@@ -36,7 +36,7 @@ py_mod = import('python')
 py3 = py_mod.find_installation(pure: false)
 py3_dep = py3.dependency()
 
-pybind11_dep = dependency('pybind11', version: '>=2.13')
+pybind11_dep = dependency('pybind11', version: '>=2.13.2')
 
 subdir('extern')
 subdir('src')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ requires-python = ">=3.10"
 # Should be a copy of the build dependencies below.
 dev = [
     "meson-python>=0.13.1",
-    "pybind11>=2.13,!=2.13.3",
+    "pybind11>=2.13.2,!=2.13.3",
     "setuptools_scm>=7",
     # Not required by us but setuptools_scm without a version, cso _if_
     # installed, then setuptools_scm 8 requires at least this version.
@@ -71,7 +71,7 @@ build-backend = "mesonpy"
 # Also keep in sync with optional dependencies above.
 requires = [
     "meson-python>=0.13.1",
-    "pybind11>=2.13,!=2.13.3",
+    "pybind11>=2.13.2,!=2.13.3",
     "setuptools_scm>=7",
 ]
 

--- a/requirements/dev/build-requirements.txt
+++ b/requirements/dev/build-requirements.txt
@@ -1,3 +1,3 @@
-pybind11!=2.13.3
+pybind11>=2.13.2,!=2.13.3
 meson-python
 setuptools-scm


### PR DESCRIPTION
Update minimum pybind11 to 2.13.2 as use of 2.13.1 can cause mutex problems in Python 3.13 free-threaded builds, see pybind/pybind11#5420.

It would be good to confirm exactly which version of pybind11 was used to build the matplotlib 3.9.2 cp313t wheels on PyPI. They are dated Aug 13, the same date that pybind11 2.13.2 and 2.13.3 were released. So the mpl wheels could potentially have used 2.13.1 which would be bad. The GHA run that built and uploaded the wheel is https://github.com/matplotlib/matplotlib/actions/runs/10361240538/job/28683177700 but it is not verbose enough to including the pybind11 version used.