### PR TITLE
Add documentation for Axes3d.view_init() angles

### DIFF
--- a/galleries/examples/mplot3d/2dcollections3d.py
+++ b/galleries/examples/mplot3d/2dcollections3d.py
@@ -43,7 +43,7 @@ ax.set_zlabel('Z')
 
 # Customize the view angle so it's easier to see that the scatter points lie
 # on the plane y=0
-ax.view_init(elev=20., azim=-35, roll=0)
+ax.view_init(elev=20, azim=-35, roll=0)
 
 plt.show()
 

--- a/galleries/examples/mplot3d/box3d.py
+++ b/galleries/examples/mplot3d/box3d.py
@@ -68,7 +68,7 @@ ax.set(
 )
 
 # Set zoom and angle view
-ax.view_init(40, -30, 0)
+ax.view_init(elev=40, azim=-30, roll=0)
 ax.set_box_aspect(None, zoom=0.9)
 
 # Colorbar

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1095,13 +1095,12 @@ class Axes3D(Axes):
     def view_init(self, elev=None, azim=None, roll=None, vertical_axis="z",
                   share=False):
         """
-        Set the elevation and azimuth of the Axes in degrees (not radians).
+        Set the elevation, azimuth, and roll of the Axes, in degrees (not radians).
 
         This can be used to rotate the Axes programmatically.
 
         To look normal to the primary planes, the following elevation and
-        azimuth angles can be used. A roll angle of 0, 90, 180, or 270 deg
-        will rotate these views while keeping the axes at right angles.
+        azimuth angles can be used:
 
         ==========   ====  ====
         view plane   elev  azim
@@ -1113,6 +1112,40 @@ class Axes3D(Axes):
         -XZ          0     90
         -YZ          0     180
         ==========   ====  ====
+
+        A roll angle of 0, 90, 180, or 270 degrees will rotate these views
+        while keeping the axes horizontal or vertical.
+
+        The *azim*, *elev*, *roll* angles correspond to rotations of the scene
+        observed by a stationary camera, as follows (assuming a default vertical
+        axis of 'z'). First, a left-handed rotation about the z axis is applied
+        (*azim*), then a right-handed rotation about the (camera) y axis (*elev*),
+        then a right-handed rotation about the (camera) x axis (*roll*). Here,
+        the z, y, and x axis are fixed axes (not the axes that rotate together
+        with the original scene).
+
+        If you would like to make the connection with quaternions (because
+        `Euler angles are horrible
+        <https://github.com/moble/quaternion/wiki/Euler-angles-are-horrible>`_):
+        the *azim*, *elev*, *roll* angles relate to the (intrinsic) rotation of
+        the plot via:
+
+             *q* = exp(+roll **x̂** / 2) exp(+elev **ŷ** / 2) exp(−azim **ẑ** / 2)
+
+        (with angles given in radians instead of degrees). That is, the angles
+        are a kind of `Tait-Bryan angles
+        <https://en.wikipedia.org/wiki/Euler_angles#Tait%E2%80%93Bryan_angles>`_:
+        −z, +y', +x", rather than classic `Euler angles
+        <https://en.wikipedia.org/wiki/Euler_angles>`_.
+
+        To avoid confusion, provide the view angles as keyword
+        arguments: ``.view_init(elev=30, azim=-60, roll=0, ...)``.
+        This specific order is consistent with the order of positional arguments.
+        Unfortunately, this order does not match the order in which rotations are
+        applied, and it differs from the order used in other programs (``azim, elev``)
+        and in `matplotlib.colors.LightSource`. However, it cannot be
+        changed, since that would compromise backward compatibility.
+
 
         Parameters
         ----------
@@ -1606,13 +1639,8 @@ class Axes3D(Axes):
 
             # update view
             vertical_axis = self._axis_names[self._vertical_axis]
-            self.view_init(
-                elev=elev,
-                azim=azim,
-                roll=roll,
-                vertical_axis=vertical_axis,
-                share=True,
-            )
+            self.view_init(elev, azim, roll, vertical_axis=vertical_axis,
+                           share=True)
             self.stale = True
 
         # Pan

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -10,9 +10,9 @@ def test_scatter_3d_projection_conservation():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     # fix axes3d projection
-    ax.roll = 0
     ax.elev = 0
     ax.azim = -45
+    ax.roll = 0
     ax.stale = True
 
     x = [0, 1, 2, 3, 4]

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -177,7 +177,7 @@ def test_bar3d_shaded():
     )
     for ax, (elev, azim, roll) in zip(axs, views):
         ax.bar3d(x2d, y2d, x2d * 0, 1, 1, z, shade=True)
-        ax.view_init(elev=elev, azim=azim, roll=roll)
+        ax.view_init(elev, azim, roll)
     fig.canvas.draw()
 
 
@@ -708,7 +708,7 @@ def test_surface3d_masked():
     norm = mcolors.Normalize(vmax=z.max(), vmin=z.min())
     colors = mpl.colormaps["plasma"](norm(z))
     ax.plot_surface(x, y, z, facecolors=colors)
-    ax.view_init(30, -80, 0)
+    ax.view_init(elev=30, azim=-80, roll=0)
 
 
 @check_figures_equal(extensions=["png"])
@@ -748,7 +748,7 @@ def test_surface3d_masked_strides():
     z = np.ma.masked_less(x * y, 2)
 
     ax.plot_surface(x, y, z, rstride=4, cstride=4)
-    ax.view_init(60, -45, 0)
+    ax.view_init(elev=60, azim=-45, roll=0)
 
 
 @mpl3d_image_comparison(['text3d.png'], remove_text=False, style='mpl20')
@@ -1160,7 +1160,7 @@ def test_axes3d_cla():
 def test_axes3d_rotated():
     fig = plt.figure()
     ax = fig.add_subplot(1, 1, 1, projection='3d')
-    ax.view_init(90, 45, 0)  # look down, rotated. Should be square
+    ax.view_init(elev=90, azim=45, roll=0)  # look down, rotated. Should be square
 
 
 def test_plotsurface_1d_raises():
@@ -1870,11 +1870,11 @@ def test_shared_view(fig_test, fig_ref):
     ax2 = fig_test.add_subplot(132, projection="3d", shareview=ax1)
     ax3 = fig_test.add_subplot(133, projection="3d")
     ax3.shareview(ax1)
-    ax2.view_init(elev=elev, azim=azim, roll=roll, share=True)
+    ax2.view_init(elev, azim, roll, share=True)
 
     for subplot_num in (131, 132, 133):
         ax = fig_ref.add_subplot(subplot_num, projection="3d")
-        ax.view_init(elev=elev, azim=azim, roll=roll)
+        ax.view_init(elev, azim, roll)
 
 
 def test_shared_axes_retick():


### PR DESCRIPTION
## PR summary
This is an alternative for PR #28395, it adds documentation to clarify the relation between the Axes3d.view_init() angles and the rotation of the scene, and add recommendation to use keyword arguments; but unlike #28395, it leaves the original order (elev, azim, roll) unaffected. It closes Issue #28353.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #28353" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
