### PR TITLE
Modify Axes.clear() to remove data while preserving layout and formatting

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1386,13 +1386,33 @@ class _AxesBase(martist.Artist):
         self.stale = True
 
     def clear(self):
-        """Clear the Axes."""
-        # Act as an alias, or as the superclass implementation depending on the
-        # subclass implementation.
-        if self._subclass_uses_cla:
-            self.cla()
-        else:
-            self.__clear()
+        """
+        Clear the axes.
+
+        This removes all data-like content (lines, images, collections, etc.) and
+        resets text labels, but preserves the axes layout, position, and formatting.
+        """
+
+        # Remove data-like artists
+        self.lines.clear()
+        self.patches.clear()
+        self.images.clear()
+        self.collections.clear()
+        self.containers.clear()
+        self.tables.clear()
+        self.texts.clear()  # If you want to remove any added text annotations
+        self.artists.clear()
+    
+        # Note: Do not clear self.texts if you want to preserve text annotations
+
+        # Reset text labels
+        self.set_title("")
+        self.set_xlabel("")
+        self.set_ylabel("")
+
+        # Clear the legend
+        self.legend_ = None
+        # Preserve layout and formatting (do not reset axes limits, ticks, etc.)
 
     def cla(self):
         """Clear the Axes."""


### PR DESCRIPTION

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This PR addresses [issue #28851](https://github.com/matplotlib/matplotlib/issues/28851) by refining the functionality of the Axes.clear() method to provide a clearer and more consistent definition of what "clear" means. The change was motivated by the need to resolve the ambiguity in the current behavior of this method. 
Axes.clear() now removes data-related artists only (such as Line2D, Image, and Collection).
Layout and formatting properties are retained. This allows the Axes to be reused for new data without losing its existing styling.



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #28851 " is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
