### PR TITLE
Don't pass redundant inline=True to example clabel() calls.

### DIFF
--- a/galleries/examples/images_contours_and_fields/contour_demo.py
+++ b/galleries/examples/images_contours_and_fields/contour_demo.py
@@ -30,7 +30,7 @@ Z = (Z1 - Z2) * 2
 
 fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z)
-ax.clabel(CS, inline=True, fontsize=10)
+ax.clabel(CS, fontsize=10)
 ax.set_title('Simplest default with labels')
 
 # %%
@@ -42,7 +42,7 @@ fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z)
 manual_locations = [
     (-1, -1.4), (-0.62, -0.7), (-2, 0.5), (1.7, 1.2), (2.0, 1.4), (2.4, 1.7)]
-ax.clabel(CS, inline=True, fontsize=10, manual=manual_locations)
+ax.clabel(CS, fontsize=10, manual=manual_locations)
 ax.set_title('labels at selected locations')
 
 # %%
@@ -50,7 +50,7 @@ ax.set_title('labels at selected locations')
 
 fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z, 6, colors='k')  # Negative contours default to dashed.
-ax.clabel(CS, fontsize=9, inline=True)
+ax.clabel(CS, fontsize=9)
 ax.set_title('Single color - negative contours dashed')
 
 # %%
@@ -59,7 +59,7 @@ ax.set_title('Single color - negative contours dashed')
 plt.rcParams['contour.negative_linestyle'] = 'solid'
 fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z, 6, colors='k')  # Negative contours default to dashed.
-ax.clabel(CS, fontsize=9, inline=True)
+ax.clabel(CS, fontsize=9)
 ax.set_title('Single color - negative contours solid')
 
 # %%
@@ -70,7 +70,7 @@ CS = ax.contour(X, Y, Z, 6,
                 linewidths=np.arange(.5, 4, .5),
                 colors=('r', 'green', 'blue', (1, 1, 0), '#afeeee', '0.5'),
                 )
-ax.clabel(CS, fontsize=9, inline=True)
+ax.clabel(CS, fontsize=9)
 ax.set_title('Crazy lines')
 
 # %%
@@ -90,7 +90,7 @@ lws[6] = 4
 CS.set_linewidth(lws)
 
 ax.clabel(CS, levels[1::2],  # label every second level
-          inline=True, fmt='%1.1f', fontsize=14)
+          fmt='%1.1f', fontsize=14)
 
 # make a colorbar for the contour lines
 CB = fig.colorbar(CS, shrink=0.8)

--- a/galleries/examples/images_contours_and_fields/contour_label_demo.py
+++ b/galleries/examples/images_contours_and_fields/contour_label_demo.py
@@ -43,7 +43,7 @@ def fmt(x):
 fig, ax = plt.subplots()
 CS = ax.contour(X, Y, Z)
 
-ax.clabel(CS, CS.levels, inline=True, fmt=fmt, fontsize=10)
+ax.clabel(CS, CS.levels, fmt=fmt, fontsize=10)
 
 # %%
 # Label contours with arbitrary strings using a dictionary
@@ -59,7 +59,7 @@ for l, s in zip(CS1.levels, strs):
     fmt[l] = s
 
 # Label every other level using strings
-ax1.clabel(CS1, CS1.levels[::2], inline=True, fmt=fmt, fontsize=10)
+ax1.clabel(CS1, CS1.levels[::2], fmt=fmt, fontsize=10)
 
 # %%
 # Use a Formatter

--- a/galleries/examples/misc/demo_agg_filter.py
+++ b/galleries/examples/misc/demo_agg_filter.py
@@ -188,7 +188,6 @@ def filtered_text(ax):
 
     # contour label
     cl = ax.clabel(CS, levels[1::2],  # label every second level
-                   inline=True,
                    fmt='%1.1f',
                    fontsize=11)
 


### PR DESCRIPTION
`inline=True` ("break the contour lines under the labels) is already the default.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please provide at least 1-2 sentences describing the pull request in detail
(Why is this change required?  What problem does it solve?) and link to relevant
issues and PRs.

Also please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
