### PR TITLE
Update secondary_axis tutorial

### DIFF
--- a/galleries/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/secondary_axis.py
@@ -116,7 +116,7 @@ x1_vals = np.arange(2, 11, 0.4)
 x2_vals = x1_vals ** 2
 ydata = 50.0 + 20 * np.random.randn(len(x1_vals))
 ax.plot(x1_vals, ydata, label='Plotted data')
-ax.plot(x1_vals, x2_vals, label=r'$x_2(x_1)$')
+ax.plot(x1_vals, x2_vals, label=r'$x_2 = x_1^2$')
 ax.set_xlabel(r'$x_1$')
 ax.legend()
 

--- a/galleries/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/secondary_axis.py
@@ -120,10 +120,9 @@ ax.plot(x1_vals, x2_vals, label=r'$x_2 = x_1^2$')
 ax.set_xlabel(r'$x_1$')
 ax.legend()
 
-# need to define mapped values outside of plotted range to ensure the secondary
-# axis is plotted correctly
-x1n = np.concatenate(([-1e10, 0], x1_vals, [20, 1e10]))
-x2n = np.concatenate(([-1e10, 0], x2_vals, [20**2, 1e10**2]))
+# the forward and inverse functions must be defined on the complete visible axis range
+x1n = np.linspace(0, 20, 201)
+x2n = x1n**2
 
 
 def forward(x):

--- a/galleries/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/secondary_axis.py
@@ -111,8 +111,6 @@ plt.show()
 fig, ax = plt.subplots(layout='constrained')
 x1_vals = np.arange(2, 11, 0.4)
 # second independent variable is a nonlinear function of the other.
-# this simple example can be more easily handled without interpolation, and is done
-# this way only for pedagogical purposes.
 x2_vals = x1_vals ** 2
 ydata = 50.0 + 20 * np.random.randn(len(x1_vals))
 ax.plot(x1_vals, ydata, label='Plotted data')

--- a/galleries/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/secondary_axis.py
@@ -17,7 +17,6 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 import matplotlib.dates as mdates
-from matplotlib.ticker import AutoMinorLocator
 
 fig, ax = plt.subplots(layout='constrained')
 x = np.arange(0, 360, 1)
@@ -96,48 +95,50 @@ secax.set_xlabel('period [s]')
 plt.show()
 
 # %%
-# Sometime we want to relate the axes in a transform that is ad-hoc from
-# the data, and is derived empirically.  In that case we can set the
-# forward and inverse transforms functions to be linear interpolations from the
-# one data set to the other.
+# Sometime we want to relate the axes in a transform that is ad-hoc from the data, and
+# is derived empirically. Or, one axis could be a complicated nonlinear function of the
+# other. In these cases we can set the forward and inverse transform functions to be
+# linear interpolations from the one set of independent variables to the other.
 #
 # .. note::
 #
 #   In order to properly handle the data margins, the mapping functions
 #   (``forward`` and ``inverse`` in this example) need to be defined beyond the
-#   nominal plot limits.
-#
-#   In the specific case of the numpy linear interpolation, `numpy.interp`,
-#   this condition can be arbitrarily enforced by providing optional keyword
-#   arguments *left*, *right* such that values outside the data range are
-#   mapped well outside the plot limits.
+#   nominal plot limits. This condition can be enforced by extending the
+#   interpolation beyond the plotted values, both to the left and the right,
+#   see ``x1n`` and ``x2n`` below.
 
 fig, ax = plt.subplots(layout='constrained')
-xdata = np.arange(1, 11, 0.4)
-ydata = np.random.randn(len(xdata))
-ax.plot(xdata, ydata, label='Plotted data')
-
-xold = np.arange(0, 11, 0.2)
-# fake data set relating x coordinate to another data-derived coordinate.
-# xnew must be monotonic, so we sort...
-xnew = np.sort(10 * np.exp(-xold / 4) + np.random.randn(len(xold)) / 3)
-
-ax.plot(xold[3:], xnew[3:], label='Transform data')
-ax.set_xlabel('X [m]')
+x1_vals = np.arange(2, 11, 0.4)
+# second independent variable is a nonlinear function of the other.
+# this simple example can be more easily handled without interpolation, and is done
+# this way only for pedagogical purposes.
+x2_vals = x1_vals ** 2
+ydata = 50.0 + 20 * np.random.randn(len(x1_vals))
+ax.plot(x1_vals, ydata, label='Plotted data')
+ax.plot(x1_vals, x2_vals, label=r'$x_2(x_1)$')
+ax.set_xlabel(r'$x_1$')
 ax.legend()
+
+# need to define mapped values outside of plotted range to ensure the secondary
+# axis is plotted correctly
+x1n = np.concatenate(([0.0], x1_vals, [20]))
+x2n = np.concatenate(([0.0], x2_vals, [20**2]))
 
 
 def forward(x):
-    return np.interp(x, xold, xnew)
+    return np.interp(x, x1n, x2n)
 
 
 def inverse(x):
-    return np.interp(x, xnew, xold)
+    return np.interp(x, x2n, x1n)
 
-
+# use axvline to prove that the derived secondary axis is correctly plotted
+ax.axvline(np.sqrt(40), color="grey", ls="--")
+ax.axvline(10, color="grey", ls="--")
 secax = ax.secondary_xaxis('top', functions=(forward, inverse))
-secax.xaxis.set_minor_locator(AutoMinorLocator())
-secax.set_xlabel('$X_{other}$')
+secax.set_xticks([10, 20, 40, 60, 80, 100])
+secax.set_xlabel(r'$x_2$')
 
 plt.show()
 

--- a/galleries/examples/subplots_axes_and_figures/secondary_axis.py
+++ b/galleries/examples/subplots_axes_and_figures/secondary_axis.py
@@ -122,8 +122,8 @@ ax.legend()
 
 # need to define mapped values outside of plotted range to ensure the secondary
 # axis is plotted correctly
-x1n = np.concatenate(([0.0], x1_vals, [20]))
-x2n = np.concatenate(([0.0], x2_vals, [20**2]))
+x1n = np.concatenate(([-1e10, 0], x1_vals, [20, 1e10]))
+x2n = np.concatenate(([-1e10, 0], x2_vals, [20**2, 1e10**2]))
 
 
 def forward(x):


### PR DESCRIPTION
## PR summary
Closes #29067
Fixes a small [issue](https://github.com/matplotlib/matplotlib/issues/29067) with the secondary_axis tutorial where the interpolation from one axis to the other needs to be defined outside the bounds of the data that is plotted. This was previously noted in the tutorial but was not implemented correctly. The example in question has been simplified and updated so that the secondary axis is correctly derived from the primary axis.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
