### PR TITLE
Update colormap usage documentation to prioritize string colormap names

### DIFF
--- a/doc/users/prev_whats_new/whats_new_3.10.0.rst
+++ b/doc/users/prev_whats_new/whats_new_3.10.0.rst
@@ -56,9 +56,9 @@ colour maps version 8.0.1 (DOI: https://doi.org/10.5281/zenodo.1243862).
     img = np.sin(x*y)
 
     _, ax = plt.subplots(1, 3)
-    ax[0].imshow(img, cmap=plt.cm.berlin)
-    ax[1].imshow(img, cmap=plt.cm.managua)
-    ax[2].imshow(img, cmap=plt.cm.vanimo)
+    ax[0].imshow(img, cmap="berlin")
+    ax[1].imshow(img, cmap="managua")
+    ax[2].imshow(img, cmap="vanimo")
 
 
 

--- a/galleries/examples/axisartist/demo_curvelinear_grid2.py
+++ b/galleries/examples/axisartist/demo_curvelinear_grid2.py
@@ -41,7 +41,7 @@ def curvelinear_test1(fig):
     # itself (i.e., transData) is not affected by the given transform.
 
     ax1.imshow(np.arange(25).reshape(5, 5),
-               vmax=50, cmap=plt.cm.gray_r, origin="lower")
+               vmax=50, cmap="gray_r", origin="lower")
 
 
 if __name__ == "__main__":

