### PR TITLE
Check pressed mouse buttons in pan/zoom drag handlers.

### DIFF
--- a/lib/matplotlib/backend_bases.pyi
+++ b/lib/matplotlib/backend_bases.pyi
@@ -429,7 +429,7 @@ class NavigationToolbar2:
     def zoom(self, *args) -> None: ...
 
     class _ZoomInfo(NamedTuple):
-        direction: Literal["in", "out"]
+        button: MouseButton
         start_xy: tuple[float, float]
         axes: list[Axes]
         cid: int

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -260,6 +260,8 @@ def test_interactive_colorbar(plot_func, orientation, tool, button, expected):
     # Set up the mouse movements
     start_event = MouseEvent(
         "button_press_event", fig.canvas, *s0, button)
+    drag_event = MouseEvent(
+        "motion_notify_event", fig.canvas, *s1, button, buttons={button})
     stop_event = MouseEvent(
         "button_release_event", fig.canvas, *s1, button)
 
@@ -267,12 +269,12 @@ def test_interactive_colorbar(plot_func, orientation, tool, button, expected):
     if tool == "zoom":
         tb.zoom()
         tb.press_zoom(start_event)
-        tb.drag_zoom(stop_event)
+        tb.drag_zoom(drag_event)
         tb.release_zoom(stop_event)
     else:
         tb.pan()
         tb.press_pan(start_event)
-        tb.drag_pan(stop_event)
+        tb.drag_pan(drag_event)
         tb.release_pan(stop_event)
 
     # Should be close, but won't be exact due to screen integer resolution
@@ -395,6 +397,9 @@ def test_interactive_pan(key, mouseend, expectedxlim, expectedylim):
     start_event = MouseEvent(
         "button_press_event", fig.canvas, *sstart, button=MouseButton.LEFT,
         key=key)
+    drag_event = MouseEvent(
+        "motion_notify_event", fig.canvas, *send, button=MouseButton.LEFT,
+        buttons={MouseButton.LEFT}, key=key)
     stop_event = MouseEvent(
         "button_release_event", fig.canvas, *send, button=MouseButton.LEFT,
         key=key)
@@ -402,7 +407,7 @@ def test_interactive_pan(key, mouseend, expectedxlim, expectedylim):
     tb = NavigationToolbar2(fig.canvas)
     tb.pan()
     tb.press_pan(start_event)
-    tb.drag_pan(stop_event)
+    tb.drag_pan(drag_event)
     tb.release_pan(stop_event)
     # Should be close, but won't be exact due to screen integer resolution
     assert tuple(ax.get_xlim()) == pytest.approx(expectedxlim, abs=0.02)
@@ -510,6 +515,8 @@ def test_interactive_pan_zoom_events(tool, button, patch_vis, forward_nav, t_s):
 
     # Set up the mouse movements
     start_event = MouseEvent("button_press_event", fig.canvas, *s0, button)
+    drag_event = MouseEvent(
+        "motion_notify_event", fig.canvas, *s1, button, buttons={button})
     stop_event = MouseEvent("button_release_event", fig.canvas, *s1, button)
 
     tb = NavigationToolbar2(fig.canvas)
@@ -534,7 +541,7 @@ def test_interactive_pan_zoom_events(tool, button, patch_vis, forward_nav, t_s):
 
         tb.zoom()
         tb.press_zoom(start_event)
-        tb.drag_zoom(stop_event)
+        tb.drag_zoom(drag_event)
         tb.release_zoom(stop_event)
 
         assert ax_t.get_xlim() == pytest.approx(xlim_t, abs=0.15)
@@ -570,7 +577,7 @@ def test_interactive_pan_zoom_events(tool, button, patch_vis, forward_nav, t_s):
 
         tb.pan()
         tb.press_pan(start_event)
-        tb.drag_pan(stop_event)
+        tb.drag_pan(drag_event)
         tb.release_pan(stop_event)
 
         assert ax_t.get_xlim() == pytest.approx(xlim_t, abs=0.15)

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2130,6 +2130,8 @@ def test_toolbar_zoom_pan(tool, button, key, expected):
     # Set up the mouse movements
     start_event = MouseEvent(
         "button_press_event", fig.canvas, *s0, button, key=key)
+    drag_event = MouseEvent(
+        "motion_notify_event", fig.canvas, *s1, button, key=key, buttons={button})
     stop_event = MouseEvent(
         "button_release_event", fig.canvas, *s1, button, key=key)
 
@@ -2137,12 +2139,12 @@ def test_toolbar_zoom_pan(tool, button, key, expected):
     if tool == "zoom":
         tb.zoom()
         tb.press_zoom(start_event)
-        tb.drag_zoom(stop_event)
+        tb.drag_zoom(drag_event)
         tb.release_zoom(stop_event)
     else:
         tb.pan()
         tb.press_pan(start_event)
-        tb.drag_pan(stop_event)
+        tb.drag_pan(drag_event)
         tb.release_pan(stop_event)
 
     # Should be close, but won't be exact due to screen integer resolution


### PR DESCRIPTION
Sometimes, the mouse_release_event ending a pan/zoom can be lost, if it occurs while the canvas does not have focus (a typical case is when a context menu is implemented on top of the canvas, see example below); this can result in rather confusing behavior as the pan/zoom continues which no mouse button is pressed.  To fix this, always check that the correct button is still pressed in the motion_notify_event handlers.

To test, use e.g.
```
from matplotlib import pyplot as plt
from matplotlib.backends.qt_compat import QtWidgets

def on_button_press(event):
    if event.button != 3:  # Right-click.
        return
    menu = QtWidgets.QMenu()
    menu.addAction("Some menu action", lambda: None)
    menu.exec(event.guiEvent.globalPosition().toPoint())

fig = plt.figure()
fig.canvas.mpl_connect("button_press_event", on_button_press)
fig.add_subplot()
plt.show()
```
enter pan/zoom mode, right-click to open the context menu, exit the menu, and continue moving the mouse.

Followup to #28453 (and the original motivation for it).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
