### PR TITLE
[DOC] Fix indentation in sync_cmaps example

### DIFF
--- a/galleries/examples/images_contours_and_fields/multi_image.py
+++ b/galleries/examples/images_contours_and_fields/multi_image.py
@@ -63,8 +63,8 @@ plt.show()
 #
 #     def sync_cmaps(changed_image):
 #         for im in images:
-#         if changed_image.get_cmap() != im.get_cmap():
-#             im.set_cmap(changed_image.get_cmap())
+#             if changed_image.get_cmap() != im.get_cmap():
+#                 im.set_cmap(changed_image.get_cmap())
 #
 #     for im in images:
 #         im.callbacks.connect('changed', sync_cmaps)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->

This PR  fixes the indentation in the `sync_cmaps` example in the "Advanced: Additionally sync the colormap" docs.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