--- a/galleries/examples/images_contours_and_fields/contour_demo.py
+++ b/galleries/examples/images_contours_and_fields/contour_demo.py
@@ -13,8 +13,6 @@ See also the :doc:`contour image example
 import matplotlib.pyplot as plt
 import numpy as np
 
-import matplotlib.cm as cm
-
 delta = 0.025
 x = np.arange(-3.0, 3.0, delta)
 y = np.arange(-2.0, 2.0, delta)
@@ -79,7 +77,7 @@ ax.set_title('Crazy lines')
 
 fig, ax = plt.subplots()
 im = ax.imshow(Z, interpolation='bilinear', origin='lower',
-               cmap=cm.gray, extent=(-3, 3, -2, 2))
+               cmap="gray", extent=(-3, 3, -2, 2))
 levels = np.arange(-1.2, 1.6, 0.2)
 CS = ax.contour(Z, levels, origin='lower', cmap='flag', extend='both',
                 linewidths=2, extent=(-3, 3, -2, 2))

--- a/galleries/examples/images_contours_and_fields/contour_image.py
+++ b/galleries/examples/images_contours_and_fields/contour_image.py
@@ -35,7 +35,7 @@ Z = (Z1 - Z2) * 2
 levels = np.arange(-2.0, 1.601, 0.4)
 
 norm = cm.colors.Normalize(vmax=abs(Z).max(), vmin=-abs(Z).max())
-cmap = cm.PRGn
+cmap = plt.colormaps["PRGn"]
 
 fig, _axs = plt.subplots(nrows=2, ncols=2)
 fig.subplots_adjust(hspace=0.3)

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -39,7 +39,7 @@ Z[interior] = np.ma.masked
 # for purposes of illustration.
 
 fig1, ax2 = plt.subplots(layout='constrained')
-CS = ax2.contourf(X, Y, Z, 10, cmap=plt.cm.bone)
+CS = ax2.contourf(X, Y, Z, 10, cmap="bone")
 
 # Note that in the following, we explicitly pass in a subset of the contour
 # levels used for the filled contours.  Alternatively, we could pass in

--- a/galleries/examples/images_contours_and_fields/contourf_log.py
+++ b/galleries/examples/images_contours_and_fields/contourf_log.py
@@ -10,7 +10,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from numpy import ma
 
-from matplotlib import cm, ticker
+from matplotlib import ticker
 
 N = 100
 x = np.linspace(-3.0, 3.0, N)
@@ -36,7 +36,7 @@ z = ma.masked_where(z <= 0, z)
 # Automatic selection of levels works; setting the
 # log locator tells contourf to use a log scale:
 fig, ax = plt.subplots()
-cs = ax.contourf(X, Y, z, locator=ticker.LogLocator(), cmap=cm.PuBu_r)
+cs = ax.contourf(X, Y, z, locator=ticker.LogLocator(), cmap="PuBu_r")
 
 # Alternatively, you can manually set the levels
 # and the norm:

--- a/galleries/examples/images_contours_and_fields/image_demo.py
+++ b/galleries/examples/images_contours_and_fields/image_demo.py
@@ -12,7 +12,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import matplotlib.cbook as cbook
-import matplotlib.cm as cm
 from matplotlib.patches import PathPatch
 from matplotlib.path import Path
 
@@ -30,7 +29,7 @@ Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = (Z1 - Z2) * 2
 
 fig, ax = plt.subplots()
-im = ax.imshow(Z, interpolation='bilinear', cmap=cm.RdYlBu,
+im = ax.imshow(Z, interpolation='bilinear', cmap="RdYlBu",
                origin='lower', extent=[-3, 3, -3, 3],
                vmax=abs(Z).max(), vmin=-abs(Z).max())
 
@@ -58,7 +57,7 @@ fig, ax = plt.subplot_mosaic([
 ax['hopper'].imshow(image)
 ax['hopper'].axis('off')  # clear x-axis and y-axis
 
-im = ax['mri'].imshow(A, cmap=plt.cm.hot, origin='upper', extent=extent)
+im = ax['mri'].imshow(A, cmap="hot", origin='upper', extent=extent)
 
 markers = [(15.9, 14.5), (16.8, 15)]
 x, y = zip(*markers)
@@ -163,7 +162,7 @@ patch = PathPatch(path, facecolor='none')
 fig, ax = plt.subplots()
 ax.add_patch(patch)
 
-im = ax.imshow(Z, interpolation='bilinear', cmap=cm.gray,
+im = ax.imshow(Z, interpolation='bilinear', cmap="gray",
                origin='lower', extent=[-3, 3, -3, 3],
                clip_path=patch, clip_on=True)
 im.set_clip_path(patch)

--- a/galleries/examples/images_contours_and_fields/image_masked.py
+++ b/galleries/examples/images_contours_and_fields/image_masked.py
@@ -25,7 +25,7 @@ Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = (Z1 - Z2) * 2
 
 # Set up a colormap:
-palette = plt.cm.gray.with_extremes(over='r', under='g', bad='b')
+palette = plt.colormaps["gray"].with_extremes(over='r', under='g', bad='b')
 # Alternatively, we could use
 # palette.set_bad(alpha = 0.0)
 # to make the bad region transparent.  This is the default.

--- a/galleries/examples/images_contours_and_fields/image_nonuniform.py
+++ b/galleries/examples/images_contours_and_fields/image_nonuniform.py
@@ -11,7 +11,6 @@ Axes instance as shown here.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cm
 from matplotlib.image import NonUniformImage
 
 interp = 'nearest'
@@ -30,7 +29,7 @@ fig, axs = plt.subplots(nrows=2, ncols=2, layout='constrained')
 fig.suptitle('NonUniformImage class', fontsize='large')
 ax = axs[0, 0]
 im = NonUniformImage(ax, interpolation=interp, extent=(-4, 4, -4, 4),
-                     cmap=cm.Purples)
+                     cmap="Purples")
 im.set_data(x, y, z)
 ax.add_image(im)
 ax.set_xlim(-4, 4)
@@ -39,7 +38,7 @@ ax.set_title(interp)
 
 ax = axs[0, 1]
 im = NonUniformImage(ax, interpolation=interp, extent=(-64, 64, -4, 4),
-                     cmap=cm.Purples)
+                     cmap="Purples")
 im.set_data(x2, y, z)
 ax.add_image(im)
 ax.set_xlim(-64, 64)
@@ -50,7 +49,7 @@ interp = 'bilinear'
 
 ax = axs[1, 0]
 im = NonUniformImage(ax, interpolation=interp, extent=(-4, 4, -4, 4),
-                     cmap=cm.Purples)
+                     cmap="Purples")
 im.set_data(x, y, z)
 ax.add_image(im)
 ax.set_xlim(-4, 4)
@@ -59,7 +58,7 @@ ax.set_title(interp)
 
 ax = axs[1, 1]
 im = NonUniformImage(ax, interpolation=interp, extent=(-64, 64, -4, 4),
-                     cmap=cm.Purples)
+                     cmap="Purples")
 im.set_data(x2, y, z)
 ax.add_image(im)
 ax.set_xlim(-64, 64)

--- a/galleries/examples/images_contours_and_fields/layer_images.py
+++ b/galleries/examples/images_contours_and_fields/layer_images.py
@@ -31,12 +31,12 @@ extent = np.min(x), np.max(x), np.min(y), np.max(y)
 fig = plt.figure(frameon=False)
 
 Z1 = np.add.outer(range(8), range(8)) % 2  # chessboard
-im1 = plt.imshow(Z1, cmap=plt.cm.gray, interpolation='nearest',
+im1 = plt.imshow(Z1, cmap="gray", interpolation='nearest',
                  extent=extent)
 
 Z2 = func3(X, Y)
 
-im2 = plt.imshow(Z2, cmap=plt.cm.viridis, alpha=.9, interpolation='bilinear',
+im2 = plt.imshow(Z2, cmap="viridis", alpha=.9, interpolation='bilinear',
                  extent=extent)
 
 plt.show()

--- a/galleries/examples/images_contours_and_fields/shading_example.py
+++ b/galleries/examples/images_contours_and_fields/shading_example.py
@@ -25,10 +25,10 @@ def main():
     dem = cbook.get_sample_data('jacksboro_fault_dem.npz')
     elev = dem['elevation']
 
-    fig = compare(z, plt.cm.copper)
+    fig = compare(z, plt.colormaps["copper"])
     fig.suptitle('HSV Blending Looks Best with Smooth Surfaces', y=0.95)
 
-    fig = compare(elev, plt.cm.gist_earth, ve=0.05)
+    fig = compare(elev, plt.colormaps["gist_earth"], ve=0.05)
     fig.suptitle('Overlay Blending Looks Best with Rough Surfaces', y=0.95)
 
     plt.show()

--- a/galleries/examples/lines_bars_and_markers/gradient_bar.py
+++ b/galleries/examples/lines_bars_and_markers/gradient_bar.py
@@ -56,7 +56,7 @@ def gradient_bar(ax, x, y, width=0.5, bottom=0):
     for left, top in zip(x, y):
         right = left + width
         gradient_image(ax, extent=(left, right, bottom, top),
-                       cmap=plt.cm.Blues_r, cmap_range=(0, 0.8))
+                       cmap="Blues_r", cmap_range=(0, 0.8))
 
 
 fig, ax = plt.subplots()
@@ -64,7 +64,7 @@ ax.set(xlim=(0, 10), ylim=(0, 1))
 
 # background image
 gradient_image(ax, direction=1, extent=(0, 1, 0, 1), transform=ax.transAxes,
-               cmap=plt.cm.RdYlGn, cmap_range=(0.2, 0.8), alpha=0.5)
+               cmap="RdYlGn", cmap_range=(0.2, 0.8), alpha=0.5)
 
 N = 10
 x = np.arange(N) + 0.15

--- a/galleries/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/galleries/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -39,7 +39,7 @@ for skill, takeoff, thrust, mood, pos in data:
     t = Affine2D().scale(skill).rotate_deg(takeoff)
     m = MarkerStyle(SUCCESS_SYMBOLS[mood], transform=t)
     ax.plot(pos[0], pos[1], marker=m, color=cmap(thrust))
-fig.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap=cmap),
+fig.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap="plasma"),
              ax=ax, label="Normalized Thrust [a.u.]")
 ax.set_xlabel("X position [m]")
 ax.set_ylabel("Y position [m]")

--- a/galleries/examples/misc/contour_manual.py
+++ b/galleries/examples/misc/contour_manual.py
@@ -8,7 +8,6 @@ Example of displaying your own contour lines and polygons using ContourSet.
 
 import matplotlib.pyplot as plt
 
-import matplotlib.cm as cm
 from matplotlib.contour import ContourSet
 from matplotlib.path import Path
 
@@ -30,12 +29,12 @@ filled12 = [[[2, 0], [3, 0], [3, 2], [1, 3], [1, 2]],   # Note two polygons.
 fig, ax = plt.subplots()
 
 # Filled contours using filled=True.
-cs = ContourSet(ax, [0, 1, 2], [filled01, filled12], filled=True, cmap=cm.bone)
+cs = ContourSet(ax, [0, 1, 2], [filled01, filled12], filled=True, cmap="bone")
 cbar = fig.colorbar(cs)
 
 # Contour lines (non-filled).
 lines = ContourSet(
-    ax, [0, 1, 2], [lines0, lines1, lines2], cmap=cm.cool, linewidths=3)
+    ax, [0, 1, 2], [lines0, lines1, lines2], cmap="cool", linewidths=3)
 cbar.add_lines(lines)
 
 ax.set(xlim=(-0.5, 3.5), ylim=(-0.5, 4.5),

--- a/galleries/examples/misc/demo_agg_filter.py
+++ b/galleries/examples/misc/demo_agg_filter.py
@@ -14,7 +14,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from matplotlib.artist import Artist
-import matplotlib.cm as cm
 from matplotlib.colors import LightSource
 import matplotlib.transforms as mtransforms
 
@@ -179,7 +178,7 @@ def filtered_text(ax):
 
     # draw
     ax.imshow(Z, interpolation='bilinear', origin='lower',
-              cmap=cm.gray, extent=(-3, 3, -2, 2), aspect='auto')
+              cmap="gray", extent=(-3, 3, -2, 2), aspect='auto')
     levels = np.arange(-1.2, 1.6, 0.2)
     CS = ax.contour(Z, levels,
                     origin='lower',

--- a/galleries/examples/misc/hyperlinks_sgskip.py
+++ b/galleries/examples/misc/hyperlinks_sgskip.py
@@ -13,8 +13,6 @@ This currently only works with the SVG backend.
 import matplotlib.pyplot as plt
 import numpy as np
 
-import matplotlib.cm as cm
-
 # %%
 
 fig = plt.figure()
@@ -32,7 +30,7 @@ Z1 = np.exp(-X**2 - Y**2)
 Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = (Z1 - Z2) * 2
 
-im = plt.imshow(Z, interpolation='bilinear', cmap=cm.gray,
+im = plt.imshow(Z, interpolation='bilinear', cmap="gray",
                 origin='lower', extent=(-3, 3, -3, 3))
 
 im.set_url('https://www.google.com/')

--- a/galleries/examples/misc/table_demo.py
+++ b/galleries/examples/misc/table_demo.py
@@ -21,7 +21,7 @@ values = np.arange(0, 2500, 500)
 value_increment = 1000
 
 # Get some pastel shades for the colors
-colors = plt.cm.BuPu(np.linspace(0, 0.5, len(rows)))
+colors = plt.colormaps["BuPu"](np.linspace(0, 0.5, len(rows)))
 n_rows = len(data)
 
 index = np.arange(len(columns)) + 0.3

--- a/galleries/examples/mplot3d/contour3d.py
+++ b/galleries/examples/mplot3d/contour3d.py
@@ -9,13 +9,12 @@ plotted on the plane ``z=c``.
 
 import matplotlib.pyplot as plt
 
-from matplotlib import cm
 from mpl_toolkits.mplot3d import axes3d
 
 ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
 
-ax.contour(X, Y, Z, cmap=cm.coolwarm)  # Plot contour curves
+ax.contour(X, Y, Z, cmap="coolwarm")  # Plot contour curves
 
 plt.show()
 

--- a/galleries/examples/mplot3d/contour3d_2.py
+++ b/galleries/examples/mplot3d/contour3d_2.py
@@ -9,12 +9,11 @@ extend the curves vertically into 'ribbons'.
 
 import matplotlib.pyplot as plt
 
-from matplotlib import cm
 from mpl_toolkits.mplot3d import axes3d
 
 ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
-ax.contour(X, Y, Z, extend3d=True, cmap=cm.coolwarm)
+ax.contour(X, Y, Z, extend3d=True, cmap="coolwarm")
 
 plt.show()
 

--- a/galleries/examples/mplot3d/contourf3d.py
+++ b/galleries/examples/mplot3d/contourf3d.py
@@ -12,12 +12,11 @@ corresponding to the level c is graphed on the plane ``z=c``.
 
 import matplotlib.pyplot as plt
 
-from matplotlib import cm
 from mpl_toolkits.mplot3d import axes3d
 
 ax = plt.figure().add_subplot(projection='3d')
 X, Y, Z = axes3d.get_test_data(0.05)
-ax.contourf(X, Y, Z, cmap=cm.coolwarm)
+ax.contourf(X, Y, Z, cmap="coolwarm")
 
 plt.show()
 

--- a/galleries/examples/mplot3d/custom_shaded_3d_surface.py
+++ b/galleries/examples/mplot3d/custom_shaded_3d_surface.py
@@ -9,7 +9,7 @@ Demonstrates using custom hillshading in a 3D surface plot.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cbook, cm
+from matplotlib import cbook
 from matplotlib.colors import LightSource
 
 # Load and format data
@@ -29,7 +29,7 @@ fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
 ls = LightSource(270, 45)
 # To use a custom hillshading mode, override the built-in shading and pass
 # in the rgb colors of the shaded surface calculated from "shade".
-rgb = ls.shade(z, cmap=cm.gist_earth, vert_exag=0.1, blend_mode='soft')
+rgb = ls.shade(z, cmap=plt.colormaps["gist_earth"], vert_exag=0.1, blend_mode='soft')
 surf = ax.plot_surface(x, y, z, rstride=1, cstride=1, facecolors=rgb,
                        linewidth=0, antialiased=False, shade=False)
 

--- a/galleries/examples/mplot3d/subplot3d.py
+++ b/galleries/examples/mplot3d/subplot3d.py
@@ -9,7 +9,6 @@ Demonstrate including 3D plots as subplots.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cm
 from mpl_toolkits.mplot3d.axes3d import get_test_data
 
 # set up a figure twice as wide as it is tall
@@ -27,7 +26,7 @@ Y = np.arange(-5, 5, 0.25)
 X, Y = np.meshgrid(X, Y)
 R = np.sqrt(X**2 + Y**2)
 Z = np.sin(R)
-surf = ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap=cm.coolwarm,
+surf = ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap="coolwarm",
                        linewidth=0, antialiased=False)
 ax.set_zlim(-1.01, 1.01)
 fig.colorbar(surf, shrink=0.5, aspect=10)

--- a/galleries/examples/mplot3d/surface3d.py
+++ b/galleries/examples/mplot3d/surface3d.py
@@ -13,7 +13,6 @@ z axis tick labels.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cm
 from matplotlib.ticker import LinearLocator
 
 fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
@@ -26,7 +25,7 @@ R = np.sqrt(X**2 + Y**2)
 Z = np.sin(R)
 
 # Plot the surface.
-surf = ax.plot_surface(X, Y, Z, cmap=cm.coolwarm,
+surf = ax.plot_surface(X, Y, Z, cmap="coolwarm",
                        linewidth=0, antialiased=False)
 
 # Customize the z axis.

--- a/galleries/examples/mplot3d/surface3d_radial.py
+++ b/galleries/examples/mplot3d/surface3d_radial.py
@@ -26,7 +26,7 @@ Z = ((R**2 - 1)**2)
 X, Y = R*np.cos(P), R*np.sin(P)
 
 # Plot the surface.
-ax.plot_surface(X, Y, Z, cmap=plt.cm.YlGnBu_r)
+ax.plot_surface(X, Y, Z, cmap="YlGnBu_r")
 
 # Tweak the limits and add latex math labels.
 ax.set_zlim(0, 1)

--- a/galleries/examples/mplot3d/tricontour3d.py
+++ b/galleries/examples/mplot3d/tricontour3d.py
@@ -37,7 +37,7 @@ triang.set_mask(np.hypot(x[triang.triangles].mean(axis=1),
                 < min_radius)
 
 ax = plt.figure().add_subplot(projection='3d')
-ax.tricontour(triang, z, cmap=plt.cm.CMRmap)
+ax.tricontour(triang, z, cmap="CMRmap")
 
 # Customize the view angle so it's easier to understand the plot.
 ax.view_init(elev=45.)

--- a/galleries/examples/mplot3d/tricontourf3d.py
+++ b/galleries/examples/mplot3d/tricontourf3d.py
@@ -38,7 +38,7 @@ triang.set_mask(np.hypot(x[triang.triangles].mean(axis=1),
                 < min_radius)
 
 ax = plt.figure().add_subplot(projection='3d')
-ax.tricontourf(triang, z, cmap=plt.cm.CMRmap)
+ax.tricontourf(triang, z, cmap="CMRmap")
 
 # Customize the view angle so it's easier to understand the plot.
 ax.view_init(elev=45.)

--- a/galleries/examples/mplot3d/trisurf3d_2.py
+++ b/galleries/examples/mplot3d/trisurf3d_2.py
@@ -39,7 +39,7 @@ tri = mtri.Triangulation(u, v)
 # Plot the surface.  The triangles in parameter space determine which x, y, z
 # points are connected by an edge.
 ax = fig.add_subplot(1, 2, 1, projection='3d')
-ax.plot_trisurf(x, y, z, triangles=tri.triangles, cmap=plt.cm.Spectral)
+ax.plot_trisurf(x, y, z, triangles=tri.triangles, cmap="Spectral")
 ax.set_zlim(-1, 1)
 
 
@@ -73,7 +73,7 @@ triang.set_mask(mask)
 
 # Plot the surface.
 ax = fig.add_subplot(1, 2, 2, projection='3d')
-ax.plot_trisurf(triang, z, cmap=plt.cm.CMRmap)
+ax.plot_trisurf(triang, z, cmap="CMRmap")
 
 
 plt.show()

--- a/galleries/examples/pie_and_polar_charts/polar_bar.py
+++ b/galleries/examples/pie_and_polar_charts/polar_bar.py
@@ -16,7 +16,7 @@ N = 20
 theta = np.linspace(0.0, 2 * np.pi, N, endpoint=False)
 radii = 10 * np.random.rand(N)
 width = np.pi / 4 * np.random.rand(N)
-colors = plt.cm.viridis(radii / 10.)
+colors = plt.colormaps["viridis"](radii / 10.)
 
 ax = plt.subplot(projection='polar')
 ax.bar(theta, radii, width=width, bottom=0.0, color=colors, alpha=0.5)

--- a/galleries/examples/shapes_and_collections/dolphin.py
+++ b/galleries/examples/shapes_and_collections/dolphin.py
@@ -11,7 +11,6 @@ and nodes using the `~.path.Path`, `~.patches.PathPatch` and
 import matplotlib.pyplot as plt
 import numpy as np
 
-import matplotlib.cm as cm
 from matplotlib.patches import Circle, PathPatch
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
@@ -31,7 +30,7 @@ circle = Circle((0, 0), 1, facecolor='none',
 ax.add_patch(circle)
 
 im = plt.imshow(np.random.random((100, 100)),
-                origin='lower', cmap=cm.winter,
+                origin='lower', cmap="winter",
                 interpolation='spline36',
                 extent=(-1, 1, -1, 1))
 im.set_clip_path(circle)

--- a/galleries/examples/showcase/mandelbrot.py
+++ b/galleries/examples/showcase/mandelbrot.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
 
     # Shaded rendering
     light = colors.LightSource(azdeg=315, altdeg=10)
-    M = light.shade(M, cmap=plt.cm.hot, vert_exag=1.5,
+    M = light.shade(M, cmap=plt.colormaps["hot"], vert_exag=1.5,
                     norm=colors.PowerNorm(0.3), blend_mode='hsv')
     ax.imshow(M, extent=[xmin, xmax, ymin, ymax], interpolation="bicubic")
     ax.set_xticks([])

--- a/galleries/examples/specialty_plots/advanced_hillshading.py
+++ b/galleries/examples/specialty_plots/advanced_hillshading.py
@@ -16,7 +16,7 @@ def display_colorbar():
     y, x = np.mgrid[-4:2:200j, -4:2:200j]
     z = 10 * np.cos(x**2 + y**2)
 
-    cmap = plt.cm.copper
+    cmap = plt.colormaps["copper"]
     ls = LightSource(315, 45)
     rgb = ls.shade(z, cmap)
 
@@ -43,11 +43,11 @@ def avoid_outliers():
     ls = LightSource(315, 45)
     fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(8, 4.5))
 
-    rgb = ls.shade(z, plt.cm.copper)
+    rgb = ls.shade(z, plt.colormaps["copper"])
     ax1.imshow(rgb, interpolation='bilinear')
     ax1.set_title('Full range of data')
 
-    rgb = ls.shade(z, plt.cm.copper, vmin=-10, vmax=10)
+    rgb = ls.shade(z, plt.colormaps["copper"], vmin=-10, vmax=10)
     ax2.imshow(rgb, interpolation='bilinear')
     ax2.set_title('Manually set range')
 
@@ -61,7 +61,7 @@ def shade_other_data():
     z2 = np.cos(x**2 + y**2)  # Data to color
 
     norm = Normalize(z2.min(), z2.max())
-    cmap = plt.cm.RdBu
+    cmap = plt.colormaps["RdBu"]
 
     ls = LightSource(315, 45)
     rgb = ls.shade_rgb(cmap(norm(z2)), z1)

--- a/galleries/examples/specialty_plots/leftventricle_bullseye.py
+++ b/galleries/examples/specialty_plots/leftventricle_bullseye.py
@@ -104,7 +104,7 @@ fig.canvas.manager.set_window_title('Left Ventricle Bulls Eyes (AHA)')
 
 # Set the colormap and norm to correspond to the data for which
 # the colorbar will be used.
-cmap = mpl.cm.viridis
+cmap = mpl.colormaps["viridis"]
 norm = mpl.colors.Normalize(vmin=1, vmax=17)
 # Create an empty ScalarMappable to set the colorbar's colormap and norm.
 # The following gives a basic continuous colorbar with ticks and labels.
@@ -114,7 +114,7 @@ fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap, norm=norm),
 
 
 # And again for the second colorbar.
-cmap2 = mpl.cm.cool
+cmap2 = mpl.colormaps["cool"]
 norm2 = mpl.colors.Normalize(vmin=1, vmax=17)
 fig.colorbar(mpl.cm.ScalarMappable(cmap=cmap2, norm=norm2),
              cax=axs[1].inset_axes([0, -.15, 1, .1]),

--- a/galleries/examples/specialty_plots/topographic_hillshading.py
+++ b/galleries/examples/specialty_plots/topographic_hillshading.py
@@ -40,7 +40,7 @@ dx = 111200 * dx * np.cos(np.radians(dem['ymin']))
 
 # Shade from the northwest, with the sun 45 degrees from horizontal
 ls = LightSource(azdeg=315, altdeg=45)
-cmap = plt.cm.gist_earth
+cmap = plt.colormaps["gist_earth"]
 
 fig, axs = plt.subplots(nrows=4, ncols=3, figsize=(8, 9))
 plt.setp(axs.flat, xticks=[], yticks=[])

--- a/galleries/examples/statistics/hist.py
+++ b/galleries/examples/statistics/hist.py
@@ -61,7 +61,7 @@ norm = colors.Normalize(fracs.min(), fracs.max())
 
 # Now, we'll loop through our objects and set the color of each accordingly
 for thisfrac, thispatch in zip(fracs, patches):
-    color = plt.cm.viridis(norm(thisfrac))
+    color = plt.colormaps["viridis"](norm(thisfrac))
     thispatch.set_facecolor(color)
 
 # We can also normalize our inputs by the total number of counts

--- a/galleries/examples/subplots_axes_and_figures/axes_box_aspect.py
+++ b/galleries/examples/subplots_axes_and_figures/axes_box_aspect.py
@@ -143,7 +143,7 @@ fig7, axs = plt.subplots(2, 3, subplot_kw=dict(box_aspect=1),
                          sharex=True, sharey=True, layout="constrained")
 
 for i, ax in enumerate(axs.flat):
-    ax.scatter(i % 3, -((i // 3) - 0.5)*200, c=[plt.cm.hsv(i / 6)], s=300)
+    ax.scatter(i % 3, -((i // 3) - 0.5)*200, c=[plt.colormaps["hsv"](i / 6)], s=300)
 plt.show()
 
 # %%

--- a/galleries/examples/text_labels_and_annotations/custom_legends.py
+++ b/galleries/examples/text_labels_and_annotations/custom_legends.py
@@ -31,7 +31,7 @@ np.random.seed(19680801)
 # %%
 N = 10
 data = (np.geomspace(1, 10, 100) + np.random.randn(N, 100)).T
-cmap = plt.cm.coolwarm
+cmap = plt.colormaps["coolwarm"]
 mpl.rcParams['axes.prop_cycle'] = cycler(color=cmap(np.linspace(0, 1, N)))
 
 fig, ax = plt.subplots()

--- a/galleries/examples/text_labels_and_annotations/demo_text_path.py
+++ b/galleries/examples/text_labels_and_annotations/demo_text_path.py
@@ -87,7 +87,7 @@ if __name__ == "__main__":
                             )
         ax1.add_artist(ab)
 
-    ax1.imshow([[0, 1, 2], [1, 2, 3]], cmap=plt.cm.gist_gray_r,
+    ax1.imshow([[0, 1, 2], [1, 2, 3]], cmap="gist_gray_r",
                interpolation="bilinear", aspect="auto")
 
     # EXAMPLE 2

--- a/galleries/examples/user_interfaces/embedding_in_wx3_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_wx3_sgskip.py
@@ -30,7 +30,6 @@ from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
 from matplotlib.backends.backend_wxagg import \
     NavigationToolbar2WxAgg as NavigationToolbar
 import matplotlib.cbook as cbook
-import matplotlib.cm as cm
 from matplotlib.figure import Figure
 
 ERR_TOL = 1e-5  # floating point slop for peak-detection
@@ -61,7 +60,7 @@ class PlotPanel(wx.Panel):
         y = np.arange(100.0) * 2 * np.pi / 50.0
         self.x, self.y = np.meshgrid(x, y)
         z = np.sin(self.x) + np.cos(self.y)
-        self.im = ax.imshow(z, cmap=cm.RdBu, origin='lower')
+        self.im = ax.imshow(z, cmap="RdBu", origin='lower')
 
         zmax = np.max(z) - ERR_TOL
         ymax_i, xmax_i = np.nonzero(z >= zmax)

--- a/galleries/plot_types/3D/surface3d_simple.py
+++ b/galleries/plot_types/3D/surface3d_simple.py
@@ -8,8 +8,6 @@ See `~mpl_toolkits.mplot3d.axes3d.Axes3D.plot_surface`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cm
-
 plt.style.use('_mpl-gallery')
 
 # Make data
@@ -21,7 +19,7 @@ Z = np.sin(R)
 
 # Plot the surface
 fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
-ax.plot_surface(X, Y, Z, vmin=Z.min() * 2, cmap=cm.Blues)
+ax.plot_surface(X, Y, Z, vmin=Z.min() * 2, cmap="Blues")
 
 ax.set(xticklabels=[],
        yticklabels=[],

--- a/galleries/plot_types/3D/trisurf3d_simple.py
+++ b/galleries/plot_types/3D/trisurf3d_simple.py
@@ -8,8 +8,6 @@ See `~mpl_toolkits.mplot3d.axes3d.Axes3D.plot_trisurf`.
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cm
-
 plt.style.use('_mpl-gallery')
 
 n_radii = 8
@@ -26,7 +24,7 @@ z = np.sin(-x*y)
 
 # Plot
 fig, ax = plt.subplots(subplot_kw={'projection': '3d'})
-ax.plot_trisurf(x, y, z, vmin=z.min() * 2, cmap=cm.Blues)
+ax.plot_trisurf(x, y, z, vmin=z.min() * 2, cmap="Blues")
 
 ax.set(xticklabels=[],
        yticklabels=[],

--- a/galleries/users_explain/colors/colorbar_only.py
+++ b/galleries/users_explain/colors/colorbar_only.py
@@ -15,6 +15,7 @@ use a `.ScalarMappable` with no associated data.
 """
 
 import matplotlib.pyplot as plt
+
 import matplotlib as mpl
 
 # %%
@@ -30,10 +31,9 @@ import matplotlib as mpl
 
 fig, ax = plt.subplots(figsize=(6, 1), layout='constrained')
 
-cmap = mpl.cm.cool
 norm = mpl.colors.Normalize(vmin=5, vmax=10)
 
-fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap="cool"),
              cax=ax, orientation='horizontal', label='Some Units')
 
 # %%
@@ -61,11 +61,11 @@ fig.colorbar(mpl.cm.ScalarMappable(norm=mpl.colors.Normalize(0, 1), cmap='magma'
 
 fig, ax = plt.subplots(figsize=(6, 1), layout='constrained')
 
-cmap = mpl.cm.viridis
+cmap = mpl.colormaps["viridis"]
 bounds = [-1, 2, 5, 7, 12, 15]
 norm = mpl.colors.BoundaryNorm(bounds, cmap.N, extend='both')
 
-fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap=cmap),
+fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap="viridis"),
              cax=ax, orientation='horizontal',
              label="Discrete intervals with extend='both' keyword")
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -49,7 +49,6 @@ can clearly be seen:
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib import cm
 import matplotlib.cbook as cbook
 import matplotlib.colors as colors
 
@@ -101,7 +100,7 @@ Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
 Z = (0.9*Z1 - 0.5*Z2) * 2
 
 # select a divergent colormap
-cmap = cm.coolwarm
+cmap = "coolwarm"
 
 fig, (ax1, ax2) = plt.subplots(ncols=2)
 pc = ax1.pcolormesh(Z, cmap=cmap)
@@ -262,8 +261,8 @@ latitude = dem['latitude']
 fig, ax = plt.subplots()
 # make a colormap that has land and ocean clearly delineated and of the
 # same length (256 + 256)
-colors_undersea = plt.cm.terrain(np.linspace(0, 0.17, 256))
-colors_land = plt.cm.terrain(np.linspace(0.25, 1, 256))
+colors_undersea = plt.colormaps["terrain"](np.linspace(0, 0.17, 256))
+colors_land = plt.colormaps["terrain"](np.linspace(0.25, 1, 256))
 all_colors = np.vstack((colors_undersea, colors_land))
 terrain_map = colors.LinearSegmentedColormap.from_list(
     'terrain_map', all_colors)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -317,7 +317,7 @@ def test_remove_from_figure_cl():
 def test_colorbarbase():
     # smoke test from #3805
     ax = plt.gca()
-    Colorbar(ax, cmap=plt.cm.bone)
+    Colorbar(ax, cmap=plt.colormaps["bone"])
 
 
 def test_parentless_mappable():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -108,7 +108,7 @@ def test_double_register_builtin_cmap():
 
 
 def test_colormap_copy():
-    cmap = plt.cm.Reds
+    cmap = plt.colormaps["Reds"]
     copied_cmap = copy.copy(cmap)
     with np.errstate(invalid='ignore'):
         ret1 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
@@ -118,7 +118,7 @@ def test_colormap_copy():
         ret2 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     assert_array_equal(ret1, ret2)
     # again with the .copy method:
-    cmap = plt.cm.Reds
+    cmap = plt.colormaps["Reds"]
     copied_cmap = cmap.copy()
     with np.errstate(invalid='ignore'):
         ret1 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
@@ -950,7 +950,7 @@ def test_light_source_shading_default():
     y, x = np.mgrid[-1.2:1.2:8j, -1.2:1.2:8j]
     z = 10 * np.cos(x**2 + y**2)
 
-    cmap = plt.cm.copper
+    cmap = plt.colormaps["copper"]
     ls = mcolors.LightSource(315, 45)
     rgb = ls.shade(z, cmap)
 
@@ -1001,7 +1001,7 @@ def test_light_source_shading_empty_mask():
     z0 = 10 * np.cos(x**2 + y**2)
     z1 = np.ma.array(z0)
 
-    cmap = plt.cm.copper
+    cmap = plt.colormaps["copper"]
     ls = mcolors.LightSource(315, 45)
     rgb0 = ls.shade(z0, cmap)
     rgb1 = ls.shade(z1, cmap)
@@ -1022,7 +1022,7 @@ def test_light_source_masked_shading():
 
     z = np.ma.masked_greater(z, 9.9)
 
-    cmap = plt.cm.copper
+    cmap = plt.colormaps["copper"]
     ls = mcolors.LightSource(315, 45)
     rgb = ls.shade(z, cmap)
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -863,7 +863,7 @@ def test_mask_image_over_under():
           (2 * np.pi * 0.5 * 1.5))
     Z = 10*(Z2 - Z1)  # difference of Gaussians
 
-    palette = plt.cm.gray.with_extremes(over='r', under='g', bad='b')
+    palette = plt.colormaps["gray"].with_extremes(over='r', under='g', bad='b')
     Zm = np.ma.masked_where(Z > 1.2, Z)
     fig, (ax1, ax2) = plt.subplots(1, 2)
     im = ax1.imshow(Zm, interpolation='bilinear',
@@ -1435,7 +1435,7 @@ def test_rgba_antialias():
     aa[70:90, 195:215] = 1e6
     aa[20:30, 195:215] = -1e6
 
-    cmap = copy(plt.cm.RdBu_r)
+    cmap = plt.colormaps["RdBu_r"]
     cmap.set_over('yellow')
     cmap.set_under('cyan')
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -915,7 +915,7 @@ def test_legend_pathcollection_labelcolor_markeredgecolor_cmap():
     # test the labelcolor for labelcolor='markeredgecolor' on PathCollection
     # with a colormap
     fig, ax = plt.subplots()
-    edgecolors = mpl.cm.viridis(np.random.rand(10))
+    edgecolors = mpl.colormaps["viridis"](np.random.rand(10))
     ax.scatter(
         np.arange(10),
         np.arange(10),
@@ -970,7 +970,7 @@ def test_legend_pathcollection_labelcolor_markfacecolor_cmap():
     # test the labelcolor for labelcolor='markerfacecolor' on PathCollection
     # with colormaps
     fig, ax = plt.subplots()
-    colors = mpl.cm.viridis(np.random.rand(10))
+    colors = mpl.colormaps["viridis"](np.random.rand(10))
     ax.scatter(
         np.arange(10),
         np.arange(10),

--- a/lib/matplotlib/tests/test_streamplot.py
+++ b/lib/matplotlib/tests/test_streamplot.py
@@ -40,7 +40,7 @@ def test_startpoints():
 def test_colormap():
     X, Y, U, V = velocity_field()
     plt.streamplot(X, Y, U, V, color=U, density=0.6, linewidth=2,
-                   cmap=plt.cm.autumn)
+                   cmap="autumn")
     plt.colorbar()
 
 
@@ -64,7 +64,7 @@ def test_masks_and_nans():
     U = np.ma.array(U, mask=mask)
     ax = plt.figure().subplots()
     with np.errstate(invalid='ignore'):
-        ax.streamplot(X, Y, U, V, color=U, cmap=plt.cm.Blues)
+        ax.streamplot(X, Y, U, V, color=U, cmap="Blues")
 
 
 @image_comparison(['streamplot_maxlength.png'],

--- a/lib/matplotlib/tests/test_table.py
+++ b/lib/matplotlib/tests/test_table.py
@@ -55,7 +55,7 @@ def test_label_colours():
     dim = 3
 
     c = np.linspace(0, 1, dim)
-    colours = plt.cm.RdYlGn(c)
+    colours = plt.colormaps["RdYlGn"](c)
     cellText = [['1'] * dim] * dim
 
     fig = plt.figure()

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -229,9 +229,9 @@ def test_contour3d():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    ax.contour(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
-    ax.contour(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
-    ax.contour(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
+    ax.contour(X, Y, Z, zdir='z', offset=-100, cmap="coolwarm")
+    ax.contour(X, Y, Z, zdir='x', offset=-40, cmap="coolwarm")
+    ax.contour(X, Y, Z, zdir='y', offset=40, cmap="coolwarm")
     ax.axis(xmin=-40, xmax=40, ymin=-40, ymax=40, zmin=-100, zmax=100)
 
 
@@ -241,7 +241,7 @@ def test_contour3d_extend3d():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    ax.contour(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm, extend3d=True)
+    ax.contour(X, Y, Z, zdir='z', offset=-100, cmap="coolwarm", extend3d=True)
     ax.set_xlim(-30, 30)
     ax.set_ylim(-20, 40)
     ax.set_zlim(-80, 80)
@@ -253,9 +253,9 @@ def test_contourf3d():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     X, Y, Z = axes3d.get_test_data(0.05)
-    ax.contourf(X, Y, Z, zdir='z', offset=-100, cmap=cm.coolwarm)
-    ax.contourf(X, Y, Z, zdir='x', offset=-40, cmap=cm.coolwarm)
-    ax.contourf(X, Y, Z, zdir='y', offset=40, cmap=cm.coolwarm)
+    ax.contourf(X, Y, Z, zdir='z', offset=-100, cmap="coolwarm")
+    ax.contourf(X, Y, Z, zdir='x', offset=-40, cmap="coolwarm")
+    ax.contourf(X, Y, Z, zdir='y', offset=40, cmap="coolwarm")
     ax.set_xlim(-40, 40)
     ax.set_ylim(-40, 40)
     ax.set_zlim(-100, 100)
@@ -271,7 +271,7 @@ def test_contourf3d_fill():
     # This produces holes in the z=0 surface that causes rendering errors if
     # the Poly3DCollection is not aware of path code information (issue #4784)
     Z[::5, ::5] = 0.1
-    ax.contourf(X, Y, Z, offset=0, levels=[-0.1, 0], cmap=cm.coolwarm)
+    ax.contourf(X, Y, Z, offset=0, levels=[-0.1, 0], cmap="coolwarm")
     ax.set_xlim(-2, 2)
     ax.set_ylim(-2, 2)
     ax.set_zlim(-1, 1)
@@ -648,7 +648,7 @@ def test_surface3d():
     X, Y = np.meshgrid(X, Y)
     R = np.hypot(X, Y)
     Z = np.sin(R)
-    surf = ax.plot_surface(X, Y, Z, rcount=40, ccount=40, cmap=cm.coolwarm,
+    surf = ax.plot_surface(X, Y, Z, rcount=40, ccount=40, cmap="coolwarm",
                            lw=0, antialiased=False)
     plt.rcParams['axes3d.automargin'] = True  # Remove when image is regenerated
     ax.set_zlim(-1.01, 1.01)
@@ -816,7 +816,7 @@ def test_trisurf3d():
 
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
-    ax.plot_trisurf(x, y, z, cmap=cm.jet, linewidth=0.2)
+    ax.plot_trisurf(x, y, z, cmap="jet", linewidth=0.2)
 
 
 @mpl3d_image_comparison(['trisurf3d_shaded.png'], tol=0.03, style='mpl20')
@@ -936,7 +936,7 @@ def test_quiver3d_colorcoded():
     x = y = dx = dz = np.zeros(10)
     z = dy = np.arange(10.)
 
-    color = plt.cm.Reds(dy/dy.max())
+    color = plt.colormaps["Reds"](dy/dy.max())
     ax.quiver(x, y, z, dx, dy, dz, colors=color)
     ax.set_ylim(0, 10)
 


### PR DESCRIPTION
Fixes: #28915

This update suggests using string colormap names directly for cmap arguments due to their readability and ease of use. The update also recommends plt.colormaps[name] to retrieve colormap instances, offering a scalable approach that supports both built-in and user-registered colormaps. 