### PR TITLE
DOC: Update page to note installation for ninja library

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -207,7 +207,7 @@ Additionally, the following non-Python dependencies must also be installed local
 
 .. rst-class:: checklist
 
-* :ref:`c++ compiler<compile-dependencies>`
+* :ref:`compile-build-dependencies`
 * :ref:`external tools used by the documentation build <doc-dependencies-external>`
 
 

--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -229,9 +229,6 @@ means that the dependencies must be explicitly installed, either by :ref:`creati
 (recommended) or by manually installing the following packages:
 
 - `meson-python <https://meson-python.readthedocs.io/>`_ (>= 0.13.1).
-- `ninja <https://ninja-build.org/>`_ (>= 1.8.2). This may be available in your package
-  manager or bundled with Meson, but may be installed via ``pip`` if otherwise not
-  available.
 - `PyBind11 <https://pypi.org/project/pybind11/>`_ (>= 2.13.2). Used to connect C/C++ code
   with Python.
 - `setuptools_scm <https://pypi.org/project/setuptools-scm/>`_ (>= 7).  Used to
@@ -240,10 +237,22 @@ means that the dependencies must be explicitly installed, either by :ref:`creati
 - `NumPy <https://numpy.org>`_ (>= 1.22).  Also a runtime dependency.
 
 
+.. _compile-build-dependencies:
+
+Compilers and external build tools
+----------------------------------
+
+When setting up a virtual environment for development, `ninja <https://ninja-build.org/>`_
+(>= 1.8.2) may need to be installed separately. This may be available
+as a `pre-built binary <https://github.com/ninja-build/ninja/releases>`_ or from a
+`package manager <https://github.com/ninja-build/ninja/wiki/Pre-built-Ninja-packages>`_
+or bundled with Meson. Ninja may also be installed via ``pip`` if otherwise not
+available.
+
 .. _compile-dependencies:
 
-Compiled extensions
--------------------
+Compilers
+^^^^^^^^^
 
 Matplotlib requires a C++ compiler that supports C++17, and each platform has a
 development environment that must be installed before a compiler can be installed.


### PR DESCRIPTION
## PR summary

At the sprints for PyData NYC, as I was setting up the repo for local development, I ran into an issue with  installing `ninja` directly from the dev requirements file. After chatting with @story645, she suggested I update the documentation and make a separate section to make external dependency on `ninja` more clear.

This PR changes the docs page to add a new section for the `ninja` external dependency, and removes it from the Python section. I also added `ninja` to the list of external dependencies in the documentation.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines