### PR TITLE
FIX: Don't set_wmclass on GTK3

### DIFF
--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -143,7 +143,6 @@ class _FigureManagerGTK(FigureManagerBase):
         super().__init__(canvas, num)
 
         if gtk_ver == 3:
-            self.window.set_wmclass("matplotlib", "Matplotlib")
             icon_ext = "png" if sys.platform == "win32" else "svg"
             self.window.set_icon_from_file(
                 str(cbook._get_data_path(f"images/matplotlib.{icon_ext}")))


### PR DESCRIPTION
The method is deprecated, and according to docs should just not be used: https://docs.gtk.org/gtk3/method.Window.set_wmclass.html

The docs suggest gtk_window_set_role(), but AFAICS this is only helpful if one want to place the window in a certain position when restarting a session. I assume we don't want/need that.

This might also resolve this test failure https://github.com/matplotlib/matplotlib/pull/27766#issuecomment-2422998894 - t.b.c.