### PR TITLE
DOC: Replaced green with blue for colorblindness

### DIFF
--- a/galleries/examples/widgets/check_buttons.py
+++ b/galleries/examples/widgets/check_buttons.py
@@ -27,7 +27,7 @@ s2 = np.sin(6*np.pi*t)
 fig, ax = plt.subplots()
 l0, = ax.plot(t, s0, visible=False, lw=2, color='black', label='1 Hz')
 l1, = ax.plot(t, s1, lw=2, color='red', label='2 Hz')
-l2, = ax.plot(t, s2, lw=2, color='green', label='3 Hz')
+l2, = ax.plot(t, s2, lw=2, color='blue', label='3 Hz')
 
 lines_by_label = {l.get_label(): l for l in [l0, l1, l2]}
 line_colors = [l.get_color() for l in lines_by_label.values()]


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Changed green with blue colorblindness accessibility for the Check buttons example.

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
