### PR TITLE
ENH: add back/forward buttons to osx backend move

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -289,10 +289,13 @@ PyObject* mpl_buttons()
     PyGILState_STATE gstate = PyGILState_Ensure();
     PyObject* set = NULL;
     NSUInteger buttons = [NSEvent pressedMouseButtons];
+
     if (!(set = PySet_New(NULL))
         || mpl_check_button(buttons & (1 << 0), set, "LEFT")
         || mpl_check_button(buttons & (1 << 1), set, "RIGHT")
-        || mpl_check_button(buttons & (1 << 2), set, "MIDDLE")) {
+        || mpl_check_button(buttons & (1 << 2), set, "MIDDLE")
+        || mpl_check_button(buttons & (1 << 3), set, "BACK")
+        || mpl_check_button(buttons & (1 << 4), set, "FORWARD")) {
         Py_CLEAR(set);  // On failure, return NULL with an exception set.
     }
     PyGILState_Release(gstate);


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

closes #29045

Adds bit mapping for forward and back buttons on mouse


