### PR TITLE
FIX: Update GTK3Agg backend export name for consistency

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3agg.py
+++ b/lib/matplotlib/backends/backend_gtk3agg.py
@@ -70,5 +70,5 @@ class FigureCanvasGTK3Agg(backend_agg.FigureCanvasAgg,
 
 
 @_BackendGTK3.export
-class _BackendGTK3Cairo(_BackendGTK3):
+class _BackendGTK3Agg(_BackendGTK3):
     FigureCanvas = FigureCanvasGTK3Agg


### PR DESCRIPTION
## PR summary

Reading through the code I found it weird that the backend export class is called "Cairo" within the "Agg" section, I think this was just a typo originally in https://github.com/matplotlib/matplotlib/pull/8773. The actual monkeypatching happens based on the module name,
https://github.com/matplotlib/matplotlib/blob/0b6222b7ffe2ab479c59d90a7b6c83257d8bccc7/lib/matplotlib/backend_bases.py#L3562
not this class so we were using the proper Agg/Cairo renderers as expected. This just helps with naming consistency when looking through the code.