### PR TITLE
MNT: remove _ttconv.pyi

### DIFF
--- a/lib/matplotlib/meson.build
+++ b/lib/matplotlib/meson.build
@@ -91,7 +91,6 @@ typing_sources = [
   '_enums.pyi',
   '_path.pyi',
   '_pylab_helpers.pyi',
-  '_ttconv.pyi',
   'animation.pyi',
   'artist.pyi',
   'axis.pyi',


### PR DESCRIPTION
This was missed in #20866


## PR summary
We should not include a stub file for a removed c-extension
