### PR TITLE
Raise warning if both c and facecolors are used in scatter plot.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4613,9 +4613,19 @@ class Axes(_AxesBase):
                 edgecolors = kwcolor
             if facecolors is None:
                 facecolors = kwcolor
-
+         
+ 
         if edgecolors is None and not mpl.rcParams['_internal.classic_mode']:
             edgecolors = mpl.rcParams['scatter.edgecolors']
+
+        # Raise a warning if both `c` and `facecolor` are set (issue #24404).
+        if c is not None and facecolors is not None:
+            _api.warn_external(
+                "You passed both c and facecolor/facecolors for the markers. "
+                "Matplotlib is ignoring the facecolor "
+                "in favor of what you specified in c. "
+                "This behavior may change in the future."
+            )
 
         c_was_none = c is None
         if c is None:


### PR DESCRIPTION
This is to fulfill @tacaswell's recommendation (at the PyData sprint I joined last week) that for a quick fix to close issue #24404, we raise a warning when such a script is attempted.
The complaint in that issue was: that if both c and facecolors args are specified for a plot's markers (specifically a scatterplot), then the facecolors arg is ignored, while a user might expect that facecolors would be used for the fill and the 'c' color would remain at the edges.
I have the code raise a warning in the style of others I saw in _axes.py : 
                "You passed both c and facecolor/facecolors for the markers. "
                "Matplotlib is ignoring the facecolor "
                "in favor of what you specified in c. "
                "This behavior may change in the future."
I am hoping that in the future we can implement c as edgecolors in that case, and we are not forced at some point to cause the plot to fail.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [✅ ]     "Resolves #24404  " is in the body of the PR description to [Resolve #24404 ](https://github.com/matplotlib/matplotlib/issues/24404)
- [✅ ]     new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A]     *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [I think N/A, but let me know.] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [I think N/A, but let me know. ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
