### PR TITLE
DOC: Format aliases in kwargs tables

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1586,7 +1586,8 @@ class ArtistInspector:
         if target in self._NOT_LINKABLE:
             return f'``{s}``'
 
-        aliases = ''.join(' or %s' % x for x in sorted(self.aliasd.get(s, [])))
+        aliases = ''.join(
+            f' or :meth:`{a} <{target}>`' for a in sorted(self.aliasd.get(s, [])))
         return f':meth:`{s} <{target}>`{aliases}'
 
     def pprint_setters(self, prop=None, leadingspace=2):


### PR DESCRIPTION
The primary property name was given as link and code-formatted but the aliases were plain-text.

![image](https://github.com/user-attachments/assets/d31ed7c4-cb03-421a-a916-584fa4a5ef4f)

This PR adds consistent formatting to the aliases as well, <s>but still does not link them (by setting the `!` prefix).</s>

