### PR TITLE
Creating_parse_bar_color_args to unify color handling in plt.bar with precedence and sequence support for facecolor and edgecolor

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1,8813 +1,9479 @@
-import functools
-import itertools
-import logging
-import math
-from numbers import Integral, Number, Real
+import contextlib
+from collections import namedtuple, deque
+import datetime
+from decimal import Decimal
+from functools import partial
+import gc
+import inspect
+import io
+from itertools import product
+import platform
+import sys
+from types import SimpleNamespace
 
-import re
+import dateutil.tz
+
 import numpy as np
+from numpy import ma
+from cycler import cycler
+import pytest
 
+import matplotlib
 import matplotlib as mpl
-import matplotlib.category  # Register category unit converter as side effect.
-import matplotlib.cbook as cbook
-import matplotlib.collections as mcoll
-import matplotlib.colorizer as mcolorizer
+from matplotlib import rc_context, patheffects
 import matplotlib.colors as mcolors
-import matplotlib.contour as mcontour
-import matplotlib.dates  # noqa: F401, Register date unit converter as side effect.
-import matplotlib.image as mimage
-import matplotlib.inset as minset
-import matplotlib.legend as mlegend
-import matplotlib.lines as mlines
+import matplotlib.dates as mdates
+from matplotlib.figure import Figure
+from matplotlib.axes import Axes
+from matplotlib.lines import Line2D
+from matplotlib.collections import PathCollection
+import matplotlib.font_manager as mfont_manager
 import matplotlib.markers as mmarkers
-import matplotlib.mlab as mlab
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath
-import matplotlib.quiver as mquiver
-import matplotlib.stackplot as mstack
-import matplotlib.streamplot as mstream
-import matplotlib.table as mtable
+from matplotlib.projections.geo import HammerAxes
+from matplotlib.projections.polar import PolarAxes
+import matplotlib.pyplot as plt
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
-import matplotlib.tri as mtri
-import matplotlib.units as munits
-from matplotlib import _api, _docstring, _preprocess_data
-from matplotlib.axes._base import (
-    _AxesBase, _TransformedBoundsLocator, _process_plot_format)
-from matplotlib.axes._secondary_axes import SecondaryAxis
-from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
-from matplotlib.transforms import _ScaledRotation
+import mpl_toolkits.axisartist as AA  # type: ignore[import]
+from numpy.testing import (
+    assert_allclose, assert_array_equal, assert_array_almost_equal)
+from matplotlib.testing.decorators import (
+    image_comparison, check_figures_equal, remove_ticks_and_titles)
+from matplotlib.testing._markers import needs_usetex
 
-_log = logging.getLogger(__name__)
-
-
-# The axes module contains all the wrappers to plotting functions.
-# All the other methods should go in the _AxesBase class.
+# Note: Some test cases are run twice: once normally and once with labeled data
+#       These two must be defined in the same test function or need to have
+#       different baseline images to prevent race conditions when pytest runs
+#       the tests with multiple threads.
 
 
-def _make_axes_method(func):
+@check_figures_equal(extensions=["png"])
+def test_invisible_axes(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    ax.set_visible(False)
+
+
+def test_get_labels():
+    fig, ax = plt.subplots()
+    ax.set_xlabel('x label')
+    ax.set_ylabel('y label')
+    assert ax.get_xlabel() == 'x label'
+    assert ax.get_ylabel() == 'y label'
+
+
+def test_repr():
+    fig, ax = plt.subplots()
+    ax.set_label('label')
+    ax.set_title('title')
+    ax.set_xlabel('x')
+    ax.set_ylabel('y')
+    assert repr(ax) == (
+        "<Axes: "
+        "label='label', title={'center': 'title'}, xlabel='x', ylabel='y'>")
+
+
+@check_figures_equal()
+def test_label_loc_vertical(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
+    ax.legend()
+    ax.set_ylabel('Y Label', loc='top')
+    ax.set_xlabel('X Label', loc='right')
+    cbar = fig_test.colorbar(sc)
+    cbar.set_label("Z Label", loc='top')
+
+    ax = fig_ref.subplots()
+    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
+    ax.legend()
+    ax.set_ylabel('Y Label', y=1, ha='right')
+    ax.set_xlabel('X Label', x=1, ha='right')
+    cbar = fig_ref.colorbar(sc)
+    cbar.set_label("Z Label", y=1, ha='right')
+
+
+@check_figures_equal()
+def test_label_loc_horizontal(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
+    ax.legend()
+    ax.set_ylabel('Y Label', loc='bottom')
+    ax.set_xlabel('X Label', loc='left')
+    cbar = fig_test.colorbar(sc, orientation='horizontal')
+    cbar.set_label("Z Label", loc='left')
+
+    ax = fig_ref.subplots()
+    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
+    ax.legend()
+    ax.set_ylabel('Y Label', y=0, ha='left')
+    ax.set_xlabel('X Label', x=0, ha='left')
+    cbar = fig_ref.colorbar(sc, orientation='horizontal')
+    cbar.set_label("Z Label", x=0, ha='left')
+
+
+@check_figures_equal()
+def test_label_loc_rc(fig_test, fig_ref):
+    with matplotlib.rc_context({"xaxis.labellocation": "right",
+                                "yaxis.labellocation": "top"}):
+        ax = fig_test.subplots()
+        sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
+        ax.legend()
+        ax.set_ylabel('Y Label')
+        ax.set_xlabel('X Label')
+        cbar = fig_test.colorbar(sc, orientation='horizontal')
+        cbar.set_label("Z Label")
+
+    ax = fig_ref.subplots()
+    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
+    ax.legend()
+    ax.set_ylabel('Y Label', y=1, ha='right')
+    ax.set_xlabel('X Label', x=1, ha='right')
+    cbar = fig_ref.colorbar(sc, orientation='horizontal')
+    cbar.set_label("Z Label", x=1, ha='right')
+
+
+def test_label_shift():
+    fig, ax = plt.subplots()
+
+    # Test label re-centering on x-axis
+    ax.set_xlabel("Test label", loc="left")
+    ax.set_xlabel("Test label", loc="center")
+    assert ax.xaxis.label.get_horizontalalignment() == "center"
+    ax.set_xlabel("Test label", loc="right")
+    assert ax.xaxis.label.get_horizontalalignment() == "right"
+    ax.set_xlabel("Test label", loc="center")
+    assert ax.xaxis.label.get_horizontalalignment() == "center"
+
+    # Test label re-centering on y-axis
+    ax.set_ylabel("Test label", loc="top")
+    ax.set_ylabel("Test label", loc="center")
+    assert ax.yaxis.label.get_horizontalalignment() == "center"
+    ax.set_ylabel("Test label", loc="bottom")
+    assert ax.yaxis.label.get_horizontalalignment() == "left"
+    ax.set_ylabel("Test label", loc="center")
+    assert ax.yaxis.label.get_horizontalalignment() == "center"
+
+
+@check_figures_equal(extensions=["png"])
+def test_acorr(fig_test, fig_ref):
+    np.random.seed(19680801)
+    Nx = 512
+    x = np.random.normal(0, 1, Nx).cumsum()
+    maxlags = Nx-1
+
+    ax_test = fig_test.subplots()
+    ax_test.acorr(x, maxlags=maxlags)
+
+    ax_ref = fig_ref.subplots()
+    # Normalized autocorrelation
+    norm_auto_corr = np.correlate(x, x, mode="full")/np.dot(x, x)
+    lags = np.arange(-maxlags, maxlags+1)
+    norm_auto_corr = norm_auto_corr[Nx-1-maxlags:Nx+maxlags]
+    ax_ref.vlines(lags, [0], norm_auto_corr)
+    ax_ref.axhline(y=0, xmin=0, xmax=1)
+
+
+@check_figures_equal(extensions=["png"])
+def test_acorr_integers(fig_test, fig_ref):
+    np.random.seed(19680801)
+    Nx = 51
+    x = (np.random.rand(Nx) * 10).cumsum()
+    x = (np.ceil(x)).astype(np.int64)
+    maxlags = Nx-1
+
+    ax_test = fig_test.subplots()
+    ax_test.acorr(x, maxlags=maxlags)
+
+    ax_ref = fig_ref.subplots()
+
+    # Normalized autocorrelation
+    norm_auto_corr = np.correlate(x, x, mode="full")/np.dot(x, x)
+    lags = np.arange(-maxlags, maxlags+1)
+    norm_auto_corr = norm_auto_corr[Nx-1-maxlags:Nx+maxlags]
+    ax_ref.vlines(lags, [0], norm_auto_corr)
+    ax_ref.axhline(y=0, xmin=0, xmax=1)
+
+
+@check_figures_equal(extensions=["png"])
+def test_spy(fig_test, fig_ref):
+    np.random.seed(19680801)
+    a = np.ones(32 * 32)
+    a[:16 * 32] = 0
+    np.random.shuffle(a)
+    a = a.reshape((32, 32))
+
+    axs_test = fig_test.subplots(2)
+    axs_test[0].spy(a)
+    axs_test[1].spy(a, marker=".", origin="lower")
+
+    axs_ref = fig_ref.subplots(2)
+    axs_ref[0].imshow(a, cmap="gray_r", interpolation="nearest")
+    axs_ref[0].xaxis.tick_top()
+    axs_ref[1].plot(*np.nonzero(a)[::-1], ".", markersize=10)
+    axs_ref[1].set(
+        aspect=1, xlim=axs_ref[0].get_xlim(), ylim=axs_ref[0].get_ylim()[::-1])
+    for ax in axs_ref:
+        ax.xaxis.set_ticks_position("both")
+
+
+def test_spy_invalid_kwargs():
+    fig, ax = plt.subplots()
+    for unsupported_kw in [{'interpolation': 'nearest'},
+                           {'marker': 'o', 'linestyle': 'solid'}]:
+        with pytest.raises(TypeError):
+            ax.spy(np.eye(3, 3), **unsupported_kw)
+
+
+@check_figures_equal(extensions=["png"])
+def test_matshow(fig_test, fig_ref):
+    mpl.style.use("mpl20")
+    a = np.random.rand(32, 32)
+    fig_test.add_subplot().matshow(a)
+    ax_ref = fig_ref.add_subplot()
+    ax_ref.imshow(a)
+    ax_ref.xaxis.tick_top()
+    ax_ref.xaxis.set_ticks_position('both')
+
+
+@image_comparison(['formatter_ticker_001',
+                   'formatter_ticker_002',
+                   'formatter_ticker_003',
+                   'formatter_ticker_004',
+                   'formatter_ticker_005',
+                   ],
+                  tol=0.031 if platform.machine() == 'arm64' else 0)
+def test_formatter_ticker():
+    import matplotlib.testing.jpl_units as units
+    units.register()
+
+    # This should affect the tick size.  (Tests issue #543)
+    matplotlib.rcParams['lines.markeredgewidth'] = 30
+
+    # This essentially test to see if user specified labels get overwritten
+    # by the auto labeler functionality of the axes.
+    xdata = [x*units.sec for x in range(10)]
+    ydata1 = [(1.5*y - 0.5)*units.km for y in range(10)]
+    ydata2 = [(1.75*y - 1.0)*units.km for y in range(10)]
+
+    ax = plt.figure().subplots()
+    ax.set_xlabel("x-label 001")
+
+    ax = plt.figure().subplots()
+    ax.set_xlabel("x-label 001")
+    ax.plot(xdata, ydata1, color='blue', xunits="sec")
+
+    ax = plt.figure().subplots()
+    ax.set_xlabel("x-label 001")
+    ax.plot(xdata, ydata1, color='blue', xunits="sec")
+    ax.set_xlabel("x-label 003")
+
+    ax = plt.figure().subplots()
+    ax.plot(xdata, ydata1, color='blue', xunits="sec")
+    ax.plot(xdata, ydata2, color='green', xunits="hour")
+    ax.set_xlabel("x-label 004")
+
+    # See SF bug 2846058
+    # https://sourceforge.net/tracker/?func=detail&aid=2846058&group_id=80706&atid=560720
+    ax = plt.figure().subplots()
+    ax.plot(xdata, ydata1, color='blue', xunits="sec")
+    ax.plot(xdata, ydata2, color='green', xunits="hour")
+    ax.set_xlabel("x-label 005")
+    ax.autoscale_view()
+
+
+def test_funcformatter_auto_formatter():
+    def _formfunc(x, pos):
+        return ''
+
+    ax = plt.figure().subplots()
+
+    assert ax.xaxis.isDefault_majfmt
+    assert ax.xaxis.isDefault_minfmt
+    assert ax.yaxis.isDefault_majfmt
+    assert ax.yaxis.isDefault_minfmt
+
+    ax.xaxis.set_major_formatter(_formfunc)
+
+    assert not ax.xaxis.isDefault_majfmt
+    assert ax.xaxis.isDefault_minfmt
+    assert ax.yaxis.isDefault_majfmt
+    assert ax.yaxis.isDefault_minfmt
+
+    targ_funcformatter = mticker.FuncFormatter(_formfunc)
+
+    assert isinstance(ax.xaxis.get_major_formatter(),
+                      mticker.FuncFormatter)
+
+    assert ax.xaxis.get_major_formatter().func == targ_funcformatter.func
+
+
+def test_strmethodformatter_auto_formatter():
+    formstr = '{x}_{pos}'
+
+    ax = plt.figure().subplots()
+
+    assert ax.xaxis.isDefault_majfmt
+    assert ax.xaxis.isDefault_minfmt
+    assert ax.yaxis.isDefault_majfmt
+    assert ax.yaxis.isDefault_minfmt
+
+    ax.yaxis.set_minor_formatter(formstr)
+
+    assert ax.xaxis.isDefault_majfmt
+    assert ax.xaxis.isDefault_minfmt
+    assert ax.yaxis.isDefault_majfmt
+    assert not ax.yaxis.isDefault_minfmt
+
+    targ_strformatter = mticker.StrMethodFormatter(formstr)
+
+    assert isinstance(ax.yaxis.get_minor_formatter(),
+                      mticker.StrMethodFormatter)
+
+    assert ax.yaxis.get_minor_formatter().fmt == targ_strformatter.fmt
+
+
+@image_comparison(["twin_axis_locators_formatters"])
+def test_twin_axis_locators_formatters():
+    vals = np.linspace(0, 1, num=5, endpoint=True)
+    locs = np.sin(np.pi * vals / 2.0)
+
+    majl = plt.FixedLocator(locs)
+    minl = plt.FixedLocator([0.1, 0.2, 0.3])
+
+    fig = plt.figure()
+    ax1 = fig.add_subplot(1, 1, 1)
+    ax1.plot([0.1, 100], [0, 1])
+    ax1.yaxis.set_major_locator(majl)
+    ax1.yaxis.set_minor_locator(minl)
+    ax1.yaxis.set_major_formatter(plt.FormatStrFormatter('%08.2lf'))
+    ax1.yaxis.set_minor_formatter(plt.FixedFormatter(['tricks', 'mind',
+                                                      'jedi']))
+
+    ax1.xaxis.set_major_locator(plt.LinearLocator())
+    ax1.xaxis.set_minor_locator(plt.FixedLocator([15, 35, 55, 75]))
+    ax1.xaxis.set_major_formatter(plt.FormatStrFormatter('%05.2lf'))
+    ax1.xaxis.set_minor_formatter(plt.FixedFormatter(['c', '3', 'p', 'o']))
+    ax1.twiny()
+    ax1.twinx()
+
+
+def test_twinx_cla():
+    fig, ax = plt.subplots()
+    ax2 = ax.twinx()
+    ax3 = ax2.twiny()
+    plt.draw()
+    assert not ax2.xaxis.get_visible()
+    assert not ax2.patch.get_visible()
+    ax2.cla()
+    ax3.cla()
+
+    assert not ax2.xaxis.get_visible()
+    assert not ax2.patch.get_visible()
+    assert ax2.yaxis.get_visible()
+
+    assert ax3.xaxis.get_visible()
+    assert not ax3.patch.get_visible()
+    assert not ax3.yaxis.get_visible()
+
+    assert ax.xaxis.get_visible()
+    assert ax.patch.get_visible()
+    assert ax.yaxis.get_visible()
+
+
+@pytest.mark.parametrize('twin', ('x', 'y'))
+def test_twin_units(twin):
+    axis_name = f'{twin}axis'
+    twin_func = f'twin{twin}'
+
+    a = ['0', '1']
+    b = ['a', 'b']
+
+    fig = Figure()
+    ax1 = fig.subplots()
+    ax1.plot(a, b)
+    assert getattr(ax1, axis_name).units is not None
+    ax2 = getattr(ax1, twin_func)()
+    assert getattr(ax2, axis_name).units is not None
+    assert getattr(ax2, axis_name).units is getattr(ax1, axis_name).units
+
+
+@pytest.mark.parametrize('twin', ('x', 'y'))
+@check_figures_equal(extensions=['png'], tol=0.19)
+def test_twin_logscale(fig_test, fig_ref, twin):
+    twin_func = f'twin{twin}'  # test twinx or twiny
+    set_scale = f'set_{twin}scale'
+    x = np.arange(1, 100)
+
+    # Change scale after twinning.
+    ax_test = fig_test.add_subplot(2, 1, 1)
+    ax_twin = getattr(ax_test, twin_func)()
+    getattr(ax_test, set_scale)('log')
+    ax_twin.plot(x, x)
+
+    # Twin after changing scale.
+    ax_test = fig_test.add_subplot(2, 1, 2)
+    getattr(ax_test, set_scale)('log')
+    ax_twin = getattr(ax_test, twin_func)()
+    ax_twin.plot(x, x)
+
+    for i in [1, 2]:
+        ax_ref = fig_ref.add_subplot(2, 1, i)
+        getattr(ax_ref, set_scale)('log')
+        ax_ref.plot(x, x)
+
+        # This is a hack because twinned Axes double-draw the frame.
+        # Remove this when that is fixed.
+        Path = matplotlib.path.Path
+        fig_ref.add_artist(
+            matplotlib.patches.PathPatch(
+                Path([[0, 0], [0, 1],
+                      [0, 1], [1, 1],
+                      [1, 1], [1, 0],
+                      [1, 0], [0, 0]],
+                     [Path.MOVETO, Path.LINETO] * 4),
+                transform=ax_ref.transAxes,
+                facecolor='none',
+                edgecolor=mpl.rcParams['axes.edgecolor'],
+                linewidth=mpl.rcParams['axes.linewidth'],
+                capstyle='projecting'))
+
+    remove_ticks_and_titles(fig_test)
+    remove_ticks_and_titles(fig_ref)
+
+
+@image_comparison(['twin_autoscale.png'],
+                  tol=0.009 if platform.machine() == 'arm64' else 0)
+def test_twinx_axis_scales():
+    x = np.array([0, 0.5, 1])
+    y = 0.5 * x
+    x2 = np.array([0, 1, 2])
+    y2 = 2 * x2
+
+    fig = plt.figure()
+    ax = fig.add_axes((0, 0, 1, 1), autoscalex_on=False, autoscaley_on=False)
+    ax.plot(x, y, color='blue', lw=10)
+
+    ax2 = plt.twinx(ax)
+    ax2.plot(x2, y2, 'r--', lw=5)
+
+    ax.margins(0, 0)
+    ax2.margins(0, 0)
+
+
+def test_twin_inherit_autoscale_setting():
+    fig, ax = plt.subplots()
+    ax_x_on = ax.twinx()
+    ax.set_autoscalex_on(False)
+    ax_x_off = ax.twinx()
+
+    assert ax_x_on.get_autoscalex_on()
+    assert not ax_x_off.get_autoscalex_on()
+
+    ax_y_on = ax.twiny()
+    ax.set_autoscaley_on(False)
+    ax_y_off = ax.twiny()
+
+    assert ax_y_on.get_autoscaley_on()
+    assert not ax_y_off.get_autoscaley_on()
+
+
+def test_inverted_cla():
+    # GitHub PR #5450. Setting autoscale should reset
+    # axes to be non-inverted.
+    # plotting an image, then 1d graph, axis is now down
+    fig = plt.figure(0)
+    ax = fig.gca()
+    # 1. test that a new axis is not inverted per default
+    assert not ax.xaxis_inverted()
+    assert not ax.yaxis_inverted()
+    img = np.random.random((100, 100))
+    ax.imshow(img)
+    # 2. test that a image axis is inverted
+    assert not ax.xaxis_inverted()
+    assert ax.yaxis_inverted()
+    # 3. test that clearing and plotting a line, axes are
+    # not inverted
+    ax.cla()
+    x = np.linspace(0, 2*np.pi, 100)
+    ax.plot(x, np.cos(x))
+    assert not ax.xaxis_inverted()
+    assert not ax.yaxis_inverted()
+
+    # 4. autoscaling should not bring back axes to normal
+    ax.cla()
+    ax.imshow(img)
+    plt.autoscale()
+    assert not ax.xaxis_inverted()
+    assert ax.yaxis_inverted()
+
+    for ax in fig.axes:
+        ax.remove()
+    # 5. two shared axes. Inverting the leader axis should invert the shared
+    # axes; clearing the leader axis should bring axes in shared
+    # axes back to normal.
+    ax0 = plt.subplot(211)
+    ax1 = plt.subplot(212, sharey=ax0)
+    ax0.yaxis.set_inverted(True)
+    assert ax1.yaxis_inverted()
+    ax1.plot(x, np.cos(x))
+    ax0.cla()
+    assert not ax1.yaxis_inverted()
+    ax1.cla()
+    # 6. clearing the follower should not touch limits
+    ax0.imshow(img)
+    ax1.plot(x, np.cos(x))
+    ax1.cla()
+    assert ax.yaxis_inverted()
+
+    # clean up
+    plt.close(fig)
+
+
+def test_subclass_clear_cla():
+    # Ensure that subclasses of Axes call cla/clear correctly.
+    # Note, we cannot use mocking here as we want to be sure that the
+    # superclass fallback does not recurse.
+
+    with pytest.warns(PendingDeprecationWarning,
+                      match='Overriding `Axes.cla`'):
+        class ClaAxes(Axes):
+            def cla(self):
+                nonlocal called
+                called = True
+
+    with pytest.warns(PendingDeprecationWarning,
+                      match='Overriding `Axes.cla`'):
+        class ClaSuperAxes(Axes):
+            def cla(self):
+                nonlocal called
+                called = True
+                super().cla()
+
+    class SubClaAxes(ClaAxes):
+        pass
+
+    class ClearAxes(Axes):
+        def clear(self):
+            nonlocal called
+            called = True
+
+    class ClearSuperAxes(Axes):
+        def clear(self):
+            nonlocal called
+            called = True
+            super().clear()
+
+    class SubClearAxes(ClearAxes):
+        pass
+
+    fig = Figure()
+    for axes_class in [ClaAxes, ClaSuperAxes, SubClaAxes,
+                       ClearAxes, ClearSuperAxes, SubClearAxes]:
+        called = False
+        ax = axes_class(fig, [0, 0, 1, 1])
+        # Axes.__init__ has already called clear (which aliases to cla or is in
+        # the subclass).
+        assert called
+
+        called = False
+        ax.cla()
+        assert called
+
+
+def test_cla_not_redefined_internally():
+    for klass in Axes.__subclasses__():
+        # Check that cla does not get redefined in our Axes subclasses, except
+        # for in the above test function.
+        if 'test_subclass_clear_cla' not in klass.__qualname__:
+            assert 'cla' not in klass.__dict__
+
+
+@check_figures_equal(extensions=["png"])
+def test_minorticks_on_rcParams_both(fig_test, fig_ref):
+    with matplotlib.rc_context({"xtick.minor.visible": True,
+                                "ytick.minor.visible": True}):
+        ax_test = fig_test.subplots()
+        ax_test.plot([0, 1], [0, 1])
+    ax_ref = fig_ref.subplots()
+    ax_ref.plot([0, 1], [0, 1])
+    ax_ref.minorticks_on()
+
+
+@image_comparison(["autoscale_tiny_range"], remove_text=True)
+def test_autoscale_tiny_range():
+    # github pull #904
+    fig, axs = plt.subplots(2, 2)
+    for i, ax in enumerate(axs.flat):
+        y1 = 10**(-11 - i)
+        ax.plot([0, 1], [1, 1 + y1])
+
+
+@mpl.style.context('default')
+def test_autoscale_tight():
+    fig, ax = plt.subplots(1, 1)
+    ax.plot([1, 2, 3, 4])
+    ax.autoscale(enable=True, axis='x', tight=False)
+    ax.autoscale(enable=True, axis='y', tight=True)
+    assert_allclose(ax.get_xlim(), (-0.15, 3.15))
+    assert_allclose(ax.get_ylim(), (1.0, 4.0))
+
+    # Check that autoscale is on
+    assert ax.get_autoscalex_on()
+    assert ax.get_autoscaley_on()
+    assert ax.get_autoscale_on()
+    # Set enable to None
+    ax.autoscale(enable=None)
+    # Same limits
+    assert_allclose(ax.get_xlim(), (-0.15, 3.15))
+    assert_allclose(ax.get_ylim(), (1.0, 4.0))
+    # autoscale still on
+    assert ax.get_autoscalex_on()
+    assert ax.get_autoscaley_on()
+    assert ax.get_autoscale_on()
+
+
+@mpl.style.context('default')
+def test_autoscale_log_shared():
+    # related to github #7587
+    # array starts at zero to trigger _minpos handling
+    x = np.arange(100, dtype=float)
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    ax1.loglog(x, x)
+    ax2.semilogx(x, x)
+    ax1.autoscale(tight=True)
+    ax2.autoscale(tight=True)
+    plt.draw()
+    lims = (x[1], x[-1])
+    assert_allclose(ax1.get_xlim(), lims)
+    assert_allclose(ax1.get_ylim(), lims)
+    assert_allclose(ax2.get_xlim(), lims)
+    assert_allclose(ax2.get_ylim(), (x[0], x[-1]))
+
+
+@mpl.style.context('default')
+def test_use_sticky_edges():
+    fig, ax = plt.subplots()
+    ax.imshow([[0, 1], [2, 3]], origin='lower')
+    assert_allclose(ax.get_xlim(), (-0.5, 1.5))
+    assert_allclose(ax.get_ylim(), (-0.5, 1.5))
+    ax.use_sticky_edges = False
+    ax.autoscale()
+    xlim = (-0.5 - 2 * ax._xmargin, 1.5 + 2 * ax._xmargin)
+    ylim = (-0.5 - 2 * ax._ymargin, 1.5 + 2 * ax._ymargin)
+    assert_allclose(ax.get_xlim(), xlim)
+    assert_allclose(ax.get_ylim(), ylim)
+    # Make sure it is reversible:
+    ax.use_sticky_edges = True
+    ax.autoscale()
+    assert_allclose(ax.get_xlim(), (-0.5, 1.5))
+    assert_allclose(ax.get_ylim(), (-0.5, 1.5))
+
+
+@check_figures_equal(extensions=["png"])
+def test_sticky_shared_axes(fig_test, fig_ref):
+    # Check that sticky edges work whether they are set in an Axes that is a
+    # "leader" in a share, or an Axes that is a "follower".
+    Z = np.arange(15).reshape(3, 5)
+
+    ax0 = fig_test.add_subplot(211)
+    ax1 = fig_test.add_subplot(212, sharex=ax0)
+    ax1.pcolormesh(Z)
+
+    ax0 = fig_ref.add_subplot(212)
+    ax1 = fig_ref.add_subplot(211, sharex=ax0)
+    ax0.pcolormesh(Z)
+
+
+@image_comparison(['sticky_tolerance.png'], remove_text=True, style="mpl20")
+def test_sticky_tolerance():
+    fig, axs = plt.subplots(2, 2)
+
+    width = .1
+
+    axs.flat[0].bar(x=0, height=width, bottom=20000.6)
+    axs.flat[0].bar(x=1, height=width, bottom=20000.1)
+
+    axs.flat[1].bar(x=0, height=-width, bottom=20000.6)
+    axs.flat[1].bar(x=1, height=-width, bottom=20000.1)
+
+    axs.flat[2].barh(y=0, width=-width, left=-20000.6)
+    axs.flat[2].barh(y=1, width=-width, left=-20000.1)
+
+    axs.flat[3].barh(y=0, width=width, left=-20000.6)
+    axs.flat[3].barh(y=1, width=width, left=-20000.1)
+
+
+@image_comparison(['sticky_tolerance_cf.png'], remove_text=True, style="mpl20")
+def test_sticky_tolerance_contourf():
+    fig, ax = plt.subplots()
+
+    x = y = [14496.71, 14496.75]
+    data = [[0, 1], [2, 3]]
+
+    ax.contourf(x, y, data)
+
+
+def test_nargs_stem():
+    with pytest.raises(TypeError, match='0 were given'):
+        # stem() takes 1-3 arguments.
+        plt.stem()
+
+
+def test_nargs_legend():
+    with pytest.raises(TypeError, match='3 were given'):
+        ax = plt.subplot()
+        # legend() takes 0-2 arguments.
+        ax.legend(['First'], ['Second'], 3)
+
+
+def test_nargs_pcolorfast():
+    with pytest.raises(TypeError, match='2 were given'):
+        ax = plt.subplot()
+        # pcolorfast() takes 1 or 3 arguments,
+        # not passing any arguments fails at C = args[-1]
+        # before nargs_err is raised.
+        ax.pcolorfast([(0, 1), (0, 2)], [[1, 2, 3], [1, 2, 3]])
+
+
+@image_comparison(['offset_points'], remove_text=True)
+def test_basic_annotate():
+    # Setup some data
+    t = np.arange(0.0, 5.0, 0.01)
+    s = np.cos(2.0*np.pi * t)
+
+    # Offset Points
+
+    fig = plt.figure()
+    ax = fig.add_subplot(autoscale_on=False, xlim=(-1, 5), ylim=(-3, 5))
+    line, = ax.plot(t, s, lw=3, color='purple')
+
+    ax.annotate('local max', xy=(3, 1), xycoords='data',
+                xytext=(3, 3), textcoords='offset points')
+
+
+@image_comparison(['arrow_simple.png'], remove_text=True)
+def test_arrow_simple():
+    # Simple image test for ax.arrow
+    # kwargs that take discrete values
+    length_includes_head = (True, False)
+    shape = ('full', 'left', 'right')
+    head_starts_at_zero = (True, False)
+    # Create outer product of values
+    kwargs = product(length_includes_head, shape, head_starts_at_zero)
+
+    fig, axs = plt.subplots(3, 4)
+    for i, (ax, kwarg) in enumerate(zip(axs.flat, kwargs)):
+        ax.set_xlim(-2, 2)
+        ax.set_ylim(-2, 2)
+        # Unpack kwargs
+        (length_includes_head, shape, head_starts_at_zero) = kwarg
+        theta = 2 * np.pi * i / 12
+        # Draw arrow
+        ax.arrow(0, 0, np.sin(theta), np.cos(theta),
+                 width=theta/100,
+                 length_includes_head=length_includes_head,
+                 shape=shape,
+                 head_starts_at_zero=head_starts_at_zero,
+                 head_width=theta / 10,
+                 head_length=theta / 10)
+
+
+def test_arrow_empty():
+    _, ax = plt.subplots()
+    # Create an empty FancyArrow
+    ax.arrow(0, 0, 0, 0, head_length=0)
+
+
+def test_arrow_in_view():
+    _, ax = plt.subplots()
+    ax.arrow(1, 1, 1, 1)
+    assert ax.get_xlim() == (0.8, 2.2)
+    assert ax.get_ylim() == (0.8, 2.2)
+
+
+def test_annotate_default_arrow():
+    # Check that we can make an annotation arrow with only default properties.
+    fig, ax = plt.subplots()
+    ann = ax.annotate("foo", (0, 1), xytext=(2, 3))
+    assert ann.arrow_patch is None
+    ann = ax.annotate("foo", (0, 1), xytext=(2, 3), arrowprops={})
+    assert ann.arrow_patch is not None
+
+
+def test_annotate_signature():
+    """Check that the signature of Axes.annotate() matches Annotation."""
+    fig, ax = plt.subplots()
+    annotate_params = inspect.signature(ax.annotate).parameters
+    annotation_params = inspect.signature(mtext.Annotation).parameters
+    assert list(annotate_params.keys()) == list(annotation_params.keys())
+    for p1, p2 in zip(annotate_params.values(), annotation_params.values()):
+        assert p1 == p2
+
+
+@image_comparison(['fill_units.png'], savefig_kwarg={'dpi': 60})
+def test_fill_units():
+    import matplotlib.testing.jpl_units as units
+    units.register()
+
+    # generate some data
+    t = units.Epoch("ET", dt=datetime.datetime(2009, 4, 27))
+    value = 10.0 * units.deg
+    day = units.Duration("ET", 24.0 * 60.0 * 60.0)
+    dt = np.arange('2009-04-27', '2009-04-29', dtype='datetime64[D]')
+    dtn = mdates.date2num(dt)
+
+    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
+
+    ax1.plot([t], [value], yunits='deg', color='red')
+    ind = [0, 0, 1, 1]
+    ax1.fill(dtn[ind], [0.0, 0.0, 90.0, 0.0], 'b')
+
+    ax2.plot([t], [value], yunits='deg', color='red')
+    ax2.fill([t, t, t + day, t + day],
+             [0.0, 0.0, 90.0, 0.0], 'b')
+
+    ax3.plot([t], [value], yunits='deg', color='red')
+    ax3.fill(dtn[ind],
+             [0 * units.deg, 0 * units.deg, 90 * units.deg, 0 * units.deg],
+             'b')
+
+    ax4.plot([t], [value], yunits='deg', color='red')
+    ax4.fill([t, t, t + day, t + day],
+             [0 * units.deg, 0 * units.deg, 90 * units.deg, 0 * units.deg],
+             facecolor="blue")
+    fig.autofmt_xdate()
+
+
+def test_plot_format_kwarg_redundant():
+    with pytest.warns(UserWarning, match="marker .* redundantly defined"):
+        plt.plot([0], [0], 'o', marker='x')
+    with pytest.warns(UserWarning, match="linestyle .* redundantly defined"):
+        plt.plot([0], [0], '-', linestyle='--')
+    with pytest.warns(UserWarning, match="color .* redundantly defined"):
+        plt.plot([0], [0], 'r', color='blue')
+    # smoke-test: should not warn
+    plt.errorbar([0], [0], fmt='none', color='blue')
+
+
+@check_figures_equal(extensions=["png"])
+def test_errorbar_dashes(fig_test, fig_ref):
+    x = [1, 2, 3, 4]
+    y = np.sin(x)
+
+    ax_ref = fig_ref.gca()
+    ax_test = fig_test.gca()
+
+    line, *_ = ax_ref.errorbar(x, y, xerr=np.abs(y), yerr=np.abs(y))
+    line.set_dashes([2, 2])
+
+    ax_test.errorbar(x, y, xerr=np.abs(y), yerr=np.abs(y), dashes=[2, 2])
+
+
+def test_errorbar_mapview_kwarg():
+    D = {ii: ii for ii in range(10)}
+    fig, ax = plt.subplots()
+    ax.errorbar(x=D.keys(), y=D.values(), xerr=D.values())
+
+
+@image_comparison(['single_point', 'single_point'])
+def test_single_point():
+    # Issue #1796: don't let lines.marker affect the grid
+    matplotlib.rcParams['lines.marker'] = 'o'
+    matplotlib.rcParams['axes.grid'] = True
+
+    fig, (ax1, ax2) = plt.subplots(2)
+    ax1.plot([0], [0], 'o')
+    ax2.plot([1], [1], 'o')
+
+    # Reuse testcase from above for a labeled data test
+    data = {'a': [0], 'b': [1]}
+
+    fig, (ax1, ax2) = plt.subplots(2)
+    ax1.plot('a', 'a', 'o', data=data)
+    ax2.plot('b', 'b', 'o', data=data)
+
+
+@image_comparison(['single_date.png'], style='mpl20')
+def test_single_date():
+
+    # use former defaults to match existing baseline image
+    plt.rcParams['axes.formatter.limits'] = -7, 7
+    dt = mdates.date2num(np.datetime64('0000-12-31'))
+
+    time1 = [721964.0]
+    data1 = [-65.54]
+
+    fig, ax = plt.subplots(2, 1)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        ax[0].plot_date(time1 + dt, data1, 'o', color='r')
+    ax[1].plot(time1, data1, 'o', color='r')
+
+
+@check_figures_equal(extensions=["png"])
+def test_shaped_data(fig_test, fig_ref):
+    row = np.arange(10).reshape((1, -1))
+    col = np.arange(0, 100, 10).reshape((-1, 1))
+
+    axs = fig_test.subplots(2)
+    axs[0].plot(row)  # Actually plots nothing (columns are single points).
+    axs[1].plot(col)  # Same as plotting 1d.
+
+    axs = fig_ref.subplots(2)
+    # xlim from the implicit "x=0", ylim from the row datalim.
+    axs[0].set(xlim=(-.06, .06), ylim=(0, 9))
+    axs[1].plot(col.ravel())
+
+
+def test_structured_data():
+    # support for structured data
+    pts = np.array([(1, 1), (2, 2)], dtype=[("ones", float), ("twos", float)])
+
+    # this should not read second name as a format and raise ValueError
+    axs = plt.figure().subplots(2)
+    axs[0].plot("ones", "twos", data=pts)
+    axs[1].plot("ones", "twos", "r", data=pts)
+
+
+@image_comparison(['aitoff_proj'], extensions=["png"],
+                  remove_text=True, style='mpl20')
+def test_aitoff_proj():
     """
-    Patch the qualname for functions that are directly added to Axes.
-
-    Some Axes functionality is defined in functions in other submodules.
-    These are simply added as attributes to Axes. As a result, their
-    ``__qualname__`` is e.g. only "table" and not "Axes.table". This
-    function fixes that.
-
-    Note that the function itself is patched, so that
-    ``matplotlib.table.table.__qualname__` will also show "Axes.table".
-    However, since these functions are not intended to be standalone,
-    this is bearable.
+    Test aitoff projection ref.:
+    https://github.com/matplotlib/matplotlib/pull/14451
     """
-    func.__qualname__ = f"Axes.{func.__name__}"
-    return func
+    x = np.linspace(-np.pi, np.pi, 20)
+    y = np.linspace(-np.pi / 2, np.pi / 2, 20)
+    X, Y = np.meshgrid(x, y)
+
+    fig, ax = plt.subplots(figsize=(8, 4.2),
+                           subplot_kw=dict(projection="aitoff"))
+    ax.grid()
+    ax.plot(X.flat, Y.flat, 'o', markersize=4)
 
 
-@_docstring.interpd
-class Axes(_AxesBase):
+@image_comparison(['axvspan_epoch'])
+def test_axvspan_epoch():
+    import matplotlib.testing.jpl_units as units
+    units.register()
+
+    # generate some data
+    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
+    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 22))
+    dt = units.Duration("ET", units.day.convert("sec"))
+
+    ax = plt.gca()
+    ax.axvspan(t0, tf, facecolor="blue", alpha=0.25)
+    ax.set_xlim(t0 - 5.0*dt, tf + 5.0*dt)
+
+
+@image_comparison(['axhspan_epoch'], tol=0.02)
+def test_axhspan_epoch():
+    import matplotlib.testing.jpl_units as units
+    units.register()
+
+    # generate some data
+    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
+    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 22))
+    dt = units.Duration("ET", units.day.convert("sec"))
+
+    ax = plt.gca()
+    ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
+    ax.set_ylim(t0 - 5.0*dt, tf + 5.0*dt)
+
+
+@image_comparison(['hexbin_extent.png', 'hexbin_extent.png'], remove_text=True)
+def test_hexbin_extent():
+    # this test exposes sf bug 2856228
+    fig, ax = plt.subplots()
+    data = (np.arange(2000) / 2000).reshape((2, 1000))
+    x, y = data
+
+    ax.hexbin(x, y, extent=[.1, .3, .6, .7])
+
+    # Reuse testcase from above for a labeled data test
+    data = {"x": x, "y": y}
+
+    fig, ax = plt.subplots()
+    ax.hexbin("x", "y", extent=[.1, .3, .6, .7], data=data)
+
+
+def test_hexbin_bad_extents():
+    fig, ax = plt.subplots()
+    data = (np.arange(20) / 20).reshape((2, 10))
+    x, y = data
+
+    with pytest.raises(ValueError, match="In extent, xmax must be greater than xmin"):
+        ax.hexbin(x, y, extent=(1, 0, 0, 1))
+
+    with pytest.raises(ValueError, match="In extent, ymax must be greater than ymin"):
+        ax.hexbin(x, y, extent=(0, 1, 1, 0))
+
+
+def test_hexbin_string_norm():
+    fig, ax = plt.subplots()
+    hex = ax.hexbin(np.random.rand(10), np.random.rand(10), norm="log", vmin=2, vmax=5)
+    assert isinstance(hex, matplotlib.collections.PolyCollection)
+    assert isinstance(hex.norm, matplotlib.colors.LogNorm)
+    assert hex.norm.vmin == 2
+    assert hex.norm.vmax == 5
+
+
+@image_comparison(['hexbin_empty.png'], remove_text=True)
+def test_hexbin_empty():
+    # From #3886: creating hexbin from empty dataset raises ValueError
+    fig, ax = plt.subplots()
+    ax.hexbin([], [])
+    # From #23922: creating hexbin with log scaling from empty
+    # dataset raises ValueError
+    ax.hexbin([], [], bins='log')
+    # From #27103: np.max errors when handed empty data
+    ax.hexbin([], [], C=[], reduce_C_function=np.max)
+    # No string-comparison warning from NumPy.
+    ax.hexbin([], [], bins=np.arange(10))
+
+
+def test_hexbin_pickable():
+    # From #1973: Test that picking a hexbin collection works
+    fig, ax = plt.subplots()
+    data = (np.arange(200) / 200).reshape((2, 100))
+    x, y = data
+    hb = ax.hexbin(x, y, extent=[.1, .3, .6, .7], picker=-1)
+    mouse_event = SimpleNamespace(x=400, y=300)
+    assert hb.contains(mouse_event)[0]
+
+
+@image_comparison(['hexbin_log.png'], style='mpl20')
+def test_hexbin_log():
+    # Issue #1636 (and also test log scaled colorbar)
+
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
+    np.random.seed(19680801)
+    n = 100000
+    x = np.random.standard_normal(n)
+    y = 2.0 + 3.0 * x + 4.0 * np.random.standard_normal(n)
+    y = np.power(2, y * 0.5)
+
+    fig, ax = plt.subplots()
+    h = ax.hexbin(x, y, yscale='log', bins='log',
+                  marginals=True, reduce_C_function=np.sum)
+    plt.colorbar(h)
+
+    # Make sure offsets are set
+    assert h.get_offsets().shape == (11558, 2)
+
+
+def test_hexbin_log_offsets():
+    x = np.geomspace(1, 100, 500)
+
+    fig, ax = plt.subplots()
+    h = ax.hexbin(x, x, xscale='log', yscale='log', gridsize=2)
+    np.testing.assert_almost_equal(
+        h.get_offsets(),
+        np.array(
+            [[0, 0],
+             [0, 2],
+             [1, 0],
+             [1, 2],
+             [2, 0],
+             [2, 2],
+             [0.5, 1],
+             [1.5, 1]]))
+
+
+@image_comparison(["hexbin_linear.png"], style="mpl20", remove_text=True)
+def test_hexbin_linear():
+    # Issue #21165
+    np.random.seed(19680801)
+    n = 100000
+    x = np.random.standard_normal(n)
+    y = 2.0 + 3.0 * x + 4.0 * np.random.standard_normal(n)
+
+    fig, ax = plt.subplots()
+    ax.hexbin(x, y, gridsize=(10, 5), marginals=True,
+              reduce_C_function=np.sum)
+
+
+def test_hexbin_log_clim():
+    x, y = np.arange(200).reshape((2, 100))
+    fig, ax = plt.subplots()
+    h = ax.hexbin(x, y, bins='log', vmin=2, vmax=100)
+    assert h.get_clim() == (2, 100)
+
+
+@check_figures_equal(extensions=['png'])
+def test_hexbin_mincnt_behavior_upon_C_parameter(fig_test, fig_ref):
+    # see: gh:12926
+    datapoints = [
+        # list of (x, y)
+        (0, 0),
+        (0, 0),
+        (6, 0),
+        (0, 6),
+    ]
+    X, Y = zip(*datapoints)
+    C = [1] * len(X)
+    extent = [-10., 10, -10., 10]
+    gridsize = (7, 7)
+
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+
+    # without C parameter
+    ax_ref.hexbin(
+        X, Y,
+        extent=extent,
+        gridsize=gridsize,
+        mincnt=1,
+    )
+    ax_ref.set_facecolor("green")  # for contrast of background
+
+    # with C parameter
+    ax_test.hexbin(
+        X, Y,
+        C=[1] * len(X),
+        reduce_C_function=lambda v: sum(v),
+        mincnt=1,
+        extent=extent,
+        gridsize=gridsize,
+    )
+    ax_test.set_facecolor("green")
+
+
+def test_inverted_limits():
+    # Test gh:1553
+    # Calling invert_xaxis prior to plotting should not disable autoscaling
+    # while still maintaining the inverted direction
+    fig, ax = plt.subplots()
+    ax.invert_xaxis()
+    ax.plot([-5, -3, 2, 4], [1, 2, -3, 5])
+
+    assert ax.get_xlim() == (4, -5)
+    assert ax.get_ylim() == (-3, 5)
+    plt.close()
+
+    fig, ax = plt.subplots()
+    ax.invert_yaxis()
+    ax.plot([-5, -3, 2, 4], [1, 2, -3, 5])
+
+    assert ax.get_xlim() == (-5, 4)
+    assert ax.get_ylim() == (5, -3)
+
+    # Test inverting nonlinear axes.
+    fig, ax = plt.subplots()
+    ax.set_yscale("log")
+    ax.set_ylim(10, 1)
+    assert ax.get_ylim() == (10, 1)
+
+
+@image_comparison(['nonfinite_limits'])
+def test_nonfinite_limits():
+    x = np.arange(0., np.e, 0.01)
+    # silence divide by zero warning from log(0)
+    with np.errstate(divide='ignore'):
+        y = np.log(x)
+    x[len(x)//2] = np.nan
+    fig, ax = plt.subplots()
+    ax.plot(x, y)
+
+
+@mpl.style.context('default')
+@pytest.mark.parametrize('plot_fun',
+                         ['scatter', 'plot', 'fill_between'])
+@check_figures_equal(extensions=["png"])
+def test_limits_empty_data(plot_fun, fig_test, fig_ref):
+    # Check that plotting empty data doesn't change autoscaling of dates
+    x = np.arange("2010-01-01", "2011-01-01", dtype="datetime64[D]")
+
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+
+    getattr(ax_test, plot_fun)([], [])
+
+    for ax in [ax_test, ax_ref]:
+        getattr(ax, plot_fun)(x, range(len(x)), color='C0')
+
+
+@image_comparison(['imshow', 'imshow'], remove_text=True, style='mpl20')
+def test_imshow():
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+    # Create a NxN image
+    N = 100
+    (x, y) = np.indices((N, N))
+    x -= N//2
+    y -= N//2
+    r = np.sqrt(x**2+y**2-x*y)
+
+    # Create a contour plot at N/4 and extract both the clip path and transform
+    fig, ax = plt.subplots()
+    ax.imshow(r)
+
+    # Reuse testcase from above for a labeled data test
+    data = {"r": r}
+    fig, ax = plt.subplots()
+    ax.imshow("r", data=data)
+
+
+@image_comparison(
+    ['imshow_clip'], style='mpl20',
+    tol=1.24 if platform.machine() in ('aarch64', 'arm64', 'ppc64le', 's390x') else 0)
+def test_imshow_clip():
+    # As originally reported by Gellule Xg <gellule.xg@free.fr>
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
+    # Create a NxN image
+    N = 100
+    (x, y) = np.indices((N, N))
+    x -= N//2
+    y -= N//2
+    r = np.sqrt(x**2+y**2-x*y)
+
+    # Create a contour plot at N/4 and extract both the clip path and transform
+    fig, ax = plt.subplots()
+
+    c = ax.contour(r, [N/4])
+    clip_path = mtransforms.TransformedPath(c.get_paths()[0], c.get_transform())
+
+    # Plot the image clipped by the contour
+    ax.imshow(r, clip_path=clip_path)
+
+
+def test_imshow_norm_vminvmax():
+    """Parameters vmin, vmax should error if norm is given."""
+    a = [[1, 2], [3, 4]]
+    ax = plt.axes()
+    with pytest.raises(ValueError,
+                       match="Passing a Normalize instance simultaneously "
+                             "with vmin/vmax is not supported."):
+        ax.imshow(a, norm=mcolors.Normalize(-10, 10), vmin=0, vmax=5)
+
+
+@image_comparison(['polycollection_joinstyle'], remove_text=True)
+def test_polycollection_joinstyle():
+    # Bug #2890979 reported by Matthew West
+    fig, ax = plt.subplots()
+    verts = np.array([[1, 1], [1, 2], [2, 2], [2, 1]])
+    c = mpl.collections.PolyCollection([verts], linewidths=40)
+    ax.add_collection(c)
+    ax.set_xbound(0, 3)
+    ax.set_ybound(0, 3)
+
+
+@pytest.mark.parametrize(
+    'x, y1, y2', [
+        (np.zeros((2, 2)), 3, 3),
+        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
+        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ], ids=[
+        '2d_x_input',
+        '2d_y1_input',
+        '2d_y2_input'
+    ]
+)
+def test_fill_between_input(x, y1, y2):
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.fill_between(x, y1, y2)
+
+
+@pytest.mark.parametrize(
+    'y, x1, x2', [
+        (np.zeros((2, 2)), 3, 3),
+        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
+        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
+    ], ids=[
+        '2d_y_input',
+        '2d_x1_input',
+        '2d_x2_input'
+    ]
+)
+def test_fill_betweenx_input(y, x1, x2):
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.fill_betweenx(y, x1, x2)
+
+
+@image_comparison(['fill_between_interpolate'], remove_text=True,
+                  tol=0.012 if platform.machine() == 'arm64' else 0)
+def test_fill_between_interpolate():
+    x = np.arange(0.0, 2, 0.02)
+    y1 = np.sin(2*np.pi*x)
+    y2 = 1.2*np.sin(4*np.pi*x)
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
+    ax1.plot(x, y1, x, y2, color='black')
+    ax1.fill_between(x, y1, y2, where=y2 >= y1, facecolor='white', hatch='/',
+                     interpolate=True)
+    ax1.fill_between(x, y1, y2, where=y2 <= y1, facecolor='red',
+                     interpolate=True)
+
+    # Test support for masked arrays.
+    y2 = np.ma.masked_greater(y2, 1.0)
+    # Test that plotting works for masked arrays with the first element masked
+    y2[0] = np.ma.masked
+    ax2.plot(x, y1, x, y2, color='black')
+    ax2.fill_between(x, y1, y2, where=y2 >= y1, facecolor='green',
+                     interpolate=True)
+    ax2.fill_between(x, y1, y2, where=y2 <= y1, facecolor='red',
+                     interpolate=True)
+
+
+@image_comparison(['fill_between_interpolate_decreasing'],
+                  style='mpl20', remove_text=True)
+def test_fill_between_interpolate_decreasing():
+    p = np.array([724.3, 700, 655])
+    t = np.array([9.4, 7, 2.2])
+    prof = np.array([7.9, 6.6, 3.8])
+
+    fig, ax = plt.subplots(figsize=(9, 9))
+
+    ax.plot(t, p, 'tab:red')
+    ax.plot(prof, p, 'k')
+
+    ax.fill_betweenx(p, t, prof, where=prof < t,
+                     facecolor='blue', interpolate=True, alpha=0.4)
+    ax.fill_betweenx(p, t, prof, where=prof > t,
+                     facecolor='red', interpolate=True, alpha=0.4)
+
+    ax.set_xlim(0, 30)
+    ax.set_ylim(800, 600)
+
+
+@image_comparison(['fill_between_interpolate_nan'], remove_text=True)
+def test_fill_between_interpolate_nan():
+    # Tests fix for issue #18986.
+    x = np.arange(10)
+    y1 = np.asarray([8, 18, np.nan, 18, 8, 18, 24, 18, 8, 18])
+    y2 = np.asarray([18, 11, 8, 11, 18, 26, 32, 30, np.nan, np.nan])
+
+    fig, ax = plt.subplots()
+
+    ax.plot(x, y1, c='k')
+    ax.plot(x, y2, c='b')
+    ax.fill_between(x, y1, y2, where=y2 >= y1, facecolor="green",
+                    interpolate=True, alpha=0.5)
+    ax.fill_between(x, y1, y2, where=y1 >= y2, facecolor="red",
+                    interpolate=True, alpha=0.5)
+
+
+# test_symlog and test_symlog2 used to have baseline images in all three
+# formats, but the png and svg baselines got invalidated by the removal of
+# minor tick overstriking.
+@image_comparison(['symlog.pdf'])
+def test_symlog():
+    x = np.array([0, 1, 2, 4, 6, 9, 12, 24])
+    y = np.array([1000000, 500000, 100000, 100, 5, 0, 0, 0])
+
+    fig, ax = plt.subplots()
+    ax.plot(x, y)
+    ax.set_yscale('symlog')
+    ax.set_xscale('linear')
+    ax.set_ylim(-1, 10000000)
+
+
+@image_comparison(['symlog2.pdf'], remove_text=True)
+def test_symlog2():
+    # Numbers from -50 to 50, with 0.1 as step
+    x = np.arange(-50, 50, 0.001)
+
+    fig, axs = plt.subplots(5, 1)
+    for ax, linthresh in zip(axs, [20., 2., 1., 0.1, 0.01]):
+        ax.plot(x, x)
+        ax.set_xscale('symlog', linthresh=linthresh)
+        ax.grid(True)
+    axs[-1].set_ylim(-0.1, 0.1)
+
+
+def test_pcolorargs_5205():
+    # Smoketest to catch issue found in gh:5205
+    x = [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5]
+    y = [-1.5, -1.25, -1.0, -0.75, -0.5, -0.25, 0,
+         0.25, 0.5, 0.75, 1.0, 1.25, 1.5]
+    X, Y = np.meshgrid(x, y)
+    Z = np.hypot(X, Y)
+
+    plt.pcolor(Z)
+    plt.pcolor(list(Z))
+    plt.pcolor(x, y, Z[:-1, :-1])
+    plt.pcolor(X, Y, list(Z[:-1, :-1]))
+
+
+@image_comparison(['pcolormesh'], remove_text=True)
+def test_pcolormesh():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
+    n = 12
+    x = np.linspace(-1.5, 1.5, n)
+    y = np.linspace(-1.5, 1.5, n*2)
+    X, Y = np.meshgrid(x, y)
+    Qx = np.cos(Y) - np.cos(X)
+    Qz = np.sin(Y) + np.sin(X)
+    Qx = (Qx + 1.1)
+    Z = np.hypot(X, Y) / 5
+    Z = (Z - Z.min()) / np.ptp(Z)
+
+    # The color array can include masked values:
+    Zm = ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
+
+    _, (ax1, ax2, ax3) = plt.subplots(1, 3)
+    ax1.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=0.5, edgecolors='k')
+    ax2.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=2, edgecolors=['b', 'w'])
+    ax3.pcolormesh(Qx, Qz, Zm, shading="gouraud")
+
+
+@image_comparison(['pcolormesh_small'], extensions=["eps"])
+def test_pcolormesh_small():
+    n = 3
+    x = np.linspace(-1.5, 1.5, n)
+    y = np.linspace(-1.5, 1.5, n*2)
+    X, Y = np.meshgrid(x, y)
+    Qx = np.cos(Y) - np.cos(X)
+    Qz = np.sin(Y) + np.sin(X)
+    Qx = (Qx + 1.1)
+    Z = np.hypot(X, Y) / 5
+    Z = (Z - Z.min()) / np.ptp(Z)
+    Zm = ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
+    Zm2 = ma.masked_where(Qz < -0.5 * np.max(Qz), Z)
+
+    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
+    ax1.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=0.5, edgecolors='k')
+    ax2.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=2, edgecolors=['b', 'w'])
+    # gouraud with Zm yields a blank plot; there are no unmasked triangles.
+    ax3.pcolormesh(Qx, Qz, Zm, shading="gouraud")
+    # Reduce the masking to get a plot.
+    ax4.pcolormesh(Qx, Qz, Zm2, shading="gouraud")
+
+    for ax in fig.axes:
+        ax.set_axis_off()
+
+
+@image_comparison(['pcolormesh_alpha'], extensions=["png", "pdf"],
+                  remove_text=True)
+def test_pcolormesh_alpha():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
+    n = 12
+    X, Y = np.meshgrid(
+        np.linspace(-1.5, 1.5, n),
+        np.linspace(-1.5, 1.5, n*2)
+    )
+    Qx = X
+    Qy = Y + np.sin(X)
+    Z = np.hypot(X, Y) / 5
+    Z = (Z - Z.min()) / np.ptp(Z)
+    vir = mpl.colormaps["viridis"].resampled(16)
+    # make another colormap with varying alpha
+    colors = vir(np.arange(16))
+    colors[:, 3] = 0.5 + 0.5*np.sin(np.arange(16))
+    cmap = mcolors.ListedColormap(colors)
+
+    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
+    for ax in ax1, ax2, ax3, ax4:
+        ax.add_patch(mpatches.Rectangle(
+            (0, -1.5), 1.5, 3, facecolor=[.7, .1, .1, .5], zorder=0
+        ))
+    # ax1, ax2: constant alpha
+    ax1.pcolormesh(Qx, Qy, Z[:-1, :-1], cmap=vir, alpha=0.4,
+                   shading='flat', zorder=1)
+    ax2.pcolormesh(Qx, Qy, Z, cmap=vir, alpha=0.4, shading='gouraud', zorder=1)
+    # ax3, ax4: alpha from colormap
+    ax3.pcolormesh(Qx, Qy, Z[:-1, :-1], cmap=cmap, shading='flat', zorder=1)
+    ax4.pcolormesh(Qx, Qy, Z, cmap=cmap, shading='gouraud', zorder=1)
+
+
+@pytest.mark.parametrize("dims,alpha", [(3, 1), (4, 0.5)])
+@check_figures_equal(extensions=["png"])
+def test_pcolormesh_rgba(fig_test, fig_ref, dims, alpha):
+    ax = fig_test.subplots()
+    c = np.ones((5, 6, dims), dtype=float) / 2
+    ax.pcolormesh(c)
+
+    ax = fig_ref.subplots()
+    ax.pcolormesh(c[..., 0], cmap="gray", vmin=0, vmax=1, alpha=alpha)
+
+
+@image_comparison(['pcolormesh_datetime_axis.png'], style='mpl20')
+def test_pcolormesh_datetime_axis():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
+    fig = plt.figure()
+    fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
+    base = datetime.datetime(2013, 1, 1)
+    x = np.array([base + datetime.timedelta(days=d) for d in range(21)])
+    y = np.arange(21)
+    z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
+    z = z1 * z2
+    plt.subplot(221)
+    plt.pcolormesh(x[:-1], y[:-1], z[:-1, :-1])
+    plt.subplot(222)
+    plt.pcolormesh(x, y, z)
+    x = np.repeat(x[np.newaxis], 21, axis=0)
+    y = np.repeat(y[:, np.newaxis], 21, axis=1)
+    plt.subplot(223)
+    plt.pcolormesh(x[:-1, :-1], y[:-1, :-1], z[:-1, :-1])
+    plt.subplot(224)
+    plt.pcolormesh(x, y, z)
+    for ax in fig.get_axes():
+        for label in ax.get_xticklabels():
+            label.set_ha('right')
+            label.set_rotation(30)
+
+
+@image_comparison(['pcolor_datetime_axis.png'], style='mpl20')
+def test_pcolor_datetime_axis():
+    fig = plt.figure()
+    fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
+    base = datetime.datetime(2013, 1, 1)
+    x = np.array([base + datetime.timedelta(days=d) for d in range(21)])
+    y = np.arange(21)
+    z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
+    z = z1 * z2
+    plt.subplot(221)
+    plt.pcolor(x[:-1], y[:-1], z[:-1, :-1])
+    plt.subplot(222)
+    plt.pcolor(x, y, z)
+    x = np.repeat(x[np.newaxis], 21, axis=0)
+    y = np.repeat(y[:, np.newaxis], 21, axis=1)
+    plt.subplot(223)
+    plt.pcolor(x[:-1, :-1], y[:-1, :-1], z[:-1, :-1])
+    plt.subplot(224)
+    plt.pcolor(x, y, z)
+    for ax in fig.get_axes():
+        for label in ax.get_xticklabels():
+            label.set_ha('right')
+            label.set_rotation(30)
+
+
+def test_pcolorargs():
+    n = 12
+    x = np.linspace(-1.5, 1.5, n)
+    y = np.linspace(-1.5, 1.5, n*2)
+    X, Y = np.meshgrid(x, y)
+    Z = np.hypot(X, Y) / 5
+
+    _, ax = plt.subplots()
+    with pytest.raises(TypeError):
+        ax.pcolormesh(y, x, Z)
+    with pytest.raises(TypeError):
+        ax.pcolormesh(X, Y, Z.T)
+    with pytest.raises(TypeError):
+        ax.pcolormesh(x, y, Z[:-1, :-1], shading="gouraud")
+    with pytest.raises(TypeError):
+        ax.pcolormesh(X, Y, Z[:-1, :-1], shading="gouraud")
+    x[0] = np.nan
+    with pytest.raises(ValueError):
+        ax.pcolormesh(x, y, Z[:-1, :-1])
+    with np.errstate(invalid='ignore'):
+        x = np.ma.array(x, mask=(x < 0))
+    with pytest.raises(ValueError):
+        ax.pcolormesh(x, y, Z[:-1, :-1])
+    # Expect a warning with non-increasing coordinates
+    x = [359, 0, 1]
+    y = [-10, 10]
+    X, Y = np.meshgrid(x, y)
+    Z = np.zeros(X.shape)
+    with pytest.warns(UserWarning,
+                      match='are not monotonically increasing or decreasing'):
+        ax.pcolormesh(X, Y, Z, shading='auto')
+
+
+def test_pcolormesh_underflow_error():
     """
-    An Axes object encapsulates all the elements of an individual (sub-)plot in
-    a figure.
-
-    It contains most of the (sub-)plot elements: `~.axis.Axis`,
-    `~.axis.Tick`, `~.lines.Line2D`, `~.text.Text`, `~.patches.Polygon`, etc.,
-    and sets the coordinate system.
-
-    Like all visible elements in a figure, Axes is an `.Artist` subclass.
-
-    The `Axes` instance supports callbacks through a callbacks attribute which
-    is a `~.cbook.CallbackRegistry` instance.  The events you can connect to
-    are 'xlim_changed' and 'ylim_changed' and the callback will be called with
-    func(*ax*) where *ax* is the `Axes` instance.
-
-    .. note::
-
-        As a user, you do not instantiate Axes directly, but use Axes creation
-        methods instead; e.g. from `.pyplot` or `.Figure`:
-        `~.pyplot.subplots`, `~.pyplot.subplot_mosaic` or `.Figure.add_axes`.
-
+    Test that underflow errors don't crop up in pcolormesh.  Probably
+    a numpy bug (https://github.com/numpy/numpy/issues/25810).
     """
-    ### Labelling, legend and texts
-
-    def get_title(self, loc="center"):
-        """
-        Get an Axes title.
-
-        Get one of the three available Axes titles. The available titles
-        are positioned above the Axes in the center, flush with the left
-        edge, and flush with the right edge.
-
-        Parameters
-        ----------
-        loc : {'center', 'left', 'right'}, str, default: 'center'
-            Which title to return.
-
-        Returns
-        -------
-        str
-            The title text string.
-
-        """
-        titles = {'left': self._left_title,
-                  'center': self.title,
-                  'right': self._right_title}
-        title = _api.check_getitem(titles, loc=loc.lower())
-        return title.get_text()
-
-    def set_title(self, label, fontdict=None, loc=None, pad=None, *, y=None,
-                  **kwargs):
-        """
-        Set a title for the Axes.
-
-        Set one of the three available Axes titles. The available titles
-        are positioned above the Axes in the center, flush with the left
-        edge, and flush with the right edge.
-
-        Parameters
-        ----------
-        label : str
-            Text to use for the title
-
-        fontdict : dict
-
-            .. admonition:: Discouraged
-
-               The use of *fontdict* is discouraged. Parameters should be passed as
-               individual keyword arguments or using dictionary-unpacking
-               ``set_title(..., **fontdict)``.
-
-            A dictionary controlling the appearance of the title text,
-            the default *fontdict* is::
-
-               {'fontsize': rcParams['axes.titlesize'],
-                'fontweight': rcParams['axes.titleweight'],
-                'color': rcParams['axes.titlecolor'],
-                'verticalalignment': 'baseline',
-                'horizontalalignment': loc}
-
-        loc : {'center', 'left', 'right'}, default: :rc:`axes.titlelocation`
-            Which title to set.
-
-        y : float, default: :rc:`axes.titley`
-            Vertical Axes location for the title (1.0 is the top).  If
-            None (the default) and :rc:`axes.titley` is also None, y is
-            determined automatically to avoid decorators on the Axes.
-
-        pad : float, default: :rc:`axes.titlepad`
-            The offset of the title from the top of the Axes, in points.
-
-        Returns
-        -------
-        `.Text`
-            The matplotlib text instance representing the title
-
-        Other Parameters
-        ----------------
-        **kwargs : `~matplotlib.text.Text` properties
-            Other keyword arguments are text properties, see `.Text` for a list
-            of valid text properties.
-        """
-        if loc is None:
-            loc = mpl.rcParams['axes.titlelocation']
-
-        if y is None:
-            y = mpl.rcParams['axes.titley']
-        if y is None:
-            y = 1.0
-        else:
-            self._autotitlepos = False
-        kwargs['y'] = y
-
-        titles = {'left': self._left_title,
-                  'center': self.title,
-                  'right': self._right_title}
-        title = _api.check_getitem(titles, loc=loc.lower())
-        default = {
-            'fontsize': mpl.rcParams['axes.titlesize'],
-            'fontweight': mpl.rcParams['axes.titleweight'],
-            'verticalalignment': 'baseline',
-            'horizontalalignment': loc.lower()}
-        titlecolor = mpl.rcParams['axes.titlecolor']
-        if not cbook._str_lower_equal(titlecolor, 'auto'):
-            default["color"] = titlecolor
-        if pad is None:
-            pad = mpl.rcParams['axes.titlepad']
-        self._set_title_offset_trans(float(pad))
-        title.set_text(label)
-        title.update(default)
-        if fontdict is not None:
-            title.update(fontdict)
-        title._internal_update(kwargs)
-        return title
-
-    def get_legend_handles_labels(self, legend_handler_map=None):
-        """
-        Return handles and labels for legend
-
-        ``ax.legend()`` is equivalent to ::
-
-          h, l = ax.get_legend_handles_labels()
-          ax.legend(h, l)
-        """
-        # pass through to legend.
-        handles, labels = mlegend._get_legend_handles_labels(
-            [self], legend_handler_map)
-        return handles, labels
-
-    @_docstring.interpd
-    def legend(self, *args, **kwargs):
-        """
-        Place a legend on the Axes.
-
-        Call signatures::
-
-            legend()
-            legend(handles, labels)
-            legend(handles=handles)
-            legend(labels)
-
-        The call signatures correspond to the following different ways to use
-        this method:
-
-        **1. Automatic detection of elements to be shown in the legend**
-
-        The elements to be added to the legend are automatically determined,
-        when you do not pass in any extra arguments.
-
-        In this case, the labels are taken from the artist. You can specify
-        them either at artist creation or by calling the
-        :meth:`~.Artist.set_label` method on the artist::
-
-            ax.plot([1, 2, 3], label='Inline label')
-            ax.legend()
-
-        or::
-
-            line, = ax.plot([1, 2, 3])
-            line.set_label('Label via method')
-            ax.legend()
-
-        .. note::
-            Specific artists can be excluded from the automatic legend element
-            selection by using a label starting with an underscore, "_".
-            A string starting with an underscore is the default label for all
-            artists, so calling `.Axes.legend` without any arguments and
-            without setting the labels manually will result in a ``UserWarning``
-            and an empty legend being drawn.
-
-
-        **2. Explicitly listing the artists and labels in the legend**
-
-        For full control of which artists have a legend entry, it is possible
-        to pass an iterable of legend artists followed by an iterable of
-        legend labels respectively::
-
-            ax.legend([line1, line2, line3], ['label1', 'label2', 'label3'])
-
-
-        **3. Explicitly listing the artists in the legend**
-
-        This is similar to 2, but the labels are taken from the artists'
-        label properties. Example::
-
-            line1, = ax.plot([1, 2, 3], label='label1')
-            line2, = ax.plot([1, 2, 3], label='label2')
-            ax.legend(handles=[line1, line2])
-
-
-        **4. Labeling existing plot elements**
-
-        .. admonition:: Discouraged
-
-            This call signature is discouraged, because the relation between
-            plot elements and labels is only implicit by their order and can
-            easily be mixed up.
-
-        To make a legend for all artists on an Axes, call this function with
-        an iterable of strings, one for each legend item. For example::
-
-            ax.plot([1, 2, 3])
-            ax.plot([5, 6, 7])
-            ax.legend(['First line', 'Second line'])
-
-
-        Parameters
-        ----------
-        handles : list of (`.Artist` or tuple of `.Artist`), optional
-            A list of Artists (lines, patches) to be added to the legend.
-            Use this together with *labels*, if you need full control on what
-            is shown in the legend and the automatic mechanism described above
-            is not sufficient.
-
-            The length of handles and labels should be the same in this
-            case. If they are not, they are truncated to the smaller length.
-
-            If an entry contains a tuple, then the legend handler for all Artists in the
-            tuple will be placed alongside a single label.
-
-        labels : list of str, optional
-            A list of labels to show next to the artists.
-            Use this together with *handles*, if you need full control on what
-            is shown in the legend and the automatic mechanism described above
-            is not sufficient.
-
-        Returns
-        -------
-        `~matplotlib.legend.Legend`
-
-        Other Parameters
-        ----------------
-        %(_legend_kw_axes)s
-
-        See Also
-        --------
-        .Figure.legend
-
-        Notes
-        -----
-        Some artists are not supported by this function.  See
-        :ref:`legend_guide` for details.
-
-        Examples
-        --------
-        .. plot:: gallery/text_labels_and_annotations/legend.py
-        """
-        handles, labels, kwargs = mlegend._parse_legend_args([self], *args, **kwargs)
-        self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
-        self.legend_._remove_method = self._remove_legend
-        return self.legend_
-
-    def _remove_legend(self, legend):
-        self.legend_ = None
-
-    def inset_axes(self, bounds, *, transform=None, zorder=5, **kwargs):
-        """
-        Add a child inset Axes to this existing Axes.
-
-
-        Parameters
-        ----------
-        bounds : [x0, y0, width, height]
-            Lower-left corner of inset Axes, and its width and height.
-
-        transform : `.Transform`
-            Defaults to `ax.transAxes`, i.e. the units of *rect* are in
-            Axes-relative coordinates.
-
-        projection : {None, 'aitoff', 'hammer', 'lambert', 'mollweide', \
-'polar', 'rectilinear', str}, optional
-            The projection type of the inset `~.axes.Axes`. *str* is the name
-            of a custom projection, see `~matplotlib.projections`. The default
-            None results in a 'rectilinear' projection.
-
-        polar : bool, default: False
-            If True, equivalent to projection='polar'.
-
-        axes_class : subclass type of `~.axes.Axes`, optional
-            The `.axes.Axes` subclass that is instantiated.  This parameter
-            is incompatible with *projection* and *polar*.  See
-            :ref:`axisartist_users-guide-index` for examples.
-
-        zorder : number
-            Defaults to 5 (same as `.Axes.legend`).  Adjust higher or lower
-            to change whether it is above or below data plotted on the
-            parent Axes.
-
-        **kwargs
-            Other keyword arguments are passed on to the inset Axes class.
-
-        Returns
-        -------
-        ax
-            The created `~.axes.Axes` instance.
-
-        Examples
-        --------
-        This example makes two inset Axes, the first is in Axes-relative
-        coordinates, and the second in data-coordinates::
-
-            fig, ax = plt.subplots()
-            ax.plot(range(10))
-            axin1 = ax.inset_axes([0.8, 0.1, 0.15, 0.15])
-            axin2 = ax.inset_axes(
-                    [5, 7, 2.3, 2.3], transform=ax.transData)
-
-        """
-        if transform is None:
-            transform = self.transAxes
-        kwargs.setdefault('label', 'inset_axes')
-
-        # This puts the rectangle into figure-relative coordinates.
-        inset_locator = _TransformedBoundsLocator(bounds, transform)
-        bounds = inset_locator(self, None).bounds
-        fig = self.get_figure(root=False)
-        projection_class, pkw = fig._process_projection_requirements(**kwargs)
-        inset_ax = projection_class(fig, bounds, zorder=zorder, **pkw)
-
-        # this locator lets the axes move if in data coordinates.
-        # it gets called in `ax.apply_aspect() (of all places)
-        inset_ax.set_axes_locator(inset_locator)
-
-        self.add_child_axes(inset_ax)
-
-        return inset_ax
-
-    @_docstring.interpd
-    def indicate_inset(self, bounds=None, inset_ax=None, *, transform=None,
-                       facecolor='none', edgecolor='0.5', alpha=0.5,
-                       zorder=None, **kwargs):
-        """
-        Add an inset indicator to the Axes.  This is a rectangle on the plot
-        at the position indicated by *bounds* that optionally has lines that
-        connect the rectangle to an inset Axes (`.Axes.inset_axes`).
-
-        Warnings
-        --------
-        This method is experimental as of 3.0, and the API may change.
-
-        Parameters
-        ----------
-        bounds : [x0, y0, width, height], optional
-            Lower-left corner of rectangle to be marked, and its width
-            and height.  If not set, the bounds will be calculated from the
-            data limits of *inset_ax*, which must be supplied.
-
-        inset_ax : `.Axes`, optional
-            An optional inset Axes to draw connecting lines to.  Two lines are
-            drawn connecting the indicator box to the inset Axes on corners
-            chosen so as to not overlap with the indicator box.
-
-        transform : `.Transform`
-            Transform for the rectangle coordinates. Defaults to
-            ``ax.transAxes``, i.e. the units of *rect* are in Axes-relative
-            coordinates.
-
-        facecolor : :mpltype:`color`, default: 'none'
-            Facecolor of the rectangle.
-
-        edgecolor : :mpltype:`color`, default: '0.5'
-            Color of the rectangle and color of the connecting lines.
-
-        alpha : float or None, default: 0.5
-            Transparency of the rectangle and connector lines.  If not
-            ``None``, this overrides any alpha value included in the
-            *facecolor* and *edgecolor* parameters.
-
-        zorder : float, default: 4.99
-            Drawing order of the rectangle and connector lines.  The default,
-            4.99, is just below the default level of inset Axes.
-
-        **kwargs
-            Other keyword arguments are passed on to the `.Rectangle` patch:
-
-            %(Rectangle:kwdoc)s
-
-        Returns
-        -------
-        inset_indicator : `.inset.InsetIndicator`
-            An artist which contains
-
-            inset_indicator.rectangle : `.Rectangle`
-                The indicator frame.
-
-            inset_indicator.connectors : 4-tuple of `.patches.ConnectionPatch`
-                The four connector lines connecting to (lower_left, upper_left,
-                lower_right upper_right) corners of *inset_ax*. Two lines are
-                set with visibility to *False*,  but the user can set the
-                visibility to True if the automatic choice is not deemed correct.
-
-            .. versionchanged:: 3.10
-                Previously the rectangle and connectors tuple were returned.
-        """
-        # to make the Axes connectors work, we need to apply the aspect to
-        # the parent Axes.
-        self.apply_aspect()
-
-        if transform is None:
-            transform = self.transData
-        kwargs.setdefault('label', '_indicate_inset')
-
-        indicator_patch = minset.InsetIndicator(
-            bounds, inset_ax=inset_ax,
-            facecolor=facecolor, edgecolor=edgecolor, alpha=alpha,
-            zorder=zorder, transform=transform, **kwargs)
-        self.add_artist(indicator_patch)
-
-        return indicator_patch
-
-    def indicate_inset_zoom(self, inset_ax, **kwargs):
-        """
-        Add an inset indicator rectangle to the Axes based on the axis
-        limits for an *inset_ax* and draw connectors between *inset_ax*
-        and the rectangle.
-
-        Warnings
-        --------
-        This method is experimental as of 3.0, and the API may change.
-
-        Parameters
-        ----------
-        inset_ax : `.Axes`
-            Inset Axes to draw connecting lines to.  Two lines are
-            drawn connecting the indicator box to the inset Axes on corners
-            chosen so as to not overlap with the indicator box.
-
-        **kwargs
-            Other keyword arguments are passed on to `.Axes.indicate_inset`
-
-        Returns
-        -------
-        inset_indicator : `.inset.InsetIndicator`
-            An artist which contains
-
-            inset_indicator.rectangle : `.Rectangle`
-                The indicator frame.
-
-            inset_indicator.connectors : 4-tuple of `.patches.ConnectionPatch`
-                The four connector lines connecting to (lower_left, upper_left,
-                lower_right upper_right) corners of *inset_ax*. Two lines are
-                set with visibility to *False*,  but the user can set the
-                visibility to True if the automatic choice is not deemed correct.
-
-            .. versionchanged:: 3.10
-                Previously the rectangle and connectors tuple were returned.
-        """
-
-        return self.indicate_inset(None, inset_ax, **kwargs)
-
-    @_docstring.interpd
-    def secondary_xaxis(self, location, functions=None, *, transform=None, **kwargs):
-        """
-        Add a second x-axis to this `~.axes.Axes`.
-
-        For example if we want to have a second scale for the data plotted on
-        the xaxis.
-
-        %(_secax_docstring)s
-
-        Examples
-        --------
-        The main axis shows frequency, and the secondary axis shows period.
-
-        .. plot::
-
-            fig, ax = plt.subplots()
-            ax.loglog(range(1, 360, 5), range(1, 360, 5))
-            ax.set_xlabel('frequency [Hz]')
-
-            def invert(x):
-                # 1/x with special treatment of x == 0
-                x = np.array(x).astype(float)
-                near_zero = np.isclose(x, 0)
-                x[near_zero] = np.inf
-                x[~near_zero] = 1 / x[~near_zero]
-                return x
-
-            # the inverse of 1/x is itself
-            secax = ax.secondary_xaxis('top', functions=(invert, invert))
-            secax.set_xlabel('Period [s]')
-            plt.show()
-
-        To add a secondary axis relative to your data, you can pass a transform
-        to the new axis.
-
-        .. plot::
-
-            fig, ax = plt.subplots()
-            ax.plot(range(0, 5), range(-1, 4))
-
-            # Pass 'ax.transData' as a transform to place the axis
-            # relative to your data at y=0
-            secax = ax.secondary_xaxis(0, transform=ax.transData)
-        """
-        if not (location in ['top', 'bottom'] or isinstance(location, Real)):
-            raise ValueError('secondary_xaxis location must be either '
-                             'a float or "top"/"bottom"')
-
-        secondary_ax = SecondaryAxis(self, 'x', location, functions,
-                                     transform, **kwargs)
-        self.add_child_axes(secondary_ax)
-        return secondary_ax
-
-    @_docstring.interpd
-    def secondary_yaxis(self, location, functions=None, *, transform=None, **kwargs):
-        """
-        Add a second y-axis to this `~.axes.Axes`.
-
-        For example if we want to have a second scale for the data plotted on
-        the yaxis.
-
-        %(_secax_docstring)s
-
-        Examples
-        --------
-        Add a secondary Axes that converts from radians to degrees
-
-        .. plot::
-
-            fig, ax = plt.subplots()
-            ax.plot(range(1, 360, 5), range(1, 360, 5))
-            ax.set_ylabel('degrees')
-            secax = ax.secondary_yaxis('right', functions=(np.deg2rad,
-                                                           np.rad2deg))
-            secax.set_ylabel('radians')
-
-        To add a secondary axis relative to your data, you can pass a transform
-        to the new axis.
-
-        .. plot::
-
-            fig, ax = plt.subplots()
-            ax.plot(range(0, 5), range(-1, 4))
-
-            # Pass 'ax.transData' as a transform to place the axis
-            # relative to your data at x=3
-            secax = ax.secondary_yaxis(3, transform=ax.transData)
-        """
-        if not (location in ['left', 'right'] or isinstance(location, Real)):
-            raise ValueError('secondary_yaxis location must be either '
-                             'a float or "left"/"right"')
-
-        secondary_ax = SecondaryAxis(self, 'y', location, functions,
-                                     transform, **kwargs)
-        self.add_child_axes(secondary_ax)
-        return secondary_ax
-
-    @_docstring.interpd
-    def text(self, x, y, s, fontdict=None, **kwargs):
-        """
-        Add text to the Axes.
-
-        Add the text *s* to the Axes at location *x*, *y* in data coordinates,
-        with a default ``horizontalalignment`` on the ``left`` and
-        ``verticalalignment`` at the ``baseline``. See
-        :doc:`/gallery/text_labels_and_annotations/text_alignment`.
-
-        Parameters
-        ----------
-        x, y : float
-            The position to place the text. By default, this is in data
-            coordinates. The coordinate system can be changed using the
-            *transform* parameter.
-
-        s : str
-            The text.
-
-        fontdict : dict, default: None
-
-            .. admonition:: Discouraged
-
-               The use of *fontdict* is discouraged. Parameters should be passed as
-               individual keyword arguments or using dictionary-unpacking
-               ``text(..., **fontdict)``.
-
-            A dictionary to override the default text properties. If fontdict
-            is None, the defaults are determined by `.rcParams`.
-
-        Returns
-        -------
-        `.Text`
-            The created `.Text` instance.
-
-        Other Parameters
-        ----------------
-        **kwargs : `~matplotlib.text.Text` properties.
-            Other miscellaneous text parameters.
-
-            %(Text:kwdoc)s
-
-        Examples
-        --------
-        Individual keyword arguments can be used to override any given
-        parameter::
-
-            >>> text(x, y, s, fontsize=12)
-
-        The default transform specifies that text is in data coords,
-        alternatively, you can specify text in axis coords ((0, 0) is
-        lower-left and (1, 1) is upper-right).  The example below places
-        text in the center of the Axes::
-
-            >>> text(0.5, 0.5, 'matplotlib', horizontalalignment='center',
-            ...      verticalalignment='center', transform=ax.transAxes)
-
-        You can put a rectangular box around the text instance (e.g., to
-        set a background color) by using the keyword *bbox*.  *bbox* is
-        a dictionary of `~matplotlib.patches.Rectangle`
-        properties.  For example::
-
-            >>> text(x, y, s, bbox=dict(facecolor='red', alpha=0.5))
-        """
-        effective_kwargs = {
-            'verticalalignment': 'baseline',
-            'horizontalalignment': 'left',
-            'transform': self.transData,
-            'clip_on': False,
-            **(fontdict if fontdict is not None else {}),
-            **kwargs,
-        }
-        t = mtext.Text(x, y, text=s, **effective_kwargs)
-        if t.get_clip_path() is None:
-            t.set_clip_path(self.patch)
-        self._add_text(t)
-        return t
-
-    @_docstring.interpd
-    def annotate(self, text, xy, xytext=None, xycoords='data', textcoords=None,
-                 arrowprops=None, annotation_clip=None, **kwargs):
-        # Signature must match Annotation. This is verified in
-        # test_annotate_signature().
-        a = mtext.Annotation(text, xy, xytext=xytext, xycoords=xycoords,
-                             textcoords=textcoords, arrowprops=arrowprops,
-                             annotation_clip=annotation_clip, **kwargs)
-        a.set_transform(mtransforms.IdentityTransform())
-        if kwargs.get('clip_on', False) and a.get_clip_path() is None:
-            a.set_clip_path(self.patch)
-        self._add_text(a)
+    with np.errstate(under="raise"):
+        x = np.arange(0, 3, 0.1)
+        y = np.arange(0, 6, 0.1)
+        z = np.random.randn(len(y), len(x))
+        fig, ax = plt.subplots()
+        ax.pcolormesh(x, y, z)
+
+
+def test_pcolorargs_with_read_only():
+    x = np.arange(6).reshape(2, 3)
+    xmask = np.broadcast_to([False, True, False], x.shape)  # read-only array
+    assert xmask.flags.writeable is False
+    masked_x = np.ma.array(x, mask=xmask)
+    plt.pcolormesh(masked_x)
+
+    x = np.linspace(0, 1, 10)
+    y = np.linspace(0, 1, 10)
+    X, Y = np.meshgrid(x, y)
+    Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
+    mask = np.zeros(10, dtype=bool)
+    mask[-1] = True
+    mask = np.broadcast_to(mask, Z.shape)
+    assert mask.flags.writeable is False
+    masked_Z = np.ma.array(Z, mask=mask)
+    plt.pcolormesh(X, Y, masked_Z)
+
+    masked_X = np.ma.array(X, mask=mask)
+    masked_Y = np.ma.array(Y, mask=mask)
+    plt.pcolor(masked_X, masked_Y, masked_Z)
+
+
+@check_figures_equal(extensions=["png"])
+def test_pcolornearest(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    x = np.arange(0, 10)
+    y = np.arange(0, 3)
+    np.random.seed(19680801)
+    Z = np.random.randn(2, 9)
+    ax.pcolormesh(x, y, Z, shading='flat')
+
+    ax = fig_ref.subplots()
+    # specify the centers
+    x2 = x[:-1] + np.diff(x) / 2
+    y2 = y[:-1] + np.diff(y) / 2
+    ax.pcolormesh(x2, y2, Z, shading='nearest')
+
+
+@check_figures_equal(extensions=["png"])
+def test_pcolornearestunits(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    x = [datetime.datetime.fromtimestamp(x * 3600) for x in range(10)]
+    y = np.arange(0, 3)
+    np.random.seed(19680801)
+    Z = np.random.randn(2, 9)
+    ax.pcolormesh(x, y, Z, shading='flat')
+
+    ax = fig_ref.subplots()
+    # specify the centers
+    x2 = [datetime.datetime.fromtimestamp((x + 0.5) * 3600) for x in range(9)]
+    y2 = y[:-1] + np.diff(y) / 2
+    ax.pcolormesh(x2, y2, Z, shading='nearest')
+
+
+def test_pcolorflaterror():
+    fig, ax = plt.subplots()
+    x = np.arange(0, 9)
+    y = np.arange(0, 3)
+    np.random.seed(19680801)
+    Z = np.random.randn(3, 9)
+    with pytest.raises(TypeError, match='Dimensions of C'):
+        ax.pcolormesh(x, y, Z, shading='flat')
+
+
+def test_samesizepcolorflaterror():
+    fig, ax = plt.subplots()
+    x, y = np.meshgrid(np.arange(5), np.arange(3))
+    Z = x + y
+    with pytest.raises(TypeError, match=r".*one smaller than X"):
+        ax.pcolormesh(x, y, Z, shading='flat')
+
+
+@pytest.mark.parametrize('snap', [False, True])
+@check_figures_equal(extensions=["png"])
+def test_pcolorauto(fig_test, fig_ref, snap):
+    ax = fig_test.subplots()
+    x = np.arange(0, 10)
+    y = np.arange(0, 4)
+    np.random.seed(19680801)
+    Z = np.random.randn(3, 9)
+    # this is the same as flat; note that auto is default
+    ax.pcolormesh(x, y, Z, snap=snap)
+
+    ax = fig_ref.subplots()
+    # specify the centers
+    x2 = x[:-1] + np.diff(x) / 2
+    y2 = y[:-1] + np.diff(y) / 2
+    # this is same as nearest:
+    ax.pcolormesh(x2, y2, Z, snap=snap)
+
+
+@image_comparison(['canonical'], tol=0.02 if platform.machine() == 'arm64' else 0)
+def test_canonical():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3])
+
+
+@image_comparison(['arc_angles.png'], remove_text=True, style='default')
+def test_arc_angles():
+    # Ellipse parameters
+    w = 2
+    h = 1
+    centre = (0.2, 0.5)
+    scale = 2
+
+    fig, axs = plt.subplots(3, 3)
+    for i, ax in enumerate(axs.flat):
+        theta2 = i * 360 / 9
+        theta1 = theta2 - 45
+
+        ax.add_patch(mpatches.Ellipse(centre, w, h, alpha=0.3))
+        ax.add_patch(mpatches.Arc(centre, w, h, theta1=theta1, theta2=theta2))
+        # Straight lines intersecting start and end of arc
+        ax.plot([scale * np.cos(np.deg2rad(theta1)) + centre[0],
+                 centre[0],
+                 scale * np.cos(np.deg2rad(theta2)) + centre[0]],
+                [scale * np.sin(np.deg2rad(theta1)) + centre[1],
+                 centre[1],
+                 scale * np.sin(np.deg2rad(theta2)) + centre[1]])
+
+        ax.set_xlim(-scale, scale)
+        ax.set_ylim(-scale, scale)
+
+        # This looks the same, but it triggers a different code path when it
+        # gets large enough.
+        w *= 10
+        h *= 10
+        centre = (centre[0] * 10, centre[1] * 10)
+        scale *= 10
+
+
+@image_comparison(['arc_ellipse'], remove_text=True)
+def test_arc_ellipse():
+    xcenter, ycenter = 0.38, 0.52
+    width, height = 1e-1, 3e-1
+    angle = -30
+
+    theta = np.deg2rad(np.arange(360))
+    x = width / 2. * np.cos(theta)
+    y = height / 2. * np.sin(theta)
+
+    rtheta = np.deg2rad(angle)
+    R = np.array([
+        [np.cos(rtheta), -np.sin(rtheta)],
+        [np.sin(rtheta), np.cos(rtheta)]])
+
+    x, y = np.dot(R, [x, y])
+    x += xcenter
+    y += ycenter
+
+    fig = plt.figure()
+    ax = fig.add_subplot(211, aspect='auto')
+    ax.fill(x, y, alpha=0.2, facecolor='yellow', edgecolor='yellow',
+            linewidth=1, zorder=1)
+
+    e1 = mpatches.Arc((xcenter, ycenter), width, height,
+                      angle=angle, linewidth=2, fill=False, zorder=2)
+
+    ax.add_patch(e1)
+
+    ax = fig.add_subplot(212, aspect='equal')
+    ax.fill(x, y, alpha=0.2, facecolor='green', edgecolor='green', zorder=1)
+    e2 = mpatches.Arc((xcenter, ycenter), width, height,
+                      angle=angle, linewidth=2, fill=False, zorder=2)
+
+    ax.add_patch(e2)
+
+
+def test_marker_as_markerstyle():
+    fix, ax = plt.subplots()
+    m = mmarkers.MarkerStyle('o')
+    ax.plot([1, 2, 3], [3, 2, 1], marker=m)
+    ax.scatter([1, 2, 3], [4, 3, 2], marker=m)
+    ax.errorbar([1, 2, 3], [5, 4, 3], marker=m)
+
+
+@image_comparison(['markevery'], remove_text=True)
+def test_markevery():
+    x = np.linspace(0, 10, 100)
+    y = np.sin(x) * np.sqrt(x/10 + 0.5)
+
+    # check marker only plot
+    fig, ax = plt.subplots()
+    ax.plot(x, y, 'o', label='default')
+    ax.plot(x, y, 'd', markevery=None, label='mark all')
+    ax.plot(x, y, 's', markevery=10, label='mark every 10')
+    ax.plot(x, y, '+', markevery=(5, 20), label='mark every 5 starting at 10')
+    ax.legend()
+
+
+@image_comparison(['markevery_line'], remove_text=True, tol=0.005)
+def test_markevery_line():
+    # TODO: a slight change in rendering between Inkscape versions may explain
+    # why one had to introduce a small non-zero tolerance for the SVG test
+    # to pass. One may try to remove this hack once Travis' Inkscape version
+    # is modern enough. FWIW, no failure with 0.92.3 on my computer (#11358).
+    x = np.linspace(0, 10, 100)
+    y = np.sin(x) * np.sqrt(x/10 + 0.5)
+
+    # check line/marker combos
+    fig, ax = plt.subplots()
+    ax.plot(x, y, '-o', label='default')
+    ax.plot(x, y, '-d', markevery=None, label='mark all')
+    ax.plot(x, y, '-s', markevery=10, label='mark every 10')
+    ax.plot(x, y, '-+', markevery=(5, 20), label='mark every 5 starting at 10')
+    ax.legend()
+
+
+@image_comparison(['markevery_linear_scales'], remove_text=True, tol=0.001)
+def test_markevery_linear_scales():
+    cases = [None,
+             8,
+             (30, 8),
+             [16, 24, 30], [0, -1],
+             slice(100, 200, 3),
+             0.1, 0.3, 1.5,
+             (0.0, 0.1), (0.45, 0.1)]
+
+    cols = 3
+    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
+
+    delta = 0.11
+    x = np.linspace(0, 10 - 2 * delta, 200) + delta
+    y = np.sin(x) + 1.0 + delta
+
+    for i, case in enumerate(cases):
+        row = (i // cols)
+        col = i % cols
+        plt.subplot(gs[row, col])
+        plt.title('markevery=%s' % str(case))
+        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
+
+
+@image_comparison(['markevery_linear_scales_zoomed'], remove_text=True)
+def test_markevery_linear_scales_zoomed():
+    cases = [None,
+             8,
+             (30, 8),
+             [16, 24, 30], [0, -1],
+             slice(100, 200, 3),
+             0.1, 0.3, 1.5,
+             (0.0, 0.1), (0.45, 0.1)]
+
+    cols = 3
+    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
+
+    delta = 0.11
+    x = np.linspace(0, 10 - 2 * delta, 200) + delta
+    y = np.sin(x) + 1.0 + delta
+
+    for i, case in enumerate(cases):
+        row = (i // cols)
+        col = i % cols
+        plt.subplot(gs[row, col])
+        plt.title('markevery=%s' % str(case))
+        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
+        plt.xlim((6, 6.7))
+        plt.ylim((1.1, 1.7))
+
+
+@image_comparison(['markevery_log_scales'], remove_text=True)
+def test_markevery_log_scales():
+    cases = [None,
+             8,
+             (30, 8),
+             [16, 24, 30], [0, -1],
+             slice(100, 200, 3),
+             0.1, 0.3, 1.5,
+             (0.0, 0.1), (0.45, 0.1)]
+
+    cols = 3
+    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
+
+    delta = 0.11
+    x = np.linspace(0, 10 - 2 * delta, 200) + delta
+    y = np.sin(x) + 1.0 + delta
+
+    for i, case in enumerate(cases):
+        row = (i // cols)
+        col = i % cols
+        plt.subplot(gs[row, col])
+        plt.title('markevery=%s' % str(case))
+        plt.xscale('log')
+        plt.yscale('log')
+        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
+
+
+@image_comparison(['markevery_polar'], style='default', remove_text=True)
+def test_markevery_polar():
+    cases = [None,
+             8,
+             (30, 8),
+             [16, 24, 30], [0, -1],
+             slice(100, 200, 3),
+             0.1, 0.3, 1.5,
+             (0.0, 0.1), (0.45, 0.1)]
+
+    cols = 3
+    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
+
+    r = np.linspace(0, 3.0, 200)
+    theta = 2 * np.pi * r
+
+    for i, case in enumerate(cases):
+        row = (i // cols)
+        col = i % cols
+        plt.subplot(gs[row, col], polar=True)
+        plt.title('markevery=%s' % str(case))
+        plt.plot(theta, r, 'o', ls='-', ms=4,  markevery=case)
+
+
+@image_comparison(['markevery_linear_scales_nans'], remove_text=True)
+def test_markevery_linear_scales_nans():
+    cases = [None,
+             8,
+             (30, 8),
+             [16, 24, 30], [0, -1],
+             slice(100, 200, 3),
+             0.1, 0.3, 1.5,
+             (0.0, 0.1), (0.45, 0.1)]
+
+    cols = 3
+    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
+
+    delta = 0.11
+    x = np.linspace(0, 10 - 2 * delta, 200) + delta
+    y = np.sin(x) + 1.0 + delta
+    y[:10] = y[-20:] = y[50:70] = np.nan
+
+    for i, case in enumerate(cases):
+        row = (i // cols)
+        col = i % cols
+        plt.subplot(gs[row, col])
+        plt.title('markevery=%s' % str(case))
+        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
+
+
+@image_comparison(['marker_edges'], remove_text=True)
+def test_marker_edges():
+    x = np.linspace(0, 1, 10)
+    fig, ax = plt.subplots()
+    ax.plot(x, np.sin(x), 'y.', ms=30.0, mew=0, mec='r')
+    ax.plot(x+0.1, np.sin(x), 'y.', ms=30.0, mew=1, mec='r')
+    ax.plot(x+0.2, np.sin(x), 'y.', ms=30.0, mew=2, mec='b')
+
+
+@image_comparison(['bar_tick_label_single.png', 'bar_tick_label_single.png'])
+def test_bar_tick_label_single():
+    # From 2516: plot bar with array of string labels for x axis
+    ax = plt.gca()
+    ax.bar(0, 1, align='edge', tick_label='0')
+
+    # Reuse testcase from above for a labeled data test
+    data = {"a": 0, "b": 1}
+    fig, ax = plt.subplots()
+    ax = plt.gca()
+    ax.bar("a", "b", align='edge', tick_label='0', data=data)
+
+
+def test_nan_bar_values():
+    fig, ax = plt.subplots()
+    ax.bar([0, 1], [np.nan, 4])
+
+
+def test_bar_ticklabel_fail():
+    fig, ax = plt.subplots()
+    ax.bar([], [])
+
+
+@image_comparison(['bar_tick_label_multiple.png'])
+def test_bar_tick_label_multiple():
+    # From 2516: plot bar with array of string labels for x axis
+    ax = plt.gca()
+    ax.bar([1, 2.5], [1, 2], width=[0.2, 0.5], tick_label=['a', 'b'],
+           align='center')
+
+
+@image_comparison(['bar_tick_label_multiple_old_label_alignment.png'])
+def test_bar_tick_label_multiple_old_alignment():
+    # Test that the alignment for class is backward compatible
+    matplotlib.rcParams["ytick.alignment"] = "center"
+    ax = plt.gca()
+    ax.bar([1, 2.5], [1, 2], width=[0.2, 0.5], tick_label=['a', 'b'],
+           align='center')
+
+
+@check_figures_equal(extensions=["png"])
+def test_bar_decimal_center(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    x0 = [1.5, 8.4, 5.3, 4.2]
+    y0 = [1.1, 2.2, 3.3, 4.4]
+    x = [Decimal(x) for x in x0]
+    y = [Decimal(y) for y in y0]
+    # Test image - vertical, align-center bar chart with Decimal() input
+    ax.bar(x, y, align='center')
+    # Reference image
+    ax = fig_ref.subplots()
+    ax.bar(x0, y0, align='center')
+
+
+@check_figures_equal(extensions=["png"])
+def test_barh_decimal_center(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    x0 = [1.5, 8.4, 5.3, 4.2]
+    y0 = [1.1, 2.2, 3.3, 4.4]
+    x = [Decimal(x) for x in x0]
+    y = [Decimal(y) for y in y0]
+    # Test image - horizontal, align-center bar chart with Decimal() input
+    ax.barh(x, y, height=[0.5, 0.5, 1, 1], align='center')
+    # Reference image
+    ax = fig_ref.subplots()
+    ax.barh(x0, y0, height=[0.5, 0.5, 1, 1], align='center')
+
+
+@check_figures_equal(extensions=["png"])
+def test_bar_decimal_width(fig_test, fig_ref):
+    x = [1.5, 8.4, 5.3, 4.2]
+    y = [1.1, 2.2, 3.3, 4.4]
+    w0 = [0.7, 1.45, 1, 2]
+    w = [Decimal(i) for i in w0]
+    # Test image - vertical bar chart with Decimal() width
+    ax = fig_test.subplots()
+    ax.bar(x, y, width=w, align='center')
+    # Reference image
+    ax = fig_ref.subplots()
+    ax.bar(x, y, width=w0, align='center')
+
+
+@check_figures_equal(extensions=["png"])
+def test_barh_decimal_height(fig_test, fig_ref):
+    x = [1.5, 8.4, 5.3, 4.2]
+    y = [1.1, 2.2, 3.3, 4.4]
+    h0 = [0.7, 1.45, 1, 2]
+    h = [Decimal(i) for i in h0]
+    # Test image - horizontal bar chart with Decimal() height
+    ax = fig_test.subplots()
+    ax.barh(x, y, height=h, align='center')
+    # Reference image
+    ax = fig_ref.subplots()
+    ax.barh(x, y, height=h0, align='center')
+
+
+def test_bar_color_none_alpha():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='none', edgecolor='r')
+    for rect in rects:
+        assert rect.get_facecolor() == (0, 0, 0, 0)
+        assert rect.get_edgecolor() == (1, 0, 0, 0.3)
+
+
+def test_bar_edgecolor_none_alpha():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='r', edgecolor='none')
+    for rect in rects:
+        assert rect.get_facecolor() == (1, 0, 0, 0.3)
+        assert rect.get_edgecolor() == (0, 0, 0, 0)
+
+
+@image_comparison(['barh_tick_label.png'])
+def test_barh_tick_label():
+    # From 2516: plot barh with array of string labels for y axis
+    ax = plt.gca()
+    ax.barh([1, 2.5], [1, 2], height=[0.2, 0.5], tick_label=['a', 'b'],
+            align='center')
+
+
+def test_bar_timedelta():
+    """Smoketest that bar can handle width and height in delta units."""
+    fig, ax = plt.subplots()
+    ax.bar(datetime.datetime(2018, 1, 1), 1.,
+           width=datetime.timedelta(hours=3))
+    ax.bar(datetime.datetime(2018, 1, 1), 1.,
+           xerr=datetime.timedelta(hours=2),
+           width=datetime.timedelta(hours=3))
+    fig, ax = plt.subplots()
+    ax.barh(datetime.datetime(2018, 1, 1), 1,
+            height=datetime.timedelta(hours=3))
+    ax.barh(datetime.datetime(2018, 1, 1), 1,
+            height=datetime.timedelta(hours=3),
+            yerr=datetime.timedelta(hours=2))
+    fig, ax = plt.subplots()
+    ax.barh([datetime.datetime(2018, 1, 1), datetime.datetime(2018, 1, 1)],
+            np.array([1, 1.5]),
+            height=datetime.timedelta(hours=3))
+    ax.barh([datetime.datetime(2018, 1, 1), datetime.datetime(2018, 1, 1)],
+            np.array([1, 1.5]),
+            height=[datetime.timedelta(hours=t) for t in [1, 2]])
+    ax.broken_barh([(datetime.datetime(2018, 1, 1),
+                     datetime.timedelta(hours=1))],
+                   (10, 20))
+
+
+def test_bar_datetime_start():
+    """test that tickers are correct for datetimes"""
+    start = np.array([np.datetime64('2012-01-01'), np.datetime64('2012-02-01'),
+                      np.datetime64('2012-01-15')])
+    stop = np.array([np.datetime64('2012-02-07'), np.datetime64('2012-02-13'),
+                     np.datetime64('2012-02-12')])
+
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 3], height=stop-start, bottom=start)
+    assert isinstance(ax.yaxis.get_major_formatter(), mdates.AutoDateFormatter)
+
+    fig, ax = plt.subplots()
+    ax.barh([0, 1, 3], width=stop-start, left=start)
+    assert isinstance(ax.xaxis.get_major_formatter(), mdates.AutoDateFormatter)
+
+
+def test_boxplot_dates_pandas(pd):
+    # smoke test for boxplot and dates in pandas
+    data = np.random.rand(5, 2)
+    years = pd.date_range('1/1/2000',
+                          periods=2, freq=pd.DateOffset(years=1)).year
+    plt.figure()
+    plt.boxplot(data, positions=years)
+
+
+def test_boxplot_capwidths():
+    data = np.random.rand(5, 3)
+    fig, axs = plt.subplots(9)
+
+    axs[0].boxplot(data, capwidths=[0.3, 0.2, 0.1], widths=[0.1, 0.2, 0.3])
+    axs[1].boxplot(data, capwidths=[0.3, 0.2, 0.1], widths=0.2)
+    axs[2].boxplot(data, capwidths=[0.3, 0.2, 0.1])
+
+    axs[3].boxplot(data, capwidths=0.5, widths=[0.1, 0.2, 0.3])
+    axs[4].boxplot(data, capwidths=0.5, widths=0.2)
+    axs[5].boxplot(data, capwidths=0.5)
+
+    axs[6].boxplot(data, widths=[0.1, 0.2, 0.3])
+    axs[7].boxplot(data, widths=0.2)
+    axs[8].boxplot(data)
+
+
+def test_pcolor_regression(pd):
+    from pandas.plotting import (
+        register_matplotlib_converters,
+        deregister_matplotlib_converters,
+    )
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111)
+
+    times = [datetime.datetime(2021, 1, 1)]
+    while len(times) < 7:
+        times.append(times[-1] + datetime.timedelta(seconds=120))
+
+    y_vals = np.arange(5)
+
+    time_axis, y_axis = np.meshgrid(times, y_vals)
+    shape = (len(y_vals) - 1, len(times) - 1)
+    z_data = np.arange(shape[0] * shape[1])
+
+    z_data.shape = shape
+    try:
+        register_matplotlib_converters()
+
+        im = ax.pcolormesh(time_axis, y_axis, z_data)
+        # make sure this does not raise!
+        fig.canvas.draw()
+    finally:
+        deregister_matplotlib_converters()
+
+
+def test_bar_pandas(pd):
+    # Smoke test for pandas
+    df = pd.DataFrame(
+        {'year': [2018, 2018, 2018],
+         'month': [1, 1, 1],
+         'day': [1, 2, 3],
+         'value': [1, 2, 3]})
+    df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
+
+    monthly = df[['date', 'value']].groupby(['date']).sum()
+    dates = monthly.index
+    forecast = monthly['value']
+    baseline = monthly['value']
+
+    fig, ax = plt.subplots()
+    ax.bar(dates, forecast, width=10, align='center')
+    ax.plot(dates, baseline, color='orange', lw=4)
+
+
+def test_bar_pandas_indexed(pd):
+    # Smoke test for indexed pandas
+    df = pd.DataFrame({"x": [1., 2., 3.], "width": [.2, .4, .6]},
+                      index=[1, 2, 3])
+    fig, ax = plt.subplots()
+    ax.bar(df.x, 1., width=df.width)
+
+
+@mpl.style.context('default')
+@check_figures_equal()
+def test_bar_hatches(fig_test, fig_ref):
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+
+    x = [1, 2]
+    y = [2, 3]
+    hatches = ['x', 'o']
+    for i in range(2):
+        ax_ref.bar(x[i], y[i], color='C0', hatch=hatches[i])
+
+    ax_test.bar(x, y, hatch=hatches)
+
+
+@pytest.mark.parametrize(
+    ("x", "width", "label", "expected_labels", "container_label"),
+    [
+        ("x", 1, "x", ["_nolegend_"], "x"),
+        (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"],
+         ["A", "B", "C"], "_nolegend_"),
+        (["a", "b", "c"], [10, 20, 15], ["R", "Y", "_nolegend_"],
+         ["R", "Y", "_nolegend_"], "_nolegend_"),
+        (["a", "b", "c"], [10, 20, 15], "bars",
+         ["_nolegend_", "_nolegend_", "_nolegend_"], "bars"),
+    ]
+)
+def test_bar_labels(x, width, label, expected_labels, container_label):
+    _, ax = plt.subplots()
+    bar_container = ax.bar(x, width, label=label)
+    bar_labels = [bar.get_label() for bar in bar_container]
+    assert expected_labels == bar_labels
+    assert bar_container.get_label() == container_label
+
+
+def test_bar_labels_length():
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.bar(["x", "y"], [1, 2], label=["X", "Y", "Z"])
+    _, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.bar(["x", "y"], [1, 2], label=["X"])
+
+
+def test_pandas_minimal_plot(pd):
+    # smoke test that series and index objects do not warn
+    for x in [pd.Series([1, 2], dtype="float64"),
+              pd.Series([1, 2], dtype="Float64")]:
+        plt.plot(x, x)
+        plt.plot(x.index, x)
+        plt.plot(x)
+        plt.plot(x.index)
+    df = pd.DataFrame({'col': [1, 2, 3]})
+    plt.plot(df)
+    plt.plot(df, df)
+
+
+@image_comparison(['hist_log'], remove_text=True)
+def test_hist_log():
+    data0 = np.linspace(0, 1, 200)**3
+    data = np.concatenate([1 - data0, 1 + data0])
+    fig, ax = plt.subplots()
+    ax.hist(data, fill=False, log=True)
+
+
+@check_figures_equal(extensions=["png"])
+def test_hist_log_2(fig_test, fig_ref):
+    axs_test = fig_test.subplots(2, 3)
+    axs_ref = fig_ref.subplots(2, 3)
+    for i, histtype in enumerate(["bar", "step", "stepfilled"]):
+        # Set log scale, then call hist().
+        axs_test[0, i].set_yscale("log")
+        axs_test[0, i].hist(1, 1, histtype=histtype)
+        # Call hist(), then set log scale.
+        axs_test[1, i].hist(1, 1, histtype=histtype)
+        axs_test[1, i].set_yscale("log")
+        # Use hist(..., log=True).
+        for ax in axs_ref[:, i]:
+            ax.hist(1, 1, log=True, histtype=histtype)
+
+
+def test_hist_log_barstacked():
+    fig, axs = plt.subplots(2)
+    axs[0].hist([[0], [0, 1]], 2, histtype="barstacked")
+    axs[0].set_yscale("log")
+    axs[1].hist([0, 0, 1], 2, histtype="barstacked")
+    axs[1].set_yscale("log")
+    fig.canvas.draw()
+    assert axs[0].get_ylim() == axs[1].get_ylim()
+
+
+@image_comparison(['hist_bar_empty.png'], remove_text=True)
+def test_hist_bar_empty():
+    # From #3886: creating hist from empty dataset raises ValueError
+    ax = plt.gca()
+    ax.hist([], histtype='bar')
+
+
+def test_hist_float16():
+    np.random.seed(19680801)
+    values = np.clip(
+        np.random.normal(0.5, 0.3, size=1000), 0, 1).astype(np.float16)
+    h = plt.hist(values, bins=3, alpha=0.5)
+    bc = h[2]
+    # Check that there are no overlapping rectangles
+    for r in range(1, len(bc)):
+        rleft = bc[r-1].get_corners()
+        rright = bc[r].get_corners()
+        # right hand position of left rectangle <=
+        # left hand position of right rectangle
+        assert rleft[1][0] <= rright[0][0]
+
+
+@image_comparison(['hist_step_empty.png'], remove_text=True)
+def test_hist_step_empty():
+    # From #3886: creating hist from empty dataset raises ValueError
+    ax = plt.gca()
+    ax.hist([], histtype='step')
+
+
+@image_comparison(['hist_step_filled.png'], remove_text=True)
+def test_hist_step_filled():
+    np.random.seed(0)
+    x = np.random.randn(1000, 3)
+    n_bins = 10
+
+    kwargs = [{'fill': True}, {'fill': False}, {'fill': None}, {}]*2
+    types = ['step']*4+['stepfilled']*4
+    fig, axs = plt.subplots(nrows=2, ncols=4)
+
+    for kg, _type, ax in zip(kwargs, types, axs.flat):
+        ax.hist(x, n_bins, histtype=_type, stacked=True, **kg)
+        ax.set_title(f'{kg}/{_type}')
+        ax.set_ylim(bottom=-50)
+
+    patches = axs[0, 0].patches
+    assert all(p.get_facecolor() == p.get_edgecolor() for p in patches)
+
+
+@image_comparison(['hist_density.png'])
+def test_hist_density():
+    np.random.seed(19680801)
+    data = np.random.standard_normal(2000)
+    fig, ax = plt.subplots()
+    ax.hist(data, density=True)
+
+
+def test_hist_unequal_bins_density():
+    # Test correct behavior of normalized histogram with unequal bins
+    # https://github.com/matplotlib/matplotlib/issues/9557
+    rng = np.random.RandomState(57483)
+    t = rng.randn(100)
+    bins = [-3, -1, -0.5, 0, 1, 5]
+    mpl_heights, _, _ = plt.hist(t, bins=bins, density=True)
+    np_heights, _ = np.histogram(t, bins=bins, density=True)
+    assert_allclose(mpl_heights, np_heights)
+
+
+def test_hist_datetime_datasets():
+    data = [[datetime.datetime(2017, 1, 1), datetime.datetime(2017, 1, 1)],
+            [datetime.datetime(2017, 1, 1), datetime.datetime(2017, 1, 2)]]
+    fig, ax = plt.subplots()
+    ax.hist(data, stacked=True)
+    ax.hist(data, stacked=False)
+
+
+@pytest.mark.parametrize("bins_preprocess",
+                         [mpl.dates.date2num,
+                          lambda bins: bins,
+                          lambda bins: np.asarray(bins, 'datetime64')],
+                         ids=['date2num', 'datetime.datetime',
+                              'np.datetime64'])
+def test_hist_datetime_datasets_bins(bins_preprocess):
+    data = [[datetime.datetime(2019, 1, 5), datetime.datetime(2019, 1, 11),
+             datetime.datetime(2019, 2, 1), datetime.datetime(2019, 3, 1)],
+            [datetime.datetime(2019, 1, 11), datetime.datetime(2019, 2, 5),
+             datetime.datetime(2019, 2, 18), datetime.datetime(2019, 3, 1)]]
+
+    date_edges = [datetime.datetime(2019, 1, 1), datetime.datetime(2019, 2, 1),
+                  datetime.datetime(2019, 3, 1)]
+
+    fig, ax = plt.subplots()
+    _, bins, _ = ax.hist(data, bins=bins_preprocess(date_edges), stacked=True)
+    np.testing.assert_allclose(bins, mpl.dates.date2num(date_edges))
+
+    _, bins, _ = ax.hist(data, bins=bins_preprocess(date_edges), stacked=False)
+    np.testing.assert_allclose(bins, mpl.dates.date2num(date_edges))
+
+
+@pytest.mark.parametrize('data, expected_number_of_hists',
+                         [([], 1),
+                          ([[]], 1),
+                          ([[], []], 2)])
+def test_hist_with_empty_input(data, expected_number_of_hists):
+    hists, _, _ = plt.hist(data)
+    hists = np.asarray(hists)
+
+    if hists.ndim == 1:
+        assert 1 == expected_number_of_hists
+    else:
+        assert hists.shape[0] == expected_number_of_hists
+
+
+@pytest.mark.parametrize("histtype, zorder",
+                         [("bar", mpl.patches.Patch.zorder),
+                          ("step", mpl.lines.Line2D.zorder),
+                          ("stepfilled", mpl.patches.Patch.zorder)])
+def test_hist_zorder(histtype, zorder):
+    ax = plt.figure().add_subplot()
+    ax.hist([1, 2], histtype=histtype)
+    assert ax.patches
+    for patch in ax.patches:
+        assert patch.get_zorder() == zorder
+
+
+def test_stairs_no_baseline_fill_warns():
+    fig, ax = plt.subplots()
+    with pytest.warns(UserWarning, match="baseline=None and fill=True"):
+        ax.stairs(
+            [4, 5, 1, 0, 2],
+            [1, 2, 3, 4, 5, 6],
+            facecolor="blue",
+            baseline=None,
+            fill=True
+        )
+
+
+@check_figures_equal(extensions=['png'])
+def test_stairs(fig_test, fig_ref):
+    import matplotlib.lines as mlines
+    y = np.array([6, 14, 32, 37, 48, 32, 21,  4])  # hist
+    x = np.array([1., 2., 3., 4., 5., 6., 7., 8., 9.])  # bins
+
+    test_axes = fig_test.subplots(3, 2).flatten()
+    test_axes[0].stairs(y, x, baseline=None)
+    test_axes[1].stairs(y, x, baseline=None, orientation='horizontal')
+    test_axes[2].stairs(y, x)
+    test_axes[3].stairs(y, x, orientation='horizontal')
+    test_axes[4].stairs(y, x)
+    test_axes[4].semilogy()
+    test_axes[5].stairs(y, x, orientation='horizontal')
+    test_axes[5].semilogx()
+
+    # defaults of `PathPatch` to be used for all following Line2D
+    style = {'solid_joinstyle': 'miter', 'solid_capstyle': 'butt'}
+
+    ref_axes = fig_ref.subplots(3, 2).flatten()
+    ref_axes[0].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+    ref_axes[1].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
+
+    ref_axes[2].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+    ref_axes[2].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]], **style))
+    ref_axes[2].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]], **style))
+    ref_axes[2].set_ylim(0, None)
+
+    ref_axes[3].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
+    ref_axes[3].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]], **style))
+    ref_axes[3].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]], **style))
+    ref_axes[3].set_xlim(0, None)
+
+    ref_axes[4].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+    ref_axes[4].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]], **style))
+    ref_axes[4].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]], **style))
+    ref_axes[4].semilogy()
+
+    ref_axes[5].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
+    ref_axes[5].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]], **style))
+    ref_axes[5].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]], **style))
+    ref_axes[5].semilogx()
+
+
+@check_figures_equal(extensions=['png'])
+def test_stairs_fill(fig_test, fig_ref):
+    h, bins = [1, 2, 3, 4, 2], [0, 1, 2, 3, 4, 5]
+    bs = -2
+    # Test
+    test_axes = fig_test.subplots(2, 2).flatten()
+    test_axes[0].stairs(h, bins, fill=True)
+    test_axes[1].stairs(h, bins, orientation='horizontal', fill=True)
+    test_axes[2].stairs(h, bins, baseline=bs, fill=True)
+    test_axes[3].stairs(h, bins, baseline=bs, orientation='horizontal',
+                        fill=True)
+
+    # # Ref
+    ref_axes = fig_ref.subplots(2, 2).flatten()
+    ref_axes[0].fill_between(bins, np.append(h, h[-1]), step='post', lw=0)
+    ref_axes[0].set_ylim(0, None)
+    ref_axes[1].fill_betweenx(bins, np.append(h, h[-1]), step='post', lw=0)
+    ref_axes[1].set_xlim(0, None)
+    ref_axes[2].fill_between(bins, np.append(h, h[-1]),
+                             np.ones(len(h)+1)*bs, step='post', lw=0)
+    ref_axes[2].set_ylim(bs, None)
+    ref_axes[3].fill_betweenx(bins, np.append(h, h[-1]),
+                              np.ones(len(h)+1)*bs, step='post', lw=0)
+    ref_axes[3].set_xlim(bs, None)
+
+
+@check_figures_equal(extensions=['png'])
+def test_stairs_update(fig_test, fig_ref):
+    # fixed ylim because stairs() does autoscale, but updating data does not
+    ylim = -3, 4
+    # Test
+    test_ax = fig_test.add_subplot()
+    h = test_ax.stairs([1, 2, 3])
+    test_ax.set_ylim(ylim)
+    h.set_data([3, 2, 1])
+    h.set_data(edges=np.arange(4)+2)
+    h.set_data([1, 2, 1], np.arange(4)/2)
+    h.set_data([1, 2, 3])
+    h.set_data(None, np.arange(4))
+    assert np.allclose(h.get_data()[0], np.arange(1, 4))
+    assert np.allclose(h.get_data()[1], np.arange(4))
+    h.set_data(baseline=-2)
+    assert h.get_data().baseline == -2
+
+    # Ref
+    ref_ax = fig_ref.add_subplot()
+    h = ref_ax.stairs([1, 2, 3], baseline=-2)
+    ref_ax.set_ylim(ylim)
+
+
+@check_figures_equal(extensions=['png'])
+def test_stairs_baseline_None(fig_test, fig_ref):
+    x = np.array([0, 2, 3, 5, 10])
+    y = np.array([1.148, 1.231, 1.248, 1.25])
+
+    test_axes = fig_test.add_subplot()
+    test_axes.stairs(y, x, baseline=None)
+
+    style = {'solid_joinstyle': 'miter', 'solid_capstyle': 'butt'}
+
+    ref_axes = fig_ref.add_subplot()
+    ref_axes.plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
+
+
+def test_stairs_empty():
+    ax = plt.figure().add_subplot()
+    ax.stairs([], [42])
+    assert ax.get_xlim() == (39, 45)
+    assert ax.get_ylim() == (-0.06, 0.06)
+
+
+def test_stairs_invalid_nan():
+    with pytest.raises(ValueError, match='Nan values in "edges"'):
+        plt.stairs([1, 2], [0, np.nan, 1])
+
+
+def test_stairs_invalid_mismatch():
+    with pytest.raises(ValueError, match='Size mismatch'):
+        plt.stairs([1, 2], [0, 1])
+
+
+def test_stairs_invalid_update():
+    h = plt.stairs([1, 2], [0, 1, 2])
+    with pytest.raises(ValueError, match='Nan values in "edges"'):
+        h.set_data(edges=[1, np.nan, 2])
+
+
+def test_stairs_invalid_update2():
+    h = plt.stairs([1, 2], [0, 1, 2])
+    with pytest.raises(ValueError, match='Size mismatch'):
+        h.set_data(edges=np.arange(5))
+
+
+@image_comparison(['test_stairs_options.png'], remove_text=True)
+def test_stairs_options():
+    x, y = np.array([1, 2, 3, 4, 5]), np.array([1, 2, 3, 4]).astype(float)
+    yn = y.copy()
+    yn[1] = np.nan
+
+    fig, ax = plt.subplots()
+    ax.stairs(y*3, x, color='green', fill=True, label="A")
+    ax.stairs(y, x*3-3, color='red', fill=True,
+              orientation='horizontal', label="B")
+    ax.stairs(yn, x, color='orange', ls='--', lw=2, label="C")
+    ax.stairs(yn/3, x*3-2, ls='--', lw=2, baseline=0.5,
+              orientation='horizontal', label="D")
+    ax.stairs(y[::-1]*3+13, x-1, color='red', ls='--', lw=2, baseline=None,
+              label="E")
+    ax.stairs(y[::-1]*3+14, x, baseline=26,
+              color='purple', ls='--', lw=2, label="F")
+    ax.stairs(yn[::-1]*3+15, x+1, baseline=np.linspace(27, 25, len(y)),
+              color='blue', ls='--', label="G", fill=True)
+    ax.stairs(y[:-1][::-1]*2+11, x[:-1]+0.5, color='black', ls='--', lw=2,
+              baseline=12, hatch='//', label="H")
+    ax.legend(loc=0)
+
+
+@image_comparison(['test_stairs_datetime.png'])
+def test_stairs_datetime():
+    f, ax = plt.subplots(constrained_layout=True)
+    ax.stairs(np.arange(36),
+              np.arange(np.datetime64('2001-12-27'),
+                        np.datetime64('2002-02-02')))
+    plt.xticks(rotation=30)
+
+
+@check_figures_equal(extensions=['png'])
+def test_stairs_edge_handling(fig_test, fig_ref):
+    # Test
+    test_ax = fig_test.add_subplot()
+    test_ax.stairs([1, 2, 3], color='red', fill=True)
+
+    # Ref
+    ref_ax = fig_ref.add_subplot()
+    st = ref_ax.stairs([1, 2, 3], fill=True)
+    st.set_color('red')
+
+
+def contour_dat():
+    x = np.linspace(-3, 5, 150)
+    y = np.linspace(-3, 5, 120)
+    z = np.cos(x) + np.sin(y[:, np.newaxis])
+    return x, y, z
+
+
+@image_comparison(['contour_hatching'], remove_text=True, style='mpl20')
+def test_contour_hatching():
+    x, y, z = contour_dat()
+    fig, ax = plt.subplots()
+    ax.contourf(x, y, z, 7, hatches=['/', '\\', '//', '-'],
+                cmap=mpl.colormaps['gray'],
+                extend='both', alpha=0.5)
+
+
+@image_comparison(
+    ['contour_colorbar'], style='mpl20',
+    tol=0.54 if platform.machine() in ('aarch64', 'arm64', 'ppc64le', 's390x') else 0)
+def test_contour_colorbar():
+    x, y, z = contour_dat()
+
+    fig, ax = plt.subplots()
+    cs = ax.contourf(x, y, z, levels=np.arange(-1.8, 1.801, 0.2),
+                     cmap=mpl.colormaps['RdBu'],
+                     vmin=-0.6,
+                     vmax=0.6,
+                     extend='both')
+    cs1 = ax.contour(x, y, z, levels=np.arange(-2.2, -0.599, 0.2),
+                     colors=['y'],
+                     linestyles='solid',
+                     linewidths=2)
+    cs2 = ax.contour(x, y, z, levels=np.arange(0.6, 2.2, 0.2),
+                     colors=['c'],
+                     linewidths=2)
+    cbar = fig.colorbar(cs, ax=ax)
+    cbar.add_lines(cs1)
+    cbar.add_lines(cs2, erase=False)
+
+
+@image_comparison(['hist2d', 'hist2d'], remove_text=True, style='mpl20')
+def test_hist2d():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
+    np.random.seed(0)
+    # make it not symmetric in case we switch x and y axis
+    x = np.random.randn(100)*2+5
+    y = np.random.randn(100)-2
+    fig, ax = plt.subplots()
+    ax.hist2d(x, y, bins=10, rasterized=True)
+
+    # Reuse testcase from above for a labeled data test
+    data = {"x": x, "y": y}
+    fig, ax = plt.subplots()
+    ax.hist2d("x", "y", bins=10, data=data, rasterized=True)
+
+
+@image_comparison(['hist2d_transpose'], remove_text=True, style='mpl20')
+def test_hist2d_transpose():
+    # Remove this line when this test image is regenerated.
+    plt.rcParams['pcolormesh.snap'] = False
+
+    np.random.seed(0)
+    # make sure the output from np.histogram is transposed before
+    # passing to pcolorfast
+    x = np.array([5]*100)
+    y = np.random.randn(100)-2
+    fig, ax = plt.subplots()
+    ax.hist2d(x, y, bins=10, rasterized=True)
+
+
+def test_hist2d_density():
+    x, y = np.random.random((2, 100))
+    ax = plt.figure().subplots()
+    for obj in [ax, plt]:
+        obj.hist2d(x, y, density=True)
+
+
+class TestScatter:
+    @image_comparison(['scatter'], style='mpl20', remove_text=True)
+    def test_scatter_plot(self):
+        data = {"x": np.array([3, 4, 2, 6]), "y": np.array([2, 5, 2, 3]),
+                "c": ['r', 'y', 'b', 'lime'], "s": [24, 15, 19, 29],
+                "c2": ['0.5', '0.6', '0.7', '0.8']}
+
+        fig, ax = plt.subplots()
+        ax.scatter(data["x"] - 1., data["y"] - 1., c=data["c"], s=data["s"])
+        ax.scatter(data["x"] + 1., data["y"] + 1., c=data["c2"], s=data["s"])
+        ax.scatter("x", "y", c="c", s="s", data=data)
+
+    @image_comparison(['scatter_marker.png'], remove_text=True)
+    def test_scatter_marker(self):
+        fig, (ax0, ax1, ax2) = plt.subplots(ncols=3)
+        ax0.scatter([3, 4, 2, 6], [2, 5, 2, 3],
+                    c=[(1, 0, 0), 'y', 'b', 'lime'],
+                    s=[60, 50, 40, 30],
+                    edgecolors=['k', 'r', 'g', 'b'],
+                    marker='s')
+        ax1.scatter([3, 4, 2, 6], [2, 5, 2, 3],
+                    c=[(1, 0, 0), 'y', 'b', 'lime'],
+                    s=[60, 50, 40, 30],
+                    edgecolors=['k', 'r', 'g', 'b'],
+                    marker=mmarkers.MarkerStyle('o', fillstyle='top'))
+        # unit area ellipse
+        rx, ry = 3, 1
+        area = rx * ry * np.pi
+        theta = np.linspace(0, 2 * np.pi, 21)
+        verts = np.column_stack([np.cos(theta) * rx / area,
+                                 np.sin(theta) * ry / area])
+        ax2.scatter([3, 4, 2, 6], [2, 5, 2, 3],
+                    c=[(1, 0, 0), 'y', 'b', 'lime'],
+                    s=[60, 50, 40, 30],
+                    edgecolors=['k', 'r', 'g', 'b'],
+                    marker=verts)
+
+    @image_comparison(['scatter_2D'], remove_text=True, extensions=['png'])
+    def test_scatter_2D(self):
+        x = np.arange(3)
+        y = np.arange(2)
+        x, y = np.meshgrid(x, y)
+        z = x + y
+        fig, ax = plt.subplots()
+        ax.scatter(x, y, c=z, s=200, edgecolors='face')
+
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_decimal(self, fig_test, fig_ref):
+        x0 = np.array([1.5, 8.4, 5.3, 4.2])
+        y0 = np.array([1.1, 2.2, 3.3, 4.4])
+        x = np.array([Decimal(i) for i in x0])
+        y = np.array([Decimal(i) for i in y0])
+        c = ['r', 'y', 'b', 'lime']
+        s = [24, 15, 19, 29]
+        # Test image - scatter plot with Decimal() input
+        ax = fig_test.subplots()
+        ax.scatter(x, y, c=c, s=s)
+        # Reference image
+        ax = fig_ref.subplots()
+        ax.scatter(x0, y0, c=c, s=s)
+
+    def test_scatter_color(self):
+        # Try to catch cases where 'c' kwarg should have been used.
+        with pytest.raises(ValueError):
+            plt.scatter([1, 2], [1, 2], color=[0.1, 0.2])
+        with pytest.raises(ValueError):
+            plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
+
+    @pytest.mark.parametrize('kwargs',
+                                [
+                                    {'cmap': 'gray'},
+                                    {'norm': mcolors.Normalize()},
+                                    {'vmin': 0},
+                                    {'vmax': 0}
+                                ])
+    def test_scatter_color_warning(self, kwargs):
+        warn_match = "No data for colormapping provided "
+        # Warn for cases where 'cmap', 'norm', 'vmin', 'vmax'
+        # kwargs are being overridden
+        with pytest.warns(Warning, match=warn_match):
+            plt.scatter([], [], **kwargs)
+        with pytest.warns(Warning, match=warn_match):
+            plt.scatter([1, 2], [3, 4], c=[], **kwargs)
+        # Do not warn for cases where 'c' matches 'x' and 'y'
+        plt.scatter([], [], c=[], **kwargs)
+        plt.scatter([1, 2], [3, 4], c=[4, 5], **kwargs)
+
+    def test_scatter_unfilled(self):
+        coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
+                           marker=mmarkers.MarkerStyle('o', fillstyle='none'),
+                           linewidths=[1.1, 1.2, 1.3])
+        assert coll.get_facecolors().shape == (0, 4)  # no facecolors
+        assert_array_equal(coll.get_edgecolors(), [[0.1, 0.1, 0.1, 1],
+                                                   [0.3, 0.3, 0.3, 1],
+                                                   [0.5, 0.5, 0.5, 1]])
+        assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
+
+    @mpl.style.context('default')
+    def test_scatter_unfillable(self):
+        coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
+                           marker='x',
+                           linewidths=[1.1, 1.2, 1.3])
+        assert_array_equal(coll.get_facecolors(), coll.get_edgecolors())
+        assert_array_equal(coll.get_edgecolors(), [[0.1, 0.1, 0.1, 1],
+                                                   [0.3, 0.3, 0.3, 1],
+                                                   [0.5, 0.5, 0.5, 1]])
+        assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
+
+    def test_scatter_size_arg_size(self):
+        x = np.arange(4)
+        with pytest.raises(ValueError, match='same size as x and y'):
+            plt.scatter(x, x, x[1:])
+        with pytest.raises(ValueError, match='same size as x and y'):
+            plt.scatter(x[1:], x[1:], x)
+        with pytest.raises(ValueError, match='float array-like'):
+            plt.scatter(x, x, 'foo')
+
+    def test_scatter_edgecolor_RGB(self):
+        # GitHub issue 19066
+        coll = plt.scatter([1, 2, 3], [1, np.nan, np.nan],
+                            edgecolor=(1, 0, 0))
+        assert mcolors.same_color(coll.get_edgecolor(), (1, 0, 0))
+        coll = plt.scatter([1, 2, 3, 4], [1, np.nan, np.nan, 1],
+                            edgecolor=(1, 0, 0, 1))
+        assert mcolors.same_color(coll.get_edgecolor(), (1, 0, 0, 1))
+
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_invalid_color(self, fig_test, fig_ref):
+        ax = fig_test.subplots()
+        cmap = mpl.colormaps["viridis"].resampled(16)
+        cmap.set_bad("k", 1)
+        # Set a nonuniform size to prevent the last call to `scatter` (plotting
+        # the invalid points separately in fig_ref) from using the marker
+        # stamping fast path, which would result in slightly offset markers.
+        ax.scatter(range(4), range(4),
+                   c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
+                   cmap=cmap, plotnonfinite=True)
+        ax = fig_ref.subplots()
+        cmap = mpl.colormaps["viridis"].resampled(16)
+        ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
+        ax.scatter([1, 3], [1, 3], s=[2, 4], color="k")
+
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_no_invalid_color(self, fig_test, fig_ref):
+        # With plotnonfinite=False we plot only 2 points.
+        ax = fig_test.subplots()
+        cmap = mpl.colormaps["viridis"].resampled(16)
+        cmap.set_bad("k", 1)
+        ax.scatter(range(4), range(4),
+                   c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
+                   cmap=cmap, plotnonfinite=False)
+        ax = fig_ref.subplots()
+        ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
+
+    def test_scatter_norm_vminvmax(self):
+        """Parameters vmin, vmax should error if norm is given."""
+        x = [1, 2, 3]
+        ax = plt.axes()
+        with pytest.raises(ValueError,
+                           match="Passing a Normalize instance simultaneously "
+                                 "with vmin/vmax is not supported."):
+            ax.scatter(x, x, c=x, norm=mcolors.Normalize(-10, 10),
+                       vmin=0, vmax=5)
+
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_single_point(self, fig_test, fig_ref):
+        ax = fig_test.subplots()
+        ax.scatter(1, 1, c=1)
+        ax = fig_ref.subplots()
+        ax.scatter([1], [1], c=[1])
+
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_different_shapes(self, fig_test, fig_ref):
+        x = np.arange(10)
+        ax = fig_test.subplots()
+        ax.scatter(x, x.reshape(2, 5), c=x.reshape(5, 2))
+        ax = fig_ref.subplots()
+        ax.scatter(x.reshape(5, 2), x, c=x.reshape(2, 5))
+
+    # Parameters for *test_scatter_c*. NB: assuming that the
+    # scatter plot will have 4 elements. The tuple scheme is:
+    # (*c* parameter case, exception regexp key or None if no exception)
+    params_test_scatter_c = [
+        # single string:
+        ('0.5', None),
+        # Single letter-sequences
+        (["rgby"], "conversion"),
+        # Special cases
+        ("red", None),
+        ("none", None),
+        (None, None),
+        (["r", "g", "b", "none"], None),
+        # Non-valid color spec (FWIW, 'jaune' means yellow in French)
+        ("jaune", "conversion"),
+        (["jaune"], "conversion"),  # wrong type before wrong size
+        (["jaune"]*4, "conversion"),
+        # Value-mapping like
+        ([0.5]*3, None),  # should emit a warning for user's eyes though
+        ([0.5]*4, None),  # NB: no warning as matching size allows mapping
+        ([0.5]*5, "shape"),
+        # list of strings:
+        (['0.5', '0.4', '0.6', '0.7'], None),
+        (['0.5', 'red', '0.6', 'C5'], None),
+        (['0.5', 0.5, '0.6', 'C5'], "conversion"),
+        # RGB values
+        ([[1, 0, 0]], None),
+        ([[1, 0, 0]]*3, "shape"),
+        ([[1, 0, 0]]*4, None),
+        ([[1, 0, 0]]*5, "shape"),
+        # RGBA values
+        ([[1, 0, 0, 0.5]], None),
+        ([[1, 0, 0, 0.5]]*3, "shape"),
+        ([[1, 0, 0, 0.5]]*4, None),
+        ([[1, 0, 0, 0.5]]*5, "shape"),
+        # Mix of valid color specs
+        ([[1, 0, 0, 0.5]]*3 + [[1, 0, 0]], None),
+        ([[1, 0, 0, 0.5], "red", "0.0"], "shape"),
+        ([[1, 0, 0, 0.5], "red", "0.0", "C5"], None),
+        ([[1, 0, 0, 0.5], "red", "0.0", "C5", [0, 1, 0]], "shape"),
+        # Mix of valid and non valid color specs
+        ([[1, 0, 0, 0.5], "red", "jaune"], "conversion"),
+        ([[1, 0, 0, 0.5], "red", "0.0", "jaune"], "conversion"),
+        ([[1, 0, 0, 0.5], "red", "0.0", "C5", "jaune"], "conversion"),
+    ]
+
+    @pytest.mark.parametrize('c_case, re_key', params_test_scatter_c)
+    def test_scatter_c(self, c_case, re_key):
+        def get_next_color():
+            return 'blue'  # currently unused
+
+        xsize = 4
+        # Additional checking of *c* (introduced in #11383).
+        REGEXP = {
+            "shape": "^'c' argument has [0-9]+ elements",  # shape mismatch
+            "conversion": "^'c' argument must be a color",  # bad vals
+            }
+
+        assert_context = (
+            pytest.raises(ValueError, match=REGEXP[re_key])
+            if re_key is not None
+            else pytest.warns(match="argument looks like a single numeric RGB")
+            if isinstance(c_case, list) and len(c_case) == 3
+            else contextlib.nullcontext()
+        )
+        with assert_context:
+            mpl.axes.Axes._parse_scatter_color_args(
+                c=c_case, edgecolors="black", kwargs={}, xsize=xsize,
+                get_next_color_func=get_next_color)
+
+    @mpl.style.context('default')
+    @check_figures_equal(extensions=["png"])
+    def test_scatter_single_color_c(self, fig_test, fig_ref):
+        rgb = [[1, 0.5, 0.05]]
+        rgba = [[1, 0.5, 0.05, .5]]
+
+        # set via color kwarg
+        ax_ref = fig_ref.subplots()
+        ax_ref.scatter(np.ones(3), range(3), color=rgb)
+        ax_ref.scatter(np.ones(4)*2, range(4), color=rgba)
+
+        # set via broadcasting via c
+        ax_test = fig_test.subplots()
+        ax_test.scatter(np.ones(3), range(3), c=rgb)
+        ax_test.scatter(np.ones(4)*2, range(4), c=rgba)
+
+    def test_scatter_linewidths(self):
+        x = np.arange(5)
+
+        fig, ax = plt.subplots()
+        for i in range(3):
+            pc = ax.scatter(x, np.full(5, i), c=f'C{i}', marker='x', s=100,
+                            linewidths=i + 1)
+            assert pc.get_linewidths() == i + 1
+
+        pc = ax.scatter(x, np.full(5, 3), c='C3', marker='x', s=100,
+                        linewidths=[*range(1, 5), None])
+        assert_array_equal(pc.get_linewidths(),
+                           [*range(1, 5), mpl.rcParams['lines.linewidth']])
+
+    def test_scatter_singular_plural_arguments(self):
+
+        with pytest.raises(TypeError,
+                           match="Got both 'linewidth' and 'linewidths',\
+ which are aliases of one another"):
+            plt.scatter([1, 2, 3], [1, 2, 3], linewidths=[0.5, 0.4, 0.3], linewidth=0.2)
+
+        with pytest.raises(TypeError,
+                           match="Got both 'edgecolor' and 'edgecolors',\
+ which are aliases of one another"):
+            plt.scatter([1, 2, 3], [1, 2, 3],
+                        edgecolors=["#ffffff", "#000000", "#f0f0f0"],
+                          edgecolor="#ffffff")
+
+        with pytest.raises(TypeError,
+                           match="Got both 'facecolors' and 'facecolor',\
+ which are aliases of one another"):
+            plt.scatter([1, 2, 3], [1, 2, 3],
+                        facecolors=["#ffffff", "#000000", "#f0f0f0"],
+                            facecolor="#ffffff")
+
+
+def _params(c=None, xsize=2, *, edgecolors=None, **kwargs):
+    return (c, edgecolors, kwargs, xsize)
+_result = namedtuple('_result', 'c, colors')
+
+
+@pytest.mark.parametrize(
+    'params, expected_result',
+    [(_params(),
+      _result(c='b', colors=np.array([[0, 0, 1, 1]]))),
+     (_params(c='r'),
+      _result(c='r', colors=np.array([[1, 0, 0, 1]]))),
+     (_params(c='r', colors='b'),
+      _result(c='r', colors=np.array([[1, 0, 0, 1]]))),
+     # color
+     (_params(color='b'),
+      _result(c='b', colors=np.array([[0, 0, 1, 1]]))),
+     (_params(color=['b', 'g']),
+      _result(c=['b', 'g'], colors=np.array([[0, 0, 1, 1], [0, .5, 0, 1]]))),
+     ])
+def test_parse_scatter_color_args(params, expected_result):
+    def get_next_color():
+        return 'blue'  # currently unused
+
+    c, colors, _edgecolors = mpl.axes.Axes._parse_scatter_color_args(
+        *params, get_next_color_func=get_next_color)
+    assert c == expected_result.c
+    assert_allclose(colors, expected_result.colors)
+
+del _params
+del _result
+
+
+@pytest.mark.parametrize(
+    'kwargs, expected_edgecolors',
+    [(dict(), None),
+     (dict(c='b'), None),
+     (dict(edgecolors='r'), 'r'),
+     (dict(edgecolors=['r', 'g']), ['r', 'g']),
+     (dict(edgecolor='r'), 'r'),
+     (dict(edgecolors='face'), 'face'),
+     (dict(edgecolors='none'), 'none'),
+     (dict(edgecolor='r', edgecolors='g'), 'r'),
+     (dict(c='b', edgecolor='r', edgecolors='g'), 'r'),
+     (dict(color='r'), 'r'),
+     (dict(color='r', edgecolor='g'), 'g'),
+     ])
+def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
+    def get_next_color():
+        return 'blue'  # currently unused
+
+    c = kwargs.pop('c', None)
+    edgecolors = kwargs.pop('edgecolors', None)
+    _, _, result_edgecolors = \
+        mpl.axes.Axes._parse_scatter_color_args(
+            c, edgecolors, kwargs, xsize=2, get_next_color_func=get_next_color)
+    assert result_edgecolors == expected_edgecolors
+
+
+def test_parse_scatter_color_args_error():
+    def get_next_color():
+        return 'blue'  # currently unused
+
+    with pytest.raises(ValueError,
+                       match="RGBA values should be within 0-1 range"):
+        c = np.array([[0.1, 0.2, 0.7], [0.2, 0.4, 1.4]])  # value > 1
+        mpl.axes.Axes._parse_scatter_color_args(
+            c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)
+
+
+def test_as_mpl_axes_api():
+    # tests the _as_mpl_axes api
+    class Polar:
+        def __init__(self):
+            self.theta_offset = 0
+
+        def _as_mpl_axes(self):
+            # implement the matplotlib axes interface
+            return PolarAxes, {'theta_offset': self.theta_offset}
+
+    prj = Polar()
+    prj2 = Polar()
+    prj2.theta_offset = np.pi
+
+    # testing axes creation with plt.axes
+    ax = plt.axes((0, 0, 1, 1), projection=prj)
+    assert type(ax) is PolarAxes
+    plt.close()
+
+    # testing axes creation with subplot
+    ax = plt.subplot(121, projection=prj)
+    assert type(ax) is PolarAxes
+    plt.close()
+
+
+def test_pyplot_axes():
+    # test focusing of Axes in other Figure
+    fig1, ax1 = plt.subplots()
+    fig2, ax2 = plt.subplots()
+    plt.sca(ax1)
+    assert ax1 is plt.gca()
+    assert fig1 is plt.gcf()
+    plt.close(fig1)
+    plt.close(fig2)
+
+
+def test_log_scales():
+    fig, ax = plt.subplots()
+    ax.plot(np.log(np.linspace(0.1, 100)))
+    ax.set_yscale('log', base=5.5)
+    ax.invert_yaxis()
+    ax.set_xscale('log', base=9.0)
+    xticks, yticks = (
+        [(t.get_loc(), t.label1.get_text()) for t in axis._update_ticks()]
+        for axis in [ax.xaxis, ax.yaxis]
+    )
+    assert xticks == [
+        (1.0, '$\\mathdefault{9^{0}}$'),
+        (9.0, '$\\mathdefault{9^{1}}$'),
+        (81.0, '$\\mathdefault{9^{2}}$'),
+        (2.0, ''),
+        (3.0, ''),
+        (4.0, ''),
+        (5.0, ''),
+        (6.0, ''),
+        (7.0, ''),
+        (8.0, ''),
+        (18.0, ''),
+        (27.0, ''),
+        (36.0, ''),
+        (45.0, ''),
+        (54.0, ''),
+        (63.0, ''),
+        (72.0, ''),
+    ]
+    assert yticks == [
+        (0.18181818181818182, '$\\mathdefault{5.5^{-1}}$'),
+        (1.0, '$\\mathdefault{5.5^{0}}$'),
+        (5.5, '$\\mathdefault{5.5^{1}}$'),
+        (0.36363636363636365, ''),
+        (0.5454545454545454, ''),
+        (0.7272727272727273, ''),
+        (0.9090909090909092, ''),
+        (2.0, ''),
+        (3.0, ''),
+        (4.0, ''),
+        (5.0, ''),
+    ]
+
+
+def test_log_scales_no_data():
+    _, ax = plt.subplots()
+    ax.set(xscale="log", yscale="log")
+    ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
+    assert ax.get_xlim() == ax.get_ylim() == (1, 10)
+
+
+def test_log_scales_invalid():
+    fig, ax = plt.subplots()
+    ax.set_xscale('log')
+    with pytest.warns(UserWarning, match='Attempt to set non-positive'):
+        ax.set_xlim(-1, 10)
+    ax.set_yscale('log')
+    with pytest.warns(UserWarning, match='Attempt to set non-positive'):
+        ax.set_ylim(-1, 10)
+
+
+@image_comparison(['stackplot_test_image', 'stackplot_test_image'],
+                  tol=0.031 if platform.machine() == 'arm64' else 0)
+def test_stackplot():
+    fig = plt.figure()
+    x = np.linspace(0, 10, 10)
+    y1 = 1.0 * x
+    y2 = 2.0 * x + 1
+    y3 = 3.0 * x + 2
+    ax = fig.add_subplot(1, 1, 1)
+    ax.stackplot(x, y1, y2, y3)
+    ax.set_xlim((0, 10))
+    ax.set_ylim((0, 70))
+
+    # Reuse testcase from above for a test with labeled data and with colours
+    # from the Axes property cycle.
+    data = {"x": x, "y1": y1, "y2": y2, "y3": y3}
+    fig, ax = plt.subplots()
+    ax.stackplot("x", "y1", "y2", "y3", data=data, colors=["C0", "C1", "C2"])
+    ax.set_xlim((0, 10))
+    ax.set_ylim((0, 70))
+
+
+@image_comparison(['stackplot_test_baseline'], remove_text=True)
+def test_stackplot_baseline():
+    np.random.seed(0)
+
+    def layers(n, m):
+        a = np.zeros((m, n))
+        for i in range(n):
+            for j in range(5):
+                x = 1 / (.1 + np.random.random())
+                y = 2 * np.random.random() - .5
+                z = 10 / (.1 + np.random.random())
+                a[:, i] += x * np.exp(-((np.arange(m) / m - y) * z) ** 2)
         return a
-    annotate.__doc__ = mtext.Annotation.__init__.__doc__
-    #### Lines and spans
 
-    @_docstring.interpd
-    def axhline(self, y=0, xmin=0, xmax=1, **kwargs):
+    d = layers(3, 100)
+    d[50, :] = 0  # test for fixed weighted wiggle (issue #6313)
+
+    fig, axs = plt.subplots(2, 2)
+
+    axs[0, 0].stackplot(range(100), d.T, baseline='zero')
+    axs[0, 1].stackplot(range(100), d.T, baseline='sym')
+    axs[1, 0].stackplot(range(100), d.T, baseline='wiggle')
+    axs[1, 1].stackplot(range(100), d.T, baseline='weighted_wiggle')
+
+
+@check_figures_equal()
+def test_stackplot_hatching(fig_ref, fig_test):
+    x = np.linspace(0, 10, 10)
+    y1 = 1.0 * x
+    y2 = 2.0 * x + 1
+    y3 = 3.0 * x + 2
+    # stackplot with different hatching styles (issue #27146)
+    ax_test = fig_test.subplots()
+    ax_test.stackplot(x, y1, y2, y3, hatch=["x", "//", "\\\\"], colors=["white"])
+    ax_test.set_xlim((0, 10))
+    ax_test.set_ylim((0, 70))
+    # compare with result from hatching each layer individually
+    stack_baseline = np.zeros(len(x))
+    ax_ref = fig_ref.subplots()
+    ax_ref.fill_between(x, stack_baseline, y1, hatch="x", facecolor="white")
+    ax_ref.fill_between(x, y1, y1+y2, hatch="//", facecolor="white")
+    ax_ref.fill_between(x, y1+y2, y1+y2+y3, hatch="\\\\", facecolor="white")
+    ax_ref.set_xlim((0, 10))
+    ax_ref.set_ylim((0, 70))
+
+
+def _bxp_test_helper(
+        stats_kwargs={}, transform_stats=lambda s: s, bxp_kwargs={}):
+    np.random.seed(937)
+    logstats = mpl.cbook.boxplot_stats(
+        np.random.lognormal(mean=1.25, sigma=1., size=(37, 4)), **stats_kwargs)
+    fig, ax = plt.subplots()
+    if bxp_kwargs.get('orientation', 'vertical') == 'vertical':
+        ax.set_yscale('log')
+    else:
+        ax.set_xscale('log')
+    # Work around baseline images generate back when bxp did not respect the
+    # boxplot.boxprops.linewidth rcParam when patch_artist is False.
+    if not bxp_kwargs.get('patch_artist', False):
+        mpl.rcParams['boxplot.boxprops.linewidth'] = \
+            mpl.rcParams['lines.linewidth']
+    ax.bxp(transform_stats(logstats), **bxp_kwargs)
+
+
+@image_comparison(['bxp_baseline.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_baseline():
+    _bxp_test_helper()
+
+
+@image_comparison(['bxp_rangewhis.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_rangewhis():
+    _bxp_test_helper(stats_kwargs=dict(whis=[0, 100]))
+
+
+@image_comparison(['bxp_percentilewhis.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_percentilewhis():
+    _bxp_test_helper(stats_kwargs=dict(whis=[5, 95]))
+
+
+@image_comparison(['bxp_with_xlabels.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_with_xlabels():
+    def transform(stats):
+        for s, label in zip(stats, list('ABCD')):
+            s['label'] = label
+        return stats
+
+    _bxp_test_helper(transform_stats=transform)
+
+
+@image_comparison(['bxp_horizontal.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default',
+                  tol=0.1)
+def test_bxp_horizontal():
+    _bxp_test_helper(bxp_kwargs=dict(orientation='horizontal'))
+
+
+@image_comparison(['bxp_with_ylabels.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default',
+                  tol=0.1)
+def test_bxp_with_ylabels():
+    def transform(stats):
+        for s, label in zip(stats, list('ABCD')):
+            s['label'] = label
+        return stats
+
+    _bxp_test_helper(transform_stats=transform,
+                     bxp_kwargs=dict(orientation='horizontal'))
+
+
+@image_comparison(['bxp_patchartist.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_patchartist():
+    _bxp_test_helper(bxp_kwargs=dict(patch_artist=True))
+
+
+@image_comparison(['bxp_custompatchartist.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 100},
+                  style='default')
+def test_bxp_custompatchartist():
+    _bxp_test_helper(bxp_kwargs=dict(
+        patch_artist=True,
+        boxprops=dict(facecolor='yellow', edgecolor='green', ls=':')))
+
+
+@image_comparison(['bxp_customoutlier.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_customoutlier():
+    _bxp_test_helper(bxp_kwargs=dict(
+        flierprops=dict(linestyle='none', marker='d', mfc='g')))
+
+
+@image_comparison(['bxp_withmean_custompoint.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_showcustommean():
+    _bxp_test_helper(bxp_kwargs=dict(
+        showmeans=True,
+        meanprops=dict(linestyle='none', marker='d', mfc='green'),
+    ))
+
+
+@image_comparison(['bxp_custombox.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_custombox():
+    _bxp_test_helper(bxp_kwargs=dict(
+        boxprops=dict(linestyle='--', color='b', lw=3)))
+
+
+@image_comparison(['bxp_custommedian.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_custommedian():
+    _bxp_test_helper(bxp_kwargs=dict(
+        medianprops=dict(linestyle='--', color='b', lw=3)))
+
+
+@image_comparison(['bxp_customcap.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_customcap():
+    _bxp_test_helper(bxp_kwargs=dict(
+        capprops=dict(linestyle='--', color='g', lw=3)))
+
+
+@image_comparison(['bxp_customwhisker.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_customwhisker():
+    _bxp_test_helper(bxp_kwargs=dict(
+        whiskerprops=dict(linestyle='-', color='m', lw=3)))
+
+
+@check_figures_equal()
+def test_boxplot_median_bound_by_box(fig_test, fig_ref):
+    data = np.arange(3)
+    medianprops_test = {"linewidth": 12}
+    medianprops_ref = {**medianprops_test, "solid_capstyle": "butt"}
+    fig_test.subplots().boxplot(data,  medianprops=medianprops_test)
+    fig_ref.subplots().boxplot(data, medianprops=medianprops_ref)
+
+
+@image_comparison(['bxp_withnotch.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_shownotches():
+    _bxp_test_helper(bxp_kwargs=dict(shownotches=True))
+
+
+@image_comparison(['bxp_nocaps.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_nocaps():
+    _bxp_test_helper(bxp_kwargs=dict(showcaps=False))
+
+
+@image_comparison(['bxp_nobox.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_nobox():
+    _bxp_test_helper(bxp_kwargs=dict(showbox=False))
+
+
+@image_comparison(['bxp_no_flier_stats.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_no_flier_stats():
+    def transform(stats):
+        for s in stats:
+            s.pop('fliers', None)
+        return stats
+
+    _bxp_test_helper(transform_stats=transform,
+                     bxp_kwargs=dict(showfliers=False))
+
+
+@image_comparison(['bxp_withmean_point.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_showmean():
+    _bxp_test_helper(bxp_kwargs=dict(showmeans=True, meanline=False))
+
+
+@image_comparison(['bxp_withmean_line.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_showmeanasline():
+    _bxp_test_helper(bxp_kwargs=dict(showmeans=True, meanline=True))
+
+
+@image_comparison(['bxp_scalarwidth.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_scalarwidth():
+    _bxp_test_helper(bxp_kwargs=dict(widths=.25))
+
+
+@image_comparison(['bxp_customwidths.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_customwidths():
+    _bxp_test_helper(bxp_kwargs=dict(widths=[0.10, 0.25, 0.65, 0.85]))
+
+
+@image_comparison(['bxp_custompositions.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_custompositions():
+    _bxp_test_helper(bxp_kwargs=dict(positions=[1, 5, 6, 7]))
+
+
+def test_bxp_bad_widths():
+    with pytest.raises(ValueError):
+        _bxp_test_helper(bxp_kwargs=dict(widths=[1]))
+
+
+def test_bxp_bad_positions():
+    with pytest.raises(ValueError):
+        _bxp_test_helper(bxp_kwargs=dict(positions=[2, 3]))
+
+
+@image_comparison(['bxp_custom_capwidths.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_custom_capwidths():
+    _bxp_test_helper(bxp_kwargs=dict(capwidths=[0.0, 0.1, 0.5, 1.0]))
+
+
+@image_comparison(['bxp_custom_capwidth.png'],
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_bxp_custom_capwidth():
+    _bxp_test_helper(bxp_kwargs=dict(capwidths=0.6))
+
+
+def test_bxp_bad_capwidths():
+    with pytest.raises(ValueError):
+        _bxp_test_helper(bxp_kwargs=dict(capwidths=[1]))
+
+
+@image_comparison(['boxplot', 'boxplot'], tol=1.28, style='default')
+def test_boxplot():
+    # Randomness used for bootstrapping.
+    np.random.seed(937)
+
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, ax = plt.subplots()
+
+    ax.boxplot([x, x], bootstrap=10000, notch=1)
+    ax.set_ylim((-30, 30))
+
+    # Reuse testcase from above for a labeled data test
+    data = {"x": [x, x]}
+    fig, ax = plt.subplots()
+    ax.boxplot("x", bootstrap=10000, notch=1, data=data)
+    ax.set_ylim((-30, 30))
+
+
+@check_figures_equal(extensions=["png"])
+def test_boxplot_masked(fig_test, fig_ref):
+    # Check that masked values are ignored when plotting a boxplot
+    x_orig = np.linspace(-1, 1, 200)
+
+    ax = fig_test.subplots()
+    x = x_orig[x_orig >= 0]
+    ax.boxplot(x)
+
+    x = np.ma.masked_less(x_orig, 0)
+    ax = fig_ref.subplots()
+    ax.boxplot(x)
+
+
+@image_comparison(['boxplot_custom_capwidths.png'],
+                  savefig_kwarg={'dpi': 40}, style='default')
+def test_boxplot_custom_capwidths():
+
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, ax = plt.subplots()
+
+    ax.boxplot([x, x], notch=1, capwidths=[0.01, 0.2])
+
+
+@image_comparison(['boxplot_sym2.png'], remove_text=True, style='default')
+def test_boxplot_sym2():
+    # Randomness used for bootstrapping.
+    np.random.seed(937)
+
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, [ax1, ax2] = plt.subplots(1, 2)
+
+    ax1.boxplot([x, x], bootstrap=10000, sym='^')
+    ax1.set_ylim((-30, 30))
+
+    ax2.boxplot([x, x], bootstrap=10000, sym='g')
+    ax2.set_ylim((-30, 30))
+
+
+@image_comparison(['boxplot_sym.png'],
+                  remove_text=True,
+                  savefig_kwarg={'dpi': 40},
+                  style='default')
+def test_boxplot_sym():
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, ax = plt.subplots()
+
+    ax.boxplot([x, x], sym='gs')
+    ax.set_ylim((-30, 30))
+
+
+@image_comparison(['boxplot_autorange_false_whiskers.png',
+                   'boxplot_autorange_true_whiskers.png'],
+                  style='default')
+def test_boxplot_autorange_whiskers():
+    # Randomness used for bootstrapping.
+    np.random.seed(937)
+
+    x = np.ones(140)
+    x = np.hstack([0, x, 2])
+
+    fig1, ax1 = plt.subplots()
+    ax1.boxplot([x, x], bootstrap=10000, notch=1)
+    ax1.set_ylim((-5, 5))
+
+    fig2, ax2 = plt.subplots()
+    ax2.boxplot([x, x], bootstrap=10000, notch=1, autorange=True)
+    ax2.set_ylim((-5, 5))
+
+
+def _rc_test_bxp_helper(ax, rc_dict):
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    with matplotlib.rc_context(rc_dict):
+        ax.boxplot([x, x])
+    return ax
+
+
+@image_comparison(['boxplot_rc_parameters'],
+                  savefig_kwarg={'dpi': 100}, remove_text=True,
+                  tol=1, style='default')
+def test_boxplot_rc_parameters():
+    # Randomness used for bootstrapping.
+    np.random.seed(937)
+
+    fig, ax = plt.subplots(3)
+
+    rc_axis0 = {
+        'boxplot.notch': True,
+        'boxplot.whiskers': [5, 95],
+        'boxplot.bootstrap': 10000,
+
+        'boxplot.flierprops.color': 'b',
+        'boxplot.flierprops.marker': 'o',
+        'boxplot.flierprops.markerfacecolor': 'g',
+        'boxplot.flierprops.markeredgecolor': 'b',
+        'boxplot.flierprops.markersize': 5,
+        'boxplot.flierprops.linestyle': '--',
+        'boxplot.flierprops.linewidth': 2.0,
+
+        'boxplot.boxprops.color': 'r',
+        'boxplot.boxprops.linewidth': 2.0,
+        'boxplot.boxprops.linestyle': '--',
+
+        'boxplot.capprops.color': 'c',
+        'boxplot.capprops.linewidth': 2.0,
+        'boxplot.capprops.linestyle': '--',
+
+        'boxplot.medianprops.color': 'k',
+        'boxplot.medianprops.linewidth': 2.0,
+        'boxplot.medianprops.linestyle': '--',
+    }
+
+    rc_axis1 = {
+        'boxplot.whiskers': [0, 100],
+        'boxplot.patchartist': True,
+    }
+
+    rc_axis2 = {
+        'boxplot.whiskers': 2.0,
+        'boxplot.showcaps': False,
+        'boxplot.showbox': False,
+        'boxplot.showfliers': False,
+        'boxplot.showmeans': True,
+        'boxplot.meanline': True,
+
+        'boxplot.meanprops.color': 'c',
+        'boxplot.meanprops.linewidth': 2.0,
+        'boxplot.meanprops.linestyle': '--',
+
+        'boxplot.whiskerprops.color': 'r',
+        'boxplot.whiskerprops.linewidth': 2.0,
+        'boxplot.whiskerprops.linestyle': '-.',
+    }
+    dict_list = [rc_axis0, rc_axis1, rc_axis2]
+    for axis, rc_axis in zip(ax, dict_list):
+        _rc_test_bxp_helper(axis, rc_axis)
+
+    assert (matplotlib.patches.PathPatch in
+            [type(t) for t in ax[1].get_children()])
+
+
+@image_comparison(['boxplot_with_CIarray.png'],
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
+def test_boxplot_with_CIarray():
+    # Randomness used for bootstrapping.
+    np.random.seed(937)
+
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, ax = plt.subplots()
+    CIs = np.array([[-1.5, 3.], [-1., 3.5]])
+
+    # show a boxplot with Matplotlib medians and confidence intervals, and
+    # another with manual values
+    ax.boxplot([x, x], bootstrap=10000, usermedians=[None, 1.0],
+               conf_intervals=CIs, notch=1)
+    ax.set_ylim((-30, 30))
+
+
+@image_comparison(['boxplot_no_inverted_whisker.png'],
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
+def test_boxplot_no_weird_whisker():
+    x = np.array([3, 9000, 150, 88, 350, 200000, 1400, 960],
+                 dtype=np.float64)
+    ax1 = plt.axes()
+    ax1.boxplot(x)
+    ax1.set_yscale('log')
+    ax1.yaxis.grid(False, which='minor')
+    ax1.xaxis.grid(False)
+
+
+def test_boxplot_bad_medians():
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.boxplot(x, usermedians=[1, 2])
+    with pytest.raises(ValueError):
+        ax.boxplot([x, x], usermedians=[[1, 2], [1, 2]])
+
+
+def test_boxplot_bad_ci():
+    x = np.linspace(-7, 7, 140)
+    x = np.hstack([-25, x, 25])
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.boxplot([x, x], conf_intervals=[[1, 2]])
+    with pytest.raises(ValueError):
+        ax.boxplot([x, x], conf_intervals=[[1, 2], [1]])
+
+
+def test_boxplot_zorder():
+    x = np.arange(10)
+    fix, ax = plt.subplots()
+    assert ax.boxplot(x)['boxes'][0].get_zorder() == 2
+    assert ax.boxplot(x, zorder=10)['boxes'][0].get_zorder() == 10
+
+
+def test_boxplot_marker_behavior():
+    plt.rcParams['lines.marker'] = 's'
+    plt.rcParams['boxplot.flierprops.marker'] = 'o'
+    plt.rcParams['boxplot.meanprops.marker'] = '^'
+    fig, ax = plt.subplots()
+    test_data = np.arange(100)
+    test_data[-1] = 150  # a flier point
+    bxp_handle = ax.boxplot(test_data, showmeans=True)
+    for bxp_lines in ['whiskers', 'caps', 'boxes', 'medians']:
+        for each_line in bxp_handle[bxp_lines]:
+            # Ensure that the rcParams['lines.marker'] is overridden by ''
+            assert each_line.get_marker() == ''
+
+    # Ensure that markers for fliers and means aren't overridden with ''
+    assert bxp_handle['fliers'][0].get_marker() == 'o'
+    assert bxp_handle['means'][0].get_marker() == '^'
+
+
+@image_comparison(['boxplot_mod_artists_after_plotting.png'],
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
+def test_boxplot_mod_artist_after_plotting():
+    x = [0.15, 0.11, 0.06, 0.06, 0.12, 0.56, -0.56]
+    fig, ax = plt.subplots()
+    bp = ax.boxplot(x, sym="o")
+    for key in bp:
+        for obj in bp[key]:
+            obj.set_color('green')
+
+
+@image_comparison(['violinplot_vert_baseline.png',
+                   'violinplot_vert_baseline.png'])
+def test_vert_violinplot_baseline():
+    # First 9 digits of frac(sqrt(2))
+    np.random.seed(414213562)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax = plt.axes()
+    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
+                  showmedians=False)
+
+    # Reuse testcase from above for a labeled data test
+    data = {"d": data}
+    fig, ax = plt.subplots()
+    ax.violinplot("d", positions=range(4), showmeans=False, showextrema=False,
+                  showmedians=False, data=data)
+
+
+@image_comparison(['violinplot_vert_showmeans.png'])
+def test_vert_violinplot_showmeans():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(3))
+    np.random.seed(732050807)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), showmeans=True, showextrema=False,
+                  showmedians=False)
+
+
+@image_comparison(['violinplot_vert_showextrema.png'])
+def test_vert_violinplot_showextrema():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(5))
+    np.random.seed(236067977)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=True,
+                  showmedians=False)
+
+
+@image_comparison(['violinplot_vert_showmedians.png'])
+def test_vert_violinplot_showmedians():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(7))
+    np.random.seed(645751311)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
+                  showmedians=True)
+
+
+@image_comparison(['violinplot_vert_showall.png'])
+def test_vert_violinplot_showall():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(11))
+    np.random.seed(316624790)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), showmeans=True, showextrema=True,
+                  showmedians=True,
+                  quantiles=[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]])
+
+
+@image_comparison(['violinplot_vert_custompoints_10.png'])
+def test_vert_violinplot_custompoints_10():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(13))
+    np.random.seed(605551275)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
+                  showmedians=False, points=10)
+
+
+@image_comparison(['violinplot_vert_custompoints_200.png'])
+def test_vert_violinplot_custompoints_200():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(17))
+    np.random.seed(123105625)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
+                  showmedians=False, points=200)
+
+
+@image_comparison(['violinplot_horiz_baseline.png'])
+def test_horiz_violinplot_baseline():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(19))
+    np.random.seed(358898943)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
+                  showextrema=False, showmedians=False)
+
+
+@image_comparison(['violinplot_horiz_showmedians.png'])
+def test_horiz_violinplot_showmedians():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(23))
+    np.random.seed(795831523)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
+                  showextrema=False, showmedians=True)
+
+
+@image_comparison(['violinplot_horiz_showmeans.png'])
+def test_horiz_violinplot_showmeans():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(29))
+    np.random.seed(385164807)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=True,
+                  showextrema=False, showmedians=False)
+
+
+@image_comparison(['violinplot_horiz_showextrema.png'])
+def test_horiz_violinplot_showextrema():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(31))
+    np.random.seed(567764362)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
+                  showextrema=True, showmedians=False)
+
+
+@image_comparison(['violinplot_horiz_showall.png'])
+def test_horiz_violinplot_showall():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(37))
+    np.random.seed(82762530)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=True,
+                  showextrema=True, showmedians=True,
+                  quantiles=[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]])
+
+
+@image_comparison(['violinplot_horiz_custompoints_10.png'])
+def test_horiz_violinplot_custompoints_10():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(41))
+    np.random.seed(403124237)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
+                  showextrema=False, showmedians=False, points=10)
+
+
+@image_comparison(['violinplot_horiz_custompoints_200.png'])
+def test_horiz_violinplot_custompoints_200():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(43))
+    np.random.seed(557438524)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
+                  showextrema=False, showmedians=False, points=200)
+
+
+@image_comparison(['violinplot_sides.png'], remove_text=True, style='mpl20')
+def test_violinplot_sides():
+    ax = plt.axes()
+    np.random.seed(19680801)
+    data = [np.random.normal(size=100)]
+    # Check horizontal violinplot
+    for pos, side in zip([0, -0.5, 0.5], ['both', 'low', 'high']):
+        ax.violinplot(data, positions=[pos], orientation='horizontal', showmeans=False,
+                      showextrema=True, showmedians=True, side=side)
+    # Check vertical violinplot
+    for pos, side in zip([4, 3.5, 4.5], ['both', 'low', 'high']):
+        ax.violinplot(data, positions=[pos], orientation='vertical', showmeans=False,
+                      showextrema=True, showmedians=True, side=side)
+
+
+def test_violinplot_bad_positions():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(47))
+    np.random.seed(855654600)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    with pytest.raises(ValueError):
+        ax.violinplot(data, positions=range(5))
+
+
+def test_violinplot_bad_widths():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(53))
+    np.random.seed(280109889)
+    data = [np.random.normal(size=100) for _ in range(4)]
+    with pytest.raises(ValueError):
+        ax.violinplot(data, positions=range(4), widths=[1, 2, 3])
+
+
+def test_violinplot_bad_quantiles():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(73))
+    np.random.seed(544003745)
+    data = [np.random.normal(size=100)]
+
+    # Different size quantile list and plots
+    with pytest.raises(ValueError):
+        ax.violinplot(data, quantiles=[[0.1, 0.2], [0.5, 0.7]])
+
+
+def test_violinplot_outofrange_quantiles():
+    ax = plt.axes()
+    # First 9 digits of frac(sqrt(79))
+    np.random.seed(888194417)
+    data = [np.random.normal(size=100)]
+
+    # Quantile value above 100
+    with pytest.raises(ValueError):
+        ax.violinplot(data, quantiles=[[0.1, 0.2, 0.3, 1.05]])
+
+    # Quantile value below 0
+    with pytest.raises(ValueError):
+        ax.violinplot(data, quantiles=[[-0.05, 0.2, 0.3, 0.75]])
+
+
+@check_figures_equal(extensions=["png"])
+def test_violinplot_single_list_quantiles(fig_test, fig_ref):
+    # Ensures quantile list for 1D can be passed in as single list
+    # First 9 digits of frac(sqrt(83))
+    np.random.seed(110433579)
+    data = [np.random.normal(size=100)]
+
+    # Test image
+    ax = fig_test.subplots()
+    ax.violinplot(data, quantiles=[0.1, 0.3, 0.9])
+
+    # Reference image
+    ax = fig_ref.subplots()
+    ax.violinplot(data, quantiles=[[0.1, 0.3, 0.9]])
+
+
+@check_figures_equal(extensions=["png"])
+def test_violinplot_pandas_series(fig_test, fig_ref, pd):
+    np.random.seed(110433579)
+    s1 = pd.Series(np.random.normal(size=7), index=[9, 8, 7, 6, 5, 4, 3])
+    s2 = pd.Series(np.random.normal(size=9), index=list('ABCDEFGHI'))
+    s3 = pd.Series(np.random.normal(size=11))
+    fig_test.subplots().violinplot([s1, s2, s3])
+    fig_ref.subplots().violinplot([s1.values, s2.values, s3.values])
+
+
+def test_manage_xticks():
+    _, ax = plt.subplots()
+    ax.set_xlim(0, 4)
+    old_xlim = ax.get_xlim()
+    np.random.seed(0)
+    y1 = np.random.normal(10, 3, 20)
+    y2 = np.random.normal(3, 1, 20)
+    ax.boxplot([y1, y2], positions=[1, 2], manage_ticks=False)
+    new_xlim = ax.get_xlim()
+    assert_array_equal(old_xlim, new_xlim)
+
+
+def test_boxplot_not_single():
+    fig, ax = plt.subplots()
+    ax.boxplot(np.random.rand(100), positions=[3])
+    ax.boxplot(np.random.rand(100), positions=[5])
+    fig.canvas.draw()
+    assert ax.get_xlim() == (2.5, 5.5)
+    assert list(ax.get_xticks()) == [3, 5]
+    assert [t.get_text() for t in ax.get_xticklabels()] == ["3", "5"]
+
+
+def test_tick_space_size_0():
+    # allow font size to be zero, which affects ticks when there is
+    # no other text in the figure.
+    plt.plot([0, 1], [0, 1])
+    matplotlib.rcParams.update({'font.size': 0})
+    b = io.BytesIO()
+    plt.savefig(b, dpi=80, format='raw')
+
+
+@image_comparison(['errorbar_basic', 'errorbar_mixed', 'errorbar_basic'])
+def test_errorbar():
+    # longdouble due to floating point rounding issues with certain
+    # computer chipsets
+    x = np.arange(0.1, 4, 0.5, dtype=np.longdouble)
+    y = np.exp(-x)
+
+    yerr = 0.1 + 0.2*np.sqrt(x)
+    xerr = 0.1 + yerr
+
+    # First illustrate basic pyplot interface, using defaults where possible.
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.errorbar(x, y, xerr=0.2, yerr=0.4)
+    ax.set_title("Simplest errorbars, 0.2 in x, 0.4 in y")
+
+    # Now switch to a more OO interface to exercise more features.
+    fig, axs = plt.subplots(nrows=2, ncols=2, sharex=True)
+    ax = axs[0, 0]
+    ax.errorbar(x, y, yerr=yerr, fmt='o')
+    ax.set_title('Vert. symmetric')
+
+    # With 4 subplots, reduce the number of axis ticks to avoid crowding.
+    ax.locator_params(nbins=4)
+
+    ax = axs[0, 1]
+    ax.errorbar(x, y, xerr=xerr, fmt='o', alpha=0.4)
+    ax.set_title('Hor. symmetric w/ alpha')
+
+    ax = axs[1, 0]
+    ax.errorbar(x, y, yerr=[yerr, 2*yerr], xerr=[xerr, 2*xerr], fmt='--o')
+    ax.set_title('H, V asymmetric')
+
+    ax = axs[1, 1]
+    ax.set_yscale('log')
+    # Here we have to be careful to keep all y values positive:
+    ylower = np.maximum(1e-2, y - yerr)
+    yerr_lower = y - ylower
+
+    ax.errorbar(x, y, yerr=[yerr_lower, 2*yerr], xerr=xerr,
+                fmt='o', ecolor='g', capthick=2)
+    ax.set_title('Mixed sym., log y')
+    # Force limits due to floating point slop potentially expanding the range
+    ax.set_ylim(1e-2, 1e1)
+
+    fig.suptitle('Variable errorbars')
+
+    # Reuse the first testcase from above for a labeled data test
+    data = {"x": x, "y": y}
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.errorbar("x", "y", xerr=0.2, yerr=0.4, data=data)
+    ax.set_title("Simplest errorbars, 0.2 in x, 0.4 in y")
+
+
+@image_comparison(['mixed_errorbar_polar_caps'], extensions=['png'],
+                  remove_text=True)
+def test_mixed_errorbar_polar_caps():
+    """
+    Mix several polar errorbar use cases in a single test figure.
+
+    It is advisable to position individual points off the grid. If there are
+    problems with reproducibility of this test, consider removing grid.
+    """
+    fig = plt.figure()
+    ax = plt.subplot(111, projection='polar')
+
+    # symmetric errorbars
+    th_sym = [1, 2, 3]
+    r_sym = [0.9]*3
+    ax.errorbar(th_sym, r_sym, xerr=0.35, yerr=0.2, fmt="o")
+
+    # long errorbars
+    th_long = [np.pi/2 + .1, np.pi + .1]
+    r_long = [1.8, 2.2]
+    ax.errorbar(th_long, r_long, xerr=0.8 * np.pi, yerr=0.15, fmt="o")
+
+    # asymmetric errorbars
+    th_asym = [4*np.pi/3 + .1, 5*np.pi/3 + .1, 2*np.pi-0.1]
+    r_asym = [1.1]*3
+    xerr = [[.3, .3, .2], [.2, .3, .3]]
+    yerr = [[.35, .5, .5], [.5, .35, .5]]
+    ax.errorbar(th_asym, r_asym, xerr=xerr, yerr=yerr, fmt="o")
+
+    # overlapping errorbar
+    th_over = [2.1]
+    r_over = [3.1]
+    ax.errorbar(th_over, r_over, xerr=10, yerr=.2, fmt="o")
+
+
+def test_errorbar_colorcycle():
+
+    f, ax = plt.subplots()
+    x = np.arange(10)
+    y = 2*x
+
+    e1, _, _ = ax.errorbar(x, y, c=None)
+    e2, _, _ = ax.errorbar(x, 2*y, c=None)
+    ln1, = ax.plot(x, 4*y)
+
+    assert mcolors.to_rgba(e1.get_color()) == mcolors.to_rgba('C0')
+    assert mcolors.to_rgba(e2.get_color()) == mcolors.to_rgba('C1')
+    assert mcolors.to_rgba(ln1.get_color()) == mcolors.to_rgba('C2')
+
+
+@check_figures_equal()
+def test_errorbar_cycle_ecolor(fig_test, fig_ref):
+    x = np.arange(0.1, 4, 0.5)
+    y = [np.exp(-x+n) for n in range(4)]
+
+    axt = fig_test.subplots()
+    axr = fig_ref.subplots()
+
+    for yi, color in zip(y, ['C0', 'C1', 'C2', 'C3']):
+        axt.errorbar(x, yi, yerr=(yi * 0.25), linestyle='-',
+                     marker='o', ecolor='black')
+        axr.errorbar(x, yi, yerr=(yi * 0.25), linestyle='-',
+                     marker='o', color=color, ecolor='black')
+
+
+def test_errorbar_shape():
+    fig = plt.figure()
+    ax = fig.gca()
+
+    x = np.arange(0.1, 4, 0.5)
+    y = np.exp(-x)
+    yerr1 = 0.1 + 0.2*np.sqrt(x)
+    yerr = np.vstack((yerr1, 2*yerr1)).T
+    xerr = 0.1 + yerr
+
+    with pytest.raises(ValueError):
+        ax.errorbar(x, y, yerr=yerr, fmt='o')
+    with pytest.raises(ValueError):
+        ax.errorbar(x, y, xerr=xerr, fmt='o')
+    with pytest.raises(ValueError):
+        ax.errorbar(x, y, yerr=yerr, xerr=xerr, fmt='o')
+
+
+@image_comparison(['errorbar_limits'])
+def test_errorbar_limits():
+    x = np.arange(0.5, 5.5, 0.5)
+    y = np.exp(-x)
+    xerr = 0.1
+    yerr = 0.2
+    ls = 'dotted'
+
+    fig, ax = plt.subplots()
+
+    # standard error bars
+    ax.errorbar(x, y, xerr=xerr, yerr=yerr, ls=ls, color='blue')
+
+    # including upper limits
+    uplims = np.zeros_like(x)
+    uplims[[1, 5, 9]] = True
+    ax.errorbar(x, y+0.5, xerr=xerr, yerr=yerr, uplims=uplims, ls=ls,
+                color='green')
+
+    # including lower limits
+    lolims = np.zeros_like(x)
+    lolims[[2, 4, 8]] = True
+    ax.errorbar(x, y+1.0, xerr=xerr, yerr=yerr, lolims=lolims, ls=ls,
+                color='red')
+
+    # including upper and lower limits
+    ax.errorbar(x, y+1.5, marker='o', ms=8, xerr=xerr, yerr=yerr,
+                lolims=lolims, uplims=uplims, ls=ls, color='magenta')
+
+    # including xlower and xupper limits
+    xerr = 0.2
+    yerr = np.full_like(x, 0.2)
+    yerr[[3, 6]] = 0.3
+    xlolims = lolims
+    xuplims = uplims
+    lolims = np.zeros_like(x)
+    uplims = np.zeros_like(x)
+    lolims[[6]] = True
+    uplims[[3]] = True
+    ax.errorbar(x, y+2.1, marker='o', ms=8, xerr=xerr, yerr=yerr,
+                xlolims=xlolims, xuplims=xuplims, uplims=uplims,
+                lolims=lolims, ls='none', mec='blue', capsize=0,
+                color='cyan')
+    ax.set_xlim((0, 5.5))
+    ax.set_title('Errorbar upper and lower limits')
+
+
+def test_errorbar_nonefmt():
+    # Check that passing 'none' as a format still plots errorbars
+    x = np.arange(5)
+    y = np.arange(5)
+
+    plotline, _, barlines = plt.errorbar(x, y, xerr=1, yerr=1, fmt='none')
+    assert plotline is None
+    for errbar in barlines:
+        assert np.all(errbar.get_color() == mcolors.to_rgba('C0'))
+
+
+def test_errorbar_line_specific_kwargs():
+    # Check that passing line-specific keyword arguments will not result in
+    # errors.
+    x = np.arange(5)
+    y = np.arange(5)
+
+    plotline, _, _ = plt.errorbar(x, y, xerr=1, yerr=1, ls='None',
+                                  marker='s', fillstyle='full',
+                                  drawstyle='steps-mid',
+                                  dash_capstyle='round',
+                                  dash_joinstyle='miter',
+                                  solid_capstyle='butt',
+                                  solid_joinstyle='bevel')
+    assert plotline.get_fillstyle() == 'full'
+    assert plotline.get_drawstyle() == 'steps-mid'
+
+
+@check_figures_equal(extensions=['png'])
+def test_errorbar_with_prop_cycle(fig_test, fig_ref):
+    ax = fig_ref.subplots()
+    ax.errorbar(x=[2, 4, 10], y=[0, 1, 2], yerr=0.5,
+                ls='--', marker='s', mfc='k')
+    ax.errorbar(x=[2, 4, 10], y=[2, 3, 4], yerr=0.5, color='tab:green',
+                ls=':', marker='s', mfc='y')
+    ax.errorbar(x=[2, 4, 10], y=[4, 5, 6], yerr=0.5, fmt='tab:blue',
+                ls='-.', marker='o', mfc='c')
+    ax.set_xlim(1, 11)
+
+    _cycle = cycler(ls=['--', ':', '-.'], marker=['s', 's', 'o'],
+                    mfc=['k', 'y', 'c'], color=['b', 'g', 'r'])
+    plt.rc("axes", prop_cycle=_cycle)
+    ax = fig_test.subplots()
+    ax.errorbar(x=[2, 4, 10], y=[0, 1, 2], yerr=0.5)
+    ax.errorbar(x=[2, 4, 10], y=[2, 3, 4], yerr=0.5, color='tab:green')
+    ax.errorbar(x=[2, 4, 10], y=[4, 5, 6], yerr=0.5, fmt='tab:blue')
+    ax.set_xlim(1, 11)
+
+
+def test_errorbar_every_invalid():
+    x = np.linspace(0, 1, 15)
+    y = x * (1-x)
+    yerr = y/6
+
+    ax = plt.figure().subplots()
+
+    with pytest.raises(ValueError, match='not a tuple of two integers'):
+        ax.errorbar(x, y, yerr, errorevery=(1, 2, 3))
+    with pytest.raises(ValueError, match='not a tuple of two integers'):
+        ax.errorbar(x, y, yerr, errorevery=(1.3, 3))
+    with pytest.raises(ValueError, match='not a valid NumPy fancy index'):
+        ax.errorbar(x, y, yerr, errorevery=[False, True])
+    with pytest.raises(ValueError, match='not a recognized value'):
+        ax.errorbar(x, y, yerr, errorevery='foobar')
+
+
+def test_xerr_yerr_not_negative():
+    ax = plt.figure().subplots()
+
+    with pytest.raises(ValueError,
+                       match="'xerr' must not contain negative values"):
+        ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]], yerr=[[-0.5], [1]])
+    with pytest.raises(ValueError,
+                       match="'xerr' must not contain negative values"):
+        ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]])
+    with pytest.raises(ValueError,
+                       match="'yerr' must not contain negative values"):
+        ax.errorbar(x=[0], y=[0], yerr=[[-0.5], [1]])
+    with pytest.raises(ValueError,
+                       match="'yerr' must not contain negative values"):
+        x = np.arange(5)
+        y = [datetime.datetime(2021, 9, i * 2 + 1) for i in x]
+        ax.errorbar(x=x,
+                    y=y,
+                    yerr=datetime.timedelta(days=-10))
+
+
+def test_xerr_yerr_not_none():
+    ax = plt.figure().subplots()
+
+    with pytest.raises(ValueError,
+                       match="'xerr' must not contain None"):
+        ax.errorbar(x=[0], y=[0], xerr=[[None], [1]], yerr=[[None], [1]])
+    with pytest.raises(ValueError,
+                       match="'xerr' must not contain None"):
+        ax.errorbar(x=[0], y=[0], xerr=[[None], [1]])
+    with pytest.raises(ValueError,
+                       match="'yerr' must not contain None"):
+        ax.errorbar(x=[0], y=[0], yerr=[[None], [1]])
+
+
+@check_figures_equal()
+def test_errorbar_every(fig_test, fig_ref):
+    x = np.linspace(0, 1, 15)
+    y = x * (1-x)
+    yerr = y/6
+
+    ax_ref = fig_ref.subplots()
+    ax_test = fig_test.subplots()
+
+    for color, shift in zip('rgbk', [0, 0, 2, 7]):
+        y += .02
+
+        # Check errorevery using an explicit offset and step.
+        ax_test.errorbar(x, y, yerr, errorevery=(shift, 4),
+                         capsize=4, c=color)
+
+        # Using manual errorbars
+        # n.b. errorbar draws the main plot at z=2.1 by default
+        ax_ref.plot(x, y, c=color, zorder=2.1)
+        ax_ref.errorbar(x[shift::4], y[shift::4], yerr[shift::4],
+                        capsize=4, c=color, fmt='none')
+
+    # Check that markevery is propagated to line, without affecting errorbars.
+    ax_test.errorbar(x, y + 0.1, yerr, markevery=(1, 4), capsize=4, fmt='o')
+    ax_ref.plot(x[1::4], y[1::4] + 0.1, 'o', zorder=2.1)
+    ax_ref.errorbar(x, y + 0.1, yerr, capsize=4, fmt='none')
+
+    # Check that passing a slice to markevery/errorevery works.
+    ax_test.errorbar(x, y + 0.2, yerr, errorevery=slice(2, None, 3),
+                     markevery=slice(2, None, 3),
+                     capsize=4, c='C0', fmt='o')
+    ax_ref.plot(x[2::3], y[2::3] + 0.2, 'o', c='C0', zorder=2.1)
+    ax_ref.errorbar(x[2::3], y[2::3] + 0.2, yerr[2::3],
+                    capsize=4, c='C0', fmt='none')
+
+    # Check that passing an iterable to markevery/errorevery works.
+    ax_test.errorbar(x, y + 0.2, yerr, errorevery=[False, True, False] * 5,
+                     markevery=[False, True, False] * 5,
+                     capsize=4, c='C1', fmt='o')
+    ax_ref.plot(x[1::3], y[1::3] + 0.2, 'o', c='C1', zorder=2.1)
+    ax_ref.errorbar(x[1::3], y[1::3] + 0.2, yerr[1::3],
+                    capsize=4, c='C1', fmt='none')
+
+
+@pytest.mark.parametrize('elinewidth', [[1, 2, 3],
+                                        np.array([1, 2, 3]),
+                                        1])
+def test_errorbar_linewidth_type(elinewidth):
+    plt.errorbar([1, 2, 3], [1, 2, 3], yerr=[1, 2, 3], elinewidth=elinewidth)
+
+
+@check_figures_equal(extensions=["png"])
+def test_errorbar_nan(fig_test, fig_ref):
+    ax = fig_test.add_subplot()
+    xs = range(5)
+    ys = np.array([1, 2, np.nan, np.nan, 3])
+    es = np.array([4, 5, np.nan, np.nan, 6])
+    ax.errorbar(xs, ys, es)
+    ax = fig_ref.add_subplot()
+    ax.errorbar([0, 1], [1, 2], [4, 5])
+    ax.errorbar([4], [3], [6], fmt="C0")
+
+
+@image_comparison(['hist_stacked_stepfilled', 'hist_stacked_stepfilled'])
+def test_hist_stacked_stepfilled():
+    # make some data
+    d1 = np.linspace(1, 3, 20)
+    d2 = np.linspace(0, 10, 50)
+    fig, ax = plt.subplots()
+    ax.hist((d1, d2), histtype="stepfilled", stacked=True)
+
+    # Reuse testcase from above for a labeled data test
+    data = {"x": (d1, d2)}
+    fig, ax = plt.subplots()
+    ax.hist("x", histtype="stepfilled", stacked=True, data=data)
+
+
+@image_comparison(['hist_offset'])
+def test_hist_offset():
+    # make some data
+    d1 = np.linspace(0, 10, 50)
+    d2 = np.linspace(1, 3, 20)
+    fig, ax = plt.subplots()
+    ax.hist(d1, bottom=5)
+    ax.hist(d2, bottom=15)
+
+
+@image_comparison(['hist_step.png'], remove_text=True)
+def test_hist_step():
+    # make some data
+    d1 = np.linspace(1, 3, 20)
+    fig, ax = plt.subplots()
+    ax.hist(d1, histtype="step")
+    ax.set_ylim(0, 10)
+    ax.set_xlim(-1, 5)
+
+
+@image_comparison(['hist_step_horiz.png'])
+def test_hist_step_horiz():
+    # make some data
+    d1 = np.linspace(0, 10, 50)
+    d2 = np.linspace(1, 3, 20)
+    fig, ax = plt.subplots()
+    ax.hist((d1, d2), histtype="step", orientation="horizontal")
+
+
+@image_comparison(['hist_stacked_weights'])
+def test_hist_stacked_weighted():
+    # make some data
+    d1 = np.linspace(0, 10, 50)
+    d2 = np.linspace(1, 3, 20)
+    w1 = np.linspace(0.01, 3.5, 50)
+    w2 = np.linspace(0.05, 2., 20)
+    fig, ax = plt.subplots()
+    ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
+
+
+@image_comparison(['stem.png'], style='mpl20', remove_text=True)
+def test_stem():
+    x = np.linspace(0.1, 2 * np.pi, 100)
+
+    fig, ax = plt.subplots()
+    # Label is a single space to force a legend to be drawn, but to avoid any
+    # text being drawn
+    ax.stem(x, np.cos(x),
+            linefmt='C2-.', markerfmt='k+', basefmt='C1-.', label=' ')
+    ax.legend()
+
+
+def test_stem_args():
+    """Test that stem() correctly identifies x and y values."""
+    def _assert_equal(stem_container, expected):
+        x, y = map(list, stem_container.markerline.get_data())
+        assert x == expected[0]
+        assert y == expected[1]
+
+    fig, ax = plt.subplots()
+
+    x = [1, 3, 5]
+    y = [9, 8, 7]
+
+    # Test the call signatures
+    _assert_equal(ax.stem(y), expected=([0, 1, 2], y))
+    _assert_equal(ax.stem(x, y), expected=(x, y))
+    _assert_equal(ax.stem(x, y, linefmt='r--'), expected=(x, y))
+    _assert_equal(ax.stem(x, y, 'r--'), expected=(x, y))
+    _assert_equal(ax.stem(x, y, linefmt='r--', basefmt='b--'), expected=(x, y))
+    _assert_equal(ax.stem(y, linefmt='r--'), expected=([0, 1, 2], y))
+    _assert_equal(ax.stem(y, 'r--'), expected=([0, 1, 2], y))
+
+
+def test_stem_markerfmt():
+    """Test that stem(..., markerfmt=...) produces the intended markers."""
+    def _assert_equal(stem_container, linecolor=None, markercolor=None,
+                      marker=None):
         """
-        Add a horizontal line spanning the whole or fraction of the Axes.
-
-        Note: If you want to set x-limits in data coordinates, use
-        `~.Axes.hlines` instead.
-
-        Parameters
-        ----------
-        y : float, default: 0
-            y position in :ref:`data coordinates <coordinate-systems>`.
-
-        xmin : float, default: 0
-            The start x-position in :ref:`axes coordinates <coordinate-systems>`.
-            Should be between 0 and 1, 0 being the far left of the plot,
-            1 the far right of the plot.
-
-        xmax : float, default: 1
-            The end x-position in :ref:`axes coordinates <coordinate-systems>`.
-            Should be between 0 and 1, 0 being the far left of the plot,
-            1 the far right of the plot.
-
-        Returns
-        -------
-        `~matplotlib.lines.Line2D`
-            A `.Line2D` specified via two points ``(xmin, y)``, ``(xmax, y)``.
-            Its transform is set such that *x* is in
-            :ref:`axes coordinates <coordinate-systems>` and *y* is in
-            :ref:`data coordinates <coordinate-systems>`.
-
-            This is still a generic line and the horizontal character is only
-            realized through using identical *y* values for both points. Thus,
-            if you want to change the *y* value later, you have to provide two
-            values ``line.set_ydata([3, 3])``.
-
-        Other Parameters
-        ----------------
-        **kwargs
-            Valid keyword arguments are `.Line2D` properties, except for
-            'transform':
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        hlines : Add horizontal lines in data coordinates.
-        axhspan : Add a horizontal span (rectangle) across the axis.
-        axline : Add a line with an arbitrary slope.
-
-        Examples
-        --------
-        * draw a thick red hline at 'y' = 0 that spans the xrange::
-
-            >>> axhline(linewidth=4, color='r')
-
-        * draw a default hline at 'y' = 1 that spans the xrange::
-
-            >>> axhline(y=1)
-
-        * draw a default hline at 'y' = .5 that spans the middle half of
-          the xrange::
-
-            >>> axhline(y=.5, xmin=0.25, xmax=0.75)
+        Check that the given StemContainer has the properties listed as
+        keyword-arguments.
         """
-        self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
-        if "transform" in kwargs:
-            raise ValueError("'transform' is not allowed as a keyword "
-                             "argument; axhline generates its own transform.")
-        ymin, ymax = self.get_ybound()
-
-        # Strip away the units for comparison with non-unitized bounds.
-        yy, = self._process_unit_info([("y", y)], kwargs)
-        scaley = (yy < ymin) or (yy > ymax)
-
-        trans = self.get_yaxis_transform(which='grid')
-        l = mlines.Line2D([xmin, xmax], [y, y], transform=trans, **kwargs)
-        self.add_line(l)
-        l.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
-        if scaley:
-            self._request_autoscale_view("y")
-        return l
-
-    @_docstring.interpd
-    def axvline(self, x=0, ymin=0, ymax=1, **kwargs):
-        """
-        Add a vertical line spanning the whole or fraction of the Axes.
-
-        Note: If you want to set y-limits in data coordinates, use
-        `~.Axes.vlines` instead.
-
-        Parameters
-        ----------
-        x : float, default: 0
-            y position in :ref:`data coordinates <coordinate-systems>`.
-
-        ymin : float, default: 0
-            The start y-position in :ref:`axes coordinates <coordinate-systems>`.
-            Should be between 0 and 1, 0 being the bottom of the plot, 1 the
-            top of the plot.
-
-        ymax : float, default: 1
-            The end y-position in :ref:`axes coordinates <coordinate-systems>`.
-            Should be between 0 and 1, 0 being the bottom of the plot, 1 the
-            top of the plot.
-
-        Returns
-        -------
-        `~matplotlib.lines.Line2D`
-            A `.Line2D` specified via two points ``(x, ymin)``, ``(x, ymax)``.
-            Its transform is set such that *x* is in
-            :ref:`data coordinates <coordinate-systems>` and *y* is in
-            :ref:`axes coordinates <coordinate-systems>`.
-
-            This is still a generic line and the vertical character is only
-            realized through using identical *x* values for both points. Thus,
-            if you want to change the *x* value later, you have to provide two
-            values ``line.set_xdata([3, 3])``.
-
-        Other Parameters
-        ----------------
-        **kwargs
-            Valid keyword arguments are `.Line2D` properties, except for
-            'transform':
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        vlines : Add vertical lines in data coordinates.
-        axvspan : Add a vertical span (rectangle) across the axis.
-        axline : Add a line with an arbitrary slope.
-
-        Examples
-        --------
-        * draw a thick red vline at *x* = 0 that spans the yrange::
-
-            >>> axvline(linewidth=4, color='r')
-
-        * draw a default vline at *x* = 1 that spans the yrange::
-
-            >>> axvline(x=1)
-
-        * draw a default vline at *x* = .5 that spans the middle half of
-          the yrange::
-
-            >>> axvline(x=.5, ymin=0.25, ymax=0.75)
-        """
-        self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
-        if "transform" in kwargs:
-            raise ValueError("'transform' is not allowed as a keyword "
-                             "argument; axvline generates its own transform.")
-        xmin, xmax = self.get_xbound()
-
-        # Strip away the units for comparison with non-unitized bounds.
-        xx, = self._process_unit_info([("x", x)], kwargs)
-        scalex = (xx < xmin) or (xx > xmax)
-
-        trans = self.get_xaxis_transform(which='grid')
-        l = mlines.Line2D([x, x], [ymin, ymax], transform=trans, **kwargs)
-        self.add_line(l)
-        l.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
-        if scalex:
-            self._request_autoscale_view("x")
-        return l
-
-    @staticmethod
-    def _check_no_units(vals, names):
-        # Helper method to check that vals are not unitized
-        for val, name in zip(vals, names):
-            if not munits._is_natively_supported(val):
-                raise ValueError(f"{name} must be a single scalar value, "
-                                 f"but got {val}")
-
-    @_docstring.interpd
-    def axline(self, xy1, xy2=None, *, slope=None, **kwargs):
-        """
-        Add an infinitely long straight line.
-
-        The line can be defined either by two points *xy1* and *xy2*, or
-        by one point *xy1* and a *slope*.
-
-        This draws a straight line "on the screen", regardless of the x and y
-        scales, and is thus also suitable for drawing exponential decays in
-        semilog plots, power laws in loglog plots, etc. However, *slope*
-        should only be used with linear scales; It has no clear meaning for
-        all other scales, and thus the behavior is undefined. Please specify
-        the line using the points *xy1*, *xy2* for non-linear scales.
-
-        The *transform* keyword argument only applies to the points *xy1*,
-        *xy2*. The *slope* (if given) is always in data coordinates. This can
-        be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
-        slope.
-
-        Parameters
-        ----------
-        xy1, xy2 : (float, float)
-            Points for the line to pass through.
-            Either *xy2* or *slope* has to be given.
-        slope : float, optional
-            The slope of the line. Either *xy2* or *slope* has to be given.
-
-        Returns
-        -------
-        `.AxLine`
-
-        Other Parameters
-        ----------------
-        **kwargs
-            Valid kwargs are `.Line2D` properties
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        axhline : for horizontal lines
-        axvline : for vertical lines
-
-        Examples
-        --------
-        Draw a thick red line passing through (0, 0) and (1, 1)::
-
-            >>> axline((0, 0), (1, 1), linewidth=4, color='r')
-        """
-        if slope is not None and (self.get_xscale() != 'linear' or
-                                  self.get_yscale() != 'linear'):
-            raise TypeError("'slope' cannot be used with non-linear scales")
-
-        datalim = [xy1] if xy2 is None else [xy1, xy2]
-        if "transform" in kwargs:
-            # if a transform is passed (i.e. line points not in data space),
-            # data limits should not be adjusted.
-            datalim = []
-
-        line = mlines.AxLine(xy1, xy2, slope, **kwargs)
-        # Like add_line, but correctly handling data limits.
-        self._set_artist_props(line)
-        if line.get_clip_path() is None:
-            line.set_clip_path(self.patch)
-        if not line.get_label():
-            line.set_label(f"_child{len(self._children)}")
-        self._children.append(line)
-        line._remove_method = self._children.remove
-        self.update_datalim(datalim)
-
-        self._request_autoscale_view()
-        return line
-
-    @_docstring.interpd
-    def axhspan(self, ymin, ymax, xmin=0, xmax=1, **kwargs):
-        """
-        Add a horizontal span (rectangle) across the Axes.
-
-        The rectangle spans from *ymin* to *ymax* vertically, and, by default,
-        the whole x-axis horizontally.  The x-span can be set using *xmin*
-        (default: 0) and *xmax* (default: 1) which are in axis units; e.g.
-        ``xmin = 0.5`` always refers to the middle of the x-axis regardless of
-        the limits set by `~.Axes.set_xlim`.
-
-        Parameters
-        ----------
-        ymin : float
-            Lower y-coordinate of the span, in data units.
-        ymax : float
-            Upper y-coordinate of the span, in data units.
-        xmin : float, default: 0
-            Lower x-coordinate of the span, in x-axis (0-1) units.
-        xmax : float, default: 1
-            Upper x-coordinate of the span, in x-axis (0-1) units.
-
-        Returns
-        -------
-        `~matplotlib.patches.Rectangle`
-            Horizontal span (rectangle) from (xmin, ymin) to (xmax, ymax).
-
-        Other Parameters
-        ----------------
-        **kwargs : `~matplotlib.patches.Rectangle` properties
-
-        %(Rectangle:kwdoc)s
-
-        See Also
-        --------
-        axvspan : Add a vertical span across the Axes.
-        """
-        # Strip units away.
-        self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
-        (ymin, ymax), = self._process_unit_info([("y", [ymin, ymax])], kwargs)
-
-        p = mpatches.Rectangle((xmin, ymin), xmax - xmin, ymax - ymin, **kwargs)
-        p.set_transform(self.get_yaxis_transform(which="grid"))
-        # For Rectangles and non-separable transforms, add_patch can be buggy
-        # and update the x limits even though it shouldn't do so for an
-        # yaxis_transformed patch, so undo that update.
-        ix = self.dataLim.intervalx.copy()
-        mx = self.dataLim.minposx
-        self.add_patch(p)
-        self.dataLim.intervalx = ix
-        self.dataLim.minposx = mx
-        p.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
-        self._request_autoscale_view("y")
-        return p
-
-    @_docstring.interpd
-    def axvspan(self, xmin, xmax, ymin=0, ymax=1, **kwargs):
-        """
-        Add a vertical span (rectangle) across the Axes.
-
-        The rectangle spans from *xmin* to *xmax* horizontally, and, by
-        default, the whole y-axis vertically.  The y-span can be set using
-        *ymin* (default: 0) and *ymax* (default: 1) which are in axis units;
-        e.g. ``ymin = 0.5`` always refers to the middle of the y-axis
-        regardless of the limits set by `~.Axes.set_ylim`.
-
-        Parameters
-        ----------
-        xmin : float
-            Lower x-coordinate of the span, in data units.
-        xmax : float
-            Upper x-coordinate of the span, in data units.
-        ymin : float, default: 0
-            Lower y-coordinate of the span, in y-axis units (0-1).
-        ymax : float, default: 1
-            Upper y-coordinate of the span, in y-axis units (0-1).
-
-        Returns
-        -------
-        `~matplotlib.patches.Rectangle`
-            Vertical span (rectangle) from (xmin, ymin) to (xmax, ymax).
-
-        Other Parameters
-        ----------------
-        **kwargs : `~matplotlib.patches.Rectangle` properties
-
-        %(Rectangle:kwdoc)s
-
-        See Also
-        --------
-        axhspan : Add a horizontal span across the Axes.
-
-        Examples
-        --------
-        Draw a vertical, green, translucent rectangle from x = 1.25 to
-        x = 1.55 that spans the yrange of the Axes.
-
-        >>> axvspan(1.25, 1.55, facecolor='g', alpha=0.5)
-
-        """
-        # Strip units away.
-        self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
-        (xmin, xmax), = self._process_unit_info([("x", [xmin, xmax])], kwargs)
-
-        p = mpatches.Rectangle((xmin, ymin), xmax - xmin, ymax - ymin, **kwargs)
-        p.set_transform(self.get_xaxis_transform(which="grid"))
-        # For Rectangles and non-separable transforms, add_patch can be buggy
-        # and update the y limits even though it shouldn't do so for an
-        # xaxis_transformed patch, so undo that update.
-        iy = self.dataLim.intervaly.copy()
-        my = self.dataLim.minposy
-        self.add_patch(p)
-        self.dataLim.intervaly = iy
-        self.dataLim.minposy = my
-        p.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
-        self._request_autoscale_view("x")
-        return p
-
-    @_api.make_keyword_only("3.9", "label")
-    @_preprocess_data(replace_names=["y", "xmin", "xmax", "colors"],
-                      label_namer="y")
-    def hlines(self, y, xmin, xmax, colors=None, linestyles='solid',
-               label='', **kwargs):
-        """
-        Plot horizontal lines at each *y* from *xmin* to *xmax*.
-
-        Parameters
-        ----------
-        y : float or array-like
-            y-indexes where to plot the lines.
-
-        xmin, xmax : float or array-like
-            Respective beginning and end of each line. If scalars are
-            provided, all lines will have the same length.
-
-        colors : :mpltype:`color` or list of color , default: :rc:`lines.color`
-
-        linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, default: 'solid'
-
-        label : str, default: ''
-
-        Returns
-        -------
-        `~matplotlib.collections.LineCollection`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-        **kwargs :  `~matplotlib.collections.LineCollection` properties.
-
-        See Also
-        --------
-        vlines : vertical lines
-        axhline : horizontal line across the Axes
-        """
-
-        # We do the conversion first since not all unitized data is uniform
-        xmin, xmax, y = self._process_unit_info(
-            [("x", xmin), ("x", xmax), ("y", y)], kwargs)
-
-        if not np.iterable(y):
-            y = [y]
-        if not np.iterable(xmin):
-            xmin = [xmin]
-        if not np.iterable(xmax):
-            xmax = [xmax]
-
-        # Create and combine masked_arrays from input
-        y, xmin, xmax = cbook._combine_masks(y, xmin, xmax)
-        y = np.ravel(y)
-        xmin = np.ravel(xmin)
-        xmax = np.ravel(xmax)
-
-        masked_verts = np.ma.empty((len(y), 2, 2))
-        masked_verts[:, 0, 0] = xmin
-        masked_verts[:, 0, 1] = y
-        masked_verts[:, 1, 0] = xmax
-        masked_verts[:, 1, 1] = y
-
-        lines = mcoll.LineCollection(masked_verts, colors=colors,
-                                     linestyles=linestyles, label=label)
-        self.add_collection(lines, autolim=False)
-        lines._internal_update(kwargs)
-
-        if len(y) > 0:
-            # Extreme values of xmin/xmax/y.  Using masked_verts here handles
-            # the case of y being a masked *object* array (as can be generated
-            # e.g. by errorbar()), which would make nanmin/nanmax stumble.
-            updatex = True
-            updatey = True
-            if self.name == "rectilinear":
-                datalim = lines.get_datalim(self.transData)
-                t = lines.get_transform()
-                updatex, updatey = t.contains_branch_seperately(self.transData)
-                minx = np.nanmin(datalim.xmin)
-                maxx = np.nanmax(datalim.xmax)
-                miny = np.nanmin(datalim.ymin)
-                maxy = np.nanmax(datalim.ymax)
+        if linecolor is not None:
+            assert mcolors.same_color(
+                stem_container.stemlines.get_color(),
+                linecolor)
+        if markercolor is not None:
+            assert mcolors.same_color(
+                stem_container.markerline.get_color(),
+                markercolor)
+        if marker is not None:
+            assert stem_container.markerline.get_marker() == marker
+        assert stem_container.markerline.get_linestyle() == 'None'
+
+    fig, ax = plt.subplots()
+
+    x = [1, 3, 5]
+    y = [9, 8, 7]
+
+    # no linefmt
+    _assert_equal(ax.stem(x, y), markercolor='C0', marker='o')
+    _assert_equal(ax.stem(x, y, markerfmt='x'), markercolor='C0', marker='x')
+    _assert_equal(ax.stem(x, y, markerfmt='rx'), markercolor='r', marker='x')
+
+    # positional linefmt
+    _assert_equal(
+        ax.stem(x, y, 'r'),  # marker color follows linefmt if not given
+        linecolor='r', markercolor='r', marker='o')
+    _assert_equal(
+        ax.stem(x, y, 'rx'),  # the marker is currently not taken from linefmt
+        linecolor='r', markercolor='r', marker='o')
+    _assert_equal(
+        ax.stem(x, y, 'r', markerfmt='x'),  # only marker type specified
+        linecolor='r', markercolor='r', marker='x')
+    _assert_equal(
+        ax.stem(x, y, 'r', markerfmt='g'),  # only marker color specified
+        linecolor='r', markercolor='g', marker='o')
+    _assert_equal(
+        ax.stem(x, y, 'r', markerfmt='gx'),  # marker type and color specified
+        linecolor='r', markercolor='g', marker='x')
+    _assert_equal(
+        ax.stem(x, y, 'r', markerfmt=' '),  # markerfmt=' ' for no marker
+        linecolor='r', markercolor='r', marker='None')
+    _assert_equal(
+        ax.stem(x, y, 'r', markerfmt=''),  # markerfmt='' for no marker
+        linecolor='r', markercolor='r', marker='None')
+
+    # with linefmt kwarg
+    _assert_equal(
+        ax.stem(x, y, linefmt='r'),
+        linecolor='r', markercolor='r', marker='o')
+    _assert_equal(
+        ax.stem(x, y, linefmt='r', markerfmt='x'),
+        linecolor='r', markercolor='r', marker='x')
+    _assert_equal(
+        ax.stem(x, y, linefmt='r', markerfmt='gx'),
+        linecolor='r', markercolor='g', marker='x')
+
+
+def test_stem_dates():
+    fig, ax = plt.subplots(1, 1)
+    xs = [dateutil.parser.parse("2013-9-28 11:00:00"),
+          dateutil.parser.parse("2013-9-28 12:00:00")]
+    ys = [100, 200]
+    ax.stem(xs, ys)
+
+
+@image_comparison(['stem_orientation.png'], style='mpl20', remove_text=True)
+def test_stem_orientation():
+    x = np.linspace(0.1, 2*np.pi, 50)
+
+    fig, ax = plt.subplots()
+    ax.stem(x, np.cos(x),
+            linefmt='C2-.', markerfmt='kx', basefmt='C1-.',
+            orientation='horizontal')
+
+
+@image_comparison(['hist_stacked_stepfilled_alpha'])
+def test_hist_stacked_stepfilled_alpha():
+    # make some data
+    d1 = np.linspace(1, 3, 20)
+    d2 = np.linspace(0, 10, 50)
+    fig, ax = plt.subplots()
+    ax.hist((d1, d2), histtype="stepfilled", stacked=True, alpha=0.5)
+
+
+@image_comparison(['hist_stacked_step'])
+def test_hist_stacked_step():
+    # make some data
+    d1 = np.linspace(1, 3, 20)
+    d2 = np.linspace(0, 10, 50)
+    fig, ax = plt.subplots()
+    ax.hist((d1, d2), histtype="step", stacked=True)
+
+
+@image_comparison(['hist_stacked_normed'])
+def test_hist_stacked_density():
+    # make some data
+    d1 = np.linspace(1, 3, 20)
+    d2 = np.linspace(0, 10, 50)
+    fig, ax = plt.subplots()
+    ax.hist((d1, d2), stacked=True, density=True)
+
+
+@image_comparison(['hist_step_bottom.png'], remove_text=True)
+def test_hist_step_bottom():
+    # make some data
+    d1 = np.linspace(1, 3, 20)
+    fig, ax = plt.subplots()
+    ax.hist(d1, bottom=np.arange(10), histtype="stepfilled")
+
+
+def test_hist_step_geometry():
+    bins = [0, 1, 2, 3]
+    data = [0, 0, 1, 1, 1, 2]
+    top = [[0, 0], [0, 2], [1, 2], [1, 3], [2, 3], [2, 1], [3, 1], [3, 0]]
+    bottom = [[2, 0], [2, 0], [1, 0], [1, 0], [0, 0]]
+
+    for histtype, xy in [('step', top), ('stepfilled', top + bottom)]:
+        _, _, (polygon, ) = plt.hist(data, bins=bins, histtype=histtype)
+        assert_array_equal(polygon.get_xy(), xy)
+
+
+def test_hist_step_bottom_geometry():
+    bins = [0, 1, 2, 3]
+    data = [0, 0, 1, 1, 1, 2]
+    top = [[0, 1], [0, 3], [1, 3], [1, 5], [2, 5], [2, 2.5], [3, 2.5], [3, 1.5]]
+    bottom = [[2, 1.5], [2, 2], [1, 2], [1, 1], [0, 1]]
+
+    for histtype, xy in [('step', top), ('stepfilled', top + bottom)]:
+        _, _, (polygon, ) = plt.hist(data, bins=bins, bottom=[1, 2, 1.5],
+                                     histtype=histtype)
+        assert_array_equal(polygon.get_xy(), xy)
+
+
+def test_hist_stacked_step_geometry():
+    bins = [0, 1, 2, 3]
+    data_1 = [0, 0, 1, 1, 1, 2]
+    data_2 = [0, 1, 2]
+    tops = [
+        [[0, 0], [0, 2], [1, 2], [1, 3], [2, 3], [2, 1], [3, 1], [3, 0]],
+        [[0, 2], [0, 3], [1, 3], [1, 4], [2, 4], [2, 2], [3, 2], [3, 1]],
+    ]
+    bottoms = [
+        [[2, 0], [2, 0], [1, 0], [1, 0], [0, 0]],
+        [[2, 1], [2, 3], [1, 3], [1, 2], [0, 2]],
+    ]
+    combined = [t + b for t, b in zip(tops, bottoms)]
+
+    for histtype, xy in [('step', tops), ('stepfilled', combined)]:
+        _, _, patches = plt.hist([data_1, data_2], bins=bins, stacked=True,
+                                 histtype=histtype)
+        assert len(patches) == 2
+        polygon, = patches[0]
+        assert_array_equal(polygon.get_xy(), xy[0])
+        polygon, = patches[1]
+        assert_array_equal(polygon.get_xy(), xy[1])
+
+
+def test_hist_stacked_step_bottom_geometry():
+    bins = [0, 1, 2, 3]
+    data_1 = [0, 0, 1, 1, 1, 2]
+    data_2 = [0, 1, 2]
+    tops = [
+        [[0, 1], [0, 3], [1, 3], [1, 5], [2, 5], [2, 2.5], [3, 2.5], [3, 1.5]],
+        [[0, 3], [0, 4], [1, 4], [1, 6], [2, 6], [2, 3.5], [3, 3.5], [3, 2.5]],
+    ]
+    bottoms = [
+        [[2, 1.5], [2, 2], [1, 2], [1, 1], [0, 1]],
+        [[2, 2.5], [2, 5], [1, 5], [1, 3], [0, 3]],
+    ]
+    combined = [t + b for t, b in zip(tops, bottoms)]
+
+    for histtype, xy in [('step', tops), ('stepfilled', combined)]:
+        _, _, patches = plt.hist([data_1, data_2], bins=bins, stacked=True,
+                                 bottom=[1, 2, 1.5], histtype=histtype)
+        assert len(patches) == 2
+        polygon, = patches[0]
+        assert_array_equal(polygon.get_xy(), xy[0])
+        polygon, = patches[1]
+        assert_array_equal(polygon.get_xy(), xy[1])
+
+
+@image_comparison(['hist_stacked_bar'])
+def test_hist_stacked_bar():
+    # make some data
+    d = [[100, 100, 100, 100, 200, 320, 450, 80, 20, 600, 310, 800],
+         [20, 23, 50, 11, 100, 420], [120, 120, 120, 140, 140, 150, 180],
+         [60, 60, 60, 60, 300, 300, 5, 5, 5, 5, 10, 300],
+         [555, 555, 555, 30, 30, 30, 30, 30, 100, 100, 100, 100, 30, 30],
+         [30, 30, 30, 30, 400, 400, 400, 400, 400, 400, 400, 400]]
+    colors = [(0.5759849696758961, 1.0, 0.0), (0.0, 1.0, 0.350624650815206),
+              (0.0, 1.0, 0.6549834156005998), (0.0, 0.6569064625276622, 1.0),
+              (0.28302699607823545, 0.0, 1.0), (0.6849123462299822, 0.0, 1.0)]
+    labels = ['green', 'orange', ' yellow', 'magenta', 'black']
+    fig, ax = plt.subplots()
+    ax.hist(d, bins=10, histtype='barstacked', align='mid', color=colors,
+            label=labels)
+    ax.legend(loc='upper right', bbox_to_anchor=(1.0, 1.0), ncols=1)
+
+
+@pytest.mark.parametrize('kwargs', ({'facecolor': ["b", "g", "r"]},
+                                    {'edgecolor': ["b", "g", "r"]},
+                                    {'hatch': ["/", "\\", "."]},
+                                    {'linestyle': ["-", "--", ":"]},
+                                    {'linewidth': [1, 1.5, 2]},
+                                    {'color': ["b", "g", "r"]}))
+@check_figures_equal(extensions=["png"])
+def test_hist_vectorized_params(fig_test, fig_ref, kwargs):
+    np.random.seed(19680801)
+    xs = [np.random.randn(n) for n in [20, 50, 100]]
+
+    (axt1, axt2) = fig_test.subplots(2)
+    (axr1, axr2) = fig_ref.subplots(2)
+
+    for histtype, axt, axr in [("stepfilled", axt1, axr1), ("step", axt2, axr2)]:
+        _, bins, _ = axt.hist(xs, bins=10, histtype=histtype, **kwargs)
+
+        kw, values = next(iter(kwargs.items()))
+        for i, (x, value) in enumerate(zip(xs, values)):
+            axr.hist(x, bins=bins, histtype=histtype, **{kw: value},
+                     zorder=(len(xs)-i)/2)
+
+
+@pytest.mark.parametrize('kwargs, patch_face, patch_edge',
+                         # 'C0'(blue) stands for the first color of the
+                         # default color cycle as well as the patch.facecolor rcParam
+                         # When the expected edgecolor is 'k'(black),
+                         # it corresponds to the patch.edgecolor rcParam
+                         [({'histtype': 'stepfilled', 'color': 'r',
+                            'facecolor': 'y', 'edgecolor': 'g'}, 'y', 'g'),
+                          ({'histtype': 'step', 'color': 'r',
+                            'facecolor': 'y', 'edgecolor': 'g'}, ('y', 0), 'g'),
+                          ({'histtype': 'stepfilled', 'color': 'r',
+                            'edgecolor': 'g'}, 'r', 'g'),
+                          ({'histtype': 'step', 'color': 'r',
+                            'edgecolor': 'g'}, ('r', 0), 'g'),
+                          ({'histtype': 'stepfilled', 'color': 'r',
+                            'facecolor': 'y'}, 'y', 'k'),
+                          ({'histtype': 'step', 'color': 'r',
+                            'facecolor': 'y'}, ('y', 0), 'r'),
+                          ({'histtype': 'stepfilled',
+                            'facecolor': 'y', 'edgecolor': 'g'}, 'y', 'g'),
+                          ({'histtype': 'step', 'facecolor': 'y',
+                            'edgecolor': 'g'}, ('y', 0), 'g'),
+                          ({'histtype': 'stepfilled', 'color': 'r'}, 'r', 'k'),
+                          ({'histtype': 'step', 'color': 'r'}, ('r', 0), 'r'),
+                          ({'histtype': 'stepfilled', 'facecolor': 'y'}, 'y', 'k'),
+                          ({'histtype': 'step', 'facecolor': 'y'}, ('y', 0), 'C0'),
+                          ({'histtype': 'stepfilled', 'edgecolor': 'g'}, 'C0', 'g'),
+                          ({'histtype': 'step', 'edgecolor': 'g'}, ('C0', 0), 'g'),
+                          ({'histtype': 'stepfilled'}, 'C0', 'k'),
+                          ({'histtype': 'step'}, ('C0', 0), 'C0')])
+def test_hist_color_semantics(kwargs, patch_face, patch_edge):
+    _, _, patches = plt.figure().subplots().hist([1, 2, 3], **kwargs)
+    assert all(mcolors.same_color([p.get_facecolor(), p.get_edgecolor()],
+                                  [patch_face, patch_edge]) for p in patches)
+
+
+def test_hist_barstacked_bottom_unchanged():
+    b = np.array([10, 20])
+    plt.hist([[0, 1], [0, 1]], 2, histtype="barstacked", bottom=b)
+    assert b.tolist() == [10, 20]
+
+
+def test_hist_emptydata():
+    fig, ax = plt.subplots()
+    ax.hist([[], range(10), range(10)], histtype="step")
+
+
+def test_hist_unused_labels():
+    # When a list with one dataset and N elements is provided and N labels, ensure
+    # that the first label is used for the dataset and all other labels are ignored
+    fig, ax = plt.subplots()
+    ax.hist([[1, 2, 3]], label=["values", "unused", "also unused"])
+    _, labels = ax.get_legend_handles_labels()
+    assert labels == ["values"]
+
+
+def test_hist_labels():
+    # test singleton labels OK
+    fig, ax = plt.subplots()
+    _, _, bars = ax.hist([0, 1], label=0)
+    assert bars[0].get_label() == '0'
+    _, _, bars = ax.hist([0, 1], label=[0])
+    assert bars[0].get_label() == '0'
+    _, _, bars = ax.hist([0, 1], label=None)
+    assert bars[0].get_label() == '_nolegend_'
+    _, _, bars = ax.hist([0, 1], label='0')
+    assert bars[0].get_label() == '0'
+    _, _, bars = ax.hist([0, 1], label='00')
+    assert bars[0].get_label() == '00'
+
+
+@image_comparison(['transparent_markers'], remove_text=True)
+def test_transparent_markers():
+    np.random.seed(0)
+    data = np.random.random(50)
+
+    fig, ax = plt.subplots()
+    ax.plot(data, 'D', mfc='none', markersize=100)
+
+
+@image_comparison(['rgba_markers'], remove_text=True)
+def test_rgba_markers():
+    fig, axs = plt.subplots(ncols=2)
+    rcolors = [(1, 0, 0, 1), (1, 0, 0, 0.5)]
+    bcolors = [(0, 0, 1, 1), (0, 0, 1, 0.5)]
+    alphas = [None, 0.2]
+    kw = dict(ms=100, mew=20)
+    for i, alpha in enumerate(alphas):
+        for j, rcolor in enumerate(rcolors):
+            for k, bcolor in enumerate(bcolors):
+                axs[i].plot(j+1, k+1, 'o', mfc=bcolor, mec=rcolor,
+                            alpha=alpha, **kw)
+                axs[i].plot(j+1, k+3, 'x', mec=rcolor, alpha=alpha, **kw)
+    for ax in axs:
+        ax.axis([-1, 4, 0, 5])
+
+
+@image_comparison(['mollweide_grid'], remove_text=True)
+def test_mollweide_grid():
+    # test that both horizontal and vertical gridlines appear on the Mollweide
+    # projection
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='mollweide')
+    ax.grid()
+
+
+def test_mollweide_forward_inverse_closure():
+    # test that the round-trip Mollweide forward->inverse transformation is an
+    # approximate identity
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='mollweide')
+
+    # set up 1-degree grid in longitude, latitude
+    lon = np.linspace(-np.pi, np.pi, 360)
+    # The poles are degenerate and thus sensitive to floating point precision errors
+    lat = np.linspace(-np.pi / 2.0, np.pi / 2.0, 180)[1:-1]
+    lon, lat = np.meshgrid(lon, lat)
+    ll = np.vstack((lon.flatten(), lat.flatten())).T
+
+    # perform forward transform
+    xy = ax.transProjection.transform(ll)
+
+    # perform inverse transform
+    ll2 = ax.transProjection.inverted().transform(xy)
+
+    # compare
+    np.testing.assert_array_almost_equal(ll, ll2, 3)
+
+
+def test_mollweide_inverse_forward_closure():
+    # test that the round-trip Mollweide inverse->forward transformation is an
+    # approximate identity
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='mollweide')
+
+    # set up grid in x, y
+    x = np.linspace(0, 1, 500)
+    x, y = np.meshgrid(x, x)
+    xy = np.vstack((x.flatten(), y.flatten())).T
+
+    # perform inverse transform
+    ll = ax.transProjection.inverted().transform(xy)
+
+    # perform forward transform
+    xy2 = ax.transProjection.transform(ll)
+
+    # compare
+    np.testing.assert_array_almost_equal(xy, xy2, 3)
+
+
+@image_comparison(['test_alpha'], remove_text=True)
+def test_alpha():
+    np.random.seed(0)
+    data = np.random.random(50)
+
+    fig, ax = plt.subplots()
+
+    # alpha=.5 markers, solid line
+    ax.plot(data, '-D', color=[1, 0, 0], mfc=[1, 0, 0, .5],
+            markersize=20, lw=10)
+
+    # everything solid by kwarg
+    ax.plot(data + 2, '-D', color=[1, 0, 0, .5], mfc=[1, 0, 0, .5],
+            markersize=20, lw=10,
+            alpha=1)
+
+    # everything alpha=.5 by kwarg
+    ax.plot(data + 4, '-D', color=[1, 0, 0], mfc=[1, 0, 0],
+            markersize=20, lw=10,
+            alpha=.5)
+
+    # everything alpha=.5 by colors
+    ax.plot(data + 6, '-D', color=[1, 0, 0, .5], mfc=[1, 0, 0, .5],
+            markersize=20, lw=10)
+
+    # alpha=.5 line, solid markers
+    ax.plot(data + 8, '-D', color=[1, 0, 0, .5], mfc=[1, 0, 0],
+            markersize=20, lw=10)
+
+
+@image_comparison(['eventplot', 'eventplot'], remove_text=True)
+def test_eventplot():
+    np.random.seed(0)
+
+    data1 = np.random.random([32, 20]).tolist()
+    data2 = np.random.random([6, 20]).tolist()
+    data = data1 + data2
+    num_datasets = len(data)
+
+    colors1 = [[0, 1, .7]] * len(data1)
+    colors2 = [[1, 0, 0],
+               [0, 1, 0],
+               [0, 0, 1],
+               [1, .75, 0],
+               [1, 0, 1],
+               [0, 1, 1]]
+    colors = colors1 + colors2
+
+    lineoffsets1 = 12 + np.arange(0, len(data1)) * .33
+    lineoffsets2 = [-15, -3, 1, 1.5, 6, 10]
+    lineoffsets = lineoffsets1.tolist() + lineoffsets2
+
+    linelengths1 = [.33] * len(data1)
+    linelengths2 = [5, 2, 1, 1, 3, 1.5]
+    linelengths = linelengths1 + linelengths2
+
+    fig = plt.figure()
+    axobj = fig.add_subplot()
+    colls = axobj.eventplot(data, colors=colors, lineoffsets=lineoffsets,
+                            linelengths=linelengths)
+
+    num_collections = len(colls)
+    assert num_collections == num_datasets
+
+    # Reuse testcase from above for a labeled data test
+    data = {"pos": data, "c": colors, "lo": lineoffsets, "ll": linelengths}
+    fig = plt.figure()
+    axobj = fig.add_subplot()
+    colls = axobj.eventplot("pos", colors="c", lineoffsets="lo",
+                            linelengths="ll", data=data)
+    num_collections = len(colls)
+    assert num_collections == num_datasets
+
+
+@image_comparison(['test_eventplot_defaults.png'], remove_text=True)
+def test_eventplot_defaults():
+    """
+    test that eventplot produces the correct output given the default params
+    (see bug #3728)
+    """
+    np.random.seed(0)
+
+    data1 = np.random.random([32, 20]).tolist()
+    data2 = np.random.random([6, 20]).tolist()
+    data = data1 + data2
+
+    fig = plt.figure()
+    axobj = fig.add_subplot()
+    axobj.eventplot(data)
+
+
+@pytest.mark.parametrize(('colors'), [
+    ('0.5',),  # string color with multiple characters: not OK before #8193 fix
+    ('tab:orange', 'tab:pink', 'tab:cyan', 'bLacK'),  # case-insensitive
+    ('red', (0, 1, 0), None, (1, 0, 1, 0.5)),  # a tricky case mixing types
+])
+def test_eventplot_colors(colors):
+    """Test the *colors* parameter of eventplot. Inspired by issue #8193."""
+    data = [[0], [1], [2], [3]]  # 4 successive events of different nature
+
+    # Build the list of the expected colors
+    expected = [c if c is not None else 'C0' for c in colors]
+    # Convert the list into an array of RGBA values
+    # NB: ['rgbk'] is not a valid argument for to_rgba_array, while 'rgbk' is.
+    if len(expected) == 1:
+        expected = expected[0]
+    expected = np.broadcast_to(mcolors.to_rgba_array(expected), (len(data), 4))
+
+    fig, ax = plt.subplots()
+    if len(colors) == 1:  # tuple with a single string (like '0.5' or 'rgbk')
+        colors = colors[0]
+    collections = ax.eventplot(data, colors=colors)
+
+    for coll, color in zip(collections, expected):
+        assert_allclose(coll.get_color(), color)
+
+
+def test_eventplot_alpha():
+    fig, ax = plt.subplots()
+
+    # one alpha for all
+    collections = ax.eventplot([[0, 2, 4], [1, 3, 5, 7]], alpha=0.7)
+    assert collections[0].get_alpha() == 0.7
+    assert collections[1].get_alpha() == 0.7
+
+    # one alpha per collection
+    collections = ax.eventplot([[0, 2, 4], [1, 3, 5, 7]], alpha=[0.5, 0.7])
+    assert collections[0].get_alpha() == 0.5
+    assert collections[1].get_alpha() == 0.7
+
+    with pytest.raises(ValueError, match="alpha and positions are unequal"):
+        ax.eventplot([[0, 2, 4], [1, 3, 5, 7]], alpha=[0.5, 0.7, 0.9])
+
+    with pytest.raises(ValueError, match="alpha and positions are unequal"):
+        ax.eventplot([0, 2, 4], alpha=[0.5, 0.7])
+
+
+@image_comparison(['test_eventplot_problem_kwargs.png'], remove_text=True)
+def test_eventplot_problem_kwargs(recwarn):
+    """
+    test that 'singular' versions of LineCollection props raise an
+    MatplotlibDeprecationWarning rather than overriding the 'plural' versions
+    (e.g., to prevent 'color' from overriding 'colors', see issue #4297)
+    """
+    np.random.seed(0)
+
+    data1 = np.random.random([20]).tolist()
+    data2 = np.random.random([10]).tolist()
+    data = [data1, data2]
+
+    fig = plt.figure()
+    axobj = fig.add_subplot()
+
+    axobj.eventplot(data,
+                    colors=['r', 'b'],
+                    color=['c', 'm'],
+                    linewidths=[2, 1],
+                    linewidth=[1, 2],
+                    linestyles=['solid', 'dashed'],
+                    linestyle=['dashdot', 'dotted'])
+
+    assert len(recwarn) == 3
+    assert all(issubclass(wi.category, mpl.MatplotlibDeprecationWarning)
+               for wi in recwarn)
+
+
+def test_empty_eventplot():
+    fig, ax = plt.subplots(1, 1)
+    ax.eventplot([[]], colors=[(0.0, 0.0, 0.0, 0.0)])
+    plt.draw()
+
+
+@pytest.mark.parametrize('data', [[[]], [[], [0, 1]], [[0, 1], []]])
+@pytest.mark.parametrize('orientation', [None, 'vertical', 'horizontal'])
+def test_eventplot_orientation(data, orientation):
+    """Introduced when fixing issue #6412."""
+    opts = {} if orientation is None else {'orientation': orientation}
+    fig, ax = plt.subplots(1, 1)
+    ax.eventplot(data, **opts)
+    plt.draw()
+
+
+@check_figures_equal(extensions=['png'])
+def test_eventplot_units_list(fig_test, fig_ref):
+    # test that list of lists converted properly:
+    ts_1 = [datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2),
+            datetime.datetime(2021, 1, 3)]
+    ts_2 = [datetime.datetime(2021, 1, 15), datetime.datetime(2021, 1, 16)]
+
+    ax = fig_ref.subplots()
+    ax.eventplot(ts_1, lineoffsets=0)
+    ax.eventplot(ts_2, lineoffsets=1)
+
+    ax = fig_test.subplots()
+    ax.eventplot([ts_1, ts_2])
+
+
+@image_comparison(['marker_styles.png'], remove_text=True)
+def test_marker_styles():
+    fig, ax = plt.subplots()
+    # Since generation of the test image, None was removed but 'none' was
+    # added. By moving 'none' to the front (=former sorted place of None)
+    # we can avoid regenerating the test image. This can be removed if the
+    # test image has to be regenerated for other reasons.
+    markers = sorted(matplotlib.markers.MarkerStyle.markers,
+                     key=lambda x: str(type(x))+str(x))
+    markers.remove('none')
+    markers = ['none', *markers]
+    for y, marker in enumerate(markers):
+        ax.plot((y % 2)*5 + np.arange(10)*10, np.ones(10)*10*y, linestyle='',
+                marker=marker, markersize=10+y/5, label=marker)
+
+
+@image_comparison(['rc_markerfill.png'],
+                  tol=0.037 if platform.machine() == 'arm64' else 0)
+def test_markers_fillstyle_rcparams():
+    fig, ax = plt.subplots()
+    x = np.arange(7)
+    for idx, (style, marker) in enumerate(
+            [('top', 's'), ('bottom', 'o'), ('none', '^')]):
+        matplotlib.rcParams['markers.fillstyle'] = style
+        ax.plot(x+idx, marker=marker)
+
+
+@image_comparison(['vertex_markers.png'], remove_text=True)
+def test_vertex_markers():
+    data = list(range(10))
+    marker_as_tuple = ((-1, -1), (1, -1), (1, 1), (-1, 1))
+    marker_as_list = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
+    fig, ax = plt.subplots()
+    ax.plot(data, linestyle='', marker=marker_as_tuple, mfc='k')
+    ax.plot(data[::-1], linestyle='', marker=marker_as_list, mfc='b')
+    ax.set_xlim([-1, 10])
+    ax.set_ylim([-1, 10])
+
+
+@image_comparison(['vline_hline_zorder', 'errorbar_zorder'],
+                  tol=0 if platform.machine() == 'x86_64' else 0.026)
+def test_eb_line_zorder():
+    x = list(range(10))
+
+    # First illustrate basic pyplot interface, using defaults where possible.
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.plot(x, lw=10, zorder=5)
+    ax.axhline(1, color='red', lw=10, zorder=1)
+    ax.axhline(5, color='green', lw=10, zorder=10)
+    ax.axvline(7, color='m', lw=10, zorder=7)
+    ax.axvline(2, color='k', lw=10, zorder=3)
+
+    ax.set_title("axvline and axhline zorder test")
+
+    # Now switch to a more OO interface to exercise more features.
+    fig = plt.figure()
+    ax = fig.gca()
+    x = list(range(10))
+    y = np.zeros(10)
+    yerr = list(range(10))
+    ax.errorbar(x, y, yerr=yerr, zorder=5, lw=5, color='r')
+    for j in range(10):
+        ax.axhline(j, lw=5, color='k', zorder=j)
+        ax.axhline(-j, lw=5, color='k', zorder=j)
+
+    ax.set_title("errorbar zorder test")
+
+
+@check_figures_equal()
+def test_axline_loglog(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
+    ax.loglog([.3, .6], [.3, .6], ".-")
+    ax.axline((1, 1e-3), (10, 1e-2), c="k")
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
+    ax.loglog([.3, .6], [.3, .6], ".-")
+    ax.loglog([1, 10], [1e-3, 1e-2], c="k")
+
+
+@check_figures_equal()
+def test_axline(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.axline((0, 0), (1, 1))
+    ax.axline((0, 0), (1, 0), color='C1')
+    ax.axline((0, 0.5), (1, 0.5), color='C2')
+    # slopes
+    ax.axline((-0.7, -0.5), slope=0, color='C3')
+    ax.axline((1, -0.5), slope=-0.5, color='C4')
+    ax.axline((-0.5, 1), slope=float('inf'), color='C5')
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.plot([-1, 1], [-1, 1])
+    ax.axhline(0, color='C1')
+    ax.axhline(0.5, color='C2')
+    # slopes
+    ax.axhline(-0.5, color='C3')
+    ax.plot([-1, 1], [0.5, -0.5], color='C4')
+    ax.axvline(-0.5, color='C5')
+
+
+@check_figures_equal()
+def test_axline_transaxes(fig_test, fig_ref):
+    ax = fig_test.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.axline((0, 0), slope=1, transform=ax.transAxes)
+    ax.axline((1, 0.5), slope=1, color='C1', transform=ax.transAxes)
+    ax.axline((0.5, 0.5), slope=0, color='C2', transform=ax.transAxes)
+    ax.axline((0.5, 0), (0.5, 1), color='C3', transform=ax.transAxes)
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.plot([-1, 1], [-1, 1])
+    ax.plot([0, 1], [-1, 0], color='C1')
+    ax.plot([-1, 1], [0, 0], color='C2')
+    ax.plot([0, 0], [-1, 1], color='C3')
+
+
+@check_figures_equal()
+def test_axline_transaxes_panzoom(fig_test, fig_ref):
+    # test that it is robust against pan/zoom and
+    # figure resize after plotting
+    ax = fig_test.subplots()
+    ax.set(xlim=(-1, 1), ylim=(-1, 1))
+    ax.axline((0, 0), slope=1, transform=ax.transAxes)
+    ax.axline((0.5, 0.5), slope=2, color='C1', transform=ax.transAxes)
+    ax.axline((0.5, 0.5), slope=0, color='C2', transform=ax.transAxes)
+    ax.set(xlim=(0, 5), ylim=(0, 10))
+    fig_test.set_size_inches(3, 3)
+
+    ax = fig_ref.subplots()
+    ax.set(xlim=(0, 5), ylim=(0, 10))
+    fig_ref.set_size_inches(3, 3)
+    ax.plot([0, 5], [0, 5])
+    ax.plot([0, 5], [0, 10], color='C1')
+    ax.plot([0, 5], [5, 5], color='C2')
+
+
+def test_axline_args():
+    """Exactly one of *xy2* and *slope* must be specified."""
+    fig, ax = plt.subplots()
+    with pytest.raises(TypeError):
+        ax.axline((0, 0))  # missing second parameter
+    with pytest.raises(TypeError):
+        ax.axline((0, 0), (1, 1), slope=1)  # redundant parameters
+    ax.set_xscale('log')
+    with pytest.raises(TypeError):
+        ax.axline((0, 0), slope=1)
+    ax.set_xscale('linear')
+    ax.set_yscale('log')
+    with pytest.raises(TypeError):
+        ax.axline((0, 0), slope=1)
+    ax.set_yscale('linear')
+    with pytest.raises(ValueError):
+        ax.axline((0, 0), (0, 0))  # two identical points are not allowed
+        plt.draw()
+
+
+@image_comparison(['vlines_basic', 'vlines_with_nan', 'vlines_masked'],
+                  extensions=['png'])
+def test_vlines():
+    # normal
+    x1 = [2, 3, 4, 5, 7]
+    y1 = [2, -6, 3, 8, 2]
+    fig1, ax1 = plt.subplots()
+    ax1.vlines(x1, 0, y1, colors='g', linewidth=5)
+
+    # GH #7406
+    x2 = [2, 3, 4, 5, 6, 7]
+    y2 = [2, -6, 3, 8, np.nan, 2]
+    fig2, (ax2, ax3, ax4) = plt.subplots(nrows=3, figsize=(4, 8))
+    ax2.vlines(x2, 0, y2, colors='g', linewidth=5)
+
+    x3 = [2, 3, 4, 5, 6, 7]
+    y3 = [np.nan, 2, -6, 3, 8, 2]
+    ax3.vlines(x3, 0, y3, colors='r', linewidth=3, linestyle='--')
+
+    x4 = [2, 3, 4, 5, 6, 7]
+    y4 = [np.nan, 2, -6, 3, 8, np.nan]
+    ax4.vlines(x4, 0, y4, colors='k', linewidth=2)
+
+    # tweak the x-axis so we can see the lines better
+    for ax in [ax1, ax2, ax3, ax4]:
+        ax.set_xlim(0, 10)
+
+    # check that the y-lims are all automatically the same
+    assert ax1.get_ylim() == ax2.get_ylim()
+    assert ax1.get_ylim() == ax3.get_ylim()
+    assert ax1.get_ylim() == ax4.get_ylim()
+
+    fig3, ax5 = plt.subplots()
+    x5 = np.ma.masked_equal([2, 4, 6, 8, 10, 12], 8)
+    ymin5 = np.ma.masked_equal([0, 1, -1, 0, 2, 1], 2)
+    ymax5 = np.ma.masked_equal([13, 14, 15, 16, 17, 18], 18)
+    ax5.vlines(x5, ymin5, ymax5, colors='k', linewidth=2)
+    ax5.set_xlim(0, 15)
+
+
+def test_vlines_default():
+    fig, ax = plt.subplots()
+    with mpl.rc_context({'lines.color': 'red'}):
+        lines = ax.vlines(0.5, 0, 1)
+        assert mpl.colors.same_color(lines.get_color(), 'red')
+
+
+@image_comparison(['hlines_basic', 'hlines_with_nan', 'hlines_masked'],
+                  extensions=['png'])
+def test_hlines():
+    # normal
+    y1 = [2, 3, 4, 5, 7]
+    x1 = [2, -6, 3, 8, 2]
+    fig1, ax1 = plt.subplots()
+    ax1.hlines(y1, 0, x1, colors='g', linewidth=5)
+
+    # GH #7406
+    y2 = [2, 3, 4, 5, 6, 7]
+    x2 = [2, -6, 3, 8, np.nan, 2]
+    fig2, (ax2, ax3, ax4) = plt.subplots(nrows=3, figsize=(4, 8))
+    ax2.hlines(y2, 0, x2, colors='g', linewidth=5)
+
+    y3 = [2, 3, 4, 5, 6, 7]
+    x3 = [np.nan, 2, -6, 3, 8, 2]
+    ax3.hlines(y3, 0, x3, colors='r', linewidth=3, linestyle='--')
+
+    y4 = [2, 3, 4, 5, 6, 7]
+    x4 = [np.nan, 2, -6, 3, 8, np.nan]
+    ax4.hlines(y4, 0, x4, colors='k', linewidth=2)
+
+    # tweak the y-axis so we can see the lines better
+    for ax in [ax1, ax2, ax3, ax4]:
+        ax.set_ylim(0, 10)
+
+    # check that the x-lims are all automatically the same
+    assert ax1.get_xlim() == ax2.get_xlim()
+    assert ax1.get_xlim() == ax3.get_xlim()
+    assert ax1.get_xlim() == ax4.get_xlim()
+
+    fig3, ax5 = plt.subplots()
+    y5 = np.ma.masked_equal([2, 4, 6, 8, 10, 12], 8)
+    xmin5 = np.ma.masked_equal([0, 1, -1, 0, 2, 1], 2)
+    xmax5 = np.ma.masked_equal([13, 14, 15, 16, 17, 18], 18)
+    ax5.hlines(y5, xmin5, xmax5, colors='k', linewidth=2)
+    ax5.set_ylim(0, 15)
+
+
+def test_hlines_default():
+    fig, ax = plt.subplots()
+    with mpl.rc_context({'lines.color': 'red'}):
+        lines = ax.hlines(0.5, 0, 1)
+        assert mpl.colors.same_color(lines.get_color(), 'red')
+
+
+@pytest.mark.parametrize('data', [[1, 2, 3, np.nan, 5],
+                                  np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
+@check_figures_equal(extensions=["png"])
+def test_lines_with_colors(fig_test, fig_ref, data):
+    test_colors = ['red', 'green', 'blue', 'purple', 'orange']
+    fig_test.add_subplot(2, 1, 1).vlines(data, 0, 1,
+                                         colors=test_colors, linewidth=5)
+    fig_test.add_subplot(2, 1, 2).hlines(data, 0, 1,
+                                         colors=test_colors, linewidth=5)
+
+    expect_xy = [1, 2, 3, 5]
+    expect_color = ['red', 'green', 'blue', 'orange']
+    fig_ref.add_subplot(2, 1, 1).vlines(expect_xy, 0, 1,
+                                        colors=expect_color, linewidth=5)
+    fig_ref.add_subplot(2, 1, 2).hlines(expect_xy, 0, 1,
+                                        colors=expect_color, linewidth=5)
+
+
+@image_comparison(['vlines_hlines_blended_transform'],
+                  extensions=['png'], style='mpl20')
+def test_vlines_hlines_blended_transform():
+    t = np.arange(5.0, 10.0, 0.1)
+    s = np.exp(-t) + np.sin(2 * np.pi * t) + 10
+    fig, (hax, vax) = plt.subplots(2, 1, figsize=(6, 6))
+    hax.plot(t, s, '^')
+    hax.hlines([10, 9], xmin=0, xmax=0.5,
+               transform=hax.get_yaxis_transform(), colors='r')
+    vax.plot(t, s, '^')
+    vax.vlines([6, 7], ymin=0, ymax=0.15, transform=vax.get_xaxis_transform(),
+               colors='r')
+
+
+@image_comparison(['step_linestyle', 'step_linestyle'], remove_text=True,
+                  tol=0.2)
+def test_step_linestyle():
+    # Tolerance caused by reordering of floating-point operations
+    # Remove when regenerating the images
+    x = y = np.arange(10)
+
+    # First illustrate basic pyplot interface, using defaults where possible.
+    fig, ax_lst = plt.subplots(2, 2)
+    ax_lst = ax_lst.flatten()
+
+    ln_styles = ['-', '--', '-.', ':']
+
+    for ax, ls in zip(ax_lst, ln_styles):
+        ax.step(x, y, lw=5, linestyle=ls, where='pre')
+        ax.step(x, y + 1, lw=5, linestyle=ls, where='mid')
+        ax.step(x, y + 2, lw=5, linestyle=ls, where='post')
+        ax.set_xlim([-1, 5])
+        ax.set_ylim([-1, 7])
+
+    # Reuse testcase from above for a labeled data test
+    data = {"X": x, "Y0": y, "Y1": y+1, "Y2": y+2}
+    fig, ax_lst = plt.subplots(2, 2)
+    ax_lst = ax_lst.flatten()
+    ln_styles = ['-', '--', '-.', ':']
+    for ax, ls in zip(ax_lst, ln_styles):
+        ax.step("X", "Y0", lw=5, linestyle=ls, where='pre', data=data)
+        ax.step("X", "Y1", lw=5, linestyle=ls, where='mid', data=data)
+        ax.step("X", "Y2", lw=5, linestyle=ls, where='post', data=data)
+        ax.set_xlim([-1, 5])
+        ax.set_ylim([-1, 7])
+
+
+@image_comparison(['mixed_collection'], remove_text=True)
+def test_mixed_collection():
+    # First illustrate basic pyplot interface, using defaults where possible.
+    fig, ax = plt.subplots()
+
+    c = mpatches.Circle((8, 8), radius=4, facecolor='none', edgecolor='green')
+
+    # PDF can optimize this one
+    p1 = mpl.collections.PatchCollection([c], match_original=True)
+    p1.set_offsets([[0, 0], [24, 24]])
+    p1.set_linewidths([1, 5])
+
+    # PDF can't optimize this one, because the alpha of the edge changes
+    p2 = mpl.collections.PatchCollection([c], match_original=True)
+    p2.set_offsets([[48, 0], [-32, -16]])
+    p2.set_linewidths([1, 5])
+    p2.set_edgecolors([[0, 0, 0.1, 1.0], [0, 0, 0.1, 0.5]])
+
+    ax.patch.set_color('0.5')
+    ax.add_collection(p1)
+    ax.add_collection(p2)
+
+    ax.set_xlim(0, 16)
+    ax.set_ylim(0, 16)
+
+
+def test_subplot_key_hash():
+    ax = plt.subplot(np.int32(5), np.int64(1), 1)
+    ax.twinx()
+    assert ax.get_subplotspec().get_geometry() == (5, 1, 0, 0)
+
+
+@image_comparison(
+    ["specgram_freqs.png", "specgram_freqs_linear.png",
+     "specgram_noise.png", "specgram_noise_linear.png"],
+    remove_text=True, tol=0.07, style="default")
+def test_specgram():
+    """Test axes.specgram in default (psd) mode."""
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
+    n = 1000
+    Fs = 10.
+
+    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
+    NFFT_freqs = int(10 * Fs / np.min(fstims))
+    x = np.arange(0, n, 1/Fs)
+    y_freqs = np.concatenate(
+        np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1))
+
+    NFFT_noise = int(10 * Fs / 11)
+    np.random.seed(0)
+    y_noise = np.concatenate([np.random.standard_normal(n), np.random.rand(n)])
+
+    all_sides = ["default", "onesided", "twosided"]
+    for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
+        noverlap = NFFT // 2
+        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                        pad_to=pad_to, sides=sides)
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                        pad_to=pad_to, sides=sides,
+                        scale="linear", norm=matplotlib.colors.LogNorm())
+
+
+@image_comparison(
+    ["specgram_magnitude_freqs.png", "specgram_magnitude_freqs_linear.png",
+     "specgram_magnitude_noise.png", "specgram_magnitude_noise_linear.png"],
+    remove_text=True, tol=0.07, style="default")
+def test_specgram_magnitude():
+    """Test axes.specgram in magnitude mode."""
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
+    n = 1000
+    Fs = 10.
+
+    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
+    NFFT_freqs = int(100 * Fs / np.min(fstims))
+    x = np.arange(0, n, 1/Fs)
+    y = np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1)
+    y[:, -1] = 1
+    y_freqs = np.hstack(y)
+
+    NFFT_noise = int(10 * Fs / 11)
+    np.random.seed(0)
+    y_noise = np.concatenate([np.random.standard_normal(n), np.random.rand(n)])
+
+    all_sides = ["default", "onesided", "twosided"]
+    for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
+        noverlap = NFFT // 2
+        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                        pad_to=pad_to, sides=sides, mode="magnitude")
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                        pad_to=pad_to, sides=sides, mode="magnitude",
+                        scale="linear", norm=matplotlib.colors.LogNorm())
+
+
+@image_comparison(
+    ["specgram_angle_freqs.png", "specgram_phase_freqs.png",
+     "specgram_angle_noise.png", "specgram_phase_noise.png"],
+    remove_text=True, tol=0.07, style="default")
+def test_specgram_angle():
+    """Test axes.specgram in angle and phase modes."""
+
+    # use former defaults to match existing baseline image
+    matplotlib.rcParams['image.interpolation'] = 'nearest'
+
+    n = 1000
+    Fs = 10.
+
+    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
+    NFFT_freqs = int(10 * Fs / np.min(fstims))
+    x = np.arange(0, n, 1/Fs)
+    y = np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1)
+    y[:, -1] = 1
+    y_freqs = np.hstack(y)
+
+    NFFT_noise = int(10 * Fs / 11)
+    np.random.seed(0)
+    y_noise = np.concatenate([np.random.standard_normal(n), np.random.rand(n)])
+
+    all_sides = ["default", "onesided", "twosided"]
+    for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
+        noverlap = NFFT // 2
+        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        for mode in ["angle", "phase"]:
+            for ax, sides in zip(plt.figure().subplots(3), all_sides):
+                ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                            pad_to=pad_to, sides=sides, mode=mode)
+                with pytest.raises(ValueError):
+                    ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
+                                pad_to=pad_to, sides=sides, mode=mode,
+                                scale="dB")
+
+
+def test_specgram_fs_none():
+    """Test axes.specgram when Fs is None, should not throw error."""
+    spec, freqs, t, im = plt.specgram(np.ones(300), Fs=None, scale='linear')
+    xmin, xmax, freq0, freq1 = im.get_extent()
+    assert xmin == 32 and xmax == 96
+
+
+@check_figures_equal(extensions=["png"])
+def test_specgram_origin_rcparam(fig_test, fig_ref):
+    """Test specgram ignores image.origin rcParam and uses origin 'upper'."""
+    t = np.arange(500)
+    signal = np.sin(t)
+
+    plt.rcParams["image.origin"] = 'upper'
+
+    # Reference: First graph using default origin in imshow (upper),
+    fig_ref.subplots().specgram(signal)
+
+    # Try to overwrite the setting trying to flip the specgram
+    plt.rcParams["image.origin"] = 'lower'
+
+    # Test: origin='lower' should be ignored
+    fig_test.subplots().specgram(signal)
+
+
+def test_specgram_origin_kwarg():
+    """Ensure passing origin as a kwarg raises a TypeError."""
+    t = np.arange(500)
+    signal = np.sin(t)
+
+    with pytest.raises(TypeError):
+        plt.specgram(signal, origin='lower')
+
+
+@image_comparison(
+    ["psd_freqs.png", "csd_freqs.png", "psd_noise.png", "csd_noise.png"],
+    remove_text=True, tol=0.002)
+def test_psd_csd():
+    n = 10000
+    Fs = 100.
+
+    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
+    NFFT_freqs = int(1000 * Fs / np.min(fstims))
+    x = np.arange(0, n, 1/Fs)
+    ys_freqs = np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1)
+
+    NFFT_noise = int(1000 * Fs / 11)
+    np.random.seed(0)
+    ys_noise = [np.random.standard_normal(n), np.random.rand(n)]
+
+    all_kwargs = [{"sides": "default"},
+                  {"sides": "onesided", "return_line": False},
+                  {"sides": "twosided", "return_line": True}]
+    for ys, NFFT in [(ys_freqs, NFFT_freqs), (ys_noise, NFFT_noise)]:
+        noverlap = NFFT // 2
+        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+        for ax, kwargs in zip(plt.figure().subplots(3), all_kwargs):
+            ret = ax.psd(np.concatenate(ys), NFFT=NFFT, Fs=Fs,
+                         noverlap=noverlap, pad_to=pad_to, **kwargs)
+            assert len(ret) == 2 + kwargs.get("return_line", False)
+            ax.set(xlabel="", ylabel="")
+        for ax, kwargs in zip(plt.figure().subplots(3), all_kwargs):
+            ret = ax.csd(*ys, NFFT=NFFT, Fs=Fs,
+                         noverlap=noverlap, pad_to=pad_to, **kwargs)
+            assert len(ret) == 2 + kwargs.get("return_line", False)
+            ax.set(xlabel="", ylabel="")
+
+
+@image_comparison(
+    ["magnitude_spectrum_freqs_linear.png",
+     "magnitude_spectrum_freqs_dB.png",
+     "angle_spectrum_freqs.png",
+     "phase_spectrum_freqs.png",
+     "magnitude_spectrum_noise_linear.png",
+     "magnitude_spectrum_noise_dB.png",
+     "angle_spectrum_noise.png",
+     "phase_spectrum_noise.png"],
+    remove_text=True)
+def test_spectrum():
+    n = 10000
+    Fs = 100.
+
+    fstims1 = [Fs/4, Fs/5, Fs/11]
+    NFFT = int(1000 * Fs / min(fstims1))
+    pad_to = int(2 ** np.ceil(np.log2(NFFT)))
+
+    x = np.arange(0, n, 1/Fs)
+    y_freqs = ((np.sin(2 * np.pi * np.outer(x, fstims1)) * 10**np.arange(3))
+               .sum(axis=1))
+    np.random.seed(0)
+    y_noise = np.hstack([np.random.standard_normal(n), np.random.rand(n)]) - .5
+
+    all_sides = ["default", "onesided", "twosided"]
+    kwargs = {"Fs": Fs, "pad_to": pad_to}
+    for y in [y_freqs, y_noise]:
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            spec, freqs, line = ax.magnitude_spectrum(y, sides=sides, **kwargs)
+            ax.set(xlabel="", ylabel="")
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            spec, freqs, line = ax.magnitude_spectrum(y, sides=sides, **kwargs,
+                                                      scale="dB")
+            ax.set(xlabel="", ylabel="")
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            spec, freqs, line = ax.angle_spectrum(y, sides=sides, **kwargs)
+            ax.set(xlabel="", ylabel="")
+        for ax, sides in zip(plt.figure().subplots(3), all_sides):
+            spec, freqs, line = ax.phase_spectrum(y, sides=sides, **kwargs)
+            ax.set(xlabel="", ylabel="")
+
+
+def test_psd_csd_edge_cases():
+    # Inverted yaxis or fully zero inputs used to throw exceptions.
+    axs = plt.figure().subplots(2)
+    for ax in axs:
+        ax.yaxis.set(inverted=True)
+    with np.errstate(divide="ignore"):
+        axs[0].psd(np.zeros(5))
+        axs[1].csd(np.zeros(5), np.zeros(5))
+
+
+@check_figures_equal(extensions=['png'])
+def test_twin_remove(fig_test, fig_ref):
+    ax_test = fig_test.add_subplot()
+    ax_twinx = ax_test.twinx()
+    ax_twiny = ax_test.twiny()
+    ax_twinx.remove()
+    ax_twiny.remove()
+
+    ax_ref = fig_ref.add_subplot()
+    # Ideally we also undo tick changes when calling ``remove()``, but for now
+    # manually set the ticks of the reference image to match the test image
+    ax_ref.xaxis.tick_bottom()
+    ax_ref.yaxis.tick_left()
+
+
+@image_comparison(['twin_spines.png'], remove_text=True,
+                  tol=0.022 if platform.machine() == 'arm64' else 0)
+def test_twin_spines():
+
+    def make_patch_spines_invisible(ax):
+        ax.set_frame_on(True)
+        ax.patch.set_visible(False)
+        ax.spines[:].set_visible(False)
+
+    fig = plt.figure(figsize=(4, 3))
+    fig.subplots_adjust(right=0.75)
+
+    host = fig.add_subplot()
+    par1 = host.twinx()
+    par2 = host.twinx()
+
+    # Offset the right spine of par2.  The ticks and label have already been
+    # placed on the right by twinx above.
+    par2.spines.right.set_position(("axes", 1.2))
+    # Having been created by twinx, par2 has its frame off, so the line of
+    # its detached spine is invisible.  First, activate the frame but make
+    # the patch and spines invisible.
+    make_patch_spines_invisible(par2)
+    # Second, show the right spine.
+    par2.spines.right.set_visible(True)
+
+    p1, = host.plot([0, 1, 2], [0, 1, 2], "b-")
+    p2, = par1.plot([0, 1, 2], [0, 3, 2], "r-")
+    p3, = par2.plot([0, 1, 2], [50, 30, 15], "g-")
+
+    host.set_xlim(0, 2)
+    host.set_ylim(0, 2)
+    par1.set_ylim(0, 4)
+    par2.set_ylim(1, 65)
+
+    host.yaxis.label.set_color(p1.get_color())
+    par1.yaxis.label.set_color(p2.get_color())
+    par2.yaxis.label.set_color(p3.get_color())
+
+    tkw = dict(size=4, width=1.5)
+    host.tick_params(axis='y', colors=p1.get_color(), **tkw)
+    par1.tick_params(axis='y', colors=p2.get_color(), **tkw)
+    par2.tick_params(axis='y', colors=p3.get_color(), **tkw)
+    host.tick_params(axis='x', **tkw)
+
+
+@image_comparison(['twin_spines_on_top.png', 'twin_spines_on_top.png'],
+                  remove_text=True)
+def test_twin_spines_on_top():
+    matplotlib.rcParams['axes.linewidth'] = 48.0
+    matplotlib.rcParams['lines.linewidth'] = 48.0
+
+    fig = plt.figure()
+    ax1 = fig.add_subplot(1, 1, 1)
+
+    data = np.array([[1000, 1100, 1200, 1250],
+                     [310, 301, 360, 400]])
+
+    ax2 = ax1.twinx()
+
+    ax1.plot(data[0], data[1]/1E3, color='#BEAED4')
+    ax1.fill_between(data[0], data[1]/1E3, color='#BEAED4', alpha=.8)
+
+    ax2.plot(data[0], data[1]/1E3, color='#7FC97F')
+    ax2.fill_between(data[0], data[1]/1E3, color='#7FC97F', alpha=.5)
+
+    # Reuse testcase from above for a labeled data test
+    data = {"i": data[0], "j": data[1]/1E3}
+    fig = plt.figure()
+    ax1 = fig.add_subplot(1, 1, 1)
+    ax2 = ax1.twinx()
+    ax1.plot("i", "j", color='#BEAED4', data=data)
+    ax1.fill_between("i", "j", color='#BEAED4', alpha=.8, data=data)
+    ax2.plot("i", "j", color='#7FC97F', data=data)
+    ax2.fill_between("i", "j", color='#7FC97F', alpha=.5, data=data)
+
+
+@pytest.mark.parametrize("grid_which, major_visible, minor_visible", [
+    ("both", True, True),
+    ("major", True, False),
+    ("minor", False, True),
+])
+def test_rcparam_grid_minor(grid_which, major_visible, minor_visible):
+    mpl.rcParams.update({"axes.grid": True, "axes.grid.which": grid_which})
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+    assert all(tick.gridline.get_visible() == major_visible
+               for tick in ax.xaxis.majorTicks)
+    assert all(tick.gridline.get_visible() == minor_visible
+               for tick in ax.xaxis.minorTicks)
+
+
+def test_grid():
+    fig, ax = plt.subplots()
+    ax.grid()
+    fig.canvas.draw()
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(visible=False)
+    fig.canvas.draw()
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(visible=True)
+    fig.canvas.draw()
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid()
+    fig.canvas.draw()
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
+
+
+def test_reset_grid():
+    fig, ax = plt.subplots()
+    ax.tick_params(reset=True, which='major', labelsize=10)
+    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
+    ax.grid(color='red')  # enables grid
+    assert ax.xaxis.majorTicks[0].gridline.get_visible()
+
+    with plt.rc_context({'axes.grid': True}):
+        ax.clear()
+        ax.tick_params(reset=True, which='major', labelsize=10)
+        assert ax.xaxis.majorTicks[0].gridline.get_visible()
+
+
+@check_figures_equal(extensions=['png'])
+def test_reset_ticks(fig_test, fig_ref):
+    for fig in [fig_ref, fig_test]:
+        ax = fig.add_subplot()
+        ax.grid(True)
+        ax.tick_params(
+            direction='in', length=10, width=5, color='C0', pad=12,
+            labelsize=14, labelcolor='C1', labelrotation=45,
+            grid_color='C2', grid_alpha=0.8, grid_linewidth=3,
+            grid_linestyle='--')
+        fig.draw_without_rendering()
+
+    # After we've changed any setting on ticks, reset_ticks will mean
+    # re-creating them from scratch. This *should* appear the same as not
+    # resetting them.
+    for ax in fig_test.axes:
+        ax.xaxis.reset_ticks()
+        ax.yaxis.reset_ticks()
+
+
+@mpl.style.context('mpl20')
+def test_context_ticks():
+    with plt.rc_context({
+            'xtick.direction': 'in', 'xtick.major.size': 30, 'xtick.major.width': 5,
+            'xtick.color': 'C0', 'xtick.major.pad': 12,
+            'xtick.bottom': True, 'xtick.top': True,
+            'xtick.labelsize': 14, 'xtick.labelcolor': 'C1'}):
+        fig, ax = plt.subplots()
+    # Draw outside the context so that all-but-first tick are generated with the normal
+    # mpl20 style in place.
+    fig.draw_without_rendering()
+
+    first_tick = ax.xaxis.majorTicks[0]
+    for tick in ax.xaxis.majorTicks[1:]:
+        assert tick._size == first_tick._size
+        assert tick._width == first_tick._width
+        assert tick._base_pad == first_tick._base_pad
+        assert tick._labelrotation == first_tick._labelrotation
+        assert tick._zorder == first_tick._zorder
+        assert tick._tickdir == first_tick._tickdir
+
+
+def test_vline_limit():
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.axvline(0.5)
+    ax.plot([-0.1, 0, 0.2, 0.1])
+    assert_allclose(ax.get_ylim(), (-.1, .2))
+
+
+@pytest.mark.parametrize('fv, fh, args', [[plt.axvline, plt.axhline, (1,)],
+                                          [plt.axvspan, plt.axhspan, (1, 1)]])
+def test_axline_minmax(fv, fh, args):
+    bad_lim = matplotlib.dates.num2date(1)
+    # Check vertical functions
+    with pytest.raises(ValueError, match='ymin must be a single scalar value'):
+        fv(*args, ymin=bad_lim, ymax=1)
+    with pytest.raises(ValueError, match='ymax must be a single scalar value'):
+        fv(*args, ymin=1, ymax=bad_lim)
+    # Check horizontal functions
+    with pytest.raises(ValueError, match='xmin must be a single scalar value'):
+        fh(*args, xmin=bad_lim, xmax=1)
+    with pytest.raises(ValueError, match='xmax must be a single scalar value'):
+        fh(*args, xmin=1, xmax=bad_lim)
+
+
+def test_empty_shared_subplots():
+    # empty plots with shared axes inherit limits from populated plots
+    fig, axs = plt.subplots(nrows=1, ncols=2, sharex=True, sharey=True)
+    axs[0].plot([1, 2, 3], [2, 4, 6])
+    x0, x1 = axs[1].get_xlim()
+    y0, y1 = axs[1].get_ylim()
+    assert x0 <= 1
+    assert x1 >= 3
+    assert y0 <= 2
+    assert y1 >= 6
+
+
+def test_shared_with_aspect_1():
+    # allow sharing one axis
+    for adjustable in ['box', 'datalim']:
+        fig, axs = plt.subplots(nrows=2, sharex=True)
+        axs[0].set_aspect(2, adjustable=adjustable, share=True)
+        assert axs[1].get_aspect() == 2
+        assert axs[1].get_adjustable() == adjustable
+
+        fig, axs = plt.subplots(nrows=2, sharex=True)
+        axs[0].set_aspect(2, adjustable=adjustable)
+        assert axs[1].get_aspect() == 'auto'
+
+
+def test_shared_with_aspect_2():
+    # Share 2 axes only with 'box':
+    fig, axs = plt.subplots(nrows=2, sharex=True, sharey=True)
+    axs[0].set_aspect(2, share=True)
+    axs[0].plot([1, 2], [3, 4])
+    axs[1].plot([3, 4], [1, 2])
+    plt.draw()  # Trigger apply_aspect().
+    assert axs[0].get_xlim() == axs[1].get_xlim()
+    assert axs[0].get_ylim() == axs[1].get_ylim()
+
+
+def test_shared_with_aspect_3():
+    # Different aspect ratios:
+    for adjustable in ['box', 'datalim']:
+        fig, axs = plt.subplots(nrows=2, sharey=True)
+        axs[0].set_aspect(2, adjustable=adjustable)
+        axs[1].set_aspect(0.5, adjustable=adjustable)
+        axs[0].plot([1, 2], [3, 4])
+        axs[1].plot([3, 4], [1, 2])
+        plt.draw()  # Trigger apply_aspect().
+        assert axs[0].get_xlim() != axs[1].get_xlim()
+        assert axs[0].get_ylim() == axs[1].get_ylim()
+        fig_aspect = fig.bbox_inches.height / fig.bbox_inches.width
+        for ax in axs:
+            p = ax.get_position()
+            box_aspect = p.height / p.width
+            lim_aspect = ax.viewLim.height / ax.viewLim.width
+            expected = fig_aspect * box_aspect / lim_aspect
+            assert round(expected, 4) == round(ax.get_aspect(), 4)
+
+
+def test_shared_aspect_error():
+    fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
+    axes[0].axis("equal")
+    with pytest.raises(RuntimeError, match=r"set_aspect\(..., adjustable="):
+        fig.draw_without_rendering()
+
+
+@pytest.mark.parametrize('err, args, kwargs, match',
+                         ((TypeError, (1, 2), {},
+                           r"axis\(\) takes from 0 to 1 positional arguments "
+                           "but 2 were given"),
+                          (ValueError, ('foo', ), {},
+                           "Unrecognized string 'foo' to axis; try 'on' or "
+                           "'off'"),
+                          (TypeError, ([1, 2], ), {},
+                           "The first argument to axis*"),
+                          (TypeError, tuple(), {'foo': None},
+                           r"axis\(\) got an unexpected keyword argument "
+                           "'foo'"),
+                          ))
+def test_axis_errors(err, args, kwargs, match):
+    with pytest.raises(err, match=match):
+        plt.axis(*args, **kwargs)
+
+
+def test_axis_method_errors():
+    ax = plt.gca()
+    with pytest.raises(ValueError, match="unknown value for which: 'foo'"):
+        ax.get_xaxis_transform('foo')
+    with pytest.raises(ValueError, match="unknown value for which: 'foo'"):
+        ax.get_yaxis_transform('foo')
+    with pytest.raises(TypeError, match="Cannot supply both positional and"):
+        ax.set_prop_cycle('foo', label='bar')
+    with pytest.raises(ValueError, match="argument must be among"):
+        ax.set_anchor('foo')
+    with pytest.raises(ValueError, match="scilimits must be a sequence"):
+        ax.ticklabel_format(scilimits=1)
+    with pytest.raises(TypeError, match="Specifying 'loc' is disallowed"):
+        ax.set_xlabel('foo', loc='left', x=1)
+    with pytest.raises(TypeError, match="Specifying 'loc' is disallowed"):
+        ax.set_ylabel('foo', loc='top', y=1)
+    with pytest.raises(TypeError, match="Cannot pass both 'left'"):
+        ax.set_xlim(left=0, xmin=1)
+    with pytest.raises(TypeError, match="Cannot pass both 'right'"):
+        ax.set_xlim(right=0, xmax=1)
+    with pytest.raises(TypeError, match="Cannot pass both 'bottom'"):
+        ax.set_ylim(bottom=0, ymin=1)
+    with pytest.raises(TypeError, match="Cannot pass both 'top'"):
+        ax.set_ylim(top=0, ymax=1)
+
+
+@pytest.mark.parametrize('twin', ('x', 'y'))
+def test_twin_with_aspect(twin):
+    fig, ax = plt.subplots()
+    # test twinx or twiny
+    ax_twin = getattr(ax, f'twin{twin}')()
+    ax.set_aspect(5)
+    ax_twin.set_aspect(2)
+    assert_array_equal(ax.bbox.extents,
+                       ax_twin.bbox.extents)
+
+
+def test_relim_visible_only():
+    x1 = (0., 10.)
+    y1 = (0., 10.)
+    x2 = (-10., 20.)
+    y2 = (-10., 30.)
+
+    fig = matplotlib.figure.Figure()
+    ax = fig.add_subplot()
+    ax.plot(x1, y1)
+    assert ax.get_xlim() == x1
+    assert ax.get_ylim() == y1
+    line, = ax.plot(x2, y2)
+    assert ax.get_xlim() == x2
+    assert ax.get_ylim() == y2
+    line.set_visible(False)
+    assert ax.get_xlim() == x2
+    assert ax.get_ylim() == y2
+
+    ax.relim(visible_only=True)
+    ax.autoscale_view()
+
+    assert ax.get_xlim() == x1
+    assert ax.get_ylim() == y1
+
+
+def test_text_labelsize():
+    """
+    tests for issue #1172
+    """
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.tick_params(labelsize='large')
+    ax.tick_params(direction='out')
+
+
+# Note: The `pie` image tests were affected by Numpy 2.0 changing promotions
+# (NEP 50). While the changes were only marginal, tolerances were introduced.
+# These tolerances could likely go away when numpy 2.0 is the minimum supported
+# numpy and the images are regenerated.
+
+@image_comparison(['pie_default.png'], tol=0.01)
+def test_pie_default():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+    fig1, ax1 = plt.subplots(figsize=(8, 6))
+    ax1.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90)
+
+
+@image_comparison(['pie_linewidth_0', 'pie_linewidth_0', 'pie_linewidth_0'],
+                  extensions=['png'], style='mpl20', tol=0.01)
+def test_pie_linewidth_0():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 0})
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+    # Reuse testcase from above for a labeled data test
+    data = {"l": labels, "s": sizes, "c": colors, "ex": explode}
+    fig = plt.figure()
+    ax = fig.gca()
+    ax.pie("s", explode="ex", labels="l", colors="c",
+           autopct='%1.1f%%', shadow=True, startangle=90,
+           wedgeprops={'linewidth': 0}, data=data)
+    ax.axis('equal')
+
+    # And again to test the pyplot functions which should also be able to be
+    # called with a data kwarg
+    plt.figure()
+    plt.pie("s", explode="ex", labels="l", colors="c",
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 0}, data=data)
+    plt.axis('equal')
+
+
+@image_comparison(['pie_center_radius.png'], style='mpl20', tol=0.01)
+def test_pie_center_radius():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 0}, center=(1, 2), radius=1.5)
+
+    plt.annotate("Center point", xy=(1, 2), xytext=(1, 1.3),
+                 arrowprops=dict(arrowstyle="->",
+                                 connectionstyle="arc3"),
+                 bbox=dict(boxstyle="square", facecolor="lightgrey"))
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+
+@image_comparison(['pie_linewidth_2.png'], style='mpl20', tol=0.01)
+def test_pie_linewidth_2():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 2})
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+
+@image_comparison(['pie_ccw_true.png'], style='mpl20', tol=0.01)
+def test_pie_ccw_true():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            counterclock=True)
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+
+@image_comparison(['pie_frame_grid.png'], style='mpl20', tol=0.002)
+def test_pie_frame_grid():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    # only "explode" the 2nd slice (i.e. 'Hogs')
+    explode = (0, 0.1, 0, 0)
+
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 0},
+            frame=True, center=(2, 2))
+
+    plt.pie(sizes[::-1], explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 0},
+            frame=True, center=(5, 2))
+
+    plt.pie(sizes, explode=explode[::-1], labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            wedgeprops={'linewidth': 0},
+            frame=True, center=(3, 5))
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+
+@image_comparison(['pie_rotatelabels_true.png'], style='mpl20', tol=0.009)
+def test_pie_rotatelabels_true():
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90,
+            rotatelabels=True)
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+
+@image_comparison(['pie_no_label.png'], tol=0.01)
+def test_pie_nolabel_but_legend():
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+            autopct='%1.1f%%', shadow=True, startangle=90, labeldistance=None,
+            rotatelabels=True)
+    plt.axis('equal')
+    plt.ylim(-1.2, 1.2)
+    plt.legend()
+
+
+@image_comparison(['pie_shadow.png'], style='mpl20', tol=0.002)
+def test_pie_shadow():
+    # Also acts as a test for the shade argument of Shadow
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice
+    _, axes = plt.subplots(2, 2)
+    axes[0][0].pie(sizes, explode=explode, colors=colors,
+                   shadow=True, startangle=90,
+                   wedgeprops={'linewidth': 0})
+
+    axes[0][1].pie(sizes, explode=explode, colors=colors,
+                   shadow=False, startangle=90,
+                   wedgeprops={'linewidth': 0})
+
+    axes[1][0].pie(sizes, explode=explode, colors=colors,
+                   shadow={'ox': -0.05, 'oy': -0.05, 'shade': 0.9, 'edgecolor': 'none'},
+                   startangle=90, wedgeprops={'linewidth': 0})
+
+    axes[1][1].pie(sizes, explode=explode, colors=colors,
+                   shadow={'ox': 0.05, 'linewidth': 2, 'shade': 0.2},
+                   startangle=90, wedgeprops={'linewidth': 0})
+
+
+def test_pie_textprops():
+    data = [23, 34, 45]
+    labels = ["Long name 1", "Long name 2", "Long name 3"]
+
+    textprops = dict(horizontalalignment="center",
+                     verticalalignment="top",
+                     rotation=90,
+                     rotation_mode="anchor",
+                     size=12, color="red")
+
+    _, texts, autopct = plt.gca().pie(data, labels=labels, autopct='%.2f',
+                                      textprops=textprops)
+    for labels in [texts, autopct]:
+        for tx in labels:
+            assert tx.get_ha() == textprops["horizontalalignment"]
+            assert tx.get_va() == textprops["verticalalignment"]
+            assert tx.get_rotation() == textprops["rotation"]
+            assert tx.get_rotation_mode() == textprops["rotation_mode"]
+            assert tx.get_size() == textprops["size"]
+            assert tx.get_color() == textprops["color"]
+
+
+def test_pie_get_negative_values():
+    # Test the ValueError raised when feeding negative values into axes.pie
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.pie([5, 5, -3], explode=[0, .1, .2])
+
+
+def test_pie_invalid_explode():
+    # Test ValueError raised when feeding short explode list to axes.pie
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.pie([1, 2, 3], explode=[0.1, 0.1])
+
+
+def test_pie_invalid_labels():
+    # Test ValueError raised when feeding short labels list to axes.pie
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.pie([1, 2, 3], labels=["One", "Two"])
+
+
+def test_pie_invalid_radius():
+    # Test ValueError raised when feeding negative radius to axes.pie
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.pie([1, 2, 3], radius=-5)
+
+
+def test_normalize_kwarg_pie():
+    fig, ax = plt.subplots()
+    x = [0.3, 0.3, 0.1]
+    t1 = ax.pie(x=x, normalize=True)
+    assert abs(t1[0][-1].theta2 - 360.) < 1e-3
+    t2 = ax.pie(x=x, normalize=False)
+    assert abs(t2[0][-1].theta2 - 360.) > 1e-3
+
+
+@check_figures_equal()
+def test_pie_hatch_single(fig_test, fig_ref):
+    x = [0.3, 0.3, 0.1]
+    hatch = '+'
+    fig_test.subplots().pie(x, hatch=hatch)
+    wedges, _ = fig_ref.subplots().pie(x)
+    [w.set_hatch(hatch) for w in wedges]
+
+
+@check_figures_equal()
+def test_pie_hatch_multi(fig_test, fig_ref):
+    x = [0.3, 0.3, 0.1]
+    hatch = ['/', '+', '.']
+    fig_test.subplots().pie(x, hatch=hatch)
+    wedges, _ = fig_ref.subplots().pie(x)
+    [w.set_hatch(hp) for w, hp in zip(wedges, hatch)]
+
+
+@image_comparison(['set_get_ticklabels.png'],
+                  tol=0.025 if platform.machine() == 'arm64' else 0)
+def test_set_get_ticklabels():
+    # test issue 2246
+    fig, ax = plt.subplots(2)
+    ha = ['normal', 'set_x/yticklabels']
+
+    ax[0].plot(np.arange(10))
+    ax[0].set_title(ha[0])
+
+    ax[1].plot(np.arange(10))
+    ax[1].set_title(ha[1])
+
+    # set ticklabel to 1 plot in normal way
+    ax[0].set_xticks(range(10))
+    ax[0].set_yticks(range(10))
+    ax[0].set_xticklabels(['a', 'b', 'c', 'd'] + 6 * [''])
+    ax[0].set_yticklabels(['11', '12', '13', '14'] + 6 * [''])
+
+    # set ticklabel to the other plot, expect the 2 plots have same label
+    # setting pass get_ticklabels return value as ticklabels argument
+    ax[1].set_xticks(ax[0].get_xticks())
+    ax[1].set_yticks(ax[0].get_yticks())
+    ax[1].set_xticklabels(ax[0].get_xticklabels())
+    ax[1].set_yticklabels(ax[0].get_yticklabels())
+
+
+def test_set_ticks_kwargs_raise_error_without_labels():
+    """
+    When labels=None and any kwarg is passed, axis.set_ticks() raises a
+    ValueError.
+    """
+    fig, ax = plt.subplots()
+    ticks = [1, 2, 3]
+    with pytest.raises(ValueError, match="Incorrect use of keyword argument 'alpha'"):
+        ax.xaxis.set_ticks(ticks, alpha=0.5)
+
+
+@check_figures_equal(extensions=["png"])
+def test_set_ticks_with_labels(fig_test, fig_ref):
+    """
+    Test that these two are identical::
+
+        set_xticks(ticks); set_xticklabels(labels, **kwargs)
+        set_xticks(ticks, labels, **kwargs)
+
+    """
+    ax = fig_ref.subplots()
+    ax.set_xticks([1, 2, 4, 6])
+    ax.set_xticklabels(['a', 'b', 'c', 'd'], fontweight='bold')
+    ax.set_yticks([1, 3, 5])
+    ax.set_yticks([2, 4], minor=True)
+    ax.set_yticklabels(['A', 'B'], minor=True)
+
+    ax = fig_test.subplots()
+    ax.set_xticks([1, 2, 4, 6], ['a', 'b', 'c', 'd'], fontweight='bold')
+    ax.set_yticks([1, 3, 5])
+    ax.set_yticks([2, 4], ['A', 'B'], minor=True)
+
+
+def test_xticks_bad_args():
+    ax = plt.figure().add_subplot()
+    with pytest.raises(TypeError, match='must be a sequence'):
+        ax.set_xticks([2, 9], 3.1)
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((-1, 1)))
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((1, -1)))
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((-1, 1)), labels=range(4))
+    with pytest.raises(ValueError, match='must be 1D'):
+        plt.xticks(np.arange(4).reshape((1, -1)), labels=range(4))
+
+
+def test_subsampled_ticklabels():
+    # test issue 11937
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    ax.xaxis.set_ticks(np.arange(10) + 0.1)
+    ax.locator_params(nbins=5)
+    ax.xaxis.set_ticklabels([c for c in "bcdefghijk"])
+    plt.draw()
+    labels = [t.get_text() for t in ax.xaxis.get_ticklabels()]
+    assert labels == ['b', 'd', 'f', 'h', 'j']
+
+
+def test_mismatched_ticklabels():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    ax.xaxis.set_ticks([1.5, 2.5])
+    with pytest.raises(ValueError):
+        ax.xaxis.set_ticklabels(['a', 'b', 'c'])
+
+
+def test_empty_ticks_fixed_loc():
+    # Smoke test that [] can be used to unset all tick labels
+    fig, ax = plt.subplots()
+    ax.bar([1, 2], [1, 2])
+    ax.set_xticks([1, 2])
+    ax.set_xticklabels([])
+
+
+@image_comparison(['retain_tick_visibility.png'])
+def test_retain_tick_visibility():
+    fig, ax = plt.subplots()
+    plt.plot([0, 1, 2], [0, -1, 4])
+    plt.setp(ax.get_yticklabels(), visible=False)
+    ax.tick_params(axis="y", which="both", length=0)
+
+
+def test_warn_too_few_labels():
+    # note that the axis is still using an AutoLocator:
+    fig, ax = plt.subplots()
+    with pytest.warns(
+           UserWarning,
+           match=r'set_ticklabels\(\) should only be used with a fixed number'):
+        ax.set_xticklabels(['0', '0.1'])
+    # note that the axis is still using a FixedLocator:
+    fig, ax = plt.subplots()
+    ax.set_xticks([0, 0.5, 1])
+    with pytest.raises(ValueError,
+                       match='The number of FixedLocator locations'):
+        ax.set_xticklabels(['0', '0.1'])
+
+
+def test_tick_label_update():
+    # test issue 9397
+
+    fig, ax = plt.subplots()
+
+    # Set up a dummy formatter
+    def formatter_func(x, pos):
+        return "unit value" if x == 1 else ""
+    ax.xaxis.set_major_formatter(plt.FuncFormatter(formatter_func))
+
+    # Force some of the x-axis ticks to be outside of the drawn range
+    ax.set_xticks([-1, 0, 1, 2, 3])
+    ax.set_xlim(-0.5, 2.5)
+
+    fig.canvas.draw()
+    tick_texts = [tick.get_text() for tick in ax.xaxis.get_ticklabels()]
+    assert tick_texts == ["", "", "unit value", "", ""]
+
+
+@image_comparison(['o_marker_path_snap.png'], savefig_kwarg={'dpi': 72})
+def test_o_marker_path_snap():
+    fig, ax = plt.subplots()
+    ax.margins(.1)
+    for ms in range(1, 15):
+        ax.plot([1, 2, ], np.ones(2) + ms, 'o', ms=ms)
+
+    for ms in np.linspace(1, 10, 25):
+        ax.plot([3, 4, ], np.ones(2) + ms, 'o', ms=ms)
+
+
+def test_margins():
+    # test all ways margins can be called
+    data = [1, 10]
+    xmin = 0.0
+    xmax = len(data) - 1.0
+    ymin = min(data)
+    ymax = max(data)
+
+    fig1, ax1 = plt.subplots(1, 1)
+    ax1.plot(data)
+    ax1.margins(1)
+    assert ax1.margins() == (1, 1)
+    assert ax1.get_xlim() == (xmin - (xmax - xmin) * 1,
+                              xmax + (xmax - xmin) * 1)
+    assert ax1.get_ylim() == (ymin - (ymax - ymin) * 1,
+                              ymax + (ymax - ymin) * 1)
+
+    fig2, ax2 = plt.subplots(1, 1)
+    ax2.plot(data)
+    ax2.margins(0.5, 2)
+    assert ax2.margins() == (0.5, 2)
+    assert ax2.get_xlim() == (xmin - (xmax - xmin) * 0.5,
+                              xmax + (xmax - xmin) * 0.5)
+    assert ax2.get_ylim() == (ymin - (ymax - ymin) * 2,
+                              ymax + (ymax - ymin) * 2)
+
+    fig3, ax3 = plt.subplots(1, 1)
+    ax3.plot(data)
+    ax3.margins(x=-0.2, y=0.5)
+    assert ax3.margins() == (-0.2, 0.5)
+    assert ax3.get_xlim() == (xmin - (xmax - xmin) * -0.2,
+                              xmax + (xmax - xmin) * -0.2)
+    assert ax3.get_ylim() == (ymin - (ymax - ymin) * 0.5,
+                              ymax + (ymax - ymin) * 0.5)
+
+
+def test_margin_getters():
+    fig = plt.figure()
+    ax = fig.add_subplot()
+    ax.margins(0.2, 0.3)
+    assert ax.get_xmargin() == 0.2
+    assert ax.get_ymargin() == 0.3
+
+
+def test_set_margin_updates_limits():
+    mpl.style.use("default")
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [1, 2])
+    ax.set(xscale="log", xmargin=0)
+    assert ax.get_xlim() == (1, 2)
+
+
+@pytest.mark.parametrize('err, args, kwargs, match', (
+        (ValueError, (-1,), {}, r'margin must be greater than -0\.5'),
+        (ValueError, (1, -1), {}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'x': -1}, r'margin must be greater than -0\.5'),
+        (ValueError, tuple(), {'y': -1}, r'margin must be greater than -0\.5'),
+        (TypeError, (1, ), {'x': 1, 'y': 1},
+         'Cannot pass both positional and keyword arguments for x and/or y'),
+        (TypeError, (1, ), {'x': 1},
+         'Cannot pass both positional and keyword arguments for x and/or y'),
+        (TypeError, (1, 1, 1), {}, 'Must pass a single positional argument'),
+))
+def test_margins_errors(err, args, kwargs, match):
+    with pytest.raises(err, match=match):
+        fig = plt.figure()
+        ax = fig.add_subplot()
+        ax.margins(*args, **kwargs)
+
+
+def test_length_one_hist():
+    fig, ax = plt.subplots()
+    ax.hist(1)
+    ax.hist([1])
+
+
+def test_set_xy_bound():
+    fig = plt.figure()
+    ax = fig.add_subplot()
+    ax.set_xbound(2.0, 3.0)
+    assert ax.get_xbound() == (2.0, 3.0)
+    assert ax.get_xlim() == (2.0, 3.0)
+    ax.set_xbound(upper=4.0)
+    assert ax.get_xbound() == (2.0, 4.0)
+    assert ax.get_xlim() == (2.0, 4.0)
+    ax.set_xbound(lower=3.0)
+    assert ax.get_xbound() == (3.0, 4.0)
+    assert ax.get_xlim() == (3.0, 4.0)
+
+    ax.set_ybound(2.0, 3.0)
+    assert ax.get_ybound() == (2.0, 3.0)
+    assert ax.get_ylim() == (2.0, 3.0)
+    ax.set_ybound(upper=4.0)
+    assert ax.get_ybound() == (2.0, 4.0)
+    assert ax.get_ylim() == (2.0, 4.0)
+    ax.set_ybound(lower=3.0)
+    assert ax.get_ybound() == (3.0, 4.0)
+    assert ax.get_ylim() == (3.0, 4.0)
+
+
+def test_pathological_hexbin():
+    # issue #2863
+    mylist = [10] * 100
+    fig, ax = plt.subplots(1, 1)
+    ax.hexbin(mylist, mylist)
+    fig.savefig(io.BytesIO())  # Check that no warning is emitted.
+
+
+def test_color_None():
+    # issue 3855
+    fig, ax = plt.subplots()
+    ax.plot([1, 2], [1, 2], color=None)
+
+
+def test_color_alias():
+    # issues 4157 and 4162
+    fig, ax = plt.subplots()
+    line = ax.plot([0, 1], c='lime')[0]
+    assert 'lime' == line.get_color()
+
+
+def test_numerical_hist_label():
+    fig, ax = plt.subplots()
+    ax.hist([range(15)] * 5, label=range(5))
+    ax.legend()
+
+
+def test_unicode_hist_label():
+    fig, ax = plt.subplots()
+    a = (b'\xe5\xbe\x88\xe6\xbc\x82\xe4\xba\xae, ' +
+         b'r\xc3\xb6m\xc3\xa4n ch\xc3\xa4r\xc3\xa1ct\xc3\xa8rs')
+    b = b'\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d'
+    labels = [a.decode('utf-8'),
+              'hi aardvark',
+              b.decode('utf-8'),
+              ]
+
+    ax.hist([range(15)] * 3, label=labels)
+    ax.legend()
+
+
+def test_move_offsetlabel():
+    data = np.random.random(10) * 1e-22
+
+    fig, ax = plt.subplots()
+    ax.plot(data)
+    fig.canvas.draw()
+    before = ax.yaxis.offsetText.get_position()
+    assert ax.yaxis.offsetText.get_horizontalalignment() == 'left'
+    ax.yaxis.tick_right()
+    fig.canvas.draw()
+    after = ax.yaxis.offsetText.get_position()
+    assert after[0] > before[0] and after[1] == before[1]
+    assert ax.yaxis.offsetText.get_horizontalalignment() == 'right'
+
+    fig, ax = plt.subplots()
+    ax.plot(data)
+    fig.canvas.draw()
+    before = ax.xaxis.offsetText.get_position()
+    assert ax.xaxis.offsetText.get_verticalalignment() == 'top'
+    ax.xaxis.tick_top()
+    fig.canvas.draw()
+    after = ax.xaxis.offsetText.get_position()
+    assert after[0] == before[0] and after[1] > before[1]
+    assert ax.xaxis.offsetText.get_verticalalignment() == 'bottom'
+
+
+@image_comparison(['rc_spines.png'], savefig_kwarg={'dpi': 40})
+def test_rc_spines():
+    rc_dict = {
+        'axes.spines.left': False,
+        'axes.spines.right': False,
+        'axes.spines.top': False,
+        'axes.spines.bottom': False}
+    with matplotlib.rc_context(rc_dict):
+        plt.subplots()  # create a figure and axes with the spine properties
+
+
+@image_comparison(['rc_grid.png'], savefig_kwarg={'dpi': 40})
+def test_rc_grid():
+    fig = plt.figure()
+    rc_dict0 = {
+        'axes.grid': True,
+        'axes.grid.axis': 'both'
+    }
+    rc_dict1 = {
+        'axes.grid': True,
+        'axes.grid.axis': 'x'
+    }
+    rc_dict2 = {
+        'axes.grid': True,
+        'axes.grid.axis': 'y'
+    }
+    dict_list = [rc_dict0, rc_dict1, rc_dict2]
+
+    for i, rc_dict in enumerate(dict_list, 1):
+        with matplotlib.rc_context(rc_dict):
+            fig.add_subplot(3, 1, i)
+
+
+def test_rc_tick():
+    d = {'xtick.bottom': False, 'xtick.top': True,
+         'ytick.left': True, 'ytick.right': False}
+    with plt.rc_context(rc=d):
+        fig = plt.figure()
+        ax1 = fig.add_subplot(1, 1, 1)
+        xax = ax1.xaxis
+        yax = ax1.yaxis
+        # tick1On bottom/left
+        assert not xax._major_tick_kw['tick1On']
+        assert xax._major_tick_kw['tick2On']
+        assert not xax._minor_tick_kw['tick1On']
+        assert xax._minor_tick_kw['tick2On']
+
+        assert yax._major_tick_kw['tick1On']
+        assert not yax._major_tick_kw['tick2On']
+        assert yax._minor_tick_kw['tick1On']
+        assert not yax._minor_tick_kw['tick2On']
+
+
+def test_rc_major_minor_tick():
+    d = {'xtick.top': True, 'ytick.right': True,  # Enable all ticks
+         'xtick.bottom': True, 'ytick.left': True,
+         # Selectively disable
+         'xtick.minor.bottom': False, 'xtick.major.bottom': False,
+         'ytick.major.left': False, 'ytick.minor.left': False}
+    with plt.rc_context(rc=d):
+        fig = plt.figure()
+        ax1 = fig.add_subplot(1, 1, 1)
+        xax = ax1.xaxis
+        yax = ax1.yaxis
+        # tick1On bottom/left
+        assert not xax._major_tick_kw['tick1On']
+        assert xax._major_tick_kw['tick2On']
+        assert not xax._minor_tick_kw['tick1On']
+        assert xax._minor_tick_kw['tick2On']
+
+        assert not yax._major_tick_kw['tick1On']
+        assert yax._major_tick_kw['tick2On']
+        assert not yax._minor_tick_kw['tick1On']
+        assert yax._minor_tick_kw['tick2On']
+
+
+def test_square_plot():
+    x = np.arange(4)
+    y = np.array([1., 3., 5., 7.])
+    fig, ax = plt.subplots()
+    ax.plot(x, y, 'mo')
+    ax.axis('square')
+    xlim, ylim = ax.get_xlim(), ax.get_ylim()
+    assert np.diff(xlim) == np.diff(ylim)
+    assert ax.get_aspect() == 1
+    assert_array_almost_equal(
+        ax.get_position(original=True).extents, (0.125, 0.1, 0.9, 0.9))
+    assert_array_almost_equal(
+        ax.get_position(original=False).extents, (0.2125, 0.1, 0.8125, 0.9))
+
+
+def test_bad_plot_args():
+    with pytest.raises(ValueError):
+        plt.plot(None)
+    with pytest.raises(ValueError):
+        plt.plot(None, None)
+    with pytest.raises(ValueError):
+        plt.plot(np.zeros((2, 2)), np.zeros((2, 3)))
+    with pytest.raises(ValueError):
+        plt.plot((np.arange(5).reshape((1, -1)), np.arange(5).reshape(-1, 1)))
+
+
+@pytest.mark.parametrize(
+    "xy, cls", [
+        ((), mpl.image.AxesImage),  # (0, N)
+        (((3, 7), (2, 6)), mpl.image.AxesImage),  # (xmin, xmax)
+        ((range(5), range(4)), mpl.image.AxesImage),  # regular grid
+        (([1, 2, 4, 8, 16], [0, 1, 2, 3]),  # irregular grid
+         mpl.image.PcolorImage),
+        ((np.random.random((4, 5)), np.random.random((4, 5))),  # 2D coords
+         mpl.collections.QuadMesh),
+    ]
+)
+@pytest.mark.parametrize(
+    "data", [np.arange(12).reshape((3, 4)), np.random.rand(3, 4, 3)]
+)
+def test_pcolorfast(xy, data, cls):
+    fig, ax = plt.subplots()
+    assert type(ax.pcolorfast(*xy, data)) == cls
+
+
+def test_pcolorfast_bad_dims():
+    fig, ax = plt.subplots()
+    with pytest.raises(
+            TypeError, match=("the given X was 1D and the given Y was 2D")):
+        ax.pcolorfast(np.empty(6), np.empty((4, 7)), np.empty((8, 8)))
+
+
+def test_pcolorfast_regular_xy_incompatible_size():
+    """
+    Test that the sizes of X, Y, C are compatible for regularly spaced X, Y.
+
+    Note that after the regualar-spacing check, pcolorfast may go into the
+    fast "image" mode, where the individual X, Y positions are not used anymore.
+    Therefore, the algorithm had worked with any regularly number of regularly
+    spaced values, but discarded their values.
+    """
+    fig, ax = plt.subplots()
+    with pytest.raises(
+            ValueError, match=r"Length of X \(5\) must be one larger than the "
+                              r"number of columns in C \(20\)"):
+        ax.pcolorfast(np.arange(5), np.arange(11), np.random.rand(10, 20))
+
+    with pytest.raises(
+            ValueError, match=r"Length of Y \(5\) must be one larger than the "
+                              r"number of rows in C \(10\)"):
+        ax.pcolorfast(np.arange(21), np.arange(5), np.random.rand(10, 20))
+
+
+def test_shared_scale():
+    fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
+
+    axs[0, 0].set_xscale("log")
+    axs[0, 0].set_yscale("log")
+
+    for ax in axs.flat:
+        assert ax.get_yscale() == 'log'
+        assert ax.get_xscale() == 'log'
+
+    axs[1, 1].set_xscale("linear")
+    axs[1, 1].set_yscale("linear")
+
+    for ax in axs.flat:
+        assert ax.get_yscale() == 'linear'
+        assert ax.get_xscale() == 'linear'
+
+
+def test_shared_bool():
+    with pytest.raises(TypeError):
+        plt.subplot(sharex=True)
+    with pytest.raises(TypeError):
+        plt.subplot(sharey=True)
+
+
+def test_violin_point_mass():
+    """Violin plot should handle point mass pdf gracefully."""
+    plt.violinplot(np.array([0, 0]))
+
+
+def generate_errorbar_inputs():
+    base_xy = cycler('x', [np.arange(5)]) + cycler('y', [np.ones(5)])
+    err_cycler = cycler('err', [1,
+                                [1, 1, 1, 1, 1],
+                                [[1, 1, 1, 1, 1],
+                                 [1, 1, 1, 1, 1]],
+                                np.ones(5),
+                                np.ones((2, 5)),
+                                None
+                                ])
+    xerr_cy = cycler('xerr', err_cycler)
+    yerr_cy = cycler('yerr', err_cycler)
+
+    empty = ((cycler('x', [[]]) + cycler('y', [[]])) *
+             cycler('xerr', [[], None]) * cycler('yerr', [[], None]))
+    xerr_only = base_xy * xerr_cy
+    yerr_only = base_xy * yerr_cy
+    both_err = base_xy * yerr_cy * xerr_cy
+
+    return [*xerr_only, *yerr_only, *both_err, *empty]
+
+
+@pytest.mark.parametrize('kwargs', generate_errorbar_inputs())
+def test_errorbar_inputs_shotgun(kwargs):
+    ax = plt.gca()
+    eb = ax.errorbar(**kwargs)
+    eb.remove()
+
+
+@image_comparison(["dash_offset"], remove_text=True)
+def test_dash_offset():
+    fig, ax = plt.subplots()
+    x = np.linspace(0, 10)
+    y = np.ones_like(x)
+    for j in range(0, 100, 2):
+        ax.plot(x, j*y, ls=(j, (10, 10)), lw=5, color='k')
+
+
+def test_title_pad():
+    # check that title padding puts the title in the right
+    # place...
+    fig, ax = plt.subplots()
+    ax.set_title('aardvark', pad=30.)
+    m = ax.titleOffsetTrans.get_matrix()
+    assert m[1, -1] == (30. / 72. * fig.dpi)
+    ax.set_title('aardvark', pad=0.)
+    m = ax.titleOffsetTrans.get_matrix()
+    assert m[1, -1] == 0.
+    # check that it is reverted...
+    ax.set_title('aardvark', pad=None)
+    m = ax.titleOffsetTrans.get_matrix()
+    assert m[1, -1] == (matplotlib.rcParams['axes.titlepad'] / 72. * fig.dpi)
+
+
+def test_title_location_roundtrip():
+    fig, ax = plt.subplots()
+    # set default title location
+    plt.rcParams['axes.titlelocation'] = 'center'
+    ax.set_title('aardvark')
+    ax.set_title('left', loc='left')
+    ax.set_title('right', loc='right')
+
+    assert 'left' == ax.get_title(loc='left')
+    assert 'right' == ax.get_title(loc='right')
+    assert 'aardvark' == ax.get_title(loc='center')
+
+    with pytest.raises(ValueError):
+        ax.get_title(loc='foo')
+    with pytest.raises(ValueError):
+        ax.set_title('fail', loc='foo')
+
+
+@pytest.mark.parametrize('sharex', [True, False])
+def test_title_location_shared(sharex):
+    fig, axs = plt.subplots(2, 1, sharex=sharex)
+    axs[0].set_title('A', pad=-40)
+    axs[1].set_title('B', pad=-40)
+    fig.draw_without_rendering()
+    x, y1 = axs[0].title.get_position()
+    x, y2 = axs[1].title.get_position()
+    assert y1 == y2 == 1.0
+
+
+@image_comparison(["loglog.png"], remove_text=True, tol=0.02)
+def test_loglog():
+    fig, ax = plt.subplots()
+    x = np.arange(1, 11)
+    ax.loglog(x, x**3, lw=5)
+    ax.tick_params(length=25, width=2)
+    ax.tick_params(length=15, width=2, which='minor')
+
+
+@image_comparison(["test_loglog_nonpos.png"], remove_text=True, style='mpl20',
+                  tol=0.029 if platform.machine() == 'arm64' else 0)
+def test_loglog_nonpos():
+    fig, axs = plt.subplots(3, 3)
+    x = np.arange(1, 11)
+    y = x**3
+    y[7] = -3.
+    x[4] = -10
+    for (mcy, mcx), ax in zip(product(['mask', 'clip', ''], repeat=2),
+                              axs.flat):
+        if mcx == mcy:
+            if mcx:
+                ax.loglog(x, y**3, lw=2, nonpositive=mcx)
             else:
-                minx = np.nanmin(masked_verts[..., 0])
-                maxx = np.nanmax(masked_verts[..., 0])
-                miny = np.nanmin(masked_verts[..., 1])
-                maxy = np.nanmax(masked_verts[..., 1])
-
-            corners = (minx, miny), (maxx, maxy)
-            self.update_datalim(corners, updatex, updatey)
-            self._request_autoscale_view()
-        return lines
-
-    @_api.make_keyword_only("3.9", "label")
-    @_preprocess_data(replace_names=["x", "ymin", "ymax", "colors"],
-                      label_namer="x")
-    def vlines(self, x, ymin, ymax, colors=None, linestyles='solid',
-               label='', **kwargs):
-        """
-        Plot vertical lines at each *x* from *ymin* to *ymax*.
-
-        Parameters
-        ----------
-        x : float or array-like
-            x-indexes where to plot the lines.
-
-        ymin, ymax : float or array-like
-            Respective beginning and end of each line. If scalars are
-            provided, all lines will have the same length.
-
-        colors : :mpltype:`color` or list of color, default: :rc:`lines.color`
-
-        linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, default: 'solid'
-
-        label : str, default: ''
-
-        Returns
-        -------
-        `~matplotlib.collections.LineCollection`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-        **kwargs : `~matplotlib.collections.LineCollection` properties.
-
-        See Also
-        --------
-        hlines : horizontal lines
-        axvline : vertical line across the Axes
-        """
-
-        # We do the conversion first since not all unitized data is uniform
-        x, ymin, ymax = self._process_unit_info(
-            [("x", x), ("y", ymin), ("y", ymax)], kwargs)
-
-        if not np.iterable(x):
-            x = [x]
-        if not np.iterable(ymin):
-            ymin = [ymin]
-        if not np.iterable(ymax):
-            ymax = [ymax]
-
-        # Create and combine masked_arrays from input
-        x, ymin, ymax = cbook._combine_masks(x, ymin, ymax)
-        x = np.ravel(x)
-        ymin = np.ravel(ymin)
-        ymax = np.ravel(ymax)
-
-        masked_verts = np.ma.empty((len(x), 2, 2))
-        masked_verts[:, 0, 0] = x
-        masked_verts[:, 0, 1] = ymin
-        masked_verts[:, 1, 0] = x
-        masked_verts[:, 1, 1] = ymax
-
-        lines = mcoll.LineCollection(masked_verts, colors=colors,
-                                     linestyles=linestyles, label=label)
-        self.add_collection(lines, autolim=False)
-        lines._internal_update(kwargs)
-
-        if len(x) > 0:
-            # Extreme values of x/ymin/ymax.  Using masked_verts here handles
-            # the case of x being a masked *object* array (as can be generated
-            # e.g. by errorbar()), which would make nanmin/nanmax stumble.
-            updatex = True
-            updatey = True
-            if self.name == "rectilinear":
-                datalim = lines.get_datalim(self.transData)
-                t = lines.get_transform()
-                updatex, updatey = t.contains_branch_seperately(self.transData)
-                minx = np.nanmin(datalim.xmin)
-                maxx = np.nanmax(datalim.xmax)
-                miny = np.nanmin(datalim.ymin)
-                maxy = np.nanmax(datalim.ymax)
-            else:
-                minx = np.nanmin(masked_verts[..., 0])
-                maxx = np.nanmax(masked_verts[..., 0])
-                miny = np.nanmin(masked_verts[..., 1])
-                maxy = np.nanmax(masked_verts[..., 1])
-
-            corners = (minx, miny), (maxx, maxy)
-            self.update_datalim(corners, updatex, updatey)
-            self._request_autoscale_view()
-        return lines
-
-    @_api.make_keyword_only("3.9", "orientation")
-    @_preprocess_data(replace_names=["positions", "lineoffsets",
-                                     "linelengths", "linewidths",
-                                     "colors", "linestyles"])
-    @_docstring.interpd
-    def eventplot(self, positions, orientation='horizontal', lineoffsets=1,
-                  linelengths=1, linewidths=None, colors=None, alpha=None,
-                  linestyles='solid', **kwargs):
-        """
-        Plot identical parallel lines at the given positions.
-
-        This type of plot is commonly used in neuroscience for representing
-        neural events, where it is usually called a spike raster, dot raster,
-        or raster plot.
-
-        However, it is useful in any situation where you wish to show the
-        timing or position of multiple sets of discrete events, such as the
-        arrival times of people to a business on each day of the month or the
-        date of hurricanes each year of the last century.
-
-        Parameters
-        ----------
-        positions : array-like or list of array-like
-            A 1D array-like defines the positions of one sequence of events.
-
-            Multiple groups of events may be passed as a list of array-likes.
-            Each group can be styled independently by passing lists of values
-            to *lineoffsets*, *linelengths*, *linewidths*, *colors* and
-            *linestyles*.
-
-            Note that *positions* can be a 2D array, but in practice different
-            event groups usually have different counts so that one will use a
-            list of different-length arrays rather than a 2D array.
-
-        orientation : {'horizontal', 'vertical'}, default: 'horizontal'
-            The direction of the event sequence:
-
-            - 'horizontal': the events are arranged horizontally.
-              The indicator lines are vertical.
-            - 'vertical': the events are arranged vertically.
-              The indicator lines are horizontal.
-
-        lineoffsets : float or array-like, default: 1
-            The offset of the center of the lines from the origin, in the
-            direction orthogonal to *orientation*.
-
-            If *positions* is 2D, this can be a sequence with length matching
-            the length of *positions*.
-
-        linelengths : float or array-like, default: 1
-            The total height of the lines (i.e. the lines stretches from
-            ``lineoffset - linelength/2`` to ``lineoffset + linelength/2``).
-
-            If *positions* is 2D, this can be a sequence with length matching
-            the length of *positions*.
-
-        linewidths : float or array-like, default: :rc:`lines.linewidth`
-            The line width(s) of the event lines, in points.
-
-            If *positions* is 2D, this can be a sequence with length matching
-            the length of *positions*.
-
-        colors : :mpltype:`color` or list of color, default: :rc:`lines.color`
-            The color(s) of the event lines.
-
-            If *positions* is 2D, this can be a sequence with length matching
-            the length of *positions*.
-
-        alpha : float or array-like, default: 1
-            The alpha blending value(s), between 0 (transparent) and 1
-            (opaque).
-
-            If *positions* is 2D, this can be a sequence with length matching
-            the length of *positions*.
-
-        linestyles : str or tuple or list of such values, default: 'solid'
-            Default is 'solid'. Valid strings are ['solid', 'dashed',
-            'dashdot', 'dotted', '-', '--', '-.', ':']. Dash tuples
-            should be of the form::
-
-                (offset, onoffseq),
-
-            where *onoffseq* is an even length tuple of on and off ink
-            in points.
-
-            If *positions* is 2D, this can be a sequence with length matching
-            the length of *positions*.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Other keyword arguments are line collection properties.  See
-            `.LineCollection` for a list of the valid properties.
-
-        Returns
-        -------
-        list of `.EventCollection`
-            The `.EventCollection` that were added.
-
-        Notes
-        -----
-        For *linelengths*, *linewidths*, *colors*, *alpha* and *linestyles*, if
-        only a single value is given, that value is applied to all lines. If an
-        array-like is given, it must have the same length as *positions*, and
-        each value will be applied to the corresponding row of the array.
-
-        Examples
-        --------
-        .. plot:: gallery/lines_bars_and_markers/eventplot_demo.py
-        """
-
-        lineoffsets, linelengths = self._process_unit_info(
-                [("y", lineoffsets), ("y", linelengths)], kwargs)
-
-        # fix positions, noting that it can be a list of lists:
-        if not np.iterable(positions):
-            positions = [positions]
-        elif any(np.iterable(position) for position in positions):
-            positions = [np.asanyarray(position) for position in positions]
+                ax.loglog(x, y**3, lw=2)
         else:
-            positions = [np.asanyarray(positions)]
-
-        poss = []
-        for position in positions:
-            poss += self._process_unit_info([("x", position)], kwargs)
-        positions = poss
-
-        # prevent 'singular' keys from **kwargs dict from overriding the effect
-        # of 'plural' keyword arguments (e.g. 'color' overriding 'colors')
-        colors = cbook._local_over_kwdict(colors, kwargs, 'color')
-        linewidths = cbook._local_over_kwdict(linewidths, kwargs, 'linewidth')
-        linestyles = cbook._local_over_kwdict(linestyles, kwargs, 'linestyle')
-
-        if not np.iterable(lineoffsets):
-            lineoffsets = [lineoffsets]
-        if not np.iterable(linelengths):
-            linelengths = [linelengths]
-        if not np.iterable(linewidths):
-            linewidths = [linewidths]
-        if not np.iterable(colors):
-            colors = [colors]
-        if not np.iterable(alpha):
-            alpha = [alpha]
-        if hasattr(linestyles, 'lower') or not np.iterable(linestyles):
-            linestyles = [linestyles]
-
-        lineoffsets = np.asarray(lineoffsets)
-        linelengths = np.asarray(linelengths)
-        linewidths = np.asarray(linewidths)
-
-        if len(lineoffsets) == 0:
-            raise ValueError('lineoffsets cannot be empty')
-        if len(linelengths) == 0:
-            raise ValueError('linelengths cannot be empty')
-        if len(linestyles) == 0:
-            raise ValueError('linestyles cannot be empty')
-        if len(linewidths) == 0:
-            raise ValueError('linewidths cannot be empty')
-        if len(alpha) == 0:
-            raise ValueError('alpha cannot be empty')
-        if len(colors) == 0:
-            colors = [None]
-        try:
-            # Early conversion of the colors into RGBA values to take care
-            # of cases like colors='0.5' or colors='C1'.  (Issue #8193)
-            colors = mcolors.to_rgba_array(colors)
-        except ValueError:
-            # Will fail if any element of *colors* is None. But as long
-            # as len(colors) == 1 or len(positions), the rest of the
-            # code should process *colors* properly.
-            pass
-
-        if len(lineoffsets) == 1 and len(positions) != 1:
-            lineoffsets = np.tile(lineoffsets, len(positions))
-            lineoffsets[0] = 0
-            lineoffsets = np.cumsum(lineoffsets)
-        if len(linelengths) == 1:
-            linelengths = np.tile(linelengths, len(positions))
-        if len(linewidths) == 1:
-            linewidths = np.tile(linewidths, len(positions))
-        if len(colors) == 1:
-            colors = list(colors) * len(positions)
-        if len(alpha) == 1:
-            alpha = list(alpha) * len(positions)
-        if len(linestyles) == 1:
-            linestyles = [linestyles] * len(positions)
-
-        if len(lineoffsets) != len(positions):
-            raise ValueError('lineoffsets and positions are unequal sized '
-                             'sequences')
-        if len(linelengths) != len(positions):
-            raise ValueError('linelengths and positions are unequal sized '
-                             'sequences')
-        if len(linewidths) != len(positions):
-            raise ValueError('linewidths and positions are unequal sized '
-                             'sequences')
-        if len(colors) != len(positions):
-            raise ValueError('colors and positions are unequal sized '
-                             'sequences')
-        if len(alpha) != len(positions):
-            raise ValueError('alpha and positions are unequal sized '
-                             'sequences')
-        if len(linestyles) != len(positions):
-            raise ValueError('linestyles and positions are unequal sized '
-                             'sequences')
-
-        colls = []
-        for position, lineoffset, linelength, linewidth, color, alpha_, \
-            linestyle in \
-                zip(positions, lineoffsets, linelengths, linewidths,
-                    colors, alpha, linestyles):
-            coll = mcoll.EventCollection(position,
-                                         orientation=orientation,
-                                         lineoffset=lineoffset,
-                                         linelength=linelength,
-                                         linewidth=linewidth,
-                                         color=color,
-                                         alpha=alpha_,
-                                         linestyle=linestyle)
-            self.add_collection(coll, autolim=False)
-            coll._internal_update(kwargs)
-            colls.append(coll)
+            ax.loglog(x, y**3, lw=2)
+            if mcx:
+                ax.set_xscale("log", nonpositive=mcx)
+            if mcy:
+                ax.set_yscale("log", nonpositive=mcy)
+
+
+@mpl.style.context('default')
+def test_axes_margins():
+    fig, ax = plt.subplots()
+    ax.plot([0, 1, 2, 3])
+    assert ax.get_ybound()[0] != 0
+
+    fig, ax = plt.subplots()
+    ax.bar([0, 1, 2, 3], [1, 1, 1, 1])
+    assert ax.get_ybound()[0] == 0
+
+    fig, ax = plt.subplots()
+    ax.barh([0, 1, 2, 3], [1, 1, 1, 1])
+    assert ax.get_xbound()[0] == 0
+
+    fig, ax = plt.subplots()
+    ax.pcolor(np.zeros((10, 10)))
+    assert ax.get_xbound() == (0, 10)
+    assert ax.get_ybound() == (0, 10)
+
+    fig, ax = plt.subplots()
+    ax.pcolorfast(np.zeros((10, 10)))
+    assert ax.get_xbound() == (0, 10)
+    assert ax.get_ybound() == (0, 10)
+
+    fig, ax = plt.subplots()
+    ax.hist(np.arange(10))
+    assert ax.get_ybound()[0] == 0
+
+    fig, ax = plt.subplots()
+    ax.imshow(np.zeros((10, 10)))
+    assert ax.get_xbound() == (-0.5, 9.5)
+    assert ax.get_ybound() == (-0.5, 9.5)
+
+
+@pytest.fixture(params=['x', 'y'])
+def shared_axis_remover(request):
+    def _helper_x(ax):
+        ax2 = ax.twinx()
+        ax2.remove()
+        ax.set_xlim(0, 15)
+        r = ax.xaxis.get_major_locator()()
+        assert r[-1] > 14
+
+    def _helper_y(ax):
+        ax2 = ax.twiny()
+        ax2.remove()
+        ax.set_ylim(0, 15)
+        r = ax.yaxis.get_major_locator()()
+        assert r[-1] > 14
+
+    return {"x": _helper_x, "y": _helper_y}[request.param]
+
+
+@pytest.fixture(params=['gca', 'subplots', 'subplots_shared', 'add_axes'])
+def shared_axes_generator(request):
+    # test all of the ways to get fig/ax sets
+    if request.param == 'gca':
+        fig = plt.figure()
+        ax = fig.gca()
+    elif request.param == 'subplots':
+        fig, ax = plt.subplots()
+    elif request.param == 'subplots_shared':
+        fig, ax_lst = plt.subplots(2, 2, sharex='all', sharey='all')
+        ax = ax_lst[0][0]
+    elif request.param == 'add_axes':
+        fig = plt.figure()
+        ax = fig.add_axes([.1, .1, .8, .8])
+    return fig, ax
+
+
+def test_remove_shared_axes(shared_axes_generator, shared_axis_remover):
+    # test all of the ways to get fig/ax sets
+    fig, ax = shared_axes_generator
+    shared_axis_remover(ax)
+
+
+def test_remove_shared_axes_relim():
+    fig, ax_lst = plt.subplots(2, 2, sharex='all', sharey='all')
+    ax = ax_lst[0][0]
+    orig_xlim = ax_lst[0][1].get_xlim()
+    ax.remove()
+    ax.set_xlim(0, 5)
+    assert_array_equal(ax_lst[0][1].get_xlim(), orig_xlim)
+
+
+def test_shared_axes_autoscale():
+    l = np.arange(-80, 90, 40)
+    t = np.random.random_sample((l.size, l.size))
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, sharey=True)
+
+    ax1.set_xlim(-1000, 1000)
+    ax1.set_ylim(-1000, 1000)
+    ax1.contour(l, l, t)
 
-        if len(positions) > 0:
-            # try to get min/max
-            min_max = [(np.min(_p), np.max(_p)) for _p in positions
-                       if len(_p) > 0]
-            # if we have any non-empty positions, try to autoscale
-            if len(min_max) > 0:
-                mins, maxes = zip(*min_max)
-                minpos = np.min(mins)
-                maxpos = np.max(maxes)
+    ax2.contour(l, l, t)
+    assert not ax1.get_autoscalex_on() and not ax2.get_autoscalex_on()
+    assert not ax1.get_autoscaley_on() and not ax2.get_autoscaley_on()
+    assert ax1.get_xlim() == ax2.get_xlim() == (-1000, 1000)
+    assert ax1.get_ylim() == ax2.get_ylim() == (-1000, 1000)
 
-                minline = (lineoffsets - linelengths).min()
-                maxline = (lineoffsets + linelengths).max()
 
-                if orientation == "vertical":
-                    corners = (minline, minpos), (maxline, maxpos)
-                else:  # "horizontal"
-                    corners = (minpos, minline), (maxpos, maxline)
-                self.update_datalim(corners)
-                self._request_autoscale_view()
+def test_adjust_numtick_aspect():
+    fig, ax = plt.subplots()
+    ax.yaxis.get_major_locator().set_params(nbins='auto')
+    ax.set_xlim(0, 1000)
+    ax.set_aspect('equal')
+    fig.canvas.draw()
+    assert len(ax.yaxis.get_major_locator()()) == 2
+    ax.set_ylim(0, 1000)
+    fig.canvas.draw()
+    assert len(ax.yaxis.get_major_locator()()) > 2
 
-        return colls
 
-    #### Basic plotting
+@mpl.style.context("default")
+def test_auto_numticks():
+    axs = plt.figure().subplots(4, 4)
+    for ax in axs.flat:  # Tiny, empty subplots have only 3 ticks.
+        assert [*ax.get_xticks()] == [*ax.get_yticks()] == [0, 0.5, 1]
 
-    # Uses a custom implementation of data-kwarg handling in
-    # _process_plot_var_args.
-    @_docstring.interpd
-    def plot(self, *args, scalex=True, scaley=True, data=None, **kwargs):
-        """
-        Plot y versus x as lines and/or markers.
 
-        Call signatures::
+@mpl.style.context("default")
+def test_auto_numticks_log():
+    # Verify that there are not too many ticks with a large log range.
+    fig, ax = plt.subplots()
+    mpl.rcParams['axes.autolimit_mode'] = 'round_numbers'
+    ax.loglog([1e-20, 1e5], [1e-16, 10])
+    assert (np.log10(ax.get_xticks()) == np.arange(-26, 18, 4)).all()
+    assert (np.log10(ax.get_yticks()) == np.arange(-20, 10, 3)).all()
 
-            plot([x], y, [fmt], *, data=None, **kwargs)
-            plot([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
 
-        The coordinates of the points or line nodes are given by *x*, *y*.
+def test_broken_barh_empty():
+    fig, ax = plt.subplots()
+    ax.broken_barh([], (.1, .5))
 
-        The optional parameter *fmt* is a convenient way for defining basic
-        formatting like color, marker and linestyle. It's a shortcut string
-        notation described in the *Notes* section below.
 
-        >>> plot(x, y)        # plot x and y using default line style and color
-        >>> plot(x, y, 'bo')  # plot x and y using blue circle markers
-        >>> plot(y)           # plot y using x as index array 0..N-1
-        >>> plot(y, 'r+')     # ditto, but with red plusses
+def test_broken_barh_timedelta():
+    """Check that timedelta works as x, dx pair for this method."""
+    fig, ax = plt.subplots()
+    d0 = datetime.datetime(2018, 11, 9, 0, 0, 0)
+    pp = ax.broken_barh([(d0, datetime.timedelta(hours=1))], [1, 2])
+    assert pp.get_paths()[0].vertices[0, 0] == mdates.date2num(d0)
+    assert pp.get_paths()[0].vertices[2, 0] == mdates.date2num(d0) + 1 / 24
 
-        You can use `.Line2D` properties as keyword arguments for more
-        control on the appearance. Line properties and *fmt* can be mixed.
-        The following two calls yield identical results:
 
-        >>> plot(x, y, 'go--', linewidth=2, markersize=12)
-        >>> plot(x, y, color='green', marker='o', linestyle='dashed',
-        ...      linewidth=2, markersize=12)
+def test_pandas_pcolormesh(pd):
+    time = pd.date_range('2000-01-01', periods=10)
+    depth = np.arange(20)
+    data = np.random.rand(19, 9)
 
-        When conflicting with *fmt*, keyword arguments take precedence.
+    fig, ax = plt.subplots()
+    ax.pcolormesh(time, depth, data)
 
 
-        **Plotting labelled data**
-
-        There's a convenient way for plotting objects with labelled data (i.e.
-        data that can be accessed by index ``obj['y']``). Instead of giving
-        the data in *x* and *y*, you can provide the object in the *data*
-        parameter and just give the labels for *x* and *y*::
-
-        >>> plot('xlabel', 'ylabel', data=obj)
-
-        All indexable objects are supported. This could e.g. be a `dict`, a
-        `pandas.DataFrame` or a structured numpy array.
-
-
-        **Plotting multiple sets of data**
-
-        There are various ways to plot multiple sets of data.
-
-        - The most straight forward way is just to call `plot` multiple times.
-          Example:
-
-          >>> plot(x1, y1, 'bo')
-          >>> plot(x2, y2, 'go')
-
-        - If *x* and/or *y* are 2D arrays, a separate data set will be drawn
-          for every column. If both *x* and *y* are 2D, they must have the
-          same shape. If only one of them is 2D with shape (N, m) the other
-          must have length N and will be used for every data set m.
-
-          Example:
-
-          >>> x = [1, 2, 3]
-          >>> y = np.array([[1, 2], [3, 4], [5, 6]])
-          >>> plot(x, y)
-
-          is equivalent to:
-
-          >>> for col in range(y.shape[1]):
-          ...     plot(x, y[:, col])
-
-        - The third way is to specify multiple sets of *[x]*, *y*, *[fmt]*
-          groups::
-
-          >>> plot(x1, y1, 'g^', x2, y2, 'g-')
-
-          In this case, any additional keyword argument applies to all
-          datasets. Also, this syntax cannot be combined with the *data*
-          parameter.
-
-        By default, each line is assigned a different style specified by a
-        'style cycle'. The *fmt* and line property parameters are only
-        necessary if you want explicit deviations from these defaults.
-        Alternatively, you can also change the style cycle using
-        :rc:`axes.prop_cycle`.
-
-
-        Parameters
-        ----------
-        x, y : array-like or scalar
-            The horizontal / vertical coordinates of the data points.
-            *x* values are optional and default to ``range(len(y))``.
-
-            Commonly, these parameters are 1D arrays.
-
-            They can also be scalars, or two-dimensional (in that case, the
-            columns represent separate data sets).
-
-            These arguments cannot be passed as keywords.
-
-        fmt : str, optional
-            A format string, e.g. 'ro' for red circles. See the *Notes*
-            section for a full description of the format strings.
-
-            Format strings are just an abbreviation for quickly setting
-            basic line properties. All of these and more can also be
-            controlled by keyword arguments.
-
-            This argument cannot be passed as keyword.
-
-        data : indexable object, optional
-            An object with labelled data. If given, provide the label names to
-            plot in *x* and *y*.
-
-            .. note::
-                Technically there's a slight ambiguity in calls where the
-                second label is a valid *fmt*. ``plot('n', 'o', data=obj)``
-                could be ``plt(x, y)`` or ``plt(y, fmt)``. In such cases,
-                the former interpretation is chosen, but a warning is issued.
-                You may suppress the warning by adding an empty format string
-                ``plot('n', 'o', '', data=obj)``.
-
-        Returns
-        -------
-        list of `.Line2D`
-            A list of lines representing the plotted data.
-
-        Other Parameters
-        ----------------
-        scalex, scaley : bool, default: True
-            These parameters determine if the view limits are adapted to the
-            data limits. The values are passed on to
-            `~.axes.Axes.autoscale_view`.
-
-        **kwargs : `~matplotlib.lines.Line2D` properties, optional
-            *kwargs* are used to specify properties like a line label (for
-            auto legends), linewidth, antialiasing, marker face color.
-            Example::
-
-            >>> plot([1, 2, 3], [1, 2, 3], 'go-', label='line 1', linewidth=2)
-            >>> plot([1, 2, 3], [1, 4, 9], 'rs', label='line 2')
-
-            If you specify multiple lines with one plot call, the kwargs apply
-            to all those lines. In case the label object is iterable, each
-            element is used as labels for each set of data.
-
-            Here is a list of available `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        scatter : XY scatter plot with markers of varying size and/or color (
-            sometimes also called bubble chart).
-
-        Notes
-        -----
-        **Format Strings**
-
-        A format string consists of a part for color, marker and line::
-
-            fmt = '[marker][line][color]'
-
-        Each of them is optional. If not provided, the value from the style
-        cycle is used. Exception: If ``line`` is given, but no ``marker``,
-        the data will be a line without markers.
-
-        Other combinations such as ``[color][marker][line]`` are also
-        supported, but note that their parsing may be ambiguous.
-
-        **Markers**
-
-        =============   ===============================
-        character       description
-        =============   ===============================
-        ``'.'``         point marker
-        ``','``         pixel marker
-        ``'o'``         circle marker
-        ``'v'``         triangle_down marker
-        ``'^'``         triangle_up marker
-        ``'<'``         triangle_left marker
-        ``'>'``         triangle_right marker
-        ``'1'``         tri_down marker
-        ``'2'``         tri_up marker
-        ``'3'``         tri_left marker
-        ``'4'``         tri_right marker
-        ``'8'``         octagon marker
-        ``'s'``         square marker
-        ``'p'``         pentagon marker
-        ``'P'``         plus (filled) marker
-        ``'*'``         star marker
-        ``'h'``         hexagon1 marker
-        ``'H'``         hexagon2 marker
-        ``'+'``         plus marker
-        ``'x'``         x marker
-        ``'X'``         x (filled) marker
-        ``'D'``         diamond marker
-        ``'d'``         thin_diamond marker
-        ``'|'``         vline marker
-        ``'_'``         hline marker
-        =============   ===============================
-
-        **Line Styles**
-
-        =============    ===============================
-        character        description
-        =============    ===============================
-        ``'-'``          solid line style
-        ``'--'``         dashed line style
-        ``'-.'``         dash-dot line style
-        ``':'``          dotted line style
-        =============    ===============================
-
-        Example format strings::
-
-            'b'    # blue markers with default shape
-            'or'   # red circles
-            '-g'   # green solid line
-            '--'   # dashed line with default color
-            '^k:'  # black triangle_up markers connected by a dotted line
-
-        **Colors**
-
-        The supported color abbreviations are the single letter codes
-
-        =============    ===============================
-        character        color
-        =============    ===============================
-        ``'b'``          blue
-        ``'g'``          green
-        ``'r'``          red
-        ``'c'``          cyan
-        ``'m'``          magenta
-        ``'y'``          yellow
-        ``'k'``          black
-        ``'w'``          white
-        =============    ===============================
-
-        and the ``'CN'`` colors that index into the default property cycle.
-
-        If the color is the only part of the format string, you can
-        additionally use any  `matplotlib.colors` spec, e.g. full names
-        (``'green'``) or hex strings (``'#008000'``).
-        """
-        kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
-        lines = [*self._get_lines(self, *args, data=data, **kwargs)]
-        for line in lines:
-            self.add_line(line)
-        if scalex:
-            self._request_autoscale_view("x")
-        if scaley:
-            self._request_autoscale_view("y")
-        return lines
-
-    @_api.deprecated("3.9", alternative="plot")
-    @_preprocess_data(replace_names=["x", "y"], label_namer="y")
-    @_docstring.interpd
-    def plot_date(self, x, y, fmt='o', tz=None, xdate=True, ydate=False,
-                  **kwargs):
-        """
-        Plot coercing the axis to treat floats as dates.
-
-        .. deprecated:: 3.9
-
-            This method exists for historic reasons and will be removed in version 3.11.
-
-            - ``datetime``-like data should directly be plotted using
-              `~.Axes.plot`.
-            -  If you need to plot plain numeric data as :ref:`date-format` or
-               need to set a timezone, call ``ax.xaxis.axis_date`` /
-               ``ax.yaxis.axis_date`` before `~.Axes.plot`. See
-               `.Axis.axis_date`.
-
-        Similar to `.plot`, this plots *y* vs. *x* as lines or markers.
-        However, the axis labels are formatted as dates depending on *xdate*
-        and *ydate*.  Note that `.plot` will work with `datetime` and
-        `numpy.datetime64` objects without resorting to this method.
-
-        Parameters
-        ----------
-        x, y : array-like
-            The coordinates of the data points. If *xdate* or *ydate* is
-            *True*, the respective values *x* or *y* are interpreted as
-            :ref:`Matplotlib dates <date-format>`.
-
-        fmt : str, optional
-            The plot format string. For details, see the corresponding
-            parameter in `.plot`.
-
-        tz : timezone string or `datetime.tzinfo`, default: :rc:`timezone`
-            The time zone to use in labeling dates.
-
-        xdate : bool, default: True
-            If *True*, the *x*-axis will be interpreted as Matplotlib dates.
-
-        ydate : bool, default: False
-            If *True*, the *y*-axis will be interpreted as Matplotlib dates.
-
-        Returns
-        -------
-        list of `.Line2D`
-            Objects representing the plotted data.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        matplotlib.dates : Helper functions on dates.
-        matplotlib.dates.date2num : Convert dates to num.
-        matplotlib.dates.num2date : Convert num to dates.
-        matplotlib.dates.drange : Create an equally spaced sequence of dates.
-
-        Notes
-        -----
-        If you are using custom date tickers and formatters, it may be
-        necessary to set the formatters/locators after the call to
-        `.plot_date`. `.plot_date` will set the default tick locator to
-        `.AutoDateLocator` (if the tick locator is not already set to a
-        `.DateLocator` instance) and the default tick formatter to
-        `.AutoDateFormatter` (if the tick formatter is not already set to a
-        `.DateFormatter` instance).
-        """
-        if xdate:
-            self.xaxis_date(tz)
-        if ydate:
-            self.yaxis_date(tz)
-        return self.plot(x, y, fmt, **kwargs)
-
-    # @_preprocess_data() # let 'plot' do the unpacking..
-    @_docstring.interpd
-    def loglog(self, *args, **kwargs):
-        """
-        Make a plot with log scaling on both the x- and y-axis.
-
-        Call signatures::
-
-            loglog([x], y, [fmt], data=None, **kwargs)
-            loglog([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
-
-        This is just a thin wrapper around `.plot` which additionally changes
-        both the x-axis and the y-axis to log scaling. All the concepts and
-        parameters of plot can be used here as well.
-
-        The additional parameters *base*, *subs* and *nonpositive* control the
-        x/y-axis properties. They are just forwarded to `.Axes.set_xscale` and
-        `.Axes.set_yscale`. To use different properties on the x-axis and the
-        y-axis, use e.g.
-        ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.
-
-        Parameters
-        ----------
-        base : float, default: 10
-            Base of the logarithm.
-
-        subs : sequence, optional
-            The location of the minor ticks. If *None*, reasonable locations
-            are automatically chosen depending on the number of decades in the
-            plot. See `.Axes.set_xscale`/`.Axes.set_yscale` for details.
-
-        nonpositive : {'mask', 'clip'}, default: 'clip'
-            Non-positive values can be masked as invalid, or clipped to a very
-            small positive number.
-
-        **kwargs
-            All parameters supported by `.plot`.
-
-        Returns
-        -------
-        list of `.Line2D`
-            Objects representing the plotted data.
-        """
-        dx = {k: v for k, v in kwargs.items()
-              if k in ['base', 'subs', 'nonpositive',
-                       'basex', 'subsx', 'nonposx']}
-        self.set_xscale('log', **dx)
-        dy = {k: v for k, v in kwargs.items()
-              if k in ['base', 'subs', 'nonpositive',
-                       'basey', 'subsy', 'nonposy']}
-        self.set_yscale('log', **dy)
-        return self.plot(
-            *args, **{k: v for k, v in kwargs.items() if k not in {*dx, *dy}})
-
-    # @_preprocess_data() # let 'plot' do the unpacking..
-    @_docstring.interpd
-    def semilogx(self, *args, **kwargs):
-        """
-        Make a plot with log scaling on the x-axis.
-
-        Call signatures::
-
-            semilogx([x], y, [fmt], data=None, **kwargs)
-            semilogx([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
-
-        This is just a thin wrapper around `.plot` which additionally changes
-        the x-axis to log scaling. All the concepts and parameters of plot can
-        be used here as well.
-
-        The additional parameters *base*, *subs*, and *nonpositive* control the
-        x-axis properties. They are just forwarded to `.Axes.set_xscale`.
-
-        Parameters
-        ----------
-        base : float, default: 10
-            Base of the x logarithm.
-
-        subs : array-like, optional
-            The location of the minor xticks. If *None*, reasonable locations
-            are automatically chosen depending on the number of decades in the
-            plot. See `.Axes.set_xscale` for details.
-
-        nonpositive : {'mask', 'clip'}, default: 'clip'
-            Non-positive values in x can be masked as invalid, or clipped to a
-            very small positive number.
-
-        **kwargs
-            All parameters supported by `.plot`.
-
-        Returns
-        -------
-        list of `.Line2D`
-            Objects representing the plotted data.
-        """
-        d = {k: v for k, v in kwargs.items()
-             if k in ['base', 'subs', 'nonpositive',
-                      'basex', 'subsx', 'nonposx']}
-        self.set_xscale('log', **d)
-        return self.plot(
-            *args, **{k: v for k, v in kwargs.items() if k not in d})
-
-    # @_preprocess_data() # let 'plot' do the unpacking..
-    @_docstring.interpd
-    def semilogy(self, *args, **kwargs):
-        """
-        Make a plot with log scaling on the y-axis.
-
-        Call signatures::
-
-            semilogy([x], y, [fmt], data=None, **kwargs)
-            semilogy([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
-
-        This is just a thin wrapper around `.plot` which additionally changes
-        the y-axis to log scaling. All the concepts and parameters of plot can
-        be used here as well.
-
-        The additional parameters *base*, *subs*, and *nonpositive* control the
-        y-axis properties. They are just forwarded to `.Axes.set_yscale`.
-
-        Parameters
-        ----------
-        base : float, default: 10
-            Base of the y logarithm.
-
-        subs : array-like, optional
-            The location of the minor yticks. If *None*, reasonable locations
-            are automatically chosen depending on the number of decades in the
-            plot. See `.Axes.set_yscale` for details.
-
-        nonpositive : {'mask', 'clip'}, default: 'clip'
-            Non-positive values in y can be masked as invalid, or clipped to a
-            very small positive number.
-
-        **kwargs
-            All parameters supported by `.plot`.
-
-        Returns
-        -------
-        list of `.Line2D`
-            Objects representing the plotted data.
-        """
-        d = {k: v for k, v in kwargs.items()
-             if k in ['base', 'subs', 'nonpositive',
-                      'basey', 'subsy', 'nonposy']}
-        self.set_yscale('log', **d)
-        return self.plot(
-            *args, **{k: v for k, v in kwargs.items() if k not in d})
-
-    @_preprocess_data(replace_names=["x"], label_namer="x")
-    def acorr(self, x, **kwargs):
-        """
-        Plot the autocorrelation of *x*.
-
-        Parameters
-        ----------
-        x : array-like
-            Not run through Matplotlib's unit conversion, so this should
-            be a unit-less array.
-
-        detrend : callable, default: `.mlab.detrend_none` (no detrending)
-            A detrending function applied to *x*.  It must have the
-            signature ::
-
-                detrend(x: np.ndarray) -> np.ndarray
-
-        normed : bool, default: True
-            If ``True``, input vectors are normalised to unit length.
-
-        usevlines : bool, default: True
-            Determines the plot style.
-
-            If ``True``, vertical lines are plotted from 0 to the acorr value
-            using `.Axes.vlines`. Additionally, a horizontal line is plotted
-            at y=0 using `.Axes.axhline`.
-
-            If ``False``, markers are plotted at the acorr values using
-            `.Axes.plot`.
-
-        maxlags : int, default: 10
-            Number of lags to show. If ``None``, will return all
-            ``2 * len(x) - 1`` lags.
-
-        Returns
-        -------
-        lags : array (length ``2*maxlags+1``)
-            The lag vector.
-        c : array  (length ``2*maxlags+1``)
-            The auto correlation vector.
-        line : `.LineCollection` or `.Line2D`
-            `.Artist` added to the Axes of the correlation:
-
-            - `.LineCollection` if *usevlines* is True.
-            - `.Line2D` if *usevlines* is False.
-        b : `~matplotlib.lines.Line2D` or None
-            Horizontal line at 0 if *usevlines* is True
-            None *usevlines* is False.
-
-        Other Parameters
-        ----------------
-        linestyle : `~matplotlib.lines.Line2D` property, optional
-            The linestyle for plotting the data points.
-            Only used if *usevlines* is ``False``.
-
-        marker : str, default: 'o'
-            The marker for plotting the data points.
-            Only used if *usevlines* is ``False``.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Additional parameters are passed to `.Axes.vlines` and
-            `.Axes.axhline` if *usevlines* is ``True``; otherwise they are
-            passed to `.Axes.plot`.
-
-        Notes
-        -----
-        The cross correlation is performed with `numpy.correlate` with
-        ``mode = "full"``.
-        """
-        return self.xcorr(x, x, **kwargs)
-
-    @_api.make_keyword_only("3.9", "normed")
-    @_preprocess_data(replace_names=["x", "y"], label_namer="y")
-    def xcorr(self, x, y, normed=True, detrend=mlab.detrend_none,
-              usevlines=True, maxlags=10, **kwargs):
-        r"""
-        Plot the cross correlation between *x* and *y*.
-
-        The correlation with lag k is defined as
-        :math:`\sum_n x[n+k] \cdot y^*[n]`, where :math:`y^*` is the complex
-        conjugate of :math:`y`.
-
-        Parameters
-        ----------
-        x, y : array-like of length n
-            Neither *x* nor *y* are run through Matplotlib's unit conversion, so
-            these should be unit-less arrays.
-
-        detrend : callable, default: `.mlab.detrend_none` (no detrending)
-            A detrending function applied to *x* and *y*.  It must have the
-            signature ::
-
-                detrend(x: np.ndarray) -> np.ndarray
-
-        normed : bool, default: True
-            If ``True``, input vectors are normalised to unit length.
-
-        usevlines : bool, default: True
-            Determines the plot style.
-
-            If ``True``, vertical lines are plotted from 0 to the xcorr value
-            using `.Axes.vlines`. Additionally, a horizontal line is plotted
-            at y=0 using `.Axes.axhline`.
-
-            If ``False``, markers are plotted at the xcorr values using
-            `.Axes.plot`.
-
-        maxlags : int, default: 10
-            Number of lags to show. If None, will return all ``2 * len(x) - 1``
-            lags.
-
-        Returns
-        -------
-        lags : array (length ``2*maxlags+1``)
-            The lag vector.
-        c : array  (length ``2*maxlags+1``)
-            The auto correlation vector.
-        line : `.LineCollection` or `.Line2D`
-            `.Artist` added to the Axes of the correlation:
-
-            - `.LineCollection` if *usevlines* is True.
-            - `.Line2D` if *usevlines* is False.
-        b : `~matplotlib.lines.Line2D` or None
-            Horizontal line at 0 if *usevlines* is True
-            None *usevlines* is False.
-
-        Other Parameters
-        ----------------
-        linestyle : `~matplotlib.lines.Line2D` property, optional
-            The linestyle for plotting the data points.
-            Only used if *usevlines* is ``False``.
-
-        marker : str, default: 'o'
-            The marker for plotting the data points.
-            Only used if *usevlines* is ``False``.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Additional parameters are passed to `.Axes.vlines` and
-            `.Axes.axhline` if *usevlines* is ``True``; otherwise they are
-            passed to `.Axes.plot`.
-
-        Notes
-        -----
-        The cross correlation is performed with `numpy.correlate` with
-        ``mode = "full"``.
-        """
-        Nx = len(x)
-        if Nx != len(y):
-            raise ValueError('x and y must be equal length')
-
-        x = detrend(np.asarray(x))
-        y = detrend(np.asarray(y))
-
-        correls = np.correlate(x, y, mode="full")
-
-        if normed:
-            correls = correls / np.sqrt(np.dot(x, x) * np.dot(y, y))
-
-        if maxlags is None:
-            maxlags = Nx - 1
-
-        if maxlags >= Nx or maxlags < 1:
-            raise ValueError('maxlags must be None or strictly '
-                             'positive < %d' % Nx)
-
-        lags = np.arange(-maxlags, maxlags + 1)
-        correls = correls[Nx - 1 - maxlags:Nx + maxlags]
-
-        if usevlines:
-            a = self.vlines(lags, [0], correls, **kwargs)
-            # Make label empty so only vertical lines get a legend entry
-            kwargs.pop('label', '')
-            b = self.axhline(**kwargs)
+def test_pandas_indexing_dates(pd):
+    dates = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
+    values = np.sin(range(len(dates)))
+    df = pd.DataFrame({'dates': dates, 'values': values})
+
+    ax = plt.gca()
+
+    without_zero_index = df[np.array(df.index) % 2 == 1].copy()
+    ax.plot('dates', 'values', data=without_zero_index)
+
+
+def test_pandas_errorbar_indexing(pd):
+    df = pd.DataFrame(np.random.uniform(size=(5, 4)),
+                      columns=['x', 'y', 'xe', 'ye'],
+                      index=[1, 2, 3, 4, 5])
+    fig, ax = plt.subplots()
+    ax.errorbar('x', 'y', xerr='xe', yerr='ye', data=df)
+
+
+def test_pandas_index_shape(pd):
+    df = pd.DataFrame({"XX": [4, 5, 6], "YY": [7, 1, 2]})
+    fig, ax = plt.subplots()
+    ax.plot(df.index, df['YY'])
+
+
+def test_pandas_indexing_hist(pd):
+    ser_1 = pd.Series(data=[1, 2, 2, 3, 3, 4, 4, 4, 4, 5])
+    ser_2 = ser_1.iloc[1:]
+    fig, ax = plt.subplots()
+    ax.hist(ser_2)
+
+
+def test_pandas_bar_align_center(pd):
+    # Tests fix for issue 8767
+    df = pd.DataFrame({'a': range(2), 'b': range(2)})
+
+    fig, ax = plt.subplots(1)
+
+    ax.bar(df.loc[df['a'] == 1, 'b'],
+           df.loc[df['a'] == 1, 'b'],
+           align='center')
+
+    fig.canvas.draw()
+
+
+def test_axis_get_tick_params():
+    axis = plt.subplot().yaxis
+    initial_major_style_translated = {**axis.get_tick_params(which='major')}
+    initial_minor_style_translated = {**axis.get_tick_params(which='minor')}
+
+    translated_major_kw = axis._translate_tick_params(
+        axis._major_tick_kw, reverse=True
+    )
+    translated_minor_kw = axis._translate_tick_params(
+        axis._minor_tick_kw, reverse=True
+    )
+
+    assert translated_major_kw == initial_major_style_translated
+    assert translated_minor_kw == initial_minor_style_translated
+    axis.set_tick_params(labelsize=30, labelcolor='red',
+                         direction='out', which='both')
+
+    new_major_style_translated = {**axis.get_tick_params(which='major')}
+    new_minor_style_translated = {**axis.get_tick_params(which='minor')}
+    new_major_style = axis._translate_tick_params(new_major_style_translated)
+    new_minor_style = axis._translate_tick_params(new_minor_style_translated)
+    assert initial_major_style_translated != new_major_style_translated
+    assert axis._major_tick_kw == new_major_style
+    assert initial_minor_style_translated != new_minor_style_translated
+    assert axis._minor_tick_kw == new_minor_style
+
+
+def test_axis_set_tick_params_labelsize_labelcolor():
+    # Tests fix for issue 4346
+    axis_1 = plt.subplot()
+    axis_1.yaxis.set_tick_params(labelsize=30, labelcolor='red',
+                                 direction='out')
+
+    # Expected values after setting the ticks
+    assert axis_1.yaxis.majorTicks[0]._size == 4.0
+    assert axis_1.yaxis.majorTicks[0].tick1line.get_color() == 'k'
+    assert axis_1.yaxis.majorTicks[0].label1.get_size() == 30.0
+    assert axis_1.yaxis.majorTicks[0].label1.get_color() == 'red'
+
+
+def test_axes_tick_params_gridlines():
+    # Now treating grid params like other Tick params
+    ax = plt.subplot()
+    ax.tick_params(grid_color='b', grid_linewidth=5, grid_alpha=0.5,
+                   grid_linestyle='dashdot')
+    for axis in ax.xaxis, ax.yaxis:
+        assert axis.majorTicks[0].gridline.get_color() == 'b'
+        assert axis.majorTicks[0].gridline.get_linewidth() == 5
+        assert axis.majorTicks[0].gridline.get_alpha() == 0.5
+        assert axis.majorTicks[0].gridline.get_linestyle() == '-.'
+
+
+def test_axes_tick_params_ylabelside():
+    # Tests fix for issue 10267
+    ax = plt.subplot()
+    ax.tick_params(labelleft=False, labelright=True,
+                   which='major')
+    ax.tick_params(labelleft=False, labelright=True,
+                   which='minor')
+    # expects left false, right true
+    assert ax.yaxis.majorTicks[0].label1.get_visible() is False
+    assert ax.yaxis.majorTicks[0].label2.get_visible() is True
+    assert ax.yaxis.minorTicks[0].label1.get_visible() is False
+    assert ax.yaxis.minorTicks[0].label2.get_visible() is True
+
+
+def test_axes_tick_params_xlabelside():
+    # Tests fix for issue 10267
+    ax = plt.subplot()
+    ax.tick_params(labeltop=True, labelbottom=False,
+                   which='major')
+    ax.tick_params(labeltop=True, labelbottom=False,
+                   which='minor')
+    # expects top True, bottom False
+    # label1.get_visible() mapped to labelbottom
+    # label2.get_visible() mapped to labeltop
+    assert ax.xaxis.majorTicks[0].label1.get_visible() is False
+    assert ax.xaxis.majorTicks[0].label2.get_visible() is True
+    assert ax.xaxis.minorTicks[0].label1.get_visible() is False
+    assert ax.xaxis.minorTicks[0].label2.get_visible() is True
+
+
+def test_none_kwargs():
+    ax = plt.figure().subplots()
+    ln, = ax.plot(range(32), linestyle=None)
+    assert ln.get_linestyle() == '-'
+
+
+def test_bar_uint8():
+    xs = [0, 1, 2, 3]
+    b = plt.bar(np.array(xs, dtype=np.uint8), [2, 3, 4, 5], align="edge")
+    for (patch, x) in zip(b.patches, xs):
+        assert patch.xy[0] == x
+
+
+@image_comparison(['date_timezone_x.png'], tol=1.0)
+def test_date_timezone_x():
+    # Tests issue 5575
+    time_index = [datetime.datetime(2016, 2, 22, hour=x,
+                                    tzinfo=dateutil.tz.gettz('Canada/Eastern'))
+                  for x in range(3)]
+
+    # Same Timezone
+    plt.figure(figsize=(20, 12))
+    plt.subplot(2, 1, 1)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.plot_date(time_index, [3] * 3, tz='Canada/Eastern')
+
+    # Different Timezone
+    plt.subplot(2, 1, 2)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.plot_date(time_index, [3] * 3, tz='UTC')
+
+
+@image_comparison(['date_timezone_y.png'])
+def test_date_timezone_y():
+    # Tests issue 5575
+    time_index = [datetime.datetime(2016, 2, 22, hour=x,
+                                    tzinfo=dateutil.tz.gettz('Canada/Eastern'))
+                  for x in range(3)]
+
+    # Same Timezone
+    plt.figure(figsize=(20, 12))
+    plt.subplot(2, 1, 1)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.plot_date([3] * 3, time_index, tz='Canada/Eastern', xdate=False, ydate=True)
+
+    # Different Timezone
+    plt.subplot(2, 1, 2)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.plot_date([3] * 3, time_index, tz='UTC', xdate=False, ydate=True)
+
+
+@image_comparison(['date_timezone_x_and_y.png'], tol=1.0)
+def test_date_timezone_x_and_y():
+    # Tests issue 5575
+    UTC = datetime.timezone.utc
+    time_index = [datetime.datetime(2016, 2, 22, hour=x, tzinfo=UTC)
+                  for x in range(3)]
+
+    # Same Timezone
+    plt.figure(figsize=(20, 12))
+    plt.subplot(2, 1, 1)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.plot_date(time_index, time_index, tz='UTC', ydate=True)
+
+    # Different Timezone
+    plt.subplot(2, 1, 2)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.plot_date(time_index, time_index, tz='US/Eastern', ydate=True)
+
+
+@image_comparison(['axisbelow.png'], remove_text=True)
+def test_axisbelow():
+    # Test 'line' setting added in 6287.
+    # Show only grids, not frame or ticks, to make this test
+    # independent of future change to drawing order of those elements.
+    axs = plt.figure().subplots(ncols=3, sharex=True, sharey=True)
+    settings = (False, 'line', True)
+
+    for ax, setting in zip(axs, settings):
+        ax.plot((0, 10), (0, 10), lw=10, color='m')
+        circ = mpatches.Circle((3, 3), color='r')
+        ax.add_patch(circ)
+        ax.grid(color='c', linestyle='-', linewidth=3)
+        ax.tick_params(top=False, bottom=False,
+                       left=False, right=False)
+        ax.spines[:].set_visible(False)
+        ax.set_axisbelow(setting)
+        assert ax.get_axisbelow() == setting
+
+
+def test_titletwiny():
+    plt.style.use('mpl20')
+    fig, ax = plt.subplots(dpi=72)
+    ax2 = ax.twiny()
+    xlabel2 = ax2.set_xlabel('Xlabel2')
+    title = ax.set_title('Title')
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    # ------- Test that title is put above Xlabel2 (Xlabel2 at top) ----------
+    bbox_y0_title = title.get_window_extent(renderer).y0  # bottom of title
+    bbox_y1_xlabel2 = xlabel2.get_window_extent(renderer).y1  # top of xlabel2
+    y_diff = bbox_y0_title - bbox_y1_xlabel2
+    assert np.isclose(y_diff, 3)
+
+
+def test_titlesetpos():
+    # Test that title stays put if we set it manually
+    fig, ax = plt.subplots()
+    fig.subplots_adjust(top=0.8)
+    ax2 = ax.twiny()
+    ax.set_xlabel('Xlabel')
+    ax2.set_xlabel('Xlabel2')
+    ax.set_title('Title')
+    pos = (0.5, 1.11)
+    ax.title.set_position(pos)
+    renderer = fig.canvas.get_renderer()
+    ax._update_title_position(renderer)
+    assert ax.title.get_position() == pos
+
+
+def test_title_xticks_top():
+    # Test that title moves if xticks on top of axes.
+    mpl.rcParams['axes.titley'] = None
+    fig, ax = plt.subplots()
+    ax.xaxis.set_ticks_position('top')
+    ax.set_title('xlabel top')
+    fig.canvas.draw()
+    assert ax.title.get_position()[1] > 1.04
+
+
+def test_title_xticks_top_both():
+    # Test that title moves if xticks on top of axes.
+    mpl.rcParams['axes.titley'] = None
+    fig, ax = plt.subplots()
+    ax.tick_params(axis="x",
+                   bottom=True, top=True, labelbottom=True, labeltop=True)
+    ax.set_title('xlabel top')
+    fig.canvas.draw()
+    assert ax.title.get_position()[1] > 1.04
+
+
+@pytest.mark.parametrize(
+    'left, center', [
+        ('left', ''),
+        ('', 'center'),
+        ('left', 'center')
+    ], ids=[
+        'left title moved',
+        'center title kept',
+        'both titles aligned'
+    ]
+)
+def test_title_above_offset(left, center):
+    # Test that title moves if overlaps with yaxis offset text.
+    mpl.rcParams['axes.titley'] = None
+    fig, ax = plt.subplots()
+    ax.set_ylim(1e11)
+    ax.set_title(left, loc='left')
+    ax.set_title(center)
+    fig.draw_without_rendering()
+    if left and not center:
+        assert ax._left_title.get_position()[1] > 1.0
+    elif not left and center:
+        assert ax.title.get_position()[1] == 1.0
+    else:
+        yleft = ax._left_title.get_position()[1]
+        ycenter = ax.title.get_position()[1]
+        assert yleft > 1.0
+        assert ycenter == yleft
+
+
+def test_title_no_move_off_page():
+    # If an Axes is off the figure (ie. if it is cropped during a save)
+    # make sure that the automatic title repositioning does not get done.
+    mpl.rcParams['axes.titley'] = None
+    fig = plt.figure()
+    ax = fig.add_axes([0.1, -0.5, 0.8, 0.2])
+    ax.tick_params(axis="x",
+                   bottom=True, top=True, labelbottom=True, labeltop=True)
+    tt = ax.set_title('Boo')
+    fig.canvas.draw()
+    assert tt.get_position()[1] == 1.0
+
+
+def test_title_inset_ax():
+    # Title should be above any child axes
+    mpl.rcParams['axes.titley'] = None
+    fig, ax = plt.subplots()
+    ax.set_title('Title')
+    fig.draw_without_rendering()
+    assert ax.title.get_position()[1] == 1
+    ax.inset_axes([0, 1, 1, 0.1])
+    fig.draw_without_rendering()
+    assert ax.title.get_position()[1] == 1.1
+
+
+def test_offset_label_color():
+    # Tests issue 6440
+    fig, ax = plt.subplots()
+    ax.plot([1.01e9, 1.02e9, 1.03e9])
+    ax.yaxis.set_tick_params(labelcolor='red')
+    assert ax.yaxis.get_offset_text().get_color() == 'red'
+
+
+def test_offset_text_visible():
+    fig, ax = plt.subplots()
+    ax.plot([1.01e9, 1.02e9, 1.03e9])
+    ax.yaxis.set_tick_params(label1On=False, label2On=True)
+    assert ax.yaxis.get_offset_text().get_visible()
+    ax.yaxis.set_tick_params(label2On=False)
+    assert not ax.yaxis.get_offset_text().get_visible()
+
+
+def test_large_offset():
+    fig, ax = plt.subplots()
+    ax.plot((1 + np.array([0, 1.e-12])) * 1.e27)
+    fig.canvas.draw()
+
+
+def test_barb_units():
+    fig, ax = plt.subplots()
+    dates = [datetime.datetime(2017, 7, 15, 18, i) for i in range(0, 60, 10)]
+    y = np.linspace(0, 5, len(dates))
+    u = v = np.linspace(0, 50, len(dates))
+    ax.barbs(dates, y, u, v)
+
+
+def test_quiver_units():
+    fig, ax = plt.subplots()
+    dates = [datetime.datetime(2017, 7, 15, 18, i) for i in range(0, 60, 10)]
+    y = np.linspace(0, 5, len(dates))
+    u = v = np.linspace(0, 50, len(dates))
+    ax.quiver(dates, y, u, v)
+
+
+def test_bar_color_cycle():
+    to_rgb = mcolors.to_rgb
+    fig, ax = plt.subplots()
+    for j in range(5):
+        ln, = ax.plot(range(3))
+        brs = ax.bar(range(3), range(3))
+        for br in brs:
+            assert to_rgb(ln.get_color()) == to_rgb(br.get_facecolor())
+
+
+def test_tick_param_label_rotation():
+    fix, (ax, ax2) = plt.subplots(1, 2)
+    ax.plot([0, 1], [0, 1])
+    ax2.plot([0, 1], [0, 1])
+    ax.xaxis.set_tick_params(which='both', rotation=75)
+    ax.yaxis.set_tick_params(which='both', rotation=90)
+    for text in ax.get_xticklabels(which='both'):
+        assert text.get_rotation() == 75
+    for text in ax.get_yticklabels(which='both'):
+        assert text.get_rotation() == 90
+
+    ax2.tick_params(axis='x', labelrotation=53)
+    ax2.tick_params(axis='y', rotation=35)
+    for text in ax2.get_xticklabels(which='major'):
+        assert text.get_rotation() == 53
+    for text in ax2.get_yticklabels(which='major'):
+        assert text.get_rotation() == 35
+
+
+@mpl.style.context('default')
+def test_fillbetween_cycle():
+    fig, ax = plt.subplots()
+
+    for j in range(3):
+        cc = ax.fill_between(range(3), range(3))
+        target = mcolors.to_rgba(f'C{j}')
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
+
+    for j in range(3, 6):
+        cc = ax.fill_betweenx(range(3), range(3))
+        target = mcolors.to_rgba(f'C{j}')
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
+
+    target = mcolors.to_rgba('k')
+
+    for al in ['facecolor', 'facecolors', 'color']:
+        cc = ax.fill_between(range(3), range(3), **{al: 'k'})
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
+
+    edge_target = mcolors.to_rgba('k')
+    for j, el in enumerate(['edgecolor', 'edgecolors'], start=6):
+        cc = ax.fill_between(range(3), range(3), **{el: 'k'})
+        face_target = mcolors.to_rgba(f'C{j}')
+        assert tuple(cc.get_facecolors().squeeze()) == tuple(face_target)
+        assert tuple(cc.get_edgecolors().squeeze()) == tuple(edge_target)
+
+
+def test_log_margins():
+    plt.rcParams['axes.autolimit_mode'] = 'data'
+    fig, ax = plt.subplots()
+    margin = 0.05
+    ax.set_xmargin(margin)
+    ax.semilogx([10, 100], [10, 100])
+    xlim0, xlim1 = ax.get_xlim()
+    transform = ax.xaxis.get_transform()
+    xlim0t, xlim1t = transform.transform([xlim0, xlim1])
+    x0t, x1t = transform.transform([10, 100])
+    delta = (x1t - x0t) * margin
+    assert_allclose([xlim0t + delta, xlim1t - delta], [x0t, x1t])
+
+
+def test_color_length_mismatch():
+    N = 5
+    x, y = np.arange(N), np.arange(N)
+    colors = np.arange(N+1)
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError):
+        ax.scatter(x, y, c=colors)
+    with pytest.warns(match="argument looks like a single numeric RGB"):
+        ax.scatter(x, y, c=(0.5, 0.5, 0.5))
+    ax.scatter(x, y, c=[(0.5, 0.5, 0.5)] * N)
+
+
+def test_eventplot_legend():
+    plt.eventplot([1.0], label='Label')
+    plt.legend()
+
+
+@pytest.mark.parametrize('err, args, kwargs, match', (
+        (ValueError, [[1]], {'lineoffsets': []}, 'lineoffsets cannot be empty'),
+        (ValueError, [[1]], {'linelengths': []}, 'linelengths cannot be empty'),
+        (ValueError, [[1]], {'linewidths': []}, 'linewidths cannot be empty'),
+        (ValueError, [[1]], {'linestyles': []}, 'linestyles cannot be empty'),
+        (ValueError, [[1]], {'alpha': []}, 'alpha cannot be empty'),
+        (ValueError, [1], {}, 'positions must be one-dimensional'),
+        (ValueError, [[1]], {'lineoffsets': [1, 2]},
+         'lineoffsets and positions are unequal sized sequences'),
+        (ValueError, [[1]], {'linelengths': [1, 2]},
+         'linelengths and positions are unequal sized sequences'),
+        (ValueError, [[1]], {'linewidths': [1, 2]},
+         'linewidths and positions are unequal sized sequences'),
+        (ValueError, [[1]], {'linestyles': [1, 2]},
+         'linestyles and positions are unequal sized sequences'),
+        (ValueError, [[1]], {'alpha': [1, 2]},
+         'alpha and positions are unequal sized sequences'),
+        (ValueError, [[1]], {'colors': [1, 2]},
+         'colors and positions are unequal sized sequences'),
+))
+def test_eventplot_errors(err, args, kwargs, match):
+    with pytest.raises(err, match=match):
+        plt.eventplot(*args, **kwargs)
+
+
+def test_bar_broadcast_args():
+    fig, ax = plt.subplots()
+    # Check that a bar chart with a single height for all bars works.
+    ax.bar(range(4), 1)
+    # Check that a horizontal chart with one width works.
+    ax.barh(0, 1, left=range(4), height=1)
+    # Check that edgecolor gets broadcast.
+    rect1, rect2 = ax.bar([0, 1], [0, 1], edgecolor=(.1, .2, .3, .4))
+    assert rect1.get_edgecolor() == rect2.get_edgecolor() == (.1, .2, .3, .4)
+
+
+def test_invalid_axis_limits():
+    plt.plot([0, 1], [0, 1])
+    with pytest.raises(ValueError):
+        plt.xlim(np.nan)
+    with pytest.raises(ValueError):
+        plt.xlim(np.inf)
+    with pytest.raises(ValueError):
+        plt.ylim(np.nan)
+    with pytest.raises(ValueError):
+        plt.ylim(np.inf)
+
+
+# Test all 4 combinations of logs/symlogs for minorticks_on()
+@pytest.mark.parametrize('xscale', ['symlog', 'log'])
+@pytest.mark.parametrize('yscale', ['symlog', 'log'])
+def test_minorticks_on(xscale, yscale):
+    ax = plt.subplot()
+    ax.plot([1, 2, 3, 4])
+    ax.set_xscale(xscale)
+    ax.set_yscale(yscale)
+    ax.minorticks_on()
+
+
+def test_twinx_knows_limits():
+    fig, ax = plt.subplots()
+
+    ax.axvspan(1, 2)
+    xtwin = ax.twinx()
+    xtwin.plot([0, 0.5], [1, 2])
+    # control axis
+    fig2, ax2 = plt.subplots()
+
+    ax2.axvspan(1, 2)
+    ax2.plot([0, 0.5], [1, 2])
+
+    assert_array_equal(xtwin.viewLim.intervalx, ax2.viewLim.intervalx)
+
+
+def test_zero_linewidth():
+    # Check that setting a zero linewidth doesn't error
+    plt.plot([0, 1], [0, 1], ls='--', lw=0)
+
+
+def test_empty_errorbar_legend():
+    fig, ax = plt.subplots()
+    ax.errorbar([], [], xerr=[], label='empty y')
+    ax.errorbar([], [], yerr=[], label='empty x')
+    ax.legend()
+
+
+@check_figures_equal(extensions=["png"])
+def test_plot_decimal(fig_test, fig_ref):
+    x0 = np.arange(-10, 10, 0.3)
+    y0 = [5.2 * x ** 3 - 2.1 * x ** 2 + 7.34 * x + 4.5 for x in x0]
+    x = [Decimal(i) for i in x0]
+    y = [Decimal(i) for i in y0]
+    # Test image - line plot with Decimal input
+    fig_test.subplots().plot(x, y)
+    # Reference image
+    fig_ref.subplots().plot(x0, y0)
+
+
+# pdf and svg tests fail using travis' old versions of gs and inkscape.
+@check_figures_equal(extensions=["png"])
+def test_markerfacecolor_none_alpha(fig_test, fig_ref):
+    fig_test.subplots().plot(0, "o", mfc="none", alpha=.5)
+    fig_ref.subplots().plot(0, "o", mfc="w", alpha=.5)
+
+
+def test_tick_padding_tightbbox():
+    """Test that tick padding gets turned off if axis is off"""
+    plt.rcParams["xtick.direction"] = "out"
+    plt.rcParams["ytick.direction"] = "out"
+    fig, ax = plt.subplots()
+    bb = ax.get_tightbbox(fig.canvas.get_renderer())
+    ax.axis('off')
+    bb2 = ax.get_tightbbox(fig.canvas.get_renderer())
+    assert bb.x0 < bb2.x0
+    assert bb.y0 < bb2.y0
+
+
+def test_inset():
+    """
+    Ensure that inset_ax argument is indeed optional
+    """
+    dx, dy = 0.05, 0.05
+    # generate 2 2d grids for the x & y bounds
+    y, x = np.mgrid[slice(1, 5 + dy, dy),
+                    slice(1, 5 + dx, dx)]
+    z = np.sin(x) ** 10 + np.cos(10 + y * x) * np.cos(x)
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(x, y, z[:-1, :-1])
+    ax.set_aspect(1.)
+    ax.apply_aspect()
+    # we need to apply_aspect to make the drawing below work.
+
+    xlim = [1.5, 2.15]
+    ylim = [2, 2.5]
+
+    rect = [xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0]]
+
+    inset = ax.indicate_inset(bounds=rect)
+    assert inset.connectors is None
+    fig.canvas.draw()
+    xx = np.array([[1.5, 2.],
+                   [2.15, 2.5]])
+    assert np.all(inset.rectangle.get_bbox().get_points() == xx)
+
+
+def test_zoom_inset():
+    dx, dy = 0.05, 0.05
+    # generate 2 2d grids for the x & y bounds
+    y, x = np.mgrid[slice(1, 5 + dy, dy),
+                    slice(1, 5 + dx, dx)]
+    z = np.sin(x)**10 + np.cos(10 + y*x) * np.cos(x)
+
+    fig, ax = plt.subplots()
+    ax.pcolormesh(x, y, z[:-1, :-1])
+    ax.set_aspect(1.)
+    ax.apply_aspect()
+    # we need to apply_aspect to make the drawing below work.
+
+    # Make the inset_axes...  Position axes coordinates...
+    axin1 = ax.inset_axes([0.7, 0.7, 0.35, 0.35])
+    # redraw the data in the inset axes...
+    axin1.pcolormesh(x, y, z[:-1, :-1])
+    axin1.set_xlim([1.5, 2.15])
+    axin1.set_ylim([2, 2.5])
+    axin1.set_aspect(ax.get_aspect())
+
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        rec, connectors = ax.indicate_inset_zoom(axin1)
+    fig.canvas.draw()
+    assert len(connectors) == 4
+    xx = np.array([[1.5,  2.],
+                   [2.15, 2.5]])
+    assert np.all(rec.get_bbox().get_points() == xx)
+    xx = np.array([[0.6325, 0.692308],
+                   [0.8425, 0.907692]])
+    np.testing.assert_allclose(
+        axin1.get_position().get_points(), xx, rtol=1e-4)
+
+
+@image_comparison(['inset_polar.png'], remove_text=True, style='mpl20')
+def test_inset_polar():
+    _, ax = plt.subplots()
+    axins = ax.inset_axes([0.5, 0.1, 0.45, 0.45], polar=True)
+    assert isinstance(axins, PolarAxes)
+
+    r = np.arange(0, 2, 0.01)
+    theta = 2 * np.pi * r
+
+    ax.plot(theta, r)
+    axins.plot(theta, r)
+
+
+def test_inset_projection():
+    _, ax = plt.subplots()
+    axins = ax.inset_axes([0.2, 0.2, 0.3, 0.3], projection="hammer")
+    assert isinstance(axins, HammerAxes)
+
+
+def test_inset_subclass():
+    _, ax = plt.subplots()
+    axins = ax.inset_axes([0.2, 0.2, 0.3, 0.3], axes_class=AA.Axes)
+    assert isinstance(axins, AA.Axes)
+
+
+@pytest.mark.parametrize('x_inverted', [False, True])
+@pytest.mark.parametrize('y_inverted', [False, True])
+def test_indicate_inset_inverted(x_inverted, y_inverted):
+    """
+    Test that the inset lines are correctly located with inverted data axes.
+    """
+    fig, (ax1, ax2) = plt.subplots(1, 2)
+
+    x = np.arange(10)
+    ax1.plot(x, x, 'o')
+    if x_inverted:
+        ax1.invert_xaxis()
+    if y_inverted:
+        ax1.invert_yaxis()
+
+    inset = ax1.indicate_inset([2, 2, 5, 4], ax2)
+    lower_left, upper_left, lower_right, upper_right = inset.connectors
+
+    sign_x = -1 if x_inverted else 1
+    sign_y = -1 if y_inverted else 1
+    assert sign_x * (lower_right.xy2[0] - lower_left.xy2[0]) > 0
+    assert sign_x * (upper_right.xy2[0] - upper_left.xy2[0]) > 0
+    assert sign_y * (upper_left.xy2[1] - lower_left.xy2[1]) > 0
+    assert sign_y * (upper_right.xy2[1] - lower_right.xy2[1]) > 0
+
+
+def test_set_position():
+    fig, ax = plt.subplots()
+    ax.set_aspect(3.)
+    ax.set_position([0.1, 0.1, 0.4, 0.4], which='both')
+    assert np.allclose(ax.get_position().width, 0.1)
+    ax.set_aspect(2.)
+    ax.set_position([0.1, 0.1, 0.4, 0.4], which='original')
+    assert np.allclose(ax.get_position().width, 0.15)
+    ax.set_aspect(3.)
+    ax.set_position([0.1, 0.1, 0.4, 0.4], which='active')
+    assert np.allclose(ax.get_position().width, 0.1)
+
+
+def test_spines_properbbox_after_zoom():
+    fig, ax = plt.subplots()
+    bb = ax.spines.bottom.get_window_extent(fig.canvas.get_renderer())
+    # this is what zoom calls:
+    ax._set_view_from_bbox((320, 320, 500, 500), 'in',
+                           None, False, False)
+    bb2 = ax.spines.bottom.get_window_extent(fig.canvas.get_renderer())
+    np.testing.assert_allclose(bb.get_points(), bb2.get_points(), rtol=1e-6)
+
+
+def test_limits_after_scroll_zoom():
+    fig, ax = plt.subplots()
+    #
+    xlim = (-0.5, 0.5)
+    ylim = (-1, 2)
+    ax.set_xlim(xlim)
+    ax.set_ylim(ymin=ylim[0], ymax=ylim[1])
+    # This is what scroll zoom calls:
+    # Zoom with factor 1, small numerical change
+    ax._set_view_from_bbox((200, 200, 1.))
+    np.testing.assert_allclose(xlim, ax.get_xlim(), atol=1e-16)
+    np.testing.assert_allclose(ylim, ax.get_ylim(), atol=1e-16)
+
+    # Zoom in
+    ax._set_view_from_bbox((200, 200, 2.))
+    # Hard-coded values
+    new_xlim = (-0.3790322580645161, 0.12096774193548387)
+    new_ylim = (-0.40625, 1.09375)
+
+    res_xlim = ax.get_xlim()
+    res_ylim = ax.get_ylim()
+    np.testing.assert_allclose(res_xlim[1] - res_xlim[0], 0.5)
+    np.testing.assert_allclose(res_ylim[1] - res_ylim[0], 1.5)
+    np.testing.assert_allclose(new_xlim, res_xlim, atol=1e-16)
+    np.testing.assert_allclose(new_ylim, res_ylim)
+
+    # Zoom out, should be same as before, except for numerical issues
+    ax._set_view_from_bbox((200, 200, 0.5))
+    res_xlim = ax.get_xlim()
+    res_ylim = ax.get_ylim()
+    np.testing.assert_allclose(res_xlim[1] - res_xlim[0], 1)
+    np.testing.assert_allclose(res_ylim[1] - res_ylim[0], 3)
+    np.testing.assert_allclose(xlim, res_xlim, atol=1e-16)
+    np.testing.assert_allclose(ylim, res_ylim, atol=1e-16)
+
+
+def test_gettightbbox_ignore_nan():
+    fig, ax = plt.subplots()
+    remove_ticks_and_titles(fig)
+    ax.text(np.nan, 1, 'Boo')
+    renderer = fig.canvas.get_renderer()
+    np.testing.assert_allclose(ax.get_tightbbox(renderer).width, 496)
+
+
+def test_scatter_series_non_zero_index(pd):
+    # create non-zero index
+    ids = range(10, 18)
+    x = pd.Series(np.random.uniform(size=8), index=ids)
+    y = pd.Series(np.random.uniform(size=8), index=ids)
+    c = pd.Series([1, 1, 1, 1, 1, 0, 0, 0], index=ids)
+    plt.scatter(x, y, c)
+
+
+def test_scatter_empty_data():
+    # making sure this does not raise an exception
+    plt.scatter([], [])
+    plt.scatter([], [], s=[], c=[])
+
+
+@image_comparison(['annotate_across_transforms.png'], style='mpl20', remove_text=True,
+                  tol=0.025 if platform.machine() == 'arm64' else 0)
+def test_annotate_across_transforms():
+    x = np.linspace(0, 10, 200)
+    y = np.exp(-x) * np.sin(x)
+
+    fig, ax = plt.subplots(figsize=(3.39, 3))
+    ax.plot(x, y)
+    axins = ax.inset_axes([0.4, 0.5, 0.3, 0.3])
+    axins.set_aspect(0.2)
+    axins.xaxis.set_visible(False)
+    axins.yaxis.set_visible(False)
+    ax.annotate("", xy=(x[150], y[150]), xycoords=ax.transData,
+                xytext=(1, 0), textcoords=axins.transAxes,
+                arrowprops=dict(arrowstyle="->"))
+
+
+class _Translation(mtransforms.Transform):
+    input_dims = 1
+    output_dims = 1
+
+    def __init__(self, dx):
+        self.dx = dx
+
+    def transform(self, values):
+        return values + self.dx
+
+    def inverted(self):
+        return _Translation(-self.dx)
+
+
+@image_comparison(['secondary_xy.png'], style='mpl20',
+                  tol=0.027 if platform.machine() == 'arm64' else 0)
+def test_secondary_xy():
+    fig, axs = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)
+
+    def invert(x):
+        with np.errstate(divide='ignore'):
+            return 1 / x
+
+    for nn, ax in enumerate(axs):
+        ax.plot(np.arange(2, 11), np.arange(2, 11))
+        if nn == 0:
+            secax = ax.secondary_xaxis
         else:
-            kwargs.setdefault('marker', 'o')
-            kwargs.setdefault('linestyle', 'None')
-            a, = self.plot(lags, correls, **kwargs)
-            b = None
-        return lags, correls, a, b
-
-    #### Specialized plotting
-
-    # @_preprocess_data() # let 'plot' do the unpacking..
-    def step(self, x, y, *args, where='pre', data=None, **kwargs):
-        """
-        Make a step plot.
-
-        Call signatures::
-
-            step(x, y, [fmt], *, data=None, where='pre', **kwargs)
-            step(x, y, [fmt], x2, y2, [fmt2], ..., *, where='pre', **kwargs)
-
-        This is just a thin wrapper around `.plot` which changes some
-        formatting options. Most of the concepts and parameters of plot can be
-        used here as well.
-
-        .. note::
-
-            This method uses a standard plot with a step drawstyle: The *x*
-            values are the reference positions and steps extend left/right/both
-            directions depending on *where*.
-
-            For the common case where you know the values and edges of the
-            steps, use `~.Axes.stairs` instead.
-
-        Parameters
-        ----------
-        x : array-like
-            1D sequence of x positions. It is assumed, but not checked, that
-            it is uniformly increasing.
-
-        y : array-like
-            1D sequence of y levels.
-
-        fmt : str, optional
-            A format string, e.g. 'g' for a green line. See `.plot` for a more
-            detailed description.
-
-            Note: While full format strings are accepted, it is recommended to
-            only specify the color. Line styles are currently ignored (use
-            the keyword argument *linestyle* instead). Markers are accepted
-            and plotted on the given positions, however, this is a rarely
-            needed feature for step plots.
-
-        where : {'pre', 'post', 'mid'}, default: 'pre'
-            Define where the steps should be placed:
-
-            - 'pre': The y value is continued constantly to the left from
-              every *x* position, i.e. the interval ``(x[i-1], x[i]]`` has the
-              value ``y[i]``.
-            - 'post': The y value is continued constantly to the right from
-              every *x* position, i.e. the interval ``[x[i], x[i+1])`` has the
-              value ``y[i]``.
-            - 'mid': Steps occur half-way between the *x* positions.
-
-        data : indexable object, optional
-            An object with labelled data. If given, provide the label names to
-            plot in *x* and *y*.
-
-        **kwargs
-            Additional parameters are the same as those for `.plot`.
-
-        Returns
-        -------
-        list of `.Line2D`
-            Objects representing the plotted data.
-        """
-        _api.check_in_list(('pre', 'post', 'mid'), where=where)
-        kwargs['drawstyle'] = 'steps-' + where
-        return self.plot(x, y, *args, data=data, **kwargs)
-
-    @staticmethod
-    def _convert_dx(dx, x0, xconv, convert):
-        """
-        Small helper to do logic of width conversion flexibly.
-
-        *dx* and *x0* have units, but *xconv* has already been converted
-        to unitless (and is an ndarray).  This allows the *dx* to have units
-        that are different from *x0*, but are still accepted by the
-        ``__add__`` operator of *x0*.
-        """
-
-        # x should be an array...
-        assert type(xconv) is np.ndarray
-
-        if xconv.size == 0:
-            # xconv has already been converted, but maybe empty...
-            return convert(dx)
-
-        try:
-            # attempt to add the width to x0; this works for
-            # datetime+timedelta, for instance
-
-            # only use the first element of x and x0.  This saves
-            # having to be sure addition works across the whole
-            # vector.  This is particularly an issue if
-            # x0 and dx are lists so x0 + dx just concatenates the lists.
-            # We can't just cast x0 and dx to numpy arrays because that
-            # removes the units from unit packages like `pint` that
-            # wrap numpy arrays.
-            try:
-                x0 = cbook._safe_first_finite(x0)
-            except (TypeError, IndexError, KeyError):
-                pass
-
-            try:
-                x = cbook._safe_first_finite(xconv)
-            except (TypeError, IndexError, KeyError):
-                x = xconv
-
-            delist = False
-            if not np.iterable(dx):
-                dx = [dx]
-                delist = True
-            dx = [convert(x0 + ddx) - x for ddx in dx]
-            if delist:
-                dx = dx[0]
-        except (ValueError, TypeError, AttributeError):
-            # if the above fails (for any reason) just fallback to what
-            # we do by default and convert dx by itself.
-            dx = convert(dx)
-        return dx
-
-    def _parse_bar_color_args(self, kwargs):
-        """
-        Helper function to process color-related arguments of `.Axes.bar`.
-
-        Argument precedence for facecolors:
-
-        - kwargs['facecolor']
-        - kwargs['color']
-        - 'Result of ``self._get_patches_for_fill.get_next_color``
-
-        Argument precedence for edgecolors:
-
-        - kwargs['edgecolor']
-        - None
-
-        Parameters
-        ----------
-        self : Axes
-
-        kwargs : dict
-            Additional kwargs. If these keys exist, we pop and process them:
-            'facecolor', 'edgecolor', 'color'
-            Note: The dict is modified by this function.
-
-
-        Returns
-        -------
-        facecolor
-            The facecolor. One or more colors as (N, 4) rgba array.
-        edgecolor
-            The edgecolor. Not normalized; may be any valid color spec or None.
-        """
-        color = kwargs.pop('color', None)
-
-        facecolor = kwargs.pop('facecolor', color)
-        edgecolor = kwargs.pop('edgecolor', None)
-
-        facecolor = (facecolor if facecolor is not None
-                     else self._get_patches_for_fill.get_next_color())
-
-        try:
-            facecolor = mcolors.to_rgba_array(facecolor)
-        except ValueError as err:
-            raise ValueError(
-                "'facecolor' or 'color' argument must be a valid color or"
-                    "sequence of colors."
-            ) from err
-
-        return facecolor, edgecolor
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def bar(self, x, height, width=0.8, bottom=None, *, align="center",
-            **kwargs):
-        r"""
-        Make a bar plot.
-
-        The bars are positioned at *x* with the given *align*\ment. Their
-        dimensions are given by *height* and *width*. The vertical baseline
-        is *bottom* (default 0).
-
-        Many parameters can take either a single value applying to all bars
-        or a sequence of values, one for each bar.
-
-        Parameters
-        ----------
-        x : float or array-like
-            The x coordinates of the bars. See also *align* for the
-            alignment of the bars to the coordinates.
-
-        height : float or array-like
-            The height(s) of the bars.
-
-            Note that if *bottom* has units (e.g. datetime), *height* should be in
-            units that are a difference from the value of *bottom* (e.g. timedelta).
-
-        width : float or array-like, default: 0.8
-            The width(s) of the bars.
-
-            Note that if *x* has units (e.g. datetime), then *width* should be in
-            units that are a difference (e.g. timedelta) around the *x* values.
-
-        bottom : float or array-like, default: 0
-            The y coordinate(s) of the bottom side(s) of the bars.
-
-            Note that if *bottom* has units, then the y-axis will get a Locator and
-            Formatter appropriate for the units (e.g. dates, or categorical).
-
-        align : {'center', 'edge'}, default: 'center'
-            Alignment of the bars to the *x* coordinates:
-
-            - 'center': Center the base on the *x* positions.
-            - 'edge': Align the left edges of the bars with the *x* positions.
-
-            To align the bars on the right edge pass a negative *width* and
-            ``align='edge'``.
-
-        Returns
-        -------
-        `.BarContainer`
-            Container with all the bars and optionally errorbars.
-
-        Other Parameters
-        ----------------
-        color : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar faces. This is an alias for *facecolor*.
-            If both are given, *facecolor* takes precedence.
-
-        facecolor : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar faces.
-            If both *color* and *facecolor are given, *facecolor* takes precedence.
-
-        edgecolor : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar edges.
-
-        linewidth : float or array-like, optional
-            Width of the bar edge(s). If 0, don't draw edges.
-
-        tick_label : str or list of str, optional
-            The tick labels of the bars.
-            Default: None (Use default numeric labels.)
-
-        label : str or list of str, optional
-            A single label is attached to the resulting `.BarContainer` as a
-            label for the whole dataset.
-            If a list is provided, it must be the same length as *x* and
-            labels the individual bars. Repeated labels are not de-duplicated
-            and will cause repeated label entries, so this is best used when
-            bars also differ in style (e.g., by passing a list to *color*.)
-
-        xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
-            If not *None*, add horizontal / vertical errorbars to the bar tips.
-            The values are +/- sizes relative to the data:
-
-            - scalar: symmetric +/- values for all bars
-            - shape(N,): symmetric +/- values for each bar
-            - shape(2, N): Separate - and + values for each bar. First row
-              contains the lower errors, the second row contains the upper
-              errors.
-            - *None*: No errorbar. (Default)
-
-            See :doc:`/gallery/statistics/errorbar_features` for an example on
-            the usage of *xerr* and *yerr*.
-
-        ecolor : :mpltype:`color` or list of :mpltype:`color`, default: 'black'
-            The line color of the errorbars.
-
-        capsize : float, default: :rc:`errorbar.capsize`
-           The length of the error bar caps in points.
-
-        error_kw : dict, optional
-            Dictionary of keyword arguments to be passed to the
-            `~.Axes.errorbar` method. Values of *ecolor* or *capsize* defined
-            here take precedence over the independent keyword arguments.
-
-        log : bool, default: False
-            If *True*, set the y-axis to be log scale.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs : `.Rectangle` properties
-
-        %(Rectangle:kwdoc)s
-
-        See Also
-        --------
-        barh : Plot a horizontal bar plot.
-
-        Notes
-        -----
-        Stacked bars can be achieved by passing individual *bottom* values per
-        bar. See :doc:`/gallery/lines_bars_and_markers/bar_stacked`.
-        """
-        kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
-        facecolor, edgecolor = self._parse_bar_color_args(kwargs)
-
-        linewidth = kwargs.pop('linewidth', None)
-        hatch = kwargs.pop('hatch', None)
-
-        # Because xerr and yerr will be passed to errorbar, most dimension
-        # checking and processing will be left to the errorbar method.
-        xerr = kwargs.pop('xerr', None)
-        yerr = kwargs.pop('yerr', None)
-        error_kw = kwargs.pop('error_kw', None)
-        error_kw = {} if error_kw is None else error_kw.copy()
-        ezorder = error_kw.pop('zorder', None)
-        if ezorder is None:
-            ezorder = kwargs.get('zorder', None)
-            if ezorder is not None:
-                # If using the bar zorder, increment slightly to make sure
-                # errorbars are drawn on top of bars
-                ezorder += 0.01
-        error_kw.setdefault('zorder', ezorder)
-        ecolor = kwargs.pop('ecolor', 'k')
-        capsize = kwargs.pop('capsize', mpl.rcParams["errorbar.capsize"])
-        error_kw.setdefault('ecolor', ecolor)
-        error_kw.setdefault('capsize', capsize)
-
-        # The keyword argument *orientation* is used by barh() to defer all
-        # logic and drawing to bar(). It is considered internal and is
-        # intentionally not mentioned in the docstring.
-        orientation = kwargs.pop('orientation', 'vertical')
-        _api.check_in_list(['vertical', 'horizontal'], orientation=orientation)
-        log = kwargs.pop('log', False)
-        label = kwargs.pop('label', '')
-        tick_labels = kwargs.pop('tick_label', None)
-
-        y = bottom  # Matches barh call signature.
-        if orientation == 'vertical':
-            if y is None:
-                y = 0
-        else:  # horizontal
-            if x is None:
-                x = 0
-
-        if orientation == 'vertical':
-            # It is possible for y (bottom) to contain unit information.
-            # However, it is also possible for y=0 for the default and height
-            # to contain unit information.  This will prioritize the units of y.
-            self._process_unit_info(
-                [("x", x), ("y", y), ("y", height)], kwargs, convert=False)
-            if log:
-                self.set_yscale('log', nonpositive='clip')
-        else:  # horizontal
-            # It is possible for x (left) to contain unit information.
-            # However, it is also possible for x=0 for the default and width
-            # to contain unit information.  This will prioritize the units of x.
-            self._process_unit_info(
-                [("x", x), ("x", width), ("y", y)], kwargs, convert=False)
-            if log:
-                self.set_xscale('log', nonpositive='clip')
-
-        # lets do some conversions now since some types cannot be
-        # subtracted uniformly
-        if self.xaxis is not None:
-            x0 = x
-            x = np.asarray(self.convert_xunits(x))
-            width = self._convert_dx(width, x0, x, self.convert_xunits)
-            if xerr is not None:
-                xerr = self._convert_dx(xerr, x0, x, self.convert_xunits)
-        if self.yaxis is not None:
-            y0 = y
-            y = np.asarray(self.convert_yunits(y))
-            height = self._convert_dx(height, y0, y, self.convert_yunits)
-            if yerr is not None:
-                yerr = self._convert_dx(yerr, y0, y, self.convert_yunits)
-
-        x, height, width, y, linewidth, hatch = np.broadcast_arrays(
-            # Make args iterable too.
-            np.atleast_1d(x), height, width, y, linewidth, hatch)
-
-        # Now that units have been converted, set the tick locations.
-        if orientation == 'vertical':
-            tick_label_axis = self.xaxis
-            tick_label_position = x
-        else:  # horizontal
-            tick_label_axis = self.yaxis
-            tick_label_position = y
-
-        if not isinstance(label, str) and np.iterable(label):
-            bar_container_label = '_nolegend_'
-            patch_labels = label
-        else:
-            bar_container_label = label
-            patch_labels = ['_nolegend_'] * len(x)
-        if len(patch_labels) != len(x):
-            raise ValueError(f'number of labels ({len(patch_labels)}) '
-                             f'does not match number of bars ({len(x)}).')
-
-        linewidth = itertools.cycle(np.atleast_1d(linewidth))
-        hatch = itertools.cycle(np.atleast_1d(hatch))
-        facecolor = itertools.chain(itertools.cycle(facecolor),
-                                    # Fallback if color == "none".
-                                    itertools.repeat('none'))
-        if edgecolor is None:
-            edgecolor = itertools.repeat(None)
-        else:
-            edgecolor = itertools.chain(
-                itertools.cycle(mcolors.to_rgba_array(edgecolor)),
-                # Fallback if edgecolor == "none".
-                itertools.repeat('none'))
-
-        # We will now resolve the alignment and really have
-        # left, bottom, width, height vectors
-        _api.check_in_list(['center', 'edge'], align=align)
-        if align == 'center':
-            if orientation == 'vertical':
-                try:
-                    left = x - width / 2
-                except TypeError as e:
-                    raise TypeError(f'the dtypes of parameters x ({x.dtype}) '
-                                    f'and width ({width.dtype}) '
-                                    f'are incompatible') from e
-                bottom = y
-            else:  # horizontal
-                try:
-                    bottom = y - height / 2
-                except TypeError as e:
-                    raise TypeError(f'the dtypes of parameters y ({y.dtype}) '
-                                    f'and height ({height.dtype}) '
-                                    f'are incompatible') from e
-                left = x
-        else:  # edge
-            left = x
-            bottom = y
-
-        patches = []
-        args = zip(left, bottom, width, height, facecolor, edgecolor, linewidth,
-                   hatch, patch_labels)
-        for l, b, w, h, c, e, lw, htch, lbl in args:
-            r = mpatches.Rectangle(
-                xy=(l, b), width=w, height=h,
-                facecolor=c,
-                edgecolor=e,
-                linewidth=lw,
-                label=lbl,
-                hatch=htch,
-                )
-            r._internal_update(kwargs)
-            r.get_path()._interpolation_steps = 100
-            if orientation == 'vertical':
-                r.sticky_edges.y.append(b)
-            else:  # horizontal
-                r.sticky_edges.x.append(l)
-            self.add_patch(r)
-            patches.append(r)
-
-        if xerr is not None or yerr is not None:
-            if orientation == 'vertical':
-                # using list comps rather than arrays to preserve unit info
-                ex = [l + 0.5 * w for l, w in zip(left, width)]
-                ey = [b + h for b, h in zip(bottom, height)]
-
-            else:  # horizontal
-                # using list comps rather than arrays to preserve unit info
-                ex = [l + w for l, w in zip(left, width)]
-                ey = [b + 0.5 * h for b, h in zip(bottom, height)]
-
-            error_kw.setdefault("label", '_nolegend_')
-
-            errorbar = self.errorbar(ex, ey, yerr=yerr, xerr=xerr, fmt='none',
-                                     **error_kw)
-        else:
-            errorbar = None
-
-        self._request_autoscale_view()
-
-        if orientation == 'vertical':
-            datavalues = height
-        else:  # horizontal
-            datavalues = width
-
-        bar_container = BarContainer(patches, errorbar, datavalues=datavalues,
-                                     orientation=orientation,
-                                     label=bar_container_label)
-        self.add_container(bar_container)
-
-        if tick_labels is not None:
-            tick_labels = np.broadcast_to(tick_labels, len(patches))
-            tick_label_axis.set_ticks(tick_label_position)
-            tick_label_axis.set_ticklabels(tick_labels)
-
-        return bar_container
-
-    # @_preprocess_data() # let 'bar' do the unpacking..
-    @_docstring.interpd
-    def barh(self, y, width, height=0.8, left=None, *, align="center",
-             data=None, **kwargs):
-        r"""
-        Make a horizontal bar plot.
-
-        The bars are positioned at *y* with the given *align*\ment. Their
-        dimensions are given by *width* and *height*. The horizontal baseline
-        is *left* (default 0).
-
-        Many parameters can take either a single value applying to all bars
-        or a sequence of values, one for each bar.
-
-        Parameters
-        ----------
-        y : float or array-like
-            The y coordinates of the bars. See also *align* for the
-            alignment of the bars to the coordinates.
-
-        width : float or array-like
-            The width(s) of the bars.
-
-            Note that if *left* has units (e.g. datetime), *width* should be in
-            units that are a difference from the value of *left* (e.g. timedelta).
-
-        height : float or array-like, default: 0.8
-            The heights of the bars.
-
-            Note that if *y* has units (e.g. datetime), then *height* should be in
-            units that are a difference (e.g. timedelta) around the *y* values.
-
-        left : float or array-like, default: 0
-            The x coordinates of the left side(s) of the bars.
-
-            Note that if *left* has units, then the x-axis will get a Locator and
-            Formatter appropriate for the units (e.g. dates, or categorical).
-
-        align : {'center', 'edge'}, default: 'center'
-            Alignment of the base to the *y* coordinates*:
-
-            - 'center': Center the bars on the *y* positions.
-            - 'edge': Align the bottom edges of the bars with the *y*
-              positions.
-
-            To align the bars on the top edge pass a negative *height* and
-            ``align='edge'``.
-
-        Returns
-        -------
-        `.BarContainer`
-            Container with all the bars and optionally errorbars.
-
-        Other Parameters
-        ----------------
-        color : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar faces.
-
-        edgecolor : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar edges.
-
-        linewidth : float or array-like, optional
-            Width of the bar edge(s). If 0, don't draw edges.
-
-        tick_label : str or list of str, optional
-            The tick labels of the bars.
-            Default: None (Use default numeric labels.)
-
-        label : str or list of str, optional
-            A single label is attached to the resulting `.BarContainer` as a
-            label for the whole dataset.
-            If a list is provided, it must be the same length as *y* and
-            labels the individual bars. Repeated labels are not de-duplicated
-            and will cause repeated label entries, so this is best used when
-            bars also differ in style (e.g., by passing a list to *color*.)
-
-        xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
-            If not *None*, add horizontal / vertical errorbars to the bar tips.
-            The values are +/- sizes relative to the data:
-
-            - scalar: symmetric +/- values for all bars
-            - shape(N,): symmetric +/- values for each bar
-            - shape(2, N): Separate - and + values for each bar. First row
-              contains the lower errors, the second row contains the upper
-              errors.
-            - *None*: No errorbar. (default)
-
-            See :doc:`/gallery/statistics/errorbar_features` for an example on
-            the usage of *xerr* and *yerr*.
-
-        ecolor : :mpltype:`color` or list of :mpltype:`color`, default: 'black'
-            The line color of the errorbars.
-
-        capsize : float, default: :rc:`errorbar.capsize`
-           The length of the error bar caps in points.
-
-        error_kw : dict, optional
-            Dictionary of keyword arguments to be passed to the
-            `~.Axes.errorbar` method. Values of *ecolor* or *capsize* defined
-            here take precedence over the independent keyword arguments.
-
-        log : bool, default: False
-            If ``True``, set the x-axis to be log scale.
-
-        data : indexable object, optional
-            If given, all parameters also accept a string ``s``, which is
-            interpreted as ``data[s]`` if  ``s`` is a key in ``data``.
-
-        **kwargs : `.Rectangle` properties
-
-        %(Rectangle:kwdoc)s
-
-        See Also
-        --------
-        bar : Plot a vertical bar plot.
-
-        Notes
-        -----
-        Stacked bars can be achieved by passing individual *left* values per
-        bar. See
-        :doc:`/gallery/lines_bars_and_markers/horizontal_barchart_distribution`.
-        """
-        kwargs.setdefault('orientation', 'horizontal')
-        patches = self.bar(x=left, height=height, width=width, bottom=y,
-                           align=align, data=data, **kwargs)
-        return patches
-
-    def bar_label(self, container, labels=None, *, fmt="%g", label_type="edge",
-                  padding=0, **kwargs):
-        """
-        Label a bar plot.
-
-        Adds labels to bars in the given `.BarContainer`.
-        You may need to adjust the axis limits to fit the labels.
-
-        Parameters
-        ----------
-        container : `.BarContainer`
-            Container with all the bars and optionally errorbars, likely
-            returned from `.bar` or `.barh`.
-
-        labels : array-like, optional
-            A list of label texts, that should be displayed. If not given, the
-            label texts will be the data values formatted with *fmt*.
-
-        fmt : str or callable, default: '%g'
-            An unnamed %-style or {}-style format string for the label or a
-            function to call with the value as the first argument.
-            When *fmt* is a string and can be interpreted in both formats,
-            %-style takes precedence over {}-style.
-
-            .. versionadded:: 3.7
-               Support for {}-style format string and callables.
-
-        label_type : {'edge', 'center'}, default: 'edge'
-            The label type. Possible values:
-
-            - 'edge': label placed at the end-point of the bar segment, and the
-              value displayed will be the position of that end-point.
-            - 'center': label placed in the center of the bar segment, and the
-              value displayed will be the length of that segment.
-              (useful for stacked bars, i.e.,
-              :doc:`/gallery/lines_bars_and_markers/bar_label_demo`)
-
-        padding : float, default: 0
-            Distance of label from the end of the bar, in points.
-
-        **kwargs
-            Any remaining keyword arguments are passed through to
-            `.Axes.annotate`. The alignment parameters (
-            *horizontalalignment* / *ha*, *verticalalignment* / *va*) are
-            not supported because the labels are automatically aligned to
-            the bars.
-
-        Returns
-        -------
-        list of `.Annotation`
-            A list of `.Annotation` instances for the labels.
-        """
-        for key in ['horizontalalignment', 'ha', 'verticalalignment', 'va']:
-            if key in kwargs:
-                raise ValueError(
-                    f"Passing {key!r} to bar_label() is not supported.")
-
-        a, b = self.yaxis.get_view_interval()
-        y_inverted = a > b
-        c, d = self.xaxis.get_view_interval()
-        x_inverted = c > d
-
-        # want to know whether to put label on positive or negative direction
-        # cannot use np.sign here because it will return 0 if x == 0
-        def sign(x):
-            return 1 if x >= 0 else -1
-
-        _api.check_in_list(['edge', 'center'], label_type=label_type)
-
-        bars = container.patches
-        errorbar = container.errorbar
-        datavalues = container.datavalues
-        orientation = container.orientation
-
-        if errorbar:
-            # check "ErrorbarContainer" for the definition of these elements
-            lines = errorbar.lines  # attribute of "ErrorbarContainer" (tuple)
-            barlinecols = lines[2]  # 0: data_line, 1: caplines, 2: barlinecols
-            barlinecol = barlinecols[0]  # the "LineCollection" of error bars
-            errs = barlinecol.get_segments()
-        else:
-            errs = []
-
-        if labels is None:
-            labels = []
-
-        annotations = []
-
-        for bar, err, dat, lbl in itertools.zip_longest(
-                bars, errs, datavalues, labels
-        ):
-            (x0, y0), (x1, y1) = bar.get_bbox().get_points()
-            xc, yc = (x0 + x1) / 2, (y0 + y1) / 2
-
-            if orientation == "vertical":
-                extrema = max(y0, y1) if dat >= 0 else min(y0, y1)
-                length = abs(y0 - y1)
-            else:  # horizontal
-                extrema = max(x0, x1) if dat >= 0 else min(x0, x1)
-                length = abs(x0 - x1)
-
-            if err is None or np.size(err) == 0:
-                endpt = extrema
-            elif orientation == "vertical":
-                endpt = err[:, 1].max() if dat >= 0 else err[:, 1].min()
-            else:  # horizontal
-                endpt = err[:, 0].max() if dat >= 0 else err[:, 0].min()
-
-            if label_type == "center":
-                value = sign(dat) * length
-            else:  # edge
-                value = extrema
-
-            if label_type == "center":
-                xy = (0.5, 0.5)
-                kwargs["xycoords"] = (
-                    lambda r, b=bar:
-                        mtransforms.Bbox.intersection(
-                            b.get_window_extent(r), b.get_clip_box()
-                        ) or mtransforms.Bbox.null()
-                )
-            else:  # edge
-                if orientation == "vertical":
-                    xy = xc, endpt
-                else:  # horizontal
-                    xy = endpt, yc
-
-            if orientation == "vertical":
-                y_direction = -1 if y_inverted else 1
-                xytext = 0, y_direction * sign(dat) * padding
-            else:  # horizontal
-                x_direction = -1 if x_inverted else 1
-                xytext = x_direction * sign(dat) * padding, 0
-
-            if label_type == "center":
-                ha, va = "center", "center"
-            else:  # edge
-                if orientation == "vertical":
-                    ha = 'center'
-                    if y_inverted:
-                        va = 'top' if dat > 0 else 'bottom'  # also handles NaN
-                    else:
-                        va = 'top' if dat < 0 else 'bottom'  # also handles NaN
-                else:  # horizontal
-                    if x_inverted:
-                        ha = 'right' if dat > 0 else 'left'  # also handles NaN
-                    else:
-                        ha = 'right' if dat < 0 else 'left'  # also handles NaN
-                    va = 'center'
-
-            if np.isnan(dat):
-                lbl = ''
-
-            if lbl is None:
-                if isinstance(fmt, str):
-                    lbl = cbook._auto_format_str(fmt, value)
-                elif callable(fmt):
-                    lbl = fmt(value)
-                else:
-                    raise TypeError("fmt must be a str or callable")
-            annotation = self.annotate(lbl,
-                                       xy, xytext, textcoords="offset points",
-                                       ha=ha, va=va, **kwargs)
-            annotations.append(annotation)
-
-        return annotations
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def broken_barh(self, xranges, yrange, **kwargs):
-        """
-        Plot a horizontal sequence of rectangles.
-
-        A rectangle is drawn for each element of *xranges*. All rectangles
-        have the same vertical position and size defined by *yrange*.
-
-        Parameters
-        ----------
-        xranges : sequence of tuples (*xmin*, *xwidth*)
-            The x-positions and extents of the rectangles. For each tuple
-            (*xmin*, *xwidth*) a rectangle is drawn from *xmin* to *xmin* +
-            *xwidth*.
-        yrange : (*ymin*, *yheight*)
-            The y-position and extent for all the rectangles.
-
-        Returns
-        -------
-        `~.collections.PolyCollection`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-        **kwargs : `.PolyCollection` properties
-
-            Each *kwarg* can be either a single argument applying to all
-            rectangles, e.g.::
-
-                facecolors='black'
-
-            or a sequence of arguments over which is cycled, e.g.::
-
-                facecolors=('black', 'blue')
-
-            would create interleaving black and blue rectangles.
-
-            Supported keywords:
-
-            %(PolyCollection:kwdoc)s
-        """
-        # process the unit information
-        xdata = cbook._safe_first_finite(xranges) if len(xranges) else None
-        ydata = cbook._safe_first_finite(yrange) if len(yrange) else None
-        self._process_unit_info(
-            [("x", xdata), ("y", ydata)], kwargs, convert=False)
-
-        vertices = []
-        y0, dy = yrange
-        y0, y1 = self.convert_yunits((y0, y0 + dy))
-        for xr in xranges:  # convert the absolute values, not the x and dx
-            try:
-                x0, dx = xr
-            except Exception:
-                raise ValueError(
-                    "each range in xrange must be a sequence with two "
-                    "elements (i.e. xrange must be an (N, 2) array)") from None
-            x0, x1 = self.convert_xunits((x0, x0 + dx))
-            vertices.append([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
-
-        col = mcoll.PolyCollection(np.array(vertices), **kwargs)
-        self.add_collection(col, autolim=True)
-        self._request_autoscale_view()
-
-        return col
-
-    @_preprocess_data()
-    def stem(self, *args, linefmt=None, markerfmt=None, basefmt=None, bottom=0,
-             label=None, orientation='vertical'):
-        """
-        Create a stem plot.
-
-        A stem plot draws lines perpendicular to a baseline at each location
-        *locs* from the baseline to *heads*, and places a marker there. For
-        vertical stem plots (the default), the *locs* are *x* positions, and
-        the *heads* are *y* values. For horizontal stem plots, the *locs* are
-        *y* positions, and the *heads* are *x* values.
-
-        Call signature::
-
-          stem([locs,] heads, linefmt=None, markerfmt=None, basefmt=None)
-
-        The *locs*-positions are optional. *linefmt* may be provided as
-        positional, but all other formats must be provided as keyword
-        arguments.
-
-        Parameters
-        ----------
-        locs : array-like, default: (0, 1, ..., len(heads) - 1)
-            For vertical stem plots, the x-positions of the stems.
-            For horizontal stem plots, the y-positions of the stems.
-
-        heads : array-like
-            For vertical stem plots, the y-values of the stem heads.
-            For horizontal stem plots, the x-values of the stem heads.
-
-        linefmt : str, optional
-            A string defining the color and/or linestyle of the vertical lines:
-
-            =========  =============
-            Character  Line Style
-            =========  =============
-            ``'-'``    solid line
-            ``'--'``   dashed line
-            ``'-.'``   dash-dot line
-            ``':'``    dotted line
-            =========  =============
-
-            Default: 'C0-', i.e. solid line with the first color of the color
-            cycle.
-
-            Note: Markers specified through this parameter (e.g. 'x') will be
-            silently ignored. Instead, markers should be specified using
-            *markerfmt*.
-
-        markerfmt : str, optional
-            A string defining the color and/or shape of the markers at the stem
-            heads. If the marker is not given, use the marker 'o', i.e. filled
-            circles. If the color is not given, use the color from *linefmt*.
-
-        basefmt : str, default: 'C3-' ('C2-' in classic mode)
-            A format string defining the properties of the baseline.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            The orientation of the stems.
-
-        bottom : float, default: 0
-            The y/x-position of the baseline (depending on *orientation*).
-
-        label : str, optional
-            The label to use for the stems in legends.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        Returns
-        -------
-        `.StemContainer`
-            The container may be treated like a tuple
-            (*markerline*, *stemlines*, *baseline*)
-
-        Notes
-        -----
-        .. seealso::
-            The MATLAB function
-            `stem <https://www.mathworks.com/help/matlab/ref/stem.html>`_
-            which inspired this method.
-        """
-        if not 1 <= len(args) <= 3:
-            raise _api.nargs_error('stem', '1-3', len(args))
-        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
-
-        if len(args) == 1:
-            heads, = args
-            locs = np.arange(len(heads))
-            args = ()
-        elif isinstance(args[1], str):
-            heads, *args = args
-            locs = np.arange(len(heads))
-        else:
-            locs, heads, *args = args
-
-        if orientation == 'vertical':
-            locs, heads = self._process_unit_info([("x", locs), ("y", heads)])
-        else:  # horizontal
-            heads, locs = self._process_unit_info([("x", heads), ("y", locs)])
-
-        # resolve line format
-        if linefmt is None:
-            linefmt = args[0] if len(args) > 0 else "C0-"
-        linestyle, linemarker, linecolor = _process_plot_format(linefmt)
-
-        # resolve marker format
-        if markerfmt is None:
-            # if not given as kwarg, fall back to 'o'
-            markerfmt = "o"
-        if markerfmt == '':
-            markerfmt = ' '  # = empty line style; '' would resolve rcParams
-        markerstyle, markermarker, markercolor = \
-            _process_plot_format(markerfmt)
-        if markermarker is None:
-            markermarker = 'o'
-        if markerstyle is None:
-            markerstyle = 'None'
-        if markercolor is None:
-            markercolor = linecolor
-
-        # resolve baseline format
-        if basefmt is None:
-            basefmt = ("C2-" if mpl.rcParams["_internal.classic_mode"] else
-                       "C3-")
-        basestyle, basemarker, basecolor = _process_plot_format(basefmt)
-
-        # New behaviour in 3.1 is to use a LineCollection for the stemlines
-        if linestyle is None:
-            linestyle = mpl.rcParams['lines.linestyle']
-        xlines = self.vlines if orientation == "vertical" else self.hlines
-        stemlines = xlines(
-            locs, bottom, heads,
-            colors=linecolor, linestyles=linestyle, label="_nolegend_")
-
-        if orientation == 'horizontal':
-            marker_x = heads
-            marker_y = locs
-            baseline_x = [bottom, bottom]
-            baseline_y = [np.min(locs), np.max(locs)]
-        else:
-            marker_x = locs
-            marker_y = heads
-            baseline_x = [np.min(locs), np.max(locs)]
-            baseline_y = [bottom, bottom]
-
-        markerline, = self.plot(marker_x, marker_y,
-                                color=markercolor, linestyle=markerstyle,
-                                marker=markermarker, label="_nolegend_")
-
-        baseline, = self.plot(baseline_x, baseline_y,
-                              color=basecolor, linestyle=basestyle,
-                              marker=basemarker, label="_nolegend_")
-
-        stem_container = StemContainer((markerline, stemlines, baseline),
-                                       label=label)
-        self.add_container(stem_container)
-        return stem_container
-
-    @_api.make_keyword_only("3.9", "explode")
-    @_preprocess_data(replace_names=["x", "explode", "labels", "colors"])
-    def pie(self, x, explode=None, labels=None, colors=None,
-            autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
-            startangle=0, radius=1, counterclock=True,
-            wedgeprops=None, textprops=None, center=(0, 0),
-            frame=False, rotatelabels=False, *, normalize=True, hatch=None):
-        """
-        Plot a pie chart.
-
-        Make a pie chart of array *x*.  The fractional area of each wedge is
-        given by ``x/sum(x)``.
-
-        The wedges are plotted counterclockwise, by default starting from the
-        x-axis.
-
-        Parameters
-        ----------
-        x : 1D array-like
-            The wedge sizes.
-
-        explode : array-like, default: None
-            If not *None*, is a ``len(x)`` array which specifies the fraction
-            of the radius with which to offset each wedge.
-
-        labels : list, default: None
-            A sequence of strings providing the labels for each wedge
-
-        colors : :mpltype:`color` or list of :mpltype:`color`, default: None
-            A sequence of colors through which the pie chart will cycle.  If
-            *None*, will use the colors in the currently active cycle.
-
-        hatch : str or list, default: None
-            Hatching pattern applied to all pie wedges or sequence of patterns
-            through which the chart will cycle. For a list of valid patterns,
-            see :doc:`/gallery/shapes_and_collections/hatch_style_reference`.
-
-            .. versionadded:: 3.7
-
-        autopct : None or str or callable, default: None
-            If not *None*, *autopct* is a string or function used to label the
-            wedges with their numeric value. The label will be placed inside
-            the wedge. If *autopct* is a format string, the label will be
-            ``fmt % pct``. If *autopct* is a function, then it will be called.
-
-        pctdistance : float, default: 0.6
-            The relative distance along the radius at which the text
-            generated by *autopct* is drawn. To draw the text outside the pie,
-            set *pctdistance* > 1. This parameter is ignored if *autopct* is
-            ``None``.
-
-        labeldistance : float or None, default: 1.1
-            The relative distance along the radius at which the labels are
-            drawn. To draw the labels inside the pie, set  *labeldistance* < 1.
-            If set to ``None``, labels are not drawn but are still stored for
-            use in `.legend`.
-
-        shadow : bool or dict, default: False
-            If bool, whether to draw a shadow beneath the pie. If dict, draw a shadow
-            passing the properties in the dict to `.Shadow`.
-
-            .. versionadded:: 3.8
-                *shadow* can be a dict.
-
-        startangle : float, default: 0 degrees
-            The angle by which the start of the pie is rotated,
-            counterclockwise from the x-axis.
-
-        radius : float, default: 1
-            The radius of the pie.
-
-        counterclock : bool, default: True
-            Specify fractions direction, clockwise or counterclockwise.
-
-        wedgeprops : dict, default: None
-            Dict of arguments passed to each `.patches.Wedge` of the pie.
-            For example, ``wedgeprops = {'linewidth': 3}`` sets the width of
-            the wedge border lines equal to 3. By default, ``clip_on=False``.
-            When there is a conflict between these properties and other
-            keywords, properties passed to *wedgeprops* take precedence.
-
-        textprops : dict, default: None
-            Dict of arguments to pass to the text objects.
-
-        center : (float, float), default: (0, 0)
-            The coordinates of the center of the chart.
-
-        frame : bool, default: False
-            Plot Axes frame with the chart if true.
-
-        rotatelabels : bool, default: False
-            Rotate each label to the angle of the corresponding slice if true.
-
-        normalize : bool, default: True
-            When *True*, always make a full pie by normalizing x so that
-            ``sum(x) == 1``. *False* makes a partial pie if ``sum(x) <= 1``
-            and raises a `ValueError` for ``sum(x) > 1``.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        Returns
-        -------
-        patches : list
-            A sequence of `matplotlib.patches.Wedge` instances
-
-        texts : list
-            A list of the label `.Text` instances.
-
-        autotexts : list
-            A list of `.Text` instances for the numeric labels. This will only
-            be returned if the parameter *autopct* is not *None*.
-
-        Notes
-        -----
-        The pie chart will probably look best if the figure and Axes are
-        square, or the Axes aspect is equal.
-        This method sets the aspect ratio of the axis to "equal".
-        The Axes aspect ratio can be controlled with `.Axes.set_aspect`.
-        """
-        self.set_aspect('equal')
-        # The use of float32 is "historical", but can't be changed without
-        # regenerating the test baselines.
-        x = np.asarray(x, np.float32)
-        if x.ndim > 1:
-            raise ValueError("x must be 1D")
-
-        if np.any(x < 0):
-            raise ValueError("Wedge sizes 'x' must be non negative values")
-
-        sx = x.sum()
-
-        if normalize:
-            x = x / sx
-        elif sx > 1:
-            raise ValueError('Cannot plot an unnormalized pie with sum(x) > 1')
-        if labels is None:
-            labels = [''] * len(x)
-        if explode is None:
-            explode = [0] * len(x)
-        if len(x) != len(labels):
-            raise ValueError(f"'labels' must be of length 'x', not {len(labels)}")
-        if len(x) != len(explode):
-            raise ValueError(f"'explode' must be of length 'x', not {len(explode)}")
-        if colors is None:
-            get_next_color = self._get_patches_for_fill.get_next_color
-        else:
-            color_cycle = itertools.cycle(colors)
-
-            def get_next_color():
-                return next(color_cycle)
-
-        hatch_cycle = itertools.cycle(np.atleast_1d(hatch))
-
-        _api.check_isinstance(Real, radius=radius, startangle=startangle)
-        if radius <= 0:
-            raise ValueError(f"'radius' must be a positive number, not {radius}")
-
-        # Starting theta1 is the start fraction of the circle
-        theta1 = startangle / 360
-
-        if wedgeprops is None:
-            wedgeprops = {}
-        if textprops is None:
-            textprops = {}
-
-        texts = []
-        slices = []
-        autotexts = []
-
-        for frac, label, expl in zip(x, labels, explode):
-            x, y = center
-            theta2 = (theta1 + frac) if counterclock else (theta1 - frac)
-            thetam = 2 * np.pi * 0.5 * (theta1 + theta2)
-            x += expl * math.cos(thetam)
-            y += expl * math.sin(thetam)
-
-            w = mpatches.Wedge((x, y), radius, 360. * min(theta1, theta2),
-                               360. * max(theta1, theta2),
-                               facecolor=get_next_color(),
-                               hatch=next(hatch_cycle),
-                               clip_on=False,
-                               label=label)
-            w.set(**wedgeprops)
-            slices.append(w)
-            self.add_patch(w)
-
-            if shadow:
-                # Make sure to add a shadow after the call to add_patch so the
-                # figure and transform props will be set.
-                shadow_dict = {'ox': -0.02, 'oy': -0.02, 'label': '_nolegend_'}
-                if isinstance(shadow, dict):
-                    shadow_dict.update(shadow)
-                self.add_patch(mpatches.Shadow(w, **shadow_dict))
-
-            if labeldistance is not None:
-                xt = x + labeldistance * radius * math.cos(thetam)
-                yt = y + labeldistance * radius * math.sin(thetam)
-                label_alignment_h = 'left' if xt > 0 else 'right'
-                label_alignment_v = 'center'
-                label_rotation = 'horizontal'
-                if rotatelabels:
-                    label_alignment_v = 'bottom' if yt > 0 else 'top'
-                    label_rotation = (np.rad2deg(thetam)
-                                      + (0 if xt > 0 else 180))
-                t = self.text(xt, yt, label,
-                              clip_on=False,
-                              horizontalalignment=label_alignment_h,
-                              verticalalignment=label_alignment_v,
-                              rotation=label_rotation,
-                              size=mpl.rcParams['xtick.labelsize'])
-                t.set(**textprops)
-                texts.append(t)
-
-            if autopct is not None:
-                xt = x + pctdistance * radius * math.cos(thetam)
-                yt = y + pctdistance * radius * math.sin(thetam)
-                if isinstance(autopct, str):
-                    s = autopct % (100. * frac)
-                elif callable(autopct):
-                    s = autopct(100. * frac)
-                else:
-                    raise TypeError(
-                        'autopct must be callable or a format string')
-                if mpl._val_or_rc(textprops.get("usetex"), "text.usetex"):
-                    # escape % (i.e. \%) if it is not already escaped
-                    s = re.sub(r"([^\\])%", r"\1\\%", s)
-                t = self.text(xt, yt, s,
-                              clip_on=False,
-                              horizontalalignment='center',
-                              verticalalignment='center')
-                t.set(**textprops)
-                autotexts.append(t)
-
-            theta1 = theta2
-
-        if frame:
-            self._request_autoscale_view()
-        else:
-            self.set(frame_on=False, xticks=[], yticks=[],
-                     xlim=(-1.25 + center[0], 1.25 + center[0]),
-                     ylim=(-1.25 + center[1], 1.25 + center[1]))
-
-        if autopct is None:
-            return slices, texts
-        else:
-            return slices, texts, autotexts
-
-    @staticmethod
-    def _errorevery_to_mask(x, errorevery):
-        """
-        Normalize `errorbar`'s *errorevery* to be a boolean mask for data *x*.
-
-        This function is split out to be usable both by 2D and 3D errorbars.
-        """
-        if isinstance(errorevery, Integral):
-            errorevery = (0, errorevery)
-        if isinstance(errorevery, tuple):
-            if (len(errorevery) == 2 and
-                    isinstance(errorevery[0], Integral) and
-                    isinstance(errorevery[1], Integral)):
-                errorevery = slice(errorevery[0], None, errorevery[1])
-            else:
-                raise ValueError(
-                    f'{errorevery=!r} is a not a tuple of two integers')
-        elif isinstance(errorevery, slice):
-            pass
-        elif not isinstance(errorevery, str) and np.iterable(errorevery):
-            try:
-                x[errorevery]  # fancy indexing
-            except (ValueError, IndexError) as err:
-                raise ValueError(
-                    f"{errorevery=!r} is iterable but not a valid NumPy fancy "
-                    "index to match 'xerr'/'yerr'") from err
-        else:
-            raise ValueError(f"{errorevery=!r} is not a recognized value")
-        everymask = np.zeros(len(x), bool)
-        everymask[errorevery] = True
-        return everymask
-
-    @_api.make_keyword_only("3.9", "ecolor")
-    @_preprocess_data(replace_names=["x", "y", "xerr", "yerr"],
-                      label_namer="y")
-    @_docstring.interpd
-    def errorbar(self, x, y, yerr=None, xerr=None,
-                 fmt='', ecolor=None, elinewidth=None, capsize=None,
-                 barsabove=False, lolims=False, uplims=False,
-                 xlolims=False, xuplims=False, errorevery=1, capthick=None,
-                 **kwargs):
-        """
-        Plot y versus x as lines and/or markers with attached errorbars.
-
-        *x*, *y* define the data locations, *xerr*, *yerr* define the errorbar
-        sizes. By default, this draws the data markers/lines as well as the
-        errorbars. Use fmt='none' to draw errorbars without any data markers.
-
-        .. versionadded:: 3.7
-           Caps and error lines are drawn in polar coordinates on polar plots.
-
-
-        Parameters
-        ----------
-        x, y : float or array-like
-            The data positions.
-
-        xerr, yerr : float or array-like, shape(N,) or shape(2, N), optional
-            The errorbar sizes:
-
-            - scalar: Symmetric +/- values for all data points.
-            - shape(N,): Symmetric +/-values for each data point.
-            - shape(2, N): Separate - and + values for each bar. First row
-              contains the lower errors, the second row contains the upper
-              errors.
-            - *None*: No errorbar.
-
-            All values must be >= 0.
-
-            See :doc:`/gallery/statistics/errorbar_features`
-            for an example on the usage of ``xerr`` and ``yerr``.
-
-        fmt : str, default: ''
-            The format for the data points / data lines. See `.plot` for
-            details.
-
-            Use 'none' (case-insensitive) to plot errorbars without any data
-            markers.
-
-        ecolor : :mpltype:`color`, default: None
-            The color of the errorbar lines.  If None, use the color of the
-            line connecting the markers.
-
-        elinewidth : float, default: None
-            The linewidth of the errorbar lines. If None, the linewidth of
-            the current style is used.
-
-        capsize : float, default: :rc:`errorbar.capsize`
-            The length of the error bar caps in points.
-
-        capthick : float, default: None
-            An alias to the keyword argument *markeredgewidth* (a.k.a. *mew*).
-            This setting is a more sensible name for the property that
-            controls the thickness of the error bar cap in points. For
-            backwards compatibility, if *mew* or *markeredgewidth* are given,
-            then they will over-ride *capthick*. This may change in future
-            releases.
-
-        barsabove : bool, default: False
-            If True, will plot the errorbars above the plot
-            symbols. Default is below.
-
-        lolims, uplims, xlolims, xuplims : bool or array-like, default: False
-            These arguments can be used to indicate that a value gives only
-            upper/lower limits.  In that case a caret symbol is used to
-            indicate this. *lims*-arguments may be scalars, or array-likes of
-            the same length as *xerr* and *yerr*.  To use limits with inverted
-            axes, `~.Axes.set_xlim` or `~.Axes.set_ylim` must be called before
-            :meth:`errorbar`.  Note the tricky parameter names: setting e.g.
-            *lolims* to True means that the y-value is a *lower* limit of the
-            True value, so, only an *upward*-pointing arrow will be drawn!
-
-        errorevery : int or (int, int), default: 1
-            draws error bars on a subset of the data. *errorevery* =N draws
-            error bars on the points (x[::N], y[::N]).
-            *errorevery* =(start, N) draws error bars on the points
-            (x[start::N], y[start::N]). e.g. errorevery=(6, 3)
-            adds error bars to the data at (x[6], x[9], x[12], x[15], ...).
-            Used to avoid overlapping error bars when two series share x-axis
-            values.
-
-        Returns
-        -------
-        `.ErrorbarContainer`
-            The container contains:
-
-            - data_line : A `~matplotlib.lines.Line2D` instance of x, y plot markers
-              and/or line.
-            - caplines : A tuple of `~matplotlib.lines.Line2D` instances of the error
-              bar caps.
-            - barlinecols : A tuple of `.LineCollection` with the horizontal and
-              vertical error ranges.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            All other keyword arguments are passed on to the `~.Axes.plot` call
-            drawing the markers. For example, this code makes big red squares
-            with thick green edges::
-
-                x, y, yerr = rand(3, 10)
-                errorbar(x, y, yerr, marker='s', mfc='red',
-                         mec='green', ms=20, mew=4)
-
-            where *mfc*, *mec*, *ms* and *mew* are aliases for the longer
-            property names, *markerfacecolor*, *markeredgecolor*, *markersize*
-            and *markeredgewidth*.
-
-            Valid kwargs for the marker properties are:
-
-            - *dashes*
-            - *dash_capstyle*
-            - *dash_joinstyle*
-            - *drawstyle*
-            - *fillstyle*
-            - *linestyle*
-            - *marker*
-            - *markeredgecolor*
-            - *markeredgewidth*
-            - *markerfacecolor*
-            - *markerfacecoloralt*
-            - *markersize*
-            - *markevery*
-            - *solid_capstyle*
-            - *solid_joinstyle*
-
-            Refer to the corresponding `.Line2D` property for more details:
-
-            %(Line2D:kwdoc)s
-        """
-        kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
-        # Drop anything that comes in as None to use the default instead.
-        kwargs = {k: v for k, v in kwargs.items() if v is not None}
-        kwargs.setdefault('zorder', 2)
-
-        # Casting to object arrays preserves units.
-        if not isinstance(x, np.ndarray):
-            x = np.asarray(x, dtype=object)
-        if not isinstance(y, np.ndarray):
-            y = np.asarray(y, dtype=object)
-
-        def _upcast_err(err):
-            """
-            Safely handle tuple of containers that carry units.
-
-            This function covers the case where the input to the xerr/yerr is a
-            length 2 tuple of equal length ndarray-subclasses that carry the
-            unit information in the container.
-
-            If we have a tuple of nested numpy array (subclasses), we defer
-            coercing the units to be consistent to the underlying unit
-            library (and implicitly the broadcasting).
-
-            Otherwise, fallback to casting to an object array.
-            """
-
-            if (
-                    # make sure it is not a scalar
-                    np.iterable(err) and
-                    # and it is not empty
-                    len(err) > 0 and
-                    # and the first element is an array sub-class use
-                    # safe_first_element because getitem is index-first not
-                    # location first on pandas objects so err[0] almost always
-                    # fails.
-                    isinstance(cbook._safe_first_finite(err), np.ndarray)
-            ):
-                # Get the type of the first element
-                atype = type(cbook._safe_first_finite(err))
-                # Promote the outer container to match the inner container
-                if atype is np.ndarray:
-                    # Converts using np.asarray, because data cannot
-                    # be directly passed to init of np.ndarray
-                    return np.asarray(err, dtype=object)
-                # If atype is not np.ndarray, directly pass data to init.
-                # This works for types such as unyts and astropy units
-                return atype(err)
-            # Otherwise wrap it in an object array
-            return np.asarray(err, dtype=object)
-
-        if xerr is not None and not isinstance(xerr, np.ndarray):
-            xerr = _upcast_err(xerr)
-        if yerr is not None and not isinstance(yerr, np.ndarray):
-            yerr = _upcast_err(yerr)
-        x, y = np.atleast_1d(x, y)  # Make sure all the args are iterable.
-        if len(x) != len(y):
-            raise ValueError("'x' and 'y' must have the same size")
-
-        everymask = self._errorevery_to_mask(x, errorevery)
-
-        label = kwargs.pop("label", None)
-        kwargs['label'] = '_nolegend_'
-
-        # Create the main line and determine overall kwargs for child artists.
-        # We avoid calling self.plot() directly, or self._get_lines(), because
-        # that would call self._process_unit_info again, and do other indirect
-        # data processing.
-        (data_line, base_style), = self._get_lines._plot_args(
-            self, (x, y) if fmt == '' else (x, y, fmt), kwargs, return_kwargs=True)
-
-        # Do this after creating `data_line` to avoid modifying `base_style`.
-        if barsabove:
-            data_line.set_zorder(kwargs['zorder'] - .1)
-        else:
-            data_line.set_zorder(kwargs['zorder'] + .1)
-
-        # Add line to plot, or throw it away and use it to determine kwargs.
-        if fmt.lower() != 'none':
-            self.add_line(data_line)
-        else:
-            data_line = None
-            # Remove alpha=0 color that _get_lines._plot_args returns for
-            # 'none' format, and replace it with user-specified color, if
-            # supplied.
-            base_style.pop('color')
-            if 'color' in kwargs:
-                base_style['color'] = kwargs.pop('color')
-
-        if 'color' not in base_style:
-            base_style['color'] = 'C0'
-        if ecolor is None:
-            ecolor = base_style['color']
-
-        # Eject any line-specific information from format string, as it's not
-        # needed for bars or caps.
-        for key in ['marker', 'markersize', 'markerfacecolor',
-                    'markerfacecoloralt',
-                    'markeredgewidth', 'markeredgecolor', 'markevery',
-                    'linestyle', 'fillstyle', 'drawstyle', 'dash_capstyle',
-                    'dash_joinstyle', 'solid_capstyle', 'solid_joinstyle',
-                    'dashes']:
-            base_style.pop(key, None)
-
-        # Make the style dict for the line collections (the bars).
-        eb_lines_style = {**base_style, 'color': ecolor}
-
-        if elinewidth is not None:
-            eb_lines_style['linewidth'] = elinewidth
-        elif 'linewidth' in kwargs:
-            eb_lines_style['linewidth'] = kwargs['linewidth']
-
-        for key in ('transform', 'alpha', 'zorder', 'rasterized'):
-            if key in kwargs:
-                eb_lines_style[key] = kwargs[key]
-
-        # Make the style dict for caps (the "hats").
-        eb_cap_style = {**base_style, 'linestyle': 'none'}
-        if capsize is None:
-            capsize = mpl.rcParams["errorbar.capsize"]
-        if capsize > 0:
-            eb_cap_style['markersize'] = 2. * capsize
-        if capthick is not None:
-            eb_cap_style['markeredgewidth'] = capthick
-
-        # For backwards-compat, allow explicit setting of
-        # 'markeredgewidth' to over-ride capthick.
-        for key in ('markeredgewidth', 'transform', 'alpha',
-                    'zorder', 'rasterized'):
-            if key in kwargs:
-                eb_cap_style[key] = kwargs[key]
-        eb_cap_style['color'] = ecolor
-
-        barcols = []
-        caplines = {'x': [], 'y': []}
-
-        # Vectorized fancy-indexer.
-        def apply_mask(arrays, mask):
-            return [array[mask] for array in arrays]
-
-        # dep: dependent dataset, indep: independent dataset
-        for (dep_axis, dep, err, lolims, uplims, indep, lines_func,
-             marker, lomarker, himarker) in [
-                ("x", x, xerr, xlolims, xuplims, y, self.hlines,
-                 "|", mlines.CARETRIGHTBASE, mlines.CARETLEFTBASE),
-                ("y", y, yerr, lolims, uplims, x, self.vlines,
-                 "_", mlines.CARETUPBASE, mlines.CARETDOWNBASE),
-        ]:
-            if err is None:
-                continue
-            lolims = np.broadcast_to(lolims, len(dep)).astype(bool)
-            uplims = np.broadcast_to(uplims, len(dep)).astype(bool)
-            try:
-                np.broadcast_to(err, (2, len(dep)))
-            except ValueError:
-                raise ValueError(
-                    f"'{dep_axis}err' (shape: {np.shape(err)}) must be a "
-                    f"scalar or a 1D or (2, n) array-like whose shape matches "
-                    f"'{dep_axis}' (shape: {np.shape(dep)})") from None
-            if err.dtype is np.dtype(object) and np.any(err == None):  # noqa: E711
-                raise ValueError(
-                    f"'{dep_axis}err' must not contain None. "
-                    "Use NaN if you want to skip a value.")
-
-            res = np.zeros(err.shape, dtype=bool)  # Default in case of nan
-            if np.any(np.less(err, -err, out=res, where=(err == err))):
-                # like err<0, but also works for timedelta and nan.
-                raise ValueError(
-                    f"'{dep_axis}err' must not contain negative values")
-            # This is like
-            #     elow, ehigh = np.broadcast_to(...)
-            #     return dep - elow * ~lolims, dep + ehigh * ~uplims
-            # except that broadcast_to would strip units.
-            low, high = dep + np.vstack([-(1 - lolims), 1 - uplims]) * err
-            barcols.append(lines_func(
-                *apply_mask([indep, low, high], everymask), **eb_lines_style))
-            if self.name == "polar" and dep_axis == "x":
-                for b in barcols:
-                    for p in b.get_paths():
-                        p._interpolation_steps = 2
-            # Normal errorbars for points without upper/lower limits.
-            nolims = ~(lolims | uplims)
-            if nolims.any() and capsize > 0:
-                indep_masked, lo_masked, hi_masked = apply_mask(
-                    [indep, low, high], nolims & everymask)
-                for lh_masked in [lo_masked, hi_masked]:
-                    # Since this has to work for x and y as dependent data, we
-                    # first set both x and y to the independent variable and
-                    # overwrite the respective dependent data in a second step.
-                    line = mlines.Line2D(indep_masked, indep_masked,
-                                         marker=marker, **eb_cap_style)
-                    line.set(**{f"{dep_axis}data": lh_masked})
-                    caplines[dep_axis].append(line)
-            for idx, (lims, hl) in enumerate([(lolims, high), (uplims, low)]):
-                if not lims.any():
+            secax = ax.secondary_yaxis
+
+        secax(0.2, functions=(invert, invert))
+        secax(0.4, functions=(lambda x: 2 * x, lambda x: x / 2))
+        secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
+        secax(0.8)
+        secax("top" if nn == 0 else "right", functions=_Translation(2))
+        secax(6.25, transform=ax.transData)
+
+
+def test_secondary_fail():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(2, 11), np.arange(2, 11))
+    with pytest.raises(ValueError):
+        ax.secondary_xaxis(0.2, functions=(lambda x: 1 / x))
+    with pytest.raises(ValueError):
+        ax.secondary_xaxis('right')
+    with pytest.raises(ValueError):
+        ax.secondary_yaxis('bottom')
+    with pytest.raises(TypeError):
+        ax.secondary_xaxis(0.2, transform='error')
+
+
+def test_secondary_resize():
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(np.arange(2, 11), np.arange(2, 11))
+
+    def invert(x):
+        with np.errstate(divide='ignore'):
+            return 1 / x
+
+    ax.secondary_xaxis('top', functions=(invert, invert))
+    fig.canvas.draw()
+    fig.set_size_inches((7, 4))
+    assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])
+
+
+def test_secondary_minorloc():
+    fig, ax = plt.subplots(figsize=(10, 5))
+    ax.plot(np.arange(2, 11), np.arange(2, 11))
+
+    def invert(x):
+        with np.errstate(divide='ignore'):
+            return 1 / x
+
+    secax = ax.secondary_xaxis('top', functions=(invert, invert))
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.NullLocator)
+    secax.minorticks_on()
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.AutoMinorLocator)
+    ax.set_xscale('log')
+    plt.draw()
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.LogLocator)
+    ax.set_xscale('linear')
+    plt.draw()
+    assert isinstance(secax._axis.get_minor_locator(),
+                      mticker.NullLocator)
+
+
+def test_secondary_formatter():
+    fig, ax = plt.subplots()
+    ax.set_xscale("log")
+    secax = ax.secondary_xaxis("top")
+    secax.xaxis.set_major_formatter(mticker.ScalarFormatter())
+    fig.canvas.draw()
+    assert isinstance(
+        secax.xaxis.get_major_formatter(), mticker.ScalarFormatter)
+
+
+def test_secondary_repr():
+    fig, ax = plt.subplots()
+    secax = ax.secondary_xaxis("top")
+    assert repr(secax) == '<SecondaryAxis: >'
+
+
+@image_comparison(['axis_options.png'], remove_text=True, style='mpl20')
+def test_axis_options():
+    fig, axes = plt.subplots(2, 3)
+    for i, option in enumerate(('scaled', 'tight', 'image')):
+        # Draw a line and a circle fitting within the boundaries of the line
+        # The circle should look like a circle for 'scaled' and 'image'
+        # High/narrow aspect ratio
+        axes[0, i].plot((1, 2), (1, 3.2))
+        axes[0, i].axis(option)
+        axes[0, i].add_artist(mpatches.Circle((1.5, 1.5), radius=0.5,
+                                              facecolor='none', edgecolor='k'))
+        # Low/wide aspect ratio
+        axes[1, i].plot((1, 2.25), (1, 1.75))
+        axes[1, i].axis(option)
+        axes[1, i].add_artist(mpatches.Circle((1.5, 1.25), radius=0.25,
+                                              facecolor='none', edgecolor='k'))
+
+
+def color_boxes(fig, ax):
+    """
+    Helper for the tests below that test the extents of various Axes elements
+    """
+    fig.canvas.draw()
+
+    renderer = fig.canvas.get_renderer()
+    bbaxis = []
+    for nn, axx in enumerate([ax.xaxis, ax.yaxis]):
+        bb = axx.get_tightbbox(renderer)
+        if bb:
+            axisr = mpatches.Rectangle(
+                (bb.x0, bb.y0), width=bb.width, height=bb.height,
+                linewidth=0.7, edgecolor='y', facecolor="none", transform=None,
+                zorder=3)
+            fig.add_artist(axisr)
+        bbaxis += [bb]
+
+    bbspines = []
+    for nn, a in enumerate(['bottom', 'top', 'left', 'right']):
+        bb = ax.spines[a].get_window_extent(renderer)
+        spiner = mpatches.Rectangle(
+            (bb.x0, bb.y0), width=bb.width, height=bb.height,
+            linewidth=0.7, edgecolor="green", facecolor="none", transform=None,
+            zorder=3)
+        fig.add_artist(spiner)
+        bbspines += [bb]
+
+    bb = ax.get_window_extent()
+    rect2 = mpatches.Rectangle(
+        (bb.x0, bb.y0), width=bb.width, height=bb.height,
+        linewidth=1.5, edgecolor="magenta", facecolor="none", transform=None,
+        zorder=2)
+    fig.add_artist(rect2)
+    bbax = bb
+
+    bb2 = ax.get_tightbbox(renderer)
+    rect2 = mpatches.Rectangle(
+        (bb2.x0, bb2.y0), width=bb2.width, height=bb2.height,
+        linewidth=3, edgecolor="red", facecolor="none", transform=None,
+        zorder=1)
+    fig.add_artist(rect2)
+    bbtb = bb2
+    return bbaxis, bbspines, bbax, bbtb
+
+
+def test_normal_axes():
+    with rc_context({'_internal.classic_mode': False}):
+        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
+        fig.canvas.draw()
+        plt.close(fig)
+        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+
+    # test the axis bboxes
+    target = [
+        [123.375, 75.88888888888886, 983.25, 33.0],
+        [85.51388888888889, 99.99999999999997, 53.375, 993.0]
+    ]
+    for nn, b in enumerate(bbaxis):
+        targetbb = mtransforms.Bbox.from_bounds(*target[nn])
+        assert_array_almost_equal(b.bounds, targetbb.bounds, decimal=2)
+
+    target = [
+        [150.0, 119.999, 930.0, 11.111],
+        [150.0, 1080.0, 930.0, 0.0],
+        [150.0, 119.9999, 11.111, 960.0],
+        [1068.8888, 119.9999, 11.111, 960.0]
+    ]
+    for nn, b in enumerate(bbspines):
+        targetbb = mtransforms.Bbox.from_bounds(*target[nn])
+        assert_array_almost_equal(b.bounds, targetbb.bounds, decimal=2)
+
+    target = [150.0, 119.99999999999997, 930.0, 960.0]
+    targetbb = mtransforms.Bbox.from_bounds(*target)
+    assert_array_almost_equal(bbax.bounds, targetbb.bounds, decimal=2)
+
+    target = [85.5138, 75.88888, 1021.11, 1017.11]
+    targetbb = mtransforms.Bbox.from_bounds(*target)
+    assert_array_almost_equal(bbtb.bounds, targetbb.bounds, decimal=2)
+
+    # test that get_position roundtrips to get_window_extent
+    axbb = ax.get_position().transformed(fig.transFigure).bounds
+    assert_array_almost_equal(axbb, ax.get_window_extent().bounds, decimal=2)
+
+
+def test_nodecorator():
+    with rc_context({'_internal.classic_mode': False}):
+        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
+        fig.canvas.draw()
+        ax.set(xticklabels=[], yticklabels=[])
+        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+
+    # test the axis bboxes
+    for nn, b in enumerate(bbaxis):
+        assert b is None
+
+    target = [
+        [150.0, 119.999, 930.0, 11.111],
+        [150.0, 1080.0, 930.0, 0.0],
+        [150.0, 119.9999, 11.111, 960.0],
+        [1068.8888, 119.9999, 11.111, 960.0]
+    ]
+    for nn, b in enumerate(bbspines):
+        targetbb = mtransforms.Bbox.from_bounds(*target[nn])
+        assert_allclose(b.bounds, targetbb.bounds, atol=1e-2)
+
+    target = [150.0, 119.99999999999997, 930.0, 960.0]
+    targetbb = mtransforms.Bbox.from_bounds(*target)
+    assert_allclose(bbax.bounds, targetbb.bounds, atol=1e-2)
+
+    target = [150., 120., 930., 960.]
+    targetbb = mtransforms.Bbox.from_bounds(*target)
+    assert_allclose(bbtb.bounds, targetbb.bounds, atol=1e-2)
+
+
+def test_displaced_spine():
+    with rc_context({'_internal.classic_mode': False}):
+        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
+        ax.set(xticklabels=[], yticklabels=[])
+        ax.spines.bottom.set_position(('axes', -0.1))
+        fig.canvas.draw()
+        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+
+    targets = [
+        [150., 24., 930., 11.111111],
+        [150.0, 1080.0, 930.0, 0.0],
+        [150.0, 119.9999, 11.111, 960.0],
+        [1068.8888, 119.9999, 11.111, 960.0]
+    ]
+    for target, bbspine in zip(targets, bbspines):
+        targetbb = mtransforms.Bbox.from_bounds(*target)
+        assert_allclose(bbspine.bounds, targetbb.bounds, atol=1e-2)
+
+    target = [150.0, 119.99999999999997, 930.0, 960.0]
+    targetbb = mtransforms.Bbox.from_bounds(*target)
+    assert_allclose(bbax.bounds, targetbb.bounds, atol=1e-2)
+
+    target = [150., 24., 930., 1056.]
+    targetbb = mtransforms.Bbox.from_bounds(*target)
+    assert_allclose(bbtb.bounds, targetbb.bounds, atol=1e-2)
+
+
+def test_tickdirs():
+    """
+    Switch the tickdirs and make sure the bboxes switch with them
+    """
+    targets = [[[150.0, 120.0, 930.0, 11.1111],
+                [150.0, 120.0, 11.111, 960.0]],
+               [[150.0, 108.8889, 930.0, 11.111111111111114],
+                [138.889, 120, 11.111, 960.0]],
+               [[150.0, 114.44444444444441, 930.0, 11.111111111111114],
+                [144.44444444444446, 119.999, 11.111, 960.0]]]
+    for dnum, dirs in enumerate(['in', 'out', 'inout']):
+        with rc_context({'_internal.classic_mode': False}):
+            fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
+            ax.tick_params(direction=dirs)
+            fig.canvas.draw()
+            bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+            for nn, num in enumerate([0, 2]):
+                targetbb = mtransforms.Bbox.from_bounds(*targets[dnum][nn])
+                assert_allclose(
+                    bbspines[num].bounds, targetbb.bounds, atol=1e-2)
+
+
+def test_minor_accountedfor():
+    with rc_context({'_internal.classic_mode': False}):
+        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
+        fig.canvas.draw()
+        ax.tick_params(which='both', direction='out')
+
+        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+        targets = [[150.0, 108.88888888888886, 930.0, 11.111111111111114],
+                   [138.8889, 119.9999, 11.1111, 960.0]]
+        for n in range(2):
+            targetbb = mtransforms.Bbox.from_bounds(*targets[n])
+            assert_allclose(
+                bbspines[n * 2].bounds, targetbb.bounds, atol=1e-2)
+
+        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
+        fig.canvas.draw()
+        ax.tick_params(which='both', direction='out')
+        ax.minorticks_on()
+        ax.tick_params(axis='both', which='minor', length=30)
+        fig.canvas.draw()
+        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
+        targets = [[150.0, 36.66666666666663, 930.0, 83.33333333333334],
+                   [66.6667, 120.0, 83.3333, 960.0]]
+
+        for n in range(2):
+            targetbb = mtransforms.Bbox.from_bounds(*targets[n])
+            assert_allclose(
+                bbspines[n * 2].bounds, targetbb.bounds, atol=1e-2)
+
+
+@check_figures_equal(extensions=["png"])
+def test_axis_bool_arguments(fig_test, fig_ref):
+    # Test if False and "off" give the same
+    fig_test.add_subplot(211).axis(False)
+    fig_ref.add_subplot(211).axis("off")
+    # Test if True after False gives the same as "on"
+    ax = fig_test.add_subplot(212)
+    ax.axis(False)
+    ax.axis(True)
+    fig_ref.add_subplot(212).axis("on")
+
+
+def test_axis_extent_arg():
+    fig, ax = plt.subplots()
+    xmin = 5
+    xmax = 10
+    ymin = 15
+    ymax = 20
+    extent = ax.axis([xmin, xmax, ymin, ymax])
+
+    # test that the docstring is correct
+    assert tuple(extent) == (xmin, xmax, ymin, ymax)
+
+    # test that limits were set per the docstring
+    assert (xmin, xmax) == ax.get_xlim()
+    assert (ymin, ymax) == ax.get_ylim()
+
+
+def test_axis_extent_arg2():
+    # Same as test_axis_extent_arg, but with keyword arguments
+    fig, ax = plt.subplots()
+    xmin = 5
+    xmax = 10
+    ymin = 15
+    ymax = 20
+    extent = ax.axis(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
+
+    # test that the docstring is correct
+    assert tuple(extent) == (xmin, xmax, ymin, ymax)
+
+    # test that limits were set per the docstring
+    assert (xmin, xmax) == ax.get_xlim()
+    assert (ymin, ymax) == ax.get_ylim()
+
+
+def test_hist_auto_bins():
+    _, bins, _ = plt.hist([[1, 2, 3], [3, 4, 5, 6]], bins='auto')
+    assert bins[0] <= 1
+    assert bins[-1] >= 6
+
+
+def test_hist_nan_data():
+    fig, (ax1, ax2) = plt.subplots(2)
+
+    data = [1, 2, 3]
+    nan_data = data + [np.nan]
+
+    bins, edges, _ = ax1.hist(data)
+    with np.errstate(invalid='ignore'):
+        nanbins, nanedges, _ = ax2.hist(nan_data)
+
+    np.testing.assert_allclose(bins, nanbins)
+    np.testing.assert_allclose(edges, nanedges)
+
+
+def test_hist_range_and_density():
+    _, bins, _ = plt.hist(np.random.rand(10), "auto",
+                          range=(0, 1), density=True)
+    assert bins[0] == 0
+    assert bins[-1] == 1
+
+
+def test_bar_errbar_zorder():
+    # Check that the zorder of errorbars is always greater than the bar they
+    # are plotted on
+    fig, ax = plt.subplots()
+    x = [1, 2, 3]
+    barcont = ax.bar(x=x, height=x, yerr=x, capsize=5, zorder=3)
+
+    data_line, caplines, barlinecols = barcont.errorbar.lines
+    for bar in barcont.patches:
+        for capline in caplines:
+            assert capline.zorder > bar.zorder
+        for barlinecol in barlinecols:
+            assert barlinecol.zorder > bar.zorder
+
+
+def test_set_ticks_inverted():
+    fig, ax = plt.subplots()
+    ax.invert_xaxis()
+    ax.set_xticks([.3, .7])
+    assert ax.get_xlim() == (1, 0)
+    ax.set_xticks([-1])
+    assert ax.get_xlim() == (1, -1)
+
+
+def test_aspect_nonlinear_adjustable_box():
+    fig = plt.figure(figsize=(10, 10))  # Square.
+
+    ax = fig.add_subplot()
+    ax.plot([.4, .6], [.4, .6])  # Set minpos to keep logit happy.
+    ax.set(xscale="log", xlim=(1, 10),
+           yscale="logit", ylim=(1/11, 1/1001),
+           aspect=1, adjustable="box")
+    ax.margins(0)
+    pos = fig.transFigure.transform_bbox(ax.get_position())
+    assert pos.height / pos.width == pytest.approx(2)
+
+
+def test_aspect_nonlinear_adjustable_datalim():
+    fig = plt.figure(figsize=(10, 10))  # Square.
+
+    ax = fig.add_axes([.1, .1, .8, .8])  # Square.
+    ax.plot([.4, .6], [.4, .6])  # Set minpos to keep logit happy.
+    ax.set(xscale="log", xlim=(1, 100),
+           yscale="logit", ylim=(1 / 101, 1 / 11),
+           aspect=1, adjustable="datalim")
+    ax.margins(0)
+    ax.apply_aspect()
+
+    assert ax.get_xlim() == pytest.approx([1*10**(1/2), 100/10**(1/2)])
+    assert ax.get_ylim() == (1 / 101, 1 / 11)
+
+
+def test_box_aspect():
+    # Test if axes with box_aspect=1 has same dimensions
+    # as axes with aspect equal and adjustable="box"
+
+    fig1, ax1 = plt.subplots()
+    axtwin = ax1.twinx()
+    axtwin.plot([12, 344])
+
+    ax1.set_box_aspect(1)
+    assert ax1.get_box_aspect() == 1.0
+
+    fig2, ax2 = plt.subplots()
+    ax2.margins(0)
+    ax2.plot([0, 2], [6, 8])
+    ax2.set_aspect("equal", adjustable="box")
+
+    fig1.canvas.draw()
+    fig2.canvas.draw()
+
+    bb1 = ax1.get_position()
+    bbt = axtwin.get_position()
+    bb2 = ax2.get_position()
+
+    assert_array_equal(bb1.extents, bb2.extents)
+    assert_array_equal(bbt.extents, bb2.extents)
+
+
+def test_box_aspect_custom_position():
+    # Test if axes with custom position and box_aspect
+    # behaves the same independent of the order of setting those.
+
+    fig1, ax1 = plt.subplots()
+    ax1.set_position([0.1, 0.1, 0.9, 0.2])
+    fig1.canvas.draw()
+    ax1.set_box_aspect(1.)
+
+    fig2, ax2 = plt.subplots()
+    ax2.set_box_aspect(1.)
+    fig2.canvas.draw()
+    ax2.set_position([0.1, 0.1, 0.9, 0.2])
+
+    fig1.canvas.draw()
+    fig2.canvas.draw()
+
+    bb1 = ax1.get_position()
+    bb2 = ax2.get_position()
+
+    assert_array_equal(bb1.extents, bb2.extents)
+
+
+def test_bbox_aspect_axes_init():
+    # Test that box_aspect can be given to axes init and produces
+    # all equal square axes.
+    fig, axs = plt.subplots(2, 3, subplot_kw=dict(box_aspect=1),
+                            constrained_layout=True)
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    sizes = []
+    for ax in axs.flat:
+        bb = ax.get_window_extent(renderer)
+        sizes.extend([bb.width, bb.height])
+
+    assert_allclose(sizes, sizes[0])
+
+
+def test_set_aspect_negative():
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match="must be finite and positive"):
+        ax.set_aspect(-1)
+    with pytest.raises(ValueError, match="must be finite and positive"):
+        ax.set_aspect(0)
+    with pytest.raises(ValueError, match="must be finite and positive"):
+        ax.set_aspect(np.inf)
+    with pytest.raises(ValueError, match="must be finite and positive"):
+        ax.set_aspect(-np.inf)
+
+
+def test_redraw_in_frame():
+    fig, ax = plt.subplots(1, 1)
+    ax.plot([1, 2, 3])
+    fig.canvas.draw()
+    ax.redraw_in_frame()
+
+
+def test_invisible_axes_events():
+    # invisible axes should not respond to events...
+    fig, ax = plt.subplots()
+    assert fig.canvas.inaxes((200, 200)) is not None
+    ax.set_visible(False)
+    assert fig.canvas.inaxes((200, 200)) is None
+
+
+def test_xtickcolor_is_not_markercolor():
+    plt.rcParams['lines.markeredgecolor'] = 'white'
+    ax = plt.axes()
+    ticks = ax.xaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.tick1line.get_markeredgecolor() != 'white'
+
+
+def test_ytickcolor_is_not_markercolor():
+    plt.rcParams['lines.markeredgecolor'] = 'white'
+    ax = plt.axes()
+    ticks = ax.yaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.tick1line.get_markeredgecolor() != 'white'
+
+
+@pytest.mark.parametrize('axis', ('x', 'y'))
+@pytest.mark.parametrize('auto', (True, False, None))
+def test_unautoscale(axis, auto):
+    fig, ax = plt.subplots()
+    x = np.arange(100)
+    y = np.linspace(-.1, .1, 100)
+    ax.scatter(y, x)
+
+    get_autoscale_on = getattr(ax, f'get_autoscale{axis}_on')
+    set_lim = getattr(ax, f'set_{axis}lim')
+    get_lim = getattr(ax, f'get_{axis}lim')
+
+    post_auto = get_autoscale_on() if auto is None else auto
+
+    set_lim((-0.5, 0.5), auto=auto)
+    assert post_auto == get_autoscale_on()
+    fig.canvas.draw()
+    assert_array_equal(get_lim(), (-0.5, 0.5))
+
+
+@check_figures_equal(extensions=["png"])
+def test_polar_interpolation_steps_variable_r(fig_test, fig_ref):
+    l, = fig_test.add_subplot(projection="polar").plot([0, np.pi/2], [1, 2])
+    l.get_path()._interpolation_steps = 100
+    fig_ref.add_subplot(projection="polar").plot(
+        np.linspace(0, np.pi/2, 101), np.linspace(1, 2, 101))
+
+
+@mpl.style.context('default')
+def test_autoscale_tiny_sticky():
+    fig, ax = plt.subplots()
+    ax.bar(0, 1e-9)
+    fig.canvas.draw()
+    assert ax.get_ylim() == (0, 1.05e-9)
+
+
+def test_xtickcolor_is_not_xticklabelcolor():
+    plt.rcParams['xtick.color'] = 'yellow'
+    plt.rcParams['xtick.labelcolor'] = 'blue'
+    ax = plt.axes()
+    ticks = ax.xaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.tick1line.get_color() == 'yellow'
+        assert tick.label1.get_color() == 'blue'
+
+
+def test_ytickcolor_is_not_yticklabelcolor():
+    plt.rcParams['ytick.color'] = 'yellow'
+    plt.rcParams['ytick.labelcolor'] = 'blue'
+    ax = plt.axes()
+    ticks = ax.yaxis.get_major_ticks()
+    for tick in ticks:
+        assert tick.tick1line.get_color() == 'yellow'
+        assert tick.label1.get_color() == 'blue'
+
+
+def test_xaxis_offsetText_color():
+    plt.rcParams['xtick.labelcolor'] = 'blue'
+    ax = plt.axes()
+    assert ax.xaxis.offsetText.get_color() == 'blue'
+
+    plt.rcParams['xtick.color'] = 'yellow'
+    plt.rcParams['xtick.labelcolor'] = 'inherit'
+    ax = plt.axes()
+    assert ax.xaxis.offsetText.get_color() == 'yellow'
+
+
+def test_yaxis_offsetText_color():
+    plt.rcParams['ytick.labelcolor'] = 'green'
+    ax = plt.axes()
+    assert ax.yaxis.offsetText.get_color() == 'green'
+
+    plt.rcParams['ytick.color'] = 'red'
+    plt.rcParams['ytick.labelcolor'] = 'inherit'
+    ax = plt.axes()
+    assert ax.yaxis.offsetText.get_color() == 'red'
+
+
+@pytest.mark.parametrize('size', [size for size in mfont_manager.font_scalings
+                                  if size is not None] + [8, 10, 12])
+@mpl.style.context('default')
+def test_relative_ticklabel_sizes(size):
+    mpl.rcParams['xtick.labelsize'] = size
+    mpl.rcParams['ytick.labelsize'] = size
+    fig, ax = plt.subplots()
+    fig.canvas.draw()
+
+    for name, axis in zip(['x', 'y'], [ax.xaxis, ax.yaxis]):
+        for tick in axis.get_major_ticks():
+            assert tick.label1.get_size() == axis._get_tick_label_size(name)
+
+
+def test_multiplot_autoscale():
+    fig = plt.figure()
+    ax1, ax2 = fig.subplots(2, 1, sharex='all')
+    ax1.plot([18000, 18250, 18500, 18750], [2, 3, 2, 3])
+    ax2.axhspan(-5, 5)
+    xlim = ax1.get_xlim()
+    assert np.allclose(xlim, [18000, 18800])
+
+
+def test_sharing_does_not_link_positions():
+    fig = plt.figure()
+    ax0 = fig.add_subplot(221)
+    ax1 = fig.add_axes([.6, .6, .3, .3], sharex=ax0)
+    init_pos = ax1.get_position()
+    fig.subplots_adjust(left=0)
+    assert (ax1.get_position().get_points() == init_pos.get_points()).all()
+
+
+@check_figures_equal(extensions=["pdf"])
+def test_2dcolor_plot(fig_test, fig_ref):
+    color = np.array([0.1, 0.2, 0.3])
+    # plot with 1D-color:
+    axs = fig_test.subplots(5)
+    axs[0].plot([1, 2], [1, 2], c=color.reshape(-1))
+    with pytest.warns(match="argument looks like a single numeric RGB"):
+        axs[1].scatter([1, 2], [1, 2], c=color.reshape(-1))
+    axs[2].step([1, 2], [1, 2], c=color.reshape(-1))
+    axs[3].hist(np.arange(10), color=color.reshape(-1))
+    axs[4].bar(np.arange(10), np.arange(10), color=color.reshape(-1))
+    # plot with 2D-color:
+    axs = fig_ref.subplots(5)
+    axs[0].plot([1, 2], [1, 2], c=color.reshape((1, -1)))
+    axs[1].scatter([1, 2], [1, 2], c=color.reshape((1, -1)))
+    axs[2].step([1, 2], [1, 2], c=color.reshape((1, -1)))
+    axs[3].hist(np.arange(10), color=color.reshape((1, -1)))
+    axs[4].bar(np.arange(10), np.arange(10), color=color.reshape((1, -1)))
+
+
+@check_figures_equal(extensions=['png'])
+def test_shared_axes_clear(fig_test, fig_ref):
+    x = np.arange(0.0, 2*np.pi, 0.01)
+    y = np.sin(x)
+
+    axs = fig_ref.subplots(2, 2, sharex=True, sharey=True)
+    for ax in axs.flat:
+        ax.plot(x, y)
+
+    axs = fig_test.subplots(2, 2, sharex=True, sharey=True)
+    for ax in axs.flat:
+        ax.clear()
+        ax.plot(x, y)
+
+
+def test_shared_axes_retick():
+    fig, axs = plt.subplots(2, 2, sharex='all', sharey='all')
+
+    for ax in axs.flat:
+        ax.plot([0, 2], 'o-')
+
+    axs[0, 0].set_xticks([-0.5, 0, 1, 1.5])  # should affect all axes xlims
+    for ax in axs.flat:
+        assert ax.get_xlim() == axs[0, 0].get_xlim()
+
+    axs[0, 0].set_yticks([-0.5, 0, 2, 2.5])  # should affect all axes ylims
+    for ax in axs.flat:
+        assert ax.get_ylim() == axs[0, 0].get_ylim()
+
+
+@pytest.mark.parametrize('ha', ['left', 'center', 'right'])
+def test_ylabel_ha_with_position(ha):
+    fig = Figure()
+    ax = fig.subplots()
+    ax.set_ylabel("test", y=1, ha=ha)
+    ax.yaxis.set_label_position("right")
+    assert ax.yaxis.label.get_ha() == ha
+
+
+def test_bar_label_location_vertical():
+    ax = plt.gca()
+    xs, heights = [1, 2], [3, -4]
+    rects = ax.bar(xs, heights)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (xs[0], heights[0])
+    assert labels[0].get_horizontalalignment() == 'center'
+    assert labels[0].get_verticalalignment() == 'bottom'
+    assert labels[1].xy == (xs[1], heights[1])
+    assert labels[1].get_horizontalalignment() == 'center'
+    assert labels[1].get_verticalalignment() == 'top'
+
+
+def test_bar_label_location_vertical_yinverted():
+    ax = plt.gca()
+    ax.invert_yaxis()
+    xs, heights = [1, 2], [3, -4]
+    rects = ax.bar(xs, heights)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (xs[0], heights[0])
+    assert labels[0].get_horizontalalignment() == 'center'
+    assert labels[0].get_verticalalignment() == 'top'
+    assert labels[1].xy == (xs[1], heights[1])
+    assert labels[1].get_horizontalalignment() == 'center'
+    assert labels[1].get_verticalalignment() == 'bottom'
+
+
+def test_bar_label_location_horizontal():
+    ax = plt.gca()
+    ys, widths = [1, 2], [3, -4]
+    rects = ax.barh(ys, widths)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (widths[0], ys[0])
+    assert labels[0].get_horizontalalignment() == 'left'
+    assert labels[0].get_verticalalignment() == 'center'
+    assert labels[1].xy == (widths[1], ys[1])
+    assert labels[1].get_horizontalalignment() == 'right'
+    assert labels[1].get_verticalalignment() == 'center'
+
+
+def test_bar_label_location_horizontal_yinverted():
+    ax = plt.gca()
+    ax.invert_yaxis()
+    ys, widths = [1, 2], [3, -4]
+    rects = ax.barh(ys, widths)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (widths[0], ys[0])
+    assert labels[0].get_horizontalalignment() == 'left'
+    assert labels[0].get_verticalalignment() == 'center'
+    assert labels[1].xy == (widths[1], ys[1])
+    assert labels[1].get_horizontalalignment() == 'right'
+    assert labels[1].get_verticalalignment() == 'center'
+
+
+def test_bar_label_location_horizontal_xinverted():
+    ax = plt.gca()
+    ax.invert_xaxis()
+    ys, widths = [1, 2], [3, -4]
+    rects = ax.barh(ys, widths)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (widths[0], ys[0])
+    assert labels[0].get_horizontalalignment() == 'right'
+    assert labels[0].get_verticalalignment() == 'center'
+    assert labels[1].xy == (widths[1], ys[1])
+    assert labels[1].get_horizontalalignment() == 'left'
+    assert labels[1].get_verticalalignment() == 'center'
+
+
+def test_bar_label_location_horizontal_xyinverted():
+    ax = plt.gca()
+    ax.invert_xaxis()
+    ax.invert_yaxis()
+    ys, widths = [1, 2], [3, -4]
+    rects = ax.barh(ys, widths)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (widths[0], ys[0])
+    assert labels[0].get_horizontalalignment() == 'right'
+    assert labels[0].get_verticalalignment() == 'center'
+    assert labels[1].xy == (widths[1], ys[1])
+    assert labels[1].get_horizontalalignment() == 'left'
+    assert labels[1].get_verticalalignment() == 'center'
+
+
+def test_bar_label_location_center():
+    ax = plt.gca()
+    ys, widths = [1, 2], [3, -4]
+    rects = ax.barh(ys, widths)
+    labels = ax.bar_label(rects, label_type='center')
+    assert labels[0].xy == (0.5, 0.5)
+    assert labels[0].get_horizontalalignment() == 'center'
+    assert labels[0].get_verticalalignment() == 'center'
+    assert labels[1].xy == (0.5, 0.5)
+    assert labels[1].get_horizontalalignment() == 'center'
+    assert labels[1].get_verticalalignment() == 'center'
+
+
+@image_comparison(['test_centered_bar_label_nonlinear.svg'])
+def test_centered_bar_label_nonlinear():
+    _, ax = plt.subplots()
+    bar_container = ax.barh(['c', 'b', 'a'], [1_000, 5_000, 7_000])
+    ax.set_xscale('log')
+    ax.set_xlim(1, None)
+    ax.bar_label(bar_container, label_type='center')
+    ax.set_axis_off()
+
+
+def test_centered_bar_label_label_beyond_limits():
+    fig, ax = plt.subplots()
+
+    last = 0
+    for label, value in zip(['a', 'b', 'c'], [10, 20, 50]):
+        bar_container = ax.barh('col', value, label=label, left=last)
+        ax.bar_label(bar_container, label_type='center')
+        last += value
+    ax.set_xlim(None, 20)
+
+    fig.draw_without_rendering()
+
+
+def test_bar_label_location_errorbars():
+    ax = plt.gca()
+    xs, heights = [1, 2], [3, -4]
+    rects = ax.bar(xs, heights, yerr=1)
+    labels = ax.bar_label(rects)
+    assert labels[0].xy == (xs[0], heights[0] + 1)
+    assert labels[0].get_horizontalalignment() == 'center'
+    assert labels[0].get_verticalalignment() == 'bottom'
+    assert labels[1].xy == (xs[1], heights[1] - 1)
+    assert labels[1].get_horizontalalignment() == 'center'
+    assert labels[1].get_verticalalignment() == 'top'
+
+
+@pytest.mark.parametrize('fmt', [
+    '%.2f', '{:.2f}', '{:.2f}'.format
+])
+def test_bar_label_fmt(fmt):
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [3, -4])
+    labels = ax.bar_label(rects, fmt=fmt)
+    assert labels[0].get_text() == '3.00'
+    assert labels[1].get_text() == '-4.00'
+
+
+def test_bar_label_fmt_error():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [3, -4])
+    with pytest.raises(TypeError, match='str or callable'):
+        _ = ax.bar_label(rects, fmt=10)
+
+
+def test_bar_label_labels():
+    ax = plt.gca()
+    rects = ax.bar([1, 2], [3, -4])
+    labels = ax.bar_label(rects, labels=['A', 'B'])
+    assert labels[0].get_text() == 'A'
+    assert labels[1].get_text() == 'B'
+
+
+def test_bar_label_nan_ydata():
+    ax = plt.gca()
+    bars = ax.bar([2, 3], [np.nan, 1])
+    labels = ax.bar_label(bars)
+    assert [l.get_text() for l in labels] == ['', '1']
+    assert labels[0].xy == (2, 0)
+    assert labels[0].get_verticalalignment() == 'bottom'
+
+
+def test_bar_label_nan_ydata_inverted():
+    ax = plt.gca()
+    ax.yaxis_inverted()
+    bars = ax.bar([2, 3], [np.nan, 1])
+    labels = ax.bar_label(bars)
+    assert [l.get_text() for l in labels] == ['', '1']
+    assert labels[0].xy == (2, 0)
+    assert labels[0].get_verticalalignment() == 'bottom'
+
+
+def test_nan_barlabels():
+    fig, ax = plt.subplots()
+    bars = ax.bar([1, 2, 3], [np.nan, 1, 2], yerr=[0.2, 0.4, 0.6])
+    labels = ax.bar_label(bars)
+    assert [l.get_text() for l in labels] == ['', '1', '2']
+    assert np.allclose(ax.get_ylim(), (0.0, 3.0))
+
+    fig, ax = plt.subplots()
+    bars = ax.bar([1, 2, 3], [0, 1, 2], yerr=[0.2, np.nan, 0.6])
+    labels = ax.bar_label(bars)
+    assert [l.get_text() for l in labels] == ['0', '1', '2']
+    assert np.allclose(ax.get_ylim(), (-0.5, 3.0))
+
+    fig, ax = plt.subplots()
+    bars = ax.bar([1, 2, 3], [np.nan, 1, 2], yerr=[np.nan, np.nan, 0.6])
+    labels = ax.bar_label(bars)
+    assert [l.get_text() for l in labels] == ['', '1', '2']
+    assert np.allclose(ax.get_ylim(), (0.0, 3.0))
+
+
+def test_patch_bounds():  # PR 19078
+    fig, ax = plt.subplots()
+    ax.add_patch(mpatches.Wedge((0, -1), 1.05, 60, 120, width=0.1))
+    bot = 1.9*np.sin(15*np.pi/180)**2
+    np.testing.assert_array_almost_equal_nulp(
+        np.array((-0.525, -(bot+0.05), 1.05, bot+0.1)), ax.dataLim.bounds, 16)
+
+
+@mpl.style.context('default')
+def test_warn_ignored_scatter_kwargs():
+    with pytest.warns(UserWarning,
+                      match=r"You passed a edgecolor/edgecolors"):
+        plt.scatter([0], [0], marker="+", s=500, facecolor="r", edgecolor="b")
+
+
+def test_artist_sublists():
+    fig, ax = plt.subplots()
+    lines = [ax.plot(np.arange(i, i + 5))[0] for i in range(6)]
+    col = ax.scatter(np.arange(5), np.arange(5))
+    im = ax.imshow(np.zeros((5, 5)))
+    patch = ax.add_patch(mpatches.Rectangle((0, 0), 5, 5))
+    text = ax.text(0, 0, 'foo')
+
+    # Get items, which should not be mixed.
+    assert list(ax.collections) == [col]
+    assert list(ax.images) == [im]
+    assert list(ax.lines) == lines
+    assert list(ax.patches) == [patch]
+    assert not ax.tables
+    assert list(ax.texts) == [text]
+
+    # Get items should work like lists/tuple.
+    assert ax.lines[0] is lines[0]
+    assert ax.lines[-1] is lines[-1]
+    with pytest.raises(IndexError, match='out of range'):
+        ax.lines[len(lines) + 1]
+
+    # Adding to other lists should produce a regular list.
+    assert ax.lines + [1, 2, 3] == [*lines, 1, 2, 3]
+    assert [1, 2, 3] + ax.lines == [1, 2, 3, *lines]
+
+    # Adding to other tuples should produce a regular tuples.
+    assert ax.lines + (1, 2, 3) == (*lines, 1, 2, 3)
+    assert (1, 2, 3) + ax.lines == (1, 2, 3, *lines)
+
+    # Lists should be empty after removing items.
+    col.remove()
+    assert not ax.collections
+    im.remove()
+    assert not ax.images
+    patch.remove()
+    assert not ax.patches
+    assert not ax.tables
+    text.remove()
+    assert not ax.texts
+
+    for ln in ax.lines:
+        ln.remove()
+    assert len(ax.lines) == 0
+
+
+def test_empty_line_plots():
+    # Incompatible nr columns, plot "nothing"
+    x = np.ones(10)
+    y = np.ones((10, 0))
+    _, ax = plt.subplots()
+    line = ax.plot(x, y)
+    assert len(line) == 0
+
+    # Ensure plot([],[]) creates line
+    _, ax = plt.subplots()
+    line = ax.plot([], [])
+    assert len(line) == 1
+
+
+@pytest.mark.parametrize('fmt, match', (
+    ("f", r"'f' is not a valid format string \(unrecognized character 'f'\)"),
+    ("o+", r"'o\+' is not a valid format string \(two marker symbols\)"),
+    (":-", r"':-' is not a valid format string \(two linestyle symbols\)"),
+    ("rk", r"'rk' is not a valid format string \(two color symbols\)"),
+    (":o-r", r"':o-r' is not a valid format string \(two linestyle symbols\)"),
+    ("C", r"'C' is not a valid format string \('C' must be followed by a number\)"),
+    (".C", r"'.C' is not a valid format string \('C' must be followed by a number\)"),
+))
+@pytest.mark.parametrize("data", [None, {"string": range(3)}])
+def test_plot_format_errors(fmt, match, data):
+    fig, ax = plt.subplots()
+    if data is not None:
+        match = match.replace("not", "neither a data key nor")
+    with pytest.raises(ValueError, match=r"\A" + match + r"\Z"):
+        ax.plot("string", fmt, data=data)
+
+
+def test_plot_format():
+    fig, ax = plt.subplots()
+    line = ax.plot([1, 2, 3], '1.0')
+    assert line[0].get_color() == (1.0, 1.0, 1.0, 1.0)
+    assert line[0].get_marker() == 'None'
+    fig, ax = plt.subplots()
+    line = ax.plot([1, 2, 3], '1')
+    assert line[0].get_marker() == '1'
+    fig, ax = plt.subplots()
+    line = ax.plot([1, 2], [1, 2], '1.0', "1")
+    fig.canvas.draw()
+    assert line[0].get_color() == (1.0, 1.0, 1.0, 1.0)
+    assert ax.get_yticklabels()[0].get_text() == '1'
+    fig, ax = plt.subplots()
+    line = ax.plot([1, 2], [1, 2], '1', "1.0")
+    fig.canvas.draw()
+    assert line[0].get_marker() == '1'
+    assert ax.get_yticklabels()[0].get_text() == '1.0'
+    fig, ax = plt.subplots()
+    line = ax.plot([1, 2, 3], 'k3')
+    assert line[0].get_marker() == '3'
+    assert line[0].get_color() == 'k'
+    fig, ax = plt.subplots()
+    line = ax.plot([1, 2, 3], '.C12:')
+    assert line[0].get_marker() == '.'
+    assert line[0].get_color() == mcolors.to_rgba('C12')
+    assert line[0].get_linestyle() == ':'
+
+
+def test_automatic_legend():
+    fig, ax = plt.subplots()
+    ax.plot("a", "b", data={"d": 2})
+    leg = ax.legend()
+    fig.canvas.draw()
+    assert leg.get_texts()[0].get_text() == 'a'
+    assert ax.get_yticklabels()[0].get_text() == 'a'
+
+    fig, ax = plt.subplots()
+    ax.plot("a", "b", "c", data={"d": 2})
+    leg = ax.legend()
+    fig.canvas.draw()
+    assert leg.get_texts()[0].get_text() == 'b'
+    assert ax.get_xticklabels()[0].get_text() == 'a'
+    assert ax.get_yticklabels()[0].get_text() == 'b'
+
+
+def test_plot_errors():
+    with pytest.raises(TypeError, match=r"plot\(\) got an unexpected keyword"):
+        plt.plot([1, 2, 3], x=1)
+    with pytest.raises(ValueError, match=r"plot\(\) with multiple groups"):
+        plt.plot([1, 2, 3], [1, 2, 3], [2, 3, 4], [2, 3, 4], label=['1', '2'])
+    with pytest.raises(ValueError, match="x and y must have same first"):
+        plt.plot([1, 2, 3], [1])
+    with pytest.raises(ValueError, match="x and y can be no greater than"):
+        plt.plot(np.ones((2, 2, 2)))
+    with pytest.raises(ValueError, match="Using arbitrary long args with"):
+        plt.plot("a", "b", "c", "d", data={"a": 2})
+
+
+def test_clim():
+    ax = plt.figure().add_subplot()
+    for plot_method in [
+            partial(ax.scatter, range(3), range(3), c=range(3)),
+            partial(ax.imshow, [[0, 1], [2, 3]]),
+            partial(ax.pcolor,  [[0, 1], [2, 3]]),
+            partial(ax.pcolormesh, [[0, 1], [2, 3]]),
+            partial(ax.pcolorfast, [[0, 1], [2, 3]]),
+    ]:
+        clim = (7, 8)
+        norm = plot_method(clim=clim).norm
+        assert (norm.vmin, norm.vmax) == clim
+
+
+def test_bezier_autoscale():
+    # Check that bezier curves autoscale to their curves, and not their
+    # control points
+    verts = [[-1, 0],
+             [0, -1],
+             [1, 0],
+             [1, 0]]
+    codes = [mpath.Path.MOVETO,
+             mpath.Path.CURVE3,
+             mpath.Path.CURVE3,
+             mpath.Path.CLOSEPOLY]
+    p = mpath.Path(verts, codes)
+
+    fig, ax = plt.subplots()
+    ax.add_patch(mpatches.PathPatch(p))
+    ax.autoscale()
+    # Bottom ylim should be at the edge of the curve (-0.5), and not include
+    # the control point (at -1)
+    assert ax.get_ylim()[0] == -0.5
+
+
+def test_small_autoscale():
+    # Check that paths with small values autoscale correctly #24097.
+    verts = np.array([
+        [-5.45, 0.00], [-5.45, 0.00], [-5.29, 0.00], [-5.29, 0.00],
+        [-5.13, 0.00], [-5.13, 0.00], [-4.97, 0.00], [-4.97, 0.00],
+        [-4.81, 0.00], [-4.81, 0.00], [-4.65, 0.00], [-4.65, 0.00],
+        [-4.49, 0.00], [-4.49, 0.00], [-4.33, 0.00], [-4.33, 0.00],
+        [-4.17, 0.00], [-4.17, 0.00], [-4.01, 0.00], [-4.01, 0.00],
+        [-3.85, 0.00], [-3.85, 0.00], [-3.69, 0.00], [-3.69, 0.00],
+        [-3.53, 0.00], [-3.53, 0.00], [-3.37, 0.00], [-3.37, 0.00],
+        [-3.21, 0.00], [-3.21, 0.01], [-3.05, 0.01], [-3.05, 0.01],
+        [-2.89, 0.01], [-2.89, 0.01], [-2.73, 0.01], [-2.73, 0.02],
+        [-2.57, 0.02], [-2.57, 0.04], [-2.41, 0.04], [-2.41, 0.04],
+        [-2.25, 0.04], [-2.25, 0.06], [-2.09, 0.06], [-2.09, 0.08],
+        [-1.93, 0.08], [-1.93, 0.10], [-1.77, 0.10], [-1.77, 0.12],
+        [-1.61, 0.12], [-1.61, 0.14], [-1.45, 0.14], [-1.45, 0.17],
+        [-1.30, 0.17], [-1.30, 0.19], [-1.14, 0.19], [-1.14, 0.22],
+        [-0.98, 0.22], [-0.98, 0.25], [-0.82, 0.25], [-0.82, 0.27],
+        [-0.66, 0.27], [-0.66, 0.29], [-0.50, 0.29], [-0.50, 0.30],
+        [-0.34, 0.30], [-0.34, 0.32], [-0.18, 0.32], [-0.18, 0.33],
+        [-0.02, 0.33], [-0.02, 0.32], [0.13, 0.32], [0.13, 0.33], [0.29, 0.33],
+        [0.29, 0.31], [0.45, 0.31], [0.45, 0.30], [0.61, 0.30], [0.61, 0.28],
+        [0.77, 0.28], [0.77, 0.25], [0.93, 0.25], [0.93, 0.22], [1.09, 0.22],
+        [1.09, 0.19], [1.25, 0.19], [1.25, 0.17], [1.41, 0.17], [1.41, 0.15],
+        [1.57, 0.15], [1.57, 0.12], [1.73, 0.12], [1.73, 0.10], [1.89, 0.10],
+        [1.89, 0.08], [2.05, 0.08], [2.05, 0.07], [2.21, 0.07], [2.21, 0.05],
+        [2.37, 0.05], [2.37, 0.04], [2.53, 0.04], [2.53, 0.02], [2.69, 0.02],
+        [2.69, 0.02], [2.85, 0.02], [2.85, 0.01], [3.01, 0.01], [3.01, 0.01],
+        [3.17, 0.01], [3.17, 0.00], [3.33, 0.00], [3.33, 0.00], [3.49, 0.00],
+        [3.49, 0.00], [3.65, 0.00], [3.65, 0.00], [3.81, 0.00], [3.81, 0.00],
+        [3.97, 0.00], [3.97, 0.00], [4.13, 0.00], [4.13, 0.00], [4.29, 0.00],
+        [4.29, 0.00], [4.45, 0.00], [4.45, 0.00], [4.61, 0.00], [4.61, 0.00],
+        [4.77, 0.00], [4.77, 0.00], [4.93, 0.00], [4.93, 0.00],
+    ])
+
+    minx = np.min(verts[:, 0])
+    miny = np.min(verts[:, 1])
+    maxx = np.max(verts[:, 0])
+    maxy = np.max(verts[:, 1])
+
+    p = mpath.Path(verts)
+
+    fig, ax = plt.subplots()
+    ax.add_patch(mpatches.PathPatch(p))
+    ax.autoscale()
+
+    assert ax.get_xlim()[0] <= minx
+    assert ax.get_xlim()[1] >= maxx
+    assert ax.get_ylim()[0] <= miny
+    assert ax.get_ylim()[1] >= maxy
+
+
+def test_get_xticklabel():
+    fig, ax = plt.subplots()
+    ax.plot(np.arange(10))
+    for ind in range(10):
+        assert ax.get_xticklabels()[ind].get_text() == f'{ind}'
+        assert ax.get_yticklabels()[ind].get_text() == f'{ind}'
+
+
+def test_bar_leading_nan():
+
+    barx = np.arange(3, dtype=float)
+    barheights = np.array([0.5, 1.5, 2.0])
+    barstarts = np.array([0.77]*3)
+
+    barx[0] = np.nan
+
+    fig, ax = plt.subplots()
+
+    bars = ax.bar(barx, barheights, bottom=barstarts)
+
+    hbars = ax.barh(barx, barheights, left=barstarts)
+
+    for bar_set in (bars, hbars):
+        # the first bar should have a nan in the location
+        nanful, *rest = bar_set
+        assert (~np.isfinite(nanful.xy)).any()
+        assert np.isfinite(nanful.get_width())
+        for b in rest:
+            assert np.isfinite(b.xy).all()
+            assert np.isfinite(b.get_width())
+
+
+@check_figures_equal(extensions=["png"])
+def test_bar_all_nan(fig_test, fig_ref):
+    mpl.style.use("mpl20")
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+
+    ax_test.bar([np.nan], [np.nan])
+    ax_test.bar([1], [1])
+
+    ax_ref.bar([1], [1]).remove()
+    ax_ref.bar([1], [1])
+
+
+@image_comparison(["extent_units.png"], style="mpl20")
+def test_extent_units():
+    _, axs = plt.subplots(2, 2)
+    date_first = np.datetime64('2020-01-01', 'D')
+    date_last = np.datetime64('2020-01-11', 'D')
+    arr = [[i+j for i in range(10)] for j in range(10)]
+
+    axs[0, 0].set_title('Date extents on y axis')
+    im = axs[0, 0].imshow(arr, origin='lower',
+                          extent=[1, 11, date_first, date_last],
+                          cmap=mpl.colormaps["plasma"])
+
+    axs[0, 1].set_title('Date extents on x axis (Day of Jan 2020)')
+    im = axs[0, 1].imshow(arr, origin='lower',
+                          extent=[date_first, date_last, 1, 11],
+                          cmap=mpl.colormaps["plasma"])
+    axs[0, 1].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
+
+    im = axs[1, 0].imshow(arr, origin='lower',
+                          extent=[date_first, date_last,
+                                  date_first, date_last],
+                          cmap=mpl.colormaps["plasma"])
+    axs[1, 0].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
+    axs[1, 0].set(xlabel='Day of Jan 2020')
+
+    im = axs[1, 1].imshow(arr, origin='lower',
+                          cmap=mpl.colormaps["plasma"])
+    im.set_extent([date_last, date_first, date_last, date_first])
+    axs[1, 1].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
+    axs[1, 1].set(xlabel='Day of Jan 2020')
+
+    with pytest.raises(TypeError, match=r"set_extent\(\) got an unexpected"):
+        im.set_extent([2, 12, date_first, date_last], clip=False)
+
+
+def test_cla_clears_children_axes_and_fig():
+    fig, ax = plt.subplots()
+    lines = ax.plot([], [], [], [])
+    img = ax.imshow([[1]])
+    for art in lines + [img]:
+        assert art.axes is ax
+        assert art.get_figure() is fig
+    ax.clear()
+    for art in lines + [img]:
+        assert art.axes is None
+        assert art.get_figure() is None
+
+
+def test_child_axes_removal():
+    fig, ax = plt.subplots()
+    marginal = ax.inset_axes([1, 0, .1, 1], sharey=ax)
+    marginal_twin = marginal.twinx()
+    marginal.remove()
+    ax.set(xlim=(-1, 1), ylim=(10, 20))
+
+
+def test_scatter_color_repr_error():
+
+    def get_next_color():
+        return 'blue'  # pragma: no cover
+    msg = (
+            r"'c' argument must be a color, a sequence of colors"
+            r", or a sequence of numbers, not 'red\\n'"
+        )
+    with pytest.raises(ValueError, match=msg):
+        c = 'red\n'
+        mpl.axes.Axes._parse_scatter_color_args(
+            c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)
+
+
+def test_zorder_and_explicit_rasterization():
+    fig, ax = plt.subplots()
+    ax.set_rasterization_zorder(5)
+    ln, = ax.plot(range(5), rasterized=True, zorder=1)
+    with io.BytesIO() as b:
+        fig.savefig(b, format='pdf')
+
+
+@image_comparison(["preset_clip_paths.png"], remove_text=True, style="mpl20",
+                  tol=0.027 if platform.machine() == "arm64" else 0)
+def test_preset_clip_paths():
+    fig, ax = plt.subplots()
+
+    poly = mpl.patches.Polygon(
+        [[1, 0], [0, 1], [-1, 0], [0, -1]], facecolor="#ddffdd",
+        edgecolor="#00ff00", linewidth=2, alpha=0.5)
+
+    ax.add_patch(poly)
+
+    line = mpl.lines.Line2D((-1, 1), (0.5, 0.5), clip_on=True, clip_path=poly)
+    line.set_path_effects([patheffects.withTickedStroke()])
+    ax.add_artist(line)
+
+    line = mpl.lines.Line2D((-1, 1), (-0.5, -0.5), color='r', clip_on=True,
+                            clip_path=poly)
+    ax.add_artist(line)
+
+    poly2 = mpl.patches.Polygon(
+        [[-1, 1], [0, 1], [0, -0.25]], facecolor="#beefc0", alpha=0.3,
+        edgecolor="#faded0", linewidth=2, clip_on=True, clip_path=poly)
+    ax.add_artist(poly2)
+
+    # When text clipping works, the "Annotation" text should be clipped
+    ax.annotate('Annotation', (-0.75, -0.75), xytext=(0.1, 0.75),
+                arrowprops={'color': 'k'}, clip_on=True, clip_path=poly)
+
+    poly3 = mpl.patches.Polygon(
+        [[0, 0], [0, 0.5], [0.5, 0.5], [0.5, 0]], facecolor="g", edgecolor="y",
+        linewidth=2, alpha=0.3, clip_on=True, clip_path=poly)
+
+    fig.add_artist(poly3, clip=True)
+
+    ax.set_xlim(-1, 1)
+    ax.set_ylim(-1, 1)
+
+
+@mpl.style.context('default')
+def test_rc_axes_label_formatting():
+    mpl.rcParams['axes.labelcolor'] = 'red'
+    mpl.rcParams['axes.labelsize'] = 20
+    mpl.rcParams['axes.labelweight'] = 'bold'
+
+    ax = plt.axes()
+    assert ax.xaxis.label.get_color() == 'red'
+    assert ax.xaxis.label.get_fontsize() == 20
+    assert ax.xaxis.label.get_fontweight() == 'bold'
+
+
+@check_figures_equal(extensions=["png"])
+def test_ecdf(fig_test, fig_ref):
+    data = np.array([0, -np.inf, -np.inf, np.inf, 1, 1, 2])
+    weights = range(len(data))
+    axs_test = fig_test.subplots(1, 2)
+    for ax, orientation in zip(axs_test, ["vertical", "horizontal"]):
+        l0 = ax.ecdf(data, orientation=orientation)
+        l1 = ax.ecdf("d", "w", data={"d": np.ma.array(data), "w": weights},
+                     orientation=orientation,
+                     complementary=True, compress=True, ls=":")
+        assert len(l0.get_xdata()) == (~np.isnan(data)).sum() + 1
+        assert len(l1.get_xdata()) == len({*data[~np.isnan(data)]}) + 1
+    axs_ref = fig_ref.subplots(1, 2)
+    axs_ref[0].plot([-np.inf, -np.inf, -np.inf, 0, 1, 1, 2, np.inf],
+                    np.arange(8) / 7, ds="steps-post")
+    axs_ref[0].plot([-np.inf, 0, 1, 2, np.inf, np.inf],
+                    np.array([21, 20, 18, 14, 3, 0]) / 21,
+                    ds="steps-pre", ls=":")
+    axs_ref[1].plot(np.arange(8) / 7,
+                    [-np.inf, -np.inf, -np.inf, 0, 1, 1, 2, np.inf],
+                    ds="steps-pre")
+    axs_ref[1].plot(np.array([21, 20, 18, 14, 3, 0]) / 21,
+                    [-np.inf, 0, 1, 2, np.inf, np.inf],
+                    ds="steps-post", ls=":")
+
+
+def test_ecdf_invalid():
+    with pytest.raises(ValueError):
+        plt.ecdf([1, np.nan])
+    with pytest.raises(ValueError):
+        plt.ecdf(np.ma.array([1, 2], mask=[True, False]))
+
+
+def test_fill_between_axes_limits():
+    fig, ax = plt.subplots()
+    x = np.arange(0, 4 * np.pi, 0.01)
+    y = 0.1*np.sin(x)
+    threshold = 0.075
+    ax.plot(x, y, color='black')
+
+    original_lims = (ax.get_xlim(), ax.get_ylim())
+
+    ax.axhline(threshold, color='green', lw=2, alpha=0.7)
+    ax.fill_between(x, 0, 1, where=y > threshold,
+                    color='green', alpha=0.5, transform=ax.get_xaxis_transform())
+
+    assert (ax.get_xlim(), ax.get_ylim()) == original_lims
+
+
+def test_tick_param_labelfont():
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3, 4], [1, 2, 3, 4])
+    ax.set_xlabel('X label in Impact font', fontname='Impact')
+    ax.set_ylabel('Y label in xkcd script', fontname='xkcd script')
+    ax.tick_params(color='r', labelfontfamily='monospace')
+    plt.title('Title in sans-serif')
+    for text in ax.get_xticklabels():
+        assert text.get_fontfamily()[0] == 'monospace'
+
+
+def test_set_secondary_axis_color():
+    fig, ax = plt.subplots()
+    sax = ax.secondary_xaxis("top", color="red")
+    assert mcolors.same_color(sax.spines["bottom"].get_edgecolor(), "red")
+    assert mcolors.same_color(sax.spines["top"].get_edgecolor(), "red")
+    assert mcolors.same_color(sax.xaxis.get_tick_params()["color"], "red")
+    assert mcolors.same_color(sax.xaxis.get_tick_params()["labelcolor"], "red")
+    assert mcolors.same_color(sax.xaxis.label.get_color(), "red")
+
+
+def test_xylim_changed_shared():
+    fig, axs = plt.subplots(2, sharex=True, sharey=True)
+    events = []
+    axs[1].callbacks.connect("xlim_changed", events.append)
+    axs[1].callbacks.connect("ylim_changed", events.append)
+    axs[0].set(xlim=[1, 3], ylim=[2, 4])
+    assert events == [axs[1], axs[1]]
+
+
+@image_comparison(["axhvlinespan_interpolation.png"], style="default")
+def test_axhvlinespan_interpolation():
+    ax = plt.figure().add_subplot(projection="polar")
+    ax.set_axis_off()
+    ax.axvline(.1, c="C0")
+    ax.axvspan(.2, .3, fc="C1")
+    ax.axvspan(.4, .5, .1, .2, fc="C2")
+    ax.axhline(1, c="C0", alpha=.5)
+    ax.axhspan(.8, .9, fc="C1", alpha=.5)
+    ax.axhspan(.6, .7, .8, .9, fc="C2", alpha=.5)
+
+
+@check_figures_equal(extensions=["png"])
+@pytest.mark.parametrize("which", ("x", "y"))
+def test_axes_clear_behavior(fig_ref, fig_test, which):
+    """Test that the given tick params are not reset by ax.clear()."""
+    ax_test = fig_test.subplots()
+    ax_ref = fig_ref.subplots()
+    # the following tick params values are chosen to each create a visual difference
+    # from their defaults
+    target = {
+        "direction": "in",
+        "length": 10,
+        "width": 10,
+        "color": "xkcd:wine red",
+        "pad": 0,
+        "labelfontfamily": "serif",
+        "zorder": 7,
+        "labelrotation": 45,
+        "labelcolor": "xkcd:shocking pink",
+        # this overrides color + labelcolor, skip
+        # colors: ,
+        "grid_color": "xkcd:fluorescent green",
+        "grid_alpha": 0.5,
+        "grid_linewidth": 3,
+        "grid_linestyle": ":",
+        "bottom": False,
+        "top": True,
+        "left": False,
+        "right": True,
+        "labelbottom": True,
+        "labeltop": True,
+        "labelleft": True,
+        "labelright": True,
+    }
+
+    ax_ref.tick_params(axis=which, **target)
+
+    ax_test.tick_params(axis=which, **target)
+    ax_test.clear()
+
+    ax_ref.grid(True)
+    ax_test.grid(True)
+
+
+@pytest.mark.skipif(
+    sys.version_info[:3] == (3, 13, 0) and sys.version_info.releaselevel != "final",
+    reason="https://github.com/python/cpython/issues/124538",
+)
+def test_axes_clear_reference_cycle():
+    def assert_not_in_reference_cycle(start):
+        # Breadth first search. Return True if we encounter the starting node
+        to_visit = deque([start])
+        explored = set()
+        while len(to_visit) > 0:
+            parent = to_visit.popleft()
+            for child in gc.get_referents(parent):
+                if id(child) in explored:
                     continue
-                hlmarker = (
-                    himarker
-                    if self._axis_map[dep_axis].get_inverted() ^ idx
-                    else lomarker)
-                x_masked, y_masked, hl_masked = apply_mask(
-                    [x, y, hl], lims & everymask)
-                # As above, we set the dependent data in a second step.
-                line = mlines.Line2D(x_masked, y_masked,
-                                     marker=hlmarker, **eb_cap_style)
-                line.set(**{f"{dep_axis}data": hl_masked})
-                caplines[dep_axis].append(line)
-                if capsize > 0:
-                    caplines[dep_axis].append(mlines.Line2D(
-                        x_masked, y_masked, marker=marker, **eb_cap_style))
-        if self.name == 'polar':
-            trans_shift = self.transShift
-            for axis in caplines:
-                for l in caplines[axis]:
-                    # Rotate caps to be perpendicular to the error bars
-                    for theta, r in zip(l.get_xdata(), l.get_ydata()):
-                        rotation = _ScaledRotation(theta=theta, trans_shift=trans_shift)
-                        if axis == 'y':
-                            rotation += mtransforms.Affine2D().rotate(np.pi / 2)
-                        ms = mmarkers.MarkerStyle(marker=marker,
-                                                  transform=rotation)
-                        self.add_line(mlines.Line2D([theta], [r], marker=ms,
-                                                    **eb_cap_style))
-        else:
-            for axis in caplines:
-                for l in caplines[axis]:
-                    self.add_line(l)
-
-        self._request_autoscale_view()
-        caplines = caplines['x'] + caplines['y']
-        errorbar_container = ErrorbarContainer(
-            (data_line, tuple(caplines), tuple(barcols)),
-            has_xerr=(xerr is not None), has_yerr=(yerr is not None),
-            label=label)
-        self.containers.append(errorbar_container)
-
-        return errorbar_container  # (l0, caplines, barcols)
-
-    @_api.make_keyword_only("3.9", "notch")
-    @_preprocess_data()
-    @_api.rename_parameter("3.9", "labels", "tick_labels")
-    def boxplot(self, x, notch=None, sym=None, vert=None,
-                orientation='vertical', whis=None, positions=None,
-                widths=None, patch_artist=None, bootstrap=None,
-                usermedians=None, conf_intervals=None,
-                meanline=None, showmeans=None, showcaps=None,
-                showbox=None, showfliers=None, boxprops=None,
-                tick_labels=None, flierprops=None, medianprops=None,
-                meanprops=None, capprops=None, whiskerprops=None,
-                manage_ticks=True, autorange=False, zorder=None,
-                capwidths=None, label=None):
-        """
-        Draw a box and whisker plot.
-
-        The box extends from the first quartile (Q1) to the third
-        quartile (Q3) of the data, with a line at the median.
-        The whiskers extend from the box to the farthest data point
-        lying within 1.5x the inter-quartile range (IQR) from the box.
-        Flier points are those past the end of the whiskers.
-        See https://en.wikipedia.org/wiki/Box_plot for reference.
-
-        .. code-block:: none
-
-                  Q1-1.5IQR   Q1   median  Q3   Q3+1.5IQR
-                               |-----:-----|
-               o      |--------|     :     |--------|    o  o
-                               |-----:-----|
-             flier             <----------->            fliers
-                                    IQR
-
-
-        Parameters
-        ----------
-        x : Array or a sequence of vectors.
-            The input data.  If a 2D array, a boxplot is drawn for each column
-            in *x*.  If a sequence of 1D arrays, a boxplot is drawn for each
-            array in *x*.
-
-        notch : bool, default: :rc:`boxplot.notch`
-            Whether to draw a notched boxplot (`True`), or a rectangular
-            boxplot (`False`).  The notches represent the confidence interval
-            (CI) around the median.  The documentation for *bootstrap*
-            describes how the locations of the notches are computed by
-            default, but their locations may also be overridden by setting the
-            *conf_intervals* parameter.
-
-            .. note::
-
-                In cases where the values of the CI are less than the
-                lower quartile or greater than the upper quartile, the
-                notches will extend beyond the box, giving it a
-                distinctive "flipped" appearance. This is expected
-                behavior and consistent with other statistical
-                visualization packages.
-
-        sym : str, optional
-            The default symbol for flier points.  An empty string ('') hides
-            the fliers.  If `None`, then the fliers default to 'b+'.  More
-            control is provided by the *flierprops* parameter.
-
-        vert : bool, optional
-            .. deprecated:: 3.10
-                Use *orientation* instead.
-
-                If this is given during the deprecation period, it overrides
-                the *orientation* parameter.
-
-            If True, plots the boxes vertically.
-            If False, plots the boxes horizontally.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            If 'horizontal', plots the boxes horizontally.
-            Otherwise, plots the boxes vertically.
-
-            .. versionadded:: 3.10
-
-        whis : float or (float, float), default: 1.5
-            The position of the whiskers.
-
-            If a float, the lower whisker is at the lowest datum above
-            ``Q1 - whis*(Q3-Q1)``, and the upper whisker at the highest datum
-            below ``Q3 + whis*(Q3-Q1)``, where Q1 and Q3 are the first and
-            third quartiles.  The default value of ``whis = 1.5`` corresponds
-            to Tukey's original definition of boxplots.
-
-            If a pair of floats, they indicate the percentiles at which to
-            draw the whiskers (e.g., (5, 95)).  In particular, setting this to
-            (0, 100) results in whiskers covering the whole range of the data.
-
-            In the edge case where ``Q1 == Q3``, *whis* is automatically set
-            to (0, 100) (cover the whole range of the data) if *autorange* is
-            True.
-
-            Beyond the whiskers, data are considered outliers and are plotted
-            as individual points.
-
-        bootstrap : int, optional
-            Specifies whether to bootstrap the confidence intervals
-            around the median for notched boxplots. If *bootstrap* is
-            None, no bootstrapping is performed, and notches are
-            calculated using a Gaussian-based asymptotic approximation
-            (see McGill, R., Tukey, J.W., and Larsen, W.A., 1978, and
-            Kendall and Stuart, 1967). Otherwise, bootstrap specifies
-            the number of times to bootstrap the median to determine its
-            95% confidence intervals. Values between 1000 and 10000 are
-            recommended.
-
-        usermedians : 1D array-like, optional
-            A 1D array-like of length ``len(x)``.  Each entry that is not
-            `None` forces the value of the median for the corresponding
-            dataset.  For entries that are `None`, the medians are computed
-            by Matplotlib as normal.
-
-        conf_intervals : array-like, optional
-            A 2D array-like of shape ``(len(x), 2)``.  Each entry that is not
-            None forces the location of the corresponding notch (which is
-            only drawn if *notch* is `True`).  For entries that are `None`,
-            the notches are computed by the method specified by the other
-            parameters (e.g., *bootstrap*).
-
-        positions : array-like, optional
-            The positions of the boxes. The ticks and limits are
-            automatically set to match the positions. Defaults to
-            ``range(1, N+1)`` where N is the number of boxes to be drawn.
-
-        widths : float or array-like
-            The widths of the boxes.  The default is 0.5, or ``0.15*(distance
-            between extreme positions)``, if that is smaller.
-
-        patch_artist : bool, default: :rc:`boxplot.patchartist`
-            If `False` produces boxes with the Line2D artist. Otherwise,
-            boxes are drawn with Patch artists.
-
-        tick_labels : list of str, optional
-            The tick labels of each boxplot.
-            Ticks are always placed at the box *positions*. If *tick_labels* is given,
-            the ticks are labelled accordingly. Otherwise, they keep their numeric
-            values.
-
-            .. versionchanged:: 3.9
-                Renamed from *labels*, which is deprecated since 3.9
-                and will be removed in 3.11.
-
-        manage_ticks : bool, default: True
-            If True, the tick locations and labels will be adjusted to match
-            the boxplot positions.
-
-        autorange : bool, default: False
-            When `True` and the data are distributed such that the 25th and
-            75th percentiles are equal, *whis* is set to (0, 100) such
-            that the whisker ends are at the minimum and maximum of the data.
-
-        meanline : bool, default: :rc:`boxplot.meanline`
-            If `True` (and *showmeans* is `True`), will try to render the
-            mean as a line spanning the full width of the box according to
-            *meanprops* (see below).  Not recommended if *shownotches* is also
-            True.  Otherwise, means will be shown as points.
-
-        zorder : float, default: ``Line2D.zorder = 2``
-            The zorder of the boxplot.
-
-        Returns
-        -------
-        dict
-          A dictionary mapping each component of the boxplot to a list
-          of the `.Line2D` instances created. That dictionary has the
-          following keys (assuming vertical boxplots):
-
-          - ``boxes``: the main body of the boxplot showing the
-            quartiles and the median's confidence intervals if
-            enabled.
-
-          - ``medians``: horizontal lines at the median of each box.
-
-          - ``whiskers``: the vertical lines extending to the most
-            extreme, non-outlier data points.
-
-          - ``caps``: the horizontal lines at the ends of the
-            whiskers.
-
-          - ``fliers``: points representing data that extend beyond
-            the whiskers (fliers).
-
-          - ``means``: points or lines representing the means.
-
-        Other Parameters
-        ----------------
-        showcaps : bool, default: :rc:`boxplot.showcaps`
-            Show the caps on the ends of whiskers.
-        showbox : bool, default: :rc:`boxplot.showbox`
-            Show the central box.
-        showfliers : bool, default: :rc:`boxplot.showfliers`
-            Show the outliers beyond the caps.
-        showmeans : bool, default: :rc:`boxplot.showmeans`
-            Show the arithmetic means.
-        capprops : dict, default: None
-            The style of the caps.
-        capwidths : float or array, default: None
-            The widths of the caps.
-        boxprops : dict, default: None
-            The style of the box.
-        whiskerprops : dict, default: None
-            The style of the whiskers.
-        flierprops : dict, default: None
-            The style of the fliers.
-        medianprops : dict, default: None
-            The style of the median.
-        meanprops : dict, default: None
-            The style of the mean.
-        label : str or list of str, optional
-            Legend labels. Use a single string when all boxes have the same style and
-            you only want a single legend entry for them. Use a list of strings to
-            label all boxes individually. To be distinguishable, the boxes should be
-            styled individually, which is currently only possible by modifying the
-            returned artists, see e.g. :doc:`/gallery/statistics/boxplot_demo`.
-
-            In the case of a single string, the legend entry will technically be
-            associated with the first box only. By default, the legend will show the
-            median line (``result["medians"]``); if *patch_artist* is True, the legend
-            will show the box `.Patch` artists (``result["boxes"]``) instead.
-
-            .. versionadded:: 3.9
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        See Also
-        --------
-        .Axes.bxp : Draw a boxplot from pre-computed statistics.
-        violinplot : Draw an estimate of the probability density function.
-        """
-
-        # Missing arguments default to rcParams.
-        if whis is None:
-            whis = mpl.rcParams['boxplot.whiskers']
-        if bootstrap is None:
-            bootstrap = mpl.rcParams['boxplot.bootstrap']
-
-        bxpstats = cbook.boxplot_stats(x, whis=whis, bootstrap=bootstrap,
-                                       labels=tick_labels, autorange=autorange)
-        if notch is None:
-            notch = mpl.rcParams['boxplot.notch']
-        if patch_artist is None:
-            patch_artist = mpl.rcParams['boxplot.patchartist']
-        if meanline is None:
-            meanline = mpl.rcParams['boxplot.meanline']
-        if showmeans is None:
-            showmeans = mpl.rcParams['boxplot.showmeans']
-        if showcaps is None:
-            showcaps = mpl.rcParams['boxplot.showcaps']
-        if showbox is None:
-            showbox = mpl.rcParams['boxplot.showbox']
-        if showfliers is None:
-            showfliers = mpl.rcParams['boxplot.showfliers']
-
-        if boxprops is None:
-            boxprops = {}
-        if whiskerprops is None:
-            whiskerprops = {}
-        if capprops is None:
-            capprops = {}
-        if medianprops is None:
-            medianprops = {}
-        if meanprops is None:
-            meanprops = {}
-        if flierprops is None:
-            flierprops = {}
-
-        if patch_artist:
-            boxprops['linestyle'] = 'solid'  # Not consistent with bxp.
-            if 'color' in boxprops:
-                boxprops['edgecolor'] = boxprops.pop('color')
-
-        # if non-default sym value, put it into the flier dictionary
-        # the logic for providing the default symbol ('b+') now lives
-        # in bxp in the initial value of flierkw
-        # handle all of the *sym* related logic here so we only have to pass
-        # on the flierprops dict.
-        if sym is not None:
-            # no-flier case, which should really be done with
-            # 'showfliers=False' but none-the-less deal with it to keep back
-            # compatibility
-            if sym == '':
-                # blow away existing dict and make one for invisible markers
-                flierprops = dict(linestyle='none', marker='', color='none')
-                # turn the fliers off just to be safe
-                showfliers = False
-            # now process the symbol string
-            else:
-                # process the symbol string
-                # discarded linestyle
-                _, marker, color = _process_plot_format(sym)
-                # if we have a marker, use it
-                if marker is not None:
-                    flierprops['marker'] = marker
-                # if we have a color, use it
-                if color is not None:
-                    # assume that if color is passed in the user want
-                    # filled symbol, if the users want more control use
-                    # flierprops
-                    flierprops['color'] = color
-                    flierprops['markerfacecolor'] = color
-                    flierprops['markeredgecolor'] = color
-
-        # replace medians if necessary:
-        if usermedians is not None:
-            if (len(np.ravel(usermedians)) != len(bxpstats) or
-                    np.shape(usermedians)[0] != len(bxpstats)):
-                raise ValueError(
-                    "'usermedians' and 'x' have different lengths")
-            else:
-                # reassign medians as necessary
-                for stats, med in zip(bxpstats, usermedians):
-                    if med is not None:
-                        stats['med'] = med
-
-        if conf_intervals is not None:
-            if len(conf_intervals) != len(bxpstats):
-                raise ValueError(
-                    "'conf_intervals' and 'x' have different lengths")
-            else:
-                for stats, ci in zip(bxpstats, conf_intervals):
-                    if ci is not None:
-                        if len(ci) != 2:
-                            raise ValueError('each confidence interval must '
-                                             'have two values')
-                        else:
-                            if ci[0] is not None:
-                                stats['cilo'] = ci[0]
-                            if ci[1] is not None:
-                                stats['cihi'] = ci[1]
-
-        artists = self.bxp(bxpstats, positions=positions, widths=widths,
-                           vert=vert, patch_artist=patch_artist,
-                           shownotches=notch, showmeans=showmeans,
-                           showcaps=showcaps, showbox=showbox,
-                           boxprops=boxprops, flierprops=flierprops,
-                           medianprops=medianprops, meanprops=meanprops,
-                           meanline=meanline, showfliers=showfliers,
-                           capprops=capprops, whiskerprops=whiskerprops,
-                           manage_ticks=manage_ticks, zorder=zorder,
-                           capwidths=capwidths, label=label,
-                           orientation=orientation)
-        return artists
-
-    @_api.make_keyword_only("3.9", "widths")
-    def bxp(self, bxpstats, positions=None, widths=None, vert=None,
-            orientation='vertical', patch_artist=False, shownotches=False,
-            showmeans=False, showcaps=True, showbox=True, showfliers=True,
-            boxprops=None, whiskerprops=None, flierprops=None,
-            medianprops=None, capprops=None, meanprops=None,
-            meanline=False, manage_ticks=True, zorder=None,
-            capwidths=None, label=None):
-        """
-        Draw a box and whisker plot from pre-computed statistics.
-
-        The box extends from the first quartile *q1* to the third
-        quartile *q3* of the data, with a line at the median (*med*).
-        The whiskers extend from *whislow* to *whishi*.
-        Flier points are markers past the end of the whiskers.
-        See https://en.wikipedia.org/wiki/Box_plot for reference.
-
-        .. code-block:: none
-
-                   whislow    q1    med    q3    whishi
-                               |-----:-----|
-               o      |--------|     :     |--------|    o  o
-                               |-----:-----|
-             flier                                      fliers
-
-        .. note::
-            This is a low-level drawing function for when you already
-            have the statistical parameters. If you want a boxplot based
-            on a dataset, use `~.Axes.boxplot` instead.
-
-        Parameters
-        ----------
-        bxpstats : list of dicts
-            A list of dictionaries containing stats for each boxplot.
-            Required keys are:
-
-            - ``med``: Median (scalar).
-            - ``q1``, ``q3``: First & third quartiles (scalars).
-            - ``whislo``, ``whishi``: Lower & upper whisker positions (scalars).
-
-            Optional keys are:
-
-            - ``mean``: Mean (scalar).  Needed if ``showmeans=True``.
-            - ``fliers``: Data beyond the whiskers (array-like).
-              Needed if ``showfliers=True``.
-            - ``cilo``, ``cihi``: Lower & upper confidence intervals
-              about the median. Needed if ``shownotches=True``.
-            - ``label``: Name of the dataset (str).  If available,
-              this will be used a tick label for the boxplot
-
-        positions : array-like, default: [1, 2, ..., n]
-            The positions of the boxes. The ticks and limits
-            are automatically set to match the positions.
-
-        widths : float or array-like, default: None
-            The widths of the boxes.  The default is
-            ``clip(0.15*(distance between extreme positions), 0.15, 0.5)``.
-
-        capwidths : float or array-like, default: None
-            Either a scalar or a vector and sets the width of each cap.
-            The default is ``0.5*(width of the box)``, see *widths*.
-
-        vert : bool, optional
-            .. deprecated:: 3.10
-                Use *orientation* instead.
-
-                If this is given during the deprecation period, it overrides
-                the *orientation* parameter.
-
-            If True, plots the boxes vertically.
-            If False, plots the boxes horizontally.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            If 'horizontal', plots the boxes horizontally.
-            Otherwise, plots the boxes vertically.
-
-            .. versionadded:: 3.10
-
-        patch_artist : bool, default: False
-            If `False` produces boxes with the `.Line2D` artist.
-            If `True` produces boxes with the `~matplotlib.patches.Patch` artist.
-
-        shownotches, showmeans, showcaps, showbox, showfliers : bool
-            Whether to draw the CI notches, the mean value (both default to
-            False), the caps, the box, and the fliers (all three default to
-            True).
-
-        boxprops, whiskerprops, capprops, flierprops, medianprops, meanprops :\
- dict, optional
-            Artist properties for the boxes, whiskers, caps, fliers, medians, and
-            means.
-
-        meanline : bool, default: False
-            If `True` (and *showmeans* is `True`), will try to render the mean
-            as a line spanning the full width of the box according to
-            *meanprops*. Not recommended if *shownotches* is also True.
-            Otherwise, means will be shown as points.
-
-        manage_ticks : bool, default: True
-            If True, the tick locations and labels will be adjusted to match the
-            boxplot positions.
-
-        label : str or list of str, optional
-            Legend labels. Use a single string when all boxes have the same style and
-            you only want a single legend entry for them. Use a list of strings to
-            label all boxes individually. To be distinguishable, the boxes should be
-            styled individually, which is currently only possible by modifying the
-            returned artists, see e.g. :doc:`/gallery/statistics/boxplot_demo`.
-
-            In the case of a single string, the legend entry will technically be
-            associated with the first box only. By default, the legend will show the
-            median line (``result["medians"]``); if *patch_artist* is True, the legend
-            will show the box `.Patch` artists (``result["boxes"]``) instead.
-
-            .. versionadded:: 3.9
-
-        zorder : float, default: ``Line2D.zorder = 2``
-            The zorder of the resulting boxplot.
-
-        Returns
-        -------
-        dict
-            A dictionary mapping each component of the boxplot to a list
-            of the `.Line2D` instances created. That dictionary has the
-            following keys (assuming vertical boxplots):
-
-            - ``boxes``: main bodies of the boxplot showing the quartiles, and
-              the median's confidence intervals if enabled.
-            - ``medians``: horizontal lines at the median of each box.
-            - ``whiskers``: vertical lines up to the last non-outlier data.
-            - ``caps``: horizontal lines at the ends of the whiskers.
-            - ``fliers``: points representing data beyond the whiskers (fliers).
-            - ``means``: points or lines representing the means.
-
-        See Also
-        --------
-        boxplot : Draw a boxplot from data instead of pre-computed statistics.
-        """
-        # Clamp median line to edge of box by default.
-        medianprops = {
-            "solid_capstyle": "butt",
-            "dash_capstyle": "butt",
-            **(medianprops or {}),
-        }
-        meanprops = {
-            "solid_capstyle": "butt",
-            "dash_capstyle": "butt",
-            **(meanprops or {}),
-        }
-
-        # lists of artists to be output
-        whiskers = []
-        caps = []
-        boxes = []
-        medians = []
-        means = []
-        fliers = []
-
-        # empty list of xticklabels
-        datalabels = []
-
-        # Use default zorder if none specified
-        if zorder is None:
-            zorder = mlines.Line2D.zorder
-
-        zdelta = 0.1
-
-        def merge_kw_rc(subkey, explicit, zdelta=0, usemarker=True):
-            d = {k.split('.')[-1]: v for k, v in mpl.rcParams.items()
-                 if k.startswith(f'boxplot.{subkey}props')}
-            d['zorder'] = zorder + zdelta
-            if not usemarker:
-                d['marker'] = ''
-            d.update(cbook.normalize_kwargs(explicit, mlines.Line2D))
-            return d
-
-        box_kw = {
-            'linestyle': mpl.rcParams['boxplot.boxprops.linestyle'],
-            'linewidth': mpl.rcParams['boxplot.boxprops.linewidth'],
-            'edgecolor': mpl.rcParams['boxplot.boxprops.color'],
-            'facecolor': ('white' if mpl.rcParams['_internal.classic_mode']
-                          else mpl.rcParams['patch.facecolor']),
-            'zorder': zorder,
-            **cbook.normalize_kwargs(boxprops, mpatches.PathPatch)
-        } if patch_artist else merge_kw_rc('box', boxprops, usemarker=False)
-        whisker_kw = merge_kw_rc('whisker', whiskerprops, usemarker=False)
-        cap_kw = merge_kw_rc('cap', capprops, usemarker=False)
-        flier_kw = merge_kw_rc('flier', flierprops)
-        median_kw = merge_kw_rc('median', medianprops, zdelta, usemarker=False)
-        mean_kw = merge_kw_rc('mean', meanprops, zdelta)
-        removed_prop = 'marker' if meanline else 'linestyle'
-        # Only remove the property if it's not set explicitly as a parameter.
-        if meanprops is None or removed_prop not in meanprops:
-            mean_kw[removed_prop] = ''
-
-        # vert and orientation parameters are linked until vert's
-        # deprecation period expires. vert only takes precedence
-        # if set to False.
-        if vert is None:
-            vert = mpl.rcParams['boxplot.vertical']
-        else:
-            _api.warn_deprecated(
-                "3.10",
-                name="vert: bool",
-                alternative="orientation: {'vertical', 'horizontal'}"
-            )
-        if vert is False:
-            orientation = 'horizontal'
-        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
-
-        if not mpl.rcParams['boxplot.vertical']:
-            _api.warn_deprecated(
-                "3.10",
-                name='boxplot.vertical', obj_type="rcparam"
-            )
-
-        # vertical or horizontal plot?
-        maybe_swap = slice(None) if orientation == 'vertical' else slice(None, None, -1)
-
-        def do_plot(xs, ys, **kwargs):
-            return self.plot(*[xs, ys][maybe_swap], **kwargs)[0]
-
-        def do_patch(xs, ys, **kwargs):
-            path = mpath.Path._create_closed(
-                np.column_stack([xs, ys][maybe_swap]))
-            patch = mpatches.PathPatch(path, **kwargs)
-            self.add_artist(patch)
-            return patch
-
-        # input validation
-        N = len(bxpstats)
-        datashape_message = ("List of boxplot statistics and `{0}` "
-                             "values must have same the length")
-        # check position
-        if positions is None:
-            positions = list(range(1, N + 1))
-        elif len(positions) != N:
-            raise ValueError(datashape_message.format("positions"))
-
-        positions = np.array(positions)
-        if len(positions) > 0 and not all(isinstance(p, Real) for p in positions):
-            raise TypeError("positions should be an iterable of numbers")
-
-        # width
-        if widths is None:
-            widths = [np.clip(0.15 * np.ptp(positions), 0.15, 0.5)] * N
-        elif np.isscalar(widths):
-            widths = [widths] * N
-        elif len(widths) != N:
-            raise ValueError(datashape_message.format("widths"))
-
-        # capwidth
-        if capwidths is None:
-            capwidths = 0.5 * np.array(widths)
-        elif np.isscalar(capwidths):
-            capwidths = [capwidths] * N
-        elif len(capwidths) != N:
-            raise ValueError(datashape_message.format("capwidths"))
-
-        for pos, width, stats, capwidth in zip(positions, widths, bxpstats,
-                                               capwidths):
-            # try to find a new label
-            datalabels.append(stats.get('label', pos))
-
-            # whisker coords
-            whis_x = [pos, pos]
-            whislo_y = [stats['q1'], stats['whislo']]
-            whishi_y = [stats['q3'], stats['whishi']]
-            # cap coords
-            cap_left = pos - capwidth * 0.5
-            cap_right = pos + capwidth * 0.5
-            cap_x = [cap_left, cap_right]
-            cap_lo = np.full(2, stats['whislo'])
-            cap_hi = np.full(2, stats['whishi'])
-            # box and median coords
-            box_left = pos - width * 0.5
-            box_right = pos + width * 0.5
-            med_y = [stats['med'], stats['med']]
-            # notched boxes
-            if shownotches:
-                notch_left = pos - width * 0.25
-                notch_right = pos + width * 0.25
-                box_x = [box_left, box_right, box_right, notch_right,
-                         box_right, box_right, box_left, box_left, notch_left,
-                         box_left, box_left]
-                box_y = [stats['q1'], stats['q1'], stats['cilo'],
-                         stats['med'], stats['cihi'], stats['q3'],
-                         stats['q3'], stats['cihi'], stats['med'],
-                         stats['cilo'], stats['q1']]
-                med_x = [notch_left, notch_right]
-            # plain boxes
-            else:
-                box_x = [box_left, box_right, box_right, box_left, box_left]
-                box_y = [stats['q1'], stats['q1'], stats['q3'], stats['q3'],
-                         stats['q1']]
-                med_x = [box_left, box_right]
-
-            # maybe draw the box
-            if showbox:
-                do_box = do_patch if patch_artist else do_plot
-                boxes.append(do_box(box_x, box_y, **box_kw))
-                median_kw.setdefault('label', '_nolegend_')
-            # draw the whiskers
-            whisker_kw.setdefault('label', '_nolegend_')
-            whiskers.append(do_plot(whis_x, whislo_y, **whisker_kw))
-            whiskers.append(do_plot(whis_x, whishi_y, **whisker_kw))
-            # maybe draw the caps
-            if showcaps:
-                cap_kw.setdefault('label', '_nolegend_')
-                caps.append(do_plot(cap_x, cap_lo, **cap_kw))
-                caps.append(do_plot(cap_x, cap_hi, **cap_kw))
-            # draw the medians
-            medians.append(do_plot(med_x, med_y, **median_kw))
-            # maybe draw the means
-            if showmeans:
-                if meanline:
-                    means.append(do_plot(
-                        [box_left, box_right], [stats['mean'], stats['mean']],
-                        **mean_kw
-                    ))
-                else:
-                    means.append(do_plot([pos], [stats['mean']], **mean_kw))
-            # maybe draw the fliers
-            if showfliers:
-                flier_kw.setdefault('label', '_nolegend_')
-                flier_x = np.full(len(stats['fliers']), pos, dtype=np.float64)
-                flier_y = stats['fliers']
-                fliers.append(do_plot(flier_x, flier_y, **flier_kw))
-
-        # Set legend labels
-        if label:
-            box_or_med = boxes if showbox and patch_artist else medians
-            if cbook.is_scalar_or_string(label):
-                # assign the label only to the first box
-                box_or_med[0].set_label(label)
-            else:  # label is a sequence
-                if len(box_or_med) != len(label):
-                    raise ValueError(datashape_message.format("label"))
-                for artist, lbl in zip(box_or_med, label):
-                    artist.set_label(lbl)
-
-        if manage_ticks:
-            axis_name = "x" if orientation == 'vertical' else "y"
-            interval = getattr(self.dataLim, f"interval{axis_name}")
-            axis = self._axis_map[axis_name]
-            positions = axis.convert_units(positions)
-            # The 0.5 additional padding ensures reasonable-looking boxes
-            # even when drawing a single box.  We set the sticky edge to
-            # prevent margins expansion, in order to match old behavior (back
-            # when separate calls to boxplot() would completely reset the axis
-            # limits regardless of what was drawn before).  The sticky edges
-            # are attached to the median lines, as they are always present.
-            interval[:] = (min(interval[0], min(positions) - .5),
-                           max(interval[1], max(positions) + .5))
-            for median, position in zip(medians, positions):
-                getattr(median.sticky_edges, axis_name).extend(
-                    [position - .5, position + .5])
-            # Modified from Axis.set_ticks and Axis.set_ticklabels.
-            locator = axis.get_major_locator()
-            if not isinstance(axis.get_major_locator(),
-                              mticker.FixedLocator):
-                locator = mticker.FixedLocator([])
-                axis.set_major_locator(locator)
-            locator.locs = np.array([*locator.locs, *positions])
-            formatter = axis.get_major_formatter()
-            if not isinstance(axis.get_major_formatter(),
-                              mticker.FixedFormatter):
-                formatter = mticker.FixedFormatter([])
-                axis.set_major_formatter(formatter)
-            formatter.seq = [*formatter.seq, *datalabels]
-
-            self._request_autoscale_view()
-
-        return dict(whiskers=whiskers, caps=caps, boxes=boxes,
-                    medians=medians, fliers=fliers, means=means)
-
-    @staticmethod
-    def _parse_scatter_color_args(c, edgecolors, kwargs, xsize,
-                                  get_next_color_func):
-        """
-        Helper function to process color related arguments of `.Axes.scatter`.
-
-        Argument precedence for facecolors:
-
-        - c (if not None)
-        - kwargs['facecolor']
-        - kwargs['facecolors']
-        - kwargs['color'] (==kwcolor)
-        - 'b' if in classic mode else the result of ``get_next_color_func()``
-
-        Argument precedence for edgecolors:
-
-        - kwargs['edgecolor']
-        - edgecolors (is an explicit kw argument in scatter())
-        - kwargs['color'] (==kwcolor)
-        - 'face' if not in classic mode else None
-
-        Parameters
-        ----------
-        c : :mpltype:`color` or array-like or list of :mpltype:`color` or None
-            See argument description of `.Axes.scatter`.
-        edgecolors : :mpltype:`color` or sequence of color or {'face', 'none'} or None
-            See argument description of `.Axes.scatter`.
-        kwargs : dict
-            Additional kwargs. If these keys exist, we pop and process them:
-            'facecolors', 'facecolor', 'edgecolor', 'color'
-            Note: The dict is modified by this function.
-        xsize : int
-            The size of the x and y arrays passed to `.Axes.scatter`.
-        get_next_color_func : callable
-            A callable that returns a color. This color is used as facecolor
-            if no other color is provided.
-
-            Note, that this is a function rather than a fixed color value to
-            support conditional evaluation of the next color.  As of the
-            current implementation obtaining the next color from the
-            property cycle advances the cycle. This must only happen if we
-            actually use the color, which will only be decided within this
-            method.
-
-        Returns
-        -------
-        c
-            The input *c* if it was not *None*, else a color derived from the
-            other inputs or defaults.
-        colors : array(N, 4) or None
-            The facecolors as RGBA values, or *None* if a colormap is used.
-        edgecolors
-            The edgecolor.
-
-        """
-        facecolors = kwargs.pop('facecolors', None)
-        facecolors = kwargs.pop('facecolor', facecolors)
-        edgecolors = kwargs.pop('edgecolor', edgecolors)
-
-        kwcolor = kwargs.pop('color', None)
-
-        if kwcolor is not None and c is not None:
-            raise ValueError("Supply a 'c' argument or a 'color'"
-                             " kwarg but not both; they differ but"
-                             " their functionalities overlap.")
-
-        if kwcolor is not None:
-            try:
-                mcolors.to_rgba_array(kwcolor)
-            except ValueError as err:
-                raise ValueError(
-                    "'color' kwarg must be a color or sequence of color "
-                    "specs.  For a sequence of values to be color-mapped, use "
-                    "the 'c' argument instead.") from err
-            if edgecolors is None:
-                edgecolors = kwcolor
-            if facecolors is None:
-                facecolors = kwcolor
-
-        if edgecolors is None and not mpl.rcParams['_internal.classic_mode']:
-            edgecolors = mpl.rcParams['scatter.edgecolors']
-
-        c_was_none = c is None
-        if c is None:
-            c = (facecolors if facecolors is not None
-                 else "b" if mpl.rcParams['_internal.classic_mode']
-                 else get_next_color_func())
-        c_is_string_or_strings = (
-            isinstance(c, str)
-            or (np.iterable(c) and len(c) > 0
-                and isinstance(cbook._safe_first_finite(c), str)))
-
-        def invalid_shape_exception(csize, xsize):
-            return ValueError(
-                f"'c' argument has {csize} elements, which is inconsistent "
-                f"with 'x' and 'y' with size {xsize}.")
-
-        c_is_mapped = False  # Unless proven otherwise below.
-        valid_shape = True  # Unless proven otherwise below.
-        if not c_was_none and kwcolor is None and not c_is_string_or_strings:
-            try:  # First, does 'c' look suitable for value-mapping?
-                c = np.asanyarray(c, dtype=float)
-            except ValueError:
-                pass  # Failed to convert to float array; must be color specs.
-            else:
-                # handle the documented special case of a 2D array with 1
-                # row which as RGB(A) to broadcast.
-                if c.shape == (1, 4) or c.shape == (1, 3):
-                    c_is_mapped = False
-                    if c.size != xsize:
-                        valid_shape = False
-                # If c can be either mapped values or an RGB(A) color, prefer
-                # the former if shapes match, the latter otherwise.
-                elif c.size == xsize:
-                    c = c.ravel()
-                    c_is_mapped = True
-                else:  # Wrong size; it must not be intended for mapping.
-                    if c.shape in ((3,), (4,)):
-                        _api.warn_external(
-                            "*c* argument looks like a single numeric RGB or "
-                            "RGBA sequence, which should be avoided as value-"
-                            "mapping will have precedence in case its length "
-                            "matches with *x* & *y*.  Please use the *color* "
-                            "keyword-argument or provide a 2D array "
-                            "with a single row if you intend to specify "
-                            "the same RGB or RGBA value for all points.")
-                    valid_shape = False
-        if not c_is_mapped:
-            try:  # Is 'c' acceptable as PathCollection facecolors?
-                colors = mcolors.to_rgba_array(c)
-            except (TypeError, ValueError) as err:
-                if "RGBA values should be within 0-1 range" in str(err):
-                    raise
-                else:
-                    if not valid_shape:
-                        raise invalid_shape_exception(c.size, xsize) from err
-                    # Both the mapping *and* the RGBA conversion failed: pretty
-                    # severe failure => one may appreciate a verbose feedback.
-                    raise ValueError(
-                        f"'c' argument must be a color, a sequence of colors, "
-                        f"or a sequence of numbers, not {c!r}") from err
-            else:
-                if len(colors) not in (0, 1, xsize):
-                    # NB: remember that a single color is also acceptable.
-                    # Besides *colors* will be an empty array if c == 'none'.
-                    raise invalid_shape_exception(len(colors), xsize)
-        else:
-            colors = None  # use cmap, norm after collection is created
-        return c, colors, edgecolors
-
-    @_api.make_keyword_only("3.9", "marker")
-    @_preprocess_data(replace_names=["x", "y", "s", "linewidths",
-                                     "edgecolors", "c", "facecolor",
-                                     "facecolors", "color"],
-                      label_namer="y")
-    @_docstring.interpd
-    def scatter(self, x, y, s=None, c=None, marker=None, cmap=None, norm=None,
-                vmin=None, vmax=None, alpha=None, linewidths=None, *,
-                edgecolors=None, colorizer=None, plotnonfinite=False, **kwargs):
-        """
-        A scatter plot of *y* vs. *x* with varying marker size and/or color.
-
-        Parameters
-        ----------
-        x, y : float or array-like, shape (n, )
-            The data positions.
-
-        s : float or array-like, shape (n, ), optional
-            The marker size in points**2 (typographic points are 1/72 in.).
-            Default is ``rcParams['lines.markersize'] ** 2``.
-
-            The linewidth and edgecolor can visually interact with the marker
-            size, and can lead to artifacts if the marker size is smaller than
-            the linewidth.
-
-            If the linewidth is greater than 0 and the edgecolor is anything
-            but *'none'*, then the effective size of the marker will be
-            increased by half the linewidth because the stroke will be centered
-            on the edge of the shape.
-
-            To eliminate the marker edge either set *linewidth=0* or
-            *edgecolor='none'*.
-
-        c : array-like or list of :mpltype:`color` or :mpltype:`color`, optional
-            The marker colors. Possible values:
-
-            - A scalar or sequence of n numbers to be mapped to colors using
-              *cmap* and *norm*.
-            - A 2D array in which the rows are RGB or RGBA.
-            - A sequence of colors of length n.
-            - A single color format string.
-
-            Note that *c* should not be a single numeric RGB or RGBA sequence
-            because that is indistinguishable from an array of values to be
-            colormapped. If you want to specify the same RGB or RGBA value for
-            all points, use a 2D array with a single row.  Otherwise,
-            value-matching will have precedence in case of a size matching with
-            *x* and *y*.
-
-            If you wish to specify a single color for all points
-            prefer the *color* keyword argument.
-
-            Defaults to `None`. In that case the marker color is determined
-            by the value of *color*, *facecolor* or *facecolors*. In case
-            those are not specified or `None`, the marker color is determined
-            by the next color of the ``Axes``' current "shape and fill" color
-            cycle. This cycle defaults to :rc:`axes.prop_cycle`.
-
-        marker : `~.markers.MarkerStyle`, default: :rc:`scatter.marker`
-            The marker style. *marker* can be either an instance of the class
-            or the text shorthand for a particular marker.
-            See :mod:`matplotlib.markers` for more information about marker
-            styles.
-
-        %(cmap_doc)s
-
-            This parameter is ignored if *c* is RGB(A).
-
-        %(norm_doc)s
-
-            This parameter is ignored if *c* is RGB(A).
-
-        %(vmin_vmax_doc)s
-
-            This parameter is ignored if *c* is RGB(A).
-
-        alpha : float, default: None
-            The alpha blending value, between 0 (transparent) and 1 (opaque).
-
-        linewidths : float or array-like, default: :rc:`lines.linewidth`
-            The linewidth of the marker edges. Note: The default *edgecolors*
-            is 'face'. You may want to change this as well.
-
-        edgecolors : {'face', 'none', *None*} or :mpltype:`color` or list of \
-:mpltype:`color`, default: :rc:`scatter.edgecolors`
-            The edge color of the marker. Possible values:
-
-            - 'face': The edge color will always be the same as the face color.
-            - 'none': No patch boundary will be drawn.
-            - A color or sequence of colors.
-
-            For non-filled markers, *edgecolors* is ignored. Instead, the color
-            is determined like with 'face', i.e. from *c*, *colors*, or
-            *facecolors*.
-
-        %(colorizer_doc)s
-
-            This parameter is ignored if *c* is RGB(A).
-
-        plotnonfinite : bool, default: False
-            Whether to plot points with nonfinite *c* (i.e. ``inf``, ``-inf``
-            or ``nan``). If ``True`` the points are drawn with the *bad*
-            colormap color (see `.Colormap.set_bad`).
-
-        Returns
-        -------
-        `~matplotlib.collections.PathCollection`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-        **kwargs : `~matplotlib.collections.Collection` properties
-
-        See Also
-        --------
-        plot : To plot scatter plots when markers are identical in size and
-            color.
-
-        Notes
-        -----
-        * The `.plot` function will be faster for scatterplots where markers
-          don't vary in size or color.
-
-        * Any or all of *x*, *y*, *s*, and *c* may be masked arrays, in which
-          case all masks will be combined and only unmasked points will be
-          plotted.
-
-        * Fundamentally, scatter works with 1D arrays; *x*, *y*, *s*, and *c*
-          may be input as N-D arrays, but within scatter they will be
-          flattened. The exception is *c*, which will be flattened only if its
-          size matches the size of *x* and *y*.
-
-        """
-        # add edgecolors and linewidths to kwargs so they
-        # can be processed by normailze_kwargs
-        if edgecolors is not None:
-            kwargs.update({'edgecolors': edgecolors})
-        if linewidths is not None:
-            kwargs.update({'linewidths': linewidths})
-
-        kwargs = cbook.normalize_kwargs(kwargs, mcoll.Collection)
-        # re direct linewidth and edgecolor so it can be
-        # further processed by the rest of the function
-        linewidths = kwargs.pop('linewidth', None)
-        edgecolors = kwargs.pop('edgecolor', None)
-        # Process **kwargs to handle aliases, conflicts with explicit kwargs:
-        x, y = self._process_unit_info([("x", x), ("y", y)], kwargs)
-        # np.ma.ravel yields an ndarray, not a masked array,
-        # unless its argument is a masked array.
-        x = np.ma.ravel(x)
-        y = np.ma.ravel(y)
-        if x.size != y.size:
-            raise ValueError("x and y must be the same size")
-
-        if s is None:
-            s = (20 if mpl.rcParams['_internal.classic_mode'] else
-                 mpl.rcParams['lines.markersize'] ** 2.0)
-        s = np.ma.ravel(s)
-        if (len(s) not in (1, x.size) or
-                (not np.issubdtype(s.dtype, np.floating) and
-                 not np.issubdtype(s.dtype, np.integer))):
-            raise ValueError(
-                "s must be a scalar, "
-                "or float array-like with the same size as x and y")
-
-        # get the original edgecolor the user passed before we normalize
-        orig_edgecolor = edgecolors
-        if edgecolors is None:
-            orig_edgecolor = kwargs.get('edgecolor', None)
-        c, colors, edgecolors = \
-            self._parse_scatter_color_args(
-                c, edgecolors, kwargs, x.size,
-                get_next_color_func=self._get_patches_for_fill.get_next_color)
-
-        if plotnonfinite and colors is None:
-            c = np.ma.masked_invalid(c)
-            x, y, s, edgecolors, linewidths = \
-                cbook._combine_masks(x, y, s, edgecolors, linewidths)
-        else:
-            x, y, s, c, colors, edgecolors, linewidths = \
-                cbook._combine_masks(
-                    x, y, s, c, colors, edgecolors, linewidths)
-        # Unmask edgecolors if it was actually a single RGB or RGBA.
-        if (x.size in (3, 4)
-                and np.ma.is_masked(edgecolors)
-                and not np.ma.is_masked(orig_edgecolor)):
-            edgecolors = edgecolors.data
-
-        scales = s   # Renamed for readability below.
-
-        # load default marker from rcParams
-        if marker is None:
-            marker = mpl.rcParams['scatter.marker']
-
-        if isinstance(marker, mmarkers.MarkerStyle):
-            marker_obj = marker
-        else:
-            marker_obj = mmarkers.MarkerStyle(marker)
-
-        path = marker_obj.get_path().transformed(
-            marker_obj.get_transform())
-        if not marker_obj.is_filled():
-            if orig_edgecolor is not None:
-                _api.warn_external(
-                    f"You passed a edgecolor/edgecolors ({orig_edgecolor!r}) "
-                    f"for an unfilled marker ({marker!r}).  Matplotlib is "
-                    "ignoring the edgecolor in favor of the facecolor.  This "
-                    "behavior may change in the future."
-                )
-            # We need to handle markers that cannot be filled (like
-            # '+' and 'x') differently than markers that can be
-            # filled, but have their fillstyle set to 'none'.  This is
-            # to get:
-            #
-            #  - respecting the fillestyle if set
-            #  - maintaining back-compatibility for querying the facecolor of
-            #    the un-fillable markers.
-            #
-            # While not an ideal situation, but is better than the
-            # alternatives.
-            if marker_obj.get_fillstyle() == 'none':
-                # promote the facecolor to be the edgecolor
-                edgecolors = colors
-                # set the facecolor to 'none' (at the last chance) because
-                # we cannot fill a path if the facecolor is non-null
-                # (which is defendable at the renderer level).
-                colors = 'none'
-            else:
-                # if we are not nulling the face color we can do this
-                # simpler
-                edgecolors = 'face'
-
-            if linewidths is None:
-                linewidths = mpl.rcParams['lines.linewidth']
-            elif np.iterable(linewidths):
-                linewidths = [
-                    lw if lw is not None else mpl.rcParams['lines.linewidth']
-                    for lw in linewidths]
-
-        offsets = np.ma.column_stack([x, y])
-
-        collection = mcoll.PathCollection(
-            (path,), scales,
-            facecolors=colors,
-            edgecolors=edgecolors,
-            linewidths=linewidths,
-            offsets=offsets,
-            offset_transform=kwargs.pop('transform', self.transData),
-            alpha=alpha,
-        )
-        collection.set_transform(mtransforms.IdentityTransform())
-        if colors is None:
-            if colorizer:
-                collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
-                                                         norm=norm, vmin=vmin,
-                                                         vmax=vmax)
-            else:
-                collection.set_cmap(cmap)
-                collection.set_norm(norm)
-            collection.set_array(c)
-            collection._scale_norm(norm, vmin, vmax)
-        else:
-            extra_kwargs = {
-                    'cmap': cmap, 'norm': norm, 'vmin': vmin, 'vmax': vmax
-                    }
-            extra_keys = [k for k, v in extra_kwargs.items() if v is not None]
-            if any(extra_keys):
-                keys_str = ", ".join(f"'{k}'" for k in extra_keys)
-                _api.warn_external(
-                    "No data for colormapping provided via 'c'. "
-                    f"Parameters {keys_str} will be ignored")
-        collection._internal_update(kwargs)
-
-        # Classic mode only:
-        # ensure there are margins to allow for the
-        # finite size of the symbols.  In v2.x, margins
-        # are present by default, so we disable this
-        # scatter-specific override.
-        if mpl.rcParams['_internal.classic_mode']:
-            if self._xmargin < 0.05 and x.size > 0:
-                self.set_xmargin(0.05)
-            if self._ymargin < 0.05 and x.size > 0:
-                self.set_ymargin(0.05)
-
-        self.add_collection(collection)
-        self._request_autoscale_view()
-
-        return collection
-
-    @_api.make_keyword_only("3.9", "gridsize")
-    @_preprocess_data(replace_names=["x", "y", "C"], label_namer="y")
-    @_docstring.interpd
-    def hexbin(self, x, y, C=None, gridsize=100, bins=None,
-               xscale='linear', yscale='linear', extent=None,
-               cmap=None, norm=None, vmin=None, vmax=None,
-               alpha=None, linewidths=None, edgecolors='face',
-               reduce_C_function=np.mean, mincnt=None, marginals=False,
-               colorizer=None, **kwargs):
-        """
-        Make a 2D hexagonal binning plot of points *x*, *y*.
-
-        If *C* is *None*, the value of the hexagon is determined by the number
-        of points in the hexagon. Otherwise, *C* specifies values at the
-        coordinate (x[i], y[i]). For each hexagon, these values are reduced
-        using *reduce_C_function*.
-
-        Parameters
-        ----------
-        x, y : array-like
-            The data positions. *x* and *y* must be of the same length.
-
-        C : array-like, optional
-            If given, these values are accumulated in the bins. Otherwise,
-            every point has a value of 1. Must be of the same length as *x*
-            and *y*.
-
-        gridsize : int or (int, int), default: 100
-            If a single int, the number of hexagons in the *x*-direction.
-            The number of hexagons in the *y*-direction is chosen such that
-            the hexagons are approximately regular.
-
-            Alternatively, if a tuple (*nx*, *ny*), the number of hexagons
-            in the *x*-direction and the *y*-direction. In the
-            *y*-direction, counting is done along vertically aligned
-            hexagons, not along the zig-zag chains of hexagons; see the
-            following illustration.
-
-            .. plot::
-
-               import numpy
-               import matplotlib.pyplot as plt
-
-               np.random.seed(19680801)
-               n= 300
-               x = np.random.standard_normal(n)
-               y = np.random.standard_normal(n)
-
-               fig, ax = plt.subplots(figsize=(4, 4))
-               h = ax.hexbin(x, y, gridsize=(5, 3))
-               hx, hy = h.get_offsets().T
-               ax.plot(hx[24::3], hy[24::3], 'ro-')
-               ax.plot(hx[-3:], hy[-3:], 'ro-')
-               ax.set_title('gridsize=(5, 3)')
-               ax.axis('off')
-
-            To get approximately regular hexagons, choose
-            :math:`n_x = \\sqrt{3}\\,n_y`.
-
-        bins : 'log' or int or sequence, default: None
-            Discretization of the hexagon values.
-
-            - If *None*, no binning is applied; the color of each hexagon
-              directly corresponds to its count value.
-            - If 'log', use a logarithmic scale for the colormap.
-              Internally, :math:`log_{10}(i+1)` is used to determine the
-              hexagon color. This is equivalent to ``norm=LogNorm()``.
-            - If an integer, divide the counts in the specified number
-              of bins, and color the hexagons accordingly.
-            - If a sequence of values, the values of the lower bound of
-              the bins to be used.
-
-        xscale : {'linear', 'log'}, default: 'linear'
-            Use a linear or log10 scale on the horizontal axis.
-
-        yscale : {'linear', 'log'}, default: 'linear'
-            Use a linear or log10 scale on the vertical axis.
-
-        mincnt : int >= 0, default: *None*
-            If not *None*, only display cells with at least *mincnt*
-            number of points in the cell.
-
-        marginals : bool, default: *False*
-            If marginals is *True*, plot the marginal density as
-            colormapped rectangles along the bottom of the x-axis and
-            left of the y-axis.
-
-        extent : 4-tuple of float, default: *None*
-            The limits of the bins (xmin, xmax, ymin, ymax).
-            The default assigns the limits based on
-            *gridsize*, *x*, *y*, *xscale* and *yscale*.
-
-            If *xscale* or *yscale* is set to 'log', the limits are
-            expected to be the exponent for a power of 10. E.g. for
-            x-limits of 1 and 50 in 'linear' scale and y-limits
-            of 10 and 1000 in 'log' scale, enter (1, 50, 1, 3).
-
-        Returns
-        -------
-        `~matplotlib.collections.PolyCollection`
-            A `.PolyCollection` defining the hexagonal bins.
-
-            - `.PolyCollection.get_offsets` contains a Mx2 array containing
-              the x, y positions of the M hexagon centers in data coordinates.
-            - `.PolyCollection.get_array` contains the values of the M
-              hexagons.
-
-            If *marginals* is *True*, horizontal
-            bar and vertical bar (both PolyCollections) will be attached
-            to the return collection as attributes *hbar* and *vbar*.
-
-        Other Parameters
-        ----------------
-        %(cmap_doc)s
-
-        %(norm_doc)s
-
-        %(vmin_vmax_doc)s
-
-        alpha : float between 0 and 1, optional
-            The alpha blending value, between 0 (transparent) and 1 (opaque).
-
-        linewidths : float, default: *None*
-            If *None*, defaults to :rc:`patch.linewidth`.
-
-        edgecolors : {'face', 'none', *None*} or color, default: 'face'
-            The color of the hexagon edges. Possible values are:
-
-            - 'face': Draw the edges in the same color as the fill color.
-            - 'none': No edges are drawn. This can sometimes lead to unsightly
-              unpainted pixels between the hexagons.
-            - *None*: Draw outlines in the default color.
-            - An explicit color.
-
-        reduce_C_function : callable, default: `numpy.mean`
-            The function to aggregate *C* within the bins. It is ignored if
-            *C* is not given. This must have the signature::
-
-                def reduce_C_function(C: array) -> float
-
-            Commonly used functions are:
-
-            - `numpy.mean`: average of the points
-            - `numpy.sum`: integral of the point values
-            - `numpy.amax`: value taken from the largest point
-
-            By default will only reduce cells with at least 1 point because some
-            reduction functions (such as `numpy.amax`) will error/warn with empty
-            input. Changing *mincnt* will adjust the cutoff, and if set to 0 will
-            pass empty input to the reduction function.
-
-        %(colorizer_doc)s
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs : `~matplotlib.collections.PolyCollection` properties
-            All other keyword arguments are passed on to `.PolyCollection`:
-
-            %(PolyCollection:kwdoc)s
-
-        See Also
-        --------
-        hist2d : 2D histogram rectangular bins
-        """
-        self._process_unit_info([("x", x), ("y", y)], kwargs, convert=False)
-
-        x, y, C = cbook.delete_masked_points(x, y, C)
-
-        # Set the size of the hexagon grid
-        if np.iterable(gridsize):
-            nx, ny = gridsize
-        else:
-            nx = gridsize
-            ny = int(nx / math.sqrt(3))
-        # Count the number of data in each hexagon
-        x = np.asarray(x, float)
-        y = np.asarray(y, float)
-
-        # Will be log()'d if necessary, and then rescaled.
-        tx = x
-        ty = y
-
-        if xscale == 'log':
-            if np.any(x <= 0.0):
-                raise ValueError(
-                    "x contains non-positive values, so cannot be log-scaled")
-            tx = np.log10(tx)
-        if yscale == 'log':
-            if np.any(y <= 0.0):
-                raise ValueError(
-                    "y contains non-positive values, so cannot be log-scaled")
-            ty = np.log10(ty)
-        if extent is not None:
-            xmin, xmax, ymin, ymax = extent
-            if xmin > xmax:
-                raise ValueError("In extent, xmax must be greater than xmin")
-            if ymin > ymax:
-                raise ValueError("In extent, ymax must be greater than ymin")
-        else:
-            xmin, xmax = (tx.min(), tx.max()) if len(x) else (0, 1)
-            ymin, ymax = (ty.min(), ty.max()) if len(y) else (0, 1)
-
-            # to avoid issues with singular data, expand the min/max pairs
-            xmin, xmax = mtransforms.nonsingular(xmin, xmax, expander=0.1)
-            ymin, ymax = mtransforms.nonsingular(ymin, ymax, expander=0.1)
-
-        nx1 = nx + 1
-        ny1 = ny + 1
-        nx2 = nx
-        ny2 = ny
-        n = nx1 * ny1 + nx2 * ny2
-
-        # In the x-direction, the hexagons exactly cover the region from
-        # xmin to xmax. Need some padding to avoid roundoff errors.
-        padding = 1.e-9 * (xmax - xmin)
-        xmin -= padding
-        xmax += padding
-        sx = (xmax - xmin) / nx
-        sy = (ymax - ymin) / ny
-        # Positions in hexagon index coordinates.
-        ix = (tx - xmin) / sx
-        iy = (ty - ymin) / sy
-        ix1 = np.round(ix).astype(int)
-        iy1 = np.round(iy).astype(int)
-        ix2 = np.floor(ix).astype(int)
-        iy2 = np.floor(iy).astype(int)
-        # flat indices, plus one so that out-of-range points go to position 0.
-        i1 = np.where((0 <= ix1) & (ix1 < nx1) & (0 <= iy1) & (iy1 < ny1),
-                      ix1 * ny1 + iy1 + 1, 0)
-        i2 = np.where((0 <= ix2) & (ix2 < nx2) & (0 <= iy2) & (iy2 < ny2),
-                      ix2 * ny2 + iy2 + 1, 0)
-
-        d1 = (ix - ix1) ** 2 + 3.0 * (iy - iy1) ** 2
-        d2 = (ix - ix2 - 0.5) ** 2 + 3.0 * (iy - iy2 - 0.5) ** 2
-        bdist = (d1 < d2)
-
-        if C is None:  # [1:] drops out-of-range points.
-            counts1 = np.bincount(i1[bdist], minlength=1 + nx1 * ny1)[1:]
-            counts2 = np.bincount(i2[~bdist], minlength=1 + nx2 * ny2)[1:]
-            accum = np.concatenate([counts1, counts2]).astype(float)
-            if mincnt is not None:
-                accum[accum < mincnt] = np.nan
-            C = np.ones(len(x))
-        else:
-            # store the C values in a list per hexagon index
-            Cs_at_i1 = [[] for _ in range(1 + nx1 * ny1)]
-            Cs_at_i2 = [[] for _ in range(1 + nx2 * ny2)]
-            for i in range(len(x)):
-                if bdist[i]:
-                    Cs_at_i1[i1[i]].append(C[i])
-                else:
-                    Cs_at_i2[i2[i]].append(C[i])
-            if mincnt is None:
-                mincnt = 1
-            accum = np.array(
-                [reduce_C_function(acc) if len(acc) >= mincnt else np.nan
-                 for Cs_at_i in [Cs_at_i1, Cs_at_i2]
-                 for acc in Cs_at_i[1:]],  # [1:] drops out-of-range points.
-                float)
-
-        good_idxs = ~np.isnan(accum)
-
-        offsets = np.zeros((n, 2), float)
-        offsets[:nx1 * ny1, 0] = np.repeat(np.arange(nx1), ny1)
-        offsets[:nx1 * ny1, 1] = np.tile(np.arange(ny1), nx1)
-        offsets[nx1 * ny1:, 0] = np.repeat(np.arange(nx2) + 0.5, ny2)
-        offsets[nx1 * ny1:, 1] = np.tile(np.arange(ny2), nx2) + 0.5
-        offsets[:, 0] *= sx
-        offsets[:, 1] *= sy
-        offsets[:, 0] += xmin
-        offsets[:, 1] += ymin
-        # remove accumulation bins with no data
-        offsets = offsets[good_idxs, :]
-        accum = accum[good_idxs]
-
-        polygon = [sx, sy / 3] * np.array(
-            [[.5, -.5], [.5, .5], [0., 1.], [-.5, .5], [-.5, -.5], [0., -1.]])
-
-        if linewidths is None:
-            linewidths = [mpl.rcParams['patch.linewidth']]
-
-        if xscale == 'log' or yscale == 'log':
-            polygons = np.expand_dims(polygon, 0)
-            if xscale == 'log':
-                polygons[:, :, 0] = 10.0 ** polygons[:, :, 0]
-                xmin = 10.0 ** xmin
-                xmax = 10.0 ** xmax
-                self.set_xscale(xscale)
-            if yscale == 'log':
-                polygons[:, :, 1] = 10.0 ** polygons[:, :, 1]
-                ymin = 10.0 ** ymin
-                ymax = 10.0 ** ymax
-                self.set_yscale(yscale)
-        else:
-            polygons = [polygon]
-
-        collection = mcoll.PolyCollection(
-            polygons,
-            edgecolors=edgecolors,
-            linewidths=linewidths,
-            offsets=offsets,
-            offset_transform=mtransforms.AffineDeltaTransform(self.transData)
-        )
-
-        # Set normalizer if bins is 'log'
-        if cbook._str_equal(bins, 'log'):
-            if norm is not None:
-                _api.warn_external("Only one of 'bins' and 'norm' arguments "
-                                   f"can be supplied, ignoring {bins=}")
-            else:
-                norm = mcolors.LogNorm(vmin=vmin, vmax=vmax)
-                vmin = vmax = None
-            bins = None
-
-        if bins is not None:
-            if not np.iterable(bins):
-                minimum, maximum = min(accum), max(accum)
-                bins -= 1  # one less edge than bins
-                bins = minimum + (maximum - minimum) * np.arange(bins) / bins
-            bins = np.sort(bins)
-            accum = bins.searchsorted(accum)
-
-        if colorizer:
-            collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
-                                                     norm=norm, vmin=vmin,
-                                                     vmax=vmax)
-        else:
-            collection.set_cmap(cmap)
-            collection.set_norm(norm)
-        collection.set_array(accum)
-        collection.set_alpha(alpha)
-        collection._internal_update(kwargs)
-        collection._scale_norm(norm, vmin, vmax)
-
-        # autoscale the norm with current accum values if it hasn't been set
-        if norm is not None:
-            if collection.norm.vmin is None and collection.norm.vmax is None:
-                collection.norm.autoscale()
-
-        corners = ((xmin, ymin), (xmax, ymax))
-        self.update_datalim(corners)
-        self._request_autoscale_view(tight=True)
-
-        # add the collection last
-        self.add_collection(collection, autolim=False)
-        if not marginals:
-            return collection
-
-        # Process marginals
-        bars = []
-        for zname, z, zmin, zmax, zscale, nbins in [
-                ("x", x, xmin, xmax, xscale, nx),
-                ("y", y, ymin, ymax, yscale, 2 * ny),
-        ]:
-
-            if zscale == "log":
-                bin_edges = np.geomspace(zmin, zmax, nbins + 1)
-            else:
-                bin_edges = np.linspace(zmin, zmax, nbins + 1)
-
-            verts = np.empty((nbins, 4, 2))
-            verts[:, 0, 0] = verts[:, 1, 0] = bin_edges[:-1]
-            verts[:, 2, 0] = verts[:, 3, 0] = bin_edges[1:]
-            verts[:, 0, 1] = verts[:, 3, 1] = .00
-            verts[:, 1, 1] = verts[:, 2, 1] = .05
-            if zname == "y":
-                verts = verts[:, :, ::-1]  # Swap x and y.
-
-            # Sort z-values into bins defined by bin_edges.
-            bin_idxs = np.searchsorted(bin_edges, z) - 1
-            values = np.empty(nbins)
-            for i in range(nbins):
-                # Get C-values for each bin, and compute bin value with
-                # reduce_C_function.
-                ci = C[bin_idxs == i]
-                values[i] = reduce_C_function(ci) if len(ci) > 0 else np.nan
-
-            mask = ~np.isnan(values)
-            verts = verts[mask]
-            values = values[mask]
-
-            trans = getattr(self, f"get_{zname}axis_transform")(which="grid")
-            bar = mcoll.PolyCollection(
-                verts, transform=trans, edgecolors="face")
-            bar.set_array(values)
-            bar.set_cmap(cmap)
-            bar.set_norm(norm)
-            bar.set_alpha(alpha)
-            bar._internal_update(kwargs)
-            bars.append(self.add_collection(bar, autolim=False))
-
-        collection.hbar, collection.vbar = bars
-
-        def on_changed(collection):
-            collection.hbar.set_cmap(collection.get_cmap())
-            collection.hbar.set_cmap(collection.get_cmap())
-            collection.vbar.set_clim(collection.get_clim())
-            collection.vbar.set_clim(collection.get_clim())
-
-        collection.callbacks.connect('changed', on_changed)
-
-        return collection
-
-    @_docstring.interpd
-    def arrow(self, x, y, dx, dy, **kwargs):
-        """
-        Add an arrow to the Axes.
-
-        This draws an arrow from ``(x, y)`` to ``(x+dx, y+dy)``.
-
-        Parameters
-        ----------
-        %(FancyArrow)s
-
-        Returns
-        -------
-        `.FancyArrow`
-            The created `.FancyArrow` object.
-
-        Notes
-        -----
-        The resulting arrow is affected by the Axes aspect ratio and limits.
-        This may produce an arrow whose head is not square with its stem. To
-        create an arrow whose head is square with its stem,
-        use :meth:`annotate` for example:
-
-        >>> ax.annotate("", xy=(0.5, 0.5), xytext=(0, 0),
-        ...             arrowprops=dict(arrowstyle="->"))
-
-        """
-        # Strip away units for the underlying patch since units
-        # do not make sense to most patch-like code
-        x = self.convert_xunits(x)
-        y = self.convert_yunits(y)
-        dx = self.convert_xunits(dx)
-        dy = self.convert_yunits(dy)
-
-        a = mpatches.FancyArrow(x, y, dx, dy, **kwargs)
-        self.add_patch(a)
-        self._request_autoscale_view()
-        return a
-
-    @_docstring.copy(mquiver.QuiverKey.__init__)
-    def quiverkey(self, Q, X, Y, U, label, **kwargs):
-        qk = mquiver.QuiverKey(Q, X, Y, U, label, **kwargs)
-        self.add_artist(qk)
-        return qk
-
-    # Handle units for x and y, if they've been passed
-    def _quiver_units(self, args, kwargs):
-        if len(args) > 3:
-            x, y = args[0:2]
-            x, y = self._process_unit_info([("x", x), ("y", y)], kwargs)
-            return (x, y) + args[2:]
-        return args
-
-    # args can be a combination of X, Y, U, V, C and all should be replaced
-    @_preprocess_data()
-    @_docstring.interpd
-    def quiver(self, *args, **kwargs):
-        """%(quiver_doc)s"""
-        # Make sure units are handled for x and y values
-        args = self._quiver_units(args, kwargs)
-        q = mquiver.Quiver(self, *args, **kwargs)
-        self.add_collection(q, autolim=True)
-        self._request_autoscale_view()
-        return q
-
-    # args can be some combination of X, Y, U, V, C and all should be replaced
-    @_preprocess_data()
-    @_docstring.interpd
-    def barbs(self, *args, **kwargs):
-        """%(barbs_doc)s"""
-        # Make sure units are handled for x and y values
-        args = self._quiver_units(args, kwargs)
-        b = mquiver.Barbs(self, *args, **kwargs)
-        self.add_collection(b, autolim=True)
-        self._request_autoscale_view()
-        return b
-
-    # Uses a custom implementation of data-kwarg handling in
-    # _process_plot_var_args.
-    def fill(self, *args, data=None, **kwargs):
-        """
-        Plot filled polygons.
-
-        Parameters
-        ----------
-        *args : sequence of x, y, [color]
-            Each polygon is defined by the lists of *x* and *y* positions of
-            its nodes, optionally followed by a *color* specifier. See
-            :mod:`matplotlib.colors` for supported color specifiers. The
-            standard color cycle is used for polygons without a color
-            specifier.
-
-            You can plot multiple polygons by providing multiple *x*, *y*,
-            *[color]* groups.
-
-            For example, each of the following is legal::
-
-                ax.fill(x, y)                    # a polygon with default color
-                ax.fill(x, y, "b")               # a blue polygon
-                ax.fill(x, y, x2, y2)            # two polygons
-                ax.fill(x, y, "b", x2, y2, "r")  # a blue and a red polygon
-
-        data : indexable object, optional
-            An object with labelled data. If given, provide the label names to
-            plot in *x* and *y*, e.g.::
-
-                ax.fill("time", "signal",
-                        data={"time": [0, 1, 2], "signal": [0, 1, 0]})
-
-        Returns
-        -------
-        list of `~matplotlib.patches.Polygon`
-
-        Other Parameters
-        ----------------
-        **kwargs : `~matplotlib.patches.Polygon` properties
-
-        Notes
-        -----
-        Use :meth:`fill_between` if you would like to fill the region between
-        two curves.
-        """
-        # For compatibility(!), get aliases from Line2D rather than Patch.
-        kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
-        # _get_patches_for_fill returns a generator, convert it to a list.
-        patches = [*self._get_patches_for_fill(self, *args, data=data, **kwargs)]
-        for poly in patches:
-            self.add_patch(poly)
-        self._request_autoscale_view()
-        return patches
-
-    def _fill_between_x_or_y(
-            self, ind_dir, ind, dep1, dep2=0, *,
-            where=None, interpolate=False, step=None, **kwargs):
-        # Common implementation between fill_between (*ind_dir*="x") and
-        # fill_betweenx (*ind_dir*="y").  *ind* is the independent variable,
-        # *dep* the dependent variable.  The docstring below is interpolated
-        # to generate both methods' docstrings.
-        """
-        Fill the area between two {dir} curves.
-
-        The curves are defined by the points (*{ind}*, *{dep}1*) and (*{ind}*,
-        *{dep}2*).  This creates one or multiple polygons describing the filled
-        area.
-
-        You may exclude some {dir} sections from filling using *where*.
-
-        By default, the edges connect the given points directly.  Use *step*
-        if the filling should be a step function, i.e. constant in between
-        *{ind}*.
-
-        Parameters
-        ----------
-        {ind} : array (length N)
-            The {ind} coordinates of the nodes defining the curves.
-
-        {dep}1 : array (length N) or scalar
-            The {dep} coordinates of the nodes defining the first curve.
-
-        {dep}2 : array (length N) or scalar, default: 0
-            The {dep} coordinates of the nodes defining the second curve.
-
-        where : array of bool (length N), optional
-            Define *where* to exclude some {dir} regions from being filled.
-            The filled regions are defined by the coordinates ``{ind}[where]``.
-            More precisely, fill between ``{ind}[i]`` and ``{ind}[i+1]`` if
-            ``where[i] and where[i+1]``.  Note that this definition implies
-            that an isolated *True* value between two *False* values in *where*
-            will not result in filling.  Both sides of the *True* position
-            remain unfilled due to the adjacent *False* values.
-
-        interpolate : bool, default: False
-            This option is only relevant if *where* is used and the two curves
-            are crossing each other.
-
-            Semantically, *where* is often used for *{dep}1* > *{dep}2* or
-            similar.  By default, the nodes of the polygon defining the filled
-            region will only be placed at the positions in the *{ind}* array.
-            Such a polygon cannot describe the above semantics close to the
-            intersection.  The {ind}-sections containing the intersection are
-            simply clipped.
-
-            Setting *interpolate* to *True* will calculate the actual
-            intersection point and extend the filled region up to this point.
-
-        step : {{'pre', 'post', 'mid'}}, optional
-            Define *step* if the filling should be a step function,
-            i.e. constant in between *{ind}*.  The value determines where the
-            step will occur:
-
-            - 'pre': The {dep} value is continued constantly to the left from
-              every *{ind}* position, i.e. the interval ``({ind}[i-1], {ind}[i]]``
-              has the value ``{dep}[i]``.
-            - 'post': The y value is continued constantly to the right from
-              every *{ind}* position, i.e. the interval ``[{ind}[i], {ind}[i+1])``
-              has the value ``{dep}[i]``.
-            - 'mid': Steps occur half-way between the *{ind}* positions.
-
-        Returns
-        -------
-        `.FillBetweenPolyCollection`
-            A `.FillBetweenPolyCollection` containing the plotted polygons.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            All other keyword arguments are passed on to
-            `.FillBetweenPolyCollection`. They control the `.Polygon` properties:
-
-            %(FillBetweenPolyCollection:kwdoc)s
-
-        See Also
-        --------
-        fill_between : Fill between two sets of y-values.
-        fill_betweenx : Fill between two sets of x-values.
-        """
-        dep_dir = mcoll.FillBetweenPolyCollection._f_dir_from_t(ind_dir)
-
-        if not mpl.rcParams["_internal.classic_mode"]:
-            kwargs = cbook.normalize_kwargs(kwargs, mcoll.Collection)
-            if not any(c in kwargs for c in ("color", "facecolor")):
-                kwargs["facecolor"] = self._get_patches_for_fill.get_next_color()
-
-        ind, dep1, dep2 = self._fill_between_process_units(
-            ind_dir, dep_dir, ind, dep1, dep2, **kwargs)
-
-        collection = mcoll.FillBetweenPolyCollection(
-            ind_dir, ind, dep1, dep2,
-            where=where, interpolate=interpolate, step=step, **kwargs)
-
-        self.add_collection(collection)
-        self._request_autoscale_view()
-        return collection
-
-    def _fill_between_process_units(self, ind_dir, dep_dir, ind, dep1, dep2, **kwargs):
-        """Handle united data, such as dates."""
-        return map(np.ma.masked_invalid, self._process_unit_info(
-            [(ind_dir, ind), (dep_dir, dep1), (dep_dir, dep2)], kwargs))
-
-    def fill_between(self, x, y1, y2=0, where=None, interpolate=False,
-                     step=None, **kwargs):
-        return self._fill_between_x_or_y(
-            "x", x, y1, y2,
-            where=where, interpolate=interpolate, step=step, **kwargs)
-
-    if _fill_between_x_or_y.__doc__:
-        fill_between.__doc__ = _fill_between_x_or_y.__doc__.format(
-            dir="horizontal", ind="x", dep="y"
-        )
-    fill_between = _preprocess_data(
-        _docstring.interpd(fill_between),
-        replace_names=["x", "y1", "y2", "where"])
-
-    def fill_betweenx(self, y, x1, x2=0, where=None,
-                      step=None, interpolate=False, **kwargs):
-        return self._fill_between_x_or_y(
-            "y", y, x1, x2,
-            where=where, interpolate=interpolate, step=step, **kwargs)
-
-    if _fill_between_x_or_y.__doc__:
-        fill_betweenx.__doc__ = _fill_between_x_or_y.__doc__.format(
-            dir="vertical", ind="y", dep="x"
-        )
-    fill_betweenx = _preprocess_data(
-        _docstring.interpd(fill_betweenx),
-        replace_names=["y", "x1", "x2", "where"])
-
-    #### plotting z(x, y): imshow, pcolor and relatives, contour
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def imshow(self, X, cmap=None, norm=None, *, aspect=None,
-               interpolation=None, alpha=None,
-               vmin=None, vmax=None, colorizer=None, origin=None, extent=None,
-               interpolation_stage=None, filternorm=True, filterrad=4.0,
-               resample=None, url=None, **kwargs):
-        """
-        Display data as an image, i.e., on a 2D regular raster.
-
-        The input may either be actual RGB(A) data, or 2D scalar data, which
-        will be rendered as a pseudocolor image. For displaying a grayscale
-        image, set up the colormapping using the parameters
-        ``cmap='gray', vmin=0, vmax=255``.
-
-        The number of pixels used to render an image is set by the Axes size
-        and the figure *dpi*. This can lead to aliasing artifacts when
-        the image is resampled, because the displayed image size will usually
-        not match the size of *X* (see
-        :doc:`/gallery/images_contours_and_fields/image_antialiasing`).
-        The resampling can be controlled via the *interpolation* parameter
-        and/or :rc:`image.interpolation`.
-
-        Parameters
-        ----------
-        X : array-like or PIL image
-            The image data. Supported array shapes are:
-
-            - (M, N): an image with scalar data. The values are mapped to
-              colors using normalization and a colormap. See parameters *norm*,
-              *cmap*, *vmin*, *vmax*.
-            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
-            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
-              i.e. including transparency.
-
-            The first two dimensions (M, N) define the rows and columns of
-            the image.
-
-            Out-of-range RGB(A) values are clipped.
-
-        %(cmap_doc)s
-
-            This parameter is ignored if *X* is RGB(A).
-
-        %(norm_doc)s
-
-            This parameter is ignored if *X* is RGB(A).
-
-        %(vmin_vmax_doc)s
-
-            This parameter is ignored if *X* is RGB(A).
-
-        %(colorizer_doc)s
-
-            This parameter is ignored if *X* is RGB(A).
-
-        aspect : {'equal', 'auto'} or float or None, default: None
-            The aspect ratio of the Axes.  This parameter is particularly
-            relevant for images since it determines whether data pixels are
-            square.
-
-            This parameter is a shortcut for explicitly calling
-            `.Axes.set_aspect`. See there for further details.
-
-            - 'equal': Ensures an aspect ratio of 1. Pixels will be square
-              (unless pixel sizes are explicitly made non-square in data
-              coordinates using *extent*).
-            - 'auto': The Axes is kept fixed and the aspect is adjusted so
-              that the data fit in the Axes. In general, this will result in
-              non-square pixels.
-
-            Normally, None (the default) means to use :rc:`image.aspect`.  However, if
-            the image uses a transform that does not contain the axes data transform,
-            then None means to not modify the axes aspect at all (in that case, directly
-            call `.Axes.set_aspect` if desired).
-
-        interpolation : str, default: :rc:`image.interpolation`
-            The interpolation method used.
-
-            Supported values are 'none', 'auto', 'nearest', 'bilinear',
-            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
-            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell',
-            'sinc', 'lanczos', 'blackman'.
-
-            The data *X* is resampled to the pixel size of the image on the
-            figure canvas, using the interpolation method to either up- or
-            downsample the data.
-
-            If *interpolation* is 'none', then for the ps, pdf, and svg
-            backends no down- or upsampling occurs, and the image data is
-            passed to the backend as a native image.  Note that different ps,
-            pdf, and svg viewers may display these raw pixels differently. On
-            other backends, 'none' is the same as 'nearest'.
-
-            If *interpolation* is the default 'auto', then 'nearest'
-            interpolation is used if the image is upsampled by more than a
-            factor of three (i.e. the number of display pixels is at least
-            three times the size of the data array).  If the upsampling rate is
-            smaller than 3, or the image is downsampled, then 'hanning'
-            interpolation is used to act as an anti-aliasing filter, unless the
-            image happens to be upsampled by exactly a factor of two or one.
-
-            See
-            :doc:`/gallery/images_contours_and_fields/interpolation_methods`
-            for an overview of the supported interpolation methods, and
-            :doc:`/gallery/images_contours_and_fields/image_antialiasing` for
-            a discussion of image antialiasing.
-
-            Some interpolation methods require an additional radius parameter,
-            which can be set by *filterrad*. Additionally, the antigrain image
-            resize filter is controlled by the parameter *filternorm*.
-
-        interpolation_stage : {'auto', 'data', 'rgba'}, default: 'auto'
-            Supported values:
-
-            - 'data': Interpolation is carried out on the data provided by the user
-              This is useful if interpolating between pixels during upsampling.
-            - 'rgba': The interpolation is carried out in RGBA-space after the
-              color-mapping has been applied. This is useful if downsampling and
-              combining pixels visually.
-            - 'auto': Select a suitable interpolation stage automatically. This uses
-              'rgba' when downsampling, or upsampling at a rate less than 3, and
-              'data' when upsampling at a higher rate.
-
-            See :doc:`/gallery/images_contours_and_fields/image_antialiasing` for
-            a discussion of image antialiasing.
-
-        alpha : float or array-like, optional
-            The alpha blending value, between 0 (transparent) and 1 (opaque).
-            If *alpha* is an array, the alpha blending values are applied pixel
-            by pixel, and *alpha* must have the same shape as *X*.
-
-        origin : {'upper', 'lower'}, default: :rc:`image.origin`
-            Place the [0, 0] index of the array in the upper left or lower
-            left corner of the Axes. The convention (the default) 'upper' is
-            typically used for matrices and images.
-
-            Note that the vertical axis points upward for 'lower'
-            but downward for 'upper'.
-
-            See the :ref:`imshow_extent` tutorial for
-            examples and a more detailed description.
-
-        extent : floats (left, right, bottom, top), optional
-            The bounding box in data coordinates that the image will fill.
-            These values may be unitful and match the units of the Axes.
-            The image is stretched individually along x and y to fill the box.
-
-            The default extent is determined by the following conditions.
-            Pixels have unit size in data coordinates. Their centers are on
-            integer coordinates, and their center coordinates range from 0 to
-            columns-1 horizontally and from 0 to rows-1 vertically.
-
-            Note that the direction of the vertical axis and thus the default
-            values for top and bottom depend on *origin*:
-
-            - For ``origin == 'upper'`` the default is
-              ``(-0.5, numcols-0.5, numrows-0.5, -0.5)``.
-            - For ``origin == 'lower'`` the default is
-              ``(-0.5, numcols-0.5, -0.5, numrows-0.5)``.
-
-            See the :ref:`imshow_extent` tutorial for
-            examples and a more detailed description.
-
-        filternorm : bool, default: True
-            A parameter for the antigrain image resize filter (see the
-            antigrain documentation).  If *filternorm* is set, the filter
-            normalizes integer values and corrects the rounding errors. It
-            doesn't do anything with the source floating point values, it
-            corrects only integers according to the rule of 1.0 which means
-            that any sum of pixel weights must be equal to 1.0.  So, the
-            filter function must produce a graph of the proper shape.
-
-        filterrad : float > 0, default: 4.0
-            The filter radius for filters that have a radius parameter, i.e.
-            when interpolation is one of: 'sinc', 'lanczos' or 'blackman'.
-
-        resample : bool, default: :rc:`image.resample`
-            When *True*, use a full resampling method.  When *False*, only
-            resample when the output image is larger than the input image.
-
-        url : str, optional
-            Set the url of the created `.AxesImage`. See `.Artist.set_url`.
-
-        Returns
-        -------
-        `~matplotlib.image.AxesImage`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs : `~matplotlib.artist.Artist` properties
-            These parameters are passed on to the constructor of the
-            `.AxesImage` artist.
-
-        See Also
-        --------
-        matshow : Plot a matrix or an array as an image.
-
-        Notes
-        -----
-        Unless *extent* is used, pixel centers will be located at integer
-        coordinates. In other words: the origin will coincide with the center
-        of pixel (0, 0).
-
-        There are two common representations for RGB images with an alpha
-        channel:
-
-        -   Straight (unassociated) alpha: R, G, and B channels represent the
-            color of the pixel, disregarding its opacity.
-        -   Premultiplied (associated) alpha: R, G, and B channels represent
-            the color of the pixel, adjusted for its opacity by multiplication.
-
-        `~matplotlib.pyplot.imshow` expects RGB images adopting the straight
-        (unassociated) alpha representation.
-        """
-        im = mimage.AxesImage(self, cmap=cmap, norm=norm, colorizer=colorizer,
-                              interpolation=interpolation, origin=origin,
-                              extent=extent, filternorm=filternorm,
-                              filterrad=filterrad, resample=resample,
-                              interpolation_stage=interpolation_stage,
-                              **kwargs)
-
-        if aspect is None and not (
-                im.is_transform_set()
-                and not im.get_transform().contains_branch(self.transData)):
-            aspect = mpl.rcParams['image.aspect']
-        if aspect is not None:
-            self.set_aspect(aspect)
-
-        im.set_data(X)
-        im.set_alpha(alpha)
-        if im.get_clip_path() is None:
-            # image does not already have clipping set, clip to Axes patch
-            im.set_clip_path(self.patch)
-        im._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
-        im._scale_norm(norm, vmin, vmax)
-        im.set_url(url)
-
-        # update ax.dataLim, and, if autoscaling, set viewLim
-        # to tightly fit the image, regardless of dataLim.
-        im.set_extent(im.get_extent())
-
-        self.add_image(im)
-        return im
-
-    def _pcolorargs(self, funcname, *args, shading='auto', **kwargs):
-        # - create X and Y if not present;
-        # - reshape X and Y as needed if they are 1-D;
-        # - check for proper sizes based on `shading` kwarg;
-        # - reset shading if shading='auto' to flat or nearest
-        #   depending on size;
-
-        _valid_shading = ['gouraud', 'nearest', 'flat', 'auto']
+                assert child is not start
+                explored.add(id(child))
+                to_visit.append(child)
+
+    fig = Figure()
+    ax = fig.add_subplot()
+    points = np.random.rand(1000)
+    ax.plot(points, points)
+    ax.scatter(points, points)
+    ax_children = ax.get_children()
+    fig.clear()  # This should break the reference cycle
+
+    # Care most about the objects that scale with number of points
+    big_artists = [
+        a for a in ax_children
+        if isinstance(a, (Line2D, PathCollection))
+    ]
+    assert len(big_artists) > 0
+    for big_artist in big_artists:
+        assert_not_in_reference_cycle(big_artist)
+    assert len(ax_children) > 0
+    for child in ax_children:
+        # Make sure this doesn't raise because the child is already removed.
         try:
-            _api.check_in_list(_valid_shading, shading=shading)
-        except ValueError:
-            _api.warn_external(f"shading value '{shading}' not in list of "
-                               f"valid values {_valid_shading}. Setting "
-                               "shading='auto'.")
-            shading = 'auto'
-
-        if len(args) == 1:
-            C = np.asanyarray(args[0])
-            nrows, ncols = C.shape[:2]
-            if shading in ['gouraud', 'nearest']:
-                X, Y = np.meshgrid(np.arange(ncols), np.arange(nrows))
-            else:
-                X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
-                shading = 'flat'
-            C = cbook.safe_masked_invalid(C, copy=True)
-            return X, Y, C, shading
-
-        if len(args) == 3:
-            # Check x and y for bad data...
-            C = np.asanyarray(args[2])
-            # unit conversion allows e.g. datetime objects as axis values
-            X, Y = args[:2]
-            X, Y = self._process_unit_info([("x", X), ("y", Y)], kwargs)
-            X, Y = (cbook.safe_masked_invalid(a, copy=True) for a in [X, Y])
-
-            if funcname == 'pcolormesh':
-                if np.ma.is_masked(X) or np.ma.is_masked(Y):
-                    raise ValueError(
-                        'x and y arguments to pcolormesh cannot have '
-                        'non-finite values or be of type '
-                        'numpy.ma.MaskedArray with masked values')
-            nrows, ncols = C.shape[:2]
-        else:
-            raise _api.nargs_error(funcname, takes="1 or 3", given=len(args))
-
-        Nx = X.shape[-1]
-        Ny = Y.shape[0]
-        if X.ndim != 2 or X.shape[0] == 1:
-            x = X.reshape(1, Nx)
-            X = x.repeat(Ny, axis=0)
-        if Y.ndim != 2 or Y.shape[1] == 1:
-            y = Y.reshape(Ny, 1)
-            Y = y.repeat(Nx, axis=1)
-        if X.shape != Y.shape:
-            raise TypeError(f'Incompatible X, Y inputs to {funcname}; '
-                            f'see help({funcname})')
-
-        if shading == 'auto':
-            if ncols == Nx and nrows == Ny:
-                shading = 'nearest'
-            else:
-                shading = 'flat'
-
-        if shading == 'flat':
-            if (Nx, Ny) != (ncols + 1, nrows + 1):
-                raise TypeError(f"Dimensions of C {C.shape} should"
-                                f" be one smaller than X({Nx}) and Y({Ny})"
-                                f" while using shading='flat'"
-                                f" see help({funcname})")
-        else:    # ['nearest', 'gouraud']:
-            if (Nx, Ny) != (ncols, nrows):
-                raise TypeError('Dimensions of C %s are incompatible with'
-                                ' X (%d) and/or Y (%d); see help(%s)' % (
-                                    C.shape, Nx, Ny, funcname))
-            if shading == 'nearest':
-                # grid is specified at the center, so define corners
-                # at the midpoints between the grid centers and then use the
-                # flat algorithm.
-                def _interp_grid(X):
-                    # helper for below
-                    if np.shape(X)[1] > 1:
-                        dX = np.diff(X, axis=1) * 0.5
-                        if not (np.all(dX >= 0) or np.all(dX <= 0)):
-                            _api.warn_external(
-                                f"The input coordinates to {funcname} are "
-                                "interpreted as cell centers, but are not "
-                                "monotonically increasing or decreasing. "
-                                "This may lead to incorrectly calculated cell "
-                                "edges, in which case, please supply "
-                                f"explicit cell edges to {funcname}.")
-
-                        hstack = np.ma.hstack if np.ma.isMA(X) else np.hstack
-                        X = hstack((X[:, [0]] - dX[:, [0]],
-                                    X[:, :-1] + dX,
-                                    X[:, [-1]] + dX[:, [-1]]))
-                    else:
-                        # This is just degenerate, but we can't reliably guess
-                        # a dX if there is just one value.
-                        X = np.hstack((X, X))
-                    return X
-
-                if ncols == Nx:
-                    X = _interp_grid(X)
-                    Y = _interp_grid(Y)
-                if nrows == Ny:
-                    X = _interp_grid(X.T).T
-                    Y = _interp_grid(Y.T).T
-                shading = 'flat'
-
-        C = cbook.safe_masked_invalid(C, copy=True)
-        return X, Y, C, shading
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def pcolor(self, *args, shading=None, alpha=None, norm=None, cmap=None,
-               vmin=None, vmax=None, colorizer=None, **kwargs):
-        r"""
-        Create a pseudocolor plot with a non-regular rectangular grid.
-
-        Call signature::
-
-            pcolor([X, Y,] C, /, **kwargs)
-
-        *X* and *Y* can be used to specify the corners of the quadrilaterals.
-
-        The arguments *X*, *Y*, *C* are positional-only.
-
-        .. hint::
-
-            ``pcolor()`` can be very slow for large arrays. In most
-            cases you should use the similar but much faster
-            `~.Axes.pcolormesh` instead. See
-            :ref:`Differences between pcolor() and pcolormesh()
-            <differences-pcolor-pcolormesh>` for a discussion of the
-            differences.
-
-        Parameters
-        ----------
-        C : 2D array-like
-            The color-mapped values.  Color-mapping is controlled by *cmap*,
-            *norm*, *vmin*, and *vmax*.
-
-        X, Y : array-like, optional
-            The coordinates of the corners of quadrilaterals of a pcolormesh::
-
-                (X[i+1, j], Y[i+1, j])       (X[i+1, j+1], Y[i+1, j+1])
-                                      ●╶───╴●
-                                      │     │
-                                      ●╶───╴●
-                    (X[i, j], Y[i, j])       (X[i, j+1], Y[i, j+1])
-
-            Note that the column index corresponds to the x-coordinate, and
-            the row index corresponds to y. For details, see the
-            :ref:`Notes <axes-pcolormesh-grid-orientation>` section below.
-
-            If ``shading='flat'`` the dimensions of *X* and *Y* should be one
-            greater than those of *C*, and the quadrilateral is colored due
-            to the value at ``C[i, j]``.  If *X*, *Y* and *C* have equal
-            dimensions, a warning will be raised and the last row and column
-            of *C* will be ignored.
-
-            If ``shading='nearest'``, the dimensions of *X* and *Y* should be
-            the same as those of *C* (if not, a ValueError will be raised). The
-            color ``C[i, j]`` will be centered on ``(X[i, j], Y[i, j])``.
-
-            If *X* and/or *Y* are 1-D arrays or column vectors they will be
-            expanded as needed into the appropriate 2D arrays, making a
-            rectangular grid.
-
-        shading : {'flat', 'nearest', 'auto'}, default: :rc:`pcolor.shading`
-            The fill style for the quadrilateral. Possible values:
-
-            - 'flat': A solid color is used for each quad. The color of the
-              quad (i, j), (i+1, j), (i, j+1), (i+1, j+1) is given by
-              ``C[i, j]``. The dimensions of *X* and *Y* should be
-              one greater than those of *C*; if they are the same as *C*,
-              then a deprecation warning is raised, and the last row
-              and column of *C* are dropped.
-            - 'nearest': Each grid point will have a color centered on it,
-              extending halfway between the adjacent grid centers.  The
-              dimensions of *X* and *Y* must be the same as *C*.
-            - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
-              larger than *C*.  Choose 'nearest' if dimensions are the same.
-
-            See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`
-            for more description.
-
-        %(cmap_doc)s
-
-        %(norm_doc)s
-
-        %(vmin_vmax_doc)s
-
-        %(colorizer_doc)s
-
-        edgecolors : {'none', None, 'face', color, color sequence}, optional
-            The color of the edges. Defaults to 'none'. Possible values:
-
-            - 'none' or '': No edge.
-            - *None*: :rc:`patch.edgecolor` will be used. Note that currently
-              :rc:`patch.force_edgecolor` has to be True for this to work.
-            - 'face': Use the adjacent face color.
-            - A color or sequence of colors will set the edge color.
-
-            The singular form *edgecolor* works as an alias.
-
-        alpha : float, default: None
-            The alpha blending value of the face color, between 0 (transparent)
-            and 1 (opaque). Note: The edgecolor is currently not affected by
-            this.
-
-        snap : bool, default: False
-            Whether to snap the mesh to pixel boundaries.
-
-        Returns
-        -------
-        `matplotlib.collections.PolyQuadMesh`
-
-        Other Parameters
-        ----------------
-        antialiaseds : bool, default: False
-            The default *antialiaseds* is False if the default
-            *edgecolors*\ ="none" is used.  This eliminates artificial lines
-            at patch boundaries, and works regardless of the value of alpha.
-            If *edgecolors* is not "none", then the default *antialiaseds*
-            is taken from :rc:`patch.antialiased`.
-            Stroking the edges may be preferred if *alpha* is 1, but will
-            cause artifacts otherwise.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Additionally, the following arguments are allowed. They are passed
-            along to the `~matplotlib.collections.PolyQuadMesh` constructor:
-
-        %(PolyCollection:kwdoc)s
-
-        See Also
-        --------
-        pcolormesh : for an explanation of the differences between
-            pcolor and pcolormesh.
-        imshow : If *X* and *Y* are each equidistant, `~.Axes.imshow` can be a
-            faster alternative.
-
-        Notes
-        -----
-        **Masked arrays**
-
-        *X*, *Y* and *C* may be masked arrays. If either ``C[i, j]``, or one
-        of the vertices surrounding ``C[i, j]`` (*X* or *Y* at
-        ``[i, j], [i+1, j], [i, j+1], [i+1, j+1]``) is masked, nothing is
-        plotted.
-
-        .. _axes-pcolor-grid-orientation:
-
-        **Grid orientation**
-
-        The grid orientation follows the standard matrix convention: An array
-        *C* with shape (nrows, ncolumns) is plotted with the column number as
-        *X* and the row number as *Y*.
-        """
-
-        if shading is None:
-            shading = mpl.rcParams['pcolor.shading']
-        shading = shading.lower()
-        X, Y, C, shading = self._pcolorargs('pcolor', *args, shading=shading,
-                                            kwargs=kwargs)
-        linewidths = (0.25,)
-        if 'linewidth' in kwargs:
-            kwargs['linewidths'] = kwargs.pop('linewidth')
-        kwargs.setdefault('linewidths', linewidths)
-
-        if 'edgecolor' in kwargs:
-            kwargs['edgecolors'] = kwargs.pop('edgecolor')
-        ec = kwargs.setdefault('edgecolors', 'none')
-
-        # aa setting will default via collections to patch.antialiased
-        # unless the boundary is not stroked, in which case the
-        # default will be False; with unstroked boundaries, aa
-        # makes artifacts that are often disturbing.
-        if 'antialiaseds' in kwargs:
-            kwargs['antialiased'] = kwargs.pop('antialiaseds')
-        if 'antialiased' not in kwargs and cbook._str_lower_equal(ec, "none"):
-            kwargs['antialiased'] = False
-
-        kwargs.setdefault('snap', False)
-
-        if np.ma.isMaskedArray(X) or np.ma.isMaskedArray(Y):
-            stack = np.ma.stack
-            X = np.ma.asarray(X)
-            Y = np.ma.asarray(Y)
-            # For bounds collections later
-            x = X.compressed()
-            y = Y.compressed()
-        else:
-            stack = np.stack
-            x = X
-            y = Y
-        coords = stack([X, Y], axis=-1)
-
-        collection = mcoll.PolyQuadMesh(
-            coords, array=C, cmap=cmap, norm=norm, colorizer=colorizer,
-            alpha=alpha, **kwargs)
-        collection._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
-        collection._scale_norm(norm, vmin, vmax)
-
-        # Transform from native to data coordinates?
-        t = collection._transform
-        if (not isinstance(t, mtransforms.Transform) and
-                hasattr(t, '_as_mpl_transform')):
-            t = t._as_mpl_transform(self.axes)
-
-        if t and any(t.contains_branch_seperately(self.transData)):
-            trans_to_data = t - self.transData
-            pts = np.vstack([x, y]).T.astype(float)
-            transformed_pts = trans_to_data.transform(pts)
-            x = transformed_pts[..., 0]
-            y = transformed_pts[..., 1]
-
-        self.add_collection(collection, autolim=False)
-
-        minx = np.min(x)
-        maxx = np.max(x)
-        miny = np.min(y)
-        maxy = np.max(y)
-        collection.sticky_edges.x[:] = [minx, maxx]
-        collection.sticky_edges.y[:] = [miny, maxy]
-        corners = (minx, miny), (maxx, maxy)
-        self.update_datalim(corners)
-        self._request_autoscale_view()
-        return collection
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def pcolormesh(self, *args, alpha=None, norm=None, cmap=None, vmin=None,
-                   vmax=None, colorizer=None, shading=None, antialiased=False,
-                   **kwargs):
-        """
-        Create a pseudocolor plot with a non-regular rectangular grid.
-
-        Call signature::
-
-            pcolormesh([X, Y,] C, /, **kwargs)
-
-        *X* and *Y* can be used to specify the corners of the quadrilaterals.
-
-        The arguments *X*, *Y*, *C* are positional-only.
-
-        .. hint::
-
-           `~.Axes.pcolormesh` is similar to `~.Axes.pcolor`. It is much faster
-           and preferred in most cases. For a detailed discussion on the
-           differences see :ref:`Differences between pcolor() and pcolormesh()
-           <differences-pcolor-pcolormesh>`.
-
-        Parameters
-        ----------
-        C : array-like
-            The mesh data. Supported array shapes are:
-
-            - (M, N) or M*N: a mesh with scalar data. The values are mapped to
-              colors using normalization and a colormap. See parameters *norm*,
-              *cmap*, *vmin*, *vmax*.
-            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
-            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
-              i.e. including transparency.
-
-            The first two dimensions (M, N) define the rows and columns of
-            the mesh data.
-
-        X, Y : array-like, optional
-            The coordinates of the corners of quadrilaterals of a pcolormesh::
-
-                (X[i+1, j], Y[i+1, j])       (X[i+1, j+1], Y[i+1, j+1])
-                                      ●╶───╴●
-                                      │     │
-                                      ●╶───╴●
-                    (X[i, j], Y[i, j])       (X[i, j+1], Y[i, j+1])
-
-            Note that the column index corresponds to the x-coordinate, and
-            the row index corresponds to y. For details, see the
-            :ref:`Notes <axes-pcolormesh-grid-orientation>` section below.
-
-            If ``shading='flat'`` the dimensions of *X* and *Y* should be one
-            greater than those of *C*, and the quadrilateral is colored due
-            to the value at ``C[i, j]``.  If *X*, *Y* and *C* have equal
-            dimensions, a warning will be raised and the last row and column
-            of *C* will be ignored.
-
-            If ``shading='nearest'`` or ``'gouraud'``, the dimensions of *X*
-            and *Y* should be the same as those of *C* (if not, a ValueError
-            will be raised).  For ``'nearest'`` the color ``C[i, j]`` is
-            centered on ``(X[i, j], Y[i, j])``.  For ``'gouraud'``, a smooth
-            interpolation is carried out between the quadrilateral corners.
-
-            If *X* and/or *Y* are 1-D arrays or column vectors they will be
-            expanded as needed into the appropriate 2D arrays, making a
-            rectangular grid.
-
-        %(cmap_doc)s
-
-        %(norm_doc)s
-
-        %(vmin_vmax_doc)s
-
-        %(colorizer_doc)s
-
-        edgecolors : {'none', None, 'face', color, color sequence}, optional
-            The color of the edges. Defaults to 'none'. Possible values:
-
-            - 'none' or '': No edge.
-            - *None*: :rc:`patch.edgecolor` will be used. Note that currently
-              :rc:`patch.force_edgecolor` has to be True for this to work.
-            - 'face': Use the adjacent face color.
-            - A color or sequence of colors will set the edge color.
-
-            The singular form *edgecolor* works as an alias.
-
-        alpha : float, default: None
-            The alpha blending value, between 0 (transparent) and 1 (opaque).
-
-        shading : {'flat', 'nearest', 'gouraud', 'auto'}, optional
-            The fill style for the quadrilateral; defaults to
-            :rc:`pcolor.shading`. Possible values:
-
-            - 'flat': A solid color is used for each quad. The color of the
-              quad (i, j), (i+1, j), (i, j+1), (i+1, j+1) is given by
-              ``C[i, j]``. The dimensions of *X* and *Y* should be
-              one greater than those of *C*; if they are the same as *C*,
-              then a deprecation warning is raised, and the last row
-              and column of *C* are dropped.
-            - 'nearest': Each grid point will have a color centered on it,
-              extending halfway between the adjacent grid centers.  The
-              dimensions of *X* and *Y* must be the same as *C*.
-            - 'gouraud': Each quad will be Gouraud shaded: The color of the
-              corners (i', j') are given by ``C[i', j']``. The color values of
-              the area in between is interpolated from the corner values.
-              The dimensions of *X* and *Y* must be the same as *C*. When
-              Gouraud shading is used, *edgecolors* is ignored.
-            - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
-              larger than *C*.  Choose 'nearest' if dimensions are the same.
-
-            See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`
-            for more description.
-
-        snap : bool, default: False
-            Whether to snap the mesh to pixel boundaries.
-
-        rasterized : bool, optional
-            Rasterize the pcolormesh when drawing vector graphics.  This can
-            speed up rendering and produce smaller files for large data sets.
-            See also :doc:`/gallery/misc/rasterization_demo`.
-
-        Returns
-        -------
-        `matplotlib.collections.QuadMesh`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Additionally, the following arguments are allowed. They are passed
-            along to the `~matplotlib.collections.QuadMesh` constructor:
-
-        %(QuadMesh:kwdoc)s
-
-        See Also
-        --------
-        pcolor : An alternative implementation with slightly different
-            features. For a detailed discussion on the differences see
-            :ref:`Differences between pcolor() and pcolormesh()
-            <differences-pcolor-pcolormesh>`.
-        imshow : If *X* and *Y* are each equidistant, `~.Axes.imshow` can be a
-            faster alternative.
-
-        Notes
-        -----
-        **Masked arrays**
-
-        *C* may be a masked array. If ``C[i, j]`` is masked, the corresponding
-        quadrilateral will be transparent. Masking of *X* and *Y* is not
-        supported. Use `~.Axes.pcolor` if you need this functionality.
-
-        .. _axes-pcolormesh-grid-orientation:
-
-        **Grid orientation**
-
-        The grid orientation follows the standard matrix convention: An array
-        *C* with shape (nrows, ncolumns) is plotted with the column number as
-        *X* and the row number as *Y*.
-
-        .. _differences-pcolor-pcolormesh:
-
-        **Differences between pcolor() and pcolormesh()**
-
-        Both methods are used to create a pseudocolor plot of a 2D array
-        using quadrilaterals.
-
-        The main difference lies in the created object and internal data
-        handling:
-        While `~.Axes.pcolor` returns a `.PolyQuadMesh`, `~.Axes.pcolormesh`
-        returns a `.QuadMesh`. The latter is more specialized for the given
-        purpose and thus is faster. It should almost always be preferred.
-
-        There is also a slight difference in the handling of masked arrays.
-        Both `~.Axes.pcolor` and `~.Axes.pcolormesh` support masked arrays
-        for *C*. However, only `~.Axes.pcolor` supports masked arrays for *X*
-        and *Y*. The reason lies in the internal handling of the masked values.
-        `~.Axes.pcolor` leaves out the respective polygons from the
-        PolyQuadMesh. `~.Axes.pcolormesh` sets the facecolor of the masked
-        elements to transparent. You can see the difference when using
-        edgecolors. While all edges are drawn irrespective of masking in a
-        QuadMesh, the edge between two adjacent masked quadrilaterals in
-        `~.Axes.pcolor` is not drawn as the corresponding polygons do not
-        exist in the PolyQuadMesh. Because PolyQuadMesh draws each individual
-        polygon, it also supports applying hatches and linestyles to the collection.
-
-        Another difference is the support of Gouraud shading in
-        `~.Axes.pcolormesh`, which is not available with `~.Axes.pcolor`.
-
-        """
-        if shading is None:
-            shading = mpl.rcParams['pcolor.shading']
-        shading = shading.lower()
-        kwargs.setdefault('edgecolors', 'none')
-
-        X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
-                                            shading=shading, kwargs=kwargs)
-        coords = np.stack([X, Y], axis=-1)
-
-        kwargs.setdefault('snap', mpl.rcParams['pcolormesh.snap'])
-
-        collection = mcoll.QuadMesh(
-            coords, antialiased=antialiased, shading=shading,
-            array=C, cmap=cmap, norm=norm, colorizer=colorizer, alpha=alpha, **kwargs)
-        collection._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
-        collection._scale_norm(norm, vmin, vmax)
-
-        coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
-
-        # Transform from native to data coordinates?
-        t = collection._transform
-        if (not isinstance(t, mtransforms.Transform) and
-                hasattr(t, '_as_mpl_transform')):
-            t = t._as_mpl_transform(self.axes)
-
-        if t and any(t.contains_branch_seperately(self.transData)):
-            trans_to_data = t - self.transData
-            coords = trans_to_data.transform(coords)
-
-        self.add_collection(collection, autolim=False)
-
-        minx, miny = np.min(coords, axis=0)
-        maxx, maxy = np.max(coords, axis=0)
-        collection.sticky_edges.x[:] = [minx, maxx]
-        collection.sticky_edges.y[:] = [miny, maxy]
-        corners = (minx, miny), (maxx, maxy)
-        self.update_datalim(corners)
-        self._request_autoscale_view()
-        return collection
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def pcolorfast(self, *args, alpha=None, norm=None, cmap=None, vmin=None,
-                   vmax=None, colorizer=None, **kwargs):
-        """
-        Create a pseudocolor plot with a non-regular rectangular grid.
-
-        Call signature::
-
-            ax.pcolorfast([X, Y], C, /, **kwargs)
-
-        The arguments *X*, *Y*, *C* are positional-only.
-
-        This method is similar to `~.Axes.pcolor` and `~.Axes.pcolormesh`.
-        It's designed to provide the fastest pcolor-type plotting with the
-        Agg backend. To achieve this, it uses different algorithms internally
-        depending on the complexity of the input grid (regular rectangular,
-        non-regular rectangular or arbitrary quadrilateral).
-
-        .. warning::
-
-            This method is experimental. Compared to `~.Axes.pcolor` or
-            `~.Axes.pcolormesh` it has some limitations:
-
-            - It supports only flat shading (no outlines)
-            - It lacks support for log scaling of the axes.
-            - It does not have a pyplot wrapper.
-
-        Parameters
-        ----------
-        C : array-like
-            The image data. Supported array shapes are:
-
-            - (M, N): an image with scalar data.  Color-mapping is controlled
-              by *cmap*, *norm*, *vmin*, and *vmax*.
-            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
-            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
-              i.e. including transparency.
-
-            The first two dimensions (M, N) define the rows and columns of
-            the image.
-
-            This parameter can only be passed positionally.
-
-        X, Y : tuple or array-like, default: ``(0, N)``, ``(0, M)``
-            *X* and *Y* are used to specify the coordinates of the
-            quadrilaterals. There are different ways to do this:
-
-            - Use tuples ``X=(xmin, xmax)`` and ``Y=(ymin, ymax)`` to define
-              a *uniform rectangular grid*.
-
-              The tuples define the outer edges of the grid. All individual
-              quadrilaterals will be of the same size. This is the fastest
-              version.
-
-            - Use 1D arrays *X*, *Y* to specify a *non-uniform rectangular
-              grid*.
-
-              In this case *X* and *Y* have to be monotonic 1D arrays of length
-              *N+1* and *M+1*, specifying the x and y boundaries of the cells.
-
-              The speed is intermediate. Note: The grid is checked, and if
-              found to be uniform the fast version is used.
-
-            - Use 2D arrays *X*, *Y* if you need an *arbitrary quadrilateral
-              grid* (i.e. if the quadrilaterals are not rectangular).
-
-              In this case *X* and *Y* are 2D arrays with shape (M + 1, N + 1),
-              specifying the x and y coordinates of the corners of the colored
-              quadrilaterals.
-
-              This is the most general, but the slowest to render.  It may
-              produce faster and more compact output using ps, pdf, and
-              svg backends, however.
-
-            These arguments can only be passed positionally.
-
-        %(cmap_doc)s
-
-            This parameter is ignored if *C* is RGB(A).
-
-        %(norm_doc)s
-
-            This parameter is ignored if *C* is RGB(A).
-
-        %(vmin_vmax_doc)s
-
-            This parameter is ignored if *C* is RGB(A).
-
-        %(colorizer_doc)s
-
-            This parameter is ignored if *C* is RGB(A).
-
-        alpha : float, default: None
-            The alpha blending value, between 0 (transparent) and 1 (opaque).
-
-        snap : bool, default: False
-            Whether to snap the mesh to pixel boundaries.
-
-        Returns
-        -------
-        `.AxesImage` or `.PcolorImage` or `.QuadMesh`
-            The return type depends on the type of grid:
-
-            - `.AxesImage` for a regular rectangular grid.
-            - `.PcolorImage` for a non-regular rectangular grid.
-            - `.QuadMesh` for a non-rectangular grid.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Supported additional parameters depend on the type of grid.
-            See return types of *image* for further description.
-        """
-
-        C = args[-1]
-        nr, nc = np.shape(C)[:2]
-        if len(args) == 1:
-            style = "image"
-            x = [0, nc]
-            y = [0, nr]
-        elif len(args) == 3:
-            x, y = args[:2]
-            x = np.asarray(x)
-            y = np.asarray(y)
-            if x.ndim == 1 and y.ndim == 1:
-                if x.size == 2 and y.size == 2:
-                    style = "image"
-                else:
-                    if x.size != nc + 1:
-                        raise ValueError(
-                            f"Length of X ({x.size}) must be one larger than the "
-                            f"number of columns in C ({nc})")
-                    if y.size != nr + 1:
-                        raise ValueError(
-                            f"Length of Y ({y.size}) must be one larger than the "
-                            f"number of rows in C ({nr})"
-                        )
-                    dx = np.diff(x)
-                    dy = np.diff(y)
-                    if (np.ptp(dx) < 0.01 * abs(dx.mean()) and
-                            np.ptp(dy) < 0.01 * abs(dy.mean())):
-                        style = "image"
-                    else:
-                        style = "pcolorimage"
-            elif x.ndim == 2 and y.ndim == 2:
-                style = "quadmesh"
-            else:
-                raise TypeError(
-                    f"When 3 positional parameters are passed to pcolorfast, the first "
-                    f"two (X and Y) must be both 1D or both 2D; the given X was "
-                    f"{x.ndim}D and the given Y was {y.ndim}D")
-        else:
-            raise _api.nargs_error('pcolorfast', '1 or 3', len(args))
-
-        mcolorizer.ColorizingArtist._check_exclusionary_keywords(colorizer, vmin=vmin,
-                                                                 vmax=vmax)
-        if style == "quadmesh":
-            # data point in each cell is value at lower left corner
-            coords = np.stack([x, y], axis=-1)
-            if np.ndim(C) not in {2, 3}:
-                raise ValueError("C must be 2D or 3D")
-            collection = mcoll.QuadMesh(
-                coords, array=C,
-                alpha=alpha, cmap=cmap, norm=norm, colorizer=colorizer,
-                antialiased=False, edgecolors="none")
-            self.add_collection(collection, autolim=False)
-            xl, xr, yb, yt = x.min(), x.max(), y.min(), y.max()
-            ret = collection
-
-        else:  # It's one of the two image styles.
-            extent = xl, xr, yb, yt = x[0], x[-1], y[0], y[-1]
-            if style == "image":
-                im = mimage.AxesImage(
-                    self, cmap=cmap, norm=norm, colorizer=colorizer,
-                    data=C, alpha=alpha, extent=extent,
-                    interpolation='nearest', origin='lower',
-                    **kwargs)
-            elif style == "pcolorimage":
-                im = mimage.PcolorImage(
-                    self, x, y, C,
-                    cmap=cmap, norm=norm, colorizer=colorizer, alpha=alpha,
-                    extent=extent, **kwargs)
-            self.add_image(im)
-            ret = im
-
-        if np.ndim(C) == 2:  # C.ndim == 3 is RGB(A) so doesn't need scaling.
-            ret._scale_norm(norm, vmin, vmax)
-
-        if ret.get_clip_path() is None:
-            # image does not already have clipping set, clip to Axes patch
-            ret.set_clip_path(self.patch)
-
-        ret.sticky_edges.x[:] = [xl, xr]
-        ret.sticky_edges.y[:] = [yb, yt]
-        self.update_datalim(np.array([[xl, yb], [xr, yt]]))
-        self._request_autoscale_view(tight=True)
-        return ret
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def contour(self, *args, **kwargs):
-        """
-        Plot contour lines.
-
-        Call signature::
-
-            contour([X, Y,] Z, /, [levels], **kwargs)
-
-        The arguments *X*, *Y*, *Z* are positional-only.
-        %(contour_doc)s
-        """
-        kwargs['filled'] = False
-        contours = mcontour.QuadContourSet(self, *args, **kwargs)
-        self._request_autoscale_view()
-        return contours
-
-    @_preprocess_data()
-    @_docstring.interpd
-    def contourf(self, *args, **kwargs):
-        """
-        Plot filled contours.
-
-        Call signature::
-
-            contourf([X, Y,] Z, /, [levels], **kwargs)
-
-        The arguments *X*, *Y*, *Z* are positional-only.
-        %(contour_doc)s
-        """
-        kwargs['filled'] = True
-        contours = mcontour.QuadContourSet(self, *args, **kwargs)
-        self._request_autoscale_view()
-        return contours
-
-    def clabel(self, CS, levels=None, **kwargs):
-        """
-        Label a contour plot.
-
-        Adds labels to line contours in given `.ContourSet`.
-
-        Parameters
-        ----------
-        CS : `.ContourSet` instance
-            Line contours to label.
-
-        levels : array-like, optional
-            A list of level values, that should be labeled. The list must be
-            a subset of ``CS.levels``. If not given, all levels are labeled.
-
-        **kwargs
-            All other parameters are documented in `~.ContourLabeler.clabel`.
-        """
-        return CS.clabel(levels, **kwargs)
-
-    #### Data analysis
-
-    @_api.make_keyword_only("3.9", "range")
-    @_preprocess_data(replace_names=["x", 'weights'], label_namer="x")
-    def hist(self, x, bins=None, range=None, density=False, weights=None,
-             cumulative=False, bottom=None, histtype='bar', align='mid',
-             orientation='vertical', rwidth=None, log=False,
-             color=None, label=None, stacked=False, **kwargs):
-        """
-        Compute and plot a histogram.
-
-        This method uses `numpy.histogram` to bin the data in *x* and count the
-        number of values in each bin, then draws the distribution either as a
-        `.BarContainer` or `.Polygon`. The *bins*, *range*, *density*, and
-        *weights* parameters are forwarded to `numpy.histogram`.
-
-        If the data has already been binned and counted, use `~.bar` or
-        `~.stairs` to plot the distribution::
-
-            counts, bins = np.histogram(x)
-            plt.stairs(counts, bins)
-
-        Alternatively, plot pre-computed bins and counts using ``hist()`` by
-        treating each bin as a single point with a weight equal to its count::
-
-            plt.hist(bins[:-1], bins, weights=counts)
-
-        The data input *x* can be a singular array, a list of datasets of
-        potentially different lengths ([*x0*, *x1*, ...]), or a 2D ndarray in
-        which each column is a dataset. Note that the ndarray form is
-        transposed relative to the list form. If the input is an array, then
-        the return value is a tuple (*n*, *bins*, *patches*); if the input is a
-        sequence of arrays, then the return value is a tuple
-        ([*n0*, *n1*, ...], *bins*, [*patches0*, *patches1*, ...]).
-
-        Masked arrays are not supported.
-
-        Parameters
-        ----------
-        x : (n,) array or sequence of (n,) arrays
-            Input values, this takes either a single array or a sequence of
-            arrays which are not required to be of the same length.
-
-        bins : int or sequence or str, default: :rc:`hist.bins`
-            If *bins* is an integer, it defines the number of equal-width bins
-            in the range.
-
-            If *bins* is a sequence, it defines the bin edges, including the
-            left edge of the first bin and the right edge of the last bin;
-            in this case, bins may be unequally spaced.  All but the last
-            (righthand-most) bin is half-open.  In other words, if *bins* is::
-
-                [1, 2, 3, 4]
-
-            then the first bin is ``[1, 2)`` (including 1, but excluding 2) and
-            the second ``[2, 3)``.  The last bin, however, is ``[3, 4]``, which
-            *includes* 4.
-
-            If *bins* is a string, it is one of the binning strategies
-            supported by `numpy.histogram_bin_edges`: 'auto', 'fd', 'doane',
-            'scott', 'stone', 'rice', 'sturges', or 'sqrt'.
-
-        range : tuple or None, default: None
-            The lower and upper range of the bins. Lower and upper outliers
-            are ignored. If not provided, *range* is ``(x.min(), x.max())``.
-            Range has no effect if *bins* is a sequence.
-
-            If *bins* is a sequence or *range* is specified, autoscaling
-            is based on the specified bin range instead of the
-            range of x.
-
-        density : bool, default: False
-            If ``True``, draw and return a probability density: each bin
-            will display the bin's raw count divided by the total number of
-            counts *and the bin width*
-            (``density = counts / (sum(counts) * np.diff(bins))``),
-            so that the area under the histogram integrates to 1
-            (``np.sum(density * np.diff(bins)) == 1``).
-
-            If *stacked* is also ``True``, the sum of the histograms is
-            normalized to 1.
-
-        weights : (n,) array-like or None, default: None
-            An array of weights, of the same shape as *x*.  Each value in
-            *x* only contributes its associated weight towards the bin count
-            (instead of 1).  If *density* is ``True``, the weights are
-            normalized, so that the integral of the density over the range
-            remains 1.
-
-        cumulative : bool or -1, default: False
-            If ``True``, then a histogram is computed where each bin gives the
-            counts in that bin plus all bins for smaller values. The last bin
-            gives the total number of datapoints.
-
-            If *density* is also ``True`` then the histogram is normalized such
-            that the last bin equals 1.
-
-            If *cumulative* is a number less than 0 (e.g., -1), the direction
-            of accumulation is reversed.  In this case, if *density* is also
-            ``True``, then the histogram is normalized such that the first bin
-            equals 1.
-
-        bottom : array-like, scalar, or None, default: None
-            Location of the bottom of each bin, i.e. bins are drawn from
-            ``bottom`` to ``bottom + hist(x, bins)`` If a scalar, the bottom
-            of each bin is shifted by the same amount. If an array, each bin
-            is shifted independently and the length of bottom must match the
-            number of bins. If None, defaults to 0.
-
-        histtype : {'bar', 'barstacked', 'step', 'stepfilled'}, default: 'bar'
-            The type of histogram to draw.
-
-            - 'bar' is a traditional bar-type histogram.  If multiple data
-              are given the bars are arranged side by side.
-            - 'barstacked' is a bar-type histogram where multiple
-              data are stacked on top of each other.
-            - 'step' generates a lineplot that is by default unfilled.
-            - 'stepfilled' generates a lineplot that is by default filled.
-
-        align : {'left', 'mid', 'right'}, default: 'mid'
-            The horizontal alignment of the histogram bars.
-
-            - 'left': bars are centered on the left bin edges.
-            - 'mid': bars are centered between the bin edges.
-            - 'right': bars are centered on the right bin edges.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            If 'horizontal', `~.Axes.barh` will be used for bar-type histograms
-            and the *bottom* kwarg will be the left edges.
-
-        rwidth : float or None, default: None
-            The relative width of the bars as a fraction of the bin width.  If
-            ``None``, automatically compute the width.
-
-            Ignored if *histtype* is 'step' or 'stepfilled'.
-
-        log : bool, default: False
-            If ``True``, the histogram axis will be set to a log scale.
-
-        color : :mpltype:`color` or list of :mpltype:`color` or None, default: None
-            Color or sequence of colors, one per dataset.  Default (``None``)
-            uses the standard line color sequence.
-
-        label : str or list of str, optional
-            String, or sequence of strings to match multiple datasets.  Bar
-            charts yield multiple patches per dataset, but only the first gets
-            the label, so that `~.Axes.legend` will work as expected.
-
-        stacked : bool, default: False
-            If ``True``, multiple data are stacked on top of each other If
-            ``False`` multiple data are arranged side by side if histtype is
-            'bar' or on top of each other if histtype is 'step'
-
-        Returns
-        -------
-        n : array or list of arrays
-            The values of the histogram bins. See *density* and *weights* for a
-            description of the possible semantics.  If input *x* is an array,
-            then this is an array of length *nbins*. If input is a sequence of
-            arrays ``[data1, data2, ...]``, then this is a list of arrays with
-            the values of the histograms for each of the arrays in the same
-            order.  The dtype of the array *n* (or of its element arrays) will
-            always be float even if no weighting or normalization is used.
-
-        bins : array
-            The edges of the bins. Length nbins + 1 (nbins left edges and right
-            edge of last bin).  Always a single array even when multiple data
-            sets are passed in.
-
-        patches : `.BarContainer` or list of a single `.Polygon` or list of \
-such objects
-            Container of individual artists used to create the histogram
-            or list of such containers if there are multiple input datasets.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            `~matplotlib.patches.Patch` properties. The following properties
-            additionally accept a sequence of values corresponding to the
-            datasets in *x*:
-            *edgecolor*, *facecolor*, *linewidth*, *linestyle*, *hatch*.
-
-            .. versionadded:: 3.10
-               Allowing sequences of values in above listed Patch properties.
-
-        See Also
-        --------
-        hist2d : 2D histogram with rectangular bins
-        hexbin : 2D histogram with hexagonal bins
-        stairs : Plot a pre-computed histogram
-        bar : Plot a pre-computed histogram
-
-        Notes
-        -----
-        For large numbers of bins (>1000), plotting can be significantly
-        accelerated by using `~.Axes.stairs` to plot a pre-computed histogram
-        (``plt.stairs(*np.histogram(data))``), or by setting *histtype* to
-        'step' or 'stepfilled' rather than 'bar' or 'barstacked'.
-        """
-        # Avoid shadowing the builtin.
-        bin_range = range
-        from builtins import range
-
-        if np.isscalar(x):
-            x = [x]
-
-        if bins is None:
-            bins = mpl.rcParams['hist.bins']
-
-        # Validate string inputs here to avoid cluttering subsequent code.
-        _api.check_in_list(['bar', 'barstacked', 'step', 'stepfilled'],
-                           histtype=histtype)
-        _api.check_in_list(['left', 'mid', 'right'], align=align)
-        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
-
-        if histtype == 'barstacked' and not stacked:
-            stacked = True
-
-        # Massage 'x' for processing.
-        x = cbook._reshape_2D(x, 'x')
-        nx = len(x)  # number of datasets
-
-        # Process unit information.  _process_unit_info sets the unit and
-        # converts the first dataset; then we convert each following dataset
-        # one at a time.
-        if orientation == "vertical":
-            convert_units = self.convert_xunits
-            x = [*self._process_unit_info([("x", x[0])], kwargs),
-                 *map(convert_units, x[1:])]
-        else:  # horizontal
-            convert_units = self.convert_yunits
-            x = [*self._process_unit_info([("y", x[0])], kwargs),
-                 *map(convert_units, x[1:])]
-
-        if bin_range is not None:
-            bin_range = convert_units(bin_range)
-
-        if not cbook.is_scalar_or_string(bins):
-            bins = convert_units(bins)
-
-        # We need to do to 'weights' what was done to 'x'
-        if weights is not None:
-            w = cbook._reshape_2D(weights, 'weights')
-        else:
-            w = [None] * nx
-
-        if len(w) != nx:
-            raise ValueError('weights should have the same shape as x')
-
-        input_empty = True
-        for xi, wi in zip(x, w):
-            len_xi = len(xi)
-            if wi is not None and len(wi) != len_xi:
-                raise ValueError('weights should have the same shape as x')
-            if len_xi:
-                input_empty = False
-
-        if color is None:
-            colors = [self._get_lines.get_next_color() for i in range(nx)]
-        else:
-            colors = mcolors.to_rgba_array(color)
-            if len(colors) != nx:
-                raise ValueError(f"The 'color' keyword argument must have one "
-                                 f"color per dataset, but {nx} datasets and "
-                                 f"{len(colors)} colors were provided")
-
-        hist_kwargs = dict()
-
-        # if the bin_range is not given, compute without nan numpy
-        # does not do this for us when guessing the range (but will
-        # happily ignore nans when computing the histogram).
-        if bin_range is None:
-            xmin = np.inf
-            xmax = -np.inf
-            for xi in x:
-                if len(xi):
-                    # python's min/max ignore nan,
-                    # np.minnan returns nan for all nan input
-                    xmin = min(xmin, np.nanmin(xi))
-                    xmax = max(xmax, np.nanmax(xi))
-            if xmin <= xmax:  # Only happens if we have seen a finite value.
-                bin_range = (xmin, xmax)
-
-        # If bins are not specified either explicitly or via range,
-        # we need to figure out the range required for all datasets,
-        # and supply that to np.histogram.
-        if not input_empty and len(x) > 1:
-            if weights is not None:
-                _w = np.concatenate(w)
-            else:
-                _w = None
-            bins = np.histogram_bin_edges(
-                np.concatenate(x), bins, bin_range, _w)
-        else:
-            hist_kwargs['range'] = bin_range
-
-        density = bool(density)
-        if density and not stacked:
-            hist_kwargs['density'] = density
-
-        # List to store all the top coordinates of the histograms
-        tops = []  # Will have shape (n_datasets, n_bins).
-        # Loop through datasets
-        for i in range(nx):
-            # this will automatically overwrite bins,
-            # so that each histogram uses the same bins
-            m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
-            tops.append(m)
-        tops = np.array(tops, float)  # causes problems later if it's an int
-        bins = np.array(bins, float)  # causes problems if float16
-        if stacked:
-            tops = tops.cumsum(axis=0)
-            # If a stacked density plot, normalize so the area of all the
-            # stacked histograms together is 1
-            if density:
-                tops = (tops / np.diff(bins)) / tops[-1].sum()
-        if cumulative:
-            slc = slice(None)
-            if isinstance(cumulative, Number) and cumulative < 0:
-                slc = slice(None, None, -1)
-            if density:
-                tops = (tops * np.diff(bins))[:, slc].cumsum(axis=1)[:, slc]
-            else:
-                tops = tops[:, slc].cumsum(axis=1)[:, slc]
-
-        patches = []
-
-        if histtype.startswith('bar'):
-
-            totwidth = np.diff(bins)
-
-            if rwidth is not None:
-                dr = np.clip(rwidth, 0, 1)
-            elif (len(tops) > 1 and
-                  ((not stacked) or mpl.rcParams['_internal.classic_mode'])):
-                dr = 0.8
-            else:
-                dr = 1.0
-
-            if histtype == 'bar' and not stacked:
-                width = dr * totwidth / nx
-                dw = width
-                boffset = -0.5 * dr * totwidth * (1 - 1 / nx)
-            elif histtype == 'barstacked' or stacked:
-                width = dr * totwidth
-                boffset, dw = 0.0, 0.0
-
-            if align == 'mid':
-                boffset += 0.5 * totwidth
-            elif align == 'right':
-                boffset += totwidth
-
-            if orientation == 'horizontal':
-                _barfunc = self.barh
-                bottom_kwarg = 'left'
-            else:  # orientation == 'vertical'
-                _barfunc = self.bar
-                bottom_kwarg = 'bottom'
-
-            for top, color in zip(tops, colors):
-                if bottom is None:
-                    bottom = np.zeros(len(top))
-                if stacked:
-                    height = top - bottom
-                else:
-                    height = top
-                bars = _barfunc(bins[:-1]+boffset, height, width,
-                                align='center', log=log,
-                                color=color, **{bottom_kwarg: bottom})
-                patches.append(bars)
-                if stacked:
-                    bottom = top
-                boffset += dw
-            # Remove stickies from all bars but the lowest ones, as otherwise
-            # margin expansion would be unable to cross the stickies in the
-            # middle of the bars.
-            for bars in patches[1:]:
-                for patch in bars:
-                    patch.sticky_edges.x[:] = patch.sticky_edges.y[:] = []
-
-        elif histtype.startswith('step'):
-            # these define the perimeter of the polygon
-            x = np.zeros(4 * len(bins) - 3)
-            y = np.zeros(4 * len(bins) - 3)
-
-            x[0:2*len(bins)-1:2], x[1:2*len(bins)-1:2] = bins, bins[:-1]
-            x[2*len(bins)-1:] = x[1:2*len(bins)-1][::-1]
-
-            if bottom is None:
-                bottom = 0
-
-            y[1:2*len(bins)-1:2] = y[2:2*len(bins):2] = bottom
-            y[2*len(bins)-1:] = y[1:2*len(bins)-1][::-1]
-
-            if log:
-                if orientation == 'horizontal':
-                    self.set_xscale('log', nonpositive='clip')
-                else:  # orientation == 'vertical'
-                    self.set_yscale('log', nonpositive='clip')
-
-            if align == 'left':
-                x -= 0.5*(bins[1]-bins[0])
-            elif align == 'right':
-                x += 0.5*(bins[1]-bins[0])
-
-            # If fill kwarg is set, it will be passed to the patch collection,
-            # overriding this
-            fill = (histtype == 'stepfilled')
-
-            xvals, yvals = [], []
-            for top in tops:
-                if stacked:
-                    # top of the previous polygon becomes the bottom
-                    y[2*len(bins)-1:] = y[1:2*len(bins)-1][::-1]
-                # set the top of this polygon
-                y[1:2*len(bins)-1:2] = y[2:2*len(bins):2] = top + bottom
-
-                # The starting point of the polygon has not yet been
-                # updated. So far only the endpoint was adjusted. This
-                # assignment closes the polygon. The redundant endpoint is
-                # later discarded (for step and stepfilled).
-                y[0] = y[-1]
-
-                if orientation == 'horizontal':
-                    xvals.append(y.copy())
-                    yvals.append(x.copy())
-                else:
-                    xvals.append(x.copy())
-                    yvals.append(y.copy())
-
-            # stepfill is closed, step is not
-            split = -1 if fill else 2 * len(bins)
-            # add patches in reverse order so that when stacking,
-            # items lower in the stack are plotted on top of
-            # items higher in the stack
-            for x, y, color in reversed(list(zip(xvals, yvals, colors))):
-                patches.append(self.fill(
-                    x[:split], y[:split],
-                    closed=True if fill else None,
-                    facecolor=color,
-                    edgecolor=None if fill else color,
-                    fill=fill if fill else None,
-                    zorder=None if fill else mlines.Line2D.zorder))
-            for patch_list in patches:
-                for patch in patch_list:
-                    if orientation == 'vertical':
-                        patch.sticky_edges.y.append(0)
-                    elif orientation == 'horizontal':
-                        patch.sticky_edges.x.append(0)
-
-            # we return patches, so put it back in the expected order
-            patches.reverse()
-
-        # If None, make all labels None (via zip_longest below); otherwise,
-        # cast each element to str, but keep a single str as it.
-        labels = [] if label is None else np.atleast_1d(np.asarray(label, str))
-
-        if histtype == "step":
-            edgecolors = itertools.cycle(np.atleast_1d(kwargs.get('edgecolor',
-                                                                  colors)))
-        else:
-            edgecolors = itertools.cycle(np.atleast_1d(kwargs.get("edgecolor", None)))
-
-        facecolors = itertools.cycle(np.atleast_1d(kwargs.get('facecolor', colors)))
-        hatches = itertools.cycle(np.atleast_1d(kwargs.get('hatch', None)))
-        linewidths = itertools.cycle(np.atleast_1d(kwargs.get('linewidth', None)))
-        linestyles = itertools.cycle(np.atleast_1d(kwargs.get('linestyle', None)))
-
-        for patch, lbl in itertools.zip_longest(patches, labels):
-            if not patch:
-                continue
-            p = patch[0]
-            kwargs.update({
-                'hatch': next(hatches),
-                'linewidth': next(linewidths),
-                'linestyle': next(linestyles),
-                'edgecolor': next(edgecolors),
-                'facecolor': next(facecolors),
-            })
-            p._internal_update(kwargs)
-            if lbl is not None:
-                p.set_label(lbl)
-            for p in patch[1:]:
-                p._internal_update(kwargs)
-                p.set_label('_nolegend_')
-
-        if nx == 1:
-            return tops[0], bins, patches[0]
-        else:
-            patch_type = ("BarContainer" if histtype.startswith("bar")
-                          else "list[Polygon]")
-            return tops, bins, cbook.silent_list(patch_type, patches)
-
-    @_preprocess_data()
-    def stairs(self, values, edges=None, *,
-               orientation='vertical', baseline=0, fill=False, **kwargs):
-        """
-        Draw a stepwise constant function as a line or a filled plot.
-
-        *edges* define the x-axis positions of the steps. *values* the function values
-        between these steps. Depending on *fill*, the function is drawn either as a
-        continuous line with vertical segments at the edges, or as a filled area.
-
-        Parameters
-        ----------
-        values : array-like
-            The step heights.
-
-        edges : array-like
-            The step positions, with ``len(edges) == len(vals) + 1``,
-            between which the curve takes on vals values.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            The direction of the steps. Vertical means that *values* are along
-            the y-axis, and edges are along the x-axis.
-
-        baseline : float, array-like or None, default: 0
-            The bottom value of the bounding edges or when
-            ``fill=True``, position of lower edge. If *fill* is
-            True or an array is passed to *baseline*, a closed
-            path is drawn.
-
-            If None, then drawn as an unclosed Path.
-
-        fill : bool, default: False
-            Whether the area under the step curve should be filled.
-
-            Passing both ``fill=True` and ``baseline=None`` will likely result in
-            undesired filling: the first and last points will be connected
-            with a straight line and the fill will be between this line and the stairs.
-
-
-        Returns
-        -------
-        StepPatch : `~matplotlib.patches.StepPatch`
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            `~matplotlib.patches.StepPatch` properties
-
-        """
-
-        if 'color' in kwargs:
-            _color = kwargs.pop('color')
-        else:
-            _color = self._get_lines.get_next_color()
-        if fill:
-            kwargs.setdefault('linewidth', 0)
-            kwargs.setdefault('facecolor', _color)
-        else:
-            kwargs.setdefault('edgecolor', _color)
-
-        if edges is None:
-            edges = np.arange(len(values) + 1)
-
-        edges, values, baseline = self._process_unit_info(
-            [("x", edges), ("y", values), ("y", baseline)], kwargs)
-
-        patch = mpatches.StepPatch(values,
-                                   edges,
-                                   baseline=baseline,
-                                   orientation=orientation,
-                                   fill=fill,
-                                   **kwargs)
-        self.add_patch(patch)
-        if baseline is None and fill:
-            _api.warn_external(
-                f"Both {baseline=} and {fill=} have been passed. "
-                "baseline=None is only intended for unfilled stair plots. "
-                "Because baseline is None, the Path used to draw the stairs will "
-                "not be closed, thus because fill is True the polygon will be closed "
-                "by drawing an (unstroked) edge from the first to last point.  It is "
-                "very likely that the resulting fill patterns is not the desired "
-                "result."
-            )
-
-        if baseline is not None:
-            if orientation == 'vertical':
-                patch.sticky_edges.y.append(np.min(baseline))
-                self.update_datalim([(edges[0], np.min(baseline))])
-            else:
-                patch.sticky_edges.x.append(np.min(baseline))
-                self.update_datalim([(np.min(baseline), edges[0])])
-        self._request_autoscale_view()
-        return patch
-
-    @_api.make_keyword_only("3.9", "range")
-    @_preprocess_data(replace_names=["x", "y", "weights"])
-    @_docstring.interpd
-    def hist2d(self, x, y, bins=10, range=None, density=False, weights=None,
-               cmin=None, cmax=None, **kwargs):
-        """
-        Make a 2D histogram plot.
-
-        Parameters
-        ----------
-        x, y : array-like, shape (n, )
-            Input values
-
-        bins : None or int or [int, int] or array-like or [array, array]
-
-            The bin specification:
-
-            - If int, the number of bins for the two dimensions
-              (``nx = ny = bins``).
-            - If ``[int, int]``, the number of bins in each dimension
-              (``nx, ny = bins``).
-            - If array-like, the bin edges for the two dimensions
-              (``x_edges = y_edges = bins``).
-            - If ``[array, array]``, the bin edges in each dimension
-              (``x_edges, y_edges = bins``).
-
-            The default value is 10.
-
-        range : array-like shape(2, 2), optional
-            The leftmost and rightmost edges of the bins along each dimension
-            (if not specified explicitly in the bins parameters): ``[[xmin,
-            xmax], [ymin, ymax]]``. All values outside of this range will be
-            considered outliers and not tallied in the histogram.
-
-        density : bool, default: False
-            Normalize histogram.  See the documentation for the *density*
-            parameter of `~.Axes.hist` for more details.
-
-        weights : array-like, shape (n, ), optional
-            An array of values w_i weighing each sample (x_i, y_i).
-
-        cmin, cmax : float, default: None
-            All bins that has count less than *cmin* or more than *cmax* will not be
-            displayed (set to NaN before passing to `~.Axes.pcolormesh`) and these count
-            values in the return value count histogram will also be set to nan upon
-            return.
-
-        Returns
-        -------
-        h : 2D array
-            The bi-dimensional histogram of samples x and y. Values in x are
-            histogrammed along the first dimension and values in y are
-            histogrammed along the second dimension.
-        xedges : 1D array
-            The bin edges along the x-axis.
-        yedges : 1D array
-            The bin edges along the y-axis.
-        image : `~.matplotlib.collections.QuadMesh`
-
-        Other Parameters
-        ----------------
-        %(cmap_doc)s
-
-        %(norm_doc)s
-
-        %(vmin_vmax_doc)s
-
-        %(colorizer_doc)s
-
-        alpha : ``0 <= scalar <= 1`` or ``None``, optional
-            The alpha blending value.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Additional parameters are passed along to the
-            `~.Axes.pcolormesh` method and `~matplotlib.collections.QuadMesh`
-            constructor.
-
-        See Also
-        --------
-        hist : 1D histogram plotting
-        hexbin : 2D histogram with hexagonal bins
-
-        Notes
-        -----
-        - Currently ``hist2d`` calculates its own axis limits, and any limits
-          previously set are ignored.
-        - Rendering the histogram with a logarithmic color scale is
-          accomplished by passing a `.colors.LogNorm` instance to the *norm*
-          keyword argument. Likewise, power-law normalization (similar
-          in effect to gamma correction) can be accomplished with
-          `.colors.PowerNorm`.
-        """
-
-        h, xedges, yedges = np.histogram2d(x, y, bins=bins, range=range,
-                                           density=density, weights=weights)
-
-        if cmin is not None:
-            h[h < cmin] = None
-        if cmax is not None:
-            h[h > cmax] = None
-
-        pc = self.pcolormesh(xedges, yedges, h.T, **kwargs)
-        self.set_xlim(xedges[0], xedges[-1])
-        self.set_ylim(yedges[0], yedges[-1])
-
-        return h, xedges, yedges, pc
-
-    @_preprocess_data(replace_names=["x", "weights"], label_namer="x")
-    @_docstring.interpd
-    def ecdf(self, x, weights=None, *, complementary=False,
-             orientation="vertical", compress=False, **kwargs):
-        """
-        Compute and plot the empirical cumulative distribution function of *x*.
-
-        .. versionadded:: 3.8
-
-        Parameters
-        ----------
-        x : 1d array-like
-            The input data.  Infinite entries are kept (and move the relevant
-            end of the ecdf from 0/1), but NaNs and masked values are errors.
-
-        weights : 1d array-like or None, default: None
-            The weights of the entries; must have the same shape as *x*.
-            Weights corresponding to NaN data points are dropped, and then the
-            remaining weights are normalized to sum to 1.  If unset, all
-            entries have the same weight.
-
-        complementary : bool, default: False
-            Whether to plot a cumulative distribution function, which increases
-            from 0 to 1 (the default), or a complementary cumulative
-            distribution function, which decreases from 1 to 0.
-
-        orientation : {"vertical", "horizontal"}, default: "vertical"
-            Whether the entries are plotted along the x-axis ("vertical", the
-            default) or the y-axis ("horizontal").  This parameter takes the
-            same values as in `~.Axes.hist`.
-
-        compress : bool, default: False
-            Whether multiple entries with the same values are grouped together
-            (with a summed weight) before plotting.  This is mainly useful if
-            *x* contains many identical data points, to decrease the rendering
-            complexity of the plot. If *x* contains no duplicate points, this
-            has no effect and just uses some time and memory.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        Returns
-        -------
-        `.Line2D`
-
-        Notes
-        -----
-        The ecdf plot can be thought of as a cumulative histogram with one bin
-        per data entry; i.e. it reports on the entire dataset without any
-        arbitrary binning.
-
-        If *x* contains NaNs or masked entries, either remove them first from
-        the array (if they should not taken into account), or replace them by
-        -inf or +inf (if they should be sorted at the beginning or the end of
-        the array).
-        """
-        _api.check_in_list(["horizontal", "vertical"], orientation=orientation)
-        if "drawstyle" in kwargs or "ds" in kwargs:
-            raise TypeError("Cannot pass 'drawstyle' or 'ds' to ecdf()")
-        if np.ma.getmask(x).any():
-            raise ValueError("ecdf() does not support masked entries")
-        x = np.asarray(x)
-        if np.isnan(x).any():
-            raise ValueError("ecdf() does not support NaNs")
-        argsort = np.argsort(x)
-        x = x[argsort]
-        if weights is None:
-            # Ensure that we end at exactly 1, avoiding floating point errors.
-            cum_weights = (1 + np.arange(len(x))) / len(x)
-        else:
-            weights = np.take(weights, argsort)   # Reorder weights like we reordered x.
-            cum_weights = np.cumsum(weights / np.sum(weights))
-        if compress:
-            # Get indices of unique x values.
-            compress_idxs = [0, *(x[:-1] != x[1:]).nonzero()[0] + 1]
-            x = x[compress_idxs]
-            cum_weights = cum_weights[compress_idxs]
-        if orientation == "vertical":
-            if not complementary:
-                line, = self.plot([x[0], *x], [0, *cum_weights],
-                                  drawstyle="steps-post", **kwargs)
-            else:
-                line, = self.plot([*x, x[-1]], [1, *1 - cum_weights],
-                                  drawstyle="steps-pre", **kwargs)
-            line.sticky_edges.y[:] = [0, 1]
-        else:  # orientation == "horizontal":
-            if not complementary:
-                line, = self.plot([0, *cum_weights], [x[0], *x],
-                                  drawstyle="steps-pre", **kwargs)
-            else:
-                line, = self.plot([1, *1 - cum_weights], [*x, x[-1]],
-                                  drawstyle="steps-post", **kwargs)
-            line.sticky_edges.x[:] = [0, 1]
-        return line
-
-    @_api.make_keyword_only("3.9", "NFFT")
-    @_preprocess_data(replace_names=["x"])
-    @_docstring.interpd
-    def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
-            window=None, noverlap=None, pad_to=None,
-            sides=None, scale_by_freq=None, return_line=None, **kwargs):
-        r"""
-        Plot the power spectral density.
-
-        The power spectral density :math:`P_{xx}` by Welch's average
-        periodogram method.  The vector *x* is divided into *NFFT* length
-        segments.  Each segment is detrended by function *detrend* and
-        windowed by function *window*.  *noverlap* gives the length of
-        the overlap between segments.  The :math:`|\mathrm{fft}(i)|^2`
-        of each segment :math:`i` are averaged to compute :math:`P_{xx}`,
-        with a scaling to correct for power loss due to windowing.
-
-        If len(*x*) < *NFFT*, it will be zero padded to *NFFT*.
-
-        Parameters
-        ----------
-        x : 1-D array or sequence
-            Array or sequence containing the data
-
-        %(Spectral)s
-
-        %(PSD)s
-
-        noverlap : int, default: 0 (no overlap)
-            The number of points of overlap between segments.
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        return_line : bool, default: False
-            Whether to include the line object plotted in the returned values.
-
-        Returns
-        -------
-        Pxx : 1-D array
-            The values for the power spectrum :math:`P_{xx}` before scaling
-            (real valued).
-
-        freqs : 1-D array
-            The frequencies corresponding to the elements in *Pxx*.
-
-        line : `~matplotlib.lines.Line2D`
-            The line created by this function.
-            Only returned if *return_line* is True.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        specgram
-            Differs in the default overlap; in not returning the mean of the
-            segment periodograms; in returning the times of the segments; and
-            in plotting a colormap instead of a line.
-        magnitude_spectrum
-            Plots the magnitude spectrum.
-        csd
-            Plots the spectral density between two signals.
-
-        Notes
-        -----
-        For plotting, the power is plotted as
-        :math:`10\log_{10}(P_{xx})` for decibels, though *Pxx* itself
-        is returned.
-
-        References
-        ----------
-        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
-        John Wiley & Sons (1986)
-        """
-        if Fc is None:
-            Fc = 0
-
-        pxx, freqs = mlab.psd(x=x, NFFT=NFFT, Fs=Fs, detrend=detrend,
-                              window=window, noverlap=noverlap, pad_to=pad_to,
-                              sides=sides, scale_by_freq=scale_by_freq)
-        freqs += Fc
-
-        if scale_by_freq in (None, True):
-            psd_units = 'dB/Hz'
-        else:
-            psd_units = 'dB'
-
-        line = self.plot(freqs, 10 * np.log10(pxx), **kwargs)
-        self.set_xlabel('Frequency')
-        self.set_ylabel('Power Spectral Density (%s)' % psd_units)
-        self.grid(True)
-
-        vmin, vmax = self.get_ybound()
-        step = max(10 * int(np.log10(vmax - vmin)), 1)
-        ticks = np.arange(math.floor(vmin), math.ceil(vmax) + 1, step)
-        self.set_yticks(ticks)
-
-        if return_line is None or not return_line:
-            return pxx, freqs
-        else:
-            return pxx, freqs, line
-
-    @_api.make_keyword_only("3.9", "NFFT")
-    @_preprocess_data(replace_names=["x", "y"], label_namer="y")
-    @_docstring.interpd
-    def csd(self, x, y, NFFT=None, Fs=None, Fc=None, detrend=None,
-            window=None, noverlap=None, pad_to=None,
-            sides=None, scale_by_freq=None, return_line=None, **kwargs):
-        r"""
-        Plot the cross-spectral density.
-
-        The cross spectral density :math:`P_{xy}` by Welch's average
-        periodogram method.  The vectors *x* and *y* are divided into
-        *NFFT* length segments.  Each segment is detrended by function
-        *detrend* and windowed by function *window*.  *noverlap* gives
-        the length of the overlap between segments.  The product of
-        the direct FFTs of *x* and *y* are averaged over each segment
-        to compute :math:`P_{xy}`, with a scaling to correct for power
-        loss due to windowing.
-
-        If len(*x*) < *NFFT* or len(*y*) < *NFFT*, they will be zero
-        padded to *NFFT*.
-
-        Parameters
-        ----------
-        x, y : 1-D arrays or sequences
-            Arrays or sequences containing the data.
-
-        %(Spectral)s
-
-        %(PSD)s
-
-        noverlap : int, default: 0 (no overlap)
-            The number of points of overlap between segments.
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        return_line : bool, default: False
-            Whether to include the line object plotted in the returned values.
-
-        Returns
-        -------
-        Pxy : 1-D array
-            The values for the cross spectrum :math:`P_{xy}` before scaling
-            (complex valued).
-
-        freqs : 1-D array
-            The frequencies corresponding to the elements in *Pxy*.
-
-        line : `~matplotlib.lines.Line2D`
-            The line created by this function.
-            Only returned if *return_line* is True.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        psd : is equivalent to setting ``y = x``.
-
-        Notes
-        -----
-        For plotting, the power is plotted as
-        :math:`10 \log_{10}(P_{xy})` for decibels, though :math:`P_{xy}` itself
-        is returned.
-
-        References
-        ----------
-        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
-        John Wiley & Sons (1986)
-        """
-        if Fc is None:
-            Fc = 0
-
-        pxy, freqs = mlab.csd(x=x, y=y, NFFT=NFFT, Fs=Fs, detrend=detrend,
-                              window=window, noverlap=noverlap, pad_to=pad_to,
-                              sides=sides, scale_by_freq=scale_by_freq)
-        # pxy is complex
-        freqs += Fc
-
-        line = self.plot(freqs, 10 * np.log10(np.abs(pxy)), **kwargs)
-        self.set_xlabel('Frequency')
-        self.set_ylabel('Cross Spectrum Magnitude (dB)')
-        self.grid(True)
-
-        vmin, vmax = self.get_ybound()
-        step = max(10 * int(np.log10(vmax - vmin)), 1)
-        ticks = np.arange(math.floor(vmin), math.ceil(vmax) + 1, step)
-        self.set_yticks(ticks)
-
-        if return_line is None or not return_line:
-            return pxy, freqs
-        else:
-            return pxy, freqs, line
-
-    @_api.make_keyword_only("3.9", "Fs")
-    @_preprocess_data(replace_names=["x"])
-    @_docstring.interpd
-    def magnitude_spectrum(self, x, Fs=None, Fc=None, window=None,
-                           pad_to=None, sides=None, scale=None,
-                           **kwargs):
-        """
-        Plot the magnitude spectrum.
-
-        Compute the magnitude spectrum of *x*.  Data is padded to a
-        length of *pad_to* and the windowing function *window* is applied to
-        the signal.
-
-        Parameters
-        ----------
-        x : 1-D array or sequence
-            Array or sequence containing the data.
-
-        %(Spectral)s
-
-        %(Single_Spectrum)s
-
-        scale : {'default', 'linear', 'dB'}
-            The scaling of the values in the *spec*.  'linear' is no scaling.
-            'dB' returns the values in dB scale, i.e., the dB amplitude
-            (20 * log10). 'default' is 'linear'.
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        Returns
-        -------
-        spectrum : 1-D array
-            The values for the magnitude spectrum before scaling (real valued).
-
-        freqs : 1-D array
-            The frequencies corresponding to the elements in *spectrum*.
-
-        line : `~matplotlib.lines.Line2D`
-            The line created by this function.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        psd
-            Plots the power spectral density.
-        angle_spectrum
-            Plots the angles of the corresponding frequencies.
-        phase_spectrum
-            Plots the phase (unwrapped angle) of the corresponding frequencies.
-        specgram
-            Can plot the magnitude spectrum of segments within the signal in a
-            colormap.
-        """
-        if Fc is None:
-            Fc = 0
-
-        spec, freqs = mlab.magnitude_spectrum(x=x, Fs=Fs, window=window,
-                                              pad_to=pad_to, sides=sides)
-        freqs += Fc
-
-        yunits = _api.check_getitem(
-            {None: 'energy', 'default': 'energy', 'linear': 'energy',
-             'dB': 'dB'},
-            scale=scale)
-        if yunits == 'energy':
-            Z = spec
-        else:  # yunits == 'dB'
-            Z = 20. * np.log10(spec)
-
-        line, = self.plot(freqs, Z, **kwargs)
-        self.set_xlabel('Frequency')
-        self.set_ylabel('Magnitude (%s)' % yunits)
-
-        return spec, freqs, line
-
-    @_api.make_keyword_only("3.9", "Fs")
-    @_preprocess_data(replace_names=["x"])
-    @_docstring.interpd
-    def angle_spectrum(self, x, Fs=None, Fc=None, window=None,
-                       pad_to=None, sides=None, **kwargs):
-        """
-        Plot the angle spectrum.
-
-        Compute the angle spectrum (wrapped phase spectrum) of *x*.
-        Data is padded to a length of *pad_to* and the windowing function
-        *window* is applied to the signal.
-
-        Parameters
-        ----------
-        x : 1-D array or sequence
-            Array or sequence containing the data.
-
-        %(Spectral)s
-
-        %(Single_Spectrum)s
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        Returns
-        -------
-        spectrum : 1-D array
-            The values for the angle spectrum in radians (real valued).
-
-        freqs : 1-D array
-            The frequencies corresponding to the elements in *spectrum*.
-
-        line : `~matplotlib.lines.Line2D`
-            The line created by this function.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        magnitude_spectrum
-            Plots the magnitudes of the corresponding frequencies.
-        phase_spectrum
-            Plots the unwrapped version of this function.
-        specgram
-            Can plot the angle spectrum of segments within the signal in a
-            colormap.
-        """
-        if Fc is None:
-            Fc = 0
-
-        spec, freqs = mlab.angle_spectrum(x=x, Fs=Fs, window=window,
-                                          pad_to=pad_to, sides=sides)
-        freqs += Fc
-
-        lines = self.plot(freqs, spec, **kwargs)
-        self.set_xlabel('Frequency')
-        self.set_ylabel('Angle (radians)')
-
-        return spec, freqs, lines[0]
-
-    @_api.make_keyword_only("3.9", "Fs")
-    @_preprocess_data(replace_names=["x"])
-    @_docstring.interpd
-    def phase_spectrum(self, x, Fs=None, Fc=None, window=None,
-                       pad_to=None, sides=None, **kwargs):
-        """
-        Plot the phase spectrum.
-
-        Compute the phase spectrum (unwrapped angle spectrum) of *x*.
-        Data is padded to a length of *pad_to* and the windowing function
-        *window* is applied to the signal.
-
-        Parameters
-        ----------
-        x : 1-D array or sequence
-            Array or sequence containing the data
-
-        %(Spectral)s
-
-        %(Single_Spectrum)s
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        Returns
-        -------
-        spectrum : 1-D array
-            The values for the phase spectrum in radians (real valued).
-
-        freqs : 1-D array
-            The frequencies corresponding to the elements in *spectrum*.
-
-        line : `~matplotlib.lines.Line2D`
-            The line created by this function.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        See Also
-        --------
-        magnitude_spectrum
-            Plots the magnitudes of the corresponding frequencies.
-        angle_spectrum
-            Plots the wrapped version of this function.
-        specgram
-            Can plot the phase spectrum of segments within the signal in a
-            colormap.
-        """
-        if Fc is None:
-            Fc = 0
-
-        spec, freqs = mlab.phase_spectrum(x=x, Fs=Fs, window=window,
-                                          pad_to=pad_to, sides=sides)
-        freqs += Fc
-
-        lines = self.plot(freqs, spec, **kwargs)
-        self.set_xlabel('Frequency')
-        self.set_ylabel('Phase (radians)')
-
-        return spec, freqs, lines[0]
-
-    @_api.make_keyword_only("3.9", "NFFT")
-    @_preprocess_data(replace_names=["x", "y"])
-    @_docstring.interpd
-    def cohere(self, x, y, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,
-               window=mlab.window_hanning, noverlap=0, pad_to=None,
-               sides='default', scale_by_freq=None, **kwargs):
-        r"""
-        Plot the coherence between *x* and *y*.
-
-        Coherence is the normalized cross spectral density:
-
-        .. math::
-
-          C_{xy} = \frac{|P_{xy}|^2}{P_{xx}P_{yy}}
-
-        Parameters
-        ----------
-        %(Spectral)s
-
-        %(PSD)s
-
-        noverlap : int, default: 0 (no overlap)
-            The number of points of overlap between blocks.
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        Returns
-        -------
-        Cxy : 1-D array
-            The coherence vector.
-
-        freqs : 1-D array
-            The frequencies for the elements in *Cxy*.
-
-        Other Parameters
-        ----------------
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        **kwargs
-            Keyword arguments control the `.Line2D` properties:
-
-            %(Line2D:kwdoc)s
-
-        References
-        ----------
-        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
-        John Wiley & Sons (1986)
-        """
-        cxy, freqs = mlab.cohere(x=x, y=y, NFFT=NFFT, Fs=Fs, detrend=detrend,
-                                 window=window, noverlap=noverlap,
-                                 scale_by_freq=scale_by_freq, sides=sides,
-                                 pad_to=pad_to)
-        freqs += Fc
-
-        self.plot(freqs, cxy, **kwargs)
-        self.set_xlabel('Frequency')
-        self.set_ylabel('Coherence')
-        self.grid(True)
-
-        return cxy, freqs
-
-    @_api.make_keyword_only("3.9", "NFFT")
-    @_preprocess_data(replace_names=["x"])
-    @_docstring.interpd
-    def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
-                 window=None, noverlap=None,
-                 cmap=None, xextent=None, pad_to=None, sides=None,
-                 scale_by_freq=None, mode=None, scale=None,
-                 vmin=None, vmax=None, **kwargs):
-        """
-        Plot a spectrogram.
-
-        Compute and plot a spectrogram of data in *x*.  Data are split into
-        *NFFT* length segments and the spectrum of each section is
-        computed.  The windowing function *window* is applied to each
-        segment, and the amount of overlap of each segment is
-        specified with *noverlap*. The spectrogram is plotted as a colormap
-        (using imshow).
-
-        Parameters
-        ----------
-        x : 1-D array or sequence
-            Array or sequence containing the data.
-
-        %(Spectral)s
-
-        %(PSD)s
-
-        mode : {'default', 'psd', 'magnitude', 'angle', 'phase'}
-            What sort of spectrum to use.  Default is 'psd', which takes the
-            power spectral density.  'magnitude' returns the magnitude
-            spectrum.  'angle' returns the phase spectrum without unwrapping.
-            'phase' returns the phase spectrum with unwrapping.
-
-        noverlap : int, default: 128
-            The number of points of overlap between blocks.
-
-        scale : {'default', 'linear', 'dB'}
-            The scaling of the values in the *spec*.  'linear' is no scaling.
-            'dB' returns the values in dB scale.  When *mode* is 'psd',
-            this is dB power (10 * log10).  Otherwise, this is dB amplitude
-            (20 * log10). 'default' is 'dB' if *mode* is 'psd' or
-            'magnitude' and 'linear' otherwise.  This must be 'linear'
-            if *mode* is 'angle' or 'phase'.
-
-        Fc : int, default: 0
-            The center frequency of *x*, which offsets the x extents of the
-            plot to reflect the frequency range used when a signal is acquired
-            and then filtered and downsampled to baseband.
-
-        cmap : `.Colormap`, default: :rc:`image.cmap`
-
-        xextent : *None* or (xmin, xmax)
-            The image extent along the x-axis. The default sets *xmin* to the
-            left border of the first bin (*spectrum* column) and *xmax* to the
-            right border of the last bin. Note that for *noverlap>0* the width
-            of the bins is smaller than those of the segments.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        vmin, vmax : float, optional
-            vmin and vmax define the data range that the colormap covers.
-            By default, the colormap covers the complete value range of the
-            data.
-
-        **kwargs
-            Additional keyword arguments are passed on to `~.axes.Axes.imshow`
-            which makes the specgram image. The origin keyword argument
-            is not supported.
-
-        Returns
-        -------
-        spectrum : 2D array
-            Columns are the periodograms of successive segments.
-
-        freqs : 1-D array
-            The frequencies corresponding to the rows in *spectrum*.
-
-        t : 1-D array
-            The times corresponding to midpoints of segments (i.e., the columns
-            in *spectrum*).
-
-        im : `.AxesImage`
-            The image created by imshow containing the spectrogram.
-
-        See Also
-        --------
-        psd
-            Differs in the default overlap; in returning the mean of the
-            segment periodograms; in not returning times; and in generating a
-            line plot instead of colormap.
-        magnitude_spectrum
-            A single spectrum, similar to having a single segment when *mode*
-            is 'magnitude'. Plots a line instead of a colormap.
-        angle_spectrum
-            A single spectrum, similar to having a single segment when *mode*
-            is 'angle'. Plots a line instead of a colormap.
-        phase_spectrum
-            A single spectrum, similar to having a single segment when *mode*
-            is 'phase'. Plots a line instead of a colormap.
-
-        Notes
-        -----
-        The parameters *detrend* and *scale_by_freq* do only apply when *mode*
-        is set to 'psd'.
-        """
-        if NFFT is None:
-            NFFT = 256  # same default as in mlab.specgram()
-        if Fc is None:
-            Fc = 0  # same default as in mlab._spectral_helper()
-        if noverlap is None:
-            noverlap = 128  # same default as in mlab.specgram()
-        if Fs is None:
-            Fs = 2  # same default as in mlab._spectral_helper()
-
-        if mode == 'complex':
-            raise ValueError('Cannot plot a complex specgram')
-
-        if scale is None or scale == 'default':
-            if mode in ['angle', 'phase']:
-                scale = 'linear'
-            else:
-                scale = 'dB'
-        elif mode in ['angle', 'phase'] and scale == 'dB':
-            raise ValueError('Cannot use dB scale with angle or phase mode')
-
-        spec, freqs, t = mlab.specgram(x=x, NFFT=NFFT, Fs=Fs,
-                                       detrend=detrend, window=window,
-                                       noverlap=noverlap, pad_to=pad_to,
-                                       sides=sides,
-                                       scale_by_freq=scale_by_freq,
-                                       mode=mode)
-
-        if scale == 'linear':
-            Z = spec
-        elif scale == 'dB':
-            if mode is None or mode == 'default' or mode == 'psd':
-                Z = 10. * np.log10(spec)
-            else:
-                Z = 20. * np.log10(spec)
-        else:
-            raise ValueError(f'Unknown scale {scale!r}')
-
-        Z = np.flipud(Z)
-
-        if xextent is None:
-            # padding is needed for first and last segment:
-            pad_xextent = (NFFT-noverlap) / Fs / 2
-            xextent = np.min(t) - pad_xextent, np.max(t) + pad_xextent
-        xmin, xmax = xextent
-        freqs += Fc
-        extent = xmin, xmax, freqs[0], freqs[-1]
-
-        if 'origin' in kwargs:
-            raise _api.kwarg_error("specgram", "origin")
-
-        im = self.imshow(Z, cmap, extent=extent, vmin=vmin, vmax=vmax,
-                         origin='upper', **kwargs)
-        self.axis('auto')
-
-        return spec, freqs, t, im
-
-    @_api.make_keyword_only("3.9", "precision")
-    @_docstring.interpd
-    def spy(self, Z, precision=0, marker=None, markersize=None,
-            aspect='equal', origin="upper", **kwargs):
-        """
-        Plot the sparsity pattern of a 2D array.
-
-        This visualizes the non-zero values of the array.
-
-        Two plotting styles are available: image and marker. Both
-        are available for full arrays, but only the marker style
-        works for `scipy.sparse.spmatrix` instances.
-
-        **Image style**
-
-        If *marker* and *markersize* are *None*, `~.Axes.imshow` is used. Any
-        extra remaining keyword arguments are passed to this method.
-
-        **Marker style**
-
-        If *Z* is a `scipy.sparse.spmatrix` or *marker* or *markersize* are
-        *None*, a `.Line2D` object will be returned with the value of marker
-        determining the marker type, and any remaining keyword arguments
-        passed to `~.Axes.plot`.
-
-        Parameters
-        ----------
-        Z : (M, N) array-like
-            The array to be plotted.
-
-        precision : float or 'present', default: 0
-            If *precision* is 0, any non-zero value will be plotted. Otherwise,
-            values of :math:`|Z| > precision` will be plotted.
-
-            For `scipy.sparse.spmatrix` instances, you can also
-            pass 'present'. In this case any value present in the array
-            will be plotted, even if it is identically zero.
-
-        aspect : {'equal', 'auto', None} or float, default: 'equal'
-            The aspect ratio of the Axes.  This parameter is particularly
-            relevant for images since it determines whether data pixels are
-            square.
-
-            This parameter is a shortcut for explicitly calling
-            `.Axes.set_aspect`. See there for further details.
-
-            - 'equal': Ensures an aspect ratio of 1. Pixels will be square.
-            - 'auto': The Axes is kept fixed and the aspect is adjusted so
-              that the data fit in the Axes. In general, this will result in
-              non-square pixels.
-            - *None*: Use :rc:`image.aspect`.
-
-        origin : {'upper', 'lower'}, default: :rc:`image.origin`
-            Place the [0, 0] index of the array in the upper left or lower left
-            corner of the Axes. The convention 'upper' is typically used for
-            matrices and images.
-
-        Returns
-        -------
-        `~matplotlib.image.AxesImage` or `.Line2D`
-            The return type depends on the plotting style (see above).
-
-        Other Parameters
-        ----------------
-        **kwargs
-            The supported additional parameters depend on the plotting style.
-
-            For the image style, you can pass the following additional
-            parameters of `~.Axes.imshow`:
-
-            - *cmap*
-            - *alpha*
-            - *url*
-            - any `.Artist` properties (passed on to the `.AxesImage`)
-
-            For the marker style, you can pass any `.Line2D` property except
-            for *linestyle*:
-
-            %(Line2D:kwdoc)s
-        """
-        if marker is None and markersize is None and hasattr(Z, 'tocoo'):
-            marker = 's'
-        _api.check_in_list(["upper", "lower"], origin=origin)
-        if marker is None and markersize is None:
-            Z = np.asarray(Z)
-            mask = np.abs(Z) > precision
-
-            if 'cmap' not in kwargs:
-                kwargs['cmap'] = mcolors.ListedColormap(['w', 'k'],
-                                                        name='binary')
-            if 'interpolation' in kwargs:
-                raise _api.kwarg_error("spy", "interpolation")
-            if 'norm' not in kwargs:
-                kwargs['norm'] = mcolors.NoNorm()
-            ret = self.imshow(mask, interpolation='nearest',
-                              aspect=aspect, origin=origin,
-                              **kwargs)
-        else:
-            if hasattr(Z, 'tocoo'):
-                c = Z.tocoo()
-                if precision == 'present':
-                    y = c.row
-                    x = c.col
-                else:
-                    nonzero = np.abs(c.data) > precision
-                    y = c.row[nonzero]
-                    x = c.col[nonzero]
-            else:
-                Z = np.asarray(Z)
-                nonzero = np.abs(Z) > precision
-                y, x = np.nonzero(nonzero)
-            if marker is None:
-                marker = 's'
-            if markersize is None:
-                markersize = 10
-            if 'linestyle' in kwargs:
-                raise _api.kwarg_error("spy", "linestyle")
-            ret = mlines.Line2D(
-                x, y, linestyle='None', marker=marker, markersize=markersize,
-                **kwargs)
-            self.add_line(ret)
-            nr, nc = Z.shape
-            self.set_xlim(-0.5, nc - 0.5)
-            if origin == "upper":
-                self.set_ylim(nr - 0.5, -0.5)
-            else:
-                self.set_ylim(-0.5, nr - 0.5)
-            self.set_aspect(aspect)
-        self.title.set_y(1.05)
-        if origin == "upper":
-            self.xaxis.tick_top()
-        else:  # lower
-            self.xaxis.tick_bottom()
-        self.xaxis.set_ticks_position('both')
-        self.xaxis.set_major_locator(
-            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
-        self.yaxis.set_major_locator(
-            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
-        return ret
-
-    def matshow(self, Z, **kwargs):
-        """
-        Plot the values of a 2D matrix or array as color-coded image.
-
-        The matrix will be shown the way it would be printed, with the first
-        row at the top.  Row and column numbering is zero-based.
-
-        Parameters
-        ----------
-        Z : (M, N) array-like
-            The matrix to be displayed.
-
-        Returns
-        -------
-        `~matplotlib.image.AxesImage`
-
-        Other Parameters
-        ----------------
-        **kwargs : `~matplotlib.axes.Axes.imshow` arguments
-
-        See Also
-        --------
-        imshow : More general function to plot data on a 2D regular raster.
-
-        Notes
-        -----
-        This is just a convenience function wrapping `.imshow` to set useful
-        defaults for displaying a matrix. In particular:
-
-        - Set ``origin='upper'``.
-        - Set ``interpolation='nearest'``.
-        - Set ``aspect='equal'``.
-        - Ticks are placed to the left and above.
-        - Ticks are formatted to show integer indices.
-
-        """
-        Z = np.asanyarray(Z)
-        kw = {'origin': 'upper',
-              'interpolation': 'nearest',
-              'aspect': 'equal',          # (already the imshow default)
-              **kwargs}
-        im = self.imshow(Z, **kw)
-        self.title.set_y(1.05)
-        self.xaxis.tick_top()
-        self.xaxis.set_ticks_position('both')
-        self.xaxis.set_major_locator(
-            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
-        self.yaxis.set_major_locator(
-            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
-        return im
-
-    @_api.make_keyword_only("3.9", "vert")
-    @_preprocess_data(replace_names=["dataset"])
-    def violinplot(self, dataset, positions=None, vert=None,
-                   orientation='vertical', widths=0.5, showmeans=False,
-                   showextrema=True, showmedians=False, quantiles=None,
-                   points=100, bw_method=None, side='both',):
-        """
-        Make a violin plot.
-
-        Make a violin plot for each column of *dataset* or each vector in
-        sequence *dataset*.  Each filled area extends to represent the
-        entire data range, with optional lines at the mean, the median,
-        the minimum, the maximum, and user-specified quantiles.
-
-        Parameters
-        ----------
-        dataset : Array or a sequence of vectors.
-            The input data.
-
-        positions : array-like, default: [1, 2, ..., n]
-            The positions of the violins; i.e. coordinates on the x-axis for
-            vertical violins (or y-axis for horizontal violins).
-
-        vert : bool, optional
-            .. deprecated:: 3.10
-                Use *orientation* instead.
-
-                If this is given during the deprecation period, it overrides
-                the *orientation* parameter.
-
-            If True, plots the violins vertically.
-            If False, plots the violins horizontally.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            If 'horizontal', plots the violins horizontally.
-            Otherwise, plots the violins vertically.
-
-            .. versionadded:: 3.10
-
-        widths : float or array-like, default: 0.5
-            The maximum width of each violin in units of the *positions* axis.
-            The default is 0.5, which is half the available space when using default
-            *positions*.
-
-        showmeans : bool, default: False
-            Whether to show the mean with a line.
-
-        showextrema : bool, default: True
-            Whether to show extrema with a line.
-
-        showmedians : bool, default: False
-            Whether to show the median with a line.
-
-        quantiles : array-like, default: None
-            If not None, set a list of floats in interval [0, 1] for each violin,
-            which stands for the quantiles that will be rendered for that
-            violin.
-
-        points : int, default: 100
-            The number of points to evaluate each of the gaussian kernel density
-            estimations at.
-
-        bw_method : {'scott', 'silverman'} or float or callable, default: 'scott'
-            The method used to calculate the estimator bandwidth.  If a
-            float, this will be used directly as `kde.factor`.  If a
-            callable, it should take a `matplotlib.mlab.GaussianKDE` instance as
-            its only parameter and return a float.
-
-        side : {'both', 'low', 'high'}, default: 'both'
-            'both' plots standard violins. 'low'/'high' only
-            plots the side below/above the positions value.
-
-        data : indexable object, optional
-            DATA_PARAMETER_PLACEHOLDER
-
-        Returns
-        -------
-        dict
-            A dictionary mapping each component of the violinplot to a
-            list of the corresponding collection instances created. The
-            dictionary has the following keys:
-
-            - ``bodies``: A list of the `~.collections.PolyCollection`
-              instances containing the filled area of each violin.
-
-            - ``cmeans``: A `~.collections.LineCollection` instance that marks
-              the mean values of each of the violin's distribution.
-
-            - ``cmins``: A `~.collections.LineCollection` instance that marks
-              the bottom of each violin's distribution.
-
-            - ``cmaxes``: A `~.collections.LineCollection` instance that marks
-              the top of each violin's distribution.
-
-            - ``cbars``: A `~.collections.LineCollection` instance that marks
-              the centers of each violin's distribution.
-
-            - ``cmedians``: A `~.collections.LineCollection` instance that
-              marks the median values of each of the violin's distribution.
-
-            - ``cquantiles``: A `~.collections.LineCollection` instance created
-              to identify the quantile values of each of the violin's
-              distribution.
-
-        See Also
-        --------
-        .Axes.violin : Draw a violin from pre-computed statistics.
-        boxplot : Draw a box and whisker plot.
-        """
-
-        def _kde_method(X, coords):
-            # Unpack in case of e.g. Pandas or xarray object
-            X = cbook._unpack_to_numpy(X)
-            # fallback gracefully if the vector contains only one value
-            if np.all(X[0] == X):
-                return (X[0] == coords).astype(float)
-            kde = mlab.GaussianKDE(X, bw_method)
-            return kde.evaluate(coords)
-
-        vpstats = cbook.violin_stats(dataset, _kde_method, points=points,
-                                     quantiles=quantiles)
-        return self.violin(vpstats, positions=positions, vert=vert,
-                           orientation=orientation, widths=widths,
-                           showmeans=showmeans, showextrema=showextrema,
-                           showmedians=showmedians, side=side)
-
-    @_api.make_keyword_only("3.9", "vert")
-    def violin(self, vpstats, positions=None, vert=None,
-               orientation='vertical', widths=0.5, showmeans=False,
-               showextrema=True, showmedians=False, side='both'):
-        """
-        Draw a violin plot from pre-computed statistics.
-
-        Draw a violin plot for each column of *vpstats*. Each filled area
-        extends to represent the entire data range, with optional lines at the
-        mean, the median, the minimum, the maximum, and the quantiles values.
-
-        Parameters
-        ----------
-        vpstats : list of dicts
-            A list of dictionaries containing stats for each violin plot.
-            Required keys are:
-
-            - ``coords``: A list of scalars containing the coordinates that
-              the violin's kernel density estimate were evaluated at.
-
-            - ``vals``: A list of scalars containing the values of the
-              kernel density estimate at each of the coordinates given
-              in *coords*.
-
-            - ``mean``: The mean value for this violin's dataset.
-
-            - ``median``: The median value for this violin's dataset.
-
-            - ``min``: The minimum value for this violin's dataset.
-
-            - ``max``: The maximum value for this violin's dataset.
-
-            Optional keys are:
-
-            - ``quantiles``: A list of scalars containing the quantile values
-              for this violin's dataset.
-
-        positions : array-like, default: [1, 2, ..., n]
-            The positions of the violins; i.e. coordinates on the x-axis for
-            vertical violins (or y-axis for horizontal violins).
-
-        vert : bool, optional
-            .. deprecated:: 3.10
-                Use *orientation* instead.
-
-                If this is given during the deprecation period, it overrides
-                the *orientation* parameter.
-
-            If True, plots the violins vertically.
-            If False, plots the violins horizontally.
-
-        orientation : {'vertical', 'horizontal'}, default: 'vertical'
-            If 'horizontal', plots the violins horizontally.
-            Otherwise, plots the violins vertically.
-
-            .. versionadded:: 3.10
-
-        widths : float or array-like, default: 0.5
-            The maximum width of each violin in units of the *positions* axis.
-            The default is 0.5, which is half available space when using default
-            *positions*.
-
-        showmeans : bool, default: False
-            Whether to show the mean with a line.
-
-        showextrema : bool, default: True
-            Whether to show extrema with a line.
-
-        showmedians : bool, default: False
-            Whether to show the median with a line.
-
-        side : {'both', 'low', 'high'}, default: 'both'
-            'both' plots standard violins. 'low'/'high' only
-            plots the side below/above the positions value.
-
-        Returns
-        -------
-        dict
-            A dictionary mapping each component of the violinplot to a
-            list of the corresponding collection instances created. The
-            dictionary has the following keys:
-
-            - ``bodies``: A list of the `~.collections.PolyCollection`
-              instances containing the filled area of each violin.
-
-            - ``cmeans``: A `~.collections.LineCollection` instance that marks
-              the mean values of each of the violin's distribution.
-
-            - ``cmins``: A `~.collections.LineCollection` instance that marks
-              the bottom of each violin's distribution.
-
-            - ``cmaxes``: A `~.collections.LineCollection` instance that marks
-              the top of each violin's distribution.
-
-            - ``cbars``: A `~.collections.LineCollection` instance that marks
-              the centers of each violin's distribution.
-
-            - ``cmedians``: A `~.collections.LineCollection` instance that
-              marks the median values of each of the violin's distribution.
-
-            - ``cquantiles``: A `~.collections.LineCollection` instance created
-              to identify the quantiles values of each of the violin's
-              distribution.
-
-        See Also
-        --------
-        violinplot :
-            Draw a violin plot from data instead of pre-computed statistics.
-        """
-
-        # Statistical quantities to be plotted on the violins
-        means = []
-        mins = []
-        maxes = []
-        medians = []
-        quantiles = []
-
-        qlens = []  # Number of quantiles in each dataset.
-
-        artists = {}  # Collections to be returned
-
-        N = len(vpstats)
-        datashape_message = ("List of violinplot statistics and `{0}` "
-                             "values must have the same length")
-
-        # vert and orientation parameters are linked until vert's
-        # deprecation period expires. If both are selected,
-        # vert takes precedence.
-        if vert is not None:
-            _api.warn_deprecated(
-                "3.10",
-                name="vert: bool",
-                alternative="orientation: {'vertical', 'horizontal'}"
-                )
-            orientation = 'vertical' if vert else 'horizontal'
-        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
-
-        # Validate positions
-        if positions is None:
-            positions = range(1, N + 1)
-        elif len(positions) != N:
-            raise ValueError(datashape_message.format("positions"))
-
-        # Validate widths
-        if np.isscalar(widths):
-            widths = [widths] * N
-        elif len(widths) != N:
-            raise ValueError(datashape_message.format("widths"))
-
-        # Validate side
-        _api.check_in_list(["both", "low", "high"], side=side)
-
-        # Calculate ranges for statistics lines (shape (2, N)).
-        line_ends = [[-0.25 if side in ['both', 'low'] else 0],
-                     [0.25 if side in ['both', 'high'] else 0]] \
-                          * np.array(widths) + positions
-
-        # Colors.
-        if mpl.rcParams['_internal.classic_mode']:
-            fillcolor = 'y'
-            linecolor = 'r'
-        else:
-            fillcolor = linecolor = self._get_lines.get_next_color()
-
-        # Check whether we are rendering vertically or horizontally
-        if orientation == 'vertical':
-            fill = self.fill_betweenx
-            if side in ['low', 'high']:
-                perp_lines = functools.partial(self.hlines, colors=linecolor,
-                                                capstyle='projecting')
-                par_lines = functools.partial(self.vlines, colors=linecolor,
-                                                capstyle='projecting')
-            else:
-                perp_lines = functools.partial(self.hlines, colors=linecolor)
-                par_lines = functools.partial(self.vlines, colors=linecolor)
-        else:
-            fill = self.fill_between
-            if side in ['low', 'high']:
-                perp_lines = functools.partial(self.vlines, colors=linecolor,
-                                                capstyle='projecting')
-                par_lines = functools.partial(self.hlines, colors=linecolor,
-                                                capstyle='projecting')
-            else:
-                perp_lines = functools.partial(self.vlines, colors=linecolor)
-                par_lines = functools.partial(self.hlines, colors=linecolor)
-
-        # Render violins
-        bodies = []
-        for stats, pos, width in zip(vpstats, positions, widths):
-            # The 0.5 factor reflects the fact that we plot from v-p to v+p.
-            vals = np.array(stats['vals'])
-            vals = 0.5 * width * vals / vals.max()
-            bodies += [fill(stats['coords'],
-                            -vals + pos if side in ['both', 'low'] else pos,
-                            vals + pos if side in ['both', 'high'] else pos,
-                            facecolor=fillcolor, alpha=0.3)]
-            means.append(stats['mean'])
-            mins.append(stats['min'])
-            maxes.append(stats['max'])
-            medians.append(stats['median'])
-            q = stats.get('quantiles')  # a list of floats, or None
-            if q is None:
-                q = []
-            quantiles.extend(q)
-            qlens.append(len(q))
-        artists['bodies'] = bodies
-
-        if showmeans:  # Render means
-            artists['cmeans'] = perp_lines(means, *line_ends)
-        if showextrema:  # Render extrema
-            artists['cmaxes'] = perp_lines(maxes, *line_ends)
-            artists['cmins'] = perp_lines(mins, *line_ends)
-            artists['cbars'] = par_lines(positions, mins, maxes)
-        if showmedians:  # Render medians
-            artists['cmedians'] = perp_lines(medians, *line_ends)
-        if quantiles:  # Render quantiles: each width is repeated qlen times.
-            artists['cquantiles'] = perp_lines(
-                quantiles, *np.repeat(line_ends, qlens, axis=1))
-
-        return artists
-
-    # Methods that are entirely implemented in other modules.
-
-    table = _make_axes_method(mtable.table)
-
-    # args can be either Y or y1, y2, ... and all should be replaced
-    stackplot = _preprocess_data()(_make_axes_method(mstack.stackplot))
-
-    streamplot = _preprocess_data(
-            replace_names=["x", "y", "u", "v", "start_points"])(
-        _make_axes_method(mstream.streamplot))
-
-    tricontour = _make_axes_method(mtri.tricontour)
-    tricontourf = _make_axes_method(mtri.tricontourf)
-    tripcolor = _make_axes_method(mtri.tripcolor)
-    triplot = _make_axes_method(mtri.triplot)
-
-    def _get_aspect_ratio(self):
-        """
-        Convenience method to calculate the aspect ratio of the Axes in
-        the display coordinate system.
-        """
-        figure_size = self.get_figure().get_size_inches()
-        ll, ur = self.get_position() * figure_size
-        width, height = ur - ll
-        return height / (width * self.get_data_ratio())
+            child.remove()
+        except NotImplementedError:
+            pass  # not implemented is expected for some artists
+
+
+def test_boxplot_tick_labels():
+    # Test the renamed `tick_labels` parameter.
+    # Test for deprecation of old name `labels`.
+    np.random.seed(19680801)
+    data = np.random.random((10, 3))
+
+    fig, axs = plt.subplots(nrows=1, ncols=2, sharey=True)
+    # Should get deprecation warning for `labels`
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
+                      match='has been renamed \'tick_labels\''):
+        axs[0].boxplot(data, labels=['A', 'B', 'C'])
+    assert [l.get_text() for l in axs[0].get_xticklabels()] == ['A', 'B', 'C']
+
+    # Test the new tick_labels parameter
+    axs[1].boxplot(data, tick_labels=['A', 'B', 'C'])
+    assert [l.get_text() for l in axs[1].get_xticklabels()] == ['A', 'B', 'C']
+
+
+@needs_usetex
+@check_figures_equal()
+def test_latex_pie_percent(fig_test, fig_ref):
+
+    data = [20, 10, 70]
+
+    ax = fig_test.subplots()
+    ax.pie(data, autopct="%1.0f%%", textprops={'usetex': True})
+
+    ax1 = fig_ref.subplots()
+    ax1.pie(data, autopct=r"%1.0f\%%", textprops={'usetex': True})
+
+
+@check_figures_equal(extensions=['png'])
+def test_violinplot_orientation(fig_test, fig_ref):
+    # Test the `orientation : {'vertical', 'horizontal'}`
+    # parameter and deprecation of `vert: bool`.
+    fig, axs = plt.subplots(nrows=1, ncols=3)
+    np.random.seed(19680801)
+    all_data = [np.random.normal(0, std, 100) for std in range(6, 10)]
+
+    axs[0].violinplot(all_data)  # Default vertical plot.
+    # xticks and yticks should be at their default position.
+    assert all(axs[0].get_xticks() == np.array(
+        [0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5]))
+    assert all(axs[0].get_yticks() == np.array(
+        [-30., -20., -10., 0., 10., 20., 30.]))
+
+    # Horizontal plot using new `orientation` keyword.
+    axs[1].violinplot(all_data, orientation='horizontal')
+    # xticks and yticks should be swapped.
+    assert all(axs[1].get_xticks() == np.array(
+        [-30., -20., -10., 0., 10., 20., 30.]))
+    assert all(axs[1].get_yticks() == np.array(
+        [0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5]))
+
+    plt.close()
+
+    # Deprecation of `vert: bool` keyword
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
+                      match='vert: bool was deprecated in Matplotlib 3.10'):
+        # Compare images between a figure that
+        # uses vert and one that uses orientation.
+        ax_ref = fig_ref.subplots()
+        ax_ref.violinplot(all_data, vert=False)
+
+        ax_test = fig_test.subplots()
+        ax_test.violinplot(all_data, orientation='horizontal')
+
+
+@check_figures_equal(extensions=['png'])
+def test_boxplot_orientation(fig_test, fig_ref):
+    # Test the `orientation : {'vertical', 'horizontal'}`
+    # parameter and deprecation of `vert: bool`.
+    fig, axs = plt.subplots(nrows=1, ncols=2)
+    np.random.seed(19680801)
+    all_data = [np.random.normal(0, std, 100) for std in range(6, 10)]
+
+    axs[0].boxplot(all_data)  # Default vertical plot.
+    # xticks and yticks should be at their default position.
+    assert all(axs[0].get_xticks() == np.array(
+        [1, 2, 3, 4]))
+    assert all(axs[0].get_yticks() == np.array(
+        [-30., -20., -10., 0., 10., 20., 30.]))
+
+    # Horizontal plot using new `orientation` keyword.
+    axs[1].boxplot(all_data, orientation='horizontal')
+    # xticks and yticks should be swapped.
+    assert all(axs[1].get_xticks() == np.array(
+        [-30., -20., -10., 0., 10., 20., 30.]))
+    assert all(axs[1].get_yticks() == np.array(
+        [1, 2, 3, 4]))
+
+    plt.close()
+
+    # Deprecation of `vert: bool` keyword and
+    # 'boxplot.vertical' rcparam.
+    with pytest.warns(mpl.MatplotlibDeprecationWarning,
+                      match='was deprecated in Matplotlib 3.10'):
+        # Compare images between a figure that
+        # uses vert and one that uses orientation.
+        with mpl.rc_context({'boxplot.vertical': False}):
+            ax_ref = fig_ref.subplots()
+            ax_ref.boxplot(all_data)
+
+        ax_test = fig_test.subplots()
+        ax_test.boxplot(all_data, orientation='horizontal')
+
+
+@image_comparison(["use_colorizer_keyword.png"],
+                   tol=0.05 if platform.machine() == 'arm64' else 0)
+def test_use_colorizer_keyword():
+    # test using the colorizer keyword
+    np.random.seed(0)
+    rand_x = np.random.random(100)
+    rand_y = np.random.random(100)
+    c = np.arange(25, dtype='float32').reshape((5, 5))
+
+    fig, axes = plt.subplots(3, 4)
+    norm = mpl.colors.Normalize(4, 20)
+    cl = mpl.colorizer.Colorizer(norm=norm, cmap='RdBu')
+
+    axes[0, 0].scatter(c, c, c=c, colorizer=cl)
+    axes[0, 1].hexbin(rand_x, rand_y, colorizer=cl, gridsize=(2, 2))
+    axes[0, 2].imshow(c, colorizer=cl)
+    axes[0, 3].pcolor(c, colorizer=cl)
+    axes[1, 0].pcolormesh(c, colorizer=cl)
+    axes[1, 1].pcolorfast(c, colorizer=cl)  # style = image
+    axes[1, 2].pcolorfast((0, 1, 2, 3, 4, 5), (0, 1, 2, 3, 5, 6),  c,
+                          colorizer=cl)  # style = pcolorimage
+    axes[1, 3].pcolorfast(c.T, c, c[:4, :4], colorizer=cl)  # style = quadmesh
+    axes[2, 0].contour(c, colorizer=cl)
+    axes[2, 1].contourf(c, colorizer=cl)
+    axes[2, 2].tricontour(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl)
+    axes[2, 3].tricontourf(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl)
+
+    fig.figimage(np.repeat(np.repeat(c, 15, axis=0), 15, axis=1), colorizer=cl)
+    remove_ticks_and_titles(fig)
+
+
+def test_wrong_use_colorizer():
+    # test using the colorizer keyword and norm or cmap
+    np.random.seed(0)
+    rand_x = np.random.random(100)
+    rand_y = np.random.random(100)
+    c = np.arange(25, dtype='float32').reshape((5, 5))
+
+    fig, axes = plt.subplots(3, 4)
+    norm = mpl.colors.Normalize(4, 20)
+    cl = mpl.colorizer.Colorizer(norm=norm, cmap='RdBu')
+
+    match_str = "The `colorizer` keyword cannot be used simultaneously"
+    kwrds = [{'vmin': 0}, {'vmax': 0}, {'norm': 'log'}, {'cmap': 'viridis'}]
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[0, 0].scatter(c, c, c=c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[0, 0].scatter(c, c, c=c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[0, 1].hexbin(rand_x, rand_y, colorizer=cl, gridsize=(2, 2), **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[0, 2].imshow(c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[0, 3].pcolor(c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[1, 0].pcolormesh(c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[1, 1].pcolorfast(c, colorizer=cl, **kwrd)  # style = image
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[1, 2].pcolorfast((0, 1, 2, 3, 4, 5), (0, 1, 2, 3, 5, 6),  c,
+                                  colorizer=cl, **kwrd)  # style = pcolorimage
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[1, 3].pcolorfast(c.T, c, c[:4, :4], colorizer=cl, **kwrd)  # quadmesh
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[2, 0].contour(c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[2, 1].contourf(c, colorizer=cl, **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[2, 2].tricontour(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl,
+                                  **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            axes[2, 3].tricontourf(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl,
+                                   **kwrd)
+    for kwrd in kwrds:
+        with pytest.raises(ValueError, match=match_str):
+            fig.figimage(c, colorizer=cl, **kwrd)
+
+
+def test_bar_color_precedence():
+    # Test the precedence of 'color' and 'facecolor' in bar plots
+    fig, ax = plt.subplots()
+
+    # case 1: no color specified
+    bars = ax.bar([1, 2, 3], [4, 5, 6])
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'blue')
+
+    # case 2: Only 'color'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red')
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'red')
+
+    # case 3: Only 'facecolor'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], facecolor='yellow')
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'yellow')
+
+    # case 4: 'facecolor' and 'color'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red', facecolor='green')
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'green')

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2593,8 +2593,8 @@ class Axes(_AxesBase):
         linewidth = itertools.cycle(np.atleast_1d(linewidth))
         hatch = itertools.cycle(np.atleast_1d(hatch))
         facecolor = itertools.chain(itertools.cycle(facecolor),
-                                # Fallback if color == "none".
-                                itertools.repeat('none'))
+                                    # Fallback if color == "none".
+                                    itertools.repeat('none'))
         if edgecolor is None:
             edgecolor = itertools.repeat(None)
         else:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2334,7 +2334,6 @@ class Axes(_AxesBase):
         Argument precedence for edgecolors:
 
         - kwargs['edgecolor']
-        - kwargs['color']
         - None
 
         Parameters
@@ -2357,7 +2356,7 @@ class Axes(_AxesBase):
         color = kwargs.pop('color', None)
 
         facecolor = kwargs.pop('facecolor', color)
-        edgecolor = kwargs.pop('edgecolor', color)
+        edgecolor = kwargs.pop('edgecolor', None)
 
         facecolor = (facecolor if facecolor is not None
                      else self._get_patches_for_fill.get_next_color())
@@ -2427,7 +2426,7 @@ class Axes(_AxesBase):
         Other Parameters
         ----------------
         color : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar faces and edges.
+            The colors of the bar faces.
 
         facecolor : :mpltype:`color` or list of :mpltype:`color`, optional
             The colors of the bar faces.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2350,9 +2350,9 @@ class Axes(_AxesBase):
         Returns
         -------
         facecolor
-            The facecolor.
+            The facecolor. One or more colors as (N, 4) rgba array.
         edgecolor
-            The edgecolor.
+            The edgecolor. Not normalized; may be any valid color spec or None.
         """
         color = kwargs.pop('color', None)
 
@@ -2495,7 +2495,7 @@ class Axes(_AxesBase):
         bar. See :doc:`/gallery/lines_bars_and_markers/bar_stacked`.
         """
         kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
-        color, edgecolor = self._parse_bar_color_args(kwargs)
+        facecolor, edgecolor = self._parse_bar_color_args(kwargs)
 
         linewidth = kwargs.pop('linewidth', None)
         hatch = kwargs.pop('hatch', None)
@@ -2592,7 +2592,7 @@ class Axes(_AxesBase):
 
         linewidth = itertools.cycle(np.atleast_1d(linewidth))
         hatch = itertools.cycle(np.atleast_1d(hatch))
-        color = itertools.chain(itertools.cycle(mcolors.to_rgba_array(color)),
+        facecolor = itertools.chain(itertools.cycle(facecolor),
                                 # Fallback if color == "none".
                                 itertools.repeat('none'))
         if edgecolor is None:
@@ -2628,7 +2628,7 @@ class Axes(_AxesBase):
             bottom = y
 
         patches = []
-        args = zip(left, bottom, width, height, color, edgecolor, linewidth,
+        args = zip(left, bottom, width, height, facecolor, edgecolor, linewidth,
                    hatch, patch_labels)
         for l, b, w, h, c, e, lw, htch, lbl in args:
             r = mpatches.Rectangle(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1,9479 +1,8813 @@
-import contextlib
-from collections import namedtuple, deque
-import datetime
-from decimal import Decimal
-from functools import partial
-import gc
-import inspect
-import io
-from itertools import product
-import platform
-import sys
-from types import SimpleNamespace
+import functools
+import itertools
+import logging
+import math
+from numbers import Integral, Number, Real
 
-import dateutil.tz
-
+import re
 import numpy as np
-from numpy import ma
-from cycler import cycler
-import pytest
 
-import matplotlib
 import matplotlib as mpl
-from matplotlib import rc_context, patheffects
+import matplotlib.category  # Register category unit converter as side effect.
+import matplotlib.cbook as cbook
+import matplotlib.collections as mcoll
+import matplotlib.colorizer as mcolorizer
 import matplotlib.colors as mcolors
-import matplotlib.dates as mdates
-from matplotlib.figure import Figure
-from matplotlib.axes import Axes
-from matplotlib.lines import Line2D
-from matplotlib.collections import PathCollection
-import matplotlib.font_manager as mfont_manager
+import matplotlib.contour as mcontour
+import matplotlib.dates  # noqa: F401, Register date unit converter as side effect.
+import matplotlib.image as mimage
+import matplotlib.inset as minset
+import matplotlib.legend as mlegend
+import matplotlib.lines as mlines
 import matplotlib.markers as mmarkers
+import matplotlib.mlab as mlab
 import matplotlib.patches as mpatches
 import matplotlib.path as mpath
-from matplotlib.projections.geo import HammerAxes
-from matplotlib.projections.polar import PolarAxes
-import matplotlib.pyplot as plt
+import matplotlib.quiver as mquiver
+import matplotlib.stackplot as mstack
+import matplotlib.streamplot as mstream
+import matplotlib.table as mtable
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
-import mpl_toolkits.axisartist as AA  # type: ignore[import]
-from numpy.testing import (
-    assert_allclose, assert_array_equal, assert_array_almost_equal)
-from matplotlib.testing.decorators import (
-    image_comparison, check_figures_equal, remove_ticks_and_titles)
-from matplotlib.testing._markers import needs_usetex
+import matplotlib.tri as mtri
+import matplotlib.units as munits
+from matplotlib import _api, _docstring, _preprocess_data
+from matplotlib.axes._base import (
+    _AxesBase, _TransformedBoundsLocator, _process_plot_format)
+from matplotlib.axes._secondary_axes import SecondaryAxis
+from matplotlib.container import BarContainer, ErrorbarContainer, StemContainer
+from matplotlib.transforms import _ScaledRotation
 
-# Note: Some test cases are run twice: once normally and once with labeled data
-#       These two must be defined in the same test function or need to have
-#       different baseline images to prevent race conditions when pytest runs
-#       the tests with multiple threads.
+_log = logging.getLogger(__name__)
 
 
-@check_figures_equal(extensions=["png"])
-def test_invisible_axes(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    ax.set_visible(False)
+# The axes module contains all the wrappers to plotting functions.
+# All the other methods should go in the _AxesBase class.
 
 
-def test_get_labels():
-    fig, ax = plt.subplots()
-    ax.set_xlabel('x label')
-    ax.set_ylabel('y label')
-    assert ax.get_xlabel() == 'x label'
-    assert ax.get_ylabel() == 'y label'
-
-
-def test_repr():
-    fig, ax = plt.subplots()
-    ax.set_label('label')
-    ax.set_title('title')
-    ax.set_xlabel('x')
-    ax.set_ylabel('y')
-    assert repr(ax) == (
-        "<Axes: "
-        "label='label', title={'center': 'title'}, xlabel='x', ylabel='y'>")
-
-
-@check_figures_equal()
-def test_label_loc_vertical(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
-    ax.legend()
-    ax.set_ylabel('Y Label', loc='top')
-    ax.set_xlabel('X Label', loc='right')
-    cbar = fig_test.colorbar(sc)
-    cbar.set_label("Z Label", loc='top')
-
-    ax = fig_ref.subplots()
-    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
-    ax.legend()
-    ax.set_ylabel('Y Label', y=1, ha='right')
-    ax.set_xlabel('X Label', x=1, ha='right')
-    cbar = fig_ref.colorbar(sc)
-    cbar.set_label("Z Label", y=1, ha='right')
-
-
-@check_figures_equal()
-def test_label_loc_horizontal(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
-    ax.legend()
-    ax.set_ylabel('Y Label', loc='bottom')
-    ax.set_xlabel('X Label', loc='left')
-    cbar = fig_test.colorbar(sc, orientation='horizontal')
-    cbar.set_label("Z Label", loc='left')
-
-    ax = fig_ref.subplots()
-    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
-    ax.legend()
-    ax.set_ylabel('Y Label', y=0, ha='left')
-    ax.set_xlabel('X Label', x=0, ha='left')
-    cbar = fig_ref.colorbar(sc, orientation='horizontal')
-    cbar.set_label("Z Label", x=0, ha='left')
-
-
-@check_figures_equal()
-def test_label_loc_rc(fig_test, fig_ref):
-    with matplotlib.rc_context({"xaxis.labellocation": "right",
-                                "yaxis.labellocation": "top"}):
-        ax = fig_test.subplots()
-        sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
-        ax.legend()
-        ax.set_ylabel('Y Label')
-        ax.set_xlabel('X Label')
-        cbar = fig_test.colorbar(sc, orientation='horizontal')
-        cbar.set_label("Z Label")
-
-    ax = fig_ref.subplots()
-    sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
-    ax.legend()
-    ax.set_ylabel('Y Label', y=1, ha='right')
-    ax.set_xlabel('X Label', x=1, ha='right')
-    cbar = fig_ref.colorbar(sc, orientation='horizontal')
-    cbar.set_label("Z Label", x=1, ha='right')
-
-
-def test_label_shift():
-    fig, ax = plt.subplots()
-
-    # Test label re-centering on x-axis
-    ax.set_xlabel("Test label", loc="left")
-    ax.set_xlabel("Test label", loc="center")
-    assert ax.xaxis.label.get_horizontalalignment() == "center"
-    ax.set_xlabel("Test label", loc="right")
-    assert ax.xaxis.label.get_horizontalalignment() == "right"
-    ax.set_xlabel("Test label", loc="center")
-    assert ax.xaxis.label.get_horizontalalignment() == "center"
-
-    # Test label re-centering on y-axis
-    ax.set_ylabel("Test label", loc="top")
-    ax.set_ylabel("Test label", loc="center")
-    assert ax.yaxis.label.get_horizontalalignment() == "center"
-    ax.set_ylabel("Test label", loc="bottom")
-    assert ax.yaxis.label.get_horizontalalignment() == "left"
-    ax.set_ylabel("Test label", loc="center")
-    assert ax.yaxis.label.get_horizontalalignment() == "center"
-
-
-@check_figures_equal(extensions=["png"])
-def test_acorr(fig_test, fig_ref):
-    np.random.seed(19680801)
-    Nx = 512
-    x = np.random.normal(0, 1, Nx).cumsum()
-    maxlags = Nx-1
-
-    ax_test = fig_test.subplots()
-    ax_test.acorr(x, maxlags=maxlags)
-
-    ax_ref = fig_ref.subplots()
-    # Normalized autocorrelation
-    norm_auto_corr = np.correlate(x, x, mode="full")/np.dot(x, x)
-    lags = np.arange(-maxlags, maxlags+1)
-    norm_auto_corr = norm_auto_corr[Nx-1-maxlags:Nx+maxlags]
-    ax_ref.vlines(lags, [0], norm_auto_corr)
-    ax_ref.axhline(y=0, xmin=0, xmax=1)
-
-
-@check_figures_equal(extensions=["png"])
-def test_acorr_integers(fig_test, fig_ref):
-    np.random.seed(19680801)
-    Nx = 51
-    x = (np.random.rand(Nx) * 10).cumsum()
-    x = (np.ceil(x)).astype(np.int64)
-    maxlags = Nx-1
-
-    ax_test = fig_test.subplots()
-    ax_test.acorr(x, maxlags=maxlags)
-
-    ax_ref = fig_ref.subplots()
-
-    # Normalized autocorrelation
-    norm_auto_corr = np.correlate(x, x, mode="full")/np.dot(x, x)
-    lags = np.arange(-maxlags, maxlags+1)
-    norm_auto_corr = norm_auto_corr[Nx-1-maxlags:Nx+maxlags]
-    ax_ref.vlines(lags, [0], norm_auto_corr)
-    ax_ref.axhline(y=0, xmin=0, xmax=1)
-
-
-@check_figures_equal(extensions=["png"])
-def test_spy(fig_test, fig_ref):
-    np.random.seed(19680801)
-    a = np.ones(32 * 32)
-    a[:16 * 32] = 0
-    np.random.shuffle(a)
-    a = a.reshape((32, 32))
-
-    axs_test = fig_test.subplots(2)
-    axs_test[0].spy(a)
-    axs_test[1].spy(a, marker=".", origin="lower")
-
-    axs_ref = fig_ref.subplots(2)
-    axs_ref[0].imshow(a, cmap="gray_r", interpolation="nearest")
-    axs_ref[0].xaxis.tick_top()
-    axs_ref[1].plot(*np.nonzero(a)[::-1], ".", markersize=10)
-    axs_ref[1].set(
-        aspect=1, xlim=axs_ref[0].get_xlim(), ylim=axs_ref[0].get_ylim()[::-1])
-    for ax in axs_ref:
-        ax.xaxis.set_ticks_position("both")
-
-
-def test_spy_invalid_kwargs():
-    fig, ax = plt.subplots()
-    for unsupported_kw in [{'interpolation': 'nearest'},
-                           {'marker': 'o', 'linestyle': 'solid'}]:
-        with pytest.raises(TypeError):
-            ax.spy(np.eye(3, 3), **unsupported_kw)
-
-
-@check_figures_equal(extensions=["png"])
-def test_matshow(fig_test, fig_ref):
-    mpl.style.use("mpl20")
-    a = np.random.rand(32, 32)
-    fig_test.add_subplot().matshow(a)
-    ax_ref = fig_ref.add_subplot()
-    ax_ref.imshow(a)
-    ax_ref.xaxis.tick_top()
-    ax_ref.xaxis.set_ticks_position('both')
-
-
-@image_comparison(['formatter_ticker_001',
-                   'formatter_ticker_002',
-                   'formatter_ticker_003',
-                   'formatter_ticker_004',
-                   'formatter_ticker_005',
-                   ],
-                  tol=0.031 if platform.machine() == 'arm64' else 0)
-def test_formatter_ticker():
-    import matplotlib.testing.jpl_units as units
-    units.register()
-
-    # This should affect the tick size.  (Tests issue #543)
-    matplotlib.rcParams['lines.markeredgewidth'] = 30
-
-    # This essentially test to see if user specified labels get overwritten
-    # by the auto labeler functionality of the axes.
-    xdata = [x*units.sec for x in range(10)]
-    ydata1 = [(1.5*y - 0.5)*units.km for y in range(10)]
-    ydata2 = [(1.75*y - 1.0)*units.km for y in range(10)]
-
-    ax = plt.figure().subplots()
-    ax.set_xlabel("x-label 001")
-
-    ax = plt.figure().subplots()
-    ax.set_xlabel("x-label 001")
-    ax.plot(xdata, ydata1, color='blue', xunits="sec")
-
-    ax = plt.figure().subplots()
-    ax.set_xlabel("x-label 001")
-    ax.plot(xdata, ydata1, color='blue', xunits="sec")
-    ax.set_xlabel("x-label 003")
-
-    ax = plt.figure().subplots()
-    ax.plot(xdata, ydata1, color='blue', xunits="sec")
-    ax.plot(xdata, ydata2, color='green', xunits="hour")
-    ax.set_xlabel("x-label 004")
-
-    # See SF bug 2846058
-    # https://sourceforge.net/tracker/?func=detail&aid=2846058&group_id=80706&atid=560720
-    ax = plt.figure().subplots()
-    ax.plot(xdata, ydata1, color='blue', xunits="sec")
-    ax.plot(xdata, ydata2, color='green', xunits="hour")
-    ax.set_xlabel("x-label 005")
-    ax.autoscale_view()
-
-
-def test_funcformatter_auto_formatter():
-    def _formfunc(x, pos):
-        return ''
-
-    ax = plt.figure().subplots()
-
-    assert ax.xaxis.isDefault_majfmt
-    assert ax.xaxis.isDefault_minfmt
-    assert ax.yaxis.isDefault_majfmt
-    assert ax.yaxis.isDefault_minfmt
-
-    ax.xaxis.set_major_formatter(_formfunc)
-
-    assert not ax.xaxis.isDefault_majfmt
-    assert ax.xaxis.isDefault_minfmt
-    assert ax.yaxis.isDefault_majfmt
-    assert ax.yaxis.isDefault_minfmt
-
-    targ_funcformatter = mticker.FuncFormatter(_formfunc)
-
-    assert isinstance(ax.xaxis.get_major_formatter(),
-                      mticker.FuncFormatter)
-
-    assert ax.xaxis.get_major_formatter().func == targ_funcformatter.func
-
-
-def test_strmethodformatter_auto_formatter():
-    formstr = '{x}_{pos}'
-
-    ax = plt.figure().subplots()
-
-    assert ax.xaxis.isDefault_majfmt
-    assert ax.xaxis.isDefault_minfmt
-    assert ax.yaxis.isDefault_majfmt
-    assert ax.yaxis.isDefault_minfmt
-
-    ax.yaxis.set_minor_formatter(formstr)
-
-    assert ax.xaxis.isDefault_majfmt
-    assert ax.xaxis.isDefault_minfmt
-    assert ax.yaxis.isDefault_majfmt
-    assert not ax.yaxis.isDefault_minfmt
-
-    targ_strformatter = mticker.StrMethodFormatter(formstr)
-
-    assert isinstance(ax.yaxis.get_minor_formatter(),
-                      mticker.StrMethodFormatter)
-
-    assert ax.yaxis.get_minor_formatter().fmt == targ_strformatter.fmt
-
-
-@image_comparison(["twin_axis_locators_formatters"])
-def test_twin_axis_locators_formatters():
-    vals = np.linspace(0, 1, num=5, endpoint=True)
-    locs = np.sin(np.pi * vals / 2.0)
-
-    majl = plt.FixedLocator(locs)
-    minl = plt.FixedLocator([0.1, 0.2, 0.3])
-
-    fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
-    ax1.plot([0.1, 100], [0, 1])
-    ax1.yaxis.set_major_locator(majl)
-    ax1.yaxis.set_minor_locator(minl)
-    ax1.yaxis.set_major_formatter(plt.FormatStrFormatter('%08.2lf'))
-    ax1.yaxis.set_minor_formatter(plt.FixedFormatter(['tricks', 'mind',
-                                                      'jedi']))
-
-    ax1.xaxis.set_major_locator(plt.LinearLocator())
-    ax1.xaxis.set_minor_locator(plt.FixedLocator([15, 35, 55, 75]))
-    ax1.xaxis.set_major_formatter(plt.FormatStrFormatter('%05.2lf'))
-    ax1.xaxis.set_minor_formatter(plt.FixedFormatter(['c', '3', 'p', 'o']))
-    ax1.twiny()
-    ax1.twinx()
-
-
-def test_twinx_cla():
-    fig, ax = plt.subplots()
-    ax2 = ax.twinx()
-    ax3 = ax2.twiny()
-    plt.draw()
-    assert not ax2.xaxis.get_visible()
-    assert not ax2.patch.get_visible()
-    ax2.cla()
-    ax3.cla()
-
-    assert not ax2.xaxis.get_visible()
-    assert not ax2.patch.get_visible()
-    assert ax2.yaxis.get_visible()
-
-    assert ax3.xaxis.get_visible()
-    assert not ax3.patch.get_visible()
-    assert not ax3.yaxis.get_visible()
-
-    assert ax.xaxis.get_visible()
-    assert ax.patch.get_visible()
-    assert ax.yaxis.get_visible()
-
-
-@pytest.mark.parametrize('twin', ('x', 'y'))
-def test_twin_units(twin):
-    axis_name = f'{twin}axis'
-    twin_func = f'twin{twin}'
-
-    a = ['0', '1']
-    b = ['a', 'b']
-
-    fig = Figure()
-    ax1 = fig.subplots()
-    ax1.plot(a, b)
-    assert getattr(ax1, axis_name).units is not None
-    ax2 = getattr(ax1, twin_func)()
-    assert getattr(ax2, axis_name).units is not None
-    assert getattr(ax2, axis_name).units is getattr(ax1, axis_name).units
-
-
-@pytest.mark.parametrize('twin', ('x', 'y'))
-@check_figures_equal(extensions=['png'], tol=0.19)
-def test_twin_logscale(fig_test, fig_ref, twin):
-    twin_func = f'twin{twin}'  # test twinx or twiny
-    set_scale = f'set_{twin}scale'
-    x = np.arange(1, 100)
-
-    # Change scale after twinning.
-    ax_test = fig_test.add_subplot(2, 1, 1)
-    ax_twin = getattr(ax_test, twin_func)()
-    getattr(ax_test, set_scale)('log')
-    ax_twin.plot(x, x)
-
-    # Twin after changing scale.
-    ax_test = fig_test.add_subplot(2, 1, 2)
-    getattr(ax_test, set_scale)('log')
-    ax_twin = getattr(ax_test, twin_func)()
-    ax_twin.plot(x, x)
-
-    for i in [1, 2]:
-        ax_ref = fig_ref.add_subplot(2, 1, i)
-        getattr(ax_ref, set_scale)('log')
-        ax_ref.plot(x, x)
-
-        # This is a hack because twinned Axes double-draw the frame.
-        # Remove this when that is fixed.
-        Path = matplotlib.path.Path
-        fig_ref.add_artist(
-            matplotlib.patches.PathPatch(
-                Path([[0, 0], [0, 1],
-                      [0, 1], [1, 1],
-                      [1, 1], [1, 0],
-                      [1, 0], [0, 0]],
-                     [Path.MOVETO, Path.LINETO] * 4),
-                transform=ax_ref.transAxes,
-                facecolor='none',
-                edgecolor=mpl.rcParams['axes.edgecolor'],
-                linewidth=mpl.rcParams['axes.linewidth'],
-                capstyle='projecting'))
-
-    remove_ticks_and_titles(fig_test)
-    remove_ticks_and_titles(fig_ref)
-
-
-@image_comparison(['twin_autoscale.png'],
-                  tol=0.009 if platform.machine() == 'arm64' else 0)
-def test_twinx_axis_scales():
-    x = np.array([0, 0.5, 1])
-    y = 0.5 * x
-    x2 = np.array([0, 1, 2])
-    y2 = 2 * x2
-
-    fig = plt.figure()
-    ax = fig.add_axes((0, 0, 1, 1), autoscalex_on=False, autoscaley_on=False)
-    ax.plot(x, y, color='blue', lw=10)
-
-    ax2 = plt.twinx(ax)
-    ax2.plot(x2, y2, 'r--', lw=5)
-
-    ax.margins(0, 0)
-    ax2.margins(0, 0)
-
-
-def test_twin_inherit_autoscale_setting():
-    fig, ax = plt.subplots()
-    ax_x_on = ax.twinx()
-    ax.set_autoscalex_on(False)
-    ax_x_off = ax.twinx()
-
-    assert ax_x_on.get_autoscalex_on()
-    assert not ax_x_off.get_autoscalex_on()
-
-    ax_y_on = ax.twiny()
-    ax.set_autoscaley_on(False)
-    ax_y_off = ax.twiny()
-
-    assert ax_y_on.get_autoscaley_on()
-    assert not ax_y_off.get_autoscaley_on()
-
-
-def test_inverted_cla():
-    # GitHub PR #5450. Setting autoscale should reset
-    # axes to be non-inverted.
-    # plotting an image, then 1d graph, axis is now down
-    fig = plt.figure(0)
-    ax = fig.gca()
-    # 1. test that a new axis is not inverted per default
-    assert not ax.xaxis_inverted()
-    assert not ax.yaxis_inverted()
-    img = np.random.random((100, 100))
-    ax.imshow(img)
-    # 2. test that a image axis is inverted
-    assert not ax.xaxis_inverted()
-    assert ax.yaxis_inverted()
-    # 3. test that clearing and plotting a line, axes are
-    # not inverted
-    ax.cla()
-    x = np.linspace(0, 2*np.pi, 100)
-    ax.plot(x, np.cos(x))
-    assert not ax.xaxis_inverted()
-    assert not ax.yaxis_inverted()
-
-    # 4. autoscaling should not bring back axes to normal
-    ax.cla()
-    ax.imshow(img)
-    plt.autoscale()
-    assert not ax.xaxis_inverted()
-    assert ax.yaxis_inverted()
-
-    for ax in fig.axes:
-        ax.remove()
-    # 5. two shared axes. Inverting the leader axis should invert the shared
-    # axes; clearing the leader axis should bring axes in shared
-    # axes back to normal.
-    ax0 = plt.subplot(211)
-    ax1 = plt.subplot(212, sharey=ax0)
-    ax0.yaxis.set_inverted(True)
-    assert ax1.yaxis_inverted()
-    ax1.plot(x, np.cos(x))
-    ax0.cla()
-    assert not ax1.yaxis_inverted()
-    ax1.cla()
-    # 6. clearing the follower should not touch limits
-    ax0.imshow(img)
-    ax1.plot(x, np.cos(x))
-    ax1.cla()
-    assert ax.yaxis_inverted()
-
-    # clean up
-    plt.close(fig)
-
-
-def test_subclass_clear_cla():
-    # Ensure that subclasses of Axes call cla/clear correctly.
-    # Note, we cannot use mocking here as we want to be sure that the
-    # superclass fallback does not recurse.
-
-    with pytest.warns(PendingDeprecationWarning,
-                      match='Overriding `Axes.cla`'):
-        class ClaAxes(Axes):
-            def cla(self):
-                nonlocal called
-                called = True
-
-    with pytest.warns(PendingDeprecationWarning,
-                      match='Overriding `Axes.cla`'):
-        class ClaSuperAxes(Axes):
-            def cla(self):
-                nonlocal called
-                called = True
-                super().cla()
-
-    class SubClaAxes(ClaAxes):
-        pass
-
-    class ClearAxes(Axes):
-        def clear(self):
-            nonlocal called
-            called = True
-
-    class ClearSuperAxes(Axes):
-        def clear(self):
-            nonlocal called
-            called = True
-            super().clear()
-
-    class SubClearAxes(ClearAxes):
-        pass
-
-    fig = Figure()
-    for axes_class in [ClaAxes, ClaSuperAxes, SubClaAxes,
-                       ClearAxes, ClearSuperAxes, SubClearAxes]:
-        called = False
-        ax = axes_class(fig, [0, 0, 1, 1])
-        # Axes.__init__ has already called clear (which aliases to cla or is in
-        # the subclass).
-        assert called
-
-        called = False
-        ax.cla()
-        assert called
-
-
-def test_cla_not_redefined_internally():
-    for klass in Axes.__subclasses__():
-        # Check that cla does not get redefined in our Axes subclasses, except
-        # for in the above test function.
-        if 'test_subclass_clear_cla' not in klass.__qualname__:
-            assert 'cla' not in klass.__dict__
-
-
-@check_figures_equal(extensions=["png"])
-def test_minorticks_on_rcParams_both(fig_test, fig_ref):
-    with matplotlib.rc_context({"xtick.minor.visible": True,
-                                "ytick.minor.visible": True}):
-        ax_test = fig_test.subplots()
-        ax_test.plot([0, 1], [0, 1])
-    ax_ref = fig_ref.subplots()
-    ax_ref.plot([0, 1], [0, 1])
-    ax_ref.minorticks_on()
-
-
-@image_comparison(["autoscale_tiny_range"], remove_text=True)
-def test_autoscale_tiny_range():
-    # github pull #904
-    fig, axs = plt.subplots(2, 2)
-    for i, ax in enumerate(axs.flat):
-        y1 = 10**(-11 - i)
-        ax.plot([0, 1], [1, 1 + y1])
-
-
-@mpl.style.context('default')
-def test_autoscale_tight():
-    fig, ax = plt.subplots(1, 1)
-    ax.plot([1, 2, 3, 4])
-    ax.autoscale(enable=True, axis='x', tight=False)
-    ax.autoscale(enable=True, axis='y', tight=True)
-    assert_allclose(ax.get_xlim(), (-0.15, 3.15))
-    assert_allclose(ax.get_ylim(), (1.0, 4.0))
-
-    # Check that autoscale is on
-    assert ax.get_autoscalex_on()
-    assert ax.get_autoscaley_on()
-    assert ax.get_autoscale_on()
-    # Set enable to None
-    ax.autoscale(enable=None)
-    # Same limits
-    assert_allclose(ax.get_xlim(), (-0.15, 3.15))
-    assert_allclose(ax.get_ylim(), (1.0, 4.0))
-    # autoscale still on
-    assert ax.get_autoscalex_on()
-    assert ax.get_autoscaley_on()
-    assert ax.get_autoscale_on()
-
-
-@mpl.style.context('default')
-def test_autoscale_log_shared():
-    # related to github #7587
-    # array starts at zero to trigger _minpos handling
-    x = np.arange(100, dtype=float)
-    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
-    ax1.loglog(x, x)
-    ax2.semilogx(x, x)
-    ax1.autoscale(tight=True)
-    ax2.autoscale(tight=True)
-    plt.draw()
-    lims = (x[1], x[-1])
-    assert_allclose(ax1.get_xlim(), lims)
-    assert_allclose(ax1.get_ylim(), lims)
-    assert_allclose(ax2.get_xlim(), lims)
-    assert_allclose(ax2.get_ylim(), (x[0], x[-1]))
-
-
-@mpl.style.context('default')
-def test_use_sticky_edges():
-    fig, ax = plt.subplots()
-    ax.imshow([[0, 1], [2, 3]], origin='lower')
-    assert_allclose(ax.get_xlim(), (-0.5, 1.5))
-    assert_allclose(ax.get_ylim(), (-0.5, 1.5))
-    ax.use_sticky_edges = False
-    ax.autoscale()
-    xlim = (-0.5 - 2 * ax._xmargin, 1.5 + 2 * ax._xmargin)
-    ylim = (-0.5 - 2 * ax._ymargin, 1.5 + 2 * ax._ymargin)
-    assert_allclose(ax.get_xlim(), xlim)
-    assert_allclose(ax.get_ylim(), ylim)
-    # Make sure it is reversible:
-    ax.use_sticky_edges = True
-    ax.autoscale()
-    assert_allclose(ax.get_xlim(), (-0.5, 1.5))
-    assert_allclose(ax.get_ylim(), (-0.5, 1.5))
-
-
-@check_figures_equal(extensions=["png"])
-def test_sticky_shared_axes(fig_test, fig_ref):
-    # Check that sticky edges work whether they are set in an Axes that is a
-    # "leader" in a share, or an Axes that is a "follower".
-    Z = np.arange(15).reshape(3, 5)
-
-    ax0 = fig_test.add_subplot(211)
-    ax1 = fig_test.add_subplot(212, sharex=ax0)
-    ax1.pcolormesh(Z)
-
-    ax0 = fig_ref.add_subplot(212)
-    ax1 = fig_ref.add_subplot(211, sharex=ax0)
-    ax0.pcolormesh(Z)
-
-
-@image_comparison(['sticky_tolerance.png'], remove_text=True, style="mpl20")
-def test_sticky_tolerance():
-    fig, axs = plt.subplots(2, 2)
-
-    width = .1
-
-    axs.flat[0].bar(x=0, height=width, bottom=20000.6)
-    axs.flat[0].bar(x=1, height=width, bottom=20000.1)
-
-    axs.flat[1].bar(x=0, height=-width, bottom=20000.6)
-    axs.flat[1].bar(x=1, height=-width, bottom=20000.1)
-
-    axs.flat[2].barh(y=0, width=-width, left=-20000.6)
-    axs.flat[2].barh(y=1, width=-width, left=-20000.1)
-
-    axs.flat[3].barh(y=0, width=width, left=-20000.6)
-    axs.flat[3].barh(y=1, width=width, left=-20000.1)
-
-
-@image_comparison(['sticky_tolerance_cf.png'], remove_text=True, style="mpl20")
-def test_sticky_tolerance_contourf():
-    fig, ax = plt.subplots()
-
-    x = y = [14496.71, 14496.75]
-    data = [[0, 1], [2, 3]]
-
-    ax.contourf(x, y, data)
-
-
-def test_nargs_stem():
-    with pytest.raises(TypeError, match='0 were given'):
-        # stem() takes 1-3 arguments.
-        plt.stem()
-
-
-def test_nargs_legend():
-    with pytest.raises(TypeError, match='3 were given'):
-        ax = plt.subplot()
-        # legend() takes 0-2 arguments.
-        ax.legend(['First'], ['Second'], 3)
-
-
-def test_nargs_pcolorfast():
-    with pytest.raises(TypeError, match='2 were given'):
-        ax = plt.subplot()
-        # pcolorfast() takes 1 or 3 arguments,
-        # not passing any arguments fails at C = args[-1]
-        # before nargs_err is raised.
-        ax.pcolorfast([(0, 1), (0, 2)], [[1, 2, 3], [1, 2, 3]])
-
-
-@image_comparison(['offset_points'], remove_text=True)
-def test_basic_annotate():
-    # Setup some data
-    t = np.arange(0.0, 5.0, 0.01)
-    s = np.cos(2.0*np.pi * t)
-
-    # Offset Points
-
-    fig = plt.figure()
-    ax = fig.add_subplot(autoscale_on=False, xlim=(-1, 5), ylim=(-3, 5))
-    line, = ax.plot(t, s, lw=3, color='purple')
-
-    ax.annotate('local max', xy=(3, 1), xycoords='data',
-                xytext=(3, 3), textcoords='offset points')
-
-
-@image_comparison(['arrow_simple.png'], remove_text=True)
-def test_arrow_simple():
-    # Simple image test for ax.arrow
-    # kwargs that take discrete values
-    length_includes_head = (True, False)
-    shape = ('full', 'left', 'right')
-    head_starts_at_zero = (True, False)
-    # Create outer product of values
-    kwargs = product(length_includes_head, shape, head_starts_at_zero)
-
-    fig, axs = plt.subplots(3, 4)
-    for i, (ax, kwarg) in enumerate(zip(axs.flat, kwargs)):
-        ax.set_xlim(-2, 2)
-        ax.set_ylim(-2, 2)
-        # Unpack kwargs
-        (length_includes_head, shape, head_starts_at_zero) = kwarg
-        theta = 2 * np.pi * i / 12
-        # Draw arrow
-        ax.arrow(0, 0, np.sin(theta), np.cos(theta),
-                 width=theta/100,
-                 length_includes_head=length_includes_head,
-                 shape=shape,
-                 head_starts_at_zero=head_starts_at_zero,
-                 head_width=theta / 10,
-                 head_length=theta / 10)
-
-
-def test_arrow_empty():
-    _, ax = plt.subplots()
-    # Create an empty FancyArrow
-    ax.arrow(0, 0, 0, 0, head_length=0)
-
-
-def test_arrow_in_view():
-    _, ax = plt.subplots()
-    ax.arrow(1, 1, 1, 1)
-    assert ax.get_xlim() == (0.8, 2.2)
-    assert ax.get_ylim() == (0.8, 2.2)
-
-
-def test_annotate_default_arrow():
-    # Check that we can make an annotation arrow with only default properties.
-    fig, ax = plt.subplots()
-    ann = ax.annotate("foo", (0, 1), xytext=(2, 3))
-    assert ann.arrow_patch is None
-    ann = ax.annotate("foo", (0, 1), xytext=(2, 3), arrowprops={})
-    assert ann.arrow_patch is not None
-
-
-def test_annotate_signature():
-    """Check that the signature of Axes.annotate() matches Annotation."""
-    fig, ax = plt.subplots()
-    annotate_params = inspect.signature(ax.annotate).parameters
-    annotation_params = inspect.signature(mtext.Annotation).parameters
-    assert list(annotate_params.keys()) == list(annotation_params.keys())
-    for p1, p2 in zip(annotate_params.values(), annotation_params.values()):
-        assert p1 == p2
-
-
-@image_comparison(['fill_units.png'], savefig_kwarg={'dpi': 60})
-def test_fill_units():
-    import matplotlib.testing.jpl_units as units
-    units.register()
-
-    # generate some data
-    t = units.Epoch("ET", dt=datetime.datetime(2009, 4, 27))
-    value = 10.0 * units.deg
-    day = units.Duration("ET", 24.0 * 60.0 * 60.0)
-    dt = np.arange('2009-04-27', '2009-04-29', dtype='datetime64[D]')
-    dtn = mdates.date2num(dt)
-
-    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
-
-    ax1.plot([t], [value], yunits='deg', color='red')
-    ind = [0, 0, 1, 1]
-    ax1.fill(dtn[ind], [0.0, 0.0, 90.0, 0.0], 'b')
-
-    ax2.plot([t], [value], yunits='deg', color='red')
-    ax2.fill([t, t, t + day, t + day],
-             [0.0, 0.0, 90.0, 0.0], 'b')
-
-    ax3.plot([t], [value], yunits='deg', color='red')
-    ax3.fill(dtn[ind],
-             [0 * units.deg, 0 * units.deg, 90 * units.deg, 0 * units.deg],
-             'b')
-
-    ax4.plot([t], [value], yunits='deg', color='red')
-    ax4.fill([t, t, t + day, t + day],
-             [0 * units.deg, 0 * units.deg, 90 * units.deg, 0 * units.deg],
-             facecolor="blue")
-    fig.autofmt_xdate()
-
-
-def test_plot_format_kwarg_redundant():
-    with pytest.warns(UserWarning, match="marker .* redundantly defined"):
-        plt.plot([0], [0], 'o', marker='x')
-    with pytest.warns(UserWarning, match="linestyle .* redundantly defined"):
-        plt.plot([0], [0], '-', linestyle='--')
-    with pytest.warns(UserWarning, match="color .* redundantly defined"):
-        plt.plot([0], [0], 'r', color='blue')
-    # smoke-test: should not warn
-    plt.errorbar([0], [0], fmt='none', color='blue')
-
-
-@check_figures_equal(extensions=["png"])
-def test_errorbar_dashes(fig_test, fig_ref):
-    x = [1, 2, 3, 4]
-    y = np.sin(x)
-
-    ax_ref = fig_ref.gca()
-    ax_test = fig_test.gca()
-
-    line, *_ = ax_ref.errorbar(x, y, xerr=np.abs(y), yerr=np.abs(y))
-    line.set_dashes([2, 2])
-
-    ax_test.errorbar(x, y, xerr=np.abs(y), yerr=np.abs(y), dashes=[2, 2])
-
-
-def test_errorbar_mapview_kwarg():
-    D = {ii: ii for ii in range(10)}
-    fig, ax = plt.subplots()
-    ax.errorbar(x=D.keys(), y=D.values(), xerr=D.values())
-
-
-@image_comparison(['single_point', 'single_point'])
-def test_single_point():
-    # Issue #1796: don't let lines.marker affect the grid
-    matplotlib.rcParams['lines.marker'] = 'o'
-    matplotlib.rcParams['axes.grid'] = True
-
-    fig, (ax1, ax2) = plt.subplots(2)
-    ax1.plot([0], [0], 'o')
-    ax2.plot([1], [1], 'o')
-
-    # Reuse testcase from above for a labeled data test
-    data = {'a': [0], 'b': [1]}
-
-    fig, (ax1, ax2) = plt.subplots(2)
-    ax1.plot('a', 'a', 'o', data=data)
-    ax2.plot('b', 'b', 'o', data=data)
-
-
-@image_comparison(['single_date.png'], style='mpl20')
-def test_single_date():
-
-    # use former defaults to match existing baseline image
-    plt.rcParams['axes.formatter.limits'] = -7, 7
-    dt = mdates.date2num(np.datetime64('0000-12-31'))
-
-    time1 = [721964.0]
-    data1 = [-65.54]
-
-    fig, ax = plt.subplots(2, 1)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        ax[0].plot_date(time1 + dt, data1, 'o', color='r')
-    ax[1].plot(time1, data1, 'o', color='r')
-
-
-@check_figures_equal(extensions=["png"])
-def test_shaped_data(fig_test, fig_ref):
-    row = np.arange(10).reshape((1, -1))
-    col = np.arange(0, 100, 10).reshape((-1, 1))
-
-    axs = fig_test.subplots(2)
-    axs[0].plot(row)  # Actually plots nothing (columns are single points).
-    axs[1].plot(col)  # Same as plotting 1d.
-
-    axs = fig_ref.subplots(2)
-    # xlim from the implicit "x=0", ylim from the row datalim.
-    axs[0].set(xlim=(-.06, .06), ylim=(0, 9))
-    axs[1].plot(col.ravel())
-
-
-def test_structured_data():
-    # support for structured data
-    pts = np.array([(1, 1), (2, 2)], dtype=[("ones", float), ("twos", float)])
-
-    # this should not read second name as a format and raise ValueError
-    axs = plt.figure().subplots(2)
-    axs[0].plot("ones", "twos", data=pts)
-    axs[1].plot("ones", "twos", "r", data=pts)
-
-
-@image_comparison(['aitoff_proj'], extensions=["png"],
-                  remove_text=True, style='mpl20')
-def test_aitoff_proj():
+def _make_axes_method(func):
     """
-    Test aitoff projection ref.:
-    https://github.com/matplotlib/matplotlib/pull/14451
+    Patch the qualname for functions that are directly added to Axes.
+
+    Some Axes functionality is defined in functions in other submodules.
+    These are simply added as attributes to Axes. As a result, their
+    ``__qualname__`` is e.g. only "table" and not "Axes.table". This
+    function fixes that.
+
+    Note that the function itself is patched, so that
+    ``matplotlib.table.table.__qualname__` will also show "Axes.table".
+    However, since these functions are not intended to be standalone,
+    this is bearable.
     """
-    x = np.linspace(-np.pi, np.pi, 20)
-    y = np.linspace(-np.pi / 2, np.pi / 2, 20)
-    X, Y = np.meshgrid(x, y)
+    func.__qualname__ = f"Axes.{func.__name__}"
+    return func
 
-    fig, ax = plt.subplots(figsize=(8, 4.2),
-                           subplot_kw=dict(projection="aitoff"))
-    ax.grid()
-    ax.plot(X.flat, Y.flat, 'o', markersize=4)
 
-
-@image_comparison(['axvspan_epoch'])
-def test_axvspan_epoch():
-    import matplotlib.testing.jpl_units as units
-    units.register()
-
-    # generate some data
-    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
-    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 22))
-    dt = units.Duration("ET", units.day.convert("sec"))
-
-    ax = plt.gca()
-    ax.axvspan(t0, tf, facecolor="blue", alpha=0.25)
-    ax.set_xlim(t0 - 5.0*dt, tf + 5.0*dt)
-
-
-@image_comparison(['axhspan_epoch'], tol=0.02)
-def test_axhspan_epoch():
-    import matplotlib.testing.jpl_units as units
-    units.register()
-
-    # generate some data
-    t0 = units.Epoch("ET", dt=datetime.datetime(2009, 1, 21))
-    tf = units.Epoch("ET", dt=datetime.datetime(2009, 1, 22))
-    dt = units.Duration("ET", units.day.convert("sec"))
-
-    ax = plt.gca()
-    ax.axhspan(t0, tf, facecolor="blue", alpha=0.25)
-    ax.set_ylim(t0 - 5.0*dt, tf + 5.0*dt)
-
-
-@image_comparison(['hexbin_extent.png', 'hexbin_extent.png'], remove_text=True)
-def test_hexbin_extent():
-    # this test exposes sf bug 2856228
-    fig, ax = plt.subplots()
-    data = (np.arange(2000) / 2000).reshape((2, 1000))
-    x, y = data
-
-    ax.hexbin(x, y, extent=[.1, .3, .6, .7])
-
-    # Reuse testcase from above for a labeled data test
-    data = {"x": x, "y": y}
-
-    fig, ax = plt.subplots()
-    ax.hexbin("x", "y", extent=[.1, .3, .6, .7], data=data)
-
-
-def test_hexbin_bad_extents():
-    fig, ax = plt.subplots()
-    data = (np.arange(20) / 20).reshape((2, 10))
-    x, y = data
-
-    with pytest.raises(ValueError, match="In extent, xmax must be greater than xmin"):
-        ax.hexbin(x, y, extent=(1, 0, 0, 1))
-
-    with pytest.raises(ValueError, match="In extent, ymax must be greater than ymin"):
-        ax.hexbin(x, y, extent=(0, 1, 1, 0))
-
-
-def test_hexbin_string_norm():
-    fig, ax = plt.subplots()
-    hex = ax.hexbin(np.random.rand(10), np.random.rand(10), norm="log", vmin=2, vmax=5)
-    assert isinstance(hex, matplotlib.collections.PolyCollection)
-    assert isinstance(hex.norm, matplotlib.colors.LogNorm)
-    assert hex.norm.vmin == 2
-    assert hex.norm.vmax == 5
-
-
-@image_comparison(['hexbin_empty.png'], remove_text=True)
-def test_hexbin_empty():
-    # From #3886: creating hexbin from empty dataset raises ValueError
-    fig, ax = plt.subplots()
-    ax.hexbin([], [])
-    # From #23922: creating hexbin with log scaling from empty
-    # dataset raises ValueError
-    ax.hexbin([], [], bins='log')
-    # From #27103: np.max errors when handed empty data
-    ax.hexbin([], [], C=[], reduce_C_function=np.max)
-    # No string-comparison warning from NumPy.
-    ax.hexbin([], [], bins=np.arange(10))
-
-
-def test_hexbin_pickable():
-    # From #1973: Test that picking a hexbin collection works
-    fig, ax = plt.subplots()
-    data = (np.arange(200) / 200).reshape((2, 100))
-    x, y = data
-    hb = ax.hexbin(x, y, extent=[.1, .3, .6, .7], picker=-1)
-    mouse_event = SimpleNamespace(x=400, y=300)
-    assert hb.contains(mouse_event)[0]
-
-
-@image_comparison(['hexbin_log.png'], style='mpl20')
-def test_hexbin_log():
-    # Issue #1636 (and also test log scaled colorbar)
-
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
-    np.random.seed(19680801)
-    n = 100000
-    x = np.random.standard_normal(n)
-    y = 2.0 + 3.0 * x + 4.0 * np.random.standard_normal(n)
-    y = np.power(2, y * 0.5)
-
-    fig, ax = plt.subplots()
-    h = ax.hexbin(x, y, yscale='log', bins='log',
-                  marginals=True, reduce_C_function=np.sum)
-    plt.colorbar(h)
-
-    # Make sure offsets are set
-    assert h.get_offsets().shape == (11558, 2)
-
-
-def test_hexbin_log_offsets():
-    x = np.geomspace(1, 100, 500)
-
-    fig, ax = plt.subplots()
-    h = ax.hexbin(x, x, xscale='log', yscale='log', gridsize=2)
-    np.testing.assert_almost_equal(
-        h.get_offsets(),
-        np.array(
-            [[0, 0],
-             [0, 2],
-             [1, 0],
-             [1, 2],
-             [2, 0],
-             [2, 2],
-             [0.5, 1],
-             [1.5, 1]]))
-
-
-@image_comparison(["hexbin_linear.png"], style="mpl20", remove_text=True)
-def test_hexbin_linear():
-    # Issue #21165
-    np.random.seed(19680801)
-    n = 100000
-    x = np.random.standard_normal(n)
-    y = 2.0 + 3.0 * x + 4.0 * np.random.standard_normal(n)
-
-    fig, ax = plt.subplots()
-    ax.hexbin(x, y, gridsize=(10, 5), marginals=True,
-              reduce_C_function=np.sum)
-
-
-def test_hexbin_log_clim():
-    x, y = np.arange(200).reshape((2, 100))
-    fig, ax = plt.subplots()
-    h = ax.hexbin(x, y, bins='log', vmin=2, vmax=100)
-    assert h.get_clim() == (2, 100)
-
-
-@check_figures_equal(extensions=['png'])
-def test_hexbin_mincnt_behavior_upon_C_parameter(fig_test, fig_ref):
-    # see: gh:12926
-    datapoints = [
-        # list of (x, y)
-        (0, 0),
-        (0, 0),
-        (6, 0),
-        (0, 6),
-    ]
-    X, Y = zip(*datapoints)
-    C = [1] * len(X)
-    extent = [-10., 10, -10., 10]
-    gridsize = (7, 7)
-
-    ax_test = fig_test.subplots()
-    ax_ref = fig_ref.subplots()
-
-    # without C parameter
-    ax_ref.hexbin(
-        X, Y,
-        extent=extent,
-        gridsize=gridsize,
-        mincnt=1,
-    )
-    ax_ref.set_facecolor("green")  # for contrast of background
-
-    # with C parameter
-    ax_test.hexbin(
-        X, Y,
-        C=[1] * len(X),
-        reduce_C_function=lambda v: sum(v),
-        mincnt=1,
-        extent=extent,
-        gridsize=gridsize,
-    )
-    ax_test.set_facecolor("green")
-
-
-def test_inverted_limits():
-    # Test gh:1553
-    # Calling invert_xaxis prior to plotting should not disable autoscaling
-    # while still maintaining the inverted direction
-    fig, ax = plt.subplots()
-    ax.invert_xaxis()
-    ax.plot([-5, -3, 2, 4], [1, 2, -3, 5])
-
-    assert ax.get_xlim() == (4, -5)
-    assert ax.get_ylim() == (-3, 5)
-    plt.close()
-
-    fig, ax = plt.subplots()
-    ax.invert_yaxis()
-    ax.plot([-5, -3, 2, 4], [1, 2, -3, 5])
-
-    assert ax.get_xlim() == (-5, 4)
-    assert ax.get_ylim() == (5, -3)
-
-    # Test inverting nonlinear axes.
-    fig, ax = plt.subplots()
-    ax.set_yscale("log")
-    ax.set_ylim(10, 1)
-    assert ax.get_ylim() == (10, 1)
-
-
-@image_comparison(['nonfinite_limits'])
-def test_nonfinite_limits():
-    x = np.arange(0., np.e, 0.01)
-    # silence divide by zero warning from log(0)
-    with np.errstate(divide='ignore'):
-        y = np.log(x)
-    x[len(x)//2] = np.nan
-    fig, ax = plt.subplots()
-    ax.plot(x, y)
-
-
-@mpl.style.context('default')
-@pytest.mark.parametrize('plot_fun',
-                         ['scatter', 'plot', 'fill_between'])
-@check_figures_equal(extensions=["png"])
-def test_limits_empty_data(plot_fun, fig_test, fig_ref):
-    # Check that plotting empty data doesn't change autoscaling of dates
-    x = np.arange("2010-01-01", "2011-01-01", dtype="datetime64[D]")
-
-    ax_test = fig_test.subplots()
-    ax_ref = fig_ref.subplots()
-
-    getattr(ax_test, plot_fun)([], [])
-
-    for ax in [ax_test, ax_ref]:
-        getattr(ax, plot_fun)(x, range(len(x)), color='C0')
-
-
-@image_comparison(['imshow', 'imshow'], remove_text=True, style='mpl20')
-def test_imshow():
-    # use former defaults to match existing baseline image
-    matplotlib.rcParams['image.interpolation'] = 'nearest'
-    # Create a NxN image
-    N = 100
-    (x, y) = np.indices((N, N))
-    x -= N//2
-    y -= N//2
-    r = np.sqrt(x**2+y**2-x*y)
-
-    # Create a contour plot at N/4 and extract both the clip path and transform
-    fig, ax = plt.subplots()
-    ax.imshow(r)
-
-    # Reuse testcase from above for a labeled data test
-    data = {"r": r}
-    fig, ax = plt.subplots()
-    ax.imshow("r", data=data)
-
-
-@image_comparison(
-    ['imshow_clip'], style='mpl20',
-    tol=1.24 if platform.machine() in ('aarch64', 'arm64', 'ppc64le', 's390x') else 0)
-def test_imshow_clip():
-    # As originally reported by Gellule Xg <gellule.xg@free.fr>
-    # use former defaults to match existing baseline image
-    matplotlib.rcParams['image.interpolation'] = 'nearest'
-
-    # Create a NxN image
-    N = 100
-    (x, y) = np.indices((N, N))
-    x -= N//2
-    y -= N//2
-    r = np.sqrt(x**2+y**2-x*y)
-
-    # Create a contour plot at N/4 and extract both the clip path and transform
-    fig, ax = plt.subplots()
-
-    c = ax.contour(r, [N/4])
-    clip_path = mtransforms.TransformedPath(c.get_paths()[0], c.get_transform())
-
-    # Plot the image clipped by the contour
-    ax.imshow(r, clip_path=clip_path)
-
-
-def test_imshow_norm_vminvmax():
-    """Parameters vmin, vmax should error if norm is given."""
-    a = [[1, 2], [3, 4]]
-    ax = plt.axes()
-    with pytest.raises(ValueError,
-                       match="Passing a Normalize instance simultaneously "
-                             "with vmin/vmax is not supported."):
-        ax.imshow(a, norm=mcolors.Normalize(-10, 10), vmin=0, vmax=5)
-
-
-@image_comparison(['polycollection_joinstyle'], remove_text=True)
-def test_polycollection_joinstyle():
-    # Bug #2890979 reported by Matthew West
-    fig, ax = plt.subplots()
-    verts = np.array([[1, 1], [1, 2], [2, 2], [2, 1]])
-    c = mpl.collections.PolyCollection([verts], linewidths=40)
-    ax.add_collection(c)
-    ax.set_xbound(0, 3)
-    ax.set_ybound(0, 3)
-
-
-@pytest.mark.parametrize(
-    'x, y1, y2', [
-        (np.zeros((2, 2)), 3, 3),
-        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
-        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
-    ], ids=[
-        '2d_x_input',
-        '2d_y1_input',
-        '2d_y2_input'
-    ]
-)
-def test_fill_between_input(x, y1, y2):
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.fill_between(x, y1, y2)
-
-
-@pytest.mark.parametrize(
-    'y, x1, x2', [
-        (np.zeros((2, 2)), 3, 3),
-        (np.arange(0.0, 2, 0.02), np.zeros((2, 2)), 3),
-        (np.arange(0.0, 2, 0.02), 3, np.zeros((2, 2)))
-    ], ids=[
-        '2d_y_input',
-        '2d_x1_input',
-        '2d_x2_input'
-    ]
-)
-def test_fill_betweenx_input(y, x1, x2):
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.fill_betweenx(y, x1, x2)
-
-
-@image_comparison(['fill_between_interpolate'], remove_text=True,
-                  tol=0.012 if platform.machine() == 'arm64' else 0)
-def test_fill_between_interpolate():
-    x = np.arange(0.0, 2, 0.02)
-    y1 = np.sin(2*np.pi*x)
-    y2 = 1.2*np.sin(4*np.pi*x)
-
-    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True)
-    ax1.plot(x, y1, x, y2, color='black')
-    ax1.fill_between(x, y1, y2, where=y2 >= y1, facecolor='white', hatch='/',
-                     interpolate=True)
-    ax1.fill_between(x, y1, y2, where=y2 <= y1, facecolor='red',
-                     interpolate=True)
-
-    # Test support for masked arrays.
-    y2 = np.ma.masked_greater(y2, 1.0)
-    # Test that plotting works for masked arrays with the first element masked
-    y2[0] = np.ma.masked
-    ax2.plot(x, y1, x, y2, color='black')
-    ax2.fill_between(x, y1, y2, where=y2 >= y1, facecolor='green',
-                     interpolate=True)
-    ax2.fill_between(x, y1, y2, where=y2 <= y1, facecolor='red',
-                     interpolate=True)
-
-
-@image_comparison(['fill_between_interpolate_decreasing'],
-                  style='mpl20', remove_text=True)
-def test_fill_between_interpolate_decreasing():
-    p = np.array([724.3, 700, 655])
-    t = np.array([9.4, 7, 2.2])
-    prof = np.array([7.9, 6.6, 3.8])
-
-    fig, ax = plt.subplots(figsize=(9, 9))
-
-    ax.plot(t, p, 'tab:red')
-    ax.plot(prof, p, 'k')
-
-    ax.fill_betweenx(p, t, prof, where=prof < t,
-                     facecolor='blue', interpolate=True, alpha=0.4)
-    ax.fill_betweenx(p, t, prof, where=prof > t,
-                     facecolor='red', interpolate=True, alpha=0.4)
-
-    ax.set_xlim(0, 30)
-    ax.set_ylim(800, 600)
-
-
-@image_comparison(['fill_between_interpolate_nan'], remove_text=True)
-def test_fill_between_interpolate_nan():
-    # Tests fix for issue #18986.
-    x = np.arange(10)
-    y1 = np.asarray([8, 18, np.nan, 18, 8, 18, 24, 18, 8, 18])
-    y2 = np.asarray([18, 11, 8, 11, 18, 26, 32, 30, np.nan, np.nan])
-
-    fig, ax = plt.subplots()
-
-    ax.plot(x, y1, c='k')
-    ax.plot(x, y2, c='b')
-    ax.fill_between(x, y1, y2, where=y2 >= y1, facecolor="green",
-                    interpolate=True, alpha=0.5)
-    ax.fill_between(x, y1, y2, where=y1 >= y2, facecolor="red",
-                    interpolate=True, alpha=0.5)
-
-
-# test_symlog and test_symlog2 used to have baseline images in all three
-# formats, but the png and svg baselines got invalidated by the removal of
-# minor tick overstriking.
-@image_comparison(['symlog.pdf'])
-def test_symlog():
-    x = np.array([0, 1, 2, 4, 6, 9, 12, 24])
-    y = np.array([1000000, 500000, 100000, 100, 5, 0, 0, 0])
-
-    fig, ax = plt.subplots()
-    ax.plot(x, y)
-    ax.set_yscale('symlog')
-    ax.set_xscale('linear')
-    ax.set_ylim(-1, 10000000)
-
-
-@image_comparison(['symlog2.pdf'], remove_text=True)
-def test_symlog2():
-    # Numbers from -50 to 50, with 0.1 as step
-    x = np.arange(-50, 50, 0.001)
-
-    fig, axs = plt.subplots(5, 1)
-    for ax, linthresh in zip(axs, [20., 2., 1., 0.1, 0.01]):
-        ax.plot(x, x)
-        ax.set_xscale('symlog', linthresh=linthresh)
-        ax.grid(True)
-    axs[-1].set_ylim(-0.1, 0.1)
-
-
-def test_pcolorargs_5205():
-    # Smoketest to catch issue found in gh:5205
-    x = [-1.5, -1.0, -0.5, 0.0, 0.5, 1.0, 1.5]
-    y = [-1.5, -1.25, -1.0, -0.75, -0.5, -0.25, 0,
-         0.25, 0.5, 0.75, 1.0, 1.25, 1.5]
-    X, Y = np.meshgrid(x, y)
-    Z = np.hypot(X, Y)
-
-    plt.pcolor(Z)
-    plt.pcolor(list(Z))
-    plt.pcolor(x, y, Z[:-1, :-1])
-    plt.pcolor(X, Y, list(Z[:-1, :-1]))
-
-
-@image_comparison(['pcolormesh'], remove_text=True)
-def test_pcolormesh():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
-    n = 12
-    x = np.linspace(-1.5, 1.5, n)
-    y = np.linspace(-1.5, 1.5, n*2)
-    X, Y = np.meshgrid(x, y)
-    Qx = np.cos(Y) - np.cos(X)
-    Qz = np.sin(Y) + np.sin(X)
-    Qx = (Qx + 1.1)
-    Z = np.hypot(X, Y) / 5
-    Z = (Z - Z.min()) / np.ptp(Z)
-
-    # The color array can include masked values:
-    Zm = ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
-
-    _, (ax1, ax2, ax3) = plt.subplots(1, 3)
-    ax1.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=0.5, edgecolors='k')
-    ax2.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=2, edgecolors=['b', 'w'])
-    ax3.pcolormesh(Qx, Qz, Zm, shading="gouraud")
-
-
-@image_comparison(['pcolormesh_small'], extensions=["eps"])
-def test_pcolormesh_small():
-    n = 3
-    x = np.linspace(-1.5, 1.5, n)
-    y = np.linspace(-1.5, 1.5, n*2)
-    X, Y = np.meshgrid(x, y)
-    Qx = np.cos(Y) - np.cos(X)
-    Qz = np.sin(Y) + np.sin(X)
-    Qx = (Qx + 1.1)
-    Z = np.hypot(X, Y) / 5
-    Z = (Z - Z.min()) / np.ptp(Z)
-    Zm = ma.masked_where(np.abs(Qz) < 0.5 * np.max(Qz), Z)
-    Zm2 = ma.masked_where(Qz < -0.5 * np.max(Qz), Z)
-
-    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
-    ax1.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=0.5, edgecolors='k')
-    ax2.pcolormesh(Qx, Qz, Zm[:-1, :-1], lw=2, edgecolors=['b', 'w'])
-    # gouraud with Zm yields a blank plot; there are no unmasked triangles.
-    ax3.pcolormesh(Qx, Qz, Zm, shading="gouraud")
-    # Reduce the masking to get a plot.
-    ax4.pcolormesh(Qx, Qz, Zm2, shading="gouraud")
-
-    for ax in fig.axes:
-        ax.set_axis_off()
-
-
-@image_comparison(['pcolormesh_alpha'], extensions=["png", "pdf"],
-                  remove_text=True)
-def test_pcolormesh_alpha():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
-    n = 12
-    X, Y = np.meshgrid(
-        np.linspace(-1.5, 1.5, n),
-        np.linspace(-1.5, 1.5, n*2)
-    )
-    Qx = X
-    Qy = Y + np.sin(X)
-    Z = np.hypot(X, Y) / 5
-    Z = (Z - Z.min()) / np.ptp(Z)
-    vir = mpl.colormaps["viridis"].resampled(16)
-    # make another colormap with varying alpha
-    colors = vir(np.arange(16))
-    colors[:, 3] = 0.5 + 0.5*np.sin(np.arange(16))
-    cmap = mcolors.ListedColormap(colors)
-
-    fig, ((ax1, ax2), (ax3, ax4)) = plt.subplots(2, 2)
-    for ax in ax1, ax2, ax3, ax4:
-        ax.add_patch(mpatches.Rectangle(
-            (0, -1.5), 1.5, 3, facecolor=[.7, .1, .1, .5], zorder=0
-        ))
-    # ax1, ax2: constant alpha
-    ax1.pcolormesh(Qx, Qy, Z[:-1, :-1], cmap=vir, alpha=0.4,
-                   shading='flat', zorder=1)
-    ax2.pcolormesh(Qx, Qy, Z, cmap=vir, alpha=0.4, shading='gouraud', zorder=1)
-    # ax3, ax4: alpha from colormap
-    ax3.pcolormesh(Qx, Qy, Z[:-1, :-1], cmap=cmap, shading='flat', zorder=1)
-    ax4.pcolormesh(Qx, Qy, Z, cmap=cmap, shading='gouraud', zorder=1)
-
-
-@pytest.mark.parametrize("dims,alpha", [(3, 1), (4, 0.5)])
-@check_figures_equal(extensions=["png"])
-def test_pcolormesh_rgba(fig_test, fig_ref, dims, alpha):
-    ax = fig_test.subplots()
-    c = np.ones((5, 6, dims), dtype=float) / 2
-    ax.pcolormesh(c)
-
-    ax = fig_ref.subplots()
-    ax.pcolormesh(c[..., 0], cmap="gray", vmin=0, vmax=1, alpha=alpha)
-
-
-@image_comparison(['pcolormesh_datetime_axis.png'], style='mpl20')
-def test_pcolormesh_datetime_axis():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
-    fig = plt.figure()
-    fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
-    base = datetime.datetime(2013, 1, 1)
-    x = np.array([base + datetime.timedelta(days=d) for d in range(21)])
-    y = np.arange(21)
-    z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
-    z = z1 * z2
-    plt.subplot(221)
-    plt.pcolormesh(x[:-1], y[:-1], z[:-1, :-1])
-    plt.subplot(222)
-    plt.pcolormesh(x, y, z)
-    x = np.repeat(x[np.newaxis], 21, axis=0)
-    y = np.repeat(y[:, np.newaxis], 21, axis=1)
-    plt.subplot(223)
-    plt.pcolormesh(x[:-1, :-1], y[:-1, :-1], z[:-1, :-1])
-    plt.subplot(224)
-    plt.pcolormesh(x, y, z)
-    for ax in fig.get_axes():
-        for label in ax.get_xticklabels():
-            label.set_ha('right')
-            label.set_rotation(30)
-
-
-@image_comparison(['pcolor_datetime_axis.png'], style='mpl20')
-def test_pcolor_datetime_axis():
-    fig = plt.figure()
-    fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
-    base = datetime.datetime(2013, 1, 1)
-    x = np.array([base + datetime.timedelta(days=d) for d in range(21)])
-    y = np.arange(21)
-    z1, z2 = np.meshgrid(np.arange(20), np.arange(20))
-    z = z1 * z2
-    plt.subplot(221)
-    plt.pcolor(x[:-1], y[:-1], z[:-1, :-1])
-    plt.subplot(222)
-    plt.pcolor(x, y, z)
-    x = np.repeat(x[np.newaxis], 21, axis=0)
-    y = np.repeat(y[:, np.newaxis], 21, axis=1)
-    plt.subplot(223)
-    plt.pcolor(x[:-1, :-1], y[:-1, :-1], z[:-1, :-1])
-    plt.subplot(224)
-    plt.pcolor(x, y, z)
-    for ax in fig.get_axes():
-        for label in ax.get_xticklabels():
-            label.set_ha('right')
-            label.set_rotation(30)
-
-
-def test_pcolorargs():
-    n = 12
-    x = np.linspace(-1.5, 1.5, n)
-    y = np.linspace(-1.5, 1.5, n*2)
-    X, Y = np.meshgrid(x, y)
-    Z = np.hypot(X, Y) / 5
-
-    _, ax = plt.subplots()
-    with pytest.raises(TypeError):
-        ax.pcolormesh(y, x, Z)
-    with pytest.raises(TypeError):
-        ax.pcolormesh(X, Y, Z.T)
-    with pytest.raises(TypeError):
-        ax.pcolormesh(x, y, Z[:-1, :-1], shading="gouraud")
-    with pytest.raises(TypeError):
-        ax.pcolormesh(X, Y, Z[:-1, :-1], shading="gouraud")
-    x[0] = np.nan
-    with pytest.raises(ValueError):
-        ax.pcolormesh(x, y, Z[:-1, :-1])
-    with np.errstate(invalid='ignore'):
-        x = np.ma.array(x, mask=(x < 0))
-    with pytest.raises(ValueError):
-        ax.pcolormesh(x, y, Z[:-1, :-1])
-    # Expect a warning with non-increasing coordinates
-    x = [359, 0, 1]
-    y = [-10, 10]
-    X, Y = np.meshgrid(x, y)
-    Z = np.zeros(X.shape)
-    with pytest.warns(UserWarning,
-                      match='are not monotonically increasing or decreasing'):
-        ax.pcolormesh(X, Y, Z, shading='auto')
-
-
-def test_pcolormesh_underflow_error():
+@_docstring.interpd
+class Axes(_AxesBase):
     """
-    Test that underflow errors don't crop up in pcolormesh.  Probably
-    a numpy bug (https://github.com/numpy/numpy/issues/25810).
+    An Axes object encapsulates all the elements of an individual (sub-)plot in
+    a figure.
+
+    It contains most of the (sub-)plot elements: `~.axis.Axis`,
+    `~.axis.Tick`, `~.lines.Line2D`, `~.text.Text`, `~.patches.Polygon`, etc.,
+    and sets the coordinate system.
+
+    Like all visible elements in a figure, Axes is an `.Artist` subclass.
+
+    The `Axes` instance supports callbacks through a callbacks attribute which
+    is a `~.cbook.CallbackRegistry` instance.  The events you can connect to
+    are 'xlim_changed' and 'ylim_changed' and the callback will be called with
+    func(*ax*) where *ax* is the `Axes` instance.
+
+    .. note::
+
+        As a user, you do not instantiate Axes directly, but use Axes creation
+        methods instead; e.g. from `.pyplot` or `.Figure`:
+        `~.pyplot.subplots`, `~.pyplot.subplot_mosaic` or `.Figure.add_axes`.
+
     """
-    with np.errstate(under="raise"):
-        x = np.arange(0, 3, 0.1)
-        y = np.arange(0, 6, 0.1)
-        z = np.random.randn(len(y), len(x))
-        fig, ax = plt.subplots()
-        ax.pcolormesh(x, y, z)
-
-
-def test_pcolorargs_with_read_only():
-    x = np.arange(6).reshape(2, 3)
-    xmask = np.broadcast_to([False, True, False], x.shape)  # read-only array
-    assert xmask.flags.writeable is False
-    masked_x = np.ma.array(x, mask=xmask)
-    plt.pcolormesh(masked_x)
-
-    x = np.linspace(0, 1, 10)
-    y = np.linspace(0, 1, 10)
-    X, Y = np.meshgrid(x, y)
-    Z = np.sin(2 * np.pi * X) * np.cos(2 * np.pi * Y)
-    mask = np.zeros(10, dtype=bool)
-    mask[-1] = True
-    mask = np.broadcast_to(mask, Z.shape)
-    assert mask.flags.writeable is False
-    masked_Z = np.ma.array(Z, mask=mask)
-    plt.pcolormesh(X, Y, masked_Z)
-
-    masked_X = np.ma.array(X, mask=mask)
-    masked_Y = np.ma.array(Y, mask=mask)
-    plt.pcolor(masked_X, masked_Y, masked_Z)
-
-
-@check_figures_equal(extensions=["png"])
-def test_pcolornearest(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    x = np.arange(0, 10)
-    y = np.arange(0, 3)
-    np.random.seed(19680801)
-    Z = np.random.randn(2, 9)
-    ax.pcolormesh(x, y, Z, shading='flat')
-
-    ax = fig_ref.subplots()
-    # specify the centers
-    x2 = x[:-1] + np.diff(x) / 2
-    y2 = y[:-1] + np.diff(y) / 2
-    ax.pcolormesh(x2, y2, Z, shading='nearest')
-
-
-@check_figures_equal(extensions=["png"])
-def test_pcolornearestunits(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    x = [datetime.datetime.fromtimestamp(x * 3600) for x in range(10)]
-    y = np.arange(0, 3)
-    np.random.seed(19680801)
-    Z = np.random.randn(2, 9)
-    ax.pcolormesh(x, y, Z, shading='flat')
-
-    ax = fig_ref.subplots()
-    # specify the centers
-    x2 = [datetime.datetime.fromtimestamp((x + 0.5) * 3600) for x in range(9)]
-    y2 = y[:-1] + np.diff(y) / 2
-    ax.pcolormesh(x2, y2, Z, shading='nearest')
-
-
-def test_pcolorflaterror():
-    fig, ax = plt.subplots()
-    x = np.arange(0, 9)
-    y = np.arange(0, 3)
-    np.random.seed(19680801)
-    Z = np.random.randn(3, 9)
-    with pytest.raises(TypeError, match='Dimensions of C'):
-        ax.pcolormesh(x, y, Z, shading='flat')
-
-
-def test_samesizepcolorflaterror():
-    fig, ax = plt.subplots()
-    x, y = np.meshgrid(np.arange(5), np.arange(3))
-    Z = x + y
-    with pytest.raises(TypeError, match=r".*one smaller than X"):
-        ax.pcolormesh(x, y, Z, shading='flat')
-
-
-@pytest.mark.parametrize('snap', [False, True])
-@check_figures_equal(extensions=["png"])
-def test_pcolorauto(fig_test, fig_ref, snap):
-    ax = fig_test.subplots()
-    x = np.arange(0, 10)
-    y = np.arange(0, 4)
-    np.random.seed(19680801)
-    Z = np.random.randn(3, 9)
-    # this is the same as flat; note that auto is default
-    ax.pcolormesh(x, y, Z, snap=snap)
-
-    ax = fig_ref.subplots()
-    # specify the centers
-    x2 = x[:-1] + np.diff(x) / 2
-    y2 = y[:-1] + np.diff(y) / 2
-    # this is same as nearest:
-    ax.pcolormesh(x2, y2, Z, snap=snap)
-
-
-@image_comparison(['canonical'], tol=0.02 if platform.machine() == 'arm64' else 0)
-def test_canonical():
-    fig, ax = plt.subplots()
-    ax.plot([1, 2, 3])
-
-
-@image_comparison(['arc_angles.png'], remove_text=True, style='default')
-def test_arc_angles():
-    # Ellipse parameters
-    w = 2
-    h = 1
-    centre = (0.2, 0.5)
-    scale = 2
-
-    fig, axs = plt.subplots(3, 3)
-    for i, ax in enumerate(axs.flat):
-        theta2 = i * 360 / 9
-        theta1 = theta2 - 45
-
-        ax.add_patch(mpatches.Ellipse(centre, w, h, alpha=0.3))
-        ax.add_patch(mpatches.Arc(centre, w, h, theta1=theta1, theta2=theta2))
-        # Straight lines intersecting start and end of arc
-        ax.plot([scale * np.cos(np.deg2rad(theta1)) + centre[0],
-                 centre[0],
-                 scale * np.cos(np.deg2rad(theta2)) + centre[0]],
-                [scale * np.sin(np.deg2rad(theta1)) + centre[1],
-                 centre[1],
-                 scale * np.sin(np.deg2rad(theta2)) + centre[1]])
-
-        ax.set_xlim(-scale, scale)
-        ax.set_ylim(-scale, scale)
-
-        # This looks the same, but it triggers a different code path when it
-        # gets large enough.
-        w *= 10
-        h *= 10
-        centre = (centre[0] * 10, centre[1] * 10)
-        scale *= 10
-
-
-@image_comparison(['arc_ellipse'], remove_text=True)
-def test_arc_ellipse():
-    xcenter, ycenter = 0.38, 0.52
-    width, height = 1e-1, 3e-1
-    angle = -30
-
-    theta = np.deg2rad(np.arange(360))
-    x = width / 2. * np.cos(theta)
-    y = height / 2. * np.sin(theta)
-
-    rtheta = np.deg2rad(angle)
-    R = np.array([
-        [np.cos(rtheta), -np.sin(rtheta)],
-        [np.sin(rtheta), np.cos(rtheta)]])
-
-    x, y = np.dot(R, [x, y])
-    x += xcenter
-    y += ycenter
-
-    fig = plt.figure()
-    ax = fig.add_subplot(211, aspect='auto')
-    ax.fill(x, y, alpha=0.2, facecolor='yellow', edgecolor='yellow',
-            linewidth=1, zorder=1)
-
-    e1 = mpatches.Arc((xcenter, ycenter), width, height,
-                      angle=angle, linewidth=2, fill=False, zorder=2)
-
-    ax.add_patch(e1)
-
-    ax = fig.add_subplot(212, aspect='equal')
-    ax.fill(x, y, alpha=0.2, facecolor='green', edgecolor='green', zorder=1)
-    e2 = mpatches.Arc((xcenter, ycenter), width, height,
-                      angle=angle, linewidth=2, fill=False, zorder=2)
-
-    ax.add_patch(e2)
-
-
-def test_marker_as_markerstyle():
-    fix, ax = plt.subplots()
-    m = mmarkers.MarkerStyle('o')
-    ax.plot([1, 2, 3], [3, 2, 1], marker=m)
-    ax.scatter([1, 2, 3], [4, 3, 2], marker=m)
-    ax.errorbar([1, 2, 3], [5, 4, 3], marker=m)
-
-
-@image_comparison(['markevery'], remove_text=True)
-def test_markevery():
-    x = np.linspace(0, 10, 100)
-    y = np.sin(x) * np.sqrt(x/10 + 0.5)
-
-    # check marker only plot
-    fig, ax = plt.subplots()
-    ax.plot(x, y, 'o', label='default')
-    ax.plot(x, y, 'd', markevery=None, label='mark all')
-    ax.plot(x, y, 's', markevery=10, label='mark every 10')
-    ax.plot(x, y, '+', markevery=(5, 20), label='mark every 5 starting at 10')
-    ax.legend()
-
-
-@image_comparison(['markevery_line'], remove_text=True, tol=0.005)
-def test_markevery_line():
-    # TODO: a slight change in rendering between Inkscape versions may explain
-    # why one had to introduce a small non-zero tolerance for the SVG test
-    # to pass. One may try to remove this hack once Travis' Inkscape version
-    # is modern enough. FWIW, no failure with 0.92.3 on my computer (#11358).
-    x = np.linspace(0, 10, 100)
-    y = np.sin(x) * np.sqrt(x/10 + 0.5)
-
-    # check line/marker combos
-    fig, ax = plt.subplots()
-    ax.plot(x, y, '-o', label='default')
-    ax.plot(x, y, '-d', markevery=None, label='mark all')
-    ax.plot(x, y, '-s', markevery=10, label='mark every 10')
-    ax.plot(x, y, '-+', markevery=(5, 20), label='mark every 5 starting at 10')
-    ax.legend()
-
-
-@image_comparison(['markevery_linear_scales'], remove_text=True, tol=0.001)
-def test_markevery_linear_scales():
-    cases = [None,
-             8,
-             (30, 8),
-             [16, 24, 30], [0, -1],
-             slice(100, 200, 3),
-             0.1, 0.3, 1.5,
-             (0.0, 0.1), (0.45, 0.1)]
-
-    cols = 3
-    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
-
-    delta = 0.11
-    x = np.linspace(0, 10 - 2 * delta, 200) + delta
-    y = np.sin(x) + 1.0 + delta
-
-    for i, case in enumerate(cases):
-        row = (i // cols)
-        col = i % cols
-        plt.subplot(gs[row, col])
-        plt.title('markevery=%s' % str(case))
-        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
-
-
-@image_comparison(['markevery_linear_scales_zoomed'], remove_text=True)
-def test_markevery_linear_scales_zoomed():
-    cases = [None,
-             8,
-             (30, 8),
-             [16, 24, 30], [0, -1],
-             slice(100, 200, 3),
-             0.1, 0.3, 1.5,
-             (0.0, 0.1), (0.45, 0.1)]
-
-    cols = 3
-    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
-
-    delta = 0.11
-    x = np.linspace(0, 10 - 2 * delta, 200) + delta
-    y = np.sin(x) + 1.0 + delta
-
-    for i, case in enumerate(cases):
-        row = (i // cols)
-        col = i % cols
-        plt.subplot(gs[row, col])
-        plt.title('markevery=%s' % str(case))
-        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
-        plt.xlim((6, 6.7))
-        plt.ylim((1.1, 1.7))
-
-
-@image_comparison(['markevery_log_scales'], remove_text=True)
-def test_markevery_log_scales():
-    cases = [None,
-             8,
-             (30, 8),
-             [16, 24, 30], [0, -1],
-             slice(100, 200, 3),
-             0.1, 0.3, 1.5,
-             (0.0, 0.1), (0.45, 0.1)]
-
-    cols = 3
-    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
-
-    delta = 0.11
-    x = np.linspace(0, 10 - 2 * delta, 200) + delta
-    y = np.sin(x) + 1.0 + delta
-
-    for i, case in enumerate(cases):
-        row = (i // cols)
-        col = i % cols
-        plt.subplot(gs[row, col])
-        plt.title('markevery=%s' % str(case))
-        plt.xscale('log')
-        plt.yscale('log')
-        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
-
-
-@image_comparison(['markevery_polar'], style='default', remove_text=True)
-def test_markevery_polar():
-    cases = [None,
-             8,
-             (30, 8),
-             [16, 24, 30], [0, -1],
-             slice(100, 200, 3),
-             0.1, 0.3, 1.5,
-             (0.0, 0.1), (0.45, 0.1)]
-
-    cols = 3
-    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
-
-    r = np.linspace(0, 3.0, 200)
-    theta = 2 * np.pi * r
-
-    for i, case in enumerate(cases):
-        row = (i // cols)
-        col = i % cols
-        plt.subplot(gs[row, col], polar=True)
-        plt.title('markevery=%s' % str(case))
-        plt.plot(theta, r, 'o', ls='-', ms=4,  markevery=case)
-
-
-@image_comparison(['markevery_linear_scales_nans'], remove_text=True)
-def test_markevery_linear_scales_nans():
-    cases = [None,
-             8,
-             (30, 8),
-             [16, 24, 30], [0, -1],
-             slice(100, 200, 3),
-             0.1, 0.3, 1.5,
-             (0.0, 0.1), (0.45, 0.1)]
-
-    cols = 3
-    gs = matplotlib.gridspec.GridSpec(len(cases) // cols + 1, cols)
-
-    delta = 0.11
-    x = np.linspace(0, 10 - 2 * delta, 200) + delta
-    y = np.sin(x) + 1.0 + delta
-    y[:10] = y[-20:] = y[50:70] = np.nan
-
-    for i, case in enumerate(cases):
-        row = (i // cols)
-        col = i % cols
-        plt.subplot(gs[row, col])
-        plt.title('markevery=%s' % str(case))
-        plt.plot(x, y, 'o', ls='-', ms=4,  markevery=case)
-
-
-@image_comparison(['marker_edges'], remove_text=True)
-def test_marker_edges():
-    x = np.linspace(0, 1, 10)
-    fig, ax = plt.subplots()
-    ax.plot(x, np.sin(x), 'y.', ms=30.0, mew=0, mec='r')
-    ax.plot(x+0.1, np.sin(x), 'y.', ms=30.0, mew=1, mec='r')
-    ax.plot(x+0.2, np.sin(x), 'y.', ms=30.0, mew=2, mec='b')
-
-
-@image_comparison(['bar_tick_label_single.png', 'bar_tick_label_single.png'])
-def test_bar_tick_label_single():
-    # From 2516: plot bar with array of string labels for x axis
-    ax = plt.gca()
-    ax.bar(0, 1, align='edge', tick_label='0')
-
-    # Reuse testcase from above for a labeled data test
-    data = {"a": 0, "b": 1}
-    fig, ax = plt.subplots()
-    ax = plt.gca()
-    ax.bar("a", "b", align='edge', tick_label='0', data=data)
-
-
-def test_nan_bar_values():
-    fig, ax = plt.subplots()
-    ax.bar([0, 1], [np.nan, 4])
-
-
-def test_bar_ticklabel_fail():
-    fig, ax = plt.subplots()
-    ax.bar([], [])
-
-
-@image_comparison(['bar_tick_label_multiple.png'])
-def test_bar_tick_label_multiple():
-    # From 2516: plot bar with array of string labels for x axis
-    ax = plt.gca()
-    ax.bar([1, 2.5], [1, 2], width=[0.2, 0.5], tick_label=['a', 'b'],
-           align='center')
-
-
-@image_comparison(['bar_tick_label_multiple_old_label_alignment.png'])
-def test_bar_tick_label_multiple_old_alignment():
-    # Test that the alignment for class is backward compatible
-    matplotlib.rcParams["ytick.alignment"] = "center"
-    ax = plt.gca()
-    ax.bar([1, 2.5], [1, 2], width=[0.2, 0.5], tick_label=['a', 'b'],
-           align='center')
-
-
-@check_figures_equal(extensions=["png"])
-def test_bar_decimal_center(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    x0 = [1.5, 8.4, 5.3, 4.2]
-    y0 = [1.1, 2.2, 3.3, 4.4]
-    x = [Decimal(x) for x in x0]
-    y = [Decimal(y) for y in y0]
-    # Test image - vertical, align-center bar chart with Decimal() input
-    ax.bar(x, y, align='center')
-    # Reference image
-    ax = fig_ref.subplots()
-    ax.bar(x0, y0, align='center')
-
-
-@check_figures_equal(extensions=["png"])
-def test_barh_decimal_center(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    x0 = [1.5, 8.4, 5.3, 4.2]
-    y0 = [1.1, 2.2, 3.3, 4.4]
-    x = [Decimal(x) for x in x0]
-    y = [Decimal(y) for y in y0]
-    # Test image - horizontal, align-center bar chart with Decimal() input
-    ax.barh(x, y, height=[0.5, 0.5, 1, 1], align='center')
-    # Reference image
-    ax = fig_ref.subplots()
-    ax.barh(x0, y0, height=[0.5, 0.5, 1, 1], align='center')
-
-
-@check_figures_equal(extensions=["png"])
-def test_bar_decimal_width(fig_test, fig_ref):
-    x = [1.5, 8.4, 5.3, 4.2]
-    y = [1.1, 2.2, 3.3, 4.4]
-    w0 = [0.7, 1.45, 1, 2]
-    w = [Decimal(i) for i in w0]
-    # Test image - vertical bar chart with Decimal() width
-    ax = fig_test.subplots()
-    ax.bar(x, y, width=w, align='center')
-    # Reference image
-    ax = fig_ref.subplots()
-    ax.bar(x, y, width=w0, align='center')
-
-
-@check_figures_equal(extensions=["png"])
-def test_barh_decimal_height(fig_test, fig_ref):
-    x = [1.5, 8.4, 5.3, 4.2]
-    y = [1.1, 2.2, 3.3, 4.4]
-    h0 = [0.7, 1.45, 1, 2]
-    h = [Decimal(i) for i in h0]
-    # Test image - horizontal bar chart with Decimal() height
-    ax = fig_test.subplots()
-    ax.barh(x, y, height=h, align='center')
-    # Reference image
-    ax = fig_ref.subplots()
-    ax.barh(x, y, height=h0, align='center')
-
-
-def test_bar_color_none_alpha():
-    ax = plt.gca()
-    rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='none', edgecolor='r')
-    for rect in rects:
-        assert rect.get_facecolor() == (0, 0, 0, 0)
-        assert rect.get_edgecolor() == (1, 0, 0, 0.3)
-
-
-def test_bar_edgecolor_none_alpha():
-    ax = plt.gca()
-    rects = ax.bar([1, 2], [2, 4], alpha=0.3, color='r', edgecolor='none')
-    for rect in rects:
-        assert rect.get_facecolor() == (1, 0, 0, 0.3)
-        assert rect.get_edgecolor() == (0, 0, 0, 0)
-
-
-@image_comparison(['barh_tick_label.png'])
-def test_barh_tick_label():
-    # From 2516: plot barh with array of string labels for y axis
-    ax = plt.gca()
-    ax.barh([1, 2.5], [1, 2], height=[0.2, 0.5], tick_label=['a', 'b'],
-            align='center')
-
-
-def test_bar_timedelta():
-    """Smoketest that bar can handle width and height in delta units."""
-    fig, ax = plt.subplots()
-    ax.bar(datetime.datetime(2018, 1, 1), 1.,
-           width=datetime.timedelta(hours=3))
-    ax.bar(datetime.datetime(2018, 1, 1), 1.,
-           xerr=datetime.timedelta(hours=2),
-           width=datetime.timedelta(hours=3))
-    fig, ax = plt.subplots()
-    ax.barh(datetime.datetime(2018, 1, 1), 1,
-            height=datetime.timedelta(hours=3))
-    ax.barh(datetime.datetime(2018, 1, 1), 1,
-            height=datetime.timedelta(hours=3),
-            yerr=datetime.timedelta(hours=2))
-    fig, ax = plt.subplots()
-    ax.barh([datetime.datetime(2018, 1, 1), datetime.datetime(2018, 1, 1)],
-            np.array([1, 1.5]),
-            height=datetime.timedelta(hours=3))
-    ax.barh([datetime.datetime(2018, 1, 1), datetime.datetime(2018, 1, 1)],
-            np.array([1, 1.5]),
-            height=[datetime.timedelta(hours=t) for t in [1, 2]])
-    ax.broken_barh([(datetime.datetime(2018, 1, 1),
-                     datetime.timedelta(hours=1))],
-                   (10, 20))
-
-
-def test_bar_datetime_start():
-    """test that tickers are correct for datetimes"""
-    start = np.array([np.datetime64('2012-01-01'), np.datetime64('2012-02-01'),
-                      np.datetime64('2012-01-15')])
-    stop = np.array([np.datetime64('2012-02-07'), np.datetime64('2012-02-13'),
-                     np.datetime64('2012-02-12')])
-
-    fig, ax = plt.subplots()
-    ax.bar([0, 1, 3], height=stop-start, bottom=start)
-    assert isinstance(ax.yaxis.get_major_formatter(), mdates.AutoDateFormatter)
-
-    fig, ax = plt.subplots()
-    ax.barh([0, 1, 3], width=stop-start, left=start)
-    assert isinstance(ax.xaxis.get_major_formatter(), mdates.AutoDateFormatter)
-
-
-def test_boxplot_dates_pandas(pd):
-    # smoke test for boxplot and dates in pandas
-    data = np.random.rand(5, 2)
-    years = pd.date_range('1/1/2000',
-                          periods=2, freq=pd.DateOffset(years=1)).year
-    plt.figure()
-    plt.boxplot(data, positions=years)
-
-
-def test_boxplot_capwidths():
-    data = np.random.rand(5, 3)
-    fig, axs = plt.subplots(9)
-
-    axs[0].boxplot(data, capwidths=[0.3, 0.2, 0.1], widths=[0.1, 0.2, 0.3])
-    axs[1].boxplot(data, capwidths=[0.3, 0.2, 0.1], widths=0.2)
-    axs[2].boxplot(data, capwidths=[0.3, 0.2, 0.1])
-
-    axs[3].boxplot(data, capwidths=0.5, widths=[0.1, 0.2, 0.3])
-    axs[4].boxplot(data, capwidths=0.5, widths=0.2)
-    axs[5].boxplot(data, capwidths=0.5)
-
-    axs[6].boxplot(data, widths=[0.1, 0.2, 0.3])
-    axs[7].boxplot(data, widths=0.2)
-    axs[8].boxplot(data)
-
-
-def test_pcolor_regression(pd):
-    from pandas.plotting import (
-        register_matplotlib_converters,
-        deregister_matplotlib_converters,
-    )
-
-    fig = plt.figure()
-    ax = fig.add_subplot(111)
-
-    times = [datetime.datetime(2021, 1, 1)]
-    while len(times) < 7:
-        times.append(times[-1] + datetime.timedelta(seconds=120))
-
-    y_vals = np.arange(5)
-
-    time_axis, y_axis = np.meshgrid(times, y_vals)
-    shape = (len(y_vals) - 1, len(times) - 1)
-    z_data = np.arange(shape[0] * shape[1])
-
-    z_data.shape = shape
-    try:
-        register_matplotlib_converters()
-
-        im = ax.pcolormesh(time_axis, y_axis, z_data)
-        # make sure this does not raise!
-        fig.canvas.draw()
-    finally:
-        deregister_matplotlib_converters()
-
-
-def test_bar_pandas(pd):
-    # Smoke test for pandas
-    df = pd.DataFrame(
-        {'year': [2018, 2018, 2018],
-         'month': [1, 1, 1],
-         'day': [1, 2, 3],
-         'value': [1, 2, 3]})
-    df['date'] = pd.to_datetime(df[['year', 'month', 'day']])
-
-    monthly = df[['date', 'value']].groupby(['date']).sum()
-    dates = monthly.index
-    forecast = monthly['value']
-    baseline = monthly['value']
-
-    fig, ax = plt.subplots()
-    ax.bar(dates, forecast, width=10, align='center')
-    ax.plot(dates, baseline, color='orange', lw=4)
-
-
-def test_bar_pandas_indexed(pd):
-    # Smoke test for indexed pandas
-    df = pd.DataFrame({"x": [1., 2., 3.], "width": [.2, .4, .6]},
-                      index=[1, 2, 3])
-    fig, ax = plt.subplots()
-    ax.bar(df.x, 1., width=df.width)
-
-
-@mpl.style.context('default')
-@check_figures_equal()
-def test_bar_hatches(fig_test, fig_ref):
-    ax_test = fig_test.subplots()
-    ax_ref = fig_ref.subplots()
-
-    x = [1, 2]
-    y = [2, 3]
-    hatches = ['x', 'o']
-    for i in range(2):
-        ax_ref.bar(x[i], y[i], color='C0', hatch=hatches[i])
-
-    ax_test.bar(x, y, hatch=hatches)
-
-
-@pytest.mark.parametrize(
-    ("x", "width", "label", "expected_labels", "container_label"),
-    [
-        ("x", 1, "x", ["_nolegend_"], "x"),
-        (["a", "b", "c"], [10, 20, 15], ["A", "B", "C"],
-         ["A", "B", "C"], "_nolegend_"),
-        (["a", "b", "c"], [10, 20, 15], ["R", "Y", "_nolegend_"],
-         ["R", "Y", "_nolegend_"], "_nolegend_"),
-        (["a", "b", "c"], [10, 20, 15], "bars",
-         ["_nolegend_", "_nolegend_", "_nolegend_"], "bars"),
-    ]
-)
-def test_bar_labels(x, width, label, expected_labels, container_label):
-    _, ax = plt.subplots()
-    bar_container = ax.bar(x, width, label=label)
-    bar_labels = [bar.get_label() for bar in bar_container]
-    assert expected_labels == bar_labels
-    assert bar_container.get_label() == container_label
-
-
-def test_bar_labels_length():
-    _, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.bar(["x", "y"], [1, 2], label=["X", "Y", "Z"])
-    _, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.bar(["x", "y"], [1, 2], label=["X"])
-
-
-def test_pandas_minimal_plot(pd):
-    # smoke test that series and index objects do not warn
-    for x in [pd.Series([1, 2], dtype="float64"),
-              pd.Series([1, 2], dtype="Float64")]:
-        plt.plot(x, x)
-        plt.plot(x.index, x)
-        plt.plot(x)
-        plt.plot(x.index)
-    df = pd.DataFrame({'col': [1, 2, 3]})
-    plt.plot(df)
-    plt.plot(df, df)
-
-
-@image_comparison(['hist_log'], remove_text=True)
-def test_hist_log():
-    data0 = np.linspace(0, 1, 200)**3
-    data = np.concatenate([1 - data0, 1 + data0])
-    fig, ax = plt.subplots()
-    ax.hist(data, fill=False, log=True)
-
-
-@check_figures_equal(extensions=["png"])
-def test_hist_log_2(fig_test, fig_ref):
-    axs_test = fig_test.subplots(2, 3)
-    axs_ref = fig_ref.subplots(2, 3)
-    for i, histtype in enumerate(["bar", "step", "stepfilled"]):
-        # Set log scale, then call hist().
-        axs_test[0, i].set_yscale("log")
-        axs_test[0, i].hist(1, 1, histtype=histtype)
-        # Call hist(), then set log scale.
-        axs_test[1, i].hist(1, 1, histtype=histtype)
-        axs_test[1, i].set_yscale("log")
-        # Use hist(..., log=True).
-        for ax in axs_ref[:, i]:
-            ax.hist(1, 1, log=True, histtype=histtype)
-
-
-def test_hist_log_barstacked():
-    fig, axs = plt.subplots(2)
-    axs[0].hist([[0], [0, 1]], 2, histtype="barstacked")
-    axs[0].set_yscale("log")
-    axs[1].hist([0, 0, 1], 2, histtype="barstacked")
-    axs[1].set_yscale("log")
-    fig.canvas.draw()
-    assert axs[0].get_ylim() == axs[1].get_ylim()
-
-
-@image_comparison(['hist_bar_empty.png'], remove_text=True)
-def test_hist_bar_empty():
-    # From #3886: creating hist from empty dataset raises ValueError
-    ax = plt.gca()
-    ax.hist([], histtype='bar')
-
-
-def test_hist_float16():
-    np.random.seed(19680801)
-    values = np.clip(
-        np.random.normal(0.5, 0.3, size=1000), 0, 1).astype(np.float16)
-    h = plt.hist(values, bins=3, alpha=0.5)
-    bc = h[2]
-    # Check that there are no overlapping rectangles
-    for r in range(1, len(bc)):
-        rleft = bc[r-1].get_corners()
-        rright = bc[r].get_corners()
-        # right hand position of left rectangle <=
-        # left hand position of right rectangle
-        assert rleft[1][0] <= rright[0][0]
-
-
-@image_comparison(['hist_step_empty.png'], remove_text=True)
-def test_hist_step_empty():
-    # From #3886: creating hist from empty dataset raises ValueError
-    ax = plt.gca()
-    ax.hist([], histtype='step')
-
-
-@image_comparison(['hist_step_filled.png'], remove_text=True)
-def test_hist_step_filled():
-    np.random.seed(0)
-    x = np.random.randn(1000, 3)
-    n_bins = 10
-
-    kwargs = [{'fill': True}, {'fill': False}, {'fill': None}, {}]*2
-    types = ['step']*4+['stepfilled']*4
-    fig, axs = plt.subplots(nrows=2, ncols=4)
-
-    for kg, _type, ax in zip(kwargs, types, axs.flat):
-        ax.hist(x, n_bins, histtype=_type, stacked=True, **kg)
-        ax.set_title(f'{kg}/{_type}')
-        ax.set_ylim(bottom=-50)
-
-    patches = axs[0, 0].patches
-    assert all(p.get_facecolor() == p.get_edgecolor() for p in patches)
-
-
-@image_comparison(['hist_density.png'])
-def test_hist_density():
-    np.random.seed(19680801)
-    data = np.random.standard_normal(2000)
-    fig, ax = plt.subplots()
-    ax.hist(data, density=True)
-
-
-def test_hist_unequal_bins_density():
-    # Test correct behavior of normalized histogram with unequal bins
-    # https://github.com/matplotlib/matplotlib/issues/9557
-    rng = np.random.RandomState(57483)
-    t = rng.randn(100)
-    bins = [-3, -1, -0.5, 0, 1, 5]
-    mpl_heights, _, _ = plt.hist(t, bins=bins, density=True)
-    np_heights, _ = np.histogram(t, bins=bins, density=True)
-    assert_allclose(mpl_heights, np_heights)
-
-
-def test_hist_datetime_datasets():
-    data = [[datetime.datetime(2017, 1, 1), datetime.datetime(2017, 1, 1)],
-            [datetime.datetime(2017, 1, 1), datetime.datetime(2017, 1, 2)]]
-    fig, ax = plt.subplots()
-    ax.hist(data, stacked=True)
-    ax.hist(data, stacked=False)
-
-
-@pytest.mark.parametrize("bins_preprocess",
-                         [mpl.dates.date2num,
-                          lambda bins: bins,
-                          lambda bins: np.asarray(bins, 'datetime64')],
-                         ids=['date2num', 'datetime.datetime',
-                              'np.datetime64'])
-def test_hist_datetime_datasets_bins(bins_preprocess):
-    data = [[datetime.datetime(2019, 1, 5), datetime.datetime(2019, 1, 11),
-             datetime.datetime(2019, 2, 1), datetime.datetime(2019, 3, 1)],
-            [datetime.datetime(2019, 1, 11), datetime.datetime(2019, 2, 5),
-             datetime.datetime(2019, 2, 18), datetime.datetime(2019, 3, 1)]]
-
-    date_edges = [datetime.datetime(2019, 1, 1), datetime.datetime(2019, 2, 1),
-                  datetime.datetime(2019, 3, 1)]
-
-    fig, ax = plt.subplots()
-    _, bins, _ = ax.hist(data, bins=bins_preprocess(date_edges), stacked=True)
-    np.testing.assert_allclose(bins, mpl.dates.date2num(date_edges))
-
-    _, bins, _ = ax.hist(data, bins=bins_preprocess(date_edges), stacked=False)
-    np.testing.assert_allclose(bins, mpl.dates.date2num(date_edges))
-
-
-@pytest.mark.parametrize('data, expected_number_of_hists',
-                         [([], 1),
-                          ([[]], 1),
-                          ([[], []], 2)])
-def test_hist_with_empty_input(data, expected_number_of_hists):
-    hists, _, _ = plt.hist(data)
-    hists = np.asarray(hists)
-
-    if hists.ndim == 1:
-        assert 1 == expected_number_of_hists
-    else:
-        assert hists.shape[0] == expected_number_of_hists
-
-
-@pytest.mark.parametrize("histtype, zorder",
-                         [("bar", mpl.patches.Patch.zorder),
-                          ("step", mpl.lines.Line2D.zorder),
-                          ("stepfilled", mpl.patches.Patch.zorder)])
-def test_hist_zorder(histtype, zorder):
-    ax = plt.figure().add_subplot()
-    ax.hist([1, 2], histtype=histtype)
-    assert ax.patches
-    for patch in ax.patches:
-        assert patch.get_zorder() == zorder
-
-
-def test_stairs_no_baseline_fill_warns():
-    fig, ax = plt.subplots()
-    with pytest.warns(UserWarning, match="baseline=None and fill=True"):
-        ax.stairs(
-            [4, 5, 1, 0, 2],
-            [1, 2, 3, 4, 5, 6],
-            facecolor="blue",
-            baseline=None,
-            fill=True
+    ### Labelling, legend and texts
+
+    def get_title(self, loc="center"):
+        """
+        Get an Axes title.
+
+        Get one of the three available Axes titles. The available titles
+        are positioned above the Axes in the center, flush with the left
+        edge, and flush with the right edge.
+
+        Parameters
+        ----------
+        loc : {'center', 'left', 'right'}, str, default: 'center'
+            Which title to return.
+
+        Returns
+        -------
+        str
+            The title text string.
+
+        """
+        titles = {'left': self._left_title,
+                  'center': self.title,
+                  'right': self._right_title}
+        title = _api.check_getitem(titles, loc=loc.lower())
+        return title.get_text()
+
+    def set_title(self, label, fontdict=None, loc=None, pad=None, *, y=None,
+                  **kwargs):
+        """
+        Set a title for the Axes.
+
+        Set one of the three available Axes titles. The available titles
+        are positioned above the Axes in the center, flush with the left
+        edge, and flush with the right edge.
+
+        Parameters
+        ----------
+        label : str
+            Text to use for the title
+
+        fontdict : dict
+
+            .. admonition:: Discouraged
+
+               The use of *fontdict* is discouraged. Parameters should be passed as
+               individual keyword arguments or using dictionary-unpacking
+               ``set_title(..., **fontdict)``.
+
+            A dictionary controlling the appearance of the title text,
+            the default *fontdict* is::
+
+               {'fontsize': rcParams['axes.titlesize'],
+                'fontweight': rcParams['axes.titleweight'],
+                'color': rcParams['axes.titlecolor'],
+                'verticalalignment': 'baseline',
+                'horizontalalignment': loc}
+
+        loc : {'center', 'left', 'right'}, default: :rc:`axes.titlelocation`
+            Which title to set.
+
+        y : float, default: :rc:`axes.titley`
+            Vertical Axes location for the title (1.0 is the top).  If
+            None (the default) and :rc:`axes.titley` is also None, y is
+            determined automatically to avoid decorators on the Axes.
+
+        pad : float, default: :rc:`axes.titlepad`
+            The offset of the title from the top of the Axes, in points.
+
+        Returns
+        -------
+        `.Text`
+            The matplotlib text instance representing the title
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.text.Text` properties
+            Other keyword arguments are text properties, see `.Text` for a list
+            of valid text properties.
+        """
+        if loc is None:
+            loc = mpl.rcParams['axes.titlelocation']
+
+        if y is None:
+            y = mpl.rcParams['axes.titley']
+        if y is None:
+            y = 1.0
+        else:
+            self._autotitlepos = False
+        kwargs['y'] = y
+
+        titles = {'left': self._left_title,
+                  'center': self.title,
+                  'right': self._right_title}
+        title = _api.check_getitem(titles, loc=loc.lower())
+        default = {
+            'fontsize': mpl.rcParams['axes.titlesize'],
+            'fontweight': mpl.rcParams['axes.titleweight'],
+            'verticalalignment': 'baseline',
+            'horizontalalignment': loc.lower()}
+        titlecolor = mpl.rcParams['axes.titlecolor']
+        if not cbook._str_lower_equal(titlecolor, 'auto'):
+            default["color"] = titlecolor
+        if pad is None:
+            pad = mpl.rcParams['axes.titlepad']
+        self._set_title_offset_trans(float(pad))
+        title.set_text(label)
+        title.update(default)
+        if fontdict is not None:
+            title.update(fontdict)
+        title._internal_update(kwargs)
+        return title
+
+    def get_legend_handles_labels(self, legend_handler_map=None):
+        """
+        Return handles and labels for legend
+
+        ``ax.legend()`` is equivalent to ::
+
+          h, l = ax.get_legend_handles_labels()
+          ax.legend(h, l)
+        """
+        # pass through to legend.
+        handles, labels = mlegend._get_legend_handles_labels(
+            [self], legend_handler_map)
+        return handles, labels
+
+    @_docstring.interpd
+    def legend(self, *args, **kwargs):
+        """
+        Place a legend on the Axes.
+
+        Call signatures::
+
+            legend()
+            legend(handles, labels)
+            legend(handles=handles)
+            legend(labels)
+
+        The call signatures correspond to the following different ways to use
+        this method:
+
+        **1. Automatic detection of elements to be shown in the legend**
+
+        The elements to be added to the legend are automatically determined,
+        when you do not pass in any extra arguments.
+
+        In this case, the labels are taken from the artist. You can specify
+        them either at artist creation or by calling the
+        :meth:`~.Artist.set_label` method on the artist::
+
+            ax.plot([1, 2, 3], label='Inline label')
+            ax.legend()
+
+        or::
+
+            line, = ax.plot([1, 2, 3])
+            line.set_label('Label via method')
+            ax.legend()
+
+        .. note::
+            Specific artists can be excluded from the automatic legend element
+            selection by using a label starting with an underscore, "_".
+            A string starting with an underscore is the default label for all
+            artists, so calling `.Axes.legend` without any arguments and
+            without setting the labels manually will result in a ``UserWarning``
+            and an empty legend being drawn.
+
+
+        **2. Explicitly listing the artists and labels in the legend**
+
+        For full control of which artists have a legend entry, it is possible
+        to pass an iterable of legend artists followed by an iterable of
+        legend labels respectively::
+
+            ax.legend([line1, line2, line3], ['label1', 'label2', 'label3'])
+
+
+        **3. Explicitly listing the artists in the legend**
+
+        This is similar to 2, but the labels are taken from the artists'
+        label properties. Example::
+
+            line1, = ax.plot([1, 2, 3], label='label1')
+            line2, = ax.plot([1, 2, 3], label='label2')
+            ax.legend(handles=[line1, line2])
+
+
+        **4. Labeling existing plot elements**
+
+        .. admonition:: Discouraged
+
+            This call signature is discouraged, because the relation between
+            plot elements and labels is only implicit by their order and can
+            easily be mixed up.
+
+        To make a legend for all artists on an Axes, call this function with
+        an iterable of strings, one for each legend item. For example::
+
+            ax.plot([1, 2, 3])
+            ax.plot([5, 6, 7])
+            ax.legend(['First line', 'Second line'])
+
+
+        Parameters
+        ----------
+        handles : list of (`.Artist` or tuple of `.Artist`), optional
+            A list of Artists (lines, patches) to be added to the legend.
+            Use this together with *labels*, if you need full control on what
+            is shown in the legend and the automatic mechanism described above
+            is not sufficient.
+
+            The length of handles and labels should be the same in this
+            case. If they are not, they are truncated to the smaller length.
+
+            If an entry contains a tuple, then the legend handler for all Artists in the
+            tuple will be placed alongside a single label.
+
+        labels : list of str, optional
+            A list of labels to show next to the artists.
+            Use this together with *handles*, if you need full control on what
+            is shown in the legend and the automatic mechanism described above
+            is not sufficient.
+
+        Returns
+        -------
+        `~matplotlib.legend.Legend`
+
+        Other Parameters
+        ----------------
+        %(_legend_kw_axes)s
+
+        See Also
+        --------
+        .Figure.legend
+
+        Notes
+        -----
+        Some artists are not supported by this function.  See
+        :ref:`legend_guide` for details.
+
+        Examples
+        --------
+        .. plot:: gallery/text_labels_and_annotations/legend.py
+        """
+        handles, labels, kwargs = mlegend._parse_legend_args([self], *args, **kwargs)
+        self.legend_ = mlegend.Legend(self, handles, labels, **kwargs)
+        self.legend_._remove_method = self._remove_legend
+        return self.legend_
+
+    def _remove_legend(self, legend):
+        self.legend_ = None
+
+    def inset_axes(self, bounds, *, transform=None, zorder=5, **kwargs):
+        """
+        Add a child inset Axes to this existing Axes.
+
+
+        Parameters
+        ----------
+        bounds : [x0, y0, width, height]
+            Lower-left corner of inset Axes, and its width and height.
+
+        transform : `.Transform`
+            Defaults to `ax.transAxes`, i.e. the units of *rect* are in
+            Axes-relative coordinates.
+
+        projection : {None, 'aitoff', 'hammer', 'lambert', 'mollweide', \
+'polar', 'rectilinear', str}, optional
+            The projection type of the inset `~.axes.Axes`. *str* is the name
+            of a custom projection, see `~matplotlib.projections`. The default
+            None results in a 'rectilinear' projection.
+
+        polar : bool, default: False
+            If True, equivalent to projection='polar'.
+
+        axes_class : subclass type of `~.axes.Axes`, optional
+            The `.axes.Axes` subclass that is instantiated.  This parameter
+            is incompatible with *projection* and *polar*.  See
+            :ref:`axisartist_users-guide-index` for examples.
+
+        zorder : number
+            Defaults to 5 (same as `.Axes.legend`).  Adjust higher or lower
+            to change whether it is above or below data plotted on the
+            parent Axes.
+
+        **kwargs
+            Other keyword arguments are passed on to the inset Axes class.
+
+        Returns
+        -------
+        ax
+            The created `~.axes.Axes` instance.
+
+        Examples
+        --------
+        This example makes two inset Axes, the first is in Axes-relative
+        coordinates, and the second in data-coordinates::
+
+            fig, ax = plt.subplots()
+            ax.plot(range(10))
+            axin1 = ax.inset_axes([0.8, 0.1, 0.15, 0.15])
+            axin2 = ax.inset_axes(
+                    [5, 7, 2.3, 2.3], transform=ax.transData)
+
+        """
+        if transform is None:
+            transform = self.transAxes
+        kwargs.setdefault('label', 'inset_axes')
+
+        # This puts the rectangle into figure-relative coordinates.
+        inset_locator = _TransformedBoundsLocator(bounds, transform)
+        bounds = inset_locator(self, None).bounds
+        fig = self.get_figure(root=False)
+        projection_class, pkw = fig._process_projection_requirements(**kwargs)
+        inset_ax = projection_class(fig, bounds, zorder=zorder, **pkw)
+
+        # this locator lets the axes move if in data coordinates.
+        # it gets called in `ax.apply_aspect() (of all places)
+        inset_ax.set_axes_locator(inset_locator)
+
+        self.add_child_axes(inset_ax)
+
+        return inset_ax
+
+    @_docstring.interpd
+    def indicate_inset(self, bounds=None, inset_ax=None, *, transform=None,
+                       facecolor='none', edgecolor='0.5', alpha=0.5,
+                       zorder=None, **kwargs):
+        """
+        Add an inset indicator to the Axes.  This is a rectangle on the plot
+        at the position indicated by *bounds* that optionally has lines that
+        connect the rectangle to an inset Axes (`.Axes.inset_axes`).
+
+        Warnings
+        --------
+        This method is experimental as of 3.0, and the API may change.
+
+        Parameters
+        ----------
+        bounds : [x0, y0, width, height], optional
+            Lower-left corner of rectangle to be marked, and its width
+            and height.  If not set, the bounds will be calculated from the
+            data limits of *inset_ax*, which must be supplied.
+
+        inset_ax : `.Axes`, optional
+            An optional inset Axes to draw connecting lines to.  Two lines are
+            drawn connecting the indicator box to the inset Axes on corners
+            chosen so as to not overlap with the indicator box.
+
+        transform : `.Transform`
+            Transform for the rectangle coordinates. Defaults to
+            ``ax.transAxes``, i.e. the units of *rect* are in Axes-relative
+            coordinates.
+
+        facecolor : :mpltype:`color`, default: 'none'
+            Facecolor of the rectangle.
+
+        edgecolor : :mpltype:`color`, default: '0.5'
+            Color of the rectangle and color of the connecting lines.
+
+        alpha : float or None, default: 0.5
+            Transparency of the rectangle and connector lines.  If not
+            ``None``, this overrides any alpha value included in the
+            *facecolor* and *edgecolor* parameters.
+
+        zorder : float, default: 4.99
+            Drawing order of the rectangle and connector lines.  The default,
+            4.99, is just below the default level of inset Axes.
+
+        **kwargs
+            Other keyword arguments are passed on to the `.Rectangle` patch:
+
+            %(Rectangle:kwdoc)s
+
+        Returns
+        -------
+        inset_indicator : `.inset.InsetIndicator`
+            An artist which contains
+
+            inset_indicator.rectangle : `.Rectangle`
+                The indicator frame.
+
+            inset_indicator.connectors : 4-tuple of `.patches.ConnectionPatch`
+                The four connector lines connecting to (lower_left, upper_left,
+                lower_right upper_right) corners of *inset_ax*. Two lines are
+                set with visibility to *False*,  but the user can set the
+                visibility to True if the automatic choice is not deemed correct.
+
+            .. versionchanged:: 3.10
+                Previously the rectangle and connectors tuple were returned.
+        """
+        # to make the Axes connectors work, we need to apply the aspect to
+        # the parent Axes.
+        self.apply_aspect()
+
+        if transform is None:
+            transform = self.transData
+        kwargs.setdefault('label', '_indicate_inset')
+
+        indicator_patch = minset.InsetIndicator(
+            bounds, inset_ax=inset_ax,
+            facecolor=facecolor, edgecolor=edgecolor, alpha=alpha,
+            zorder=zorder, transform=transform, **kwargs)
+        self.add_artist(indicator_patch)
+
+        return indicator_patch
+
+    def indicate_inset_zoom(self, inset_ax, **kwargs):
+        """
+        Add an inset indicator rectangle to the Axes based on the axis
+        limits for an *inset_ax* and draw connectors between *inset_ax*
+        and the rectangle.
+
+        Warnings
+        --------
+        This method is experimental as of 3.0, and the API may change.
+
+        Parameters
+        ----------
+        inset_ax : `.Axes`
+            Inset Axes to draw connecting lines to.  Two lines are
+            drawn connecting the indicator box to the inset Axes on corners
+            chosen so as to not overlap with the indicator box.
+
+        **kwargs
+            Other keyword arguments are passed on to `.Axes.indicate_inset`
+
+        Returns
+        -------
+        inset_indicator : `.inset.InsetIndicator`
+            An artist which contains
+
+            inset_indicator.rectangle : `.Rectangle`
+                The indicator frame.
+
+            inset_indicator.connectors : 4-tuple of `.patches.ConnectionPatch`
+                The four connector lines connecting to (lower_left, upper_left,
+                lower_right upper_right) corners of *inset_ax*. Two lines are
+                set with visibility to *False*,  but the user can set the
+                visibility to True if the automatic choice is not deemed correct.
+
+            .. versionchanged:: 3.10
+                Previously the rectangle and connectors tuple were returned.
+        """
+
+        return self.indicate_inset(None, inset_ax, **kwargs)
+
+    @_docstring.interpd
+    def secondary_xaxis(self, location, functions=None, *, transform=None, **kwargs):
+        """
+        Add a second x-axis to this `~.axes.Axes`.
+
+        For example if we want to have a second scale for the data plotted on
+        the xaxis.
+
+        %(_secax_docstring)s
+
+        Examples
+        --------
+        The main axis shows frequency, and the secondary axis shows period.
+
+        .. plot::
+
+            fig, ax = plt.subplots()
+            ax.loglog(range(1, 360, 5), range(1, 360, 5))
+            ax.set_xlabel('frequency [Hz]')
+
+            def invert(x):
+                # 1/x with special treatment of x == 0
+                x = np.array(x).astype(float)
+                near_zero = np.isclose(x, 0)
+                x[near_zero] = np.inf
+                x[~near_zero] = 1 / x[~near_zero]
+                return x
+
+            # the inverse of 1/x is itself
+            secax = ax.secondary_xaxis('top', functions=(invert, invert))
+            secax.set_xlabel('Period [s]')
+            plt.show()
+
+        To add a secondary axis relative to your data, you can pass a transform
+        to the new axis.
+
+        .. plot::
+
+            fig, ax = plt.subplots()
+            ax.plot(range(0, 5), range(-1, 4))
+
+            # Pass 'ax.transData' as a transform to place the axis
+            # relative to your data at y=0
+            secax = ax.secondary_xaxis(0, transform=ax.transData)
+        """
+        if not (location in ['top', 'bottom'] or isinstance(location, Real)):
+            raise ValueError('secondary_xaxis location must be either '
+                             'a float or "top"/"bottom"')
+
+        secondary_ax = SecondaryAxis(self, 'x', location, functions,
+                                     transform, **kwargs)
+        self.add_child_axes(secondary_ax)
+        return secondary_ax
+
+    @_docstring.interpd
+    def secondary_yaxis(self, location, functions=None, *, transform=None, **kwargs):
+        """
+        Add a second y-axis to this `~.axes.Axes`.
+
+        For example if we want to have a second scale for the data plotted on
+        the yaxis.
+
+        %(_secax_docstring)s
+
+        Examples
+        --------
+        Add a secondary Axes that converts from radians to degrees
+
+        .. plot::
+
+            fig, ax = plt.subplots()
+            ax.plot(range(1, 360, 5), range(1, 360, 5))
+            ax.set_ylabel('degrees')
+            secax = ax.secondary_yaxis('right', functions=(np.deg2rad,
+                                                           np.rad2deg))
+            secax.set_ylabel('radians')
+
+        To add a secondary axis relative to your data, you can pass a transform
+        to the new axis.
+
+        .. plot::
+
+            fig, ax = plt.subplots()
+            ax.plot(range(0, 5), range(-1, 4))
+
+            # Pass 'ax.transData' as a transform to place the axis
+            # relative to your data at x=3
+            secax = ax.secondary_yaxis(3, transform=ax.transData)
+        """
+        if not (location in ['left', 'right'] or isinstance(location, Real)):
+            raise ValueError('secondary_yaxis location must be either '
+                             'a float or "left"/"right"')
+
+        secondary_ax = SecondaryAxis(self, 'y', location, functions,
+                                     transform, **kwargs)
+        self.add_child_axes(secondary_ax)
+        return secondary_ax
+
+    @_docstring.interpd
+    def text(self, x, y, s, fontdict=None, **kwargs):
+        """
+        Add text to the Axes.
+
+        Add the text *s* to the Axes at location *x*, *y* in data coordinates,
+        with a default ``horizontalalignment`` on the ``left`` and
+        ``verticalalignment`` at the ``baseline``. See
+        :doc:`/gallery/text_labels_and_annotations/text_alignment`.
+
+        Parameters
+        ----------
+        x, y : float
+            The position to place the text. By default, this is in data
+            coordinates. The coordinate system can be changed using the
+            *transform* parameter.
+
+        s : str
+            The text.
+
+        fontdict : dict, default: None
+
+            .. admonition:: Discouraged
+
+               The use of *fontdict* is discouraged. Parameters should be passed as
+               individual keyword arguments or using dictionary-unpacking
+               ``text(..., **fontdict)``.
+
+            A dictionary to override the default text properties. If fontdict
+            is None, the defaults are determined by `.rcParams`.
+
+        Returns
+        -------
+        `.Text`
+            The created `.Text` instance.
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.text.Text` properties.
+            Other miscellaneous text parameters.
+
+            %(Text:kwdoc)s
+
+        Examples
+        --------
+        Individual keyword arguments can be used to override any given
+        parameter::
+
+            >>> text(x, y, s, fontsize=12)
+
+        The default transform specifies that text is in data coords,
+        alternatively, you can specify text in axis coords ((0, 0) is
+        lower-left and (1, 1) is upper-right).  The example below places
+        text in the center of the Axes::
+
+            >>> text(0.5, 0.5, 'matplotlib', horizontalalignment='center',
+            ...      verticalalignment='center', transform=ax.transAxes)
+
+        You can put a rectangular box around the text instance (e.g., to
+        set a background color) by using the keyword *bbox*.  *bbox* is
+        a dictionary of `~matplotlib.patches.Rectangle`
+        properties.  For example::
+
+            >>> text(x, y, s, bbox=dict(facecolor='red', alpha=0.5))
+        """
+        effective_kwargs = {
+            'verticalalignment': 'baseline',
+            'horizontalalignment': 'left',
+            'transform': self.transData,
+            'clip_on': False,
+            **(fontdict if fontdict is not None else {}),
+            **kwargs,
+        }
+        t = mtext.Text(x, y, text=s, **effective_kwargs)
+        if t.get_clip_path() is None:
+            t.set_clip_path(self.patch)
+        self._add_text(t)
+        return t
+
+    @_docstring.interpd
+    def annotate(self, text, xy, xytext=None, xycoords='data', textcoords=None,
+                 arrowprops=None, annotation_clip=None, **kwargs):
+        # Signature must match Annotation. This is verified in
+        # test_annotate_signature().
+        a = mtext.Annotation(text, xy, xytext=xytext, xycoords=xycoords,
+                             textcoords=textcoords, arrowprops=arrowprops,
+                             annotation_clip=annotation_clip, **kwargs)
+        a.set_transform(mtransforms.IdentityTransform())
+        if kwargs.get('clip_on', False) and a.get_clip_path() is None:
+            a.set_clip_path(self.patch)
+        self._add_text(a)
+        return a
+    annotate.__doc__ = mtext.Annotation.__init__.__doc__
+    #### Lines and spans
+
+    @_docstring.interpd
+    def axhline(self, y=0, xmin=0, xmax=1, **kwargs):
+        """
+        Add a horizontal line spanning the whole or fraction of the Axes.
+
+        Note: If you want to set x-limits in data coordinates, use
+        `~.Axes.hlines` instead.
+
+        Parameters
+        ----------
+        y : float, default: 0
+            y position in :ref:`data coordinates <coordinate-systems>`.
+
+        xmin : float, default: 0
+            The start x-position in :ref:`axes coordinates <coordinate-systems>`.
+            Should be between 0 and 1, 0 being the far left of the plot,
+            1 the far right of the plot.
+
+        xmax : float, default: 1
+            The end x-position in :ref:`axes coordinates <coordinate-systems>`.
+            Should be between 0 and 1, 0 being the far left of the plot,
+            1 the far right of the plot.
+
+        Returns
+        -------
+        `~matplotlib.lines.Line2D`
+            A `.Line2D` specified via two points ``(xmin, y)``, ``(xmax, y)``.
+            Its transform is set such that *x* is in
+            :ref:`axes coordinates <coordinate-systems>` and *y* is in
+            :ref:`data coordinates <coordinate-systems>`.
+
+            This is still a generic line and the horizontal character is only
+            realized through using identical *y* values for both points. Thus,
+            if you want to change the *y* value later, you have to provide two
+            values ``line.set_ydata([3, 3])``.
+
+        Other Parameters
+        ----------------
+        **kwargs
+            Valid keyword arguments are `.Line2D` properties, except for
+            'transform':
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        hlines : Add horizontal lines in data coordinates.
+        axhspan : Add a horizontal span (rectangle) across the axis.
+        axline : Add a line with an arbitrary slope.
+
+        Examples
+        --------
+        * draw a thick red hline at 'y' = 0 that spans the xrange::
+
+            >>> axhline(linewidth=4, color='r')
+
+        * draw a default hline at 'y' = 1 that spans the xrange::
+
+            >>> axhline(y=1)
+
+        * draw a default hline at 'y' = .5 that spans the middle half of
+          the xrange::
+
+            >>> axhline(y=.5, xmin=0.25, xmax=0.75)
+        """
+        self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
+        if "transform" in kwargs:
+            raise ValueError("'transform' is not allowed as a keyword "
+                             "argument; axhline generates its own transform.")
+        ymin, ymax = self.get_ybound()
+
+        # Strip away the units for comparison with non-unitized bounds.
+        yy, = self._process_unit_info([("y", y)], kwargs)
+        scaley = (yy < ymin) or (yy > ymax)
+
+        trans = self.get_yaxis_transform(which='grid')
+        l = mlines.Line2D([xmin, xmax], [y, y], transform=trans, **kwargs)
+        self.add_line(l)
+        l.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
+        if scaley:
+            self._request_autoscale_view("y")
+        return l
+
+    @_docstring.interpd
+    def axvline(self, x=0, ymin=0, ymax=1, **kwargs):
+        """
+        Add a vertical line spanning the whole or fraction of the Axes.
+
+        Note: If you want to set y-limits in data coordinates, use
+        `~.Axes.vlines` instead.
+
+        Parameters
+        ----------
+        x : float, default: 0
+            y position in :ref:`data coordinates <coordinate-systems>`.
+
+        ymin : float, default: 0
+            The start y-position in :ref:`axes coordinates <coordinate-systems>`.
+            Should be between 0 and 1, 0 being the bottom of the plot, 1 the
+            top of the plot.
+
+        ymax : float, default: 1
+            The end y-position in :ref:`axes coordinates <coordinate-systems>`.
+            Should be between 0 and 1, 0 being the bottom of the plot, 1 the
+            top of the plot.
+
+        Returns
+        -------
+        `~matplotlib.lines.Line2D`
+            A `.Line2D` specified via two points ``(x, ymin)``, ``(x, ymax)``.
+            Its transform is set such that *x* is in
+            :ref:`data coordinates <coordinate-systems>` and *y* is in
+            :ref:`axes coordinates <coordinate-systems>`.
+
+            This is still a generic line and the vertical character is only
+            realized through using identical *x* values for both points. Thus,
+            if you want to change the *x* value later, you have to provide two
+            values ``line.set_xdata([3, 3])``.
+
+        Other Parameters
+        ----------------
+        **kwargs
+            Valid keyword arguments are `.Line2D` properties, except for
+            'transform':
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        vlines : Add vertical lines in data coordinates.
+        axvspan : Add a vertical span (rectangle) across the axis.
+        axline : Add a line with an arbitrary slope.
+
+        Examples
+        --------
+        * draw a thick red vline at *x* = 0 that spans the yrange::
+
+            >>> axvline(linewidth=4, color='r')
+
+        * draw a default vline at *x* = 1 that spans the yrange::
+
+            >>> axvline(x=1)
+
+        * draw a default vline at *x* = .5 that spans the middle half of
+          the yrange::
+
+            >>> axvline(x=.5, ymin=0.25, ymax=0.75)
+        """
+        self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
+        if "transform" in kwargs:
+            raise ValueError("'transform' is not allowed as a keyword "
+                             "argument; axvline generates its own transform.")
+        xmin, xmax = self.get_xbound()
+
+        # Strip away the units for comparison with non-unitized bounds.
+        xx, = self._process_unit_info([("x", x)], kwargs)
+        scalex = (xx < xmin) or (xx > xmax)
+
+        trans = self.get_xaxis_transform(which='grid')
+        l = mlines.Line2D([x, x], [ymin, ymax], transform=trans, **kwargs)
+        self.add_line(l)
+        l.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
+        if scalex:
+            self._request_autoscale_view("x")
+        return l
+
+    @staticmethod
+    def _check_no_units(vals, names):
+        # Helper method to check that vals are not unitized
+        for val, name in zip(vals, names):
+            if not munits._is_natively_supported(val):
+                raise ValueError(f"{name} must be a single scalar value, "
+                                 f"but got {val}")
+
+    @_docstring.interpd
+    def axline(self, xy1, xy2=None, *, slope=None, **kwargs):
+        """
+        Add an infinitely long straight line.
+
+        The line can be defined either by two points *xy1* and *xy2*, or
+        by one point *xy1* and a *slope*.
+
+        This draws a straight line "on the screen", regardless of the x and y
+        scales, and is thus also suitable for drawing exponential decays in
+        semilog plots, power laws in loglog plots, etc. However, *slope*
+        should only be used with linear scales; It has no clear meaning for
+        all other scales, and thus the behavior is undefined. Please specify
+        the line using the points *xy1*, *xy2* for non-linear scales.
+
+        The *transform* keyword argument only applies to the points *xy1*,
+        *xy2*. The *slope* (if given) is always in data coordinates. This can
+        be used e.g. with ``ax.transAxes`` for drawing grid lines with a fixed
+        slope.
+
+        Parameters
+        ----------
+        xy1, xy2 : (float, float)
+            Points for the line to pass through.
+            Either *xy2* or *slope* has to be given.
+        slope : float, optional
+            The slope of the line. Either *xy2* or *slope* has to be given.
+
+        Returns
+        -------
+        `.AxLine`
+
+        Other Parameters
+        ----------------
+        **kwargs
+            Valid kwargs are `.Line2D` properties
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        axhline : for horizontal lines
+        axvline : for vertical lines
+
+        Examples
+        --------
+        Draw a thick red line passing through (0, 0) and (1, 1)::
+
+            >>> axline((0, 0), (1, 1), linewidth=4, color='r')
+        """
+        if slope is not None and (self.get_xscale() != 'linear' or
+                                  self.get_yscale() != 'linear'):
+            raise TypeError("'slope' cannot be used with non-linear scales")
+
+        datalim = [xy1] if xy2 is None else [xy1, xy2]
+        if "transform" in kwargs:
+            # if a transform is passed (i.e. line points not in data space),
+            # data limits should not be adjusted.
+            datalim = []
+
+        line = mlines.AxLine(xy1, xy2, slope, **kwargs)
+        # Like add_line, but correctly handling data limits.
+        self._set_artist_props(line)
+        if line.get_clip_path() is None:
+            line.set_clip_path(self.patch)
+        if not line.get_label():
+            line.set_label(f"_child{len(self._children)}")
+        self._children.append(line)
+        line._remove_method = self._children.remove
+        self.update_datalim(datalim)
+
+        self._request_autoscale_view()
+        return line
+
+    @_docstring.interpd
+    def axhspan(self, ymin, ymax, xmin=0, xmax=1, **kwargs):
+        """
+        Add a horizontal span (rectangle) across the Axes.
+
+        The rectangle spans from *ymin* to *ymax* vertically, and, by default,
+        the whole x-axis horizontally.  The x-span can be set using *xmin*
+        (default: 0) and *xmax* (default: 1) which are in axis units; e.g.
+        ``xmin = 0.5`` always refers to the middle of the x-axis regardless of
+        the limits set by `~.Axes.set_xlim`.
+
+        Parameters
+        ----------
+        ymin : float
+            Lower y-coordinate of the span, in data units.
+        ymax : float
+            Upper y-coordinate of the span, in data units.
+        xmin : float, default: 0
+            Lower x-coordinate of the span, in x-axis (0-1) units.
+        xmax : float, default: 1
+            Upper x-coordinate of the span, in x-axis (0-1) units.
+
+        Returns
+        -------
+        `~matplotlib.patches.Rectangle`
+            Horizontal span (rectangle) from (xmin, ymin) to (xmax, ymax).
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.patches.Rectangle` properties
+
+        %(Rectangle:kwdoc)s
+
+        See Also
+        --------
+        axvspan : Add a vertical span across the Axes.
+        """
+        # Strip units away.
+        self._check_no_units([xmin, xmax], ['xmin', 'xmax'])
+        (ymin, ymax), = self._process_unit_info([("y", [ymin, ymax])], kwargs)
+
+        p = mpatches.Rectangle((xmin, ymin), xmax - xmin, ymax - ymin, **kwargs)
+        p.set_transform(self.get_yaxis_transform(which="grid"))
+        # For Rectangles and non-separable transforms, add_patch can be buggy
+        # and update the x limits even though it shouldn't do so for an
+        # yaxis_transformed patch, so undo that update.
+        ix = self.dataLim.intervalx.copy()
+        mx = self.dataLim.minposx
+        self.add_patch(p)
+        self.dataLim.intervalx = ix
+        self.dataLim.minposx = mx
+        p.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
+        self._request_autoscale_view("y")
+        return p
+
+    @_docstring.interpd
+    def axvspan(self, xmin, xmax, ymin=0, ymax=1, **kwargs):
+        """
+        Add a vertical span (rectangle) across the Axes.
+
+        The rectangle spans from *xmin* to *xmax* horizontally, and, by
+        default, the whole y-axis vertically.  The y-span can be set using
+        *ymin* (default: 0) and *ymax* (default: 1) which are in axis units;
+        e.g. ``ymin = 0.5`` always refers to the middle of the y-axis
+        regardless of the limits set by `~.Axes.set_ylim`.
+
+        Parameters
+        ----------
+        xmin : float
+            Lower x-coordinate of the span, in data units.
+        xmax : float
+            Upper x-coordinate of the span, in data units.
+        ymin : float, default: 0
+            Lower y-coordinate of the span, in y-axis units (0-1).
+        ymax : float, default: 1
+            Upper y-coordinate of the span, in y-axis units (0-1).
+
+        Returns
+        -------
+        `~matplotlib.patches.Rectangle`
+            Vertical span (rectangle) from (xmin, ymin) to (xmax, ymax).
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.patches.Rectangle` properties
+
+        %(Rectangle:kwdoc)s
+
+        See Also
+        --------
+        axhspan : Add a horizontal span across the Axes.
+
+        Examples
+        --------
+        Draw a vertical, green, translucent rectangle from x = 1.25 to
+        x = 1.55 that spans the yrange of the Axes.
+
+        >>> axvspan(1.25, 1.55, facecolor='g', alpha=0.5)
+
+        """
+        # Strip units away.
+        self._check_no_units([ymin, ymax], ['ymin', 'ymax'])
+        (xmin, xmax), = self._process_unit_info([("x", [xmin, xmax])], kwargs)
+
+        p = mpatches.Rectangle((xmin, ymin), xmax - xmin, ymax - ymin, **kwargs)
+        p.set_transform(self.get_xaxis_transform(which="grid"))
+        # For Rectangles and non-separable transforms, add_patch can be buggy
+        # and update the y limits even though it shouldn't do so for an
+        # xaxis_transformed patch, so undo that update.
+        iy = self.dataLim.intervaly.copy()
+        my = self.dataLim.minposy
+        self.add_patch(p)
+        self.dataLim.intervaly = iy
+        self.dataLim.minposy = my
+        p.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
+        self._request_autoscale_view("x")
+        return p
+
+    @_api.make_keyword_only("3.9", "label")
+    @_preprocess_data(replace_names=["y", "xmin", "xmax", "colors"],
+                      label_namer="y")
+    def hlines(self, y, xmin, xmax, colors=None, linestyles='solid',
+               label='', **kwargs):
+        """
+        Plot horizontal lines at each *y* from *xmin* to *xmax*.
+
+        Parameters
+        ----------
+        y : float or array-like
+            y-indexes where to plot the lines.
+
+        xmin, xmax : float or array-like
+            Respective beginning and end of each line. If scalars are
+            provided, all lines will have the same length.
+
+        colors : :mpltype:`color` or list of color , default: :rc:`lines.color`
+
+        linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, default: 'solid'
+
+        label : str, default: ''
+
+        Returns
+        -------
+        `~matplotlib.collections.LineCollection`
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        **kwargs :  `~matplotlib.collections.LineCollection` properties.
+
+        See Also
+        --------
+        vlines : vertical lines
+        axhline : horizontal line across the Axes
+        """
+
+        # We do the conversion first since not all unitized data is uniform
+        xmin, xmax, y = self._process_unit_info(
+            [("x", xmin), ("x", xmax), ("y", y)], kwargs)
+
+        if not np.iterable(y):
+            y = [y]
+        if not np.iterable(xmin):
+            xmin = [xmin]
+        if not np.iterable(xmax):
+            xmax = [xmax]
+
+        # Create and combine masked_arrays from input
+        y, xmin, xmax = cbook._combine_masks(y, xmin, xmax)
+        y = np.ravel(y)
+        xmin = np.ravel(xmin)
+        xmax = np.ravel(xmax)
+
+        masked_verts = np.ma.empty((len(y), 2, 2))
+        masked_verts[:, 0, 0] = xmin
+        masked_verts[:, 0, 1] = y
+        masked_verts[:, 1, 0] = xmax
+        masked_verts[:, 1, 1] = y
+
+        lines = mcoll.LineCollection(masked_verts, colors=colors,
+                                     linestyles=linestyles, label=label)
+        self.add_collection(lines, autolim=False)
+        lines._internal_update(kwargs)
+
+        if len(y) > 0:
+            # Extreme values of xmin/xmax/y.  Using masked_verts here handles
+            # the case of y being a masked *object* array (as can be generated
+            # e.g. by errorbar()), which would make nanmin/nanmax stumble.
+            updatex = True
+            updatey = True
+            if self.name == "rectilinear":
+                datalim = lines.get_datalim(self.transData)
+                t = lines.get_transform()
+                updatex, updatey = t.contains_branch_seperately(self.transData)
+                minx = np.nanmin(datalim.xmin)
+                maxx = np.nanmax(datalim.xmax)
+                miny = np.nanmin(datalim.ymin)
+                maxy = np.nanmax(datalim.ymax)
+            else:
+                minx = np.nanmin(masked_verts[..., 0])
+                maxx = np.nanmax(masked_verts[..., 0])
+                miny = np.nanmin(masked_verts[..., 1])
+                maxy = np.nanmax(masked_verts[..., 1])
+
+            corners = (minx, miny), (maxx, maxy)
+            self.update_datalim(corners, updatex, updatey)
+            self._request_autoscale_view()
+        return lines
+
+    @_api.make_keyword_only("3.9", "label")
+    @_preprocess_data(replace_names=["x", "ymin", "ymax", "colors"],
+                      label_namer="x")
+    def vlines(self, x, ymin, ymax, colors=None, linestyles='solid',
+               label='', **kwargs):
+        """
+        Plot vertical lines at each *x* from *ymin* to *ymax*.
+
+        Parameters
+        ----------
+        x : float or array-like
+            x-indexes where to plot the lines.
+
+        ymin, ymax : float or array-like
+            Respective beginning and end of each line. If scalars are
+            provided, all lines will have the same length.
+
+        colors : :mpltype:`color` or list of color, default: :rc:`lines.color`
+
+        linestyles : {'solid', 'dashed', 'dashdot', 'dotted'}, default: 'solid'
+
+        label : str, default: ''
+
+        Returns
+        -------
+        `~matplotlib.collections.LineCollection`
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        **kwargs : `~matplotlib.collections.LineCollection` properties.
+
+        See Also
+        --------
+        hlines : horizontal lines
+        axvline : vertical line across the Axes
+        """
+
+        # We do the conversion first since not all unitized data is uniform
+        x, ymin, ymax = self._process_unit_info(
+            [("x", x), ("y", ymin), ("y", ymax)], kwargs)
+
+        if not np.iterable(x):
+            x = [x]
+        if not np.iterable(ymin):
+            ymin = [ymin]
+        if not np.iterable(ymax):
+            ymax = [ymax]
+
+        # Create and combine masked_arrays from input
+        x, ymin, ymax = cbook._combine_masks(x, ymin, ymax)
+        x = np.ravel(x)
+        ymin = np.ravel(ymin)
+        ymax = np.ravel(ymax)
+
+        masked_verts = np.ma.empty((len(x), 2, 2))
+        masked_verts[:, 0, 0] = x
+        masked_verts[:, 0, 1] = ymin
+        masked_verts[:, 1, 0] = x
+        masked_verts[:, 1, 1] = ymax
+
+        lines = mcoll.LineCollection(masked_verts, colors=colors,
+                                     linestyles=linestyles, label=label)
+        self.add_collection(lines, autolim=False)
+        lines._internal_update(kwargs)
+
+        if len(x) > 0:
+            # Extreme values of x/ymin/ymax.  Using masked_verts here handles
+            # the case of x being a masked *object* array (as can be generated
+            # e.g. by errorbar()), which would make nanmin/nanmax stumble.
+            updatex = True
+            updatey = True
+            if self.name == "rectilinear":
+                datalim = lines.get_datalim(self.transData)
+                t = lines.get_transform()
+                updatex, updatey = t.contains_branch_seperately(self.transData)
+                minx = np.nanmin(datalim.xmin)
+                maxx = np.nanmax(datalim.xmax)
+                miny = np.nanmin(datalim.ymin)
+                maxy = np.nanmax(datalim.ymax)
+            else:
+                minx = np.nanmin(masked_verts[..., 0])
+                maxx = np.nanmax(masked_verts[..., 0])
+                miny = np.nanmin(masked_verts[..., 1])
+                maxy = np.nanmax(masked_verts[..., 1])
+
+            corners = (minx, miny), (maxx, maxy)
+            self.update_datalim(corners, updatex, updatey)
+            self._request_autoscale_view()
+        return lines
+
+    @_api.make_keyword_only("3.9", "orientation")
+    @_preprocess_data(replace_names=["positions", "lineoffsets",
+                                     "linelengths", "linewidths",
+                                     "colors", "linestyles"])
+    @_docstring.interpd
+    def eventplot(self, positions, orientation='horizontal', lineoffsets=1,
+                  linelengths=1, linewidths=None, colors=None, alpha=None,
+                  linestyles='solid', **kwargs):
+        """
+        Plot identical parallel lines at the given positions.
+
+        This type of plot is commonly used in neuroscience for representing
+        neural events, where it is usually called a spike raster, dot raster,
+        or raster plot.
+
+        However, it is useful in any situation where you wish to show the
+        timing or position of multiple sets of discrete events, such as the
+        arrival times of people to a business on each day of the month or the
+        date of hurricanes each year of the last century.
+
+        Parameters
+        ----------
+        positions : array-like or list of array-like
+            A 1D array-like defines the positions of one sequence of events.
+
+            Multiple groups of events may be passed as a list of array-likes.
+            Each group can be styled independently by passing lists of values
+            to *lineoffsets*, *linelengths*, *linewidths*, *colors* and
+            *linestyles*.
+
+            Note that *positions* can be a 2D array, but in practice different
+            event groups usually have different counts so that one will use a
+            list of different-length arrays rather than a 2D array.
+
+        orientation : {'horizontal', 'vertical'}, default: 'horizontal'
+            The direction of the event sequence:
+
+            - 'horizontal': the events are arranged horizontally.
+              The indicator lines are vertical.
+            - 'vertical': the events are arranged vertically.
+              The indicator lines are horizontal.
+
+        lineoffsets : float or array-like, default: 1
+            The offset of the center of the lines from the origin, in the
+            direction orthogonal to *orientation*.
+
+            If *positions* is 2D, this can be a sequence with length matching
+            the length of *positions*.
+
+        linelengths : float or array-like, default: 1
+            The total height of the lines (i.e. the lines stretches from
+            ``lineoffset - linelength/2`` to ``lineoffset + linelength/2``).
+
+            If *positions* is 2D, this can be a sequence with length matching
+            the length of *positions*.
+
+        linewidths : float or array-like, default: :rc:`lines.linewidth`
+            The line width(s) of the event lines, in points.
+
+            If *positions* is 2D, this can be a sequence with length matching
+            the length of *positions*.
+
+        colors : :mpltype:`color` or list of color, default: :rc:`lines.color`
+            The color(s) of the event lines.
+
+            If *positions* is 2D, this can be a sequence with length matching
+            the length of *positions*.
+
+        alpha : float or array-like, default: 1
+            The alpha blending value(s), between 0 (transparent) and 1
+            (opaque).
+
+            If *positions* is 2D, this can be a sequence with length matching
+            the length of *positions*.
+
+        linestyles : str or tuple or list of such values, default: 'solid'
+            Default is 'solid'. Valid strings are ['solid', 'dashed',
+            'dashdot', 'dotted', '-', '--', '-.', ':']. Dash tuples
+            should be of the form::
+
+                (offset, onoffseq),
+
+            where *onoffseq* is an even length tuple of on and off ink
+            in points.
+
+            If *positions* is 2D, this can be a sequence with length matching
+            the length of *positions*.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Other keyword arguments are line collection properties.  See
+            `.LineCollection` for a list of the valid properties.
+
+        Returns
+        -------
+        list of `.EventCollection`
+            The `.EventCollection` that were added.
+
+        Notes
+        -----
+        For *linelengths*, *linewidths*, *colors*, *alpha* and *linestyles*, if
+        only a single value is given, that value is applied to all lines. If an
+        array-like is given, it must have the same length as *positions*, and
+        each value will be applied to the corresponding row of the array.
+
+        Examples
+        --------
+        .. plot:: gallery/lines_bars_and_markers/eventplot_demo.py
+        """
+
+        lineoffsets, linelengths = self._process_unit_info(
+                [("y", lineoffsets), ("y", linelengths)], kwargs)
+
+        # fix positions, noting that it can be a list of lists:
+        if not np.iterable(positions):
+            positions = [positions]
+        elif any(np.iterable(position) for position in positions):
+            positions = [np.asanyarray(position) for position in positions]
+        else:
+            positions = [np.asanyarray(positions)]
+
+        poss = []
+        for position in positions:
+            poss += self._process_unit_info([("x", position)], kwargs)
+        positions = poss
+
+        # prevent 'singular' keys from **kwargs dict from overriding the effect
+        # of 'plural' keyword arguments (e.g. 'color' overriding 'colors')
+        colors = cbook._local_over_kwdict(colors, kwargs, 'color')
+        linewidths = cbook._local_over_kwdict(linewidths, kwargs, 'linewidth')
+        linestyles = cbook._local_over_kwdict(linestyles, kwargs, 'linestyle')
+
+        if not np.iterable(lineoffsets):
+            lineoffsets = [lineoffsets]
+        if not np.iterable(linelengths):
+            linelengths = [linelengths]
+        if not np.iterable(linewidths):
+            linewidths = [linewidths]
+        if not np.iterable(colors):
+            colors = [colors]
+        if not np.iterable(alpha):
+            alpha = [alpha]
+        if hasattr(linestyles, 'lower') or not np.iterable(linestyles):
+            linestyles = [linestyles]
+
+        lineoffsets = np.asarray(lineoffsets)
+        linelengths = np.asarray(linelengths)
+        linewidths = np.asarray(linewidths)
+
+        if len(lineoffsets) == 0:
+            raise ValueError('lineoffsets cannot be empty')
+        if len(linelengths) == 0:
+            raise ValueError('linelengths cannot be empty')
+        if len(linestyles) == 0:
+            raise ValueError('linestyles cannot be empty')
+        if len(linewidths) == 0:
+            raise ValueError('linewidths cannot be empty')
+        if len(alpha) == 0:
+            raise ValueError('alpha cannot be empty')
+        if len(colors) == 0:
+            colors = [None]
+        try:
+            # Early conversion of the colors into RGBA values to take care
+            # of cases like colors='0.5' or colors='C1'.  (Issue #8193)
+            colors = mcolors.to_rgba_array(colors)
+        except ValueError:
+            # Will fail if any element of *colors* is None. But as long
+            # as len(colors) == 1 or len(positions), the rest of the
+            # code should process *colors* properly.
+            pass
+
+        if len(lineoffsets) == 1 and len(positions) != 1:
+            lineoffsets = np.tile(lineoffsets, len(positions))
+            lineoffsets[0] = 0
+            lineoffsets = np.cumsum(lineoffsets)
+        if len(linelengths) == 1:
+            linelengths = np.tile(linelengths, len(positions))
+        if len(linewidths) == 1:
+            linewidths = np.tile(linewidths, len(positions))
+        if len(colors) == 1:
+            colors = list(colors) * len(positions)
+        if len(alpha) == 1:
+            alpha = list(alpha) * len(positions)
+        if len(linestyles) == 1:
+            linestyles = [linestyles] * len(positions)
+
+        if len(lineoffsets) != len(positions):
+            raise ValueError('lineoffsets and positions are unequal sized '
+                             'sequences')
+        if len(linelengths) != len(positions):
+            raise ValueError('linelengths and positions are unequal sized '
+                             'sequences')
+        if len(linewidths) != len(positions):
+            raise ValueError('linewidths and positions are unequal sized '
+                             'sequences')
+        if len(colors) != len(positions):
+            raise ValueError('colors and positions are unequal sized '
+                             'sequences')
+        if len(alpha) != len(positions):
+            raise ValueError('alpha and positions are unequal sized '
+                             'sequences')
+        if len(linestyles) != len(positions):
+            raise ValueError('linestyles and positions are unequal sized '
+                             'sequences')
+
+        colls = []
+        for position, lineoffset, linelength, linewidth, color, alpha_, \
+            linestyle in \
+                zip(positions, lineoffsets, linelengths, linewidths,
+                    colors, alpha, linestyles):
+            coll = mcoll.EventCollection(position,
+                                         orientation=orientation,
+                                         lineoffset=lineoffset,
+                                         linelength=linelength,
+                                         linewidth=linewidth,
+                                         color=color,
+                                         alpha=alpha_,
+                                         linestyle=linestyle)
+            self.add_collection(coll, autolim=False)
+            coll._internal_update(kwargs)
+            colls.append(coll)
+
+        if len(positions) > 0:
+            # try to get min/max
+            min_max = [(np.min(_p), np.max(_p)) for _p in positions
+                       if len(_p) > 0]
+            # if we have any non-empty positions, try to autoscale
+            if len(min_max) > 0:
+                mins, maxes = zip(*min_max)
+                minpos = np.min(mins)
+                maxpos = np.max(maxes)
+
+                minline = (lineoffsets - linelengths).min()
+                maxline = (lineoffsets + linelengths).max()
+
+                if orientation == "vertical":
+                    corners = (minline, minpos), (maxline, maxpos)
+                else:  # "horizontal"
+                    corners = (minpos, minline), (maxpos, maxline)
+                self.update_datalim(corners)
+                self._request_autoscale_view()
+
+        return colls
+
+    #### Basic plotting
+
+    # Uses a custom implementation of data-kwarg handling in
+    # _process_plot_var_args.
+    @_docstring.interpd
+    def plot(self, *args, scalex=True, scaley=True, data=None, **kwargs):
+        """
+        Plot y versus x as lines and/or markers.
+
+        Call signatures::
+
+            plot([x], y, [fmt], *, data=None, **kwargs)
+            plot([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
+
+        The coordinates of the points or line nodes are given by *x*, *y*.
+
+        The optional parameter *fmt* is a convenient way for defining basic
+        formatting like color, marker and linestyle. It's a shortcut string
+        notation described in the *Notes* section below.
+
+        >>> plot(x, y)        # plot x and y using default line style and color
+        >>> plot(x, y, 'bo')  # plot x and y using blue circle markers
+        >>> plot(y)           # plot y using x as index array 0..N-1
+        >>> plot(y, 'r+')     # ditto, but with red plusses
+
+        You can use `.Line2D` properties as keyword arguments for more
+        control on the appearance. Line properties and *fmt* can be mixed.
+        The following two calls yield identical results:
+
+        >>> plot(x, y, 'go--', linewidth=2, markersize=12)
+        >>> plot(x, y, color='green', marker='o', linestyle='dashed',
+        ...      linewidth=2, markersize=12)
+
+        When conflicting with *fmt*, keyword arguments take precedence.
+
+
+        **Plotting labelled data**
+
+        There's a convenient way for plotting objects with labelled data (i.e.
+        data that can be accessed by index ``obj['y']``). Instead of giving
+        the data in *x* and *y*, you can provide the object in the *data*
+        parameter and just give the labels for *x* and *y*::
+
+        >>> plot('xlabel', 'ylabel', data=obj)
+
+        All indexable objects are supported. This could e.g. be a `dict`, a
+        `pandas.DataFrame` or a structured numpy array.
+
+
+        **Plotting multiple sets of data**
+
+        There are various ways to plot multiple sets of data.
+
+        - The most straight forward way is just to call `plot` multiple times.
+          Example:
+
+          >>> plot(x1, y1, 'bo')
+          >>> plot(x2, y2, 'go')
+
+        - If *x* and/or *y* are 2D arrays, a separate data set will be drawn
+          for every column. If both *x* and *y* are 2D, they must have the
+          same shape. If only one of them is 2D with shape (N, m) the other
+          must have length N and will be used for every data set m.
+
+          Example:
+
+          >>> x = [1, 2, 3]
+          >>> y = np.array([[1, 2], [3, 4], [5, 6]])
+          >>> plot(x, y)
+
+          is equivalent to:
+
+          >>> for col in range(y.shape[1]):
+          ...     plot(x, y[:, col])
+
+        - The third way is to specify multiple sets of *[x]*, *y*, *[fmt]*
+          groups::
+
+          >>> plot(x1, y1, 'g^', x2, y2, 'g-')
+
+          In this case, any additional keyword argument applies to all
+          datasets. Also, this syntax cannot be combined with the *data*
+          parameter.
+
+        By default, each line is assigned a different style specified by a
+        'style cycle'. The *fmt* and line property parameters are only
+        necessary if you want explicit deviations from these defaults.
+        Alternatively, you can also change the style cycle using
+        :rc:`axes.prop_cycle`.
+
+
+        Parameters
+        ----------
+        x, y : array-like or scalar
+            The horizontal / vertical coordinates of the data points.
+            *x* values are optional and default to ``range(len(y))``.
+
+            Commonly, these parameters are 1D arrays.
+
+            They can also be scalars, or two-dimensional (in that case, the
+            columns represent separate data sets).
+
+            These arguments cannot be passed as keywords.
+
+        fmt : str, optional
+            A format string, e.g. 'ro' for red circles. See the *Notes*
+            section for a full description of the format strings.
+
+            Format strings are just an abbreviation for quickly setting
+            basic line properties. All of these and more can also be
+            controlled by keyword arguments.
+
+            This argument cannot be passed as keyword.
+
+        data : indexable object, optional
+            An object with labelled data. If given, provide the label names to
+            plot in *x* and *y*.
+
+            .. note::
+                Technically there's a slight ambiguity in calls where the
+                second label is a valid *fmt*. ``plot('n', 'o', data=obj)``
+                could be ``plt(x, y)`` or ``plt(y, fmt)``. In such cases,
+                the former interpretation is chosen, but a warning is issued.
+                You may suppress the warning by adding an empty format string
+                ``plot('n', 'o', '', data=obj)``.
+
+        Returns
+        -------
+        list of `.Line2D`
+            A list of lines representing the plotted data.
+
+        Other Parameters
+        ----------------
+        scalex, scaley : bool, default: True
+            These parameters determine if the view limits are adapted to the
+            data limits. The values are passed on to
+            `~.axes.Axes.autoscale_view`.
+
+        **kwargs : `~matplotlib.lines.Line2D` properties, optional
+            *kwargs* are used to specify properties like a line label (for
+            auto legends), linewidth, antialiasing, marker face color.
+            Example::
+
+            >>> plot([1, 2, 3], [1, 2, 3], 'go-', label='line 1', linewidth=2)
+            >>> plot([1, 2, 3], [1, 4, 9], 'rs', label='line 2')
+
+            If you specify multiple lines with one plot call, the kwargs apply
+            to all those lines. In case the label object is iterable, each
+            element is used as labels for each set of data.
+
+            Here is a list of available `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        scatter : XY scatter plot with markers of varying size and/or color (
+            sometimes also called bubble chart).
+
+        Notes
+        -----
+        **Format Strings**
+
+        A format string consists of a part for color, marker and line::
+
+            fmt = '[marker][line][color]'
+
+        Each of them is optional. If not provided, the value from the style
+        cycle is used. Exception: If ``line`` is given, but no ``marker``,
+        the data will be a line without markers.
+
+        Other combinations such as ``[color][marker][line]`` are also
+        supported, but note that their parsing may be ambiguous.
+
+        **Markers**
+
+        =============   ===============================
+        character       description
+        =============   ===============================
+        ``'.'``         point marker
+        ``','``         pixel marker
+        ``'o'``         circle marker
+        ``'v'``         triangle_down marker
+        ``'^'``         triangle_up marker
+        ``'<'``         triangle_left marker
+        ``'>'``         triangle_right marker
+        ``'1'``         tri_down marker
+        ``'2'``         tri_up marker
+        ``'3'``         tri_left marker
+        ``'4'``         tri_right marker
+        ``'8'``         octagon marker
+        ``'s'``         square marker
+        ``'p'``         pentagon marker
+        ``'P'``         plus (filled) marker
+        ``'*'``         star marker
+        ``'h'``         hexagon1 marker
+        ``'H'``         hexagon2 marker
+        ``'+'``         plus marker
+        ``'x'``         x marker
+        ``'X'``         x (filled) marker
+        ``'D'``         diamond marker
+        ``'d'``         thin_diamond marker
+        ``'|'``         vline marker
+        ``'_'``         hline marker
+        =============   ===============================
+
+        **Line Styles**
+
+        =============    ===============================
+        character        description
+        =============    ===============================
+        ``'-'``          solid line style
+        ``'--'``         dashed line style
+        ``'-.'``         dash-dot line style
+        ``':'``          dotted line style
+        =============    ===============================
+
+        Example format strings::
+
+            'b'    # blue markers with default shape
+            'or'   # red circles
+            '-g'   # green solid line
+            '--'   # dashed line with default color
+            '^k:'  # black triangle_up markers connected by a dotted line
+
+        **Colors**
+
+        The supported color abbreviations are the single letter codes
+
+        =============    ===============================
+        character        color
+        =============    ===============================
+        ``'b'``          blue
+        ``'g'``          green
+        ``'r'``          red
+        ``'c'``          cyan
+        ``'m'``          magenta
+        ``'y'``          yellow
+        ``'k'``          black
+        ``'w'``          white
+        =============    ===============================
+
+        and the ``'CN'`` colors that index into the default property cycle.
+
+        If the color is the only part of the format string, you can
+        additionally use any  `matplotlib.colors` spec, e.g. full names
+        (``'green'``) or hex strings (``'#008000'``).
+        """
+        kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
+        lines = [*self._get_lines(self, *args, data=data, **kwargs)]
+        for line in lines:
+            self.add_line(line)
+        if scalex:
+            self._request_autoscale_view("x")
+        if scaley:
+            self._request_autoscale_view("y")
+        return lines
+
+    @_api.deprecated("3.9", alternative="plot")
+    @_preprocess_data(replace_names=["x", "y"], label_namer="y")
+    @_docstring.interpd
+    def plot_date(self, x, y, fmt='o', tz=None, xdate=True, ydate=False,
+                  **kwargs):
+        """
+        Plot coercing the axis to treat floats as dates.
+
+        .. deprecated:: 3.9
+
+            This method exists for historic reasons and will be removed in version 3.11.
+
+            - ``datetime``-like data should directly be plotted using
+              `~.Axes.plot`.
+            -  If you need to plot plain numeric data as :ref:`date-format` or
+               need to set a timezone, call ``ax.xaxis.axis_date`` /
+               ``ax.yaxis.axis_date`` before `~.Axes.plot`. See
+               `.Axis.axis_date`.
+
+        Similar to `.plot`, this plots *y* vs. *x* as lines or markers.
+        However, the axis labels are formatted as dates depending on *xdate*
+        and *ydate*.  Note that `.plot` will work with `datetime` and
+        `numpy.datetime64` objects without resorting to this method.
+
+        Parameters
+        ----------
+        x, y : array-like
+            The coordinates of the data points. If *xdate* or *ydate* is
+            *True*, the respective values *x* or *y* are interpreted as
+            :ref:`Matplotlib dates <date-format>`.
+
+        fmt : str, optional
+            The plot format string. For details, see the corresponding
+            parameter in `.plot`.
+
+        tz : timezone string or `datetime.tzinfo`, default: :rc:`timezone`
+            The time zone to use in labeling dates.
+
+        xdate : bool, default: True
+            If *True*, the *x*-axis will be interpreted as Matplotlib dates.
+
+        ydate : bool, default: False
+            If *True*, the *y*-axis will be interpreted as Matplotlib dates.
+
+        Returns
+        -------
+        list of `.Line2D`
+            Objects representing the plotted data.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        matplotlib.dates : Helper functions on dates.
+        matplotlib.dates.date2num : Convert dates to num.
+        matplotlib.dates.num2date : Convert num to dates.
+        matplotlib.dates.drange : Create an equally spaced sequence of dates.
+
+        Notes
+        -----
+        If you are using custom date tickers and formatters, it may be
+        necessary to set the formatters/locators after the call to
+        `.plot_date`. `.plot_date` will set the default tick locator to
+        `.AutoDateLocator` (if the tick locator is not already set to a
+        `.DateLocator` instance) and the default tick formatter to
+        `.AutoDateFormatter` (if the tick formatter is not already set to a
+        `.DateFormatter` instance).
+        """
+        if xdate:
+            self.xaxis_date(tz)
+        if ydate:
+            self.yaxis_date(tz)
+        return self.plot(x, y, fmt, **kwargs)
+
+    # @_preprocess_data() # let 'plot' do the unpacking..
+    @_docstring.interpd
+    def loglog(self, *args, **kwargs):
+        """
+        Make a plot with log scaling on both the x- and y-axis.
+
+        Call signatures::
+
+            loglog([x], y, [fmt], data=None, **kwargs)
+            loglog([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
+
+        This is just a thin wrapper around `.plot` which additionally changes
+        both the x-axis and the y-axis to log scaling. All the concepts and
+        parameters of plot can be used here as well.
+
+        The additional parameters *base*, *subs* and *nonpositive* control the
+        x/y-axis properties. They are just forwarded to `.Axes.set_xscale` and
+        `.Axes.set_yscale`. To use different properties on the x-axis and the
+        y-axis, use e.g.
+        ``ax.set_xscale("log", base=10); ax.set_yscale("log", base=2)``.
+
+        Parameters
+        ----------
+        base : float, default: 10
+            Base of the logarithm.
+
+        subs : sequence, optional
+            The location of the minor ticks. If *None*, reasonable locations
+            are automatically chosen depending on the number of decades in the
+            plot. See `.Axes.set_xscale`/`.Axes.set_yscale` for details.
+
+        nonpositive : {'mask', 'clip'}, default: 'clip'
+            Non-positive values can be masked as invalid, or clipped to a very
+            small positive number.
+
+        **kwargs
+            All parameters supported by `.plot`.
+
+        Returns
+        -------
+        list of `.Line2D`
+            Objects representing the plotted data.
+        """
+        dx = {k: v for k, v in kwargs.items()
+              if k in ['base', 'subs', 'nonpositive',
+                       'basex', 'subsx', 'nonposx']}
+        self.set_xscale('log', **dx)
+        dy = {k: v for k, v in kwargs.items()
+              if k in ['base', 'subs', 'nonpositive',
+                       'basey', 'subsy', 'nonposy']}
+        self.set_yscale('log', **dy)
+        return self.plot(
+            *args, **{k: v for k, v in kwargs.items() if k not in {*dx, *dy}})
+
+    # @_preprocess_data() # let 'plot' do the unpacking..
+    @_docstring.interpd
+    def semilogx(self, *args, **kwargs):
+        """
+        Make a plot with log scaling on the x-axis.
+
+        Call signatures::
+
+            semilogx([x], y, [fmt], data=None, **kwargs)
+            semilogx([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
+
+        This is just a thin wrapper around `.plot` which additionally changes
+        the x-axis to log scaling. All the concepts and parameters of plot can
+        be used here as well.
+
+        The additional parameters *base*, *subs*, and *nonpositive* control the
+        x-axis properties. They are just forwarded to `.Axes.set_xscale`.
+
+        Parameters
+        ----------
+        base : float, default: 10
+            Base of the x logarithm.
+
+        subs : array-like, optional
+            The location of the minor xticks. If *None*, reasonable locations
+            are automatically chosen depending on the number of decades in the
+            plot. See `.Axes.set_xscale` for details.
+
+        nonpositive : {'mask', 'clip'}, default: 'clip'
+            Non-positive values in x can be masked as invalid, or clipped to a
+            very small positive number.
+
+        **kwargs
+            All parameters supported by `.plot`.
+
+        Returns
+        -------
+        list of `.Line2D`
+            Objects representing the plotted data.
+        """
+        d = {k: v for k, v in kwargs.items()
+             if k in ['base', 'subs', 'nonpositive',
+                      'basex', 'subsx', 'nonposx']}
+        self.set_xscale('log', **d)
+        return self.plot(
+            *args, **{k: v for k, v in kwargs.items() if k not in d})
+
+    # @_preprocess_data() # let 'plot' do the unpacking..
+    @_docstring.interpd
+    def semilogy(self, *args, **kwargs):
+        """
+        Make a plot with log scaling on the y-axis.
+
+        Call signatures::
+
+            semilogy([x], y, [fmt], data=None, **kwargs)
+            semilogy([x], y, [fmt], [x2], y2, [fmt2], ..., **kwargs)
+
+        This is just a thin wrapper around `.plot` which additionally changes
+        the y-axis to log scaling. All the concepts and parameters of plot can
+        be used here as well.
+
+        The additional parameters *base*, *subs*, and *nonpositive* control the
+        y-axis properties. They are just forwarded to `.Axes.set_yscale`.
+
+        Parameters
+        ----------
+        base : float, default: 10
+            Base of the y logarithm.
+
+        subs : array-like, optional
+            The location of the minor yticks. If *None*, reasonable locations
+            are automatically chosen depending on the number of decades in the
+            plot. See `.Axes.set_yscale` for details.
+
+        nonpositive : {'mask', 'clip'}, default: 'clip'
+            Non-positive values in y can be masked as invalid, or clipped to a
+            very small positive number.
+
+        **kwargs
+            All parameters supported by `.plot`.
+
+        Returns
+        -------
+        list of `.Line2D`
+            Objects representing the plotted data.
+        """
+        d = {k: v for k, v in kwargs.items()
+             if k in ['base', 'subs', 'nonpositive',
+                      'basey', 'subsy', 'nonposy']}
+        self.set_yscale('log', **d)
+        return self.plot(
+            *args, **{k: v for k, v in kwargs.items() if k not in d})
+
+    @_preprocess_data(replace_names=["x"], label_namer="x")
+    def acorr(self, x, **kwargs):
+        """
+        Plot the autocorrelation of *x*.
+
+        Parameters
+        ----------
+        x : array-like
+            Not run through Matplotlib's unit conversion, so this should
+            be a unit-less array.
+
+        detrend : callable, default: `.mlab.detrend_none` (no detrending)
+            A detrending function applied to *x*.  It must have the
+            signature ::
+
+                detrend(x: np.ndarray) -> np.ndarray
+
+        normed : bool, default: True
+            If ``True``, input vectors are normalised to unit length.
+
+        usevlines : bool, default: True
+            Determines the plot style.
+
+            If ``True``, vertical lines are plotted from 0 to the acorr value
+            using `.Axes.vlines`. Additionally, a horizontal line is plotted
+            at y=0 using `.Axes.axhline`.
+
+            If ``False``, markers are plotted at the acorr values using
+            `.Axes.plot`.
+
+        maxlags : int, default: 10
+            Number of lags to show. If ``None``, will return all
+            ``2 * len(x) - 1`` lags.
+
+        Returns
+        -------
+        lags : array (length ``2*maxlags+1``)
+            The lag vector.
+        c : array  (length ``2*maxlags+1``)
+            The auto correlation vector.
+        line : `.LineCollection` or `.Line2D`
+            `.Artist` added to the Axes of the correlation:
+
+            - `.LineCollection` if *usevlines* is True.
+            - `.Line2D` if *usevlines* is False.
+        b : `~matplotlib.lines.Line2D` or None
+            Horizontal line at 0 if *usevlines* is True
+            None *usevlines* is False.
+
+        Other Parameters
+        ----------------
+        linestyle : `~matplotlib.lines.Line2D` property, optional
+            The linestyle for plotting the data points.
+            Only used if *usevlines* is ``False``.
+
+        marker : str, default: 'o'
+            The marker for plotting the data points.
+            Only used if *usevlines* is ``False``.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Additional parameters are passed to `.Axes.vlines` and
+            `.Axes.axhline` if *usevlines* is ``True``; otherwise they are
+            passed to `.Axes.plot`.
+
+        Notes
+        -----
+        The cross correlation is performed with `numpy.correlate` with
+        ``mode = "full"``.
+        """
+        return self.xcorr(x, x, **kwargs)
+
+    @_api.make_keyword_only("3.9", "normed")
+    @_preprocess_data(replace_names=["x", "y"], label_namer="y")
+    def xcorr(self, x, y, normed=True, detrend=mlab.detrend_none,
+              usevlines=True, maxlags=10, **kwargs):
+        r"""
+        Plot the cross correlation between *x* and *y*.
+
+        The correlation with lag k is defined as
+        :math:`\sum_n x[n+k] \cdot y^*[n]`, where :math:`y^*` is the complex
+        conjugate of :math:`y`.
+
+        Parameters
+        ----------
+        x, y : array-like of length n
+            Neither *x* nor *y* are run through Matplotlib's unit conversion, so
+            these should be unit-less arrays.
+
+        detrend : callable, default: `.mlab.detrend_none` (no detrending)
+            A detrending function applied to *x* and *y*.  It must have the
+            signature ::
+
+                detrend(x: np.ndarray) -> np.ndarray
+
+        normed : bool, default: True
+            If ``True``, input vectors are normalised to unit length.
+
+        usevlines : bool, default: True
+            Determines the plot style.
+
+            If ``True``, vertical lines are plotted from 0 to the xcorr value
+            using `.Axes.vlines`. Additionally, a horizontal line is plotted
+            at y=0 using `.Axes.axhline`.
+
+            If ``False``, markers are plotted at the xcorr values using
+            `.Axes.plot`.
+
+        maxlags : int, default: 10
+            Number of lags to show. If None, will return all ``2 * len(x) - 1``
+            lags.
+
+        Returns
+        -------
+        lags : array (length ``2*maxlags+1``)
+            The lag vector.
+        c : array  (length ``2*maxlags+1``)
+            The auto correlation vector.
+        line : `.LineCollection` or `.Line2D`
+            `.Artist` added to the Axes of the correlation:
+
+            - `.LineCollection` if *usevlines* is True.
+            - `.Line2D` if *usevlines* is False.
+        b : `~matplotlib.lines.Line2D` or None
+            Horizontal line at 0 if *usevlines* is True
+            None *usevlines* is False.
+
+        Other Parameters
+        ----------------
+        linestyle : `~matplotlib.lines.Line2D` property, optional
+            The linestyle for plotting the data points.
+            Only used if *usevlines* is ``False``.
+
+        marker : str, default: 'o'
+            The marker for plotting the data points.
+            Only used if *usevlines* is ``False``.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Additional parameters are passed to `.Axes.vlines` and
+            `.Axes.axhline` if *usevlines* is ``True``; otherwise they are
+            passed to `.Axes.plot`.
+
+        Notes
+        -----
+        The cross correlation is performed with `numpy.correlate` with
+        ``mode = "full"``.
+        """
+        Nx = len(x)
+        if Nx != len(y):
+            raise ValueError('x and y must be equal length')
+
+        x = detrend(np.asarray(x))
+        y = detrend(np.asarray(y))
+
+        correls = np.correlate(x, y, mode="full")
+
+        if normed:
+            correls = correls / np.sqrt(np.dot(x, x) * np.dot(y, y))
+
+        if maxlags is None:
+            maxlags = Nx - 1
+
+        if maxlags >= Nx or maxlags < 1:
+            raise ValueError('maxlags must be None or strictly '
+                             'positive < %d' % Nx)
+
+        lags = np.arange(-maxlags, maxlags + 1)
+        correls = correls[Nx - 1 - maxlags:Nx + maxlags]
+
+        if usevlines:
+            a = self.vlines(lags, [0], correls, **kwargs)
+            # Make label empty so only vertical lines get a legend entry
+            kwargs.pop('label', '')
+            b = self.axhline(**kwargs)
+        else:
+            kwargs.setdefault('marker', 'o')
+            kwargs.setdefault('linestyle', 'None')
+            a, = self.plot(lags, correls, **kwargs)
+            b = None
+        return lags, correls, a, b
+
+    #### Specialized plotting
+
+    # @_preprocess_data() # let 'plot' do the unpacking..
+    def step(self, x, y, *args, where='pre', data=None, **kwargs):
+        """
+        Make a step plot.
+
+        Call signatures::
+
+            step(x, y, [fmt], *, data=None, where='pre', **kwargs)
+            step(x, y, [fmt], x2, y2, [fmt2], ..., *, where='pre', **kwargs)
+
+        This is just a thin wrapper around `.plot` which changes some
+        formatting options. Most of the concepts and parameters of plot can be
+        used here as well.
+
+        .. note::
+
+            This method uses a standard plot with a step drawstyle: The *x*
+            values are the reference positions and steps extend left/right/both
+            directions depending on *where*.
+
+            For the common case where you know the values and edges of the
+            steps, use `~.Axes.stairs` instead.
+
+        Parameters
+        ----------
+        x : array-like
+            1D sequence of x positions. It is assumed, but not checked, that
+            it is uniformly increasing.
+
+        y : array-like
+            1D sequence of y levels.
+
+        fmt : str, optional
+            A format string, e.g. 'g' for a green line. See `.plot` for a more
+            detailed description.
+
+            Note: While full format strings are accepted, it is recommended to
+            only specify the color. Line styles are currently ignored (use
+            the keyword argument *linestyle* instead). Markers are accepted
+            and plotted on the given positions, however, this is a rarely
+            needed feature for step plots.
+
+        where : {'pre', 'post', 'mid'}, default: 'pre'
+            Define where the steps should be placed:
+
+            - 'pre': The y value is continued constantly to the left from
+              every *x* position, i.e. the interval ``(x[i-1], x[i]]`` has the
+              value ``y[i]``.
+            - 'post': The y value is continued constantly to the right from
+              every *x* position, i.e. the interval ``[x[i], x[i+1])`` has the
+              value ``y[i]``.
+            - 'mid': Steps occur half-way between the *x* positions.
+
+        data : indexable object, optional
+            An object with labelled data. If given, provide the label names to
+            plot in *x* and *y*.
+
+        **kwargs
+            Additional parameters are the same as those for `.plot`.
+
+        Returns
+        -------
+        list of `.Line2D`
+            Objects representing the plotted data.
+        """
+        _api.check_in_list(('pre', 'post', 'mid'), where=where)
+        kwargs['drawstyle'] = 'steps-' + where
+        return self.plot(x, y, *args, data=data, **kwargs)
+
+    @staticmethod
+    def _convert_dx(dx, x0, xconv, convert):
+        """
+        Small helper to do logic of width conversion flexibly.
+
+        *dx* and *x0* have units, but *xconv* has already been converted
+        to unitless (and is an ndarray).  This allows the *dx* to have units
+        that are different from *x0*, but are still accepted by the
+        ``__add__`` operator of *x0*.
+        """
+
+        # x should be an array...
+        assert type(xconv) is np.ndarray
+
+        if xconv.size == 0:
+            # xconv has already been converted, but maybe empty...
+            return convert(dx)
+
+        try:
+            # attempt to add the width to x0; this works for
+            # datetime+timedelta, for instance
+
+            # only use the first element of x and x0.  This saves
+            # having to be sure addition works across the whole
+            # vector.  This is particularly an issue if
+            # x0 and dx are lists so x0 + dx just concatenates the lists.
+            # We can't just cast x0 and dx to numpy arrays because that
+            # removes the units from unit packages like `pint` that
+            # wrap numpy arrays.
+            try:
+                x0 = cbook._safe_first_finite(x0)
+            except (TypeError, IndexError, KeyError):
+                pass
+
+            try:
+                x = cbook._safe_first_finite(xconv)
+            except (TypeError, IndexError, KeyError):
+                x = xconv
+
+            delist = False
+            if not np.iterable(dx):
+                dx = [dx]
+                delist = True
+            dx = [convert(x0 + ddx) - x for ddx in dx]
+            if delist:
+                dx = dx[0]
+        except (ValueError, TypeError, AttributeError):
+            # if the above fails (for any reason) just fallback to what
+            # we do by default and convert dx by itself.
+            dx = convert(dx)
+        return dx
+
+    def _parse_bar_color_args(self, kwargs):
+        """
+        Helper function to process color-related arguments of `.Axes.bar`.
+
+        Argument precedence for facecolors:
+
+        - kwargs['facecolor']
+        - kwargs['color']
+        - 'Result of ``self._get_patches_for_fill.get_next_color``
+
+        Argument precedence for edgecolors:
+
+        - kwargs['edgecolor']
+        - None
+
+        Parameters
+        ----------
+        self : Axes
+
+        kwargs : dict
+            Additional kwargs. If these keys exist, we pop and process them:
+            'facecolor', 'edgecolor', 'color'
+            Note: The dict is modified by this function.
+
+
+        Returns
+        -------
+        facecolor
+            The facecolor. One or more colors as (N, 4) rgba array.
+        edgecolor
+            The edgecolor. Not normalized; may be any valid color spec or None.
+        """
+        color = kwargs.pop('color', None)
+
+        facecolor = kwargs.pop('facecolor', color)
+        edgecolor = kwargs.pop('edgecolor', None)
+
+        facecolor = (facecolor if facecolor is not None
+                     else self._get_patches_for_fill.get_next_color())
+
+        try:
+            facecolor = mcolors.to_rgba_array(facecolor)
+        except ValueError as err:
+            raise ValueError(
+                "'facecolor' or 'color' argument must be a valid color or"
+                    "sequence of colors."
+            ) from err
+
+        return facecolor, edgecolor
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def bar(self, x, height, width=0.8, bottom=None, *, align="center",
+            **kwargs):
+        r"""
+        Make a bar plot.
+
+        The bars are positioned at *x* with the given *align*\ment. Their
+        dimensions are given by *height* and *width*. The vertical baseline
+        is *bottom* (default 0).
+
+        Many parameters can take either a single value applying to all bars
+        or a sequence of values, one for each bar.
+
+        Parameters
+        ----------
+        x : float or array-like
+            The x coordinates of the bars. See also *align* for the
+            alignment of the bars to the coordinates.
+
+        height : float or array-like
+            The height(s) of the bars.
+
+            Note that if *bottom* has units (e.g. datetime), *height* should be in
+            units that are a difference from the value of *bottom* (e.g. timedelta).
+
+        width : float or array-like, default: 0.8
+            The width(s) of the bars.
+
+            Note that if *x* has units (e.g. datetime), then *width* should be in
+            units that are a difference (e.g. timedelta) around the *x* values.
+
+        bottom : float or array-like, default: 0
+            The y coordinate(s) of the bottom side(s) of the bars.
+
+            Note that if *bottom* has units, then the y-axis will get a Locator and
+            Formatter appropriate for the units (e.g. dates, or categorical).
+
+        align : {'center', 'edge'}, default: 'center'
+            Alignment of the bars to the *x* coordinates:
+
+            - 'center': Center the base on the *x* positions.
+            - 'edge': Align the left edges of the bars with the *x* positions.
+
+            To align the bars on the right edge pass a negative *width* and
+            ``align='edge'``.
+
+        Returns
+        -------
+        `.BarContainer`
+            Container with all the bars and optionally errorbars.
+
+        Other Parameters
+        ----------------
+        color : :mpltype:`color` or list of :mpltype:`color`, optional
+            The colors of the bar faces. This is an alias for *facecolor*.
+            If both are given, *facecolor* takes precedence.
+
+        facecolor : :mpltype:`color` or list of :mpltype:`color`, optional
+            The colors of the bar faces.
+            If both *color* and *facecolor are given, *facecolor* takes precedence.
+
+        edgecolor : :mpltype:`color` or list of :mpltype:`color`, optional
+            The colors of the bar edges.
+
+        linewidth : float or array-like, optional
+            Width of the bar edge(s). If 0, don't draw edges.
+
+        tick_label : str or list of str, optional
+            The tick labels of the bars.
+            Default: None (Use default numeric labels.)
+
+        label : str or list of str, optional
+            A single label is attached to the resulting `.BarContainer` as a
+            label for the whole dataset.
+            If a list is provided, it must be the same length as *x* and
+            labels the individual bars. Repeated labels are not de-duplicated
+            and will cause repeated label entries, so this is best used when
+            bars also differ in style (e.g., by passing a list to *color*.)
+
+        xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
+            If not *None*, add horizontal / vertical errorbars to the bar tips.
+            The values are +/- sizes relative to the data:
+
+            - scalar: symmetric +/- values for all bars
+            - shape(N,): symmetric +/- values for each bar
+            - shape(2, N): Separate - and + values for each bar. First row
+              contains the lower errors, the second row contains the upper
+              errors.
+            - *None*: No errorbar. (Default)
+
+            See :doc:`/gallery/statistics/errorbar_features` for an example on
+            the usage of *xerr* and *yerr*.
+
+        ecolor : :mpltype:`color` or list of :mpltype:`color`, default: 'black'
+            The line color of the errorbars.
+
+        capsize : float, default: :rc:`errorbar.capsize`
+           The length of the error bar caps in points.
+
+        error_kw : dict, optional
+            Dictionary of keyword arguments to be passed to the
+            `~.Axes.errorbar` method. Values of *ecolor* or *capsize* defined
+            here take precedence over the independent keyword arguments.
+
+        log : bool, default: False
+            If *True*, set the y-axis to be log scale.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs : `.Rectangle` properties
+
+        %(Rectangle:kwdoc)s
+
+        See Also
+        --------
+        barh : Plot a horizontal bar plot.
+
+        Notes
+        -----
+        Stacked bars can be achieved by passing individual *bottom* values per
+        bar. See :doc:`/gallery/lines_bars_and_markers/bar_stacked`.
+        """
+        kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
+        facecolor, edgecolor = self._parse_bar_color_args(kwargs)
+
+        linewidth = kwargs.pop('linewidth', None)
+        hatch = kwargs.pop('hatch', None)
+
+        # Because xerr and yerr will be passed to errorbar, most dimension
+        # checking and processing will be left to the errorbar method.
+        xerr = kwargs.pop('xerr', None)
+        yerr = kwargs.pop('yerr', None)
+        error_kw = kwargs.pop('error_kw', None)
+        error_kw = {} if error_kw is None else error_kw.copy()
+        ezorder = error_kw.pop('zorder', None)
+        if ezorder is None:
+            ezorder = kwargs.get('zorder', None)
+            if ezorder is not None:
+                # If using the bar zorder, increment slightly to make sure
+                # errorbars are drawn on top of bars
+                ezorder += 0.01
+        error_kw.setdefault('zorder', ezorder)
+        ecolor = kwargs.pop('ecolor', 'k')
+        capsize = kwargs.pop('capsize', mpl.rcParams["errorbar.capsize"])
+        error_kw.setdefault('ecolor', ecolor)
+        error_kw.setdefault('capsize', capsize)
+
+        # The keyword argument *orientation* is used by barh() to defer all
+        # logic and drawing to bar(). It is considered internal and is
+        # intentionally not mentioned in the docstring.
+        orientation = kwargs.pop('orientation', 'vertical')
+        _api.check_in_list(['vertical', 'horizontal'], orientation=orientation)
+        log = kwargs.pop('log', False)
+        label = kwargs.pop('label', '')
+        tick_labels = kwargs.pop('tick_label', None)
+
+        y = bottom  # Matches barh call signature.
+        if orientation == 'vertical':
+            if y is None:
+                y = 0
+        else:  # horizontal
+            if x is None:
+                x = 0
+
+        if orientation == 'vertical':
+            # It is possible for y (bottom) to contain unit information.
+            # However, it is also possible for y=0 for the default and height
+            # to contain unit information.  This will prioritize the units of y.
+            self._process_unit_info(
+                [("x", x), ("y", y), ("y", height)], kwargs, convert=False)
+            if log:
+                self.set_yscale('log', nonpositive='clip')
+        else:  # horizontal
+            # It is possible for x (left) to contain unit information.
+            # However, it is also possible for x=0 for the default and width
+            # to contain unit information.  This will prioritize the units of x.
+            self._process_unit_info(
+                [("x", x), ("x", width), ("y", y)], kwargs, convert=False)
+            if log:
+                self.set_xscale('log', nonpositive='clip')
+
+        # lets do some conversions now since some types cannot be
+        # subtracted uniformly
+        if self.xaxis is not None:
+            x0 = x
+            x = np.asarray(self.convert_xunits(x))
+            width = self._convert_dx(width, x0, x, self.convert_xunits)
+            if xerr is not None:
+                xerr = self._convert_dx(xerr, x0, x, self.convert_xunits)
+        if self.yaxis is not None:
+            y0 = y
+            y = np.asarray(self.convert_yunits(y))
+            height = self._convert_dx(height, y0, y, self.convert_yunits)
+            if yerr is not None:
+                yerr = self._convert_dx(yerr, y0, y, self.convert_yunits)
+
+        x, height, width, y, linewidth, hatch = np.broadcast_arrays(
+            # Make args iterable too.
+            np.atleast_1d(x), height, width, y, linewidth, hatch)
+
+        # Now that units have been converted, set the tick locations.
+        if orientation == 'vertical':
+            tick_label_axis = self.xaxis
+            tick_label_position = x
+        else:  # horizontal
+            tick_label_axis = self.yaxis
+            tick_label_position = y
+
+        if not isinstance(label, str) and np.iterable(label):
+            bar_container_label = '_nolegend_'
+            patch_labels = label
+        else:
+            bar_container_label = label
+            patch_labels = ['_nolegend_'] * len(x)
+        if len(patch_labels) != len(x):
+            raise ValueError(f'number of labels ({len(patch_labels)}) '
+                             f'does not match number of bars ({len(x)}).')
+
+        linewidth = itertools.cycle(np.atleast_1d(linewidth))
+        hatch = itertools.cycle(np.atleast_1d(hatch))
+        facecolor = itertools.chain(itertools.cycle(facecolor),
+                                    # Fallback if color == "none".
+                                    itertools.repeat('none'))
+        if edgecolor is None:
+            edgecolor = itertools.repeat(None)
+        else:
+            edgecolor = itertools.chain(
+                itertools.cycle(mcolors.to_rgba_array(edgecolor)),
+                # Fallback if edgecolor == "none".
+                itertools.repeat('none'))
+
+        # We will now resolve the alignment and really have
+        # left, bottom, width, height vectors
+        _api.check_in_list(['center', 'edge'], align=align)
+        if align == 'center':
+            if orientation == 'vertical':
+                try:
+                    left = x - width / 2
+                except TypeError as e:
+                    raise TypeError(f'the dtypes of parameters x ({x.dtype}) '
+                                    f'and width ({width.dtype}) '
+                                    f'are incompatible') from e
+                bottom = y
+            else:  # horizontal
+                try:
+                    bottom = y - height / 2
+                except TypeError as e:
+                    raise TypeError(f'the dtypes of parameters y ({y.dtype}) '
+                                    f'and height ({height.dtype}) '
+                                    f'are incompatible') from e
+                left = x
+        else:  # edge
+            left = x
+            bottom = y
+
+        patches = []
+        args = zip(left, bottom, width, height, facecolor, edgecolor, linewidth,
+                   hatch, patch_labels)
+        for l, b, w, h, c, e, lw, htch, lbl in args:
+            r = mpatches.Rectangle(
+                xy=(l, b), width=w, height=h,
+                facecolor=c,
+                edgecolor=e,
+                linewidth=lw,
+                label=lbl,
+                hatch=htch,
+                )
+            r._internal_update(kwargs)
+            r.get_path()._interpolation_steps = 100
+            if orientation == 'vertical':
+                r.sticky_edges.y.append(b)
+            else:  # horizontal
+                r.sticky_edges.x.append(l)
+            self.add_patch(r)
+            patches.append(r)
+
+        if xerr is not None or yerr is not None:
+            if orientation == 'vertical':
+                # using list comps rather than arrays to preserve unit info
+                ex = [l + 0.5 * w for l, w in zip(left, width)]
+                ey = [b + h for b, h in zip(bottom, height)]
+
+            else:  # horizontal
+                # using list comps rather than arrays to preserve unit info
+                ex = [l + w for l, w in zip(left, width)]
+                ey = [b + 0.5 * h for b, h in zip(bottom, height)]
+
+            error_kw.setdefault("label", '_nolegend_')
+
+            errorbar = self.errorbar(ex, ey, yerr=yerr, xerr=xerr, fmt='none',
+                                     **error_kw)
+        else:
+            errorbar = None
+
+        self._request_autoscale_view()
+
+        if orientation == 'vertical':
+            datavalues = height
+        else:  # horizontal
+            datavalues = width
+
+        bar_container = BarContainer(patches, errorbar, datavalues=datavalues,
+                                     orientation=orientation,
+                                     label=bar_container_label)
+        self.add_container(bar_container)
+
+        if tick_labels is not None:
+            tick_labels = np.broadcast_to(tick_labels, len(patches))
+            tick_label_axis.set_ticks(tick_label_position)
+            tick_label_axis.set_ticklabels(tick_labels)
+
+        return bar_container
+
+    # @_preprocess_data() # let 'bar' do the unpacking..
+    @_docstring.interpd
+    def barh(self, y, width, height=0.8, left=None, *, align="center",
+             data=None, **kwargs):
+        r"""
+        Make a horizontal bar plot.
+
+        The bars are positioned at *y* with the given *align*\ment. Their
+        dimensions are given by *width* and *height*. The horizontal baseline
+        is *left* (default 0).
+
+        Many parameters can take either a single value applying to all bars
+        or a sequence of values, one for each bar.
+
+        Parameters
+        ----------
+        y : float or array-like
+            The y coordinates of the bars. See also *align* for the
+            alignment of the bars to the coordinates.
+
+        width : float or array-like
+            The width(s) of the bars.
+
+            Note that if *left* has units (e.g. datetime), *width* should be in
+            units that are a difference from the value of *left* (e.g. timedelta).
+
+        height : float or array-like, default: 0.8
+            The heights of the bars.
+
+            Note that if *y* has units (e.g. datetime), then *height* should be in
+            units that are a difference (e.g. timedelta) around the *y* values.
+
+        left : float or array-like, default: 0
+            The x coordinates of the left side(s) of the bars.
+
+            Note that if *left* has units, then the x-axis will get a Locator and
+            Formatter appropriate for the units (e.g. dates, or categorical).
+
+        align : {'center', 'edge'}, default: 'center'
+            Alignment of the base to the *y* coordinates*:
+
+            - 'center': Center the bars on the *y* positions.
+            - 'edge': Align the bottom edges of the bars with the *y*
+              positions.
+
+            To align the bars on the top edge pass a negative *height* and
+            ``align='edge'``.
+
+        Returns
+        -------
+        `.BarContainer`
+            Container with all the bars and optionally errorbars.
+
+        Other Parameters
+        ----------------
+        color : :mpltype:`color` or list of :mpltype:`color`, optional
+            The colors of the bar faces.
+
+        edgecolor : :mpltype:`color` or list of :mpltype:`color`, optional
+            The colors of the bar edges.
+
+        linewidth : float or array-like, optional
+            Width of the bar edge(s). If 0, don't draw edges.
+
+        tick_label : str or list of str, optional
+            The tick labels of the bars.
+            Default: None (Use default numeric labels.)
+
+        label : str or list of str, optional
+            A single label is attached to the resulting `.BarContainer` as a
+            label for the whole dataset.
+            If a list is provided, it must be the same length as *y* and
+            labels the individual bars. Repeated labels are not de-duplicated
+            and will cause repeated label entries, so this is best used when
+            bars also differ in style (e.g., by passing a list to *color*.)
+
+        xerr, yerr : float or array-like of shape(N,) or shape(2, N), optional
+            If not *None*, add horizontal / vertical errorbars to the bar tips.
+            The values are +/- sizes relative to the data:
+
+            - scalar: symmetric +/- values for all bars
+            - shape(N,): symmetric +/- values for each bar
+            - shape(2, N): Separate - and + values for each bar. First row
+              contains the lower errors, the second row contains the upper
+              errors.
+            - *None*: No errorbar. (default)
+
+            See :doc:`/gallery/statistics/errorbar_features` for an example on
+            the usage of *xerr* and *yerr*.
+
+        ecolor : :mpltype:`color` or list of :mpltype:`color`, default: 'black'
+            The line color of the errorbars.
+
+        capsize : float, default: :rc:`errorbar.capsize`
+           The length of the error bar caps in points.
+
+        error_kw : dict, optional
+            Dictionary of keyword arguments to be passed to the
+            `~.Axes.errorbar` method. Values of *ecolor* or *capsize* defined
+            here take precedence over the independent keyword arguments.
+
+        log : bool, default: False
+            If ``True``, set the x-axis to be log scale.
+
+        data : indexable object, optional
+            If given, all parameters also accept a string ``s``, which is
+            interpreted as ``data[s]`` if  ``s`` is a key in ``data``.
+
+        **kwargs : `.Rectangle` properties
+
+        %(Rectangle:kwdoc)s
+
+        See Also
+        --------
+        bar : Plot a vertical bar plot.
+
+        Notes
+        -----
+        Stacked bars can be achieved by passing individual *left* values per
+        bar. See
+        :doc:`/gallery/lines_bars_and_markers/horizontal_barchart_distribution`.
+        """
+        kwargs.setdefault('orientation', 'horizontal')
+        patches = self.bar(x=left, height=height, width=width, bottom=y,
+                           align=align, data=data, **kwargs)
+        return patches
+
+    def bar_label(self, container, labels=None, *, fmt="%g", label_type="edge",
+                  padding=0, **kwargs):
+        """
+        Label a bar plot.
+
+        Adds labels to bars in the given `.BarContainer`.
+        You may need to adjust the axis limits to fit the labels.
+
+        Parameters
+        ----------
+        container : `.BarContainer`
+            Container with all the bars and optionally errorbars, likely
+            returned from `.bar` or `.barh`.
+
+        labels : array-like, optional
+            A list of label texts, that should be displayed. If not given, the
+            label texts will be the data values formatted with *fmt*.
+
+        fmt : str or callable, default: '%g'
+            An unnamed %-style or {}-style format string for the label or a
+            function to call with the value as the first argument.
+            When *fmt* is a string and can be interpreted in both formats,
+            %-style takes precedence over {}-style.
+
+            .. versionadded:: 3.7
+               Support for {}-style format string and callables.
+
+        label_type : {'edge', 'center'}, default: 'edge'
+            The label type. Possible values:
+
+            - 'edge': label placed at the end-point of the bar segment, and the
+              value displayed will be the position of that end-point.
+            - 'center': label placed in the center of the bar segment, and the
+              value displayed will be the length of that segment.
+              (useful for stacked bars, i.e.,
+              :doc:`/gallery/lines_bars_and_markers/bar_label_demo`)
+
+        padding : float, default: 0
+            Distance of label from the end of the bar, in points.
+
+        **kwargs
+            Any remaining keyword arguments are passed through to
+            `.Axes.annotate`. The alignment parameters (
+            *horizontalalignment* / *ha*, *verticalalignment* / *va*) are
+            not supported because the labels are automatically aligned to
+            the bars.
+
+        Returns
+        -------
+        list of `.Annotation`
+            A list of `.Annotation` instances for the labels.
+        """
+        for key in ['horizontalalignment', 'ha', 'verticalalignment', 'va']:
+            if key in kwargs:
+                raise ValueError(
+                    f"Passing {key!r} to bar_label() is not supported.")
+
+        a, b = self.yaxis.get_view_interval()
+        y_inverted = a > b
+        c, d = self.xaxis.get_view_interval()
+        x_inverted = c > d
+
+        # want to know whether to put label on positive or negative direction
+        # cannot use np.sign here because it will return 0 if x == 0
+        def sign(x):
+            return 1 if x >= 0 else -1
+
+        _api.check_in_list(['edge', 'center'], label_type=label_type)
+
+        bars = container.patches
+        errorbar = container.errorbar
+        datavalues = container.datavalues
+        orientation = container.orientation
+
+        if errorbar:
+            # check "ErrorbarContainer" for the definition of these elements
+            lines = errorbar.lines  # attribute of "ErrorbarContainer" (tuple)
+            barlinecols = lines[2]  # 0: data_line, 1: caplines, 2: barlinecols
+            barlinecol = barlinecols[0]  # the "LineCollection" of error bars
+            errs = barlinecol.get_segments()
+        else:
+            errs = []
+
+        if labels is None:
+            labels = []
+
+        annotations = []
+
+        for bar, err, dat, lbl in itertools.zip_longest(
+                bars, errs, datavalues, labels
+        ):
+            (x0, y0), (x1, y1) = bar.get_bbox().get_points()
+            xc, yc = (x0 + x1) / 2, (y0 + y1) / 2
+
+            if orientation == "vertical":
+                extrema = max(y0, y1) if dat >= 0 else min(y0, y1)
+                length = abs(y0 - y1)
+            else:  # horizontal
+                extrema = max(x0, x1) if dat >= 0 else min(x0, x1)
+                length = abs(x0 - x1)
+
+            if err is None or np.size(err) == 0:
+                endpt = extrema
+            elif orientation == "vertical":
+                endpt = err[:, 1].max() if dat >= 0 else err[:, 1].min()
+            else:  # horizontal
+                endpt = err[:, 0].max() if dat >= 0 else err[:, 0].min()
+
+            if label_type == "center":
+                value = sign(dat) * length
+            else:  # edge
+                value = extrema
+
+            if label_type == "center":
+                xy = (0.5, 0.5)
+                kwargs["xycoords"] = (
+                    lambda r, b=bar:
+                        mtransforms.Bbox.intersection(
+                            b.get_window_extent(r), b.get_clip_box()
+                        ) or mtransforms.Bbox.null()
+                )
+            else:  # edge
+                if orientation == "vertical":
+                    xy = xc, endpt
+                else:  # horizontal
+                    xy = endpt, yc
+
+            if orientation == "vertical":
+                y_direction = -1 if y_inverted else 1
+                xytext = 0, y_direction * sign(dat) * padding
+            else:  # horizontal
+                x_direction = -1 if x_inverted else 1
+                xytext = x_direction * sign(dat) * padding, 0
+
+            if label_type == "center":
+                ha, va = "center", "center"
+            else:  # edge
+                if orientation == "vertical":
+                    ha = 'center'
+                    if y_inverted:
+                        va = 'top' if dat > 0 else 'bottom'  # also handles NaN
+                    else:
+                        va = 'top' if dat < 0 else 'bottom'  # also handles NaN
+                else:  # horizontal
+                    if x_inverted:
+                        ha = 'right' if dat > 0 else 'left'  # also handles NaN
+                    else:
+                        ha = 'right' if dat < 0 else 'left'  # also handles NaN
+                    va = 'center'
+
+            if np.isnan(dat):
+                lbl = ''
+
+            if lbl is None:
+                if isinstance(fmt, str):
+                    lbl = cbook._auto_format_str(fmt, value)
+                elif callable(fmt):
+                    lbl = fmt(value)
+                else:
+                    raise TypeError("fmt must be a str or callable")
+            annotation = self.annotate(lbl,
+                                       xy, xytext, textcoords="offset points",
+                                       ha=ha, va=va, **kwargs)
+            annotations.append(annotation)
+
+        return annotations
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def broken_barh(self, xranges, yrange, **kwargs):
+        """
+        Plot a horizontal sequence of rectangles.
+
+        A rectangle is drawn for each element of *xranges*. All rectangles
+        have the same vertical position and size defined by *yrange*.
+
+        Parameters
+        ----------
+        xranges : sequence of tuples (*xmin*, *xwidth*)
+            The x-positions and extents of the rectangles. For each tuple
+            (*xmin*, *xwidth*) a rectangle is drawn from *xmin* to *xmin* +
+            *xwidth*.
+        yrange : (*ymin*, *yheight*)
+            The y-position and extent for all the rectangles.
+
+        Returns
+        -------
+        `~.collections.PolyCollection`
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        **kwargs : `.PolyCollection` properties
+
+            Each *kwarg* can be either a single argument applying to all
+            rectangles, e.g.::
+
+                facecolors='black'
+
+            or a sequence of arguments over which is cycled, e.g.::
+
+                facecolors=('black', 'blue')
+
+            would create interleaving black and blue rectangles.
+
+            Supported keywords:
+
+            %(PolyCollection:kwdoc)s
+        """
+        # process the unit information
+        xdata = cbook._safe_first_finite(xranges) if len(xranges) else None
+        ydata = cbook._safe_first_finite(yrange) if len(yrange) else None
+        self._process_unit_info(
+            [("x", xdata), ("y", ydata)], kwargs, convert=False)
+
+        vertices = []
+        y0, dy = yrange
+        y0, y1 = self.convert_yunits((y0, y0 + dy))
+        for xr in xranges:  # convert the absolute values, not the x and dx
+            try:
+                x0, dx = xr
+            except Exception:
+                raise ValueError(
+                    "each range in xrange must be a sequence with two "
+                    "elements (i.e. xrange must be an (N, 2) array)") from None
+            x0, x1 = self.convert_xunits((x0, x0 + dx))
+            vertices.append([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
+
+        col = mcoll.PolyCollection(np.array(vertices), **kwargs)
+        self.add_collection(col, autolim=True)
+        self._request_autoscale_view()
+
+        return col
+
+    @_preprocess_data()
+    def stem(self, *args, linefmt=None, markerfmt=None, basefmt=None, bottom=0,
+             label=None, orientation='vertical'):
+        """
+        Create a stem plot.
+
+        A stem plot draws lines perpendicular to a baseline at each location
+        *locs* from the baseline to *heads*, and places a marker there. For
+        vertical stem plots (the default), the *locs* are *x* positions, and
+        the *heads* are *y* values. For horizontal stem plots, the *locs* are
+        *y* positions, and the *heads* are *x* values.
+
+        Call signature::
+
+          stem([locs,] heads, linefmt=None, markerfmt=None, basefmt=None)
+
+        The *locs*-positions are optional. *linefmt* may be provided as
+        positional, but all other formats must be provided as keyword
+        arguments.
+
+        Parameters
+        ----------
+        locs : array-like, default: (0, 1, ..., len(heads) - 1)
+            For vertical stem plots, the x-positions of the stems.
+            For horizontal stem plots, the y-positions of the stems.
+
+        heads : array-like
+            For vertical stem plots, the y-values of the stem heads.
+            For horizontal stem plots, the x-values of the stem heads.
+
+        linefmt : str, optional
+            A string defining the color and/or linestyle of the vertical lines:
+
+            =========  =============
+            Character  Line Style
+            =========  =============
+            ``'-'``    solid line
+            ``'--'``   dashed line
+            ``'-.'``   dash-dot line
+            ``':'``    dotted line
+            =========  =============
+
+            Default: 'C0-', i.e. solid line with the first color of the color
+            cycle.
+
+            Note: Markers specified through this parameter (e.g. 'x') will be
+            silently ignored. Instead, markers should be specified using
+            *markerfmt*.
+
+        markerfmt : str, optional
+            A string defining the color and/or shape of the markers at the stem
+            heads. If the marker is not given, use the marker 'o', i.e. filled
+            circles. If the color is not given, use the color from *linefmt*.
+
+        basefmt : str, default: 'C3-' ('C2-' in classic mode)
+            A format string defining the properties of the baseline.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            The orientation of the stems.
+
+        bottom : float, default: 0
+            The y/x-position of the baseline (depending on *orientation*).
+
+        label : str, optional
+            The label to use for the stems in legends.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        Returns
+        -------
+        `.StemContainer`
+            The container may be treated like a tuple
+            (*markerline*, *stemlines*, *baseline*)
+
+        Notes
+        -----
+        .. seealso::
+            The MATLAB function
+            `stem <https://www.mathworks.com/help/matlab/ref/stem.html>`_
+            which inspired this method.
+        """
+        if not 1 <= len(args) <= 3:
+            raise _api.nargs_error('stem', '1-3', len(args))
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
+
+        if len(args) == 1:
+            heads, = args
+            locs = np.arange(len(heads))
+            args = ()
+        elif isinstance(args[1], str):
+            heads, *args = args
+            locs = np.arange(len(heads))
+        else:
+            locs, heads, *args = args
+
+        if orientation == 'vertical':
+            locs, heads = self._process_unit_info([("x", locs), ("y", heads)])
+        else:  # horizontal
+            heads, locs = self._process_unit_info([("x", heads), ("y", locs)])
+
+        # resolve line format
+        if linefmt is None:
+            linefmt = args[0] if len(args) > 0 else "C0-"
+        linestyle, linemarker, linecolor = _process_plot_format(linefmt)
+
+        # resolve marker format
+        if markerfmt is None:
+            # if not given as kwarg, fall back to 'o'
+            markerfmt = "o"
+        if markerfmt == '':
+            markerfmt = ' '  # = empty line style; '' would resolve rcParams
+        markerstyle, markermarker, markercolor = \
+            _process_plot_format(markerfmt)
+        if markermarker is None:
+            markermarker = 'o'
+        if markerstyle is None:
+            markerstyle = 'None'
+        if markercolor is None:
+            markercolor = linecolor
+
+        # resolve baseline format
+        if basefmt is None:
+            basefmt = ("C2-" if mpl.rcParams["_internal.classic_mode"] else
+                       "C3-")
+        basestyle, basemarker, basecolor = _process_plot_format(basefmt)
+
+        # New behaviour in 3.1 is to use a LineCollection for the stemlines
+        if linestyle is None:
+            linestyle = mpl.rcParams['lines.linestyle']
+        xlines = self.vlines if orientation == "vertical" else self.hlines
+        stemlines = xlines(
+            locs, bottom, heads,
+            colors=linecolor, linestyles=linestyle, label="_nolegend_")
+
+        if orientation == 'horizontal':
+            marker_x = heads
+            marker_y = locs
+            baseline_x = [bottom, bottom]
+            baseline_y = [np.min(locs), np.max(locs)]
+        else:
+            marker_x = locs
+            marker_y = heads
+            baseline_x = [np.min(locs), np.max(locs)]
+            baseline_y = [bottom, bottom]
+
+        markerline, = self.plot(marker_x, marker_y,
+                                color=markercolor, linestyle=markerstyle,
+                                marker=markermarker, label="_nolegend_")
+
+        baseline, = self.plot(baseline_x, baseline_y,
+                              color=basecolor, linestyle=basestyle,
+                              marker=basemarker, label="_nolegend_")
+
+        stem_container = StemContainer((markerline, stemlines, baseline),
+                                       label=label)
+        self.add_container(stem_container)
+        return stem_container
+
+    @_api.make_keyword_only("3.9", "explode")
+    @_preprocess_data(replace_names=["x", "explode", "labels", "colors"])
+    def pie(self, x, explode=None, labels=None, colors=None,
+            autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
+            startangle=0, radius=1, counterclock=True,
+            wedgeprops=None, textprops=None, center=(0, 0),
+            frame=False, rotatelabels=False, *, normalize=True, hatch=None):
+        """
+        Plot a pie chart.
+
+        Make a pie chart of array *x*.  The fractional area of each wedge is
+        given by ``x/sum(x)``.
+
+        The wedges are plotted counterclockwise, by default starting from the
+        x-axis.
+
+        Parameters
+        ----------
+        x : 1D array-like
+            The wedge sizes.
+
+        explode : array-like, default: None
+            If not *None*, is a ``len(x)`` array which specifies the fraction
+            of the radius with which to offset each wedge.
+
+        labels : list, default: None
+            A sequence of strings providing the labels for each wedge
+
+        colors : :mpltype:`color` or list of :mpltype:`color`, default: None
+            A sequence of colors through which the pie chart will cycle.  If
+            *None*, will use the colors in the currently active cycle.
+
+        hatch : str or list, default: None
+            Hatching pattern applied to all pie wedges or sequence of patterns
+            through which the chart will cycle. For a list of valid patterns,
+            see :doc:`/gallery/shapes_and_collections/hatch_style_reference`.
+
+            .. versionadded:: 3.7
+
+        autopct : None or str or callable, default: None
+            If not *None*, *autopct* is a string or function used to label the
+            wedges with their numeric value. The label will be placed inside
+            the wedge. If *autopct* is a format string, the label will be
+            ``fmt % pct``. If *autopct* is a function, then it will be called.
+
+        pctdistance : float, default: 0.6
+            The relative distance along the radius at which the text
+            generated by *autopct* is drawn. To draw the text outside the pie,
+            set *pctdistance* > 1. This parameter is ignored if *autopct* is
+            ``None``.
+
+        labeldistance : float or None, default: 1.1
+            The relative distance along the radius at which the labels are
+            drawn. To draw the labels inside the pie, set  *labeldistance* < 1.
+            If set to ``None``, labels are not drawn but are still stored for
+            use in `.legend`.
+
+        shadow : bool or dict, default: False
+            If bool, whether to draw a shadow beneath the pie. If dict, draw a shadow
+            passing the properties in the dict to `.Shadow`.
+
+            .. versionadded:: 3.8
+                *shadow* can be a dict.
+
+        startangle : float, default: 0 degrees
+            The angle by which the start of the pie is rotated,
+            counterclockwise from the x-axis.
+
+        radius : float, default: 1
+            The radius of the pie.
+
+        counterclock : bool, default: True
+            Specify fractions direction, clockwise or counterclockwise.
+
+        wedgeprops : dict, default: None
+            Dict of arguments passed to each `.patches.Wedge` of the pie.
+            For example, ``wedgeprops = {'linewidth': 3}`` sets the width of
+            the wedge border lines equal to 3. By default, ``clip_on=False``.
+            When there is a conflict between these properties and other
+            keywords, properties passed to *wedgeprops* take precedence.
+
+        textprops : dict, default: None
+            Dict of arguments to pass to the text objects.
+
+        center : (float, float), default: (0, 0)
+            The coordinates of the center of the chart.
+
+        frame : bool, default: False
+            Plot Axes frame with the chart if true.
+
+        rotatelabels : bool, default: False
+            Rotate each label to the angle of the corresponding slice if true.
+
+        normalize : bool, default: True
+            When *True*, always make a full pie by normalizing x so that
+            ``sum(x) == 1``. *False* makes a partial pie if ``sum(x) <= 1``
+            and raises a `ValueError` for ``sum(x) > 1``.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        Returns
+        -------
+        patches : list
+            A sequence of `matplotlib.patches.Wedge` instances
+
+        texts : list
+            A list of the label `.Text` instances.
+
+        autotexts : list
+            A list of `.Text` instances for the numeric labels. This will only
+            be returned if the parameter *autopct* is not *None*.
+
+        Notes
+        -----
+        The pie chart will probably look best if the figure and Axes are
+        square, or the Axes aspect is equal.
+        This method sets the aspect ratio of the axis to "equal".
+        The Axes aspect ratio can be controlled with `.Axes.set_aspect`.
+        """
+        self.set_aspect('equal')
+        # The use of float32 is "historical", but can't be changed without
+        # regenerating the test baselines.
+        x = np.asarray(x, np.float32)
+        if x.ndim > 1:
+            raise ValueError("x must be 1D")
+
+        if np.any(x < 0):
+            raise ValueError("Wedge sizes 'x' must be non negative values")
+
+        sx = x.sum()
+
+        if normalize:
+            x = x / sx
+        elif sx > 1:
+            raise ValueError('Cannot plot an unnormalized pie with sum(x) > 1')
+        if labels is None:
+            labels = [''] * len(x)
+        if explode is None:
+            explode = [0] * len(x)
+        if len(x) != len(labels):
+            raise ValueError(f"'labels' must be of length 'x', not {len(labels)}")
+        if len(x) != len(explode):
+            raise ValueError(f"'explode' must be of length 'x', not {len(explode)}")
+        if colors is None:
+            get_next_color = self._get_patches_for_fill.get_next_color
+        else:
+            color_cycle = itertools.cycle(colors)
+
+            def get_next_color():
+                return next(color_cycle)
+
+        hatch_cycle = itertools.cycle(np.atleast_1d(hatch))
+
+        _api.check_isinstance(Real, radius=radius, startangle=startangle)
+        if radius <= 0:
+            raise ValueError(f"'radius' must be a positive number, not {radius}")
+
+        # Starting theta1 is the start fraction of the circle
+        theta1 = startangle / 360
+
+        if wedgeprops is None:
+            wedgeprops = {}
+        if textprops is None:
+            textprops = {}
+
+        texts = []
+        slices = []
+        autotexts = []
+
+        for frac, label, expl in zip(x, labels, explode):
+            x, y = center
+            theta2 = (theta1 + frac) if counterclock else (theta1 - frac)
+            thetam = 2 * np.pi * 0.5 * (theta1 + theta2)
+            x += expl * math.cos(thetam)
+            y += expl * math.sin(thetam)
+
+            w = mpatches.Wedge((x, y), radius, 360. * min(theta1, theta2),
+                               360. * max(theta1, theta2),
+                               facecolor=get_next_color(),
+                               hatch=next(hatch_cycle),
+                               clip_on=False,
+                               label=label)
+            w.set(**wedgeprops)
+            slices.append(w)
+            self.add_patch(w)
+
+            if shadow:
+                # Make sure to add a shadow after the call to add_patch so the
+                # figure and transform props will be set.
+                shadow_dict = {'ox': -0.02, 'oy': -0.02, 'label': '_nolegend_'}
+                if isinstance(shadow, dict):
+                    shadow_dict.update(shadow)
+                self.add_patch(mpatches.Shadow(w, **shadow_dict))
+
+            if labeldistance is not None:
+                xt = x + labeldistance * radius * math.cos(thetam)
+                yt = y + labeldistance * radius * math.sin(thetam)
+                label_alignment_h = 'left' if xt > 0 else 'right'
+                label_alignment_v = 'center'
+                label_rotation = 'horizontal'
+                if rotatelabels:
+                    label_alignment_v = 'bottom' if yt > 0 else 'top'
+                    label_rotation = (np.rad2deg(thetam)
+                                      + (0 if xt > 0 else 180))
+                t = self.text(xt, yt, label,
+                              clip_on=False,
+                              horizontalalignment=label_alignment_h,
+                              verticalalignment=label_alignment_v,
+                              rotation=label_rotation,
+                              size=mpl.rcParams['xtick.labelsize'])
+                t.set(**textprops)
+                texts.append(t)
+
+            if autopct is not None:
+                xt = x + pctdistance * radius * math.cos(thetam)
+                yt = y + pctdistance * radius * math.sin(thetam)
+                if isinstance(autopct, str):
+                    s = autopct % (100. * frac)
+                elif callable(autopct):
+                    s = autopct(100. * frac)
+                else:
+                    raise TypeError(
+                        'autopct must be callable or a format string')
+                if mpl._val_or_rc(textprops.get("usetex"), "text.usetex"):
+                    # escape % (i.e. \%) if it is not already escaped
+                    s = re.sub(r"([^\\])%", r"\1\\%", s)
+                t = self.text(xt, yt, s,
+                              clip_on=False,
+                              horizontalalignment='center',
+                              verticalalignment='center')
+                t.set(**textprops)
+                autotexts.append(t)
+
+            theta1 = theta2
+
+        if frame:
+            self._request_autoscale_view()
+        else:
+            self.set(frame_on=False, xticks=[], yticks=[],
+                     xlim=(-1.25 + center[0], 1.25 + center[0]),
+                     ylim=(-1.25 + center[1], 1.25 + center[1]))
+
+        if autopct is None:
+            return slices, texts
+        else:
+            return slices, texts, autotexts
+
+    @staticmethod
+    def _errorevery_to_mask(x, errorevery):
+        """
+        Normalize `errorbar`'s *errorevery* to be a boolean mask for data *x*.
+
+        This function is split out to be usable both by 2D and 3D errorbars.
+        """
+        if isinstance(errorevery, Integral):
+            errorevery = (0, errorevery)
+        if isinstance(errorevery, tuple):
+            if (len(errorevery) == 2 and
+                    isinstance(errorevery[0], Integral) and
+                    isinstance(errorevery[1], Integral)):
+                errorevery = slice(errorevery[0], None, errorevery[1])
+            else:
+                raise ValueError(
+                    f'{errorevery=!r} is a not a tuple of two integers')
+        elif isinstance(errorevery, slice):
+            pass
+        elif not isinstance(errorevery, str) and np.iterable(errorevery):
+            try:
+                x[errorevery]  # fancy indexing
+            except (ValueError, IndexError) as err:
+                raise ValueError(
+                    f"{errorevery=!r} is iterable but not a valid NumPy fancy "
+                    "index to match 'xerr'/'yerr'") from err
+        else:
+            raise ValueError(f"{errorevery=!r} is not a recognized value")
+        everymask = np.zeros(len(x), bool)
+        everymask[errorevery] = True
+        return everymask
+
+    @_api.make_keyword_only("3.9", "ecolor")
+    @_preprocess_data(replace_names=["x", "y", "xerr", "yerr"],
+                      label_namer="y")
+    @_docstring.interpd
+    def errorbar(self, x, y, yerr=None, xerr=None,
+                 fmt='', ecolor=None, elinewidth=None, capsize=None,
+                 barsabove=False, lolims=False, uplims=False,
+                 xlolims=False, xuplims=False, errorevery=1, capthick=None,
+                 **kwargs):
+        """
+        Plot y versus x as lines and/or markers with attached errorbars.
+
+        *x*, *y* define the data locations, *xerr*, *yerr* define the errorbar
+        sizes. By default, this draws the data markers/lines as well as the
+        errorbars. Use fmt='none' to draw errorbars without any data markers.
+
+        .. versionadded:: 3.7
+           Caps and error lines are drawn in polar coordinates on polar plots.
+
+
+        Parameters
+        ----------
+        x, y : float or array-like
+            The data positions.
+
+        xerr, yerr : float or array-like, shape(N,) or shape(2, N), optional
+            The errorbar sizes:
+
+            - scalar: Symmetric +/- values for all data points.
+            - shape(N,): Symmetric +/-values for each data point.
+            - shape(2, N): Separate - and + values for each bar. First row
+              contains the lower errors, the second row contains the upper
+              errors.
+            - *None*: No errorbar.
+
+            All values must be >= 0.
+
+            See :doc:`/gallery/statistics/errorbar_features`
+            for an example on the usage of ``xerr`` and ``yerr``.
+
+        fmt : str, default: ''
+            The format for the data points / data lines. See `.plot` for
+            details.
+
+            Use 'none' (case-insensitive) to plot errorbars without any data
+            markers.
+
+        ecolor : :mpltype:`color`, default: None
+            The color of the errorbar lines.  If None, use the color of the
+            line connecting the markers.
+
+        elinewidth : float, default: None
+            The linewidth of the errorbar lines. If None, the linewidth of
+            the current style is used.
+
+        capsize : float, default: :rc:`errorbar.capsize`
+            The length of the error bar caps in points.
+
+        capthick : float, default: None
+            An alias to the keyword argument *markeredgewidth* (a.k.a. *mew*).
+            This setting is a more sensible name for the property that
+            controls the thickness of the error bar cap in points. For
+            backwards compatibility, if *mew* or *markeredgewidth* are given,
+            then they will over-ride *capthick*. This may change in future
+            releases.
+
+        barsabove : bool, default: False
+            If True, will plot the errorbars above the plot
+            symbols. Default is below.
+
+        lolims, uplims, xlolims, xuplims : bool or array-like, default: False
+            These arguments can be used to indicate that a value gives only
+            upper/lower limits.  In that case a caret symbol is used to
+            indicate this. *lims*-arguments may be scalars, or array-likes of
+            the same length as *xerr* and *yerr*.  To use limits with inverted
+            axes, `~.Axes.set_xlim` or `~.Axes.set_ylim` must be called before
+            :meth:`errorbar`.  Note the tricky parameter names: setting e.g.
+            *lolims* to True means that the y-value is a *lower* limit of the
+            True value, so, only an *upward*-pointing arrow will be drawn!
+
+        errorevery : int or (int, int), default: 1
+            draws error bars on a subset of the data. *errorevery* =N draws
+            error bars on the points (x[::N], y[::N]).
+            *errorevery* =(start, N) draws error bars on the points
+            (x[start::N], y[start::N]). e.g. errorevery=(6, 3)
+            adds error bars to the data at (x[6], x[9], x[12], x[15], ...).
+            Used to avoid overlapping error bars when two series share x-axis
+            values.
+
+        Returns
+        -------
+        `.ErrorbarContainer`
+            The container contains:
+
+            - data_line : A `~matplotlib.lines.Line2D` instance of x, y plot markers
+              and/or line.
+            - caplines : A tuple of `~matplotlib.lines.Line2D` instances of the error
+              bar caps.
+            - barlinecols : A tuple of `.LineCollection` with the horizontal and
+              vertical error ranges.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            All other keyword arguments are passed on to the `~.Axes.plot` call
+            drawing the markers. For example, this code makes big red squares
+            with thick green edges::
+
+                x, y, yerr = rand(3, 10)
+                errorbar(x, y, yerr, marker='s', mfc='red',
+                         mec='green', ms=20, mew=4)
+
+            where *mfc*, *mec*, *ms* and *mew* are aliases for the longer
+            property names, *markerfacecolor*, *markeredgecolor*, *markersize*
+            and *markeredgewidth*.
+
+            Valid kwargs for the marker properties are:
+
+            - *dashes*
+            - *dash_capstyle*
+            - *dash_joinstyle*
+            - *drawstyle*
+            - *fillstyle*
+            - *linestyle*
+            - *marker*
+            - *markeredgecolor*
+            - *markeredgewidth*
+            - *markerfacecolor*
+            - *markerfacecoloralt*
+            - *markersize*
+            - *markevery*
+            - *solid_capstyle*
+            - *solid_joinstyle*
+
+            Refer to the corresponding `.Line2D` property for more details:
+
+            %(Line2D:kwdoc)s
+        """
+        kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
+        # Drop anything that comes in as None to use the default instead.
+        kwargs = {k: v for k, v in kwargs.items() if v is not None}
+        kwargs.setdefault('zorder', 2)
+
+        # Casting to object arrays preserves units.
+        if not isinstance(x, np.ndarray):
+            x = np.asarray(x, dtype=object)
+        if not isinstance(y, np.ndarray):
+            y = np.asarray(y, dtype=object)
+
+        def _upcast_err(err):
+            """
+            Safely handle tuple of containers that carry units.
+
+            This function covers the case where the input to the xerr/yerr is a
+            length 2 tuple of equal length ndarray-subclasses that carry the
+            unit information in the container.
+
+            If we have a tuple of nested numpy array (subclasses), we defer
+            coercing the units to be consistent to the underlying unit
+            library (and implicitly the broadcasting).
+
+            Otherwise, fallback to casting to an object array.
+            """
+
+            if (
+                    # make sure it is not a scalar
+                    np.iterable(err) and
+                    # and it is not empty
+                    len(err) > 0 and
+                    # and the first element is an array sub-class use
+                    # safe_first_element because getitem is index-first not
+                    # location first on pandas objects so err[0] almost always
+                    # fails.
+                    isinstance(cbook._safe_first_finite(err), np.ndarray)
+            ):
+                # Get the type of the first element
+                atype = type(cbook._safe_first_finite(err))
+                # Promote the outer container to match the inner container
+                if atype is np.ndarray:
+                    # Converts using np.asarray, because data cannot
+                    # be directly passed to init of np.ndarray
+                    return np.asarray(err, dtype=object)
+                # If atype is not np.ndarray, directly pass data to init.
+                # This works for types such as unyts and astropy units
+                return atype(err)
+            # Otherwise wrap it in an object array
+            return np.asarray(err, dtype=object)
+
+        if xerr is not None and not isinstance(xerr, np.ndarray):
+            xerr = _upcast_err(xerr)
+        if yerr is not None and not isinstance(yerr, np.ndarray):
+            yerr = _upcast_err(yerr)
+        x, y = np.atleast_1d(x, y)  # Make sure all the args are iterable.
+        if len(x) != len(y):
+            raise ValueError("'x' and 'y' must have the same size")
+
+        everymask = self._errorevery_to_mask(x, errorevery)
+
+        label = kwargs.pop("label", None)
+        kwargs['label'] = '_nolegend_'
+
+        # Create the main line and determine overall kwargs for child artists.
+        # We avoid calling self.plot() directly, or self._get_lines(), because
+        # that would call self._process_unit_info again, and do other indirect
+        # data processing.
+        (data_line, base_style), = self._get_lines._plot_args(
+            self, (x, y) if fmt == '' else (x, y, fmt), kwargs, return_kwargs=True)
+
+        # Do this after creating `data_line` to avoid modifying `base_style`.
+        if barsabove:
+            data_line.set_zorder(kwargs['zorder'] - .1)
+        else:
+            data_line.set_zorder(kwargs['zorder'] + .1)
+
+        # Add line to plot, or throw it away and use it to determine kwargs.
+        if fmt.lower() != 'none':
+            self.add_line(data_line)
+        else:
+            data_line = None
+            # Remove alpha=0 color that _get_lines._plot_args returns for
+            # 'none' format, and replace it with user-specified color, if
+            # supplied.
+            base_style.pop('color')
+            if 'color' in kwargs:
+                base_style['color'] = kwargs.pop('color')
+
+        if 'color' not in base_style:
+            base_style['color'] = 'C0'
+        if ecolor is None:
+            ecolor = base_style['color']
+
+        # Eject any line-specific information from format string, as it's not
+        # needed for bars or caps.
+        for key in ['marker', 'markersize', 'markerfacecolor',
+                    'markerfacecoloralt',
+                    'markeredgewidth', 'markeredgecolor', 'markevery',
+                    'linestyle', 'fillstyle', 'drawstyle', 'dash_capstyle',
+                    'dash_joinstyle', 'solid_capstyle', 'solid_joinstyle',
+                    'dashes']:
+            base_style.pop(key, None)
+
+        # Make the style dict for the line collections (the bars).
+        eb_lines_style = {**base_style, 'color': ecolor}
+
+        if elinewidth is not None:
+            eb_lines_style['linewidth'] = elinewidth
+        elif 'linewidth' in kwargs:
+            eb_lines_style['linewidth'] = kwargs['linewidth']
+
+        for key in ('transform', 'alpha', 'zorder', 'rasterized'):
+            if key in kwargs:
+                eb_lines_style[key] = kwargs[key]
+
+        # Make the style dict for caps (the "hats").
+        eb_cap_style = {**base_style, 'linestyle': 'none'}
+        if capsize is None:
+            capsize = mpl.rcParams["errorbar.capsize"]
+        if capsize > 0:
+            eb_cap_style['markersize'] = 2. * capsize
+        if capthick is not None:
+            eb_cap_style['markeredgewidth'] = capthick
+
+        # For backwards-compat, allow explicit setting of
+        # 'markeredgewidth' to over-ride capthick.
+        for key in ('markeredgewidth', 'transform', 'alpha',
+                    'zorder', 'rasterized'):
+            if key in kwargs:
+                eb_cap_style[key] = kwargs[key]
+        eb_cap_style['color'] = ecolor
+
+        barcols = []
+        caplines = {'x': [], 'y': []}
+
+        # Vectorized fancy-indexer.
+        def apply_mask(arrays, mask):
+            return [array[mask] for array in arrays]
+
+        # dep: dependent dataset, indep: independent dataset
+        for (dep_axis, dep, err, lolims, uplims, indep, lines_func,
+             marker, lomarker, himarker) in [
+                ("x", x, xerr, xlolims, xuplims, y, self.hlines,
+                 "|", mlines.CARETRIGHTBASE, mlines.CARETLEFTBASE),
+                ("y", y, yerr, lolims, uplims, x, self.vlines,
+                 "_", mlines.CARETUPBASE, mlines.CARETDOWNBASE),
+        ]:
+            if err is None:
+                continue
+            lolims = np.broadcast_to(lolims, len(dep)).astype(bool)
+            uplims = np.broadcast_to(uplims, len(dep)).astype(bool)
+            try:
+                np.broadcast_to(err, (2, len(dep)))
+            except ValueError:
+                raise ValueError(
+                    f"'{dep_axis}err' (shape: {np.shape(err)}) must be a "
+                    f"scalar or a 1D or (2, n) array-like whose shape matches "
+                    f"'{dep_axis}' (shape: {np.shape(dep)})") from None
+            if err.dtype is np.dtype(object) and np.any(err == None):  # noqa: E711
+                raise ValueError(
+                    f"'{dep_axis}err' must not contain None. "
+                    "Use NaN if you want to skip a value.")
+
+            res = np.zeros(err.shape, dtype=bool)  # Default in case of nan
+            if np.any(np.less(err, -err, out=res, where=(err == err))):
+                # like err<0, but also works for timedelta and nan.
+                raise ValueError(
+                    f"'{dep_axis}err' must not contain negative values")
+            # This is like
+            #     elow, ehigh = np.broadcast_to(...)
+            #     return dep - elow * ~lolims, dep + ehigh * ~uplims
+            # except that broadcast_to would strip units.
+            low, high = dep + np.vstack([-(1 - lolims), 1 - uplims]) * err
+            barcols.append(lines_func(
+                *apply_mask([indep, low, high], everymask), **eb_lines_style))
+            if self.name == "polar" and dep_axis == "x":
+                for b in barcols:
+                    for p in b.get_paths():
+                        p._interpolation_steps = 2
+            # Normal errorbars for points without upper/lower limits.
+            nolims = ~(lolims | uplims)
+            if nolims.any() and capsize > 0:
+                indep_masked, lo_masked, hi_masked = apply_mask(
+                    [indep, low, high], nolims & everymask)
+                for lh_masked in [lo_masked, hi_masked]:
+                    # Since this has to work for x and y as dependent data, we
+                    # first set both x and y to the independent variable and
+                    # overwrite the respective dependent data in a second step.
+                    line = mlines.Line2D(indep_masked, indep_masked,
+                                         marker=marker, **eb_cap_style)
+                    line.set(**{f"{dep_axis}data": lh_masked})
+                    caplines[dep_axis].append(line)
+            for idx, (lims, hl) in enumerate([(lolims, high), (uplims, low)]):
+                if not lims.any():
+                    continue
+                hlmarker = (
+                    himarker
+                    if self._axis_map[dep_axis].get_inverted() ^ idx
+                    else lomarker)
+                x_masked, y_masked, hl_masked = apply_mask(
+                    [x, y, hl], lims & everymask)
+                # As above, we set the dependent data in a second step.
+                line = mlines.Line2D(x_masked, y_masked,
+                                     marker=hlmarker, **eb_cap_style)
+                line.set(**{f"{dep_axis}data": hl_masked})
+                caplines[dep_axis].append(line)
+                if capsize > 0:
+                    caplines[dep_axis].append(mlines.Line2D(
+                        x_masked, y_masked, marker=marker, **eb_cap_style))
+        if self.name == 'polar':
+            trans_shift = self.transShift
+            for axis in caplines:
+                for l in caplines[axis]:
+                    # Rotate caps to be perpendicular to the error bars
+                    for theta, r in zip(l.get_xdata(), l.get_ydata()):
+                        rotation = _ScaledRotation(theta=theta, trans_shift=trans_shift)
+                        if axis == 'y':
+                            rotation += mtransforms.Affine2D().rotate(np.pi / 2)
+                        ms = mmarkers.MarkerStyle(marker=marker,
+                                                  transform=rotation)
+                        self.add_line(mlines.Line2D([theta], [r], marker=ms,
+                                                    **eb_cap_style))
+        else:
+            for axis in caplines:
+                for l in caplines[axis]:
+                    self.add_line(l)
+
+        self._request_autoscale_view()
+        caplines = caplines['x'] + caplines['y']
+        errorbar_container = ErrorbarContainer(
+            (data_line, tuple(caplines), tuple(barcols)),
+            has_xerr=(xerr is not None), has_yerr=(yerr is not None),
+            label=label)
+        self.containers.append(errorbar_container)
+
+        return errorbar_container  # (l0, caplines, barcols)
+
+    @_api.make_keyword_only("3.9", "notch")
+    @_preprocess_data()
+    @_api.rename_parameter("3.9", "labels", "tick_labels")
+    def boxplot(self, x, notch=None, sym=None, vert=None,
+                orientation='vertical', whis=None, positions=None,
+                widths=None, patch_artist=None, bootstrap=None,
+                usermedians=None, conf_intervals=None,
+                meanline=None, showmeans=None, showcaps=None,
+                showbox=None, showfliers=None, boxprops=None,
+                tick_labels=None, flierprops=None, medianprops=None,
+                meanprops=None, capprops=None, whiskerprops=None,
+                manage_ticks=True, autorange=False, zorder=None,
+                capwidths=None, label=None):
+        """
+        Draw a box and whisker plot.
+
+        The box extends from the first quartile (Q1) to the third
+        quartile (Q3) of the data, with a line at the median.
+        The whiskers extend from the box to the farthest data point
+        lying within 1.5x the inter-quartile range (IQR) from the box.
+        Flier points are those past the end of the whiskers.
+        See https://en.wikipedia.org/wiki/Box_plot for reference.
+
+        .. code-block:: none
+
+                  Q1-1.5IQR   Q1   median  Q3   Q3+1.5IQR
+                               |-----:-----|
+               o      |--------|     :     |--------|    o  o
+                               |-----:-----|
+             flier             <----------->            fliers
+                                    IQR
+
+
+        Parameters
+        ----------
+        x : Array or a sequence of vectors.
+            The input data.  If a 2D array, a boxplot is drawn for each column
+            in *x*.  If a sequence of 1D arrays, a boxplot is drawn for each
+            array in *x*.
+
+        notch : bool, default: :rc:`boxplot.notch`
+            Whether to draw a notched boxplot (`True`), or a rectangular
+            boxplot (`False`).  The notches represent the confidence interval
+            (CI) around the median.  The documentation for *bootstrap*
+            describes how the locations of the notches are computed by
+            default, but their locations may also be overridden by setting the
+            *conf_intervals* parameter.
+
+            .. note::
+
+                In cases where the values of the CI are less than the
+                lower quartile or greater than the upper quartile, the
+                notches will extend beyond the box, giving it a
+                distinctive "flipped" appearance. This is expected
+                behavior and consistent with other statistical
+                visualization packages.
+
+        sym : str, optional
+            The default symbol for flier points.  An empty string ('') hides
+            the fliers.  If `None`, then the fliers default to 'b+'.  More
+            control is provided by the *flierprops* parameter.
+
+        vert : bool, optional
+            .. deprecated:: 3.10
+                Use *orientation* instead.
+
+                If this is given during the deprecation period, it overrides
+                the *orientation* parameter.
+
+            If True, plots the boxes vertically.
+            If False, plots the boxes horizontally.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            If 'horizontal', plots the boxes horizontally.
+            Otherwise, plots the boxes vertically.
+
+            .. versionadded:: 3.10
+
+        whis : float or (float, float), default: 1.5
+            The position of the whiskers.
+
+            If a float, the lower whisker is at the lowest datum above
+            ``Q1 - whis*(Q3-Q1)``, and the upper whisker at the highest datum
+            below ``Q3 + whis*(Q3-Q1)``, where Q1 and Q3 are the first and
+            third quartiles.  The default value of ``whis = 1.5`` corresponds
+            to Tukey's original definition of boxplots.
+
+            If a pair of floats, they indicate the percentiles at which to
+            draw the whiskers (e.g., (5, 95)).  In particular, setting this to
+            (0, 100) results in whiskers covering the whole range of the data.
+
+            In the edge case where ``Q1 == Q3``, *whis* is automatically set
+            to (0, 100) (cover the whole range of the data) if *autorange* is
+            True.
+
+            Beyond the whiskers, data are considered outliers and are plotted
+            as individual points.
+
+        bootstrap : int, optional
+            Specifies whether to bootstrap the confidence intervals
+            around the median for notched boxplots. If *bootstrap* is
+            None, no bootstrapping is performed, and notches are
+            calculated using a Gaussian-based asymptotic approximation
+            (see McGill, R., Tukey, J.W., and Larsen, W.A., 1978, and
+            Kendall and Stuart, 1967). Otherwise, bootstrap specifies
+            the number of times to bootstrap the median to determine its
+            95% confidence intervals. Values between 1000 and 10000 are
+            recommended.
+
+        usermedians : 1D array-like, optional
+            A 1D array-like of length ``len(x)``.  Each entry that is not
+            `None` forces the value of the median for the corresponding
+            dataset.  For entries that are `None`, the medians are computed
+            by Matplotlib as normal.
+
+        conf_intervals : array-like, optional
+            A 2D array-like of shape ``(len(x), 2)``.  Each entry that is not
+            None forces the location of the corresponding notch (which is
+            only drawn if *notch* is `True`).  For entries that are `None`,
+            the notches are computed by the method specified by the other
+            parameters (e.g., *bootstrap*).
+
+        positions : array-like, optional
+            The positions of the boxes. The ticks and limits are
+            automatically set to match the positions. Defaults to
+            ``range(1, N+1)`` where N is the number of boxes to be drawn.
+
+        widths : float or array-like
+            The widths of the boxes.  The default is 0.5, or ``0.15*(distance
+            between extreme positions)``, if that is smaller.
+
+        patch_artist : bool, default: :rc:`boxplot.patchartist`
+            If `False` produces boxes with the Line2D artist. Otherwise,
+            boxes are drawn with Patch artists.
+
+        tick_labels : list of str, optional
+            The tick labels of each boxplot.
+            Ticks are always placed at the box *positions*. If *tick_labels* is given,
+            the ticks are labelled accordingly. Otherwise, they keep their numeric
+            values.
+
+            .. versionchanged:: 3.9
+                Renamed from *labels*, which is deprecated since 3.9
+                and will be removed in 3.11.
+
+        manage_ticks : bool, default: True
+            If True, the tick locations and labels will be adjusted to match
+            the boxplot positions.
+
+        autorange : bool, default: False
+            When `True` and the data are distributed such that the 25th and
+            75th percentiles are equal, *whis* is set to (0, 100) such
+            that the whisker ends are at the minimum and maximum of the data.
+
+        meanline : bool, default: :rc:`boxplot.meanline`
+            If `True` (and *showmeans* is `True`), will try to render the
+            mean as a line spanning the full width of the box according to
+            *meanprops* (see below).  Not recommended if *shownotches* is also
+            True.  Otherwise, means will be shown as points.
+
+        zorder : float, default: ``Line2D.zorder = 2``
+            The zorder of the boxplot.
+
+        Returns
+        -------
+        dict
+          A dictionary mapping each component of the boxplot to a list
+          of the `.Line2D` instances created. That dictionary has the
+          following keys (assuming vertical boxplots):
+
+          - ``boxes``: the main body of the boxplot showing the
+            quartiles and the median's confidence intervals if
+            enabled.
+
+          - ``medians``: horizontal lines at the median of each box.
+
+          - ``whiskers``: the vertical lines extending to the most
+            extreme, non-outlier data points.
+
+          - ``caps``: the horizontal lines at the ends of the
+            whiskers.
+
+          - ``fliers``: points representing data that extend beyond
+            the whiskers (fliers).
+
+          - ``means``: points or lines representing the means.
+
+        Other Parameters
+        ----------------
+        showcaps : bool, default: :rc:`boxplot.showcaps`
+            Show the caps on the ends of whiskers.
+        showbox : bool, default: :rc:`boxplot.showbox`
+            Show the central box.
+        showfliers : bool, default: :rc:`boxplot.showfliers`
+            Show the outliers beyond the caps.
+        showmeans : bool, default: :rc:`boxplot.showmeans`
+            Show the arithmetic means.
+        capprops : dict, default: None
+            The style of the caps.
+        capwidths : float or array, default: None
+            The widths of the caps.
+        boxprops : dict, default: None
+            The style of the box.
+        whiskerprops : dict, default: None
+            The style of the whiskers.
+        flierprops : dict, default: None
+            The style of the fliers.
+        medianprops : dict, default: None
+            The style of the median.
+        meanprops : dict, default: None
+            The style of the mean.
+        label : str or list of str, optional
+            Legend labels. Use a single string when all boxes have the same style and
+            you only want a single legend entry for them. Use a list of strings to
+            label all boxes individually. To be distinguishable, the boxes should be
+            styled individually, which is currently only possible by modifying the
+            returned artists, see e.g. :doc:`/gallery/statistics/boxplot_demo`.
+
+            In the case of a single string, the legend entry will technically be
+            associated with the first box only. By default, the legend will show the
+            median line (``result["medians"]``); if *patch_artist* is True, the legend
+            will show the box `.Patch` artists (``result["boxes"]``) instead.
+
+            .. versionadded:: 3.9
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        See Also
+        --------
+        .Axes.bxp : Draw a boxplot from pre-computed statistics.
+        violinplot : Draw an estimate of the probability density function.
+        """
+
+        # Missing arguments default to rcParams.
+        if whis is None:
+            whis = mpl.rcParams['boxplot.whiskers']
+        if bootstrap is None:
+            bootstrap = mpl.rcParams['boxplot.bootstrap']
+
+        bxpstats = cbook.boxplot_stats(x, whis=whis, bootstrap=bootstrap,
+                                       labels=tick_labels, autorange=autorange)
+        if notch is None:
+            notch = mpl.rcParams['boxplot.notch']
+        if patch_artist is None:
+            patch_artist = mpl.rcParams['boxplot.patchartist']
+        if meanline is None:
+            meanline = mpl.rcParams['boxplot.meanline']
+        if showmeans is None:
+            showmeans = mpl.rcParams['boxplot.showmeans']
+        if showcaps is None:
+            showcaps = mpl.rcParams['boxplot.showcaps']
+        if showbox is None:
+            showbox = mpl.rcParams['boxplot.showbox']
+        if showfliers is None:
+            showfliers = mpl.rcParams['boxplot.showfliers']
+
+        if boxprops is None:
+            boxprops = {}
+        if whiskerprops is None:
+            whiskerprops = {}
+        if capprops is None:
+            capprops = {}
+        if medianprops is None:
+            medianprops = {}
+        if meanprops is None:
+            meanprops = {}
+        if flierprops is None:
+            flierprops = {}
+
+        if patch_artist:
+            boxprops['linestyle'] = 'solid'  # Not consistent with bxp.
+            if 'color' in boxprops:
+                boxprops['edgecolor'] = boxprops.pop('color')
+
+        # if non-default sym value, put it into the flier dictionary
+        # the logic for providing the default symbol ('b+') now lives
+        # in bxp in the initial value of flierkw
+        # handle all of the *sym* related logic here so we only have to pass
+        # on the flierprops dict.
+        if sym is not None:
+            # no-flier case, which should really be done with
+            # 'showfliers=False' but none-the-less deal with it to keep back
+            # compatibility
+            if sym == '':
+                # blow away existing dict and make one for invisible markers
+                flierprops = dict(linestyle='none', marker='', color='none')
+                # turn the fliers off just to be safe
+                showfliers = False
+            # now process the symbol string
+            else:
+                # process the symbol string
+                # discarded linestyle
+                _, marker, color = _process_plot_format(sym)
+                # if we have a marker, use it
+                if marker is not None:
+                    flierprops['marker'] = marker
+                # if we have a color, use it
+                if color is not None:
+                    # assume that if color is passed in the user want
+                    # filled symbol, if the users want more control use
+                    # flierprops
+                    flierprops['color'] = color
+                    flierprops['markerfacecolor'] = color
+                    flierprops['markeredgecolor'] = color
+
+        # replace medians if necessary:
+        if usermedians is not None:
+            if (len(np.ravel(usermedians)) != len(bxpstats) or
+                    np.shape(usermedians)[0] != len(bxpstats)):
+                raise ValueError(
+                    "'usermedians' and 'x' have different lengths")
+            else:
+                # reassign medians as necessary
+                for stats, med in zip(bxpstats, usermedians):
+                    if med is not None:
+                        stats['med'] = med
+
+        if conf_intervals is not None:
+            if len(conf_intervals) != len(bxpstats):
+                raise ValueError(
+                    "'conf_intervals' and 'x' have different lengths")
+            else:
+                for stats, ci in zip(bxpstats, conf_intervals):
+                    if ci is not None:
+                        if len(ci) != 2:
+                            raise ValueError('each confidence interval must '
+                                             'have two values')
+                        else:
+                            if ci[0] is not None:
+                                stats['cilo'] = ci[0]
+                            if ci[1] is not None:
+                                stats['cihi'] = ci[1]
+
+        artists = self.bxp(bxpstats, positions=positions, widths=widths,
+                           vert=vert, patch_artist=patch_artist,
+                           shownotches=notch, showmeans=showmeans,
+                           showcaps=showcaps, showbox=showbox,
+                           boxprops=boxprops, flierprops=flierprops,
+                           medianprops=medianprops, meanprops=meanprops,
+                           meanline=meanline, showfliers=showfliers,
+                           capprops=capprops, whiskerprops=whiskerprops,
+                           manage_ticks=manage_ticks, zorder=zorder,
+                           capwidths=capwidths, label=label,
+                           orientation=orientation)
+        return artists
+
+    @_api.make_keyword_only("3.9", "widths")
+    def bxp(self, bxpstats, positions=None, widths=None, vert=None,
+            orientation='vertical', patch_artist=False, shownotches=False,
+            showmeans=False, showcaps=True, showbox=True, showfliers=True,
+            boxprops=None, whiskerprops=None, flierprops=None,
+            medianprops=None, capprops=None, meanprops=None,
+            meanline=False, manage_ticks=True, zorder=None,
+            capwidths=None, label=None):
+        """
+        Draw a box and whisker plot from pre-computed statistics.
+
+        The box extends from the first quartile *q1* to the third
+        quartile *q3* of the data, with a line at the median (*med*).
+        The whiskers extend from *whislow* to *whishi*.
+        Flier points are markers past the end of the whiskers.
+        See https://en.wikipedia.org/wiki/Box_plot for reference.
+
+        .. code-block:: none
+
+                   whislow    q1    med    q3    whishi
+                               |-----:-----|
+               o      |--------|     :     |--------|    o  o
+                               |-----:-----|
+             flier                                      fliers
+
+        .. note::
+            This is a low-level drawing function for when you already
+            have the statistical parameters. If you want a boxplot based
+            on a dataset, use `~.Axes.boxplot` instead.
+
+        Parameters
+        ----------
+        bxpstats : list of dicts
+            A list of dictionaries containing stats for each boxplot.
+            Required keys are:
+
+            - ``med``: Median (scalar).
+            - ``q1``, ``q3``: First & third quartiles (scalars).
+            - ``whislo``, ``whishi``: Lower & upper whisker positions (scalars).
+
+            Optional keys are:
+
+            - ``mean``: Mean (scalar).  Needed if ``showmeans=True``.
+            - ``fliers``: Data beyond the whiskers (array-like).
+              Needed if ``showfliers=True``.
+            - ``cilo``, ``cihi``: Lower & upper confidence intervals
+              about the median. Needed if ``shownotches=True``.
+            - ``label``: Name of the dataset (str).  If available,
+              this will be used a tick label for the boxplot
+
+        positions : array-like, default: [1, 2, ..., n]
+            The positions of the boxes. The ticks and limits
+            are automatically set to match the positions.
+
+        widths : float or array-like, default: None
+            The widths of the boxes.  The default is
+            ``clip(0.15*(distance between extreme positions), 0.15, 0.5)``.
+
+        capwidths : float or array-like, default: None
+            Either a scalar or a vector and sets the width of each cap.
+            The default is ``0.5*(width of the box)``, see *widths*.
+
+        vert : bool, optional
+            .. deprecated:: 3.10
+                Use *orientation* instead.
+
+                If this is given during the deprecation period, it overrides
+                the *orientation* parameter.
+
+            If True, plots the boxes vertically.
+            If False, plots the boxes horizontally.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            If 'horizontal', plots the boxes horizontally.
+            Otherwise, plots the boxes vertically.
+
+            .. versionadded:: 3.10
+
+        patch_artist : bool, default: False
+            If `False` produces boxes with the `.Line2D` artist.
+            If `True` produces boxes with the `~matplotlib.patches.Patch` artist.
+
+        shownotches, showmeans, showcaps, showbox, showfliers : bool
+            Whether to draw the CI notches, the mean value (both default to
+            False), the caps, the box, and the fliers (all three default to
+            True).
+
+        boxprops, whiskerprops, capprops, flierprops, medianprops, meanprops :\
+ dict, optional
+            Artist properties for the boxes, whiskers, caps, fliers, medians, and
+            means.
+
+        meanline : bool, default: False
+            If `True` (and *showmeans* is `True`), will try to render the mean
+            as a line spanning the full width of the box according to
+            *meanprops*. Not recommended if *shownotches* is also True.
+            Otherwise, means will be shown as points.
+
+        manage_ticks : bool, default: True
+            If True, the tick locations and labels will be adjusted to match the
+            boxplot positions.
+
+        label : str or list of str, optional
+            Legend labels. Use a single string when all boxes have the same style and
+            you only want a single legend entry for them. Use a list of strings to
+            label all boxes individually. To be distinguishable, the boxes should be
+            styled individually, which is currently only possible by modifying the
+            returned artists, see e.g. :doc:`/gallery/statistics/boxplot_demo`.
+
+            In the case of a single string, the legend entry will technically be
+            associated with the first box only. By default, the legend will show the
+            median line (``result["medians"]``); if *patch_artist* is True, the legend
+            will show the box `.Patch` artists (``result["boxes"]``) instead.
+
+            .. versionadded:: 3.9
+
+        zorder : float, default: ``Line2D.zorder = 2``
+            The zorder of the resulting boxplot.
+
+        Returns
+        -------
+        dict
+            A dictionary mapping each component of the boxplot to a list
+            of the `.Line2D` instances created. That dictionary has the
+            following keys (assuming vertical boxplots):
+
+            - ``boxes``: main bodies of the boxplot showing the quartiles, and
+              the median's confidence intervals if enabled.
+            - ``medians``: horizontal lines at the median of each box.
+            - ``whiskers``: vertical lines up to the last non-outlier data.
+            - ``caps``: horizontal lines at the ends of the whiskers.
+            - ``fliers``: points representing data beyond the whiskers (fliers).
+            - ``means``: points or lines representing the means.
+
+        See Also
+        --------
+        boxplot : Draw a boxplot from data instead of pre-computed statistics.
+        """
+        # Clamp median line to edge of box by default.
+        medianprops = {
+            "solid_capstyle": "butt",
+            "dash_capstyle": "butt",
+            **(medianprops or {}),
+        }
+        meanprops = {
+            "solid_capstyle": "butt",
+            "dash_capstyle": "butt",
+            **(meanprops or {}),
+        }
+
+        # lists of artists to be output
+        whiskers = []
+        caps = []
+        boxes = []
+        medians = []
+        means = []
+        fliers = []
+
+        # empty list of xticklabels
+        datalabels = []
+
+        # Use default zorder if none specified
+        if zorder is None:
+            zorder = mlines.Line2D.zorder
+
+        zdelta = 0.1
+
+        def merge_kw_rc(subkey, explicit, zdelta=0, usemarker=True):
+            d = {k.split('.')[-1]: v for k, v in mpl.rcParams.items()
+                 if k.startswith(f'boxplot.{subkey}props')}
+            d['zorder'] = zorder + zdelta
+            if not usemarker:
+                d['marker'] = ''
+            d.update(cbook.normalize_kwargs(explicit, mlines.Line2D))
+            return d
+
+        box_kw = {
+            'linestyle': mpl.rcParams['boxplot.boxprops.linestyle'],
+            'linewidth': mpl.rcParams['boxplot.boxprops.linewidth'],
+            'edgecolor': mpl.rcParams['boxplot.boxprops.color'],
+            'facecolor': ('white' if mpl.rcParams['_internal.classic_mode']
+                          else mpl.rcParams['patch.facecolor']),
+            'zorder': zorder,
+            **cbook.normalize_kwargs(boxprops, mpatches.PathPatch)
+        } if patch_artist else merge_kw_rc('box', boxprops, usemarker=False)
+        whisker_kw = merge_kw_rc('whisker', whiskerprops, usemarker=False)
+        cap_kw = merge_kw_rc('cap', capprops, usemarker=False)
+        flier_kw = merge_kw_rc('flier', flierprops)
+        median_kw = merge_kw_rc('median', medianprops, zdelta, usemarker=False)
+        mean_kw = merge_kw_rc('mean', meanprops, zdelta)
+        removed_prop = 'marker' if meanline else 'linestyle'
+        # Only remove the property if it's not set explicitly as a parameter.
+        if meanprops is None or removed_prop not in meanprops:
+            mean_kw[removed_prop] = ''
+
+        # vert and orientation parameters are linked until vert's
+        # deprecation period expires. vert only takes precedence
+        # if set to False.
+        if vert is None:
+            vert = mpl.rcParams['boxplot.vertical']
+        else:
+            _api.warn_deprecated(
+                "3.10",
+                name="vert: bool",
+                alternative="orientation: {'vertical', 'horizontal'}"
+            )
+        if vert is False:
+            orientation = 'horizontal'
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
+
+        if not mpl.rcParams['boxplot.vertical']:
+            _api.warn_deprecated(
+                "3.10",
+                name='boxplot.vertical', obj_type="rcparam"
+            )
+
+        # vertical or horizontal plot?
+        maybe_swap = slice(None) if orientation == 'vertical' else slice(None, None, -1)
+
+        def do_plot(xs, ys, **kwargs):
+            return self.plot(*[xs, ys][maybe_swap], **kwargs)[0]
+
+        def do_patch(xs, ys, **kwargs):
+            path = mpath.Path._create_closed(
+                np.column_stack([xs, ys][maybe_swap]))
+            patch = mpatches.PathPatch(path, **kwargs)
+            self.add_artist(patch)
+            return patch
+
+        # input validation
+        N = len(bxpstats)
+        datashape_message = ("List of boxplot statistics and `{0}` "
+                             "values must have same the length")
+        # check position
+        if positions is None:
+            positions = list(range(1, N + 1))
+        elif len(positions) != N:
+            raise ValueError(datashape_message.format("positions"))
+
+        positions = np.array(positions)
+        if len(positions) > 0 and not all(isinstance(p, Real) for p in positions):
+            raise TypeError("positions should be an iterable of numbers")
+
+        # width
+        if widths is None:
+            widths = [np.clip(0.15 * np.ptp(positions), 0.15, 0.5)] * N
+        elif np.isscalar(widths):
+            widths = [widths] * N
+        elif len(widths) != N:
+            raise ValueError(datashape_message.format("widths"))
+
+        # capwidth
+        if capwidths is None:
+            capwidths = 0.5 * np.array(widths)
+        elif np.isscalar(capwidths):
+            capwidths = [capwidths] * N
+        elif len(capwidths) != N:
+            raise ValueError(datashape_message.format("capwidths"))
+
+        for pos, width, stats, capwidth in zip(positions, widths, bxpstats,
+                                               capwidths):
+            # try to find a new label
+            datalabels.append(stats.get('label', pos))
+
+            # whisker coords
+            whis_x = [pos, pos]
+            whislo_y = [stats['q1'], stats['whislo']]
+            whishi_y = [stats['q3'], stats['whishi']]
+            # cap coords
+            cap_left = pos - capwidth * 0.5
+            cap_right = pos + capwidth * 0.5
+            cap_x = [cap_left, cap_right]
+            cap_lo = np.full(2, stats['whislo'])
+            cap_hi = np.full(2, stats['whishi'])
+            # box and median coords
+            box_left = pos - width * 0.5
+            box_right = pos + width * 0.5
+            med_y = [stats['med'], stats['med']]
+            # notched boxes
+            if shownotches:
+                notch_left = pos - width * 0.25
+                notch_right = pos + width * 0.25
+                box_x = [box_left, box_right, box_right, notch_right,
+                         box_right, box_right, box_left, box_left, notch_left,
+                         box_left, box_left]
+                box_y = [stats['q1'], stats['q1'], stats['cilo'],
+                         stats['med'], stats['cihi'], stats['q3'],
+                         stats['q3'], stats['cihi'], stats['med'],
+                         stats['cilo'], stats['q1']]
+                med_x = [notch_left, notch_right]
+            # plain boxes
+            else:
+                box_x = [box_left, box_right, box_right, box_left, box_left]
+                box_y = [stats['q1'], stats['q1'], stats['q3'], stats['q3'],
+                         stats['q1']]
+                med_x = [box_left, box_right]
+
+            # maybe draw the box
+            if showbox:
+                do_box = do_patch if patch_artist else do_plot
+                boxes.append(do_box(box_x, box_y, **box_kw))
+                median_kw.setdefault('label', '_nolegend_')
+            # draw the whiskers
+            whisker_kw.setdefault('label', '_nolegend_')
+            whiskers.append(do_plot(whis_x, whislo_y, **whisker_kw))
+            whiskers.append(do_plot(whis_x, whishi_y, **whisker_kw))
+            # maybe draw the caps
+            if showcaps:
+                cap_kw.setdefault('label', '_nolegend_')
+                caps.append(do_plot(cap_x, cap_lo, **cap_kw))
+                caps.append(do_plot(cap_x, cap_hi, **cap_kw))
+            # draw the medians
+            medians.append(do_plot(med_x, med_y, **median_kw))
+            # maybe draw the means
+            if showmeans:
+                if meanline:
+                    means.append(do_plot(
+                        [box_left, box_right], [stats['mean'], stats['mean']],
+                        **mean_kw
+                    ))
+                else:
+                    means.append(do_plot([pos], [stats['mean']], **mean_kw))
+            # maybe draw the fliers
+            if showfliers:
+                flier_kw.setdefault('label', '_nolegend_')
+                flier_x = np.full(len(stats['fliers']), pos, dtype=np.float64)
+                flier_y = stats['fliers']
+                fliers.append(do_plot(flier_x, flier_y, **flier_kw))
+
+        # Set legend labels
+        if label:
+            box_or_med = boxes if showbox and patch_artist else medians
+            if cbook.is_scalar_or_string(label):
+                # assign the label only to the first box
+                box_or_med[0].set_label(label)
+            else:  # label is a sequence
+                if len(box_or_med) != len(label):
+                    raise ValueError(datashape_message.format("label"))
+                for artist, lbl in zip(box_or_med, label):
+                    artist.set_label(lbl)
+
+        if manage_ticks:
+            axis_name = "x" if orientation == 'vertical' else "y"
+            interval = getattr(self.dataLim, f"interval{axis_name}")
+            axis = self._axis_map[axis_name]
+            positions = axis.convert_units(positions)
+            # The 0.5 additional padding ensures reasonable-looking boxes
+            # even when drawing a single box.  We set the sticky edge to
+            # prevent margins expansion, in order to match old behavior (back
+            # when separate calls to boxplot() would completely reset the axis
+            # limits regardless of what was drawn before).  The sticky edges
+            # are attached to the median lines, as they are always present.
+            interval[:] = (min(interval[0], min(positions) - .5),
+                           max(interval[1], max(positions) + .5))
+            for median, position in zip(medians, positions):
+                getattr(median.sticky_edges, axis_name).extend(
+                    [position - .5, position + .5])
+            # Modified from Axis.set_ticks and Axis.set_ticklabels.
+            locator = axis.get_major_locator()
+            if not isinstance(axis.get_major_locator(),
+                              mticker.FixedLocator):
+                locator = mticker.FixedLocator([])
+                axis.set_major_locator(locator)
+            locator.locs = np.array([*locator.locs, *positions])
+            formatter = axis.get_major_formatter()
+            if not isinstance(axis.get_major_formatter(),
+                              mticker.FixedFormatter):
+                formatter = mticker.FixedFormatter([])
+                axis.set_major_formatter(formatter)
+            formatter.seq = [*formatter.seq, *datalabels]
+
+            self._request_autoscale_view()
+
+        return dict(whiskers=whiskers, caps=caps, boxes=boxes,
+                    medians=medians, fliers=fliers, means=means)
+
+    @staticmethod
+    def _parse_scatter_color_args(c, edgecolors, kwargs, xsize,
+                                  get_next_color_func):
+        """
+        Helper function to process color related arguments of `.Axes.scatter`.
+
+        Argument precedence for facecolors:
+
+        - c (if not None)
+        - kwargs['facecolor']
+        - kwargs['facecolors']
+        - kwargs['color'] (==kwcolor)
+        - 'b' if in classic mode else the result of ``get_next_color_func()``
+
+        Argument precedence for edgecolors:
+
+        - kwargs['edgecolor']
+        - edgecolors (is an explicit kw argument in scatter())
+        - kwargs['color'] (==kwcolor)
+        - 'face' if not in classic mode else None
+
+        Parameters
+        ----------
+        c : :mpltype:`color` or array-like or list of :mpltype:`color` or None
+            See argument description of `.Axes.scatter`.
+        edgecolors : :mpltype:`color` or sequence of color or {'face', 'none'} or None
+            See argument description of `.Axes.scatter`.
+        kwargs : dict
+            Additional kwargs. If these keys exist, we pop and process them:
+            'facecolors', 'facecolor', 'edgecolor', 'color'
+            Note: The dict is modified by this function.
+        xsize : int
+            The size of the x and y arrays passed to `.Axes.scatter`.
+        get_next_color_func : callable
+            A callable that returns a color. This color is used as facecolor
+            if no other color is provided.
+
+            Note, that this is a function rather than a fixed color value to
+            support conditional evaluation of the next color.  As of the
+            current implementation obtaining the next color from the
+            property cycle advances the cycle. This must only happen if we
+            actually use the color, which will only be decided within this
+            method.
+
+        Returns
+        -------
+        c
+            The input *c* if it was not *None*, else a color derived from the
+            other inputs or defaults.
+        colors : array(N, 4) or None
+            The facecolors as RGBA values, or *None* if a colormap is used.
+        edgecolors
+            The edgecolor.
+
+        """
+        facecolors = kwargs.pop('facecolors', None)
+        facecolors = kwargs.pop('facecolor', facecolors)
+        edgecolors = kwargs.pop('edgecolor', edgecolors)
+
+        kwcolor = kwargs.pop('color', None)
+
+        if kwcolor is not None and c is not None:
+            raise ValueError("Supply a 'c' argument or a 'color'"
+                             " kwarg but not both; they differ but"
+                             " their functionalities overlap.")
+
+        if kwcolor is not None:
+            try:
+                mcolors.to_rgba_array(kwcolor)
+            except ValueError as err:
+                raise ValueError(
+                    "'color' kwarg must be a color or sequence of color "
+                    "specs.  For a sequence of values to be color-mapped, use "
+                    "the 'c' argument instead.") from err
+            if edgecolors is None:
+                edgecolors = kwcolor
+            if facecolors is None:
+                facecolors = kwcolor
+
+        if edgecolors is None and not mpl.rcParams['_internal.classic_mode']:
+            edgecolors = mpl.rcParams['scatter.edgecolors']
+
+        c_was_none = c is None
+        if c is None:
+            c = (facecolors if facecolors is not None
+                 else "b" if mpl.rcParams['_internal.classic_mode']
+                 else get_next_color_func())
+        c_is_string_or_strings = (
+            isinstance(c, str)
+            or (np.iterable(c) and len(c) > 0
+                and isinstance(cbook._safe_first_finite(c), str)))
+
+        def invalid_shape_exception(csize, xsize):
+            return ValueError(
+                f"'c' argument has {csize} elements, which is inconsistent "
+                f"with 'x' and 'y' with size {xsize}.")
+
+        c_is_mapped = False  # Unless proven otherwise below.
+        valid_shape = True  # Unless proven otherwise below.
+        if not c_was_none and kwcolor is None and not c_is_string_or_strings:
+            try:  # First, does 'c' look suitable for value-mapping?
+                c = np.asanyarray(c, dtype=float)
+            except ValueError:
+                pass  # Failed to convert to float array; must be color specs.
+            else:
+                # handle the documented special case of a 2D array with 1
+                # row which as RGB(A) to broadcast.
+                if c.shape == (1, 4) or c.shape == (1, 3):
+                    c_is_mapped = False
+                    if c.size != xsize:
+                        valid_shape = False
+                # If c can be either mapped values or an RGB(A) color, prefer
+                # the former if shapes match, the latter otherwise.
+                elif c.size == xsize:
+                    c = c.ravel()
+                    c_is_mapped = True
+                else:  # Wrong size; it must not be intended for mapping.
+                    if c.shape in ((3,), (4,)):
+                        _api.warn_external(
+                            "*c* argument looks like a single numeric RGB or "
+                            "RGBA sequence, which should be avoided as value-"
+                            "mapping will have precedence in case its length "
+                            "matches with *x* & *y*.  Please use the *color* "
+                            "keyword-argument or provide a 2D array "
+                            "with a single row if you intend to specify "
+                            "the same RGB or RGBA value for all points.")
+                    valid_shape = False
+        if not c_is_mapped:
+            try:  # Is 'c' acceptable as PathCollection facecolors?
+                colors = mcolors.to_rgba_array(c)
+            except (TypeError, ValueError) as err:
+                if "RGBA values should be within 0-1 range" in str(err):
+                    raise
+                else:
+                    if not valid_shape:
+                        raise invalid_shape_exception(c.size, xsize) from err
+                    # Both the mapping *and* the RGBA conversion failed: pretty
+                    # severe failure => one may appreciate a verbose feedback.
+                    raise ValueError(
+                        f"'c' argument must be a color, a sequence of colors, "
+                        f"or a sequence of numbers, not {c!r}") from err
+            else:
+                if len(colors) not in (0, 1, xsize):
+                    # NB: remember that a single color is also acceptable.
+                    # Besides *colors* will be an empty array if c == 'none'.
+                    raise invalid_shape_exception(len(colors), xsize)
+        else:
+            colors = None  # use cmap, norm after collection is created
+        return c, colors, edgecolors
+
+    @_api.make_keyword_only("3.9", "marker")
+    @_preprocess_data(replace_names=["x", "y", "s", "linewidths",
+                                     "edgecolors", "c", "facecolor",
+                                     "facecolors", "color"],
+                      label_namer="y")
+    @_docstring.interpd
+    def scatter(self, x, y, s=None, c=None, marker=None, cmap=None, norm=None,
+                vmin=None, vmax=None, alpha=None, linewidths=None, *,
+                edgecolors=None, colorizer=None, plotnonfinite=False, **kwargs):
+        """
+        A scatter plot of *y* vs. *x* with varying marker size and/or color.
+
+        Parameters
+        ----------
+        x, y : float or array-like, shape (n, )
+            The data positions.
+
+        s : float or array-like, shape (n, ), optional
+            The marker size in points**2 (typographic points are 1/72 in.).
+            Default is ``rcParams['lines.markersize'] ** 2``.
+
+            The linewidth and edgecolor can visually interact with the marker
+            size, and can lead to artifacts if the marker size is smaller than
+            the linewidth.
+
+            If the linewidth is greater than 0 and the edgecolor is anything
+            but *'none'*, then the effective size of the marker will be
+            increased by half the linewidth because the stroke will be centered
+            on the edge of the shape.
+
+            To eliminate the marker edge either set *linewidth=0* or
+            *edgecolor='none'*.
+
+        c : array-like or list of :mpltype:`color` or :mpltype:`color`, optional
+            The marker colors. Possible values:
+
+            - A scalar or sequence of n numbers to be mapped to colors using
+              *cmap* and *norm*.
+            - A 2D array in which the rows are RGB or RGBA.
+            - A sequence of colors of length n.
+            - A single color format string.
+
+            Note that *c* should not be a single numeric RGB or RGBA sequence
+            because that is indistinguishable from an array of values to be
+            colormapped. If you want to specify the same RGB or RGBA value for
+            all points, use a 2D array with a single row.  Otherwise,
+            value-matching will have precedence in case of a size matching with
+            *x* and *y*.
+
+            If you wish to specify a single color for all points
+            prefer the *color* keyword argument.
+
+            Defaults to `None`. In that case the marker color is determined
+            by the value of *color*, *facecolor* or *facecolors*. In case
+            those are not specified or `None`, the marker color is determined
+            by the next color of the ``Axes``' current "shape and fill" color
+            cycle. This cycle defaults to :rc:`axes.prop_cycle`.
+
+        marker : `~.markers.MarkerStyle`, default: :rc:`scatter.marker`
+            The marker style. *marker* can be either an instance of the class
+            or the text shorthand for a particular marker.
+            See :mod:`matplotlib.markers` for more information about marker
+            styles.
+
+        %(cmap_doc)s
+
+            This parameter is ignored if *c* is RGB(A).
+
+        %(norm_doc)s
+
+            This parameter is ignored if *c* is RGB(A).
+
+        %(vmin_vmax_doc)s
+
+            This parameter is ignored if *c* is RGB(A).
+
+        alpha : float, default: None
+            The alpha blending value, between 0 (transparent) and 1 (opaque).
+
+        linewidths : float or array-like, default: :rc:`lines.linewidth`
+            The linewidth of the marker edges. Note: The default *edgecolors*
+            is 'face'. You may want to change this as well.
+
+        edgecolors : {'face', 'none', *None*} or :mpltype:`color` or list of \
+:mpltype:`color`, default: :rc:`scatter.edgecolors`
+            The edge color of the marker. Possible values:
+
+            - 'face': The edge color will always be the same as the face color.
+            - 'none': No patch boundary will be drawn.
+            - A color or sequence of colors.
+
+            For non-filled markers, *edgecolors* is ignored. Instead, the color
+            is determined like with 'face', i.e. from *c*, *colors*, or
+            *facecolors*.
+
+        %(colorizer_doc)s
+
+            This parameter is ignored if *c* is RGB(A).
+
+        plotnonfinite : bool, default: False
+            Whether to plot points with nonfinite *c* (i.e. ``inf``, ``-inf``
+            or ``nan``). If ``True`` the points are drawn with the *bad*
+            colormap color (see `.Colormap.set_bad`).
+
+        Returns
+        -------
+        `~matplotlib.collections.PathCollection`
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+        **kwargs : `~matplotlib.collections.Collection` properties
+
+        See Also
+        --------
+        plot : To plot scatter plots when markers are identical in size and
+            color.
+
+        Notes
+        -----
+        * The `.plot` function will be faster for scatterplots where markers
+          don't vary in size or color.
+
+        * Any or all of *x*, *y*, *s*, and *c* may be masked arrays, in which
+          case all masks will be combined and only unmasked points will be
+          plotted.
+
+        * Fundamentally, scatter works with 1D arrays; *x*, *y*, *s*, and *c*
+          may be input as N-D arrays, but within scatter they will be
+          flattened. The exception is *c*, which will be flattened only if its
+          size matches the size of *x* and *y*.
+
+        """
+        # add edgecolors and linewidths to kwargs so they
+        # can be processed by normailze_kwargs
+        if edgecolors is not None:
+            kwargs.update({'edgecolors': edgecolors})
+        if linewidths is not None:
+            kwargs.update({'linewidths': linewidths})
+
+        kwargs = cbook.normalize_kwargs(kwargs, mcoll.Collection)
+        # re direct linewidth and edgecolor so it can be
+        # further processed by the rest of the function
+        linewidths = kwargs.pop('linewidth', None)
+        edgecolors = kwargs.pop('edgecolor', None)
+        # Process **kwargs to handle aliases, conflicts with explicit kwargs:
+        x, y = self._process_unit_info([("x", x), ("y", y)], kwargs)
+        # np.ma.ravel yields an ndarray, not a masked array,
+        # unless its argument is a masked array.
+        x = np.ma.ravel(x)
+        y = np.ma.ravel(y)
+        if x.size != y.size:
+            raise ValueError("x and y must be the same size")
+
+        if s is None:
+            s = (20 if mpl.rcParams['_internal.classic_mode'] else
+                 mpl.rcParams['lines.markersize'] ** 2.0)
+        s = np.ma.ravel(s)
+        if (len(s) not in (1, x.size) or
+                (not np.issubdtype(s.dtype, np.floating) and
+                 not np.issubdtype(s.dtype, np.integer))):
+            raise ValueError(
+                "s must be a scalar, "
+                "or float array-like with the same size as x and y")
+
+        # get the original edgecolor the user passed before we normalize
+        orig_edgecolor = edgecolors
+        if edgecolors is None:
+            orig_edgecolor = kwargs.get('edgecolor', None)
+        c, colors, edgecolors = \
+            self._parse_scatter_color_args(
+                c, edgecolors, kwargs, x.size,
+                get_next_color_func=self._get_patches_for_fill.get_next_color)
+
+        if plotnonfinite and colors is None:
+            c = np.ma.masked_invalid(c)
+            x, y, s, edgecolors, linewidths = \
+                cbook._combine_masks(x, y, s, edgecolors, linewidths)
+        else:
+            x, y, s, c, colors, edgecolors, linewidths = \
+                cbook._combine_masks(
+                    x, y, s, c, colors, edgecolors, linewidths)
+        # Unmask edgecolors if it was actually a single RGB or RGBA.
+        if (x.size in (3, 4)
+                and np.ma.is_masked(edgecolors)
+                and not np.ma.is_masked(orig_edgecolor)):
+            edgecolors = edgecolors.data
+
+        scales = s   # Renamed for readability below.
+
+        # load default marker from rcParams
+        if marker is None:
+            marker = mpl.rcParams['scatter.marker']
+
+        if isinstance(marker, mmarkers.MarkerStyle):
+            marker_obj = marker
+        else:
+            marker_obj = mmarkers.MarkerStyle(marker)
+
+        path = marker_obj.get_path().transformed(
+            marker_obj.get_transform())
+        if not marker_obj.is_filled():
+            if orig_edgecolor is not None:
+                _api.warn_external(
+                    f"You passed a edgecolor/edgecolors ({orig_edgecolor!r}) "
+                    f"for an unfilled marker ({marker!r}).  Matplotlib is "
+                    "ignoring the edgecolor in favor of the facecolor.  This "
+                    "behavior may change in the future."
+                )
+            # We need to handle markers that cannot be filled (like
+            # '+' and 'x') differently than markers that can be
+            # filled, but have their fillstyle set to 'none'.  This is
+            # to get:
+            #
+            #  - respecting the fillestyle if set
+            #  - maintaining back-compatibility for querying the facecolor of
+            #    the un-fillable markers.
+            #
+            # While not an ideal situation, but is better than the
+            # alternatives.
+            if marker_obj.get_fillstyle() == 'none':
+                # promote the facecolor to be the edgecolor
+                edgecolors = colors
+                # set the facecolor to 'none' (at the last chance) because
+                # we cannot fill a path if the facecolor is non-null
+                # (which is defendable at the renderer level).
+                colors = 'none'
+            else:
+                # if we are not nulling the face color we can do this
+                # simpler
+                edgecolors = 'face'
+
+            if linewidths is None:
+                linewidths = mpl.rcParams['lines.linewidth']
+            elif np.iterable(linewidths):
+                linewidths = [
+                    lw if lw is not None else mpl.rcParams['lines.linewidth']
+                    for lw in linewidths]
+
+        offsets = np.ma.column_stack([x, y])
+
+        collection = mcoll.PathCollection(
+            (path,), scales,
+            facecolors=colors,
+            edgecolors=edgecolors,
+            linewidths=linewidths,
+            offsets=offsets,
+            offset_transform=kwargs.pop('transform', self.transData),
+            alpha=alpha,
+        )
+        collection.set_transform(mtransforms.IdentityTransform())
+        if colors is None:
+            if colorizer:
+                collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
+                                                         norm=norm, vmin=vmin,
+                                                         vmax=vmax)
+            else:
+                collection.set_cmap(cmap)
+                collection.set_norm(norm)
+            collection.set_array(c)
+            collection._scale_norm(norm, vmin, vmax)
+        else:
+            extra_kwargs = {
+                    'cmap': cmap, 'norm': norm, 'vmin': vmin, 'vmax': vmax
+                    }
+            extra_keys = [k for k, v in extra_kwargs.items() if v is not None]
+            if any(extra_keys):
+                keys_str = ", ".join(f"'{k}'" for k in extra_keys)
+                _api.warn_external(
+                    "No data for colormapping provided via 'c'. "
+                    f"Parameters {keys_str} will be ignored")
+        collection._internal_update(kwargs)
+
+        # Classic mode only:
+        # ensure there are margins to allow for the
+        # finite size of the symbols.  In v2.x, margins
+        # are present by default, so we disable this
+        # scatter-specific override.
+        if mpl.rcParams['_internal.classic_mode']:
+            if self._xmargin < 0.05 and x.size > 0:
+                self.set_xmargin(0.05)
+            if self._ymargin < 0.05 and x.size > 0:
+                self.set_ymargin(0.05)
+
+        self.add_collection(collection)
+        self._request_autoscale_view()
+
+        return collection
+
+    @_api.make_keyword_only("3.9", "gridsize")
+    @_preprocess_data(replace_names=["x", "y", "C"], label_namer="y")
+    @_docstring.interpd
+    def hexbin(self, x, y, C=None, gridsize=100, bins=None,
+               xscale='linear', yscale='linear', extent=None,
+               cmap=None, norm=None, vmin=None, vmax=None,
+               alpha=None, linewidths=None, edgecolors='face',
+               reduce_C_function=np.mean, mincnt=None, marginals=False,
+               colorizer=None, **kwargs):
+        """
+        Make a 2D hexagonal binning plot of points *x*, *y*.
+
+        If *C* is *None*, the value of the hexagon is determined by the number
+        of points in the hexagon. Otherwise, *C* specifies values at the
+        coordinate (x[i], y[i]). For each hexagon, these values are reduced
+        using *reduce_C_function*.
+
+        Parameters
+        ----------
+        x, y : array-like
+            The data positions. *x* and *y* must be of the same length.
+
+        C : array-like, optional
+            If given, these values are accumulated in the bins. Otherwise,
+            every point has a value of 1. Must be of the same length as *x*
+            and *y*.
+
+        gridsize : int or (int, int), default: 100
+            If a single int, the number of hexagons in the *x*-direction.
+            The number of hexagons in the *y*-direction is chosen such that
+            the hexagons are approximately regular.
+
+            Alternatively, if a tuple (*nx*, *ny*), the number of hexagons
+            in the *x*-direction and the *y*-direction. In the
+            *y*-direction, counting is done along vertically aligned
+            hexagons, not along the zig-zag chains of hexagons; see the
+            following illustration.
+
+            .. plot::
+
+               import numpy
+               import matplotlib.pyplot as plt
+
+               np.random.seed(19680801)
+               n= 300
+               x = np.random.standard_normal(n)
+               y = np.random.standard_normal(n)
+
+               fig, ax = plt.subplots(figsize=(4, 4))
+               h = ax.hexbin(x, y, gridsize=(5, 3))
+               hx, hy = h.get_offsets().T
+               ax.plot(hx[24::3], hy[24::3], 'ro-')
+               ax.plot(hx[-3:], hy[-3:], 'ro-')
+               ax.set_title('gridsize=(5, 3)')
+               ax.axis('off')
+
+            To get approximately regular hexagons, choose
+            :math:`n_x = \\sqrt{3}\\,n_y`.
+
+        bins : 'log' or int or sequence, default: None
+            Discretization of the hexagon values.
+
+            - If *None*, no binning is applied; the color of each hexagon
+              directly corresponds to its count value.
+            - If 'log', use a logarithmic scale for the colormap.
+              Internally, :math:`log_{10}(i+1)` is used to determine the
+              hexagon color. This is equivalent to ``norm=LogNorm()``.
+            - If an integer, divide the counts in the specified number
+              of bins, and color the hexagons accordingly.
+            - If a sequence of values, the values of the lower bound of
+              the bins to be used.
+
+        xscale : {'linear', 'log'}, default: 'linear'
+            Use a linear or log10 scale on the horizontal axis.
+
+        yscale : {'linear', 'log'}, default: 'linear'
+            Use a linear or log10 scale on the vertical axis.
+
+        mincnt : int >= 0, default: *None*
+            If not *None*, only display cells with at least *mincnt*
+            number of points in the cell.
+
+        marginals : bool, default: *False*
+            If marginals is *True*, plot the marginal density as
+            colormapped rectangles along the bottom of the x-axis and
+            left of the y-axis.
+
+        extent : 4-tuple of float, default: *None*
+            The limits of the bins (xmin, xmax, ymin, ymax).
+            The default assigns the limits based on
+            *gridsize*, *x*, *y*, *xscale* and *yscale*.
+
+            If *xscale* or *yscale* is set to 'log', the limits are
+            expected to be the exponent for a power of 10. E.g. for
+            x-limits of 1 and 50 in 'linear' scale and y-limits
+            of 10 and 1000 in 'log' scale, enter (1, 50, 1, 3).
+
+        Returns
+        -------
+        `~matplotlib.collections.PolyCollection`
+            A `.PolyCollection` defining the hexagonal bins.
+
+            - `.PolyCollection.get_offsets` contains a Mx2 array containing
+              the x, y positions of the M hexagon centers in data coordinates.
+            - `.PolyCollection.get_array` contains the values of the M
+              hexagons.
+
+            If *marginals* is *True*, horizontal
+            bar and vertical bar (both PolyCollections) will be attached
+            to the return collection as attributes *hbar* and *vbar*.
+
+        Other Parameters
+        ----------------
+        %(cmap_doc)s
+
+        %(norm_doc)s
+
+        %(vmin_vmax_doc)s
+
+        alpha : float between 0 and 1, optional
+            The alpha blending value, between 0 (transparent) and 1 (opaque).
+
+        linewidths : float, default: *None*
+            If *None*, defaults to :rc:`patch.linewidth`.
+
+        edgecolors : {'face', 'none', *None*} or color, default: 'face'
+            The color of the hexagon edges. Possible values are:
+
+            - 'face': Draw the edges in the same color as the fill color.
+            - 'none': No edges are drawn. This can sometimes lead to unsightly
+              unpainted pixels between the hexagons.
+            - *None*: Draw outlines in the default color.
+            - An explicit color.
+
+        reduce_C_function : callable, default: `numpy.mean`
+            The function to aggregate *C* within the bins. It is ignored if
+            *C* is not given. This must have the signature::
+
+                def reduce_C_function(C: array) -> float
+
+            Commonly used functions are:
+
+            - `numpy.mean`: average of the points
+            - `numpy.sum`: integral of the point values
+            - `numpy.amax`: value taken from the largest point
+
+            By default will only reduce cells with at least 1 point because some
+            reduction functions (such as `numpy.amax`) will error/warn with empty
+            input. Changing *mincnt* will adjust the cutoff, and if set to 0 will
+            pass empty input to the reduction function.
+
+        %(colorizer_doc)s
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs : `~matplotlib.collections.PolyCollection` properties
+            All other keyword arguments are passed on to `.PolyCollection`:
+
+            %(PolyCollection:kwdoc)s
+
+        See Also
+        --------
+        hist2d : 2D histogram rectangular bins
+        """
+        self._process_unit_info([("x", x), ("y", y)], kwargs, convert=False)
+
+        x, y, C = cbook.delete_masked_points(x, y, C)
+
+        # Set the size of the hexagon grid
+        if np.iterable(gridsize):
+            nx, ny = gridsize
+        else:
+            nx = gridsize
+            ny = int(nx / math.sqrt(3))
+        # Count the number of data in each hexagon
+        x = np.asarray(x, float)
+        y = np.asarray(y, float)
+
+        # Will be log()'d if necessary, and then rescaled.
+        tx = x
+        ty = y
+
+        if xscale == 'log':
+            if np.any(x <= 0.0):
+                raise ValueError(
+                    "x contains non-positive values, so cannot be log-scaled")
+            tx = np.log10(tx)
+        if yscale == 'log':
+            if np.any(y <= 0.0):
+                raise ValueError(
+                    "y contains non-positive values, so cannot be log-scaled")
+            ty = np.log10(ty)
+        if extent is not None:
+            xmin, xmax, ymin, ymax = extent
+            if xmin > xmax:
+                raise ValueError("In extent, xmax must be greater than xmin")
+            if ymin > ymax:
+                raise ValueError("In extent, ymax must be greater than ymin")
+        else:
+            xmin, xmax = (tx.min(), tx.max()) if len(x) else (0, 1)
+            ymin, ymax = (ty.min(), ty.max()) if len(y) else (0, 1)
+
+            # to avoid issues with singular data, expand the min/max pairs
+            xmin, xmax = mtransforms.nonsingular(xmin, xmax, expander=0.1)
+            ymin, ymax = mtransforms.nonsingular(ymin, ymax, expander=0.1)
+
+        nx1 = nx + 1
+        ny1 = ny + 1
+        nx2 = nx
+        ny2 = ny
+        n = nx1 * ny1 + nx2 * ny2
+
+        # In the x-direction, the hexagons exactly cover the region from
+        # xmin to xmax. Need some padding to avoid roundoff errors.
+        padding = 1.e-9 * (xmax - xmin)
+        xmin -= padding
+        xmax += padding
+        sx = (xmax - xmin) / nx
+        sy = (ymax - ymin) / ny
+        # Positions in hexagon index coordinates.
+        ix = (tx - xmin) / sx
+        iy = (ty - ymin) / sy
+        ix1 = np.round(ix).astype(int)
+        iy1 = np.round(iy).astype(int)
+        ix2 = np.floor(ix).astype(int)
+        iy2 = np.floor(iy).astype(int)
+        # flat indices, plus one so that out-of-range points go to position 0.
+        i1 = np.where((0 <= ix1) & (ix1 < nx1) & (0 <= iy1) & (iy1 < ny1),
+                      ix1 * ny1 + iy1 + 1, 0)
+        i2 = np.where((0 <= ix2) & (ix2 < nx2) & (0 <= iy2) & (iy2 < ny2),
+                      ix2 * ny2 + iy2 + 1, 0)
+
+        d1 = (ix - ix1) ** 2 + 3.0 * (iy - iy1) ** 2
+        d2 = (ix - ix2 - 0.5) ** 2 + 3.0 * (iy - iy2 - 0.5) ** 2
+        bdist = (d1 < d2)
+
+        if C is None:  # [1:] drops out-of-range points.
+            counts1 = np.bincount(i1[bdist], minlength=1 + nx1 * ny1)[1:]
+            counts2 = np.bincount(i2[~bdist], minlength=1 + nx2 * ny2)[1:]
+            accum = np.concatenate([counts1, counts2]).astype(float)
+            if mincnt is not None:
+                accum[accum < mincnt] = np.nan
+            C = np.ones(len(x))
+        else:
+            # store the C values in a list per hexagon index
+            Cs_at_i1 = [[] for _ in range(1 + nx1 * ny1)]
+            Cs_at_i2 = [[] for _ in range(1 + nx2 * ny2)]
+            for i in range(len(x)):
+                if bdist[i]:
+                    Cs_at_i1[i1[i]].append(C[i])
+                else:
+                    Cs_at_i2[i2[i]].append(C[i])
+            if mincnt is None:
+                mincnt = 1
+            accum = np.array(
+                [reduce_C_function(acc) if len(acc) >= mincnt else np.nan
+                 for Cs_at_i in [Cs_at_i1, Cs_at_i2]
+                 for acc in Cs_at_i[1:]],  # [1:] drops out-of-range points.
+                float)
+
+        good_idxs = ~np.isnan(accum)
+
+        offsets = np.zeros((n, 2), float)
+        offsets[:nx1 * ny1, 0] = np.repeat(np.arange(nx1), ny1)
+        offsets[:nx1 * ny1, 1] = np.tile(np.arange(ny1), nx1)
+        offsets[nx1 * ny1:, 0] = np.repeat(np.arange(nx2) + 0.5, ny2)
+        offsets[nx1 * ny1:, 1] = np.tile(np.arange(ny2), nx2) + 0.5
+        offsets[:, 0] *= sx
+        offsets[:, 1] *= sy
+        offsets[:, 0] += xmin
+        offsets[:, 1] += ymin
+        # remove accumulation bins with no data
+        offsets = offsets[good_idxs, :]
+        accum = accum[good_idxs]
+
+        polygon = [sx, sy / 3] * np.array(
+            [[.5, -.5], [.5, .5], [0., 1.], [-.5, .5], [-.5, -.5], [0., -1.]])
+
+        if linewidths is None:
+            linewidths = [mpl.rcParams['patch.linewidth']]
+
+        if xscale == 'log' or yscale == 'log':
+            polygons = np.expand_dims(polygon, 0)
+            if xscale == 'log':
+                polygons[:, :, 0] = 10.0 ** polygons[:, :, 0]
+                xmin = 10.0 ** xmin
+                xmax = 10.0 ** xmax
+                self.set_xscale(xscale)
+            if yscale == 'log':
+                polygons[:, :, 1] = 10.0 ** polygons[:, :, 1]
+                ymin = 10.0 ** ymin
+                ymax = 10.0 ** ymax
+                self.set_yscale(yscale)
+        else:
+            polygons = [polygon]
+
+        collection = mcoll.PolyCollection(
+            polygons,
+            edgecolors=edgecolors,
+            linewidths=linewidths,
+            offsets=offsets,
+            offset_transform=mtransforms.AffineDeltaTransform(self.transData)
         )
 
-
-@check_figures_equal(extensions=['png'])
-def test_stairs(fig_test, fig_ref):
-    import matplotlib.lines as mlines
-    y = np.array([6, 14, 32, 37, 48, 32, 21,  4])  # hist
-    x = np.array([1., 2., 3., 4., 5., 6., 7., 8., 9.])  # bins
-
-    test_axes = fig_test.subplots(3, 2).flatten()
-    test_axes[0].stairs(y, x, baseline=None)
-    test_axes[1].stairs(y, x, baseline=None, orientation='horizontal')
-    test_axes[2].stairs(y, x)
-    test_axes[3].stairs(y, x, orientation='horizontal')
-    test_axes[4].stairs(y, x)
-    test_axes[4].semilogy()
-    test_axes[5].stairs(y, x, orientation='horizontal')
-    test_axes[5].semilogx()
-
-    # defaults of `PathPatch` to be used for all following Line2D
-    style = {'solid_joinstyle': 'miter', 'solid_capstyle': 'butt'}
-
-    ref_axes = fig_ref.subplots(3, 2).flatten()
-    ref_axes[0].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
-    ref_axes[1].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
-
-    ref_axes[2].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
-    ref_axes[2].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]], **style))
-    ref_axes[2].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]], **style))
-    ref_axes[2].set_ylim(0, None)
-
-    ref_axes[3].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
-    ref_axes[3].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]], **style))
-    ref_axes[3].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]], **style))
-    ref_axes[3].set_xlim(0, None)
-
-    ref_axes[4].plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
-    ref_axes[4].add_line(mlines.Line2D([x[0], x[0]], [0, y[0]], **style))
-    ref_axes[4].add_line(mlines.Line2D([x[-1], x[-1]], [0, y[-1]], **style))
-    ref_axes[4].semilogy()
-
-    ref_axes[5].plot(np.append(y[0], y), x, drawstyle='steps-post', **style)
-    ref_axes[5].add_line(mlines.Line2D([0, y[0]], [x[0], x[0]], **style))
-    ref_axes[5].add_line(mlines.Line2D([0, y[-1]], [x[-1], x[-1]], **style))
-    ref_axes[5].semilogx()
-
-
-@check_figures_equal(extensions=['png'])
-def test_stairs_fill(fig_test, fig_ref):
-    h, bins = [1, 2, 3, 4, 2], [0, 1, 2, 3, 4, 5]
-    bs = -2
-    # Test
-    test_axes = fig_test.subplots(2, 2).flatten()
-    test_axes[0].stairs(h, bins, fill=True)
-    test_axes[1].stairs(h, bins, orientation='horizontal', fill=True)
-    test_axes[2].stairs(h, bins, baseline=bs, fill=True)
-    test_axes[3].stairs(h, bins, baseline=bs, orientation='horizontal',
-                        fill=True)
-
-    # # Ref
-    ref_axes = fig_ref.subplots(2, 2).flatten()
-    ref_axes[0].fill_between(bins, np.append(h, h[-1]), step='post', lw=0)
-    ref_axes[0].set_ylim(0, None)
-    ref_axes[1].fill_betweenx(bins, np.append(h, h[-1]), step='post', lw=0)
-    ref_axes[1].set_xlim(0, None)
-    ref_axes[2].fill_between(bins, np.append(h, h[-1]),
-                             np.ones(len(h)+1)*bs, step='post', lw=0)
-    ref_axes[2].set_ylim(bs, None)
-    ref_axes[3].fill_betweenx(bins, np.append(h, h[-1]),
-                              np.ones(len(h)+1)*bs, step='post', lw=0)
-    ref_axes[3].set_xlim(bs, None)
-
-
-@check_figures_equal(extensions=['png'])
-def test_stairs_update(fig_test, fig_ref):
-    # fixed ylim because stairs() does autoscale, but updating data does not
-    ylim = -3, 4
-    # Test
-    test_ax = fig_test.add_subplot()
-    h = test_ax.stairs([1, 2, 3])
-    test_ax.set_ylim(ylim)
-    h.set_data([3, 2, 1])
-    h.set_data(edges=np.arange(4)+2)
-    h.set_data([1, 2, 1], np.arange(4)/2)
-    h.set_data([1, 2, 3])
-    h.set_data(None, np.arange(4))
-    assert np.allclose(h.get_data()[0], np.arange(1, 4))
-    assert np.allclose(h.get_data()[1], np.arange(4))
-    h.set_data(baseline=-2)
-    assert h.get_data().baseline == -2
-
-    # Ref
-    ref_ax = fig_ref.add_subplot()
-    h = ref_ax.stairs([1, 2, 3], baseline=-2)
-    ref_ax.set_ylim(ylim)
-
-
-@check_figures_equal(extensions=['png'])
-def test_stairs_baseline_None(fig_test, fig_ref):
-    x = np.array([0, 2, 3, 5, 10])
-    y = np.array([1.148, 1.231, 1.248, 1.25])
-
-    test_axes = fig_test.add_subplot()
-    test_axes.stairs(y, x, baseline=None)
-
-    style = {'solid_joinstyle': 'miter', 'solid_capstyle': 'butt'}
-
-    ref_axes = fig_ref.add_subplot()
-    ref_axes.plot(x, np.append(y, y[-1]), drawstyle='steps-post', **style)
-
-
-def test_stairs_empty():
-    ax = plt.figure().add_subplot()
-    ax.stairs([], [42])
-    assert ax.get_xlim() == (39, 45)
-    assert ax.get_ylim() == (-0.06, 0.06)
-
-
-def test_stairs_invalid_nan():
-    with pytest.raises(ValueError, match='Nan values in "edges"'):
-        plt.stairs([1, 2], [0, np.nan, 1])
-
-
-def test_stairs_invalid_mismatch():
-    with pytest.raises(ValueError, match='Size mismatch'):
-        plt.stairs([1, 2], [0, 1])
-
-
-def test_stairs_invalid_update():
-    h = plt.stairs([1, 2], [0, 1, 2])
-    with pytest.raises(ValueError, match='Nan values in "edges"'):
-        h.set_data(edges=[1, np.nan, 2])
-
-
-def test_stairs_invalid_update2():
-    h = plt.stairs([1, 2], [0, 1, 2])
-    with pytest.raises(ValueError, match='Size mismatch'):
-        h.set_data(edges=np.arange(5))
-
-
-@image_comparison(['test_stairs_options.png'], remove_text=True)
-def test_stairs_options():
-    x, y = np.array([1, 2, 3, 4, 5]), np.array([1, 2, 3, 4]).astype(float)
-    yn = y.copy()
-    yn[1] = np.nan
-
-    fig, ax = plt.subplots()
-    ax.stairs(y*3, x, color='green', fill=True, label="A")
-    ax.stairs(y, x*3-3, color='red', fill=True,
-              orientation='horizontal', label="B")
-    ax.stairs(yn, x, color='orange', ls='--', lw=2, label="C")
-    ax.stairs(yn/3, x*3-2, ls='--', lw=2, baseline=0.5,
-              orientation='horizontal', label="D")
-    ax.stairs(y[::-1]*3+13, x-1, color='red', ls='--', lw=2, baseline=None,
-              label="E")
-    ax.stairs(y[::-1]*3+14, x, baseline=26,
-              color='purple', ls='--', lw=2, label="F")
-    ax.stairs(yn[::-1]*3+15, x+1, baseline=np.linspace(27, 25, len(y)),
-              color='blue', ls='--', label="G", fill=True)
-    ax.stairs(y[:-1][::-1]*2+11, x[:-1]+0.5, color='black', ls='--', lw=2,
-              baseline=12, hatch='//', label="H")
-    ax.legend(loc=0)
-
-
-@image_comparison(['test_stairs_datetime.png'])
-def test_stairs_datetime():
-    f, ax = plt.subplots(constrained_layout=True)
-    ax.stairs(np.arange(36),
-              np.arange(np.datetime64('2001-12-27'),
-                        np.datetime64('2002-02-02')))
-    plt.xticks(rotation=30)
-
-
-@check_figures_equal(extensions=['png'])
-def test_stairs_edge_handling(fig_test, fig_ref):
-    # Test
-    test_ax = fig_test.add_subplot()
-    test_ax.stairs([1, 2, 3], color='red', fill=True)
-
-    # Ref
-    ref_ax = fig_ref.add_subplot()
-    st = ref_ax.stairs([1, 2, 3], fill=True)
-    st.set_color('red')
-
-
-def contour_dat():
-    x = np.linspace(-3, 5, 150)
-    y = np.linspace(-3, 5, 120)
-    z = np.cos(x) + np.sin(y[:, np.newaxis])
-    return x, y, z
-
-
-@image_comparison(['contour_hatching'], remove_text=True, style='mpl20')
-def test_contour_hatching():
-    x, y, z = contour_dat()
-    fig, ax = plt.subplots()
-    ax.contourf(x, y, z, 7, hatches=['/', '\\', '//', '-'],
-                cmap=mpl.colormaps['gray'],
-                extend='both', alpha=0.5)
-
-
-@image_comparison(
-    ['contour_colorbar'], style='mpl20',
-    tol=0.54 if platform.machine() in ('aarch64', 'arm64', 'ppc64le', 's390x') else 0)
-def test_contour_colorbar():
-    x, y, z = contour_dat()
-
-    fig, ax = plt.subplots()
-    cs = ax.contourf(x, y, z, levels=np.arange(-1.8, 1.801, 0.2),
-                     cmap=mpl.colormaps['RdBu'],
-                     vmin=-0.6,
-                     vmax=0.6,
-                     extend='both')
-    cs1 = ax.contour(x, y, z, levels=np.arange(-2.2, -0.599, 0.2),
-                     colors=['y'],
-                     linestyles='solid',
-                     linewidths=2)
-    cs2 = ax.contour(x, y, z, levels=np.arange(0.6, 2.2, 0.2),
-                     colors=['c'],
-                     linewidths=2)
-    cbar = fig.colorbar(cs, ax=ax)
-    cbar.add_lines(cs1)
-    cbar.add_lines(cs2, erase=False)
-
-
-@image_comparison(['hist2d', 'hist2d'], remove_text=True, style='mpl20')
-def test_hist2d():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
-    np.random.seed(0)
-    # make it not symmetric in case we switch x and y axis
-    x = np.random.randn(100)*2+5
-    y = np.random.randn(100)-2
-    fig, ax = plt.subplots()
-    ax.hist2d(x, y, bins=10, rasterized=True)
-
-    # Reuse testcase from above for a labeled data test
-    data = {"x": x, "y": y}
-    fig, ax = plt.subplots()
-    ax.hist2d("x", "y", bins=10, data=data, rasterized=True)
-
-
-@image_comparison(['hist2d_transpose'], remove_text=True, style='mpl20')
-def test_hist2d_transpose():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
-    np.random.seed(0)
-    # make sure the output from np.histogram is transposed before
-    # passing to pcolorfast
-    x = np.array([5]*100)
-    y = np.random.randn(100)-2
-    fig, ax = plt.subplots()
-    ax.hist2d(x, y, bins=10, rasterized=True)
-
-
-def test_hist2d_density():
-    x, y = np.random.random((2, 100))
-    ax = plt.figure().subplots()
-    for obj in [ax, plt]:
-        obj.hist2d(x, y, density=True)
-
-
-class TestScatter:
-    @image_comparison(['scatter'], style='mpl20', remove_text=True)
-    def test_scatter_plot(self):
-        data = {"x": np.array([3, 4, 2, 6]), "y": np.array([2, 5, 2, 3]),
-                "c": ['r', 'y', 'b', 'lime'], "s": [24, 15, 19, 29],
-                "c2": ['0.5', '0.6', '0.7', '0.8']}
-
-        fig, ax = plt.subplots()
-        ax.scatter(data["x"] - 1., data["y"] - 1., c=data["c"], s=data["s"])
-        ax.scatter(data["x"] + 1., data["y"] + 1., c=data["c2"], s=data["s"])
-        ax.scatter("x", "y", c="c", s="s", data=data)
-
-    @image_comparison(['scatter_marker.png'], remove_text=True)
-    def test_scatter_marker(self):
-        fig, (ax0, ax1, ax2) = plt.subplots(ncols=3)
-        ax0.scatter([3, 4, 2, 6], [2, 5, 2, 3],
-                    c=[(1, 0, 0), 'y', 'b', 'lime'],
-                    s=[60, 50, 40, 30],
-                    edgecolors=['k', 'r', 'g', 'b'],
-                    marker='s')
-        ax1.scatter([3, 4, 2, 6], [2, 5, 2, 3],
-                    c=[(1, 0, 0), 'y', 'b', 'lime'],
-                    s=[60, 50, 40, 30],
-                    edgecolors=['k', 'r', 'g', 'b'],
-                    marker=mmarkers.MarkerStyle('o', fillstyle='top'))
-        # unit area ellipse
-        rx, ry = 3, 1
-        area = rx * ry * np.pi
-        theta = np.linspace(0, 2 * np.pi, 21)
-        verts = np.column_stack([np.cos(theta) * rx / area,
-                                 np.sin(theta) * ry / area])
-        ax2.scatter([3, 4, 2, 6], [2, 5, 2, 3],
-                    c=[(1, 0, 0), 'y', 'b', 'lime'],
-                    s=[60, 50, 40, 30],
-                    edgecolors=['k', 'r', 'g', 'b'],
-                    marker=verts)
-
-    @image_comparison(['scatter_2D'], remove_text=True, extensions=['png'])
-    def test_scatter_2D(self):
-        x = np.arange(3)
-        y = np.arange(2)
-        x, y = np.meshgrid(x, y)
-        z = x + y
-        fig, ax = plt.subplots()
-        ax.scatter(x, y, c=z, s=200, edgecolors='face')
-
-    @check_figures_equal(extensions=["png"])
-    def test_scatter_decimal(self, fig_test, fig_ref):
-        x0 = np.array([1.5, 8.4, 5.3, 4.2])
-        y0 = np.array([1.1, 2.2, 3.3, 4.4])
-        x = np.array([Decimal(i) for i in x0])
-        y = np.array([Decimal(i) for i in y0])
-        c = ['r', 'y', 'b', 'lime']
-        s = [24, 15, 19, 29]
-        # Test image - scatter plot with Decimal() input
-        ax = fig_test.subplots()
-        ax.scatter(x, y, c=c, s=s)
-        # Reference image
-        ax = fig_ref.subplots()
-        ax.scatter(x0, y0, c=c, s=s)
-
-    def test_scatter_color(self):
-        # Try to catch cases where 'c' kwarg should have been used.
-        with pytest.raises(ValueError):
-            plt.scatter([1, 2], [1, 2], color=[0.1, 0.2])
-        with pytest.raises(ValueError):
-            plt.scatter([1, 2, 3], [1, 2, 3], color=[1, 2, 3])
-
-    @pytest.mark.parametrize('kwargs',
-                                [
-                                    {'cmap': 'gray'},
-                                    {'norm': mcolors.Normalize()},
-                                    {'vmin': 0},
-                                    {'vmax': 0}
-                                ])
-    def test_scatter_color_warning(self, kwargs):
-        warn_match = "No data for colormapping provided "
-        # Warn for cases where 'cmap', 'norm', 'vmin', 'vmax'
-        # kwargs are being overridden
-        with pytest.warns(Warning, match=warn_match):
-            plt.scatter([], [], **kwargs)
-        with pytest.warns(Warning, match=warn_match):
-            plt.scatter([1, 2], [3, 4], c=[], **kwargs)
-        # Do not warn for cases where 'c' matches 'x' and 'y'
-        plt.scatter([], [], c=[], **kwargs)
-        plt.scatter([1, 2], [3, 4], c=[4, 5], **kwargs)
-
-    def test_scatter_unfilled(self):
-        coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
-                           marker=mmarkers.MarkerStyle('o', fillstyle='none'),
-                           linewidths=[1.1, 1.2, 1.3])
-        assert coll.get_facecolors().shape == (0, 4)  # no facecolors
-        assert_array_equal(coll.get_edgecolors(), [[0.1, 0.1, 0.1, 1],
-                                                   [0.3, 0.3, 0.3, 1],
-                                                   [0.5, 0.5, 0.5, 1]])
-        assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
-
-    @mpl.style.context('default')
-    def test_scatter_unfillable(self):
-        coll = plt.scatter([0, 1, 2], [1, 3, 2], c=['0.1', '0.3', '0.5'],
-                           marker='x',
-                           linewidths=[1.1, 1.2, 1.3])
-        assert_array_equal(coll.get_facecolors(), coll.get_edgecolors())
-        assert_array_equal(coll.get_edgecolors(), [[0.1, 0.1, 0.1, 1],
-                                                   [0.3, 0.3, 0.3, 1],
-                                                   [0.5, 0.5, 0.5, 1]])
-        assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
-
-    def test_scatter_size_arg_size(self):
-        x = np.arange(4)
-        with pytest.raises(ValueError, match='same size as x and y'):
-            plt.scatter(x, x, x[1:])
-        with pytest.raises(ValueError, match='same size as x and y'):
-            plt.scatter(x[1:], x[1:], x)
-        with pytest.raises(ValueError, match='float array-like'):
-            plt.scatter(x, x, 'foo')
-
-    def test_scatter_edgecolor_RGB(self):
-        # GitHub issue 19066
-        coll = plt.scatter([1, 2, 3], [1, np.nan, np.nan],
-                            edgecolor=(1, 0, 0))
-        assert mcolors.same_color(coll.get_edgecolor(), (1, 0, 0))
-        coll = plt.scatter([1, 2, 3, 4], [1, np.nan, np.nan, 1],
-                            edgecolor=(1, 0, 0, 1))
-        assert mcolors.same_color(coll.get_edgecolor(), (1, 0, 0, 1))
-
-    @check_figures_equal(extensions=["png"])
-    def test_scatter_invalid_color(self, fig_test, fig_ref):
-        ax = fig_test.subplots()
-        cmap = mpl.colormaps["viridis"].resampled(16)
-        cmap.set_bad("k", 1)
-        # Set a nonuniform size to prevent the last call to `scatter` (plotting
-        # the invalid points separately in fig_ref) from using the marker
-        # stamping fast path, which would result in slightly offset markers.
-        ax.scatter(range(4), range(4),
-                   c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
-                   cmap=cmap, plotnonfinite=True)
-        ax = fig_ref.subplots()
-        cmap = mpl.colormaps["viridis"].resampled(16)
-        ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
-        ax.scatter([1, 3], [1, 3], s=[2, 4], color="k")
-
-    @check_figures_equal(extensions=["png"])
-    def test_scatter_no_invalid_color(self, fig_test, fig_ref):
-        # With plotnonfinite=False we plot only 2 points.
-        ax = fig_test.subplots()
-        cmap = mpl.colormaps["viridis"].resampled(16)
-        cmap.set_bad("k", 1)
-        ax.scatter(range(4), range(4),
-                   c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
-                   cmap=cmap, plotnonfinite=False)
-        ax = fig_ref.subplots()
-        ax.scatter([0, 2], [0, 2], c=[1, 2], s=[1, 3], cmap=cmap)
-
-    def test_scatter_norm_vminvmax(self):
-        """Parameters vmin, vmax should error if norm is given."""
-        x = [1, 2, 3]
-        ax = plt.axes()
-        with pytest.raises(ValueError,
-                           match="Passing a Normalize instance simultaneously "
-                                 "with vmin/vmax is not supported."):
-            ax.scatter(x, x, c=x, norm=mcolors.Normalize(-10, 10),
-                       vmin=0, vmax=5)
-
-    @check_figures_equal(extensions=["png"])
-    def test_scatter_single_point(self, fig_test, fig_ref):
-        ax = fig_test.subplots()
-        ax.scatter(1, 1, c=1)
-        ax = fig_ref.subplots()
-        ax.scatter([1], [1], c=[1])
-
-    @check_figures_equal(extensions=["png"])
-    def test_scatter_different_shapes(self, fig_test, fig_ref):
-        x = np.arange(10)
-        ax = fig_test.subplots()
-        ax.scatter(x, x.reshape(2, 5), c=x.reshape(5, 2))
-        ax = fig_ref.subplots()
-        ax.scatter(x.reshape(5, 2), x, c=x.reshape(2, 5))
-
-    # Parameters for *test_scatter_c*. NB: assuming that the
-    # scatter plot will have 4 elements. The tuple scheme is:
-    # (*c* parameter case, exception regexp key or None if no exception)
-    params_test_scatter_c = [
-        # single string:
-        ('0.5', None),
-        # Single letter-sequences
-        (["rgby"], "conversion"),
-        # Special cases
-        ("red", None),
-        ("none", None),
-        (None, None),
-        (["r", "g", "b", "none"], None),
-        # Non-valid color spec (FWIW, 'jaune' means yellow in French)
-        ("jaune", "conversion"),
-        (["jaune"], "conversion"),  # wrong type before wrong size
-        (["jaune"]*4, "conversion"),
-        # Value-mapping like
-        ([0.5]*3, None),  # should emit a warning for user's eyes though
-        ([0.5]*4, None),  # NB: no warning as matching size allows mapping
-        ([0.5]*5, "shape"),
-        # list of strings:
-        (['0.5', '0.4', '0.6', '0.7'], None),
-        (['0.5', 'red', '0.6', 'C5'], None),
-        (['0.5', 0.5, '0.6', 'C5'], "conversion"),
-        # RGB values
-        ([[1, 0, 0]], None),
-        ([[1, 0, 0]]*3, "shape"),
-        ([[1, 0, 0]]*4, None),
-        ([[1, 0, 0]]*5, "shape"),
-        # RGBA values
-        ([[1, 0, 0, 0.5]], None),
-        ([[1, 0, 0, 0.5]]*3, "shape"),
-        ([[1, 0, 0, 0.5]]*4, None),
-        ([[1, 0, 0, 0.5]]*5, "shape"),
-        # Mix of valid color specs
-        ([[1, 0, 0, 0.5]]*3 + [[1, 0, 0]], None),
-        ([[1, 0, 0, 0.5], "red", "0.0"], "shape"),
-        ([[1, 0, 0, 0.5], "red", "0.0", "C5"], None),
-        ([[1, 0, 0, 0.5], "red", "0.0", "C5", [0, 1, 0]], "shape"),
-        # Mix of valid and non valid color specs
-        ([[1, 0, 0, 0.5], "red", "jaune"], "conversion"),
-        ([[1, 0, 0, 0.5], "red", "0.0", "jaune"], "conversion"),
-        ([[1, 0, 0, 0.5], "red", "0.0", "C5", "jaune"], "conversion"),
-    ]
-
-    @pytest.mark.parametrize('c_case, re_key', params_test_scatter_c)
-    def test_scatter_c(self, c_case, re_key):
-        def get_next_color():
-            return 'blue'  # currently unused
-
-        xsize = 4
-        # Additional checking of *c* (introduced in #11383).
-        REGEXP = {
-            "shape": "^'c' argument has [0-9]+ elements",  # shape mismatch
-            "conversion": "^'c' argument must be a color",  # bad vals
-            }
-
-        assert_context = (
-            pytest.raises(ValueError, match=REGEXP[re_key])
-            if re_key is not None
-            else pytest.warns(match="argument looks like a single numeric RGB")
-            if isinstance(c_case, list) and len(c_case) == 3
-            else contextlib.nullcontext()
-        )
-        with assert_context:
-            mpl.axes.Axes._parse_scatter_color_args(
-                c=c_case, edgecolors="black", kwargs={}, xsize=xsize,
-                get_next_color_func=get_next_color)
-
-    @mpl.style.context('default')
-    @check_figures_equal(extensions=["png"])
-    def test_scatter_single_color_c(self, fig_test, fig_ref):
-        rgb = [[1, 0.5, 0.05]]
-        rgba = [[1, 0.5, 0.05, .5]]
-
-        # set via color kwarg
-        ax_ref = fig_ref.subplots()
-        ax_ref.scatter(np.ones(3), range(3), color=rgb)
-        ax_ref.scatter(np.ones(4)*2, range(4), color=rgba)
-
-        # set via broadcasting via c
-        ax_test = fig_test.subplots()
-        ax_test.scatter(np.ones(3), range(3), c=rgb)
-        ax_test.scatter(np.ones(4)*2, range(4), c=rgba)
-
-    def test_scatter_linewidths(self):
-        x = np.arange(5)
-
-        fig, ax = plt.subplots()
-        for i in range(3):
-            pc = ax.scatter(x, np.full(5, i), c=f'C{i}', marker='x', s=100,
-                            linewidths=i + 1)
-            assert pc.get_linewidths() == i + 1
-
-        pc = ax.scatter(x, np.full(5, 3), c='C3', marker='x', s=100,
-                        linewidths=[*range(1, 5), None])
-        assert_array_equal(pc.get_linewidths(),
-                           [*range(1, 5), mpl.rcParams['lines.linewidth']])
-
-    def test_scatter_singular_plural_arguments(self):
-
-        with pytest.raises(TypeError,
-                           match="Got both 'linewidth' and 'linewidths',\
- which are aliases of one another"):
-            plt.scatter([1, 2, 3], [1, 2, 3], linewidths=[0.5, 0.4, 0.3], linewidth=0.2)
-
-        with pytest.raises(TypeError,
-                           match="Got both 'edgecolor' and 'edgecolors',\
- which are aliases of one another"):
-            plt.scatter([1, 2, 3], [1, 2, 3],
-                        edgecolors=["#ffffff", "#000000", "#f0f0f0"],
-                          edgecolor="#ffffff")
-
-        with pytest.raises(TypeError,
-                           match="Got both 'facecolors' and 'facecolor',\
- which are aliases of one another"):
-            plt.scatter([1, 2, 3], [1, 2, 3],
-                        facecolors=["#ffffff", "#000000", "#f0f0f0"],
-                            facecolor="#ffffff")
-
-
-def _params(c=None, xsize=2, *, edgecolors=None, **kwargs):
-    return (c, edgecolors, kwargs, xsize)
-_result = namedtuple('_result', 'c, colors')
-
-
-@pytest.mark.parametrize(
-    'params, expected_result',
-    [(_params(),
-      _result(c='b', colors=np.array([[0, 0, 1, 1]]))),
-     (_params(c='r'),
-      _result(c='r', colors=np.array([[1, 0, 0, 1]]))),
-     (_params(c='r', colors='b'),
-      _result(c='r', colors=np.array([[1, 0, 0, 1]]))),
-     # color
-     (_params(color='b'),
-      _result(c='b', colors=np.array([[0, 0, 1, 1]]))),
-     (_params(color=['b', 'g']),
-      _result(c=['b', 'g'], colors=np.array([[0, 0, 1, 1], [0, .5, 0, 1]]))),
-     ])
-def test_parse_scatter_color_args(params, expected_result):
-    def get_next_color():
-        return 'blue'  # currently unused
-
-    c, colors, _edgecolors = mpl.axes.Axes._parse_scatter_color_args(
-        *params, get_next_color_func=get_next_color)
-    assert c == expected_result.c
-    assert_allclose(colors, expected_result.colors)
-
-del _params
-del _result
-
-
-@pytest.mark.parametrize(
-    'kwargs, expected_edgecolors',
-    [(dict(), None),
-     (dict(c='b'), None),
-     (dict(edgecolors='r'), 'r'),
-     (dict(edgecolors=['r', 'g']), ['r', 'g']),
-     (dict(edgecolor='r'), 'r'),
-     (dict(edgecolors='face'), 'face'),
-     (dict(edgecolors='none'), 'none'),
-     (dict(edgecolor='r', edgecolors='g'), 'r'),
-     (dict(c='b', edgecolor='r', edgecolors='g'), 'r'),
-     (dict(color='r'), 'r'),
-     (dict(color='r', edgecolor='g'), 'g'),
-     ])
-def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
-    def get_next_color():
-        return 'blue'  # currently unused
-
-    c = kwargs.pop('c', None)
-    edgecolors = kwargs.pop('edgecolors', None)
-    _, _, result_edgecolors = \
-        mpl.axes.Axes._parse_scatter_color_args(
-            c, edgecolors, kwargs, xsize=2, get_next_color_func=get_next_color)
-    assert result_edgecolors == expected_edgecolors
-
-
-def test_parse_scatter_color_args_error():
-    def get_next_color():
-        return 'blue'  # currently unused
-
-    with pytest.raises(ValueError,
-                       match="RGBA values should be within 0-1 range"):
-        c = np.array([[0.1, 0.2, 0.7], [0.2, 0.4, 1.4]])  # value > 1
-        mpl.axes.Axes._parse_scatter_color_args(
-            c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)
-
-
-def test_as_mpl_axes_api():
-    # tests the _as_mpl_axes api
-    class Polar:
-        def __init__(self):
-            self.theta_offset = 0
-
-        def _as_mpl_axes(self):
-            # implement the matplotlib axes interface
-            return PolarAxes, {'theta_offset': self.theta_offset}
-
-    prj = Polar()
-    prj2 = Polar()
-    prj2.theta_offset = np.pi
-
-    # testing axes creation with plt.axes
-    ax = plt.axes((0, 0, 1, 1), projection=prj)
-    assert type(ax) is PolarAxes
-    plt.close()
-
-    # testing axes creation with subplot
-    ax = plt.subplot(121, projection=prj)
-    assert type(ax) is PolarAxes
-    plt.close()
-
-
-def test_pyplot_axes():
-    # test focusing of Axes in other Figure
-    fig1, ax1 = plt.subplots()
-    fig2, ax2 = plt.subplots()
-    plt.sca(ax1)
-    assert ax1 is plt.gca()
-    assert fig1 is plt.gcf()
-    plt.close(fig1)
-    plt.close(fig2)
-
-
-def test_log_scales():
-    fig, ax = plt.subplots()
-    ax.plot(np.log(np.linspace(0.1, 100)))
-    ax.set_yscale('log', base=5.5)
-    ax.invert_yaxis()
-    ax.set_xscale('log', base=9.0)
-    xticks, yticks = (
-        [(t.get_loc(), t.label1.get_text()) for t in axis._update_ticks()]
-        for axis in [ax.xaxis, ax.yaxis]
-    )
-    assert xticks == [
-        (1.0, '$\\mathdefault{9^{0}}$'),
-        (9.0, '$\\mathdefault{9^{1}}$'),
-        (81.0, '$\\mathdefault{9^{2}}$'),
-        (2.0, ''),
-        (3.0, ''),
-        (4.0, ''),
-        (5.0, ''),
-        (6.0, ''),
-        (7.0, ''),
-        (8.0, ''),
-        (18.0, ''),
-        (27.0, ''),
-        (36.0, ''),
-        (45.0, ''),
-        (54.0, ''),
-        (63.0, ''),
-        (72.0, ''),
-    ]
-    assert yticks == [
-        (0.18181818181818182, '$\\mathdefault{5.5^{-1}}$'),
-        (1.0, '$\\mathdefault{5.5^{0}}$'),
-        (5.5, '$\\mathdefault{5.5^{1}}$'),
-        (0.36363636363636365, ''),
-        (0.5454545454545454, ''),
-        (0.7272727272727273, ''),
-        (0.9090909090909092, ''),
-        (2.0, ''),
-        (3.0, ''),
-        (4.0, ''),
-        (5.0, ''),
-    ]
-
-
-def test_log_scales_no_data():
-    _, ax = plt.subplots()
-    ax.set(xscale="log", yscale="log")
-    ax.xaxis.set_major_locator(mticker.MultipleLocator(1))
-    assert ax.get_xlim() == ax.get_ylim() == (1, 10)
-
-
-def test_log_scales_invalid():
-    fig, ax = plt.subplots()
-    ax.set_xscale('log')
-    with pytest.warns(UserWarning, match='Attempt to set non-positive'):
-        ax.set_xlim(-1, 10)
-    ax.set_yscale('log')
-    with pytest.warns(UserWarning, match='Attempt to set non-positive'):
-        ax.set_ylim(-1, 10)
-
-
-@image_comparison(['stackplot_test_image', 'stackplot_test_image'],
-                  tol=0.031 if platform.machine() == 'arm64' else 0)
-def test_stackplot():
-    fig = plt.figure()
-    x = np.linspace(0, 10, 10)
-    y1 = 1.0 * x
-    y2 = 2.0 * x + 1
-    y3 = 3.0 * x + 2
-    ax = fig.add_subplot(1, 1, 1)
-    ax.stackplot(x, y1, y2, y3)
-    ax.set_xlim((0, 10))
-    ax.set_ylim((0, 70))
-
-    # Reuse testcase from above for a test with labeled data and with colours
-    # from the Axes property cycle.
-    data = {"x": x, "y1": y1, "y2": y2, "y3": y3}
-    fig, ax = plt.subplots()
-    ax.stackplot("x", "y1", "y2", "y3", data=data, colors=["C0", "C1", "C2"])
-    ax.set_xlim((0, 10))
-    ax.set_ylim((0, 70))
-
-
-@image_comparison(['stackplot_test_baseline'], remove_text=True)
-def test_stackplot_baseline():
-    np.random.seed(0)
-
-    def layers(n, m):
-        a = np.zeros((m, n))
-        for i in range(n):
-            for j in range(5):
-                x = 1 / (.1 + np.random.random())
-                y = 2 * np.random.random() - .5
-                z = 10 / (.1 + np.random.random())
-                a[:, i] += x * np.exp(-((np.arange(m) / m - y) * z) ** 2)
+        # Set normalizer if bins is 'log'
+        if cbook._str_equal(bins, 'log'):
+            if norm is not None:
+                _api.warn_external("Only one of 'bins' and 'norm' arguments "
+                                   f"can be supplied, ignoring {bins=}")
+            else:
+                norm = mcolors.LogNorm(vmin=vmin, vmax=vmax)
+                vmin = vmax = None
+            bins = None
+
+        if bins is not None:
+            if not np.iterable(bins):
+                minimum, maximum = min(accum), max(accum)
+                bins -= 1  # one less edge than bins
+                bins = minimum + (maximum - minimum) * np.arange(bins) / bins
+            bins = np.sort(bins)
+            accum = bins.searchsorted(accum)
+
+        if colorizer:
+            collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
+                                                     norm=norm, vmin=vmin,
+                                                     vmax=vmax)
+        else:
+            collection.set_cmap(cmap)
+            collection.set_norm(norm)
+        collection.set_array(accum)
+        collection.set_alpha(alpha)
+        collection._internal_update(kwargs)
+        collection._scale_norm(norm, vmin, vmax)
+
+        # autoscale the norm with current accum values if it hasn't been set
+        if norm is not None:
+            if collection.norm.vmin is None and collection.norm.vmax is None:
+                collection.norm.autoscale()
+
+        corners = ((xmin, ymin), (xmax, ymax))
+        self.update_datalim(corners)
+        self._request_autoscale_view(tight=True)
+
+        # add the collection last
+        self.add_collection(collection, autolim=False)
+        if not marginals:
+            return collection
+
+        # Process marginals
+        bars = []
+        for zname, z, zmin, zmax, zscale, nbins in [
+                ("x", x, xmin, xmax, xscale, nx),
+                ("y", y, ymin, ymax, yscale, 2 * ny),
+        ]:
+
+            if zscale == "log":
+                bin_edges = np.geomspace(zmin, zmax, nbins + 1)
+            else:
+                bin_edges = np.linspace(zmin, zmax, nbins + 1)
+
+            verts = np.empty((nbins, 4, 2))
+            verts[:, 0, 0] = verts[:, 1, 0] = bin_edges[:-1]
+            verts[:, 2, 0] = verts[:, 3, 0] = bin_edges[1:]
+            verts[:, 0, 1] = verts[:, 3, 1] = .00
+            verts[:, 1, 1] = verts[:, 2, 1] = .05
+            if zname == "y":
+                verts = verts[:, :, ::-1]  # Swap x and y.
+
+            # Sort z-values into bins defined by bin_edges.
+            bin_idxs = np.searchsorted(bin_edges, z) - 1
+            values = np.empty(nbins)
+            for i in range(nbins):
+                # Get C-values for each bin, and compute bin value with
+                # reduce_C_function.
+                ci = C[bin_idxs == i]
+                values[i] = reduce_C_function(ci) if len(ci) > 0 else np.nan
+
+            mask = ~np.isnan(values)
+            verts = verts[mask]
+            values = values[mask]
+
+            trans = getattr(self, f"get_{zname}axis_transform")(which="grid")
+            bar = mcoll.PolyCollection(
+                verts, transform=trans, edgecolors="face")
+            bar.set_array(values)
+            bar.set_cmap(cmap)
+            bar.set_norm(norm)
+            bar.set_alpha(alpha)
+            bar._internal_update(kwargs)
+            bars.append(self.add_collection(bar, autolim=False))
+
+        collection.hbar, collection.vbar = bars
+
+        def on_changed(collection):
+            collection.hbar.set_cmap(collection.get_cmap())
+            collection.hbar.set_cmap(collection.get_cmap())
+            collection.vbar.set_clim(collection.get_clim())
+            collection.vbar.set_clim(collection.get_clim())
+
+        collection.callbacks.connect('changed', on_changed)
+
+        return collection
+
+    @_docstring.interpd
+    def arrow(self, x, y, dx, dy, **kwargs):
+        """
+        Add an arrow to the Axes.
+
+        This draws an arrow from ``(x, y)`` to ``(x+dx, y+dy)``.
+
+        Parameters
+        ----------
+        %(FancyArrow)s
+
+        Returns
+        -------
+        `.FancyArrow`
+            The created `.FancyArrow` object.
+
+        Notes
+        -----
+        The resulting arrow is affected by the Axes aspect ratio and limits.
+        This may produce an arrow whose head is not square with its stem. To
+        create an arrow whose head is square with its stem,
+        use :meth:`annotate` for example:
+
+        >>> ax.annotate("", xy=(0.5, 0.5), xytext=(0, 0),
+        ...             arrowprops=dict(arrowstyle="->"))
+
+        """
+        # Strip away units for the underlying patch since units
+        # do not make sense to most patch-like code
+        x = self.convert_xunits(x)
+        y = self.convert_yunits(y)
+        dx = self.convert_xunits(dx)
+        dy = self.convert_yunits(dy)
+
+        a = mpatches.FancyArrow(x, y, dx, dy, **kwargs)
+        self.add_patch(a)
+        self._request_autoscale_view()
         return a
 
-    d = layers(3, 100)
-    d[50, :] = 0  # test for fixed weighted wiggle (issue #6313)
-
-    fig, axs = plt.subplots(2, 2)
-
-    axs[0, 0].stackplot(range(100), d.T, baseline='zero')
-    axs[0, 1].stackplot(range(100), d.T, baseline='sym')
-    axs[1, 0].stackplot(range(100), d.T, baseline='wiggle')
-    axs[1, 1].stackplot(range(100), d.T, baseline='weighted_wiggle')
-
-
-@check_figures_equal()
-def test_stackplot_hatching(fig_ref, fig_test):
-    x = np.linspace(0, 10, 10)
-    y1 = 1.0 * x
-    y2 = 2.0 * x + 1
-    y3 = 3.0 * x + 2
-    # stackplot with different hatching styles (issue #27146)
-    ax_test = fig_test.subplots()
-    ax_test.stackplot(x, y1, y2, y3, hatch=["x", "//", "\\\\"], colors=["white"])
-    ax_test.set_xlim((0, 10))
-    ax_test.set_ylim((0, 70))
-    # compare with result from hatching each layer individually
-    stack_baseline = np.zeros(len(x))
-    ax_ref = fig_ref.subplots()
-    ax_ref.fill_between(x, stack_baseline, y1, hatch="x", facecolor="white")
-    ax_ref.fill_between(x, y1, y1+y2, hatch="//", facecolor="white")
-    ax_ref.fill_between(x, y1+y2, y1+y2+y3, hatch="\\\\", facecolor="white")
-    ax_ref.set_xlim((0, 10))
-    ax_ref.set_ylim((0, 70))
-
-
-def _bxp_test_helper(
-        stats_kwargs={}, transform_stats=lambda s: s, bxp_kwargs={}):
-    np.random.seed(937)
-    logstats = mpl.cbook.boxplot_stats(
-        np.random.lognormal(mean=1.25, sigma=1., size=(37, 4)), **stats_kwargs)
-    fig, ax = plt.subplots()
-    if bxp_kwargs.get('orientation', 'vertical') == 'vertical':
-        ax.set_yscale('log')
-    else:
-        ax.set_xscale('log')
-    # Work around baseline images generate back when bxp did not respect the
-    # boxplot.boxprops.linewidth rcParam when patch_artist is False.
-    if not bxp_kwargs.get('patch_artist', False):
-        mpl.rcParams['boxplot.boxprops.linewidth'] = \
-            mpl.rcParams['lines.linewidth']
-    ax.bxp(transform_stats(logstats), **bxp_kwargs)
-
-
-@image_comparison(['bxp_baseline.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_baseline():
-    _bxp_test_helper()
-
-
-@image_comparison(['bxp_rangewhis.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_rangewhis():
-    _bxp_test_helper(stats_kwargs=dict(whis=[0, 100]))
-
-
-@image_comparison(['bxp_percentilewhis.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_percentilewhis():
-    _bxp_test_helper(stats_kwargs=dict(whis=[5, 95]))
-
-
-@image_comparison(['bxp_with_xlabels.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_with_xlabels():
-    def transform(stats):
-        for s, label in zip(stats, list('ABCD')):
-            s['label'] = label
-        return stats
-
-    _bxp_test_helper(transform_stats=transform)
-
-
-@image_comparison(['bxp_horizontal.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default',
-                  tol=0.1)
-def test_bxp_horizontal():
-    _bxp_test_helper(bxp_kwargs=dict(orientation='horizontal'))
-
-
-@image_comparison(['bxp_with_ylabels.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default',
-                  tol=0.1)
-def test_bxp_with_ylabels():
-    def transform(stats):
-        for s, label in zip(stats, list('ABCD')):
-            s['label'] = label
-        return stats
-
-    _bxp_test_helper(transform_stats=transform,
-                     bxp_kwargs=dict(orientation='horizontal'))
-
-
-@image_comparison(['bxp_patchartist.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_patchartist():
-    _bxp_test_helper(bxp_kwargs=dict(patch_artist=True))
-
-
-@image_comparison(['bxp_custompatchartist.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 100},
-                  style='default')
-def test_bxp_custompatchartist():
-    _bxp_test_helper(bxp_kwargs=dict(
-        patch_artist=True,
-        boxprops=dict(facecolor='yellow', edgecolor='green', ls=':')))
-
-
-@image_comparison(['bxp_customoutlier.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_customoutlier():
-    _bxp_test_helper(bxp_kwargs=dict(
-        flierprops=dict(linestyle='none', marker='d', mfc='g')))
-
-
-@image_comparison(['bxp_withmean_custompoint.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_showcustommean():
-    _bxp_test_helper(bxp_kwargs=dict(
-        showmeans=True,
-        meanprops=dict(linestyle='none', marker='d', mfc='green'),
-    ))
-
-
-@image_comparison(['bxp_custombox.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_custombox():
-    _bxp_test_helper(bxp_kwargs=dict(
-        boxprops=dict(linestyle='--', color='b', lw=3)))
-
-
-@image_comparison(['bxp_custommedian.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_custommedian():
-    _bxp_test_helper(bxp_kwargs=dict(
-        medianprops=dict(linestyle='--', color='b', lw=3)))
-
-
-@image_comparison(['bxp_customcap.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_customcap():
-    _bxp_test_helper(bxp_kwargs=dict(
-        capprops=dict(linestyle='--', color='g', lw=3)))
-
-
-@image_comparison(['bxp_customwhisker.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_customwhisker():
-    _bxp_test_helper(bxp_kwargs=dict(
-        whiskerprops=dict(linestyle='-', color='m', lw=3)))
-
-
-@check_figures_equal()
-def test_boxplot_median_bound_by_box(fig_test, fig_ref):
-    data = np.arange(3)
-    medianprops_test = {"linewidth": 12}
-    medianprops_ref = {**medianprops_test, "solid_capstyle": "butt"}
-    fig_test.subplots().boxplot(data,  medianprops=medianprops_test)
-    fig_ref.subplots().boxplot(data, medianprops=medianprops_ref)
-
-
-@image_comparison(['bxp_withnotch.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_shownotches():
-    _bxp_test_helper(bxp_kwargs=dict(shownotches=True))
-
-
-@image_comparison(['bxp_nocaps.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_nocaps():
-    _bxp_test_helper(bxp_kwargs=dict(showcaps=False))
-
-
-@image_comparison(['bxp_nobox.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_nobox():
-    _bxp_test_helper(bxp_kwargs=dict(showbox=False))
-
-
-@image_comparison(['bxp_no_flier_stats.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_no_flier_stats():
-    def transform(stats):
-        for s in stats:
-            s.pop('fliers', None)
-        return stats
-
-    _bxp_test_helper(transform_stats=transform,
-                     bxp_kwargs=dict(showfliers=False))
-
-
-@image_comparison(['bxp_withmean_point.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_showmean():
-    _bxp_test_helper(bxp_kwargs=dict(showmeans=True, meanline=False))
-
-
-@image_comparison(['bxp_withmean_line.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_showmeanasline():
-    _bxp_test_helper(bxp_kwargs=dict(showmeans=True, meanline=True))
-
-
-@image_comparison(['bxp_scalarwidth.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_scalarwidth():
-    _bxp_test_helper(bxp_kwargs=dict(widths=.25))
-
-
-@image_comparison(['bxp_customwidths.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_customwidths():
-    _bxp_test_helper(bxp_kwargs=dict(widths=[0.10, 0.25, 0.65, 0.85]))
-
-
-@image_comparison(['bxp_custompositions.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_custompositions():
-    _bxp_test_helper(bxp_kwargs=dict(positions=[1, 5, 6, 7]))
-
-
-def test_bxp_bad_widths():
-    with pytest.raises(ValueError):
-        _bxp_test_helper(bxp_kwargs=dict(widths=[1]))
-
-
-def test_bxp_bad_positions():
-    with pytest.raises(ValueError):
-        _bxp_test_helper(bxp_kwargs=dict(positions=[2, 3]))
-
-
-@image_comparison(['bxp_custom_capwidths.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_custom_capwidths():
-    _bxp_test_helper(bxp_kwargs=dict(capwidths=[0.0, 0.1, 0.5, 1.0]))
-
-
-@image_comparison(['bxp_custom_capwidth.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_bxp_custom_capwidth():
-    _bxp_test_helper(bxp_kwargs=dict(capwidths=0.6))
-
-
-def test_bxp_bad_capwidths():
-    with pytest.raises(ValueError):
-        _bxp_test_helper(bxp_kwargs=dict(capwidths=[1]))
-
-
-@image_comparison(['boxplot', 'boxplot'], tol=1.28, style='default')
-def test_boxplot():
-    # Randomness used for bootstrapping.
-    np.random.seed(937)
-
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, ax = plt.subplots()
-
-    ax.boxplot([x, x], bootstrap=10000, notch=1)
-    ax.set_ylim((-30, 30))
-
-    # Reuse testcase from above for a labeled data test
-    data = {"x": [x, x]}
-    fig, ax = plt.subplots()
-    ax.boxplot("x", bootstrap=10000, notch=1, data=data)
-    ax.set_ylim((-30, 30))
-
-
-@check_figures_equal(extensions=["png"])
-def test_boxplot_masked(fig_test, fig_ref):
-    # Check that masked values are ignored when plotting a boxplot
-    x_orig = np.linspace(-1, 1, 200)
-
-    ax = fig_test.subplots()
-    x = x_orig[x_orig >= 0]
-    ax.boxplot(x)
-
-    x = np.ma.masked_less(x_orig, 0)
-    ax = fig_ref.subplots()
-    ax.boxplot(x)
-
-
-@image_comparison(['boxplot_custom_capwidths.png'],
-                  savefig_kwarg={'dpi': 40}, style='default')
-def test_boxplot_custom_capwidths():
-
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, ax = plt.subplots()
-
-    ax.boxplot([x, x], notch=1, capwidths=[0.01, 0.2])
-
-
-@image_comparison(['boxplot_sym2.png'], remove_text=True, style='default')
-def test_boxplot_sym2():
-    # Randomness used for bootstrapping.
-    np.random.seed(937)
-
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, [ax1, ax2] = plt.subplots(1, 2)
-
-    ax1.boxplot([x, x], bootstrap=10000, sym='^')
-    ax1.set_ylim((-30, 30))
-
-    ax2.boxplot([x, x], bootstrap=10000, sym='g')
-    ax2.set_ylim((-30, 30))
-
-
-@image_comparison(['boxplot_sym.png'],
-                  remove_text=True,
-                  savefig_kwarg={'dpi': 40},
-                  style='default')
-def test_boxplot_sym():
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, ax = plt.subplots()
-
-    ax.boxplot([x, x], sym='gs')
-    ax.set_ylim((-30, 30))
-
-
-@image_comparison(['boxplot_autorange_false_whiskers.png',
-                   'boxplot_autorange_true_whiskers.png'],
-                  style='default')
-def test_boxplot_autorange_whiskers():
-    # Randomness used for bootstrapping.
-    np.random.seed(937)
-
-    x = np.ones(140)
-    x = np.hstack([0, x, 2])
-
-    fig1, ax1 = plt.subplots()
-    ax1.boxplot([x, x], bootstrap=10000, notch=1)
-    ax1.set_ylim((-5, 5))
-
-    fig2, ax2 = plt.subplots()
-    ax2.boxplot([x, x], bootstrap=10000, notch=1, autorange=True)
-    ax2.set_ylim((-5, 5))
-
-
-def _rc_test_bxp_helper(ax, rc_dict):
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    with matplotlib.rc_context(rc_dict):
-        ax.boxplot([x, x])
-    return ax
-
-
-@image_comparison(['boxplot_rc_parameters'],
-                  savefig_kwarg={'dpi': 100}, remove_text=True,
-                  tol=1, style='default')
-def test_boxplot_rc_parameters():
-    # Randomness used for bootstrapping.
-    np.random.seed(937)
-
-    fig, ax = plt.subplots(3)
-
-    rc_axis0 = {
-        'boxplot.notch': True,
-        'boxplot.whiskers': [5, 95],
-        'boxplot.bootstrap': 10000,
-
-        'boxplot.flierprops.color': 'b',
-        'boxplot.flierprops.marker': 'o',
-        'boxplot.flierprops.markerfacecolor': 'g',
-        'boxplot.flierprops.markeredgecolor': 'b',
-        'boxplot.flierprops.markersize': 5,
-        'boxplot.flierprops.linestyle': '--',
-        'boxplot.flierprops.linewidth': 2.0,
-
-        'boxplot.boxprops.color': 'r',
-        'boxplot.boxprops.linewidth': 2.0,
-        'boxplot.boxprops.linestyle': '--',
-
-        'boxplot.capprops.color': 'c',
-        'boxplot.capprops.linewidth': 2.0,
-        'boxplot.capprops.linestyle': '--',
-
-        'boxplot.medianprops.color': 'k',
-        'boxplot.medianprops.linewidth': 2.0,
-        'boxplot.medianprops.linestyle': '--',
-    }
-
-    rc_axis1 = {
-        'boxplot.whiskers': [0, 100],
-        'boxplot.patchartist': True,
-    }
-
-    rc_axis2 = {
-        'boxplot.whiskers': 2.0,
-        'boxplot.showcaps': False,
-        'boxplot.showbox': False,
-        'boxplot.showfliers': False,
-        'boxplot.showmeans': True,
-        'boxplot.meanline': True,
-
-        'boxplot.meanprops.color': 'c',
-        'boxplot.meanprops.linewidth': 2.0,
-        'boxplot.meanprops.linestyle': '--',
-
-        'boxplot.whiskerprops.color': 'r',
-        'boxplot.whiskerprops.linewidth': 2.0,
-        'boxplot.whiskerprops.linestyle': '-.',
-    }
-    dict_list = [rc_axis0, rc_axis1, rc_axis2]
-    for axis, rc_axis in zip(ax, dict_list):
-        _rc_test_bxp_helper(axis, rc_axis)
-
-    assert (matplotlib.patches.PathPatch in
-            [type(t) for t in ax[1].get_children()])
-
-
-@image_comparison(['boxplot_with_CIarray.png'],
-                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
-def test_boxplot_with_CIarray():
-    # Randomness used for bootstrapping.
-    np.random.seed(937)
-
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, ax = plt.subplots()
-    CIs = np.array([[-1.5, 3.], [-1., 3.5]])
-
-    # show a boxplot with Matplotlib medians and confidence intervals, and
-    # another with manual values
-    ax.boxplot([x, x], bootstrap=10000, usermedians=[None, 1.0],
-               conf_intervals=CIs, notch=1)
-    ax.set_ylim((-30, 30))
-
-
-@image_comparison(['boxplot_no_inverted_whisker.png'],
-                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
-def test_boxplot_no_weird_whisker():
-    x = np.array([3, 9000, 150, 88, 350, 200000, 1400, 960],
-                 dtype=np.float64)
-    ax1 = plt.axes()
-    ax1.boxplot(x)
-    ax1.set_yscale('log')
-    ax1.yaxis.grid(False, which='minor')
-    ax1.xaxis.grid(False)
-
-
-def test_boxplot_bad_medians():
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.boxplot(x, usermedians=[1, 2])
-    with pytest.raises(ValueError):
-        ax.boxplot([x, x], usermedians=[[1, 2], [1, 2]])
-
-
-def test_boxplot_bad_ci():
-    x = np.linspace(-7, 7, 140)
-    x = np.hstack([-25, x, 25])
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.boxplot([x, x], conf_intervals=[[1, 2]])
-    with pytest.raises(ValueError):
-        ax.boxplot([x, x], conf_intervals=[[1, 2], [1]])
-
-
-def test_boxplot_zorder():
-    x = np.arange(10)
-    fix, ax = plt.subplots()
-    assert ax.boxplot(x)['boxes'][0].get_zorder() == 2
-    assert ax.boxplot(x, zorder=10)['boxes'][0].get_zorder() == 10
-
-
-def test_boxplot_marker_behavior():
-    plt.rcParams['lines.marker'] = 's'
-    plt.rcParams['boxplot.flierprops.marker'] = 'o'
-    plt.rcParams['boxplot.meanprops.marker'] = '^'
-    fig, ax = plt.subplots()
-    test_data = np.arange(100)
-    test_data[-1] = 150  # a flier point
-    bxp_handle = ax.boxplot(test_data, showmeans=True)
-    for bxp_lines in ['whiskers', 'caps', 'boxes', 'medians']:
-        for each_line in bxp_handle[bxp_lines]:
-            # Ensure that the rcParams['lines.marker'] is overridden by ''
-            assert each_line.get_marker() == ''
-
-    # Ensure that markers for fliers and means aren't overridden with ''
-    assert bxp_handle['fliers'][0].get_marker() == 'o'
-    assert bxp_handle['means'][0].get_marker() == '^'
-
-
-@image_comparison(['boxplot_mod_artists_after_plotting.png'],
-                  remove_text=True, savefig_kwarg={'dpi': 40}, style='default')
-def test_boxplot_mod_artist_after_plotting():
-    x = [0.15, 0.11, 0.06, 0.06, 0.12, 0.56, -0.56]
-    fig, ax = plt.subplots()
-    bp = ax.boxplot(x, sym="o")
-    for key in bp:
-        for obj in bp[key]:
-            obj.set_color('green')
-
-
-@image_comparison(['violinplot_vert_baseline.png',
-                   'violinplot_vert_baseline.png'])
-def test_vert_violinplot_baseline():
-    # First 9 digits of frac(sqrt(2))
-    np.random.seed(414213562)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax = plt.axes()
-    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
-                  showmedians=False)
-
-    # Reuse testcase from above for a labeled data test
-    data = {"d": data}
-    fig, ax = plt.subplots()
-    ax.violinplot("d", positions=range(4), showmeans=False, showextrema=False,
-                  showmedians=False, data=data)
-
-
-@image_comparison(['violinplot_vert_showmeans.png'])
-def test_vert_violinplot_showmeans():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(3))
-    np.random.seed(732050807)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), showmeans=True, showextrema=False,
-                  showmedians=False)
-
-
-@image_comparison(['violinplot_vert_showextrema.png'])
-def test_vert_violinplot_showextrema():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(5))
-    np.random.seed(236067977)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=True,
-                  showmedians=False)
-
-
-@image_comparison(['violinplot_vert_showmedians.png'])
-def test_vert_violinplot_showmedians():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(7))
-    np.random.seed(645751311)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
-                  showmedians=True)
-
-
-@image_comparison(['violinplot_vert_showall.png'])
-def test_vert_violinplot_showall():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(11))
-    np.random.seed(316624790)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), showmeans=True, showextrema=True,
-                  showmedians=True,
-                  quantiles=[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]])
-
-
-@image_comparison(['violinplot_vert_custompoints_10.png'])
-def test_vert_violinplot_custompoints_10():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(13))
-    np.random.seed(605551275)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
-                  showmedians=False, points=10)
-
-
-@image_comparison(['violinplot_vert_custompoints_200.png'])
-def test_vert_violinplot_custompoints_200():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(17))
-    np.random.seed(123105625)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), showmeans=False, showextrema=False,
-                  showmedians=False, points=200)
-
-
-@image_comparison(['violinplot_horiz_baseline.png'])
-def test_horiz_violinplot_baseline():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(19))
-    np.random.seed(358898943)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
-                  showextrema=False, showmedians=False)
-
-
-@image_comparison(['violinplot_horiz_showmedians.png'])
-def test_horiz_violinplot_showmedians():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(23))
-    np.random.seed(795831523)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
-                  showextrema=False, showmedians=True)
-
-
-@image_comparison(['violinplot_horiz_showmeans.png'])
-def test_horiz_violinplot_showmeans():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(29))
-    np.random.seed(385164807)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=True,
-                  showextrema=False, showmedians=False)
-
-
-@image_comparison(['violinplot_horiz_showextrema.png'])
-def test_horiz_violinplot_showextrema():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(31))
-    np.random.seed(567764362)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
-                  showextrema=True, showmedians=False)
-
-
-@image_comparison(['violinplot_horiz_showall.png'])
-def test_horiz_violinplot_showall():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(37))
-    np.random.seed(82762530)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=True,
-                  showextrema=True, showmedians=True,
-                  quantiles=[[0.1, 0.9], [0.2, 0.8], [0.3, 0.7], [0.4, 0.6]])
-
-
-@image_comparison(['violinplot_horiz_custompoints_10.png'])
-def test_horiz_violinplot_custompoints_10():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(41))
-    np.random.seed(403124237)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
-                  showextrema=False, showmedians=False, points=10)
-
-
-@image_comparison(['violinplot_horiz_custompoints_200.png'])
-def test_horiz_violinplot_custompoints_200():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(43))
-    np.random.seed(557438524)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    ax.violinplot(data, positions=range(4), orientation='horizontal', showmeans=False,
-                  showextrema=False, showmedians=False, points=200)
-
-
-@image_comparison(['violinplot_sides.png'], remove_text=True, style='mpl20')
-def test_violinplot_sides():
-    ax = plt.axes()
-    np.random.seed(19680801)
-    data = [np.random.normal(size=100)]
-    # Check horizontal violinplot
-    for pos, side in zip([0, -0.5, 0.5], ['both', 'low', 'high']):
-        ax.violinplot(data, positions=[pos], orientation='horizontal', showmeans=False,
-                      showextrema=True, showmedians=True, side=side)
-    # Check vertical violinplot
-    for pos, side in zip([4, 3.5, 4.5], ['both', 'low', 'high']):
-        ax.violinplot(data, positions=[pos], orientation='vertical', showmeans=False,
-                      showextrema=True, showmedians=True, side=side)
-
-
-def test_violinplot_bad_positions():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(47))
-    np.random.seed(855654600)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    with pytest.raises(ValueError):
-        ax.violinplot(data, positions=range(5))
-
-
-def test_violinplot_bad_widths():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(53))
-    np.random.seed(280109889)
-    data = [np.random.normal(size=100) for _ in range(4)]
-    with pytest.raises(ValueError):
-        ax.violinplot(data, positions=range(4), widths=[1, 2, 3])
-
-
-def test_violinplot_bad_quantiles():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(73))
-    np.random.seed(544003745)
-    data = [np.random.normal(size=100)]
-
-    # Different size quantile list and plots
-    with pytest.raises(ValueError):
-        ax.violinplot(data, quantiles=[[0.1, 0.2], [0.5, 0.7]])
-
-
-def test_violinplot_outofrange_quantiles():
-    ax = plt.axes()
-    # First 9 digits of frac(sqrt(79))
-    np.random.seed(888194417)
-    data = [np.random.normal(size=100)]
-
-    # Quantile value above 100
-    with pytest.raises(ValueError):
-        ax.violinplot(data, quantiles=[[0.1, 0.2, 0.3, 1.05]])
-
-    # Quantile value below 0
-    with pytest.raises(ValueError):
-        ax.violinplot(data, quantiles=[[-0.05, 0.2, 0.3, 0.75]])
-
-
-@check_figures_equal(extensions=["png"])
-def test_violinplot_single_list_quantiles(fig_test, fig_ref):
-    # Ensures quantile list for 1D can be passed in as single list
-    # First 9 digits of frac(sqrt(83))
-    np.random.seed(110433579)
-    data = [np.random.normal(size=100)]
-
-    # Test image
-    ax = fig_test.subplots()
-    ax.violinplot(data, quantiles=[0.1, 0.3, 0.9])
-
-    # Reference image
-    ax = fig_ref.subplots()
-    ax.violinplot(data, quantiles=[[0.1, 0.3, 0.9]])
-
-
-@check_figures_equal(extensions=["png"])
-def test_violinplot_pandas_series(fig_test, fig_ref, pd):
-    np.random.seed(110433579)
-    s1 = pd.Series(np.random.normal(size=7), index=[9, 8, 7, 6, 5, 4, 3])
-    s2 = pd.Series(np.random.normal(size=9), index=list('ABCDEFGHI'))
-    s3 = pd.Series(np.random.normal(size=11))
-    fig_test.subplots().violinplot([s1, s2, s3])
-    fig_ref.subplots().violinplot([s1.values, s2.values, s3.values])
-
-
-def test_manage_xticks():
-    _, ax = plt.subplots()
-    ax.set_xlim(0, 4)
-    old_xlim = ax.get_xlim()
-    np.random.seed(0)
-    y1 = np.random.normal(10, 3, 20)
-    y2 = np.random.normal(3, 1, 20)
-    ax.boxplot([y1, y2], positions=[1, 2], manage_ticks=False)
-    new_xlim = ax.get_xlim()
-    assert_array_equal(old_xlim, new_xlim)
-
-
-def test_boxplot_not_single():
-    fig, ax = plt.subplots()
-    ax.boxplot(np.random.rand(100), positions=[3])
-    ax.boxplot(np.random.rand(100), positions=[5])
-    fig.canvas.draw()
-    assert ax.get_xlim() == (2.5, 5.5)
-    assert list(ax.get_xticks()) == [3, 5]
-    assert [t.get_text() for t in ax.get_xticklabels()] == ["3", "5"]
-
-
-def test_tick_space_size_0():
-    # allow font size to be zero, which affects ticks when there is
-    # no other text in the figure.
-    plt.plot([0, 1], [0, 1])
-    matplotlib.rcParams.update({'font.size': 0})
-    b = io.BytesIO()
-    plt.savefig(b, dpi=80, format='raw')
-
-
-@image_comparison(['errorbar_basic', 'errorbar_mixed', 'errorbar_basic'])
-def test_errorbar():
-    # longdouble due to floating point rounding issues with certain
-    # computer chipsets
-    x = np.arange(0.1, 4, 0.5, dtype=np.longdouble)
-    y = np.exp(-x)
-
-    yerr = 0.1 + 0.2*np.sqrt(x)
-    xerr = 0.1 + yerr
-
-    # First illustrate basic pyplot interface, using defaults where possible.
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.errorbar(x, y, xerr=0.2, yerr=0.4)
-    ax.set_title("Simplest errorbars, 0.2 in x, 0.4 in y")
-
-    # Now switch to a more OO interface to exercise more features.
-    fig, axs = plt.subplots(nrows=2, ncols=2, sharex=True)
-    ax = axs[0, 0]
-    ax.errorbar(x, y, yerr=yerr, fmt='o')
-    ax.set_title('Vert. symmetric')
-
-    # With 4 subplots, reduce the number of axis ticks to avoid crowding.
-    ax.locator_params(nbins=4)
-
-    ax = axs[0, 1]
-    ax.errorbar(x, y, xerr=xerr, fmt='o', alpha=0.4)
-    ax.set_title('Hor. symmetric w/ alpha')
-
-    ax = axs[1, 0]
-    ax.errorbar(x, y, yerr=[yerr, 2*yerr], xerr=[xerr, 2*xerr], fmt='--o')
-    ax.set_title('H, V asymmetric')
-
-    ax = axs[1, 1]
-    ax.set_yscale('log')
-    # Here we have to be careful to keep all y values positive:
-    ylower = np.maximum(1e-2, y - yerr)
-    yerr_lower = y - ylower
-
-    ax.errorbar(x, y, yerr=[yerr_lower, 2*yerr], xerr=xerr,
-                fmt='o', ecolor='g', capthick=2)
-    ax.set_title('Mixed sym., log y')
-    # Force limits due to floating point slop potentially expanding the range
-    ax.set_ylim(1e-2, 1e1)
-
-    fig.suptitle('Variable errorbars')
-
-    # Reuse the first testcase from above for a labeled data test
-    data = {"x": x, "y": y}
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.errorbar("x", "y", xerr=0.2, yerr=0.4, data=data)
-    ax.set_title("Simplest errorbars, 0.2 in x, 0.4 in y")
-
-
-@image_comparison(['mixed_errorbar_polar_caps'], extensions=['png'],
-                  remove_text=True)
-def test_mixed_errorbar_polar_caps():
-    """
-    Mix several polar errorbar use cases in a single test figure.
-
-    It is advisable to position individual points off the grid. If there are
-    problems with reproducibility of this test, consider removing grid.
-    """
-    fig = plt.figure()
-    ax = plt.subplot(111, projection='polar')
-
-    # symmetric errorbars
-    th_sym = [1, 2, 3]
-    r_sym = [0.9]*3
-    ax.errorbar(th_sym, r_sym, xerr=0.35, yerr=0.2, fmt="o")
-
-    # long errorbars
-    th_long = [np.pi/2 + .1, np.pi + .1]
-    r_long = [1.8, 2.2]
-    ax.errorbar(th_long, r_long, xerr=0.8 * np.pi, yerr=0.15, fmt="o")
-
-    # asymmetric errorbars
-    th_asym = [4*np.pi/3 + .1, 5*np.pi/3 + .1, 2*np.pi-0.1]
-    r_asym = [1.1]*3
-    xerr = [[.3, .3, .2], [.2, .3, .3]]
-    yerr = [[.35, .5, .5], [.5, .35, .5]]
-    ax.errorbar(th_asym, r_asym, xerr=xerr, yerr=yerr, fmt="o")
-
-    # overlapping errorbar
-    th_over = [2.1]
-    r_over = [3.1]
-    ax.errorbar(th_over, r_over, xerr=10, yerr=.2, fmt="o")
-
-
-def test_errorbar_colorcycle():
-
-    f, ax = plt.subplots()
-    x = np.arange(10)
-    y = 2*x
-
-    e1, _, _ = ax.errorbar(x, y, c=None)
-    e2, _, _ = ax.errorbar(x, 2*y, c=None)
-    ln1, = ax.plot(x, 4*y)
-
-    assert mcolors.to_rgba(e1.get_color()) == mcolors.to_rgba('C0')
-    assert mcolors.to_rgba(e2.get_color()) == mcolors.to_rgba('C1')
-    assert mcolors.to_rgba(ln1.get_color()) == mcolors.to_rgba('C2')
-
-
-@check_figures_equal()
-def test_errorbar_cycle_ecolor(fig_test, fig_ref):
-    x = np.arange(0.1, 4, 0.5)
-    y = [np.exp(-x+n) for n in range(4)]
-
-    axt = fig_test.subplots()
-    axr = fig_ref.subplots()
-
-    for yi, color in zip(y, ['C0', 'C1', 'C2', 'C3']):
-        axt.errorbar(x, yi, yerr=(yi * 0.25), linestyle='-',
-                     marker='o', ecolor='black')
-        axr.errorbar(x, yi, yerr=(yi * 0.25), linestyle='-',
-                     marker='o', color=color, ecolor='black')
-
-
-def test_errorbar_shape():
-    fig = plt.figure()
-    ax = fig.gca()
-
-    x = np.arange(0.1, 4, 0.5)
-    y = np.exp(-x)
-    yerr1 = 0.1 + 0.2*np.sqrt(x)
-    yerr = np.vstack((yerr1, 2*yerr1)).T
-    xerr = 0.1 + yerr
-
-    with pytest.raises(ValueError):
-        ax.errorbar(x, y, yerr=yerr, fmt='o')
-    with pytest.raises(ValueError):
-        ax.errorbar(x, y, xerr=xerr, fmt='o')
-    with pytest.raises(ValueError):
-        ax.errorbar(x, y, yerr=yerr, xerr=xerr, fmt='o')
-
-
-@image_comparison(['errorbar_limits'])
-def test_errorbar_limits():
-    x = np.arange(0.5, 5.5, 0.5)
-    y = np.exp(-x)
-    xerr = 0.1
-    yerr = 0.2
-    ls = 'dotted'
-
-    fig, ax = plt.subplots()
-
-    # standard error bars
-    ax.errorbar(x, y, xerr=xerr, yerr=yerr, ls=ls, color='blue')
-
-    # including upper limits
-    uplims = np.zeros_like(x)
-    uplims[[1, 5, 9]] = True
-    ax.errorbar(x, y+0.5, xerr=xerr, yerr=yerr, uplims=uplims, ls=ls,
-                color='green')
-
-    # including lower limits
-    lolims = np.zeros_like(x)
-    lolims[[2, 4, 8]] = True
-    ax.errorbar(x, y+1.0, xerr=xerr, yerr=yerr, lolims=lolims, ls=ls,
-                color='red')
-
-    # including upper and lower limits
-    ax.errorbar(x, y+1.5, marker='o', ms=8, xerr=xerr, yerr=yerr,
-                lolims=lolims, uplims=uplims, ls=ls, color='magenta')
-
-    # including xlower and xupper limits
-    xerr = 0.2
-    yerr = np.full_like(x, 0.2)
-    yerr[[3, 6]] = 0.3
-    xlolims = lolims
-    xuplims = uplims
-    lolims = np.zeros_like(x)
-    uplims = np.zeros_like(x)
-    lolims[[6]] = True
-    uplims[[3]] = True
-    ax.errorbar(x, y+2.1, marker='o', ms=8, xerr=xerr, yerr=yerr,
-                xlolims=xlolims, xuplims=xuplims, uplims=uplims,
-                lolims=lolims, ls='none', mec='blue', capsize=0,
-                color='cyan')
-    ax.set_xlim((0, 5.5))
-    ax.set_title('Errorbar upper and lower limits')
-
-
-def test_errorbar_nonefmt():
-    # Check that passing 'none' as a format still plots errorbars
-    x = np.arange(5)
-    y = np.arange(5)
-
-    plotline, _, barlines = plt.errorbar(x, y, xerr=1, yerr=1, fmt='none')
-    assert plotline is None
-    for errbar in barlines:
-        assert np.all(errbar.get_color() == mcolors.to_rgba('C0'))
-
-
-def test_errorbar_line_specific_kwargs():
-    # Check that passing line-specific keyword arguments will not result in
-    # errors.
-    x = np.arange(5)
-    y = np.arange(5)
-
-    plotline, _, _ = plt.errorbar(x, y, xerr=1, yerr=1, ls='None',
-                                  marker='s', fillstyle='full',
-                                  drawstyle='steps-mid',
-                                  dash_capstyle='round',
-                                  dash_joinstyle='miter',
-                                  solid_capstyle='butt',
-                                  solid_joinstyle='bevel')
-    assert plotline.get_fillstyle() == 'full'
-    assert plotline.get_drawstyle() == 'steps-mid'
-
-
-@check_figures_equal(extensions=['png'])
-def test_errorbar_with_prop_cycle(fig_test, fig_ref):
-    ax = fig_ref.subplots()
-    ax.errorbar(x=[2, 4, 10], y=[0, 1, 2], yerr=0.5,
-                ls='--', marker='s', mfc='k')
-    ax.errorbar(x=[2, 4, 10], y=[2, 3, 4], yerr=0.5, color='tab:green',
-                ls=':', marker='s', mfc='y')
-    ax.errorbar(x=[2, 4, 10], y=[4, 5, 6], yerr=0.5, fmt='tab:blue',
-                ls='-.', marker='o', mfc='c')
-    ax.set_xlim(1, 11)
-
-    _cycle = cycler(ls=['--', ':', '-.'], marker=['s', 's', 'o'],
-                    mfc=['k', 'y', 'c'], color=['b', 'g', 'r'])
-    plt.rc("axes", prop_cycle=_cycle)
-    ax = fig_test.subplots()
-    ax.errorbar(x=[2, 4, 10], y=[0, 1, 2], yerr=0.5)
-    ax.errorbar(x=[2, 4, 10], y=[2, 3, 4], yerr=0.5, color='tab:green')
-    ax.errorbar(x=[2, 4, 10], y=[4, 5, 6], yerr=0.5, fmt='tab:blue')
-    ax.set_xlim(1, 11)
-
-
-def test_errorbar_every_invalid():
-    x = np.linspace(0, 1, 15)
-    y = x * (1-x)
-    yerr = y/6
-
-    ax = plt.figure().subplots()
-
-    with pytest.raises(ValueError, match='not a tuple of two integers'):
-        ax.errorbar(x, y, yerr, errorevery=(1, 2, 3))
-    with pytest.raises(ValueError, match='not a tuple of two integers'):
-        ax.errorbar(x, y, yerr, errorevery=(1.3, 3))
-    with pytest.raises(ValueError, match='not a valid NumPy fancy index'):
-        ax.errorbar(x, y, yerr, errorevery=[False, True])
-    with pytest.raises(ValueError, match='not a recognized value'):
-        ax.errorbar(x, y, yerr, errorevery='foobar')
-
-
-def test_xerr_yerr_not_negative():
-    ax = plt.figure().subplots()
-
-    with pytest.raises(ValueError,
-                       match="'xerr' must not contain negative values"):
-        ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]], yerr=[[-0.5], [1]])
-    with pytest.raises(ValueError,
-                       match="'xerr' must not contain negative values"):
-        ax.errorbar(x=[0], y=[0], xerr=[[-0.5], [1]])
-    with pytest.raises(ValueError,
-                       match="'yerr' must not contain negative values"):
-        ax.errorbar(x=[0], y=[0], yerr=[[-0.5], [1]])
-    with pytest.raises(ValueError,
-                       match="'yerr' must not contain negative values"):
-        x = np.arange(5)
-        y = [datetime.datetime(2021, 9, i * 2 + 1) for i in x]
-        ax.errorbar(x=x,
-                    y=y,
-                    yerr=datetime.timedelta(days=-10))
-
-
-def test_xerr_yerr_not_none():
-    ax = plt.figure().subplots()
-
-    with pytest.raises(ValueError,
-                       match="'xerr' must not contain None"):
-        ax.errorbar(x=[0], y=[0], xerr=[[None], [1]], yerr=[[None], [1]])
-    with pytest.raises(ValueError,
-                       match="'xerr' must not contain None"):
-        ax.errorbar(x=[0], y=[0], xerr=[[None], [1]])
-    with pytest.raises(ValueError,
-                       match="'yerr' must not contain None"):
-        ax.errorbar(x=[0], y=[0], yerr=[[None], [1]])
-
-
-@check_figures_equal()
-def test_errorbar_every(fig_test, fig_ref):
-    x = np.linspace(0, 1, 15)
-    y = x * (1-x)
-    yerr = y/6
-
-    ax_ref = fig_ref.subplots()
-    ax_test = fig_test.subplots()
-
-    for color, shift in zip('rgbk', [0, 0, 2, 7]):
-        y += .02
-
-        # Check errorevery using an explicit offset and step.
-        ax_test.errorbar(x, y, yerr, errorevery=(shift, 4),
-                         capsize=4, c=color)
-
-        # Using manual errorbars
-        # n.b. errorbar draws the main plot at z=2.1 by default
-        ax_ref.plot(x, y, c=color, zorder=2.1)
-        ax_ref.errorbar(x[shift::4], y[shift::4], yerr[shift::4],
-                        capsize=4, c=color, fmt='none')
-
-    # Check that markevery is propagated to line, without affecting errorbars.
-    ax_test.errorbar(x, y + 0.1, yerr, markevery=(1, 4), capsize=4, fmt='o')
-    ax_ref.plot(x[1::4], y[1::4] + 0.1, 'o', zorder=2.1)
-    ax_ref.errorbar(x, y + 0.1, yerr, capsize=4, fmt='none')
-
-    # Check that passing a slice to markevery/errorevery works.
-    ax_test.errorbar(x, y + 0.2, yerr, errorevery=slice(2, None, 3),
-                     markevery=slice(2, None, 3),
-                     capsize=4, c='C0', fmt='o')
-    ax_ref.plot(x[2::3], y[2::3] + 0.2, 'o', c='C0', zorder=2.1)
-    ax_ref.errorbar(x[2::3], y[2::3] + 0.2, yerr[2::3],
-                    capsize=4, c='C0', fmt='none')
-
-    # Check that passing an iterable to markevery/errorevery works.
-    ax_test.errorbar(x, y + 0.2, yerr, errorevery=[False, True, False] * 5,
-                     markevery=[False, True, False] * 5,
-                     capsize=4, c='C1', fmt='o')
-    ax_ref.plot(x[1::3], y[1::3] + 0.2, 'o', c='C1', zorder=2.1)
-    ax_ref.errorbar(x[1::3], y[1::3] + 0.2, yerr[1::3],
-                    capsize=4, c='C1', fmt='none')
-
-
-@pytest.mark.parametrize('elinewidth', [[1, 2, 3],
-                                        np.array([1, 2, 3]),
-                                        1])
-def test_errorbar_linewidth_type(elinewidth):
-    plt.errorbar([1, 2, 3], [1, 2, 3], yerr=[1, 2, 3], elinewidth=elinewidth)
-
-
-@check_figures_equal(extensions=["png"])
-def test_errorbar_nan(fig_test, fig_ref):
-    ax = fig_test.add_subplot()
-    xs = range(5)
-    ys = np.array([1, 2, np.nan, np.nan, 3])
-    es = np.array([4, 5, np.nan, np.nan, 6])
-    ax.errorbar(xs, ys, es)
-    ax = fig_ref.add_subplot()
-    ax.errorbar([0, 1], [1, 2], [4, 5])
-    ax.errorbar([4], [3], [6], fmt="C0")
-
-
-@image_comparison(['hist_stacked_stepfilled', 'hist_stacked_stepfilled'])
-def test_hist_stacked_stepfilled():
-    # make some data
-    d1 = np.linspace(1, 3, 20)
-    d2 = np.linspace(0, 10, 50)
-    fig, ax = plt.subplots()
-    ax.hist((d1, d2), histtype="stepfilled", stacked=True)
-
-    # Reuse testcase from above for a labeled data test
-    data = {"x": (d1, d2)}
-    fig, ax = plt.subplots()
-    ax.hist("x", histtype="stepfilled", stacked=True, data=data)
-
-
-@image_comparison(['hist_offset'])
-def test_hist_offset():
-    # make some data
-    d1 = np.linspace(0, 10, 50)
-    d2 = np.linspace(1, 3, 20)
-    fig, ax = plt.subplots()
-    ax.hist(d1, bottom=5)
-    ax.hist(d2, bottom=15)
-
-
-@image_comparison(['hist_step.png'], remove_text=True)
-def test_hist_step():
-    # make some data
-    d1 = np.linspace(1, 3, 20)
-    fig, ax = plt.subplots()
-    ax.hist(d1, histtype="step")
-    ax.set_ylim(0, 10)
-    ax.set_xlim(-1, 5)
-
-
-@image_comparison(['hist_step_horiz.png'])
-def test_hist_step_horiz():
-    # make some data
-    d1 = np.linspace(0, 10, 50)
-    d2 = np.linspace(1, 3, 20)
-    fig, ax = plt.subplots()
-    ax.hist((d1, d2), histtype="step", orientation="horizontal")
-
-
-@image_comparison(['hist_stacked_weights'])
-def test_hist_stacked_weighted():
-    # make some data
-    d1 = np.linspace(0, 10, 50)
-    d2 = np.linspace(1, 3, 20)
-    w1 = np.linspace(0.01, 3.5, 50)
-    w2 = np.linspace(0.05, 2., 20)
-    fig, ax = plt.subplots()
-    ax.hist((d1, d2), weights=(w1, w2), histtype="stepfilled", stacked=True)
-
-
-@image_comparison(['stem.png'], style='mpl20', remove_text=True)
-def test_stem():
-    x = np.linspace(0.1, 2 * np.pi, 100)
-
-    fig, ax = plt.subplots()
-    # Label is a single space to force a legend to be drawn, but to avoid any
-    # text being drawn
-    ax.stem(x, np.cos(x),
-            linefmt='C2-.', markerfmt='k+', basefmt='C1-.', label=' ')
-    ax.legend()
-
-
-def test_stem_args():
-    """Test that stem() correctly identifies x and y values."""
-    def _assert_equal(stem_container, expected):
-        x, y = map(list, stem_container.markerline.get_data())
-        assert x == expected[0]
-        assert y == expected[1]
-
-    fig, ax = plt.subplots()
-
-    x = [1, 3, 5]
-    y = [9, 8, 7]
-
-    # Test the call signatures
-    _assert_equal(ax.stem(y), expected=([0, 1, 2], y))
-    _assert_equal(ax.stem(x, y), expected=(x, y))
-    _assert_equal(ax.stem(x, y, linefmt='r--'), expected=(x, y))
-    _assert_equal(ax.stem(x, y, 'r--'), expected=(x, y))
-    _assert_equal(ax.stem(x, y, linefmt='r--', basefmt='b--'), expected=(x, y))
-    _assert_equal(ax.stem(y, linefmt='r--'), expected=([0, 1, 2], y))
-    _assert_equal(ax.stem(y, 'r--'), expected=([0, 1, 2], y))
-
-
-def test_stem_markerfmt():
-    """Test that stem(..., markerfmt=...) produces the intended markers."""
-    def _assert_equal(stem_container, linecolor=None, markercolor=None,
-                      marker=None):
+    @_docstring.copy(mquiver.QuiverKey.__init__)
+    def quiverkey(self, Q, X, Y, U, label, **kwargs):
+        qk = mquiver.QuiverKey(Q, X, Y, U, label, **kwargs)
+        self.add_artist(qk)
+        return qk
+
+    # Handle units for x and y, if they've been passed
+    def _quiver_units(self, args, kwargs):
+        if len(args) > 3:
+            x, y = args[0:2]
+            x, y = self._process_unit_info([("x", x), ("y", y)], kwargs)
+            return (x, y) + args[2:]
+        return args
+
+    # args can be a combination of X, Y, U, V, C and all should be replaced
+    @_preprocess_data()
+    @_docstring.interpd
+    def quiver(self, *args, **kwargs):
+        """%(quiver_doc)s"""
+        # Make sure units are handled for x and y values
+        args = self._quiver_units(args, kwargs)
+        q = mquiver.Quiver(self, *args, **kwargs)
+        self.add_collection(q, autolim=True)
+        self._request_autoscale_view()
+        return q
+
+    # args can be some combination of X, Y, U, V, C and all should be replaced
+    @_preprocess_data()
+    @_docstring.interpd
+    def barbs(self, *args, **kwargs):
+        """%(barbs_doc)s"""
+        # Make sure units are handled for x and y values
+        args = self._quiver_units(args, kwargs)
+        b = mquiver.Barbs(self, *args, **kwargs)
+        self.add_collection(b, autolim=True)
+        self._request_autoscale_view()
+        return b
+
+    # Uses a custom implementation of data-kwarg handling in
+    # _process_plot_var_args.
+    def fill(self, *args, data=None, **kwargs):
         """
-        Check that the given StemContainer has the properties listed as
-        keyword-arguments.
+        Plot filled polygons.
+
+        Parameters
+        ----------
+        *args : sequence of x, y, [color]
+            Each polygon is defined by the lists of *x* and *y* positions of
+            its nodes, optionally followed by a *color* specifier. See
+            :mod:`matplotlib.colors` for supported color specifiers. The
+            standard color cycle is used for polygons without a color
+            specifier.
+
+            You can plot multiple polygons by providing multiple *x*, *y*,
+            *[color]* groups.
+
+            For example, each of the following is legal::
+
+                ax.fill(x, y)                    # a polygon with default color
+                ax.fill(x, y, "b")               # a blue polygon
+                ax.fill(x, y, x2, y2)            # two polygons
+                ax.fill(x, y, "b", x2, y2, "r")  # a blue and a red polygon
+
+        data : indexable object, optional
+            An object with labelled data. If given, provide the label names to
+            plot in *x* and *y*, e.g.::
+
+                ax.fill("time", "signal",
+                        data={"time": [0, 1, 2], "signal": [0, 1, 0]})
+
+        Returns
+        -------
+        list of `~matplotlib.patches.Polygon`
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.patches.Polygon` properties
+
+        Notes
+        -----
+        Use :meth:`fill_between` if you would like to fill the region between
+        two curves.
         """
-        if linecolor is not None:
-            assert mcolors.same_color(
-                stem_container.stemlines.get_color(),
-                linecolor)
-        if markercolor is not None:
-            assert mcolors.same_color(
-                stem_container.markerline.get_color(),
-                markercolor)
-        if marker is not None:
-            assert stem_container.markerline.get_marker() == marker
-        assert stem_container.markerline.get_linestyle() == 'None'
-
-    fig, ax = plt.subplots()
-
-    x = [1, 3, 5]
-    y = [9, 8, 7]
-
-    # no linefmt
-    _assert_equal(ax.stem(x, y), markercolor='C0', marker='o')
-    _assert_equal(ax.stem(x, y, markerfmt='x'), markercolor='C0', marker='x')
-    _assert_equal(ax.stem(x, y, markerfmt='rx'), markercolor='r', marker='x')
-
-    # positional linefmt
-    _assert_equal(
-        ax.stem(x, y, 'r'),  # marker color follows linefmt if not given
-        linecolor='r', markercolor='r', marker='o')
-    _assert_equal(
-        ax.stem(x, y, 'rx'),  # the marker is currently not taken from linefmt
-        linecolor='r', markercolor='r', marker='o')
-    _assert_equal(
-        ax.stem(x, y, 'r', markerfmt='x'),  # only marker type specified
-        linecolor='r', markercolor='r', marker='x')
-    _assert_equal(
-        ax.stem(x, y, 'r', markerfmt='g'),  # only marker color specified
-        linecolor='r', markercolor='g', marker='o')
-    _assert_equal(
-        ax.stem(x, y, 'r', markerfmt='gx'),  # marker type and color specified
-        linecolor='r', markercolor='g', marker='x')
-    _assert_equal(
-        ax.stem(x, y, 'r', markerfmt=' '),  # markerfmt=' ' for no marker
-        linecolor='r', markercolor='r', marker='None')
-    _assert_equal(
-        ax.stem(x, y, 'r', markerfmt=''),  # markerfmt='' for no marker
-        linecolor='r', markercolor='r', marker='None')
-
-    # with linefmt kwarg
-    _assert_equal(
-        ax.stem(x, y, linefmt='r'),
-        linecolor='r', markercolor='r', marker='o')
-    _assert_equal(
-        ax.stem(x, y, linefmt='r', markerfmt='x'),
-        linecolor='r', markercolor='r', marker='x')
-    _assert_equal(
-        ax.stem(x, y, linefmt='r', markerfmt='gx'),
-        linecolor='r', markercolor='g', marker='x')
-
-
-def test_stem_dates():
-    fig, ax = plt.subplots(1, 1)
-    xs = [dateutil.parser.parse("2013-9-28 11:00:00"),
-          dateutil.parser.parse("2013-9-28 12:00:00")]
-    ys = [100, 200]
-    ax.stem(xs, ys)
-
-
-@image_comparison(['stem_orientation.png'], style='mpl20', remove_text=True)
-def test_stem_orientation():
-    x = np.linspace(0.1, 2*np.pi, 50)
-
-    fig, ax = plt.subplots()
-    ax.stem(x, np.cos(x),
-            linefmt='C2-.', markerfmt='kx', basefmt='C1-.',
-            orientation='horizontal')
-
-
-@image_comparison(['hist_stacked_stepfilled_alpha'])
-def test_hist_stacked_stepfilled_alpha():
-    # make some data
-    d1 = np.linspace(1, 3, 20)
-    d2 = np.linspace(0, 10, 50)
-    fig, ax = plt.subplots()
-    ax.hist((d1, d2), histtype="stepfilled", stacked=True, alpha=0.5)
-
-
-@image_comparison(['hist_stacked_step'])
-def test_hist_stacked_step():
-    # make some data
-    d1 = np.linspace(1, 3, 20)
-    d2 = np.linspace(0, 10, 50)
-    fig, ax = plt.subplots()
-    ax.hist((d1, d2), histtype="step", stacked=True)
-
-
-@image_comparison(['hist_stacked_normed'])
-def test_hist_stacked_density():
-    # make some data
-    d1 = np.linspace(1, 3, 20)
-    d2 = np.linspace(0, 10, 50)
-    fig, ax = plt.subplots()
-    ax.hist((d1, d2), stacked=True, density=True)
-
-
-@image_comparison(['hist_step_bottom.png'], remove_text=True)
-def test_hist_step_bottom():
-    # make some data
-    d1 = np.linspace(1, 3, 20)
-    fig, ax = plt.subplots()
-    ax.hist(d1, bottom=np.arange(10), histtype="stepfilled")
-
-
-def test_hist_step_geometry():
-    bins = [0, 1, 2, 3]
-    data = [0, 0, 1, 1, 1, 2]
-    top = [[0, 0], [0, 2], [1, 2], [1, 3], [2, 3], [2, 1], [3, 1], [3, 0]]
-    bottom = [[2, 0], [2, 0], [1, 0], [1, 0], [0, 0]]
-
-    for histtype, xy in [('step', top), ('stepfilled', top + bottom)]:
-        _, _, (polygon, ) = plt.hist(data, bins=bins, histtype=histtype)
-        assert_array_equal(polygon.get_xy(), xy)
-
-
-def test_hist_step_bottom_geometry():
-    bins = [0, 1, 2, 3]
-    data = [0, 0, 1, 1, 1, 2]
-    top = [[0, 1], [0, 3], [1, 3], [1, 5], [2, 5], [2, 2.5], [3, 2.5], [3, 1.5]]
-    bottom = [[2, 1.5], [2, 2], [1, 2], [1, 1], [0, 1]]
-
-    for histtype, xy in [('step', top), ('stepfilled', top + bottom)]:
-        _, _, (polygon, ) = plt.hist(data, bins=bins, bottom=[1, 2, 1.5],
-                                     histtype=histtype)
-        assert_array_equal(polygon.get_xy(), xy)
-
-
-def test_hist_stacked_step_geometry():
-    bins = [0, 1, 2, 3]
-    data_1 = [0, 0, 1, 1, 1, 2]
-    data_2 = [0, 1, 2]
-    tops = [
-        [[0, 0], [0, 2], [1, 2], [1, 3], [2, 3], [2, 1], [3, 1], [3, 0]],
-        [[0, 2], [0, 3], [1, 3], [1, 4], [2, 4], [2, 2], [3, 2], [3, 1]],
-    ]
-    bottoms = [
-        [[2, 0], [2, 0], [1, 0], [1, 0], [0, 0]],
-        [[2, 1], [2, 3], [1, 3], [1, 2], [0, 2]],
-    ]
-    combined = [t + b for t, b in zip(tops, bottoms)]
-
-    for histtype, xy in [('step', tops), ('stepfilled', combined)]:
-        _, _, patches = plt.hist([data_1, data_2], bins=bins, stacked=True,
-                                 histtype=histtype)
-        assert len(patches) == 2
-        polygon, = patches[0]
-        assert_array_equal(polygon.get_xy(), xy[0])
-        polygon, = patches[1]
-        assert_array_equal(polygon.get_xy(), xy[1])
-
-
-def test_hist_stacked_step_bottom_geometry():
-    bins = [0, 1, 2, 3]
-    data_1 = [0, 0, 1, 1, 1, 2]
-    data_2 = [0, 1, 2]
-    tops = [
-        [[0, 1], [0, 3], [1, 3], [1, 5], [2, 5], [2, 2.5], [3, 2.5], [3, 1.5]],
-        [[0, 3], [0, 4], [1, 4], [1, 6], [2, 6], [2, 3.5], [3, 3.5], [3, 2.5]],
-    ]
-    bottoms = [
-        [[2, 1.5], [2, 2], [1, 2], [1, 1], [0, 1]],
-        [[2, 2.5], [2, 5], [1, 5], [1, 3], [0, 3]],
-    ]
-    combined = [t + b for t, b in zip(tops, bottoms)]
-
-    for histtype, xy in [('step', tops), ('stepfilled', combined)]:
-        _, _, patches = plt.hist([data_1, data_2], bins=bins, stacked=True,
-                                 bottom=[1, 2, 1.5], histtype=histtype)
-        assert len(patches) == 2
-        polygon, = patches[0]
-        assert_array_equal(polygon.get_xy(), xy[0])
-        polygon, = patches[1]
-        assert_array_equal(polygon.get_xy(), xy[1])
-
-
-@image_comparison(['hist_stacked_bar'])
-def test_hist_stacked_bar():
-    # make some data
-    d = [[100, 100, 100, 100, 200, 320, 450, 80, 20, 600, 310, 800],
-         [20, 23, 50, 11, 100, 420], [120, 120, 120, 140, 140, 150, 180],
-         [60, 60, 60, 60, 300, 300, 5, 5, 5, 5, 10, 300],
-         [555, 555, 555, 30, 30, 30, 30, 30, 100, 100, 100, 100, 30, 30],
-         [30, 30, 30, 30, 400, 400, 400, 400, 400, 400, 400, 400]]
-    colors = [(0.5759849696758961, 1.0, 0.0), (0.0, 1.0, 0.350624650815206),
-              (0.0, 1.0, 0.6549834156005998), (0.0, 0.6569064625276622, 1.0),
-              (0.28302699607823545, 0.0, 1.0), (0.6849123462299822, 0.0, 1.0)]
-    labels = ['green', 'orange', ' yellow', 'magenta', 'black']
-    fig, ax = plt.subplots()
-    ax.hist(d, bins=10, histtype='barstacked', align='mid', color=colors,
-            label=labels)
-    ax.legend(loc='upper right', bbox_to_anchor=(1.0, 1.0), ncols=1)
-
-
-@pytest.mark.parametrize('kwargs', ({'facecolor': ["b", "g", "r"]},
-                                    {'edgecolor': ["b", "g", "r"]},
-                                    {'hatch': ["/", "\\", "."]},
-                                    {'linestyle': ["-", "--", ":"]},
-                                    {'linewidth': [1, 1.5, 2]},
-                                    {'color': ["b", "g", "r"]}))
-@check_figures_equal(extensions=["png"])
-def test_hist_vectorized_params(fig_test, fig_ref, kwargs):
-    np.random.seed(19680801)
-    xs = [np.random.randn(n) for n in [20, 50, 100]]
-
-    (axt1, axt2) = fig_test.subplots(2)
-    (axr1, axr2) = fig_ref.subplots(2)
-
-    for histtype, axt, axr in [("stepfilled", axt1, axr1), ("step", axt2, axr2)]:
-        _, bins, _ = axt.hist(xs, bins=10, histtype=histtype, **kwargs)
-
-        kw, values = next(iter(kwargs.items()))
-        for i, (x, value) in enumerate(zip(xs, values)):
-            axr.hist(x, bins=bins, histtype=histtype, **{kw: value},
-                     zorder=(len(xs)-i)/2)
-
-
-@pytest.mark.parametrize('kwargs, patch_face, patch_edge',
-                         # 'C0'(blue) stands for the first color of the
-                         # default color cycle as well as the patch.facecolor rcParam
-                         # When the expected edgecolor is 'k'(black),
-                         # it corresponds to the patch.edgecolor rcParam
-                         [({'histtype': 'stepfilled', 'color': 'r',
-                            'facecolor': 'y', 'edgecolor': 'g'}, 'y', 'g'),
-                          ({'histtype': 'step', 'color': 'r',
-                            'facecolor': 'y', 'edgecolor': 'g'}, ('y', 0), 'g'),
-                          ({'histtype': 'stepfilled', 'color': 'r',
-                            'edgecolor': 'g'}, 'r', 'g'),
-                          ({'histtype': 'step', 'color': 'r',
-                            'edgecolor': 'g'}, ('r', 0), 'g'),
-                          ({'histtype': 'stepfilled', 'color': 'r',
-                            'facecolor': 'y'}, 'y', 'k'),
-                          ({'histtype': 'step', 'color': 'r',
-                            'facecolor': 'y'}, ('y', 0), 'r'),
-                          ({'histtype': 'stepfilled',
-                            'facecolor': 'y', 'edgecolor': 'g'}, 'y', 'g'),
-                          ({'histtype': 'step', 'facecolor': 'y',
-                            'edgecolor': 'g'}, ('y', 0), 'g'),
-                          ({'histtype': 'stepfilled', 'color': 'r'}, 'r', 'k'),
-                          ({'histtype': 'step', 'color': 'r'}, ('r', 0), 'r'),
-                          ({'histtype': 'stepfilled', 'facecolor': 'y'}, 'y', 'k'),
-                          ({'histtype': 'step', 'facecolor': 'y'}, ('y', 0), 'C0'),
-                          ({'histtype': 'stepfilled', 'edgecolor': 'g'}, 'C0', 'g'),
-                          ({'histtype': 'step', 'edgecolor': 'g'}, ('C0', 0), 'g'),
-                          ({'histtype': 'stepfilled'}, 'C0', 'k'),
-                          ({'histtype': 'step'}, ('C0', 0), 'C0')])
-def test_hist_color_semantics(kwargs, patch_face, patch_edge):
-    _, _, patches = plt.figure().subplots().hist([1, 2, 3], **kwargs)
-    assert all(mcolors.same_color([p.get_facecolor(), p.get_edgecolor()],
-                                  [patch_face, patch_edge]) for p in patches)
-
-
-def test_hist_barstacked_bottom_unchanged():
-    b = np.array([10, 20])
-    plt.hist([[0, 1], [0, 1]], 2, histtype="barstacked", bottom=b)
-    assert b.tolist() == [10, 20]
-
-
-def test_hist_emptydata():
-    fig, ax = plt.subplots()
-    ax.hist([[], range(10), range(10)], histtype="step")
-
-
-def test_hist_unused_labels():
-    # When a list with one dataset and N elements is provided and N labels, ensure
-    # that the first label is used for the dataset and all other labels are ignored
-    fig, ax = plt.subplots()
-    ax.hist([[1, 2, 3]], label=["values", "unused", "also unused"])
-    _, labels = ax.get_legend_handles_labels()
-    assert labels == ["values"]
-
-
-def test_hist_labels():
-    # test singleton labels OK
-    fig, ax = plt.subplots()
-    _, _, bars = ax.hist([0, 1], label=0)
-    assert bars[0].get_label() == '0'
-    _, _, bars = ax.hist([0, 1], label=[0])
-    assert bars[0].get_label() == '0'
-    _, _, bars = ax.hist([0, 1], label=None)
-    assert bars[0].get_label() == '_nolegend_'
-    _, _, bars = ax.hist([0, 1], label='0')
-    assert bars[0].get_label() == '0'
-    _, _, bars = ax.hist([0, 1], label='00')
-    assert bars[0].get_label() == '00'
-
-
-@image_comparison(['transparent_markers'], remove_text=True)
-def test_transparent_markers():
-    np.random.seed(0)
-    data = np.random.random(50)
-
-    fig, ax = plt.subplots()
-    ax.plot(data, 'D', mfc='none', markersize=100)
-
-
-@image_comparison(['rgba_markers'], remove_text=True)
-def test_rgba_markers():
-    fig, axs = plt.subplots(ncols=2)
-    rcolors = [(1, 0, 0, 1), (1, 0, 0, 0.5)]
-    bcolors = [(0, 0, 1, 1), (0, 0, 1, 0.5)]
-    alphas = [None, 0.2]
-    kw = dict(ms=100, mew=20)
-    for i, alpha in enumerate(alphas):
-        for j, rcolor in enumerate(rcolors):
-            for k, bcolor in enumerate(bcolors):
-                axs[i].plot(j+1, k+1, 'o', mfc=bcolor, mec=rcolor,
-                            alpha=alpha, **kw)
-                axs[i].plot(j+1, k+3, 'x', mec=rcolor, alpha=alpha, **kw)
-    for ax in axs:
-        ax.axis([-1, 4, 0, 5])
-
-
-@image_comparison(['mollweide_grid'], remove_text=True)
-def test_mollweide_grid():
-    # test that both horizontal and vertical gridlines appear on the Mollweide
-    # projection
-    fig = plt.figure()
-    ax = fig.add_subplot(projection='mollweide')
-    ax.grid()
-
-
-def test_mollweide_forward_inverse_closure():
-    # test that the round-trip Mollweide forward->inverse transformation is an
-    # approximate identity
-    fig = plt.figure()
-    ax = fig.add_subplot(projection='mollweide')
-
-    # set up 1-degree grid in longitude, latitude
-    lon = np.linspace(-np.pi, np.pi, 360)
-    # The poles are degenerate and thus sensitive to floating point precision errors
-    lat = np.linspace(-np.pi / 2.0, np.pi / 2.0, 180)[1:-1]
-    lon, lat = np.meshgrid(lon, lat)
-    ll = np.vstack((lon.flatten(), lat.flatten())).T
-
-    # perform forward transform
-    xy = ax.transProjection.transform(ll)
-
-    # perform inverse transform
-    ll2 = ax.transProjection.inverted().transform(xy)
-
-    # compare
-    np.testing.assert_array_almost_equal(ll, ll2, 3)
-
-
-def test_mollweide_inverse_forward_closure():
-    # test that the round-trip Mollweide inverse->forward transformation is an
-    # approximate identity
-    fig = plt.figure()
-    ax = fig.add_subplot(projection='mollweide')
-
-    # set up grid in x, y
-    x = np.linspace(0, 1, 500)
-    x, y = np.meshgrid(x, x)
-    xy = np.vstack((x.flatten(), y.flatten())).T
-
-    # perform inverse transform
-    ll = ax.transProjection.inverted().transform(xy)
-
-    # perform forward transform
-    xy2 = ax.transProjection.transform(ll)
-
-    # compare
-    np.testing.assert_array_almost_equal(xy, xy2, 3)
-
-
-@image_comparison(['test_alpha'], remove_text=True)
-def test_alpha():
-    np.random.seed(0)
-    data = np.random.random(50)
-
-    fig, ax = plt.subplots()
-
-    # alpha=.5 markers, solid line
-    ax.plot(data, '-D', color=[1, 0, 0], mfc=[1, 0, 0, .5],
-            markersize=20, lw=10)
-
-    # everything solid by kwarg
-    ax.plot(data + 2, '-D', color=[1, 0, 0, .5], mfc=[1, 0, 0, .5],
-            markersize=20, lw=10,
-            alpha=1)
-
-    # everything alpha=.5 by kwarg
-    ax.plot(data + 4, '-D', color=[1, 0, 0], mfc=[1, 0, 0],
-            markersize=20, lw=10,
-            alpha=.5)
-
-    # everything alpha=.5 by colors
-    ax.plot(data + 6, '-D', color=[1, 0, 0, .5], mfc=[1, 0, 0, .5],
-            markersize=20, lw=10)
-
-    # alpha=.5 line, solid markers
-    ax.plot(data + 8, '-D', color=[1, 0, 0, .5], mfc=[1, 0, 0],
-            markersize=20, lw=10)
-
-
-@image_comparison(['eventplot', 'eventplot'], remove_text=True)
-def test_eventplot():
-    np.random.seed(0)
-
-    data1 = np.random.random([32, 20]).tolist()
-    data2 = np.random.random([6, 20]).tolist()
-    data = data1 + data2
-    num_datasets = len(data)
-
-    colors1 = [[0, 1, .7]] * len(data1)
-    colors2 = [[1, 0, 0],
-               [0, 1, 0],
-               [0, 0, 1],
-               [1, .75, 0],
-               [1, 0, 1],
-               [0, 1, 1]]
-    colors = colors1 + colors2
-
-    lineoffsets1 = 12 + np.arange(0, len(data1)) * .33
-    lineoffsets2 = [-15, -3, 1, 1.5, 6, 10]
-    lineoffsets = lineoffsets1.tolist() + lineoffsets2
-
-    linelengths1 = [.33] * len(data1)
-    linelengths2 = [5, 2, 1, 1, 3, 1.5]
-    linelengths = linelengths1 + linelengths2
-
-    fig = plt.figure()
-    axobj = fig.add_subplot()
-    colls = axobj.eventplot(data, colors=colors, lineoffsets=lineoffsets,
-                            linelengths=linelengths)
-
-    num_collections = len(colls)
-    assert num_collections == num_datasets
-
-    # Reuse testcase from above for a labeled data test
-    data = {"pos": data, "c": colors, "lo": lineoffsets, "ll": linelengths}
-    fig = plt.figure()
-    axobj = fig.add_subplot()
-    colls = axobj.eventplot("pos", colors="c", lineoffsets="lo",
-                            linelengths="ll", data=data)
-    num_collections = len(colls)
-    assert num_collections == num_datasets
-
-
-@image_comparison(['test_eventplot_defaults.png'], remove_text=True)
-def test_eventplot_defaults():
-    """
-    test that eventplot produces the correct output given the default params
-    (see bug #3728)
-    """
-    np.random.seed(0)
-
-    data1 = np.random.random([32, 20]).tolist()
-    data2 = np.random.random([6, 20]).tolist()
-    data = data1 + data2
-
-    fig = plt.figure()
-    axobj = fig.add_subplot()
-    axobj.eventplot(data)
-
-
-@pytest.mark.parametrize(('colors'), [
-    ('0.5',),  # string color with multiple characters: not OK before #8193 fix
-    ('tab:orange', 'tab:pink', 'tab:cyan', 'bLacK'),  # case-insensitive
-    ('red', (0, 1, 0), None, (1, 0, 1, 0.5)),  # a tricky case mixing types
-])
-def test_eventplot_colors(colors):
-    """Test the *colors* parameter of eventplot. Inspired by issue #8193."""
-    data = [[0], [1], [2], [3]]  # 4 successive events of different nature
-
-    # Build the list of the expected colors
-    expected = [c if c is not None else 'C0' for c in colors]
-    # Convert the list into an array of RGBA values
-    # NB: ['rgbk'] is not a valid argument for to_rgba_array, while 'rgbk' is.
-    if len(expected) == 1:
-        expected = expected[0]
-    expected = np.broadcast_to(mcolors.to_rgba_array(expected), (len(data), 4))
-
-    fig, ax = plt.subplots()
-    if len(colors) == 1:  # tuple with a single string (like '0.5' or 'rgbk')
-        colors = colors[0]
-    collections = ax.eventplot(data, colors=colors)
-
-    for coll, color in zip(collections, expected):
-        assert_allclose(coll.get_color(), color)
-
-
-def test_eventplot_alpha():
-    fig, ax = plt.subplots()
-
-    # one alpha for all
-    collections = ax.eventplot([[0, 2, 4], [1, 3, 5, 7]], alpha=0.7)
-    assert collections[0].get_alpha() == 0.7
-    assert collections[1].get_alpha() == 0.7
-
-    # one alpha per collection
-    collections = ax.eventplot([[0, 2, 4], [1, 3, 5, 7]], alpha=[0.5, 0.7])
-    assert collections[0].get_alpha() == 0.5
-    assert collections[1].get_alpha() == 0.7
-
-    with pytest.raises(ValueError, match="alpha and positions are unequal"):
-        ax.eventplot([[0, 2, 4], [1, 3, 5, 7]], alpha=[0.5, 0.7, 0.9])
-
-    with pytest.raises(ValueError, match="alpha and positions are unequal"):
-        ax.eventplot([0, 2, 4], alpha=[0.5, 0.7])
-
-
-@image_comparison(['test_eventplot_problem_kwargs.png'], remove_text=True)
-def test_eventplot_problem_kwargs(recwarn):
-    """
-    test that 'singular' versions of LineCollection props raise an
-    MatplotlibDeprecationWarning rather than overriding the 'plural' versions
-    (e.g., to prevent 'color' from overriding 'colors', see issue #4297)
-    """
-    np.random.seed(0)
-
-    data1 = np.random.random([20]).tolist()
-    data2 = np.random.random([10]).tolist()
-    data = [data1, data2]
-
-    fig = plt.figure()
-    axobj = fig.add_subplot()
-
-    axobj.eventplot(data,
-                    colors=['r', 'b'],
-                    color=['c', 'm'],
-                    linewidths=[2, 1],
-                    linewidth=[1, 2],
-                    linestyles=['solid', 'dashed'],
-                    linestyle=['dashdot', 'dotted'])
-
-    assert len(recwarn) == 3
-    assert all(issubclass(wi.category, mpl.MatplotlibDeprecationWarning)
-               for wi in recwarn)
-
-
-def test_empty_eventplot():
-    fig, ax = plt.subplots(1, 1)
-    ax.eventplot([[]], colors=[(0.0, 0.0, 0.0, 0.0)])
-    plt.draw()
-
-
-@pytest.mark.parametrize('data', [[[]], [[], [0, 1]], [[0, 1], []]])
-@pytest.mark.parametrize('orientation', [None, 'vertical', 'horizontal'])
-def test_eventplot_orientation(data, orientation):
-    """Introduced when fixing issue #6412."""
-    opts = {} if orientation is None else {'orientation': orientation}
-    fig, ax = plt.subplots(1, 1)
-    ax.eventplot(data, **opts)
-    plt.draw()
-
-
-@check_figures_equal(extensions=['png'])
-def test_eventplot_units_list(fig_test, fig_ref):
-    # test that list of lists converted properly:
-    ts_1 = [datetime.datetime(2021, 1, 1), datetime.datetime(2021, 1, 2),
-            datetime.datetime(2021, 1, 3)]
-    ts_2 = [datetime.datetime(2021, 1, 15), datetime.datetime(2021, 1, 16)]
-
-    ax = fig_ref.subplots()
-    ax.eventplot(ts_1, lineoffsets=0)
-    ax.eventplot(ts_2, lineoffsets=1)
-
-    ax = fig_test.subplots()
-    ax.eventplot([ts_1, ts_2])
-
-
-@image_comparison(['marker_styles.png'], remove_text=True)
-def test_marker_styles():
-    fig, ax = plt.subplots()
-    # Since generation of the test image, None was removed but 'none' was
-    # added. By moving 'none' to the front (=former sorted place of None)
-    # we can avoid regenerating the test image. This can be removed if the
-    # test image has to be regenerated for other reasons.
-    markers = sorted(matplotlib.markers.MarkerStyle.markers,
-                     key=lambda x: str(type(x))+str(x))
-    markers.remove('none')
-    markers = ['none', *markers]
-    for y, marker in enumerate(markers):
-        ax.plot((y % 2)*5 + np.arange(10)*10, np.ones(10)*10*y, linestyle='',
-                marker=marker, markersize=10+y/5, label=marker)
-
-
-@image_comparison(['rc_markerfill.png'],
-                  tol=0.037 if platform.machine() == 'arm64' else 0)
-def test_markers_fillstyle_rcparams():
-    fig, ax = plt.subplots()
-    x = np.arange(7)
-    for idx, (style, marker) in enumerate(
-            [('top', 's'), ('bottom', 'o'), ('none', '^')]):
-        matplotlib.rcParams['markers.fillstyle'] = style
-        ax.plot(x+idx, marker=marker)
-
-
-@image_comparison(['vertex_markers.png'], remove_text=True)
-def test_vertex_markers():
-    data = list(range(10))
-    marker_as_tuple = ((-1, -1), (1, -1), (1, 1), (-1, 1))
-    marker_as_list = [(-1, -1), (1, -1), (1, 1), (-1, 1)]
-    fig, ax = plt.subplots()
-    ax.plot(data, linestyle='', marker=marker_as_tuple, mfc='k')
-    ax.plot(data[::-1], linestyle='', marker=marker_as_list, mfc='b')
-    ax.set_xlim([-1, 10])
-    ax.set_ylim([-1, 10])
-
-
-@image_comparison(['vline_hline_zorder', 'errorbar_zorder'],
-                  tol=0 if platform.machine() == 'x86_64' else 0.026)
-def test_eb_line_zorder():
-    x = list(range(10))
-
-    # First illustrate basic pyplot interface, using defaults where possible.
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.plot(x, lw=10, zorder=5)
-    ax.axhline(1, color='red', lw=10, zorder=1)
-    ax.axhline(5, color='green', lw=10, zorder=10)
-    ax.axvline(7, color='m', lw=10, zorder=7)
-    ax.axvline(2, color='k', lw=10, zorder=3)
-
-    ax.set_title("axvline and axhline zorder test")
-
-    # Now switch to a more OO interface to exercise more features.
-    fig = plt.figure()
-    ax = fig.gca()
-    x = list(range(10))
-    y = np.zeros(10)
-    yerr = list(range(10))
-    ax.errorbar(x, y, yerr=yerr, zorder=5, lw=5, color='r')
-    for j in range(10):
-        ax.axhline(j, lw=5, color='k', zorder=j)
-        ax.axhline(-j, lw=5, color='k', zorder=j)
-
-    ax.set_title("errorbar zorder test")
-
-
-@check_figures_equal()
-def test_axline_loglog(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
-    ax.loglog([.3, .6], [.3, .6], ".-")
-    ax.axline((1, 1e-3), (10, 1e-2), c="k")
-
-    ax = fig_ref.subplots()
-    ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
-    ax.loglog([.3, .6], [.3, .6], ".-")
-    ax.loglog([1, 10], [1e-3, 1e-2], c="k")
-
-
-@check_figures_equal()
-def test_axline(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.axline((0, 0), (1, 1))
-    ax.axline((0, 0), (1, 0), color='C1')
-    ax.axline((0, 0.5), (1, 0.5), color='C2')
-    # slopes
-    ax.axline((-0.7, -0.5), slope=0, color='C3')
-    ax.axline((1, -0.5), slope=-0.5, color='C4')
-    ax.axline((-0.5, 1), slope=float('inf'), color='C5')
-
-    ax = fig_ref.subplots()
-    ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.plot([-1, 1], [-1, 1])
-    ax.axhline(0, color='C1')
-    ax.axhline(0.5, color='C2')
-    # slopes
-    ax.axhline(-0.5, color='C3')
-    ax.plot([-1, 1], [0.5, -0.5], color='C4')
-    ax.axvline(-0.5, color='C5')
-
-
-@check_figures_equal()
-def test_axline_transaxes(fig_test, fig_ref):
-    ax = fig_test.subplots()
-    ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.axline((0, 0), slope=1, transform=ax.transAxes)
-    ax.axline((1, 0.5), slope=1, color='C1', transform=ax.transAxes)
-    ax.axline((0.5, 0.5), slope=0, color='C2', transform=ax.transAxes)
-    ax.axline((0.5, 0), (0.5, 1), color='C3', transform=ax.transAxes)
-
-    ax = fig_ref.subplots()
-    ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.plot([-1, 1], [-1, 1])
-    ax.plot([0, 1], [-1, 0], color='C1')
-    ax.plot([-1, 1], [0, 0], color='C2')
-    ax.plot([0, 0], [-1, 1], color='C3')
-
-
-@check_figures_equal()
-def test_axline_transaxes_panzoom(fig_test, fig_ref):
-    # test that it is robust against pan/zoom and
-    # figure resize after plotting
-    ax = fig_test.subplots()
-    ax.set(xlim=(-1, 1), ylim=(-1, 1))
-    ax.axline((0, 0), slope=1, transform=ax.transAxes)
-    ax.axline((0.5, 0.5), slope=2, color='C1', transform=ax.transAxes)
-    ax.axline((0.5, 0.5), slope=0, color='C2', transform=ax.transAxes)
-    ax.set(xlim=(0, 5), ylim=(0, 10))
-    fig_test.set_size_inches(3, 3)
-
-    ax = fig_ref.subplots()
-    ax.set(xlim=(0, 5), ylim=(0, 10))
-    fig_ref.set_size_inches(3, 3)
-    ax.plot([0, 5], [0, 5])
-    ax.plot([0, 5], [0, 10], color='C1')
-    ax.plot([0, 5], [5, 5], color='C2')
-
-
-def test_axline_args():
-    """Exactly one of *xy2* and *slope* must be specified."""
-    fig, ax = plt.subplots()
-    with pytest.raises(TypeError):
-        ax.axline((0, 0))  # missing second parameter
-    with pytest.raises(TypeError):
-        ax.axline((0, 0), (1, 1), slope=1)  # redundant parameters
-    ax.set_xscale('log')
-    with pytest.raises(TypeError):
-        ax.axline((0, 0), slope=1)
-    ax.set_xscale('linear')
-    ax.set_yscale('log')
-    with pytest.raises(TypeError):
-        ax.axline((0, 0), slope=1)
-    ax.set_yscale('linear')
-    with pytest.raises(ValueError):
-        ax.axline((0, 0), (0, 0))  # two identical points are not allowed
-        plt.draw()
-
-
-@image_comparison(['vlines_basic', 'vlines_with_nan', 'vlines_masked'],
-                  extensions=['png'])
-def test_vlines():
-    # normal
-    x1 = [2, 3, 4, 5, 7]
-    y1 = [2, -6, 3, 8, 2]
-    fig1, ax1 = plt.subplots()
-    ax1.vlines(x1, 0, y1, colors='g', linewidth=5)
-
-    # GH #7406
-    x2 = [2, 3, 4, 5, 6, 7]
-    y2 = [2, -6, 3, 8, np.nan, 2]
-    fig2, (ax2, ax3, ax4) = plt.subplots(nrows=3, figsize=(4, 8))
-    ax2.vlines(x2, 0, y2, colors='g', linewidth=5)
-
-    x3 = [2, 3, 4, 5, 6, 7]
-    y3 = [np.nan, 2, -6, 3, 8, 2]
-    ax3.vlines(x3, 0, y3, colors='r', linewidth=3, linestyle='--')
-
-    x4 = [2, 3, 4, 5, 6, 7]
-    y4 = [np.nan, 2, -6, 3, 8, np.nan]
-    ax4.vlines(x4, 0, y4, colors='k', linewidth=2)
-
-    # tweak the x-axis so we can see the lines better
-    for ax in [ax1, ax2, ax3, ax4]:
-        ax.set_xlim(0, 10)
-
-    # check that the y-lims are all automatically the same
-    assert ax1.get_ylim() == ax2.get_ylim()
-    assert ax1.get_ylim() == ax3.get_ylim()
-    assert ax1.get_ylim() == ax4.get_ylim()
-
-    fig3, ax5 = plt.subplots()
-    x5 = np.ma.masked_equal([2, 4, 6, 8, 10, 12], 8)
-    ymin5 = np.ma.masked_equal([0, 1, -1, 0, 2, 1], 2)
-    ymax5 = np.ma.masked_equal([13, 14, 15, 16, 17, 18], 18)
-    ax5.vlines(x5, ymin5, ymax5, colors='k', linewidth=2)
-    ax5.set_xlim(0, 15)
-
-
-def test_vlines_default():
-    fig, ax = plt.subplots()
-    with mpl.rc_context({'lines.color': 'red'}):
-        lines = ax.vlines(0.5, 0, 1)
-        assert mpl.colors.same_color(lines.get_color(), 'red')
-
-
-@image_comparison(['hlines_basic', 'hlines_with_nan', 'hlines_masked'],
-                  extensions=['png'])
-def test_hlines():
-    # normal
-    y1 = [2, 3, 4, 5, 7]
-    x1 = [2, -6, 3, 8, 2]
-    fig1, ax1 = plt.subplots()
-    ax1.hlines(y1, 0, x1, colors='g', linewidth=5)
-
-    # GH #7406
-    y2 = [2, 3, 4, 5, 6, 7]
-    x2 = [2, -6, 3, 8, np.nan, 2]
-    fig2, (ax2, ax3, ax4) = plt.subplots(nrows=3, figsize=(4, 8))
-    ax2.hlines(y2, 0, x2, colors='g', linewidth=5)
-
-    y3 = [2, 3, 4, 5, 6, 7]
-    x3 = [np.nan, 2, -6, 3, 8, 2]
-    ax3.hlines(y3, 0, x3, colors='r', linewidth=3, linestyle='--')
-
-    y4 = [2, 3, 4, 5, 6, 7]
-    x4 = [np.nan, 2, -6, 3, 8, np.nan]
-    ax4.hlines(y4, 0, x4, colors='k', linewidth=2)
-
-    # tweak the y-axis so we can see the lines better
-    for ax in [ax1, ax2, ax3, ax4]:
-        ax.set_ylim(0, 10)
-
-    # check that the x-lims are all automatically the same
-    assert ax1.get_xlim() == ax2.get_xlim()
-    assert ax1.get_xlim() == ax3.get_xlim()
-    assert ax1.get_xlim() == ax4.get_xlim()
-
-    fig3, ax5 = plt.subplots()
-    y5 = np.ma.masked_equal([2, 4, 6, 8, 10, 12], 8)
-    xmin5 = np.ma.masked_equal([0, 1, -1, 0, 2, 1], 2)
-    xmax5 = np.ma.masked_equal([13, 14, 15, 16, 17, 18], 18)
-    ax5.hlines(y5, xmin5, xmax5, colors='k', linewidth=2)
-    ax5.set_ylim(0, 15)
-
-
-def test_hlines_default():
-    fig, ax = plt.subplots()
-    with mpl.rc_context({'lines.color': 'red'}):
-        lines = ax.hlines(0.5, 0, 1)
-        assert mpl.colors.same_color(lines.get_color(), 'red')
-
-
-@pytest.mark.parametrize('data', [[1, 2, 3, np.nan, 5],
-                                  np.ma.masked_equal([1, 2, 3, 4, 5], 4)])
-@check_figures_equal(extensions=["png"])
-def test_lines_with_colors(fig_test, fig_ref, data):
-    test_colors = ['red', 'green', 'blue', 'purple', 'orange']
-    fig_test.add_subplot(2, 1, 1).vlines(data, 0, 1,
-                                         colors=test_colors, linewidth=5)
-    fig_test.add_subplot(2, 1, 2).hlines(data, 0, 1,
-                                         colors=test_colors, linewidth=5)
-
-    expect_xy = [1, 2, 3, 5]
-    expect_color = ['red', 'green', 'blue', 'orange']
-    fig_ref.add_subplot(2, 1, 1).vlines(expect_xy, 0, 1,
-                                        colors=expect_color, linewidth=5)
-    fig_ref.add_subplot(2, 1, 2).hlines(expect_xy, 0, 1,
-                                        colors=expect_color, linewidth=5)
-
-
-@image_comparison(['vlines_hlines_blended_transform'],
-                  extensions=['png'], style='mpl20')
-def test_vlines_hlines_blended_transform():
-    t = np.arange(5.0, 10.0, 0.1)
-    s = np.exp(-t) + np.sin(2 * np.pi * t) + 10
-    fig, (hax, vax) = plt.subplots(2, 1, figsize=(6, 6))
-    hax.plot(t, s, '^')
-    hax.hlines([10, 9], xmin=0, xmax=0.5,
-               transform=hax.get_yaxis_transform(), colors='r')
-    vax.plot(t, s, '^')
-    vax.vlines([6, 7], ymin=0, ymax=0.15, transform=vax.get_xaxis_transform(),
-               colors='r')
-
-
-@image_comparison(['step_linestyle', 'step_linestyle'], remove_text=True,
-                  tol=0.2)
-def test_step_linestyle():
-    # Tolerance caused by reordering of floating-point operations
-    # Remove when regenerating the images
-    x = y = np.arange(10)
-
-    # First illustrate basic pyplot interface, using defaults where possible.
-    fig, ax_lst = plt.subplots(2, 2)
-    ax_lst = ax_lst.flatten()
-
-    ln_styles = ['-', '--', '-.', ':']
-
-    for ax, ls in zip(ax_lst, ln_styles):
-        ax.step(x, y, lw=5, linestyle=ls, where='pre')
-        ax.step(x, y + 1, lw=5, linestyle=ls, where='mid')
-        ax.step(x, y + 2, lw=5, linestyle=ls, where='post')
-        ax.set_xlim([-1, 5])
-        ax.set_ylim([-1, 7])
-
-    # Reuse testcase from above for a labeled data test
-    data = {"X": x, "Y0": y, "Y1": y+1, "Y2": y+2}
-    fig, ax_lst = plt.subplots(2, 2)
-    ax_lst = ax_lst.flatten()
-    ln_styles = ['-', '--', '-.', ':']
-    for ax, ls in zip(ax_lst, ln_styles):
-        ax.step("X", "Y0", lw=5, linestyle=ls, where='pre', data=data)
-        ax.step("X", "Y1", lw=5, linestyle=ls, where='mid', data=data)
-        ax.step("X", "Y2", lw=5, linestyle=ls, where='post', data=data)
-        ax.set_xlim([-1, 5])
-        ax.set_ylim([-1, 7])
-
-
-@image_comparison(['mixed_collection'], remove_text=True)
-def test_mixed_collection():
-    # First illustrate basic pyplot interface, using defaults where possible.
-    fig, ax = plt.subplots()
-
-    c = mpatches.Circle((8, 8), radius=4, facecolor='none', edgecolor='green')
-
-    # PDF can optimize this one
-    p1 = mpl.collections.PatchCollection([c], match_original=True)
-    p1.set_offsets([[0, 0], [24, 24]])
-    p1.set_linewidths([1, 5])
-
-    # PDF can't optimize this one, because the alpha of the edge changes
-    p2 = mpl.collections.PatchCollection([c], match_original=True)
-    p2.set_offsets([[48, 0], [-32, -16]])
-    p2.set_linewidths([1, 5])
-    p2.set_edgecolors([[0, 0, 0.1, 1.0], [0, 0, 0.1, 0.5]])
-
-    ax.patch.set_color('0.5')
-    ax.add_collection(p1)
-    ax.add_collection(p2)
-
-    ax.set_xlim(0, 16)
-    ax.set_ylim(0, 16)
-
-
-def test_subplot_key_hash():
-    ax = plt.subplot(np.int32(5), np.int64(1), 1)
-    ax.twinx()
-    assert ax.get_subplotspec().get_geometry() == (5, 1, 0, 0)
-
-
-@image_comparison(
-    ["specgram_freqs.png", "specgram_freqs_linear.png",
-     "specgram_noise.png", "specgram_noise_linear.png"],
-    remove_text=True, tol=0.07, style="default")
-def test_specgram():
-    """Test axes.specgram in default (psd) mode."""
-
-    # use former defaults to match existing baseline image
-    matplotlib.rcParams['image.interpolation'] = 'nearest'
-
-    n = 1000
-    Fs = 10.
-
-    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
-    NFFT_freqs = int(10 * Fs / np.min(fstims))
-    x = np.arange(0, n, 1/Fs)
-    y_freqs = np.concatenate(
-        np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1))
-
-    NFFT_noise = int(10 * Fs / 11)
-    np.random.seed(0)
-    y_noise = np.concatenate([np.random.standard_normal(n), np.random.rand(n)])
-
-    all_sides = ["default", "onesided", "twosided"]
-    for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
-        noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                        pad_to=pad_to, sides=sides)
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                        pad_to=pad_to, sides=sides,
-                        scale="linear", norm=matplotlib.colors.LogNorm())
-
-
-@image_comparison(
-    ["specgram_magnitude_freqs.png", "specgram_magnitude_freqs_linear.png",
-     "specgram_magnitude_noise.png", "specgram_magnitude_noise_linear.png"],
-    remove_text=True, tol=0.07, style="default")
-def test_specgram_magnitude():
-    """Test axes.specgram in magnitude mode."""
-
-    # use former defaults to match existing baseline image
-    matplotlib.rcParams['image.interpolation'] = 'nearest'
-
-    n = 1000
-    Fs = 10.
-
-    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
-    NFFT_freqs = int(100 * Fs / np.min(fstims))
-    x = np.arange(0, n, 1/Fs)
-    y = np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1)
-    y[:, -1] = 1
-    y_freqs = np.hstack(y)
-
-    NFFT_noise = int(10 * Fs / 11)
-    np.random.seed(0)
-    y_noise = np.concatenate([np.random.standard_normal(n), np.random.rand(n)])
-
-    all_sides = ["default", "onesided", "twosided"]
-    for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
-        noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                        pad_to=pad_to, sides=sides, mode="magnitude")
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                        pad_to=pad_to, sides=sides, mode="magnitude",
-                        scale="linear", norm=matplotlib.colors.LogNorm())
-
-
-@image_comparison(
-    ["specgram_angle_freqs.png", "specgram_phase_freqs.png",
-     "specgram_angle_noise.png", "specgram_phase_noise.png"],
-    remove_text=True, tol=0.07, style="default")
-def test_specgram_angle():
-    """Test axes.specgram in angle and phase modes."""
-
-    # use former defaults to match existing baseline image
-    matplotlib.rcParams['image.interpolation'] = 'nearest'
-
-    n = 1000
-    Fs = 10.
-
-    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
-    NFFT_freqs = int(10 * Fs / np.min(fstims))
-    x = np.arange(0, n, 1/Fs)
-    y = np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1)
-    y[:, -1] = 1
-    y_freqs = np.hstack(y)
-
-    NFFT_noise = int(10 * Fs / 11)
-    np.random.seed(0)
-    y_noise = np.concatenate([np.random.standard_normal(n), np.random.rand(n)])
-
-    all_sides = ["default", "onesided", "twosided"]
-    for y, NFFT in [(y_freqs, NFFT_freqs), (y_noise, NFFT_noise)]:
-        noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
-        for mode in ["angle", "phase"]:
-            for ax, sides in zip(plt.figure().subplots(3), all_sides):
-                ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                            pad_to=pad_to, sides=sides, mode=mode)
-                with pytest.raises(ValueError):
-                    ax.specgram(y, NFFT=NFFT, Fs=Fs, noverlap=noverlap,
-                                pad_to=pad_to, sides=sides, mode=mode,
-                                scale="dB")
-
-
-def test_specgram_fs_none():
-    """Test axes.specgram when Fs is None, should not throw error."""
-    spec, freqs, t, im = plt.specgram(np.ones(300), Fs=None, scale='linear')
-    xmin, xmax, freq0, freq1 = im.get_extent()
-    assert xmin == 32 and xmax == 96
-
-
-@check_figures_equal(extensions=["png"])
-def test_specgram_origin_rcparam(fig_test, fig_ref):
-    """Test specgram ignores image.origin rcParam and uses origin 'upper'."""
-    t = np.arange(500)
-    signal = np.sin(t)
-
-    plt.rcParams["image.origin"] = 'upper'
-
-    # Reference: First graph using default origin in imshow (upper),
-    fig_ref.subplots().specgram(signal)
-
-    # Try to overwrite the setting trying to flip the specgram
-    plt.rcParams["image.origin"] = 'lower'
-
-    # Test: origin='lower' should be ignored
-    fig_test.subplots().specgram(signal)
-
-
-def test_specgram_origin_kwarg():
-    """Ensure passing origin as a kwarg raises a TypeError."""
-    t = np.arange(500)
-    signal = np.sin(t)
-
-    with pytest.raises(TypeError):
-        plt.specgram(signal, origin='lower')
-
-
-@image_comparison(
-    ["psd_freqs.png", "csd_freqs.png", "psd_noise.png", "csd_noise.png"],
-    remove_text=True, tol=0.002)
-def test_psd_csd():
-    n = 10000
-    Fs = 100.
-
-    fstims = [[Fs/4, Fs/5, Fs/11], [Fs/4.7, Fs/5.6, Fs/11.9]]
-    NFFT_freqs = int(1000 * Fs / np.min(fstims))
-    x = np.arange(0, n, 1/Fs)
-    ys_freqs = np.sin(2 * np.pi * np.multiply.outer(fstims, x)).sum(axis=1)
-
-    NFFT_noise = int(1000 * Fs / 11)
-    np.random.seed(0)
-    ys_noise = [np.random.standard_normal(n), np.random.rand(n)]
-
-    all_kwargs = [{"sides": "default"},
-                  {"sides": "onesided", "return_line": False},
-                  {"sides": "twosided", "return_line": True}]
-    for ys, NFFT in [(ys_freqs, NFFT_freqs), (ys_noise, NFFT_noise)]:
-        noverlap = NFFT // 2
-        pad_to = int(2 ** np.ceil(np.log2(NFFT)))
-        for ax, kwargs in zip(plt.figure().subplots(3), all_kwargs):
-            ret = ax.psd(np.concatenate(ys), NFFT=NFFT, Fs=Fs,
-                         noverlap=noverlap, pad_to=pad_to, **kwargs)
-            assert len(ret) == 2 + kwargs.get("return_line", False)
-            ax.set(xlabel="", ylabel="")
-        for ax, kwargs in zip(plt.figure().subplots(3), all_kwargs):
-            ret = ax.csd(*ys, NFFT=NFFT, Fs=Fs,
-                         noverlap=noverlap, pad_to=pad_to, **kwargs)
-            assert len(ret) == 2 + kwargs.get("return_line", False)
-            ax.set(xlabel="", ylabel="")
-
-
-@image_comparison(
-    ["magnitude_spectrum_freqs_linear.png",
-     "magnitude_spectrum_freqs_dB.png",
-     "angle_spectrum_freqs.png",
-     "phase_spectrum_freqs.png",
-     "magnitude_spectrum_noise_linear.png",
-     "magnitude_spectrum_noise_dB.png",
-     "angle_spectrum_noise.png",
-     "phase_spectrum_noise.png"],
-    remove_text=True)
-def test_spectrum():
-    n = 10000
-    Fs = 100.
-
-    fstims1 = [Fs/4, Fs/5, Fs/11]
-    NFFT = int(1000 * Fs / min(fstims1))
-    pad_to = int(2 ** np.ceil(np.log2(NFFT)))
-
-    x = np.arange(0, n, 1/Fs)
-    y_freqs = ((np.sin(2 * np.pi * np.outer(x, fstims1)) * 10**np.arange(3))
-               .sum(axis=1))
-    np.random.seed(0)
-    y_noise = np.hstack([np.random.standard_normal(n), np.random.rand(n)]) - .5
-
-    all_sides = ["default", "onesided", "twosided"]
-    kwargs = {"Fs": Fs, "pad_to": pad_to}
-    for y in [y_freqs, y_noise]:
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            spec, freqs, line = ax.magnitude_spectrum(y, sides=sides, **kwargs)
-            ax.set(xlabel="", ylabel="")
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            spec, freqs, line = ax.magnitude_spectrum(y, sides=sides, **kwargs,
-                                                      scale="dB")
-            ax.set(xlabel="", ylabel="")
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            spec, freqs, line = ax.angle_spectrum(y, sides=sides, **kwargs)
-            ax.set(xlabel="", ylabel="")
-        for ax, sides in zip(plt.figure().subplots(3), all_sides):
-            spec, freqs, line = ax.phase_spectrum(y, sides=sides, **kwargs)
-            ax.set(xlabel="", ylabel="")
-
-
-def test_psd_csd_edge_cases():
-    # Inverted yaxis or fully zero inputs used to throw exceptions.
-    axs = plt.figure().subplots(2)
-    for ax in axs:
-        ax.yaxis.set(inverted=True)
-    with np.errstate(divide="ignore"):
-        axs[0].psd(np.zeros(5))
-        axs[1].csd(np.zeros(5), np.zeros(5))
-
-
-@check_figures_equal(extensions=['png'])
-def test_twin_remove(fig_test, fig_ref):
-    ax_test = fig_test.add_subplot()
-    ax_twinx = ax_test.twinx()
-    ax_twiny = ax_test.twiny()
-    ax_twinx.remove()
-    ax_twiny.remove()
-
-    ax_ref = fig_ref.add_subplot()
-    # Ideally we also undo tick changes when calling ``remove()``, but for now
-    # manually set the ticks of the reference image to match the test image
-    ax_ref.xaxis.tick_bottom()
-    ax_ref.yaxis.tick_left()
-
-
-@image_comparison(['twin_spines.png'], remove_text=True,
-                  tol=0.022 if platform.machine() == 'arm64' else 0)
-def test_twin_spines():
-
-    def make_patch_spines_invisible(ax):
-        ax.set_frame_on(True)
-        ax.patch.set_visible(False)
-        ax.spines[:].set_visible(False)
-
-    fig = plt.figure(figsize=(4, 3))
-    fig.subplots_adjust(right=0.75)
-
-    host = fig.add_subplot()
-    par1 = host.twinx()
-    par2 = host.twinx()
-
-    # Offset the right spine of par2.  The ticks and label have already been
-    # placed on the right by twinx above.
-    par2.spines.right.set_position(("axes", 1.2))
-    # Having been created by twinx, par2 has its frame off, so the line of
-    # its detached spine is invisible.  First, activate the frame but make
-    # the patch and spines invisible.
-    make_patch_spines_invisible(par2)
-    # Second, show the right spine.
-    par2.spines.right.set_visible(True)
-
-    p1, = host.plot([0, 1, 2], [0, 1, 2], "b-")
-    p2, = par1.plot([0, 1, 2], [0, 3, 2], "r-")
-    p3, = par2.plot([0, 1, 2], [50, 30, 15], "g-")
-
-    host.set_xlim(0, 2)
-    host.set_ylim(0, 2)
-    par1.set_ylim(0, 4)
-    par2.set_ylim(1, 65)
-
-    host.yaxis.label.set_color(p1.get_color())
-    par1.yaxis.label.set_color(p2.get_color())
-    par2.yaxis.label.set_color(p3.get_color())
-
-    tkw = dict(size=4, width=1.5)
-    host.tick_params(axis='y', colors=p1.get_color(), **tkw)
-    par1.tick_params(axis='y', colors=p2.get_color(), **tkw)
-    par2.tick_params(axis='y', colors=p3.get_color(), **tkw)
-    host.tick_params(axis='x', **tkw)
-
-
-@image_comparison(['twin_spines_on_top.png', 'twin_spines_on_top.png'],
-                  remove_text=True)
-def test_twin_spines_on_top():
-    matplotlib.rcParams['axes.linewidth'] = 48.0
-    matplotlib.rcParams['lines.linewidth'] = 48.0
-
-    fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
-
-    data = np.array([[1000, 1100, 1200, 1250],
-                     [310, 301, 360, 400]])
-
-    ax2 = ax1.twinx()
-
-    ax1.plot(data[0], data[1]/1E3, color='#BEAED4')
-    ax1.fill_between(data[0], data[1]/1E3, color='#BEAED4', alpha=.8)
-
-    ax2.plot(data[0], data[1]/1E3, color='#7FC97F')
-    ax2.fill_between(data[0], data[1]/1E3, color='#7FC97F', alpha=.5)
-
-    # Reuse testcase from above for a labeled data test
-    data = {"i": data[0], "j": data[1]/1E3}
-    fig = plt.figure()
-    ax1 = fig.add_subplot(1, 1, 1)
-    ax2 = ax1.twinx()
-    ax1.plot("i", "j", color='#BEAED4', data=data)
-    ax1.fill_between("i", "j", color='#BEAED4', alpha=.8, data=data)
-    ax2.plot("i", "j", color='#7FC97F', data=data)
-    ax2.fill_between("i", "j", color='#7FC97F', alpha=.5, data=data)
-
-
-@pytest.mark.parametrize("grid_which, major_visible, minor_visible", [
-    ("both", True, True),
-    ("major", True, False),
-    ("minor", False, True),
-])
-def test_rcparam_grid_minor(grid_which, major_visible, minor_visible):
-    mpl.rcParams.update({"axes.grid": True, "axes.grid.which": grid_which})
-    fig, ax = plt.subplots()
-    fig.canvas.draw()
-    assert all(tick.gridline.get_visible() == major_visible
-               for tick in ax.xaxis.majorTicks)
-    assert all(tick.gridline.get_visible() == minor_visible
-               for tick in ax.xaxis.minorTicks)
-
-
-def test_grid():
-    fig, ax = plt.subplots()
-    ax.grid()
-    fig.canvas.draw()
-    assert ax.xaxis.majorTicks[0].gridline.get_visible()
-    ax.grid(visible=False)
-    fig.canvas.draw()
-    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
-    ax.grid(visible=True)
-    fig.canvas.draw()
-    assert ax.xaxis.majorTicks[0].gridline.get_visible()
-    ax.grid()
-    fig.canvas.draw()
-    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
-
-
-def test_reset_grid():
-    fig, ax = plt.subplots()
-    ax.tick_params(reset=True, which='major', labelsize=10)
-    assert not ax.xaxis.majorTicks[0].gridline.get_visible()
-    ax.grid(color='red')  # enables grid
-    assert ax.xaxis.majorTicks[0].gridline.get_visible()
-
-    with plt.rc_context({'axes.grid': True}):
-        ax.clear()
-        ax.tick_params(reset=True, which='major', labelsize=10)
-        assert ax.xaxis.majorTicks[0].gridline.get_visible()
-
-
-@check_figures_equal(extensions=['png'])
-def test_reset_ticks(fig_test, fig_ref):
-    for fig in [fig_ref, fig_test]:
-        ax = fig.add_subplot()
-        ax.grid(True)
-        ax.tick_params(
-            direction='in', length=10, width=5, color='C0', pad=12,
-            labelsize=14, labelcolor='C1', labelrotation=45,
-            grid_color='C2', grid_alpha=0.8, grid_linewidth=3,
-            grid_linestyle='--')
-        fig.draw_without_rendering()
-
-    # After we've changed any setting on ticks, reset_ticks will mean
-    # re-creating them from scratch. This *should* appear the same as not
-    # resetting them.
-    for ax in fig_test.axes:
-        ax.xaxis.reset_ticks()
-        ax.yaxis.reset_ticks()
-
-
-@mpl.style.context('mpl20')
-def test_context_ticks():
-    with plt.rc_context({
-            'xtick.direction': 'in', 'xtick.major.size': 30, 'xtick.major.width': 5,
-            'xtick.color': 'C0', 'xtick.major.pad': 12,
-            'xtick.bottom': True, 'xtick.top': True,
-            'xtick.labelsize': 14, 'xtick.labelcolor': 'C1'}):
-        fig, ax = plt.subplots()
-    # Draw outside the context so that all-but-first tick are generated with the normal
-    # mpl20 style in place.
-    fig.draw_without_rendering()
-
-    first_tick = ax.xaxis.majorTicks[0]
-    for tick in ax.xaxis.majorTicks[1:]:
-        assert tick._size == first_tick._size
-        assert tick._width == first_tick._width
-        assert tick._base_pad == first_tick._base_pad
-        assert tick._labelrotation == first_tick._labelrotation
-        assert tick._zorder == first_tick._zorder
-        assert tick._tickdir == first_tick._tickdir
-
-
-def test_vline_limit():
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.axvline(0.5)
-    ax.plot([-0.1, 0, 0.2, 0.1])
-    assert_allclose(ax.get_ylim(), (-.1, .2))
-
-
-@pytest.mark.parametrize('fv, fh, args', [[plt.axvline, plt.axhline, (1,)],
-                                          [plt.axvspan, plt.axhspan, (1, 1)]])
-def test_axline_minmax(fv, fh, args):
-    bad_lim = matplotlib.dates.num2date(1)
-    # Check vertical functions
-    with pytest.raises(ValueError, match='ymin must be a single scalar value'):
-        fv(*args, ymin=bad_lim, ymax=1)
-    with pytest.raises(ValueError, match='ymax must be a single scalar value'):
-        fv(*args, ymin=1, ymax=bad_lim)
-    # Check horizontal functions
-    with pytest.raises(ValueError, match='xmin must be a single scalar value'):
-        fh(*args, xmin=bad_lim, xmax=1)
-    with pytest.raises(ValueError, match='xmax must be a single scalar value'):
-        fh(*args, xmin=1, xmax=bad_lim)
-
-
-def test_empty_shared_subplots():
-    # empty plots with shared axes inherit limits from populated plots
-    fig, axs = plt.subplots(nrows=1, ncols=2, sharex=True, sharey=True)
-    axs[0].plot([1, 2, 3], [2, 4, 6])
-    x0, x1 = axs[1].get_xlim()
-    y0, y1 = axs[1].get_ylim()
-    assert x0 <= 1
-    assert x1 >= 3
-    assert y0 <= 2
-    assert y1 >= 6
-
-
-def test_shared_with_aspect_1():
-    # allow sharing one axis
-    for adjustable in ['box', 'datalim']:
-        fig, axs = plt.subplots(nrows=2, sharex=True)
-        axs[0].set_aspect(2, adjustable=adjustable, share=True)
-        assert axs[1].get_aspect() == 2
-        assert axs[1].get_adjustable() == adjustable
-
-        fig, axs = plt.subplots(nrows=2, sharex=True)
-        axs[0].set_aspect(2, adjustable=adjustable)
-        assert axs[1].get_aspect() == 'auto'
-
-
-def test_shared_with_aspect_2():
-    # Share 2 axes only with 'box':
-    fig, axs = plt.subplots(nrows=2, sharex=True, sharey=True)
-    axs[0].set_aspect(2, share=True)
-    axs[0].plot([1, 2], [3, 4])
-    axs[1].plot([3, 4], [1, 2])
-    plt.draw()  # Trigger apply_aspect().
-    assert axs[0].get_xlim() == axs[1].get_xlim()
-    assert axs[0].get_ylim() == axs[1].get_ylim()
-
-
-def test_shared_with_aspect_3():
-    # Different aspect ratios:
-    for adjustable in ['box', 'datalim']:
-        fig, axs = plt.subplots(nrows=2, sharey=True)
-        axs[0].set_aspect(2, adjustable=adjustable)
-        axs[1].set_aspect(0.5, adjustable=adjustable)
-        axs[0].plot([1, 2], [3, 4])
-        axs[1].plot([3, 4], [1, 2])
-        plt.draw()  # Trigger apply_aspect().
-        assert axs[0].get_xlim() != axs[1].get_xlim()
-        assert axs[0].get_ylim() == axs[1].get_ylim()
-        fig_aspect = fig.bbox_inches.height / fig.bbox_inches.width
-        for ax in axs:
-            p = ax.get_position()
-            box_aspect = p.height / p.width
-            lim_aspect = ax.viewLim.height / ax.viewLim.width
-            expected = fig_aspect * box_aspect / lim_aspect
-            assert round(expected, 4) == round(ax.get_aspect(), 4)
-
-
-def test_shared_aspect_error():
-    fig, axes = plt.subplots(1, 2, sharex=True, sharey=True)
-    axes[0].axis("equal")
-    with pytest.raises(RuntimeError, match=r"set_aspect\(..., adjustable="):
-        fig.draw_without_rendering()
-
-
-@pytest.mark.parametrize('err, args, kwargs, match',
-                         ((TypeError, (1, 2), {},
-                           r"axis\(\) takes from 0 to 1 positional arguments "
-                           "but 2 were given"),
-                          (ValueError, ('foo', ), {},
-                           "Unrecognized string 'foo' to axis; try 'on' or "
-                           "'off'"),
-                          (TypeError, ([1, 2], ), {},
-                           "The first argument to axis*"),
-                          (TypeError, tuple(), {'foo': None},
-                           r"axis\(\) got an unexpected keyword argument "
-                           "'foo'"),
-                          ))
-def test_axis_errors(err, args, kwargs, match):
-    with pytest.raises(err, match=match):
-        plt.axis(*args, **kwargs)
-
-
-def test_axis_method_errors():
-    ax = plt.gca()
-    with pytest.raises(ValueError, match="unknown value for which: 'foo'"):
-        ax.get_xaxis_transform('foo')
-    with pytest.raises(ValueError, match="unknown value for which: 'foo'"):
-        ax.get_yaxis_transform('foo')
-    with pytest.raises(TypeError, match="Cannot supply both positional and"):
-        ax.set_prop_cycle('foo', label='bar')
-    with pytest.raises(ValueError, match="argument must be among"):
-        ax.set_anchor('foo')
-    with pytest.raises(ValueError, match="scilimits must be a sequence"):
-        ax.ticklabel_format(scilimits=1)
-    with pytest.raises(TypeError, match="Specifying 'loc' is disallowed"):
-        ax.set_xlabel('foo', loc='left', x=1)
-    with pytest.raises(TypeError, match="Specifying 'loc' is disallowed"):
-        ax.set_ylabel('foo', loc='top', y=1)
-    with pytest.raises(TypeError, match="Cannot pass both 'left'"):
-        ax.set_xlim(left=0, xmin=1)
-    with pytest.raises(TypeError, match="Cannot pass both 'right'"):
-        ax.set_xlim(right=0, xmax=1)
-    with pytest.raises(TypeError, match="Cannot pass both 'bottom'"):
-        ax.set_ylim(bottom=0, ymin=1)
-    with pytest.raises(TypeError, match="Cannot pass both 'top'"):
-        ax.set_ylim(top=0, ymax=1)
-
-
-@pytest.mark.parametrize('twin', ('x', 'y'))
-def test_twin_with_aspect(twin):
-    fig, ax = plt.subplots()
-    # test twinx or twiny
-    ax_twin = getattr(ax, f'twin{twin}')()
-    ax.set_aspect(5)
-    ax_twin.set_aspect(2)
-    assert_array_equal(ax.bbox.extents,
-                       ax_twin.bbox.extents)
-
-
-def test_relim_visible_only():
-    x1 = (0., 10.)
-    y1 = (0., 10.)
-    x2 = (-10., 20.)
-    y2 = (-10., 30.)
-
-    fig = matplotlib.figure.Figure()
-    ax = fig.add_subplot()
-    ax.plot(x1, y1)
-    assert ax.get_xlim() == x1
-    assert ax.get_ylim() == y1
-    line, = ax.plot(x2, y2)
-    assert ax.get_xlim() == x2
-    assert ax.get_ylim() == y2
-    line.set_visible(False)
-    assert ax.get_xlim() == x2
-    assert ax.get_ylim() == y2
-
-    ax.relim(visible_only=True)
-    ax.autoscale_view()
-
-    assert ax.get_xlim() == x1
-    assert ax.get_ylim() == y1
-
-
-def test_text_labelsize():
-    """
-    tests for issue #1172
-    """
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.tick_params(labelsize='large')
-    ax.tick_params(direction='out')
-
-
-# Note: The `pie` image tests were affected by Numpy 2.0 changing promotions
-# (NEP 50). While the changes were only marginal, tolerances were introduced.
-# These tolerances could likely go away when numpy 2.0 is the minimum supported
-# numpy and the images are regenerated.
-
-@image_comparison(['pie_default.png'], tol=0.01)
-def test_pie_default():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-    fig1, ax1 = plt.subplots(figsize=(8, 6))
-    ax1.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90)
-
-
-@image_comparison(['pie_linewidth_0', 'pie_linewidth_0', 'pie_linewidth_0'],
-                  extensions=['png'], style='mpl20', tol=0.01)
-def test_pie_linewidth_0():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0})
-    # Set aspect ratio to be equal so that pie is drawn as a circle.
-    plt.axis('equal')
-
-    # Reuse testcase from above for a labeled data test
-    data = {"l": labels, "s": sizes, "c": colors, "ex": explode}
-    fig = plt.figure()
-    ax = fig.gca()
-    ax.pie("s", explode="ex", labels="l", colors="c",
-           autopct='%1.1f%%', shadow=True, startangle=90,
-           wedgeprops={'linewidth': 0}, data=data)
-    ax.axis('equal')
-
-    # And again to test the pyplot functions which should also be able to be
-    # called with a data kwarg
-    plt.figure()
-    plt.pie("s", explode="ex", labels="l", colors="c",
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0}, data=data)
-    plt.axis('equal')
-
-
-@image_comparison(['pie_center_radius.png'], style='mpl20', tol=0.01)
-def test_pie_center_radius():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0}, center=(1, 2), radius=1.5)
-
-    plt.annotate("Center point", xy=(1, 2), xytext=(1, 1.3),
-                 arrowprops=dict(arrowstyle="->",
-                                 connectionstyle="arc3"),
-                 bbox=dict(boxstyle="square", facecolor="lightgrey"))
-    # Set aspect ratio to be equal so that pie is drawn as a circle.
-    plt.axis('equal')
-
-
-@image_comparison(['pie_linewidth_2.png'], style='mpl20', tol=0.01)
-def test_pie_linewidth_2():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 2})
-    # Set aspect ratio to be equal so that pie is drawn as a circle.
-    plt.axis('equal')
-
-
-@image_comparison(['pie_ccw_true.png'], style='mpl20', tol=0.01)
-def test_pie_ccw_true():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            counterclock=True)
-    # Set aspect ratio to be equal so that pie is drawn as a circle.
-    plt.axis('equal')
-
-
-@image_comparison(['pie_frame_grid.png'], style='mpl20', tol=0.002)
-def test_pie_frame_grid():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    # only "explode" the 2nd slice (i.e. 'Hogs')
-    explode = (0, 0.1, 0, 0)
-
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0},
-            frame=True, center=(2, 2))
-
-    plt.pie(sizes[::-1], explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0},
-            frame=True, center=(5, 2))
-
-    plt.pie(sizes, explode=explode[::-1], labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0},
-            frame=True, center=(3, 5))
-    # Set aspect ratio to be equal so that pie is drawn as a circle.
-    plt.axis('equal')
-
-
-@image_comparison(['pie_rotatelabels_true.png'], style='mpl20', tol=0.009)
-def test_pie_rotatelabels_true():
-    # The slices will be ordered and plotted counter-clockwise.
-    labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            rotatelabels=True)
-    # Set aspect ratio to be equal so that pie is drawn as a circle.
-    plt.axis('equal')
-
-
-@image_comparison(['pie_no_label.png'], tol=0.01)
-def test_pie_nolabel_but_legend():
-    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90, labeldistance=None,
-            rotatelabels=True)
-    plt.axis('equal')
-    plt.ylim(-1.2, 1.2)
-    plt.legend()
-
-
-@image_comparison(['pie_shadow.png'], style='mpl20', tol=0.002)
-def test_pie_shadow():
-    # Also acts as a test for the shade argument of Shadow
-    sizes = [15, 30, 45, 10]
-    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice
-    _, axes = plt.subplots(2, 2)
-    axes[0][0].pie(sizes, explode=explode, colors=colors,
-                   shadow=True, startangle=90,
-                   wedgeprops={'linewidth': 0})
-
-    axes[0][1].pie(sizes, explode=explode, colors=colors,
-                   shadow=False, startangle=90,
-                   wedgeprops={'linewidth': 0})
-
-    axes[1][0].pie(sizes, explode=explode, colors=colors,
-                   shadow={'ox': -0.05, 'oy': -0.05, 'shade': 0.9, 'edgecolor': 'none'},
-                   startangle=90, wedgeprops={'linewidth': 0})
-
-    axes[1][1].pie(sizes, explode=explode, colors=colors,
-                   shadow={'ox': 0.05, 'linewidth': 2, 'shade': 0.2},
-                   startangle=90, wedgeprops={'linewidth': 0})
-
-
-def test_pie_textprops():
-    data = [23, 34, 45]
-    labels = ["Long name 1", "Long name 2", "Long name 3"]
-
-    textprops = dict(horizontalalignment="center",
-                     verticalalignment="top",
-                     rotation=90,
-                     rotation_mode="anchor",
-                     size=12, color="red")
-
-    _, texts, autopct = plt.gca().pie(data, labels=labels, autopct='%.2f',
-                                      textprops=textprops)
-    for labels in [texts, autopct]:
-        for tx in labels:
-            assert tx.get_ha() == textprops["horizontalalignment"]
-            assert tx.get_va() == textprops["verticalalignment"]
-            assert tx.get_rotation() == textprops["rotation"]
-            assert tx.get_rotation_mode() == textprops["rotation_mode"]
-            assert tx.get_size() == textprops["size"]
-            assert tx.get_color() == textprops["color"]
-
-
-def test_pie_get_negative_values():
-    # Test the ValueError raised when feeding negative values into axes.pie
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.pie([5, 5, -3], explode=[0, .1, .2])
-
-
-def test_pie_invalid_explode():
-    # Test ValueError raised when feeding short explode list to axes.pie
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.pie([1, 2, 3], explode=[0.1, 0.1])
-
-
-def test_pie_invalid_labels():
-    # Test ValueError raised when feeding short labels list to axes.pie
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.pie([1, 2, 3], labels=["One", "Two"])
-
-
-def test_pie_invalid_radius():
-    # Test ValueError raised when feeding negative radius to axes.pie
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.pie([1, 2, 3], radius=-5)
-
-
-def test_normalize_kwarg_pie():
-    fig, ax = plt.subplots()
-    x = [0.3, 0.3, 0.1]
-    t1 = ax.pie(x=x, normalize=True)
-    assert abs(t1[0][-1].theta2 - 360.) < 1e-3
-    t2 = ax.pie(x=x, normalize=False)
-    assert abs(t2[0][-1].theta2 - 360.) > 1e-3
-
-
-@check_figures_equal()
-def test_pie_hatch_single(fig_test, fig_ref):
-    x = [0.3, 0.3, 0.1]
-    hatch = '+'
-    fig_test.subplots().pie(x, hatch=hatch)
-    wedges, _ = fig_ref.subplots().pie(x)
-    [w.set_hatch(hatch) for w in wedges]
-
-
-@check_figures_equal()
-def test_pie_hatch_multi(fig_test, fig_ref):
-    x = [0.3, 0.3, 0.1]
-    hatch = ['/', '+', '.']
-    fig_test.subplots().pie(x, hatch=hatch)
-    wedges, _ = fig_ref.subplots().pie(x)
-    [w.set_hatch(hp) for w, hp in zip(wedges, hatch)]
-
-
-@image_comparison(['set_get_ticklabels.png'],
-                  tol=0.025 if platform.machine() == 'arm64' else 0)
-def test_set_get_ticklabels():
-    # test issue 2246
-    fig, ax = plt.subplots(2)
-    ha = ['normal', 'set_x/yticklabels']
-
-    ax[0].plot(np.arange(10))
-    ax[0].set_title(ha[0])
-
-    ax[1].plot(np.arange(10))
-    ax[1].set_title(ha[1])
-
-    # set ticklabel to 1 plot in normal way
-    ax[0].set_xticks(range(10))
-    ax[0].set_yticks(range(10))
-    ax[0].set_xticklabels(['a', 'b', 'c', 'd'] + 6 * [''])
-    ax[0].set_yticklabels(['11', '12', '13', '14'] + 6 * [''])
-
-    # set ticklabel to the other plot, expect the 2 plots have same label
-    # setting pass get_ticklabels return value as ticklabels argument
-    ax[1].set_xticks(ax[0].get_xticks())
-    ax[1].set_yticks(ax[0].get_yticks())
-    ax[1].set_xticklabels(ax[0].get_xticklabels())
-    ax[1].set_yticklabels(ax[0].get_yticklabels())
-
-
-def test_set_ticks_kwargs_raise_error_without_labels():
-    """
-    When labels=None and any kwarg is passed, axis.set_ticks() raises a
-    ValueError.
-    """
-    fig, ax = plt.subplots()
-    ticks = [1, 2, 3]
-    with pytest.raises(ValueError, match="Incorrect use of keyword argument 'alpha'"):
-        ax.xaxis.set_ticks(ticks, alpha=0.5)
-
-
-@check_figures_equal(extensions=["png"])
-def test_set_ticks_with_labels(fig_test, fig_ref):
-    """
-    Test that these two are identical::
-
-        set_xticks(ticks); set_xticklabels(labels, **kwargs)
-        set_xticks(ticks, labels, **kwargs)
-
-    """
-    ax = fig_ref.subplots()
-    ax.set_xticks([1, 2, 4, 6])
-    ax.set_xticklabels(['a', 'b', 'c', 'd'], fontweight='bold')
-    ax.set_yticks([1, 3, 5])
-    ax.set_yticks([2, 4], minor=True)
-    ax.set_yticklabels(['A', 'B'], minor=True)
-
-    ax = fig_test.subplots()
-    ax.set_xticks([1, 2, 4, 6], ['a', 'b', 'c', 'd'], fontweight='bold')
-    ax.set_yticks([1, 3, 5])
-    ax.set_yticks([2, 4], ['A', 'B'], minor=True)
-
-
-def test_xticks_bad_args():
-    ax = plt.figure().add_subplot()
-    with pytest.raises(TypeError, match='must be a sequence'):
-        ax.set_xticks([2, 9], 3.1)
-    with pytest.raises(ValueError, match='must be 1D'):
-        plt.xticks(np.arange(4).reshape((-1, 1)))
-    with pytest.raises(ValueError, match='must be 1D'):
-        plt.xticks(np.arange(4).reshape((1, -1)))
-    with pytest.raises(ValueError, match='must be 1D'):
-        plt.xticks(np.arange(4).reshape((-1, 1)), labels=range(4))
-    with pytest.raises(ValueError, match='must be 1D'):
-        plt.xticks(np.arange(4).reshape((1, -1)), labels=range(4))
-
-
-def test_subsampled_ticklabels():
-    # test issue 11937
-    fig, ax = plt.subplots()
-    ax.plot(np.arange(10))
-    ax.xaxis.set_ticks(np.arange(10) + 0.1)
-    ax.locator_params(nbins=5)
-    ax.xaxis.set_ticklabels([c for c in "bcdefghijk"])
-    plt.draw()
-    labels = [t.get_text() for t in ax.xaxis.get_ticklabels()]
-    assert labels == ['b', 'd', 'f', 'h', 'j']
-
-
-def test_mismatched_ticklabels():
-    fig, ax = plt.subplots()
-    ax.plot(np.arange(10))
-    ax.xaxis.set_ticks([1.5, 2.5])
-    with pytest.raises(ValueError):
-        ax.xaxis.set_ticklabels(['a', 'b', 'c'])
-
-
-def test_empty_ticks_fixed_loc():
-    # Smoke test that [] can be used to unset all tick labels
-    fig, ax = plt.subplots()
-    ax.bar([1, 2], [1, 2])
-    ax.set_xticks([1, 2])
-    ax.set_xticklabels([])
-
-
-@image_comparison(['retain_tick_visibility.png'])
-def test_retain_tick_visibility():
-    fig, ax = plt.subplots()
-    plt.plot([0, 1, 2], [0, -1, 4])
-    plt.setp(ax.get_yticklabels(), visible=False)
-    ax.tick_params(axis="y", which="both", length=0)
-
-
-def test_warn_too_few_labels():
-    # note that the axis is still using an AutoLocator:
-    fig, ax = plt.subplots()
-    with pytest.warns(
-           UserWarning,
-           match=r'set_ticklabels\(\) should only be used with a fixed number'):
-        ax.set_xticklabels(['0', '0.1'])
-    # note that the axis is still using a FixedLocator:
-    fig, ax = plt.subplots()
-    ax.set_xticks([0, 0.5, 1])
-    with pytest.raises(ValueError,
-                       match='The number of FixedLocator locations'):
-        ax.set_xticklabels(['0', '0.1'])
-
-
-def test_tick_label_update():
-    # test issue 9397
-
-    fig, ax = plt.subplots()
-
-    # Set up a dummy formatter
-    def formatter_func(x, pos):
-        return "unit value" if x == 1 else ""
-    ax.xaxis.set_major_formatter(plt.FuncFormatter(formatter_func))
-
-    # Force some of the x-axis ticks to be outside of the drawn range
-    ax.set_xticks([-1, 0, 1, 2, 3])
-    ax.set_xlim(-0.5, 2.5)
-
-    fig.canvas.draw()
-    tick_texts = [tick.get_text() for tick in ax.xaxis.get_ticklabels()]
-    assert tick_texts == ["", "", "unit value", "", ""]
-
-
-@image_comparison(['o_marker_path_snap.png'], savefig_kwarg={'dpi': 72})
-def test_o_marker_path_snap():
-    fig, ax = plt.subplots()
-    ax.margins(.1)
-    for ms in range(1, 15):
-        ax.plot([1, 2, ], np.ones(2) + ms, 'o', ms=ms)
-
-    for ms in np.linspace(1, 10, 25):
-        ax.plot([3, 4, ], np.ones(2) + ms, 'o', ms=ms)
-
-
-def test_margins():
-    # test all ways margins can be called
-    data = [1, 10]
-    xmin = 0.0
-    xmax = len(data) - 1.0
-    ymin = min(data)
-    ymax = max(data)
-
-    fig1, ax1 = plt.subplots(1, 1)
-    ax1.plot(data)
-    ax1.margins(1)
-    assert ax1.margins() == (1, 1)
-    assert ax1.get_xlim() == (xmin - (xmax - xmin) * 1,
-                              xmax + (xmax - xmin) * 1)
-    assert ax1.get_ylim() == (ymin - (ymax - ymin) * 1,
-                              ymax + (ymax - ymin) * 1)
-
-    fig2, ax2 = plt.subplots(1, 1)
-    ax2.plot(data)
-    ax2.margins(0.5, 2)
-    assert ax2.margins() == (0.5, 2)
-    assert ax2.get_xlim() == (xmin - (xmax - xmin) * 0.5,
-                              xmax + (xmax - xmin) * 0.5)
-    assert ax2.get_ylim() == (ymin - (ymax - ymin) * 2,
-                              ymax + (ymax - ymin) * 2)
-
-    fig3, ax3 = plt.subplots(1, 1)
-    ax3.plot(data)
-    ax3.margins(x=-0.2, y=0.5)
-    assert ax3.margins() == (-0.2, 0.5)
-    assert ax3.get_xlim() == (xmin - (xmax - xmin) * -0.2,
-                              xmax + (xmax - xmin) * -0.2)
-    assert ax3.get_ylim() == (ymin - (ymax - ymin) * 0.5,
-                              ymax + (ymax - ymin) * 0.5)
-
-
-def test_margin_getters():
-    fig = plt.figure()
-    ax = fig.add_subplot()
-    ax.margins(0.2, 0.3)
-    assert ax.get_xmargin() == 0.2
-    assert ax.get_ymargin() == 0.3
-
-
-def test_set_margin_updates_limits():
-    mpl.style.use("default")
-    fig, ax = plt.subplots()
-    ax.plot([1, 2], [1, 2])
-    ax.set(xscale="log", xmargin=0)
-    assert ax.get_xlim() == (1, 2)
-
-
-@pytest.mark.parametrize('err, args, kwargs, match', (
-        (ValueError, (-1,), {}, r'margin must be greater than -0\.5'),
-        (ValueError, (1, -1), {}, r'margin must be greater than -0\.5'),
-        (ValueError, tuple(), {'x': -1}, r'margin must be greater than -0\.5'),
-        (ValueError, tuple(), {'y': -1}, r'margin must be greater than -0\.5'),
-        (TypeError, (1, ), {'x': 1, 'y': 1},
-         'Cannot pass both positional and keyword arguments for x and/or y'),
-        (TypeError, (1, ), {'x': 1},
-         'Cannot pass both positional and keyword arguments for x and/or y'),
-        (TypeError, (1, 1, 1), {}, 'Must pass a single positional argument'),
-))
-def test_margins_errors(err, args, kwargs, match):
-    with pytest.raises(err, match=match):
-        fig = plt.figure()
-        ax = fig.add_subplot()
-        ax.margins(*args, **kwargs)
-
-
-def test_length_one_hist():
-    fig, ax = plt.subplots()
-    ax.hist(1)
-    ax.hist([1])
-
-
-def test_set_xy_bound():
-    fig = plt.figure()
-    ax = fig.add_subplot()
-    ax.set_xbound(2.0, 3.0)
-    assert ax.get_xbound() == (2.0, 3.0)
-    assert ax.get_xlim() == (2.0, 3.0)
-    ax.set_xbound(upper=4.0)
-    assert ax.get_xbound() == (2.0, 4.0)
-    assert ax.get_xlim() == (2.0, 4.0)
-    ax.set_xbound(lower=3.0)
-    assert ax.get_xbound() == (3.0, 4.0)
-    assert ax.get_xlim() == (3.0, 4.0)
-
-    ax.set_ybound(2.0, 3.0)
-    assert ax.get_ybound() == (2.0, 3.0)
-    assert ax.get_ylim() == (2.0, 3.0)
-    ax.set_ybound(upper=4.0)
-    assert ax.get_ybound() == (2.0, 4.0)
-    assert ax.get_ylim() == (2.0, 4.0)
-    ax.set_ybound(lower=3.0)
-    assert ax.get_ybound() == (3.0, 4.0)
-    assert ax.get_ylim() == (3.0, 4.0)
-
-
-def test_pathological_hexbin():
-    # issue #2863
-    mylist = [10] * 100
-    fig, ax = plt.subplots(1, 1)
-    ax.hexbin(mylist, mylist)
-    fig.savefig(io.BytesIO())  # Check that no warning is emitted.
-
-
-def test_color_None():
-    # issue 3855
-    fig, ax = plt.subplots()
-    ax.plot([1, 2], [1, 2], color=None)
-
-
-def test_color_alias():
-    # issues 4157 and 4162
-    fig, ax = plt.subplots()
-    line = ax.plot([0, 1], c='lime')[0]
-    assert 'lime' == line.get_color()
-
-
-def test_numerical_hist_label():
-    fig, ax = plt.subplots()
-    ax.hist([range(15)] * 5, label=range(5))
-    ax.legend()
-
-
-def test_unicode_hist_label():
-    fig, ax = plt.subplots()
-    a = (b'\xe5\xbe\x88\xe6\xbc\x82\xe4\xba\xae, ' +
-         b'r\xc3\xb6m\xc3\xa4n ch\xc3\xa4r\xc3\xa1ct\xc3\xa8rs')
-    b = b'\xd7\xa9\xd7\x9c\xd7\x95\xd7\x9d'
-    labels = [a.decode('utf-8'),
-              'hi aardvark',
-              b.decode('utf-8'),
-              ]
-
-    ax.hist([range(15)] * 3, label=labels)
-    ax.legend()
-
-
-def test_move_offsetlabel():
-    data = np.random.random(10) * 1e-22
-
-    fig, ax = plt.subplots()
-    ax.plot(data)
-    fig.canvas.draw()
-    before = ax.yaxis.offsetText.get_position()
-    assert ax.yaxis.offsetText.get_horizontalalignment() == 'left'
-    ax.yaxis.tick_right()
-    fig.canvas.draw()
-    after = ax.yaxis.offsetText.get_position()
-    assert after[0] > before[0] and after[1] == before[1]
-    assert ax.yaxis.offsetText.get_horizontalalignment() == 'right'
-
-    fig, ax = plt.subplots()
-    ax.plot(data)
-    fig.canvas.draw()
-    before = ax.xaxis.offsetText.get_position()
-    assert ax.xaxis.offsetText.get_verticalalignment() == 'top'
-    ax.xaxis.tick_top()
-    fig.canvas.draw()
-    after = ax.xaxis.offsetText.get_position()
-    assert after[0] == before[0] and after[1] > before[1]
-    assert ax.xaxis.offsetText.get_verticalalignment() == 'bottom'
-
-
-@image_comparison(['rc_spines.png'], savefig_kwarg={'dpi': 40})
-def test_rc_spines():
-    rc_dict = {
-        'axes.spines.left': False,
-        'axes.spines.right': False,
-        'axes.spines.top': False,
-        'axes.spines.bottom': False}
-    with matplotlib.rc_context(rc_dict):
-        plt.subplots()  # create a figure and axes with the spine properties
-
-
-@image_comparison(['rc_grid.png'], savefig_kwarg={'dpi': 40})
-def test_rc_grid():
-    fig = plt.figure()
-    rc_dict0 = {
-        'axes.grid': True,
-        'axes.grid.axis': 'both'
-    }
-    rc_dict1 = {
-        'axes.grid': True,
-        'axes.grid.axis': 'x'
-    }
-    rc_dict2 = {
-        'axes.grid': True,
-        'axes.grid.axis': 'y'
-    }
-    dict_list = [rc_dict0, rc_dict1, rc_dict2]
-
-    for i, rc_dict in enumerate(dict_list, 1):
-        with matplotlib.rc_context(rc_dict):
-            fig.add_subplot(3, 1, i)
-
-
-def test_rc_tick():
-    d = {'xtick.bottom': False, 'xtick.top': True,
-         'ytick.left': True, 'ytick.right': False}
-    with plt.rc_context(rc=d):
-        fig = plt.figure()
-        ax1 = fig.add_subplot(1, 1, 1)
-        xax = ax1.xaxis
-        yax = ax1.yaxis
-        # tick1On bottom/left
-        assert not xax._major_tick_kw['tick1On']
-        assert xax._major_tick_kw['tick2On']
-        assert not xax._minor_tick_kw['tick1On']
-        assert xax._minor_tick_kw['tick2On']
-
-        assert yax._major_tick_kw['tick1On']
-        assert not yax._major_tick_kw['tick2On']
-        assert yax._minor_tick_kw['tick1On']
-        assert not yax._minor_tick_kw['tick2On']
-
-
-def test_rc_major_minor_tick():
-    d = {'xtick.top': True, 'ytick.right': True,  # Enable all ticks
-         'xtick.bottom': True, 'ytick.left': True,
-         # Selectively disable
-         'xtick.minor.bottom': False, 'xtick.major.bottom': False,
-         'ytick.major.left': False, 'ytick.minor.left': False}
-    with plt.rc_context(rc=d):
-        fig = plt.figure()
-        ax1 = fig.add_subplot(1, 1, 1)
-        xax = ax1.xaxis
-        yax = ax1.yaxis
-        # tick1On bottom/left
-        assert not xax._major_tick_kw['tick1On']
-        assert xax._major_tick_kw['tick2On']
-        assert not xax._minor_tick_kw['tick1On']
-        assert xax._minor_tick_kw['tick2On']
-
-        assert not yax._major_tick_kw['tick1On']
-        assert yax._major_tick_kw['tick2On']
-        assert not yax._minor_tick_kw['tick1On']
-        assert yax._minor_tick_kw['tick2On']
-
-
-def test_square_plot():
-    x = np.arange(4)
-    y = np.array([1., 3., 5., 7.])
-    fig, ax = plt.subplots()
-    ax.plot(x, y, 'mo')
-    ax.axis('square')
-    xlim, ylim = ax.get_xlim(), ax.get_ylim()
-    assert np.diff(xlim) == np.diff(ylim)
-    assert ax.get_aspect() == 1
-    assert_array_almost_equal(
-        ax.get_position(original=True).extents, (0.125, 0.1, 0.9, 0.9))
-    assert_array_almost_equal(
-        ax.get_position(original=False).extents, (0.2125, 0.1, 0.8125, 0.9))
-
-
-def test_bad_plot_args():
-    with pytest.raises(ValueError):
-        plt.plot(None)
-    with pytest.raises(ValueError):
-        plt.plot(None, None)
-    with pytest.raises(ValueError):
-        plt.plot(np.zeros((2, 2)), np.zeros((2, 3)))
-    with pytest.raises(ValueError):
-        plt.plot((np.arange(5).reshape((1, -1)), np.arange(5).reshape(-1, 1)))
-
-
-@pytest.mark.parametrize(
-    "xy, cls", [
-        ((), mpl.image.AxesImage),  # (0, N)
-        (((3, 7), (2, 6)), mpl.image.AxesImage),  # (xmin, xmax)
-        ((range(5), range(4)), mpl.image.AxesImage),  # regular grid
-        (([1, 2, 4, 8, 16], [0, 1, 2, 3]),  # irregular grid
-         mpl.image.PcolorImage),
-        ((np.random.random((4, 5)), np.random.random((4, 5))),  # 2D coords
-         mpl.collections.QuadMesh),
-    ]
-)
-@pytest.mark.parametrize(
-    "data", [np.arange(12).reshape((3, 4)), np.random.rand(3, 4, 3)]
-)
-def test_pcolorfast(xy, data, cls):
-    fig, ax = plt.subplots()
-    assert type(ax.pcolorfast(*xy, data)) == cls
-
-
-def test_pcolorfast_bad_dims():
-    fig, ax = plt.subplots()
-    with pytest.raises(
-            TypeError, match=("the given X was 1D and the given Y was 2D")):
-        ax.pcolorfast(np.empty(6), np.empty((4, 7)), np.empty((8, 8)))
-
-
-def test_pcolorfast_regular_xy_incompatible_size():
-    """
-    Test that the sizes of X, Y, C are compatible for regularly spaced X, Y.
-
-    Note that after the regualar-spacing check, pcolorfast may go into the
-    fast "image" mode, where the individual X, Y positions are not used anymore.
-    Therefore, the algorithm had worked with any regularly number of regularly
-    spaced values, but discarded their values.
-    """
-    fig, ax = plt.subplots()
-    with pytest.raises(
-            ValueError, match=r"Length of X \(5\) must be one larger than the "
-                              r"number of columns in C \(20\)"):
-        ax.pcolorfast(np.arange(5), np.arange(11), np.random.rand(10, 20))
-
-    with pytest.raises(
-            ValueError, match=r"Length of Y \(5\) must be one larger than the "
-                              r"number of rows in C \(10\)"):
-        ax.pcolorfast(np.arange(21), np.arange(5), np.random.rand(10, 20))
-
-
-def test_shared_scale():
-    fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
-
-    axs[0, 0].set_xscale("log")
-    axs[0, 0].set_yscale("log")
-
-    for ax in axs.flat:
-        assert ax.get_yscale() == 'log'
-        assert ax.get_xscale() == 'log'
-
-    axs[1, 1].set_xscale("linear")
-    axs[1, 1].set_yscale("linear")
-
-    for ax in axs.flat:
-        assert ax.get_yscale() == 'linear'
-        assert ax.get_xscale() == 'linear'
-
-
-def test_shared_bool():
-    with pytest.raises(TypeError):
-        plt.subplot(sharex=True)
-    with pytest.raises(TypeError):
-        plt.subplot(sharey=True)
-
-
-def test_violin_point_mass():
-    """Violin plot should handle point mass pdf gracefully."""
-    plt.violinplot(np.array([0, 0]))
-
-
-def generate_errorbar_inputs():
-    base_xy = cycler('x', [np.arange(5)]) + cycler('y', [np.ones(5)])
-    err_cycler = cycler('err', [1,
-                                [1, 1, 1, 1, 1],
-                                [[1, 1, 1, 1, 1],
-                                 [1, 1, 1, 1, 1]],
-                                np.ones(5),
-                                np.ones((2, 5)),
-                                None
-                                ])
-    xerr_cy = cycler('xerr', err_cycler)
-    yerr_cy = cycler('yerr', err_cycler)
-
-    empty = ((cycler('x', [[]]) + cycler('y', [[]])) *
-             cycler('xerr', [[], None]) * cycler('yerr', [[], None]))
-    xerr_only = base_xy * xerr_cy
-    yerr_only = base_xy * yerr_cy
-    both_err = base_xy * yerr_cy * xerr_cy
-
-    return [*xerr_only, *yerr_only, *both_err, *empty]
-
-
-@pytest.mark.parametrize('kwargs', generate_errorbar_inputs())
-def test_errorbar_inputs_shotgun(kwargs):
-    ax = plt.gca()
-    eb = ax.errorbar(**kwargs)
-    eb.remove()
-
-
-@image_comparison(["dash_offset"], remove_text=True)
-def test_dash_offset():
-    fig, ax = plt.subplots()
-    x = np.linspace(0, 10)
-    y = np.ones_like(x)
-    for j in range(0, 100, 2):
-        ax.plot(x, j*y, ls=(j, (10, 10)), lw=5, color='k')
-
-
-def test_title_pad():
-    # check that title padding puts the title in the right
-    # place...
-    fig, ax = plt.subplots()
-    ax.set_title('aardvark', pad=30.)
-    m = ax.titleOffsetTrans.get_matrix()
-    assert m[1, -1] == (30. / 72. * fig.dpi)
-    ax.set_title('aardvark', pad=0.)
-    m = ax.titleOffsetTrans.get_matrix()
-    assert m[1, -1] == 0.
-    # check that it is reverted...
-    ax.set_title('aardvark', pad=None)
-    m = ax.titleOffsetTrans.get_matrix()
-    assert m[1, -1] == (matplotlib.rcParams['axes.titlepad'] / 72. * fig.dpi)
-
-
-def test_title_location_roundtrip():
-    fig, ax = plt.subplots()
-    # set default title location
-    plt.rcParams['axes.titlelocation'] = 'center'
-    ax.set_title('aardvark')
-    ax.set_title('left', loc='left')
-    ax.set_title('right', loc='right')
-
-    assert 'left' == ax.get_title(loc='left')
-    assert 'right' == ax.get_title(loc='right')
-    assert 'aardvark' == ax.get_title(loc='center')
-
-    with pytest.raises(ValueError):
-        ax.get_title(loc='foo')
-    with pytest.raises(ValueError):
-        ax.set_title('fail', loc='foo')
-
-
-@pytest.mark.parametrize('sharex', [True, False])
-def test_title_location_shared(sharex):
-    fig, axs = plt.subplots(2, 1, sharex=sharex)
-    axs[0].set_title('A', pad=-40)
-    axs[1].set_title('B', pad=-40)
-    fig.draw_without_rendering()
-    x, y1 = axs[0].title.get_position()
-    x, y2 = axs[1].title.get_position()
-    assert y1 == y2 == 1.0
-
-
-@image_comparison(["loglog.png"], remove_text=True, tol=0.02)
-def test_loglog():
-    fig, ax = plt.subplots()
-    x = np.arange(1, 11)
-    ax.loglog(x, x**3, lw=5)
-    ax.tick_params(length=25, width=2)
-    ax.tick_params(length=15, width=2, which='minor')
-
-
-@image_comparison(["test_loglog_nonpos.png"], remove_text=True, style='mpl20',
-                  tol=0.029 if platform.machine() == 'arm64' else 0)
-def test_loglog_nonpos():
-    fig, axs = plt.subplots(3, 3)
-    x = np.arange(1, 11)
-    y = x**3
-    y[7] = -3.
-    x[4] = -10
-    for (mcy, mcx), ax in zip(product(['mask', 'clip', ''], repeat=2),
-                              axs.flat):
-        if mcx == mcy:
-            if mcx:
-                ax.loglog(x, y**3, lw=2, nonpositive=mcx)
-            else:
-                ax.loglog(x, y**3, lw=2)
-        else:
-            ax.loglog(x, y**3, lw=2)
-            if mcx:
-                ax.set_xscale("log", nonpositive=mcx)
-            if mcy:
-                ax.set_yscale("log", nonpositive=mcy)
-
-
-@mpl.style.context('default')
-def test_axes_margins():
-    fig, ax = plt.subplots()
-    ax.plot([0, 1, 2, 3])
-    assert ax.get_ybound()[0] != 0
-
-    fig, ax = plt.subplots()
-    ax.bar([0, 1, 2, 3], [1, 1, 1, 1])
-    assert ax.get_ybound()[0] == 0
-
-    fig, ax = plt.subplots()
-    ax.barh([0, 1, 2, 3], [1, 1, 1, 1])
-    assert ax.get_xbound()[0] == 0
-
-    fig, ax = plt.subplots()
-    ax.pcolor(np.zeros((10, 10)))
-    assert ax.get_xbound() == (0, 10)
-    assert ax.get_ybound() == (0, 10)
-
-    fig, ax = plt.subplots()
-    ax.pcolorfast(np.zeros((10, 10)))
-    assert ax.get_xbound() == (0, 10)
-    assert ax.get_ybound() == (0, 10)
-
-    fig, ax = plt.subplots()
-    ax.hist(np.arange(10))
-    assert ax.get_ybound()[0] == 0
-
-    fig, ax = plt.subplots()
-    ax.imshow(np.zeros((10, 10)))
-    assert ax.get_xbound() == (-0.5, 9.5)
-    assert ax.get_ybound() == (-0.5, 9.5)
-
-
-@pytest.fixture(params=['x', 'y'])
-def shared_axis_remover(request):
-    def _helper_x(ax):
-        ax2 = ax.twinx()
-        ax2.remove()
-        ax.set_xlim(0, 15)
-        r = ax.xaxis.get_major_locator()()
-        assert r[-1] > 14
-
-    def _helper_y(ax):
-        ax2 = ax.twiny()
-        ax2.remove()
-        ax.set_ylim(0, 15)
-        r = ax.yaxis.get_major_locator()()
-        assert r[-1] > 14
-
-    return {"x": _helper_x, "y": _helper_y}[request.param]
-
-
-@pytest.fixture(params=['gca', 'subplots', 'subplots_shared', 'add_axes'])
-def shared_axes_generator(request):
-    # test all of the ways to get fig/ax sets
-    if request.param == 'gca':
-        fig = plt.figure()
-        ax = fig.gca()
-    elif request.param == 'subplots':
-        fig, ax = plt.subplots()
-    elif request.param == 'subplots_shared':
-        fig, ax_lst = plt.subplots(2, 2, sharex='all', sharey='all')
-        ax = ax_lst[0][0]
-    elif request.param == 'add_axes':
-        fig = plt.figure()
-        ax = fig.add_axes([.1, .1, .8, .8])
-    return fig, ax
-
-
-def test_remove_shared_axes(shared_axes_generator, shared_axis_remover):
-    # test all of the ways to get fig/ax sets
-    fig, ax = shared_axes_generator
-    shared_axis_remover(ax)
-
-
-def test_remove_shared_axes_relim():
-    fig, ax_lst = plt.subplots(2, 2, sharex='all', sharey='all')
-    ax = ax_lst[0][0]
-    orig_xlim = ax_lst[0][1].get_xlim()
-    ax.remove()
-    ax.set_xlim(0, 5)
-    assert_array_equal(ax_lst[0][1].get_xlim(), orig_xlim)
-
-
-def test_shared_axes_autoscale():
-    l = np.arange(-80, 90, 40)
-    t = np.random.random_sample((l.size, l.size))
-
-    fig, (ax1, ax2) = plt.subplots(2, 1, sharex=True, sharey=True)
-
-    ax1.set_xlim(-1000, 1000)
-    ax1.set_ylim(-1000, 1000)
-    ax1.contour(l, l, t)
-
-    ax2.contour(l, l, t)
-    assert not ax1.get_autoscalex_on() and not ax2.get_autoscalex_on()
-    assert not ax1.get_autoscaley_on() and not ax2.get_autoscaley_on()
-    assert ax1.get_xlim() == ax2.get_xlim() == (-1000, 1000)
-    assert ax1.get_ylim() == ax2.get_ylim() == (-1000, 1000)
-
-
-def test_adjust_numtick_aspect():
-    fig, ax = plt.subplots()
-    ax.yaxis.get_major_locator().set_params(nbins='auto')
-    ax.set_xlim(0, 1000)
-    ax.set_aspect('equal')
-    fig.canvas.draw()
-    assert len(ax.yaxis.get_major_locator()()) == 2
-    ax.set_ylim(0, 1000)
-    fig.canvas.draw()
-    assert len(ax.yaxis.get_major_locator()()) > 2
-
-
-@mpl.style.context("default")
-def test_auto_numticks():
-    axs = plt.figure().subplots(4, 4)
-    for ax in axs.flat:  # Tiny, empty subplots have only 3 ticks.
-        assert [*ax.get_xticks()] == [*ax.get_yticks()] == [0, 0.5, 1]
-
-
-@mpl.style.context("default")
-def test_auto_numticks_log():
-    # Verify that there are not too many ticks with a large log range.
-    fig, ax = plt.subplots()
-    mpl.rcParams['axes.autolimit_mode'] = 'round_numbers'
-    ax.loglog([1e-20, 1e5], [1e-16, 10])
-    assert (np.log10(ax.get_xticks()) == np.arange(-26, 18, 4)).all()
-    assert (np.log10(ax.get_yticks()) == np.arange(-20, 10, 3)).all()
-
-
-def test_broken_barh_empty():
-    fig, ax = plt.subplots()
-    ax.broken_barh([], (.1, .5))
-
-
-def test_broken_barh_timedelta():
-    """Check that timedelta works as x, dx pair for this method."""
-    fig, ax = plt.subplots()
-    d0 = datetime.datetime(2018, 11, 9, 0, 0, 0)
-    pp = ax.broken_barh([(d0, datetime.timedelta(hours=1))], [1, 2])
-    assert pp.get_paths()[0].vertices[0, 0] == mdates.date2num(d0)
-    assert pp.get_paths()[0].vertices[2, 0] == mdates.date2num(d0) + 1 / 24
-
-
-def test_pandas_pcolormesh(pd):
-    time = pd.date_range('2000-01-01', periods=10)
-    depth = np.arange(20)
-    data = np.random.rand(19, 9)
-
-    fig, ax = plt.subplots()
-    ax.pcolormesh(time, depth, data)
-
-
-def test_pandas_indexing_dates(pd):
-    dates = np.arange('2005-02', '2005-03', dtype='datetime64[D]')
-    values = np.sin(range(len(dates)))
-    df = pd.DataFrame({'dates': dates, 'values': values})
-
-    ax = plt.gca()
-
-    without_zero_index = df[np.array(df.index) % 2 == 1].copy()
-    ax.plot('dates', 'values', data=without_zero_index)
-
-
-def test_pandas_errorbar_indexing(pd):
-    df = pd.DataFrame(np.random.uniform(size=(5, 4)),
-                      columns=['x', 'y', 'xe', 'ye'],
-                      index=[1, 2, 3, 4, 5])
-    fig, ax = plt.subplots()
-    ax.errorbar('x', 'y', xerr='xe', yerr='ye', data=df)
-
-
-def test_pandas_index_shape(pd):
-    df = pd.DataFrame({"XX": [4, 5, 6], "YY": [7, 1, 2]})
-    fig, ax = plt.subplots()
-    ax.plot(df.index, df['YY'])
-
-
-def test_pandas_indexing_hist(pd):
-    ser_1 = pd.Series(data=[1, 2, 2, 3, 3, 4, 4, 4, 4, 5])
-    ser_2 = ser_1.iloc[1:]
-    fig, ax = plt.subplots()
-    ax.hist(ser_2)
-
-
-def test_pandas_bar_align_center(pd):
-    # Tests fix for issue 8767
-    df = pd.DataFrame({'a': range(2), 'b': range(2)})
-
-    fig, ax = plt.subplots(1)
-
-    ax.bar(df.loc[df['a'] == 1, 'b'],
-           df.loc[df['a'] == 1, 'b'],
-           align='center')
-
-    fig.canvas.draw()
-
-
-def test_axis_get_tick_params():
-    axis = plt.subplot().yaxis
-    initial_major_style_translated = {**axis.get_tick_params(which='major')}
-    initial_minor_style_translated = {**axis.get_tick_params(which='minor')}
-
-    translated_major_kw = axis._translate_tick_params(
-        axis._major_tick_kw, reverse=True
-    )
-    translated_minor_kw = axis._translate_tick_params(
-        axis._minor_tick_kw, reverse=True
-    )
-
-    assert translated_major_kw == initial_major_style_translated
-    assert translated_minor_kw == initial_minor_style_translated
-    axis.set_tick_params(labelsize=30, labelcolor='red',
-                         direction='out', which='both')
-
-    new_major_style_translated = {**axis.get_tick_params(which='major')}
-    new_minor_style_translated = {**axis.get_tick_params(which='minor')}
-    new_major_style = axis._translate_tick_params(new_major_style_translated)
-    new_minor_style = axis._translate_tick_params(new_minor_style_translated)
-    assert initial_major_style_translated != new_major_style_translated
-    assert axis._major_tick_kw == new_major_style
-    assert initial_minor_style_translated != new_minor_style_translated
-    assert axis._minor_tick_kw == new_minor_style
-
-
-def test_axis_set_tick_params_labelsize_labelcolor():
-    # Tests fix for issue 4346
-    axis_1 = plt.subplot()
-    axis_1.yaxis.set_tick_params(labelsize=30, labelcolor='red',
-                                 direction='out')
-
-    # Expected values after setting the ticks
-    assert axis_1.yaxis.majorTicks[0]._size == 4.0
-    assert axis_1.yaxis.majorTicks[0].tick1line.get_color() == 'k'
-    assert axis_1.yaxis.majorTicks[0].label1.get_size() == 30.0
-    assert axis_1.yaxis.majorTicks[0].label1.get_color() == 'red'
-
-
-def test_axes_tick_params_gridlines():
-    # Now treating grid params like other Tick params
-    ax = plt.subplot()
-    ax.tick_params(grid_color='b', grid_linewidth=5, grid_alpha=0.5,
-                   grid_linestyle='dashdot')
-    for axis in ax.xaxis, ax.yaxis:
-        assert axis.majorTicks[0].gridline.get_color() == 'b'
-        assert axis.majorTicks[0].gridline.get_linewidth() == 5
-        assert axis.majorTicks[0].gridline.get_alpha() == 0.5
-        assert axis.majorTicks[0].gridline.get_linestyle() == '-.'
-
-
-def test_axes_tick_params_ylabelside():
-    # Tests fix for issue 10267
-    ax = plt.subplot()
-    ax.tick_params(labelleft=False, labelright=True,
-                   which='major')
-    ax.tick_params(labelleft=False, labelright=True,
-                   which='minor')
-    # expects left false, right true
-    assert ax.yaxis.majorTicks[0].label1.get_visible() is False
-    assert ax.yaxis.majorTicks[0].label2.get_visible() is True
-    assert ax.yaxis.minorTicks[0].label1.get_visible() is False
-    assert ax.yaxis.minorTicks[0].label2.get_visible() is True
-
-
-def test_axes_tick_params_xlabelside():
-    # Tests fix for issue 10267
-    ax = plt.subplot()
-    ax.tick_params(labeltop=True, labelbottom=False,
-                   which='major')
-    ax.tick_params(labeltop=True, labelbottom=False,
-                   which='minor')
-    # expects top True, bottom False
-    # label1.get_visible() mapped to labelbottom
-    # label2.get_visible() mapped to labeltop
-    assert ax.xaxis.majorTicks[0].label1.get_visible() is False
-    assert ax.xaxis.majorTicks[0].label2.get_visible() is True
-    assert ax.xaxis.minorTicks[0].label1.get_visible() is False
-    assert ax.xaxis.minorTicks[0].label2.get_visible() is True
-
-
-def test_none_kwargs():
-    ax = plt.figure().subplots()
-    ln, = ax.plot(range(32), linestyle=None)
-    assert ln.get_linestyle() == '-'
-
-
-def test_bar_uint8():
-    xs = [0, 1, 2, 3]
-    b = plt.bar(np.array(xs, dtype=np.uint8), [2, 3, 4, 5], align="edge")
-    for (patch, x) in zip(b.patches, xs):
-        assert patch.xy[0] == x
-
-
-@image_comparison(['date_timezone_x.png'], tol=1.0)
-def test_date_timezone_x():
-    # Tests issue 5575
-    time_index = [datetime.datetime(2016, 2, 22, hour=x,
-                                    tzinfo=dateutil.tz.gettz('Canada/Eastern'))
-                  for x in range(3)]
-
-    # Same Timezone
-    plt.figure(figsize=(20, 12))
-    plt.subplot(2, 1, 1)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        plt.plot_date(time_index, [3] * 3, tz='Canada/Eastern')
-
-    # Different Timezone
-    plt.subplot(2, 1, 2)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        plt.plot_date(time_index, [3] * 3, tz='UTC')
-
-
-@image_comparison(['date_timezone_y.png'])
-def test_date_timezone_y():
-    # Tests issue 5575
-    time_index = [datetime.datetime(2016, 2, 22, hour=x,
-                                    tzinfo=dateutil.tz.gettz('Canada/Eastern'))
-                  for x in range(3)]
-
-    # Same Timezone
-    plt.figure(figsize=(20, 12))
-    plt.subplot(2, 1, 1)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        plt.plot_date([3] * 3, time_index, tz='Canada/Eastern', xdate=False, ydate=True)
-
-    # Different Timezone
-    plt.subplot(2, 1, 2)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        plt.plot_date([3] * 3, time_index, tz='UTC', xdate=False, ydate=True)
-
-
-@image_comparison(['date_timezone_x_and_y.png'], tol=1.0)
-def test_date_timezone_x_and_y():
-    # Tests issue 5575
-    UTC = datetime.timezone.utc
-    time_index = [datetime.datetime(2016, 2, 22, hour=x, tzinfo=UTC)
-                  for x in range(3)]
-
-    # Same Timezone
-    plt.figure(figsize=(20, 12))
-    plt.subplot(2, 1, 1)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        plt.plot_date(time_index, time_index, tz='UTC', ydate=True)
-
-    # Different Timezone
-    plt.subplot(2, 1, 2)
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        plt.plot_date(time_index, time_index, tz='US/Eastern', ydate=True)
-
-
-@image_comparison(['axisbelow.png'], remove_text=True)
-def test_axisbelow():
-    # Test 'line' setting added in 6287.
-    # Show only grids, not frame or ticks, to make this test
-    # independent of future change to drawing order of those elements.
-    axs = plt.figure().subplots(ncols=3, sharex=True, sharey=True)
-    settings = (False, 'line', True)
-
-    for ax, setting in zip(axs, settings):
-        ax.plot((0, 10), (0, 10), lw=10, color='m')
-        circ = mpatches.Circle((3, 3), color='r')
-        ax.add_patch(circ)
-        ax.grid(color='c', linestyle='-', linewidth=3)
-        ax.tick_params(top=False, bottom=False,
-                       left=False, right=False)
-        ax.spines[:].set_visible(False)
-        ax.set_axisbelow(setting)
-        assert ax.get_axisbelow() == setting
-
-
-def test_titletwiny():
-    plt.style.use('mpl20')
-    fig, ax = plt.subplots(dpi=72)
-    ax2 = ax.twiny()
-    xlabel2 = ax2.set_xlabel('Xlabel2')
-    title = ax.set_title('Title')
-    fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()
-    # ------- Test that title is put above Xlabel2 (Xlabel2 at top) ----------
-    bbox_y0_title = title.get_window_extent(renderer).y0  # bottom of title
-    bbox_y1_xlabel2 = xlabel2.get_window_extent(renderer).y1  # top of xlabel2
-    y_diff = bbox_y0_title - bbox_y1_xlabel2
-    assert np.isclose(y_diff, 3)
-
-
-def test_titlesetpos():
-    # Test that title stays put if we set it manually
-    fig, ax = plt.subplots()
-    fig.subplots_adjust(top=0.8)
-    ax2 = ax.twiny()
-    ax.set_xlabel('Xlabel')
-    ax2.set_xlabel('Xlabel2')
-    ax.set_title('Title')
-    pos = (0.5, 1.11)
-    ax.title.set_position(pos)
-    renderer = fig.canvas.get_renderer()
-    ax._update_title_position(renderer)
-    assert ax.title.get_position() == pos
-
-
-def test_title_xticks_top():
-    # Test that title moves if xticks on top of axes.
-    mpl.rcParams['axes.titley'] = None
-    fig, ax = plt.subplots()
-    ax.xaxis.set_ticks_position('top')
-    ax.set_title('xlabel top')
-    fig.canvas.draw()
-    assert ax.title.get_position()[1] > 1.04
-
-
-def test_title_xticks_top_both():
-    # Test that title moves if xticks on top of axes.
-    mpl.rcParams['axes.titley'] = None
-    fig, ax = plt.subplots()
-    ax.tick_params(axis="x",
-                   bottom=True, top=True, labelbottom=True, labeltop=True)
-    ax.set_title('xlabel top')
-    fig.canvas.draw()
-    assert ax.title.get_position()[1] > 1.04
-
-
-@pytest.mark.parametrize(
-    'left, center', [
-        ('left', ''),
-        ('', 'center'),
-        ('left', 'center')
-    ], ids=[
-        'left title moved',
-        'center title kept',
-        'both titles aligned'
-    ]
-)
-def test_title_above_offset(left, center):
-    # Test that title moves if overlaps with yaxis offset text.
-    mpl.rcParams['axes.titley'] = None
-    fig, ax = plt.subplots()
-    ax.set_ylim(1e11)
-    ax.set_title(left, loc='left')
-    ax.set_title(center)
-    fig.draw_without_rendering()
-    if left and not center:
-        assert ax._left_title.get_position()[1] > 1.0
-    elif not left and center:
-        assert ax.title.get_position()[1] == 1.0
-    else:
-        yleft = ax._left_title.get_position()[1]
-        ycenter = ax.title.get_position()[1]
-        assert yleft > 1.0
-        assert ycenter == yleft
-
-
-def test_title_no_move_off_page():
-    # If an Axes is off the figure (ie. if it is cropped during a save)
-    # make sure that the automatic title repositioning does not get done.
-    mpl.rcParams['axes.titley'] = None
-    fig = plt.figure()
-    ax = fig.add_axes([0.1, -0.5, 0.8, 0.2])
-    ax.tick_params(axis="x",
-                   bottom=True, top=True, labelbottom=True, labeltop=True)
-    tt = ax.set_title('Boo')
-    fig.canvas.draw()
-    assert tt.get_position()[1] == 1.0
-
-
-def test_title_inset_ax():
-    # Title should be above any child axes
-    mpl.rcParams['axes.titley'] = None
-    fig, ax = plt.subplots()
-    ax.set_title('Title')
-    fig.draw_without_rendering()
-    assert ax.title.get_position()[1] == 1
-    ax.inset_axes([0, 1, 1, 0.1])
-    fig.draw_without_rendering()
-    assert ax.title.get_position()[1] == 1.1
-
-
-def test_offset_label_color():
-    # Tests issue 6440
-    fig, ax = plt.subplots()
-    ax.plot([1.01e9, 1.02e9, 1.03e9])
-    ax.yaxis.set_tick_params(labelcolor='red')
-    assert ax.yaxis.get_offset_text().get_color() == 'red'
-
-
-def test_offset_text_visible():
-    fig, ax = plt.subplots()
-    ax.plot([1.01e9, 1.02e9, 1.03e9])
-    ax.yaxis.set_tick_params(label1On=False, label2On=True)
-    assert ax.yaxis.get_offset_text().get_visible()
-    ax.yaxis.set_tick_params(label2On=False)
-    assert not ax.yaxis.get_offset_text().get_visible()
-
-
-def test_large_offset():
-    fig, ax = plt.subplots()
-    ax.plot((1 + np.array([0, 1.e-12])) * 1.e27)
-    fig.canvas.draw()
-
-
-def test_barb_units():
-    fig, ax = plt.subplots()
-    dates = [datetime.datetime(2017, 7, 15, 18, i) for i in range(0, 60, 10)]
-    y = np.linspace(0, 5, len(dates))
-    u = v = np.linspace(0, 50, len(dates))
-    ax.barbs(dates, y, u, v)
-
-
-def test_quiver_units():
-    fig, ax = plt.subplots()
-    dates = [datetime.datetime(2017, 7, 15, 18, i) for i in range(0, 60, 10)]
-    y = np.linspace(0, 5, len(dates))
-    u = v = np.linspace(0, 50, len(dates))
-    ax.quiver(dates, y, u, v)
-
-
-def test_bar_color_cycle():
-    to_rgb = mcolors.to_rgb
-    fig, ax = plt.subplots()
-    for j in range(5):
-        ln, = ax.plot(range(3))
-        brs = ax.bar(range(3), range(3))
-        for br in brs:
-            assert to_rgb(ln.get_color()) == to_rgb(br.get_facecolor())
-
-
-def test_tick_param_label_rotation():
-    fix, (ax, ax2) = plt.subplots(1, 2)
-    ax.plot([0, 1], [0, 1])
-    ax2.plot([0, 1], [0, 1])
-    ax.xaxis.set_tick_params(which='both', rotation=75)
-    ax.yaxis.set_tick_params(which='both', rotation=90)
-    for text in ax.get_xticklabels(which='both'):
-        assert text.get_rotation() == 75
-    for text in ax.get_yticklabels(which='both'):
-        assert text.get_rotation() == 90
-
-    ax2.tick_params(axis='x', labelrotation=53)
-    ax2.tick_params(axis='y', rotation=35)
-    for text in ax2.get_xticklabels(which='major'):
-        assert text.get_rotation() == 53
-    for text in ax2.get_yticklabels(which='major'):
-        assert text.get_rotation() == 35
-
-
-@mpl.style.context('default')
-def test_fillbetween_cycle():
-    fig, ax = plt.subplots()
-
-    for j in range(3):
-        cc = ax.fill_between(range(3), range(3))
-        target = mcolors.to_rgba(f'C{j}')
-        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
-
-    for j in range(3, 6):
-        cc = ax.fill_betweenx(range(3), range(3))
-        target = mcolors.to_rgba(f'C{j}')
-        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
-
-    target = mcolors.to_rgba('k')
-
-    for al in ['facecolor', 'facecolors', 'color']:
-        cc = ax.fill_between(range(3), range(3), **{al: 'k'})
-        assert tuple(cc.get_facecolors().squeeze()) == tuple(target)
-
-    edge_target = mcolors.to_rgba('k')
-    for j, el in enumerate(['edgecolor', 'edgecolors'], start=6):
-        cc = ax.fill_between(range(3), range(3), **{el: 'k'})
-        face_target = mcolors.to_rgba(f'C{j}')
-        assert tuple(cc.get_facecolors().squeeze()) == tuple(face_target)
-        assert tuple(cc.get_edgecolors().squeeze()) == tuple(edge_target)
-
-
-def test_log_margins():
-    plt.rcParams['axes.autolimit_mode'] = 'data'
-    fig, ax = plt.subplots()
-    margin = 0.05
-    ax.set_xmargin(margin)
-    ax.semilogx([10, 100], [10, 100])
-    xlim0, xlim1 = ax.get_xlim()
-    transform = ax.xaxis.get_transform()
-    xlim0t, xlim1t = transform.transform([xlim0, xlim1])
-    x0t, x1t = transform.transform([10, 100])
-    delta = (x1t - x0t) * margin
-    assert_allclose([xlim0t + delta, xlim1t - delta], [x0t, x1t])
-
-
-def test_color_length_mismatch():
-    N = 5
-    x, y = np.arange(N), np.arange(N)
-    colors = np.arange(N+1)
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError):
-        ax.scatter(x, y, c=colors)
-    with pytest.warns(match="argument looks like a single numeric RGB"):
-        ax.scatter(x, y, c=(0.5, 0.5, 0.5))
-    ax.scatter(x, y, c=[(0.5, 0.5, 0.5)] * N)
-
-
-def test_eventplot_legend():
-    plt.eventplot([1.0], label='Label')
-    plt.legend()
-
-
-@pytest.mark.parametrize('err, args, kwargs, match', (
-        (ValueError, [[1]], {'lineoffsets': []}, 'lineoffsets cannot be empty'),
-        (ValueError, [[1]], {'linelengths': []}, 'linelengths cannot be empty'),
-        (ValueError, [[1]], {'linewidths': []}, 'linewidths cannot be empty'),
-        (ValueError, [[1]], {'linestyles': []}, 'linestyles cannot be empty'),
-        (ValueError, [[1]], {'alpha': []}, 'alpha cannot be empty'),
-        (ValueError, [1], {}, 'positions must be one-dimensional'),
-        (ValueError, [[1]], {'lineoffsets': [1, 2]},
-         'lineoffsets and positions are unequal sized sequences'),
-        (ValueError, [[1]], {'linelengths': [1, 2]},
-         'linelengths and positions are unequal sized sequences'),
-        (ValueError, [[1]], {'linewidths': [1, 2]},
-         'linewidths and positions are unequal sized sequences'),
-        (ValueError, [[1]], {'linestyles': [1, 2]},
-         'linestyles and positions are unequal sized sequences'),
-        (ValueError, [[1]], {'alpha': [1, 2]},
-         'alpha and positions are unequal sized sequences'),
-        (ValueError, [[1]], {'colors': [1, 2]},
-         'colors and positions are unequal sized sequences'),
-))
-def test_eventplot_errors(err, args, kwargs, match):
-    with pytest.raises(err, match=match):
-        plt.eventplot(*args, **kwargs)
-
-
-def test_bar_broadcast_args():
-    fig, ax = plt.subplots()
-    # Check that a bar chart with a single height for all bars works.
-    ax.bar(range(4), 1)
-    # Check that a horizontal chart with one width works.
-    ax.barh(0, 1, left=range(4), height=1)
-    # Check that edgecolor gets broadcast.
-    rect1, rect2 = ax.bar([0, 1], [0, 1], edgecolor=(.1, .2, .3, .4))
-    assert rect1.get_edgecolor() == rect2.get_edgecolor() == (.1, .2, .3, .4)
-
-
-def test_invalid_axis_limits():
-    plt.plot([0, 1], [0, 1])
-    with pytest.raises(ValueError):
-        plt.xlim(np.nan)
-    with pytest.raises(ValueError):
-        plt.xlim(np.inf)
-    with pytest.raises(ValueError):
-        plt.ylim(np.nan)
-    with pytest.raises(ValueError):
-        plt.ylim(np.inf)
-
-
-# Test all 4 combinations of logs/symlogs for minorticks_on()
-@pytest.mark.parametrize('xscale', ['symlog', 'log'])
-@pytest.mark.parametrize('yscale', ['symlog', 'log'])
-def test_minorticks_on(xscale, yscale):
-    ax = plt.subplot()
-    ax.plot([1, 2, 3, 4])
-    ax.set_xscale(xscale)
-    ax.set_yscale(yscale)
-    ax.minorticks_on()
-
-
-def test_twinx_knows_limits():
-    fig, ax = plt.subplots()
-
-    ax.axvspan(1, 2)
-    xtwin = ax.twinx()
-    xtwin.plot([0, 0.5], [1, 2])
-    # control axis
-    fig2, ax2 = plt.subplots()
-
-    ax2.axvspan(1, 2)
-    ax2.plot([0, 0.5], [1, 2])
-
-    assert_array_equal(xtwin.viewLim.intervalx, ax2.viewLim.intervalx)
-
-
-def test_zero_linewidth():
-    # Check that setting a zero linewidth doesn't error
-    plt.plot([0, 1], [0, 1], ls='--', lw=0)
-
-
-def test_empty_errorbar_legend():
-    fig, ax = plt.subplots()
-    ax.errorbar([], [], xerr=[], label='empty y')
-    ax.errorbar([], [], yerr=[], label='empty x')
-    ax.legend()
-
-
-@check_figures_equal(extensions=["png"])
-def test_plot_decimal(fig_test, fig_ref):
-    x0 = np.arange(-10, 10, 0.3)
-    y0 = [5.2 * x ** 3 - 2.1 * x ** 2 + 7.34 * x + 4.5 for x in x0]
-    x = [Decimal(i) for i in x0]
-    y = [Decimal(i) for i in y0]
-    # Test image - line plot with Decimal input
-    fig_test.subplots().plot(x, y)
-    # Reference image
-    fig_ref.subplots().plot(x0, y0)
-
-
-# pdf and svg tests fail using travis' old versions of gs and inkscape.
-@check_figures_equal(extensions=["png"])
-def test_markerfacecolor_none_alpha(fig_test, fig_ref):
-    fig_test.subplots().plot(0, "o", mfc="none", alpha=.5)
-    fig_ref.subplots().plot(0, "o", mfc="w", alpha=.5)
-
-
-def test_tick_padding_tightbbox():
-    """Test that tick padding gets turned off if axis is off"""
-    plt.rcParams["xtick.direction"] = "out"
-    plt.rcParams["ytick.direction"] = "out"
-    fig, ax = plt.subplots()
-    bb = ax.get_tightbbox(fig.canvas.get_renderer())
-    ax.axis('off')
-    bb2 = ax.get_tightbbox(fig.canvas.get_renderer())
-    assert bb.x0 < bb2.x0
-    assert bb.y0 < bb2.y0
-
-
-def test_inset():
-    """
-    Ensure that inset_ax argument is indeed optional
-    """
-    dx, dy = 0.05, 0.05
-    # generate 2 2d grids for the x & y bounds
-    y, x = np.mgrid[slice(1, 5 + dy, dy),
-                    slice(1, 5 + dx, dx)]
-    z = np.sin(x) ** 10 + np.cos(10 + y * x) * np.cos(x)
-
-    fig, ax = plt.subplots()
-    ax.pcolormesh(x, y, z[:-1, :-1])
-    ax.set_aspect(1.)
-    ax.apply_aspect()
-    # we need to apply_aspect to make the drawing below work.
-
-    xlim = [1.5, 2.15]
-    ylim = [2, 2.5]
-
-    rect = [xlim[0], ylim[0], xlim[1] - xlim[0], ylim[1] - ylim[0]]
-
-    inset = ax.indicate_inset(bounds=rect)
-    assert inset.connectors is None
-    fig.canvas.draw()
-    xx = np.array([[1.5, 2.],
-                   [2.15, 2.5]])
-    assert np.all(inset.rectangle.get_bbox().get_points() == xx)
-
-
-def test_zoom_inset():
-    dx, dy = 0.05, 0.05
-    # generate 2 2d grids for the x & y bounds
-    y, x = np.mgrid[slice(1, 5 + dy, dy),
-                    slice(1, 5 + dx, dx)]
-    z = np.sin(x)**10 + np.cos(10 + y*x) * np.cos(x)
-
-    fig, ax = plt.subplots()
-    ax.pcolormesh(x, y, z[:-1, :-1])
-    ax.set_aspect(1.)
-    ax.apply_aspect()
-    # we need to apply_aspect to make the drawing below work.
-
-    # Make the inset_axes...  Position axes coordinates...
-    axin1 = ax.inset_axes([0.7, 0.7, 0.35, 0.35])
-    # redraw the data in the inset axes...
-    axin1.pcolormesh(x, y, z[:-1, :-1])
-    axin1.set_xlim([1.5, 2.15])
-    axin1.set_ylim([2, 2.5])
-    axin1.set_aspect(ax.get_aspect())
-
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        rec, connectors = ax.indicate_inset_zoom(axin1)
-    fig.canvas.draw()
-    assert len(connectors) == 4
-    xx = np.array([[1.5,  2.],
-                   [2.15, 2.5]])
-    assert np.all(rec.get_bbox().get_points() == xx)
-    xx = np.array([[0.6325, 0.692308],
-                   [0.8425, 0.907692]])
-    np.testing.assert_allclose(
-        axin1.get_position().get_points(), xx, rtol=1e-4)
-
-
-@image_comparison(['inset_polar.png'], remove_text=True, style='mpl20')
-def test_inset_polar():
-    _, ax = plt.subplots()
-    axins = ax.inset_axes([0.5, 0.1, 0.45, 0.45], polar=True)
-    assert isinstance(axins, PolarAxes)
-
-    r = np.arange(0, 2, 0.01)
-    theta = 2 * np.pi * r
-
-    ax.plot(theta, r)
-    axins.plot(theta, r)
-
-
-def test_inset_projection():
-    _, ax = plt.subplots()
-    axins = ax.inset_axes([0.2, 0.2, 0.3, 0.3], projection="hammer")
-    assert isinstance(axins, HammerAxes)
-
-
-def test_inset_subclass():
-    _, ax = plt.subplots()
-    axins = ax.inset_axes([0.2, 0.2, 0.3, 0.3], axes_class=AA.Axes)
-    assert isinstance(axins, AA.Axes)
-
-
-@pytest.mark.parametrize('x_inverted', [False, True])
-@pytest.mark.parametrize('y_inverted', [False, True])
-def test_indicate_inset_inverted(x_inverted, y_inverted):
-    """
-    Test that the inset lines are correctly located with inverted data axes.
-    """
-    fig, (ax1, ax2) = plt.subplots(1, 2)
-
-    x = np.arange(10)
-    ax1.plot(x, x, 'o')
-    if x_inverted:
-        ax1.invert_xaxis()
-    if y_inverted:
-        ax1.invert_yaxis()
-
-    inset = ax1.indicate_inset([2, 2, 5, 4], ax2)
-    lower_left, upper_left, lower_right, upper_right = inset.connectors
-
-    sign_x = -1 if x_inverted else 1
-    sign_y = -1 if y_inverted else 1
-    assert sign_x * (lower_right.xy2[0] - lower_left.xy2[0]) > 0
-    assert sign_x * (upper_right.xy2[0] - upper_left.xy2[0]) > 0
-    assert sign_y * (upper_left.xy2[1] - lower_left.xy2[1]) > 0
-    assert sign_y * (upper_right.xy2[1] - lower_right.xy2[1]) > 0
-
-
-def test_set_position():
-    fig, ax = plt.subplots()
-    ax.set_aspect(3.)
-    ax.set_position([0.1, 0.1, 0.4, 0.4], which='both')
-    assert np.allclose(ax.get_position().width, 0.1)
-    ax.set_aspect(2.)
-    ax.set_position([0.1, 0.1, 0.4, 0.4], which='original')
-    assert np.allclose(ax.get_position().width, 0.15)
-    ax.set_aspect(3.)
-    ax.set_position([0.1, 0.1, 0.4, 0.4], which='active')
-    assert np.allclose(ax.get_position().width, 0.1)
-
-
-def test_spines_properbbox_after_zoom():
-    fig, ax = plt.subplots()
-    bb = ax.spines.bottom.get_window_extent(fig.canvas.get_renderer())
-    # this is what zoom calls:
-    ax._set_view_from_bbox((320, 320, 500, 500), 'in',
-                           None, False, False)
-    bb2 = ax.spines.bottom.get_window_extent(fig.canvas.get_renderer())
-    np.testing.assert_allclose(bb.get_points(), bb2.get_points(), rtol=1e-6)
-
-
-def test_limits_after_scroll_zoom():
-    fig, ax = plt.subplots()
-    #
-    xlim = (-0.5, 0.5)
-    ylim = (-1, 2)
-    ax.set_xlim(xlim)
-    ax.set_ylim(ymin=ylim[0], ymax=ylim[1])
-    # This is what scroll zoom calls:
-    # Zoom with factor 1, small numerical change
-    ax._set_view_from_bbox((200, 200, 1.))
-    np.testing.assert_allclose(xlim, ax.get_xlim(), atol=1e-16)
-    np.testing.assert_allclose(ylim, ax.get_ylim(), atol=1e-16)
-
-    # Zoom in
-    ax._set_view_from_bbox((200, 200, 2.))
-    # Hard-coded values
-    new_xlim = (-0.3790322580645161, 0.12096774193548387)
-    new_ylim = (-0.40625, 1.09375)
-
-    res_xlim = ax.get_xlim()
-    res_ylim = ax.get_ylim()
-    np.testing.assert_allclose(res_xlim[1] - res_xlim[0], 0.5)
-    np.testing.assert_allclose(res_ylim[1] - res_ylim[0], 1.5)
-    np.testing.assert_allclose(new_xlim, res_xlim, atol=1e-16)
-    np.testing.assert_allclose(new_ylim, res_ylim)
-
-    # Zoom out, should be same as before, except for numerical issues
-    ax._set_view_from_bbox((200, 200, 0.5))
-    res_xlim = ax.get_xlim()
-    res_ylim = ax.get_ylim()
-    np.testing.assert_allclose(res_xlim[1] - res_xlim[0], 1)
-    np.testing.assert_allclose(res_ylim[1] - res_ylim[0], 3)
-    np.testing.assert_allclose(xlim, res_xlim, atol=1e-16)
-    np.testing.assert_allclose(ylim, res_ylim, atol=1e-16)
-
-
-def test_gettightbbox_ignore_nan():
-    fig, ax = plt.subplots()
-    remove_ticks_and_titles(fig)
-    ax.text(np.nan, 1, 'Boo')
-    renderer = fig.canvas.get_renderer()
-    np.testing.assert_allclose(ax.get_tightbbox(renderer).width, 496)
-
-
-def test_scatter_series_non_zero_index(pd):
-    # create non-zero index
-    ids = range(10, 18)
-    x = pd.Series(np.random.uniform(size=8), index=ids)
-    y = pd.Series(np.random.uniform(size=8), index=ids)
-    c = pd.Series([1, 1, 1, 1, 1, 0, 0, 0], index=ids)
-    plt.scatter(x, y, c)
-
-
-def test_scatter_empty_data():
-    # making sure this does not raise an exception
-    plt.scatter([], [])
-    plt.scatter([], [], s=[], c=[])
-
-
-@image_comparison(['annotate_across_transforms.png'], style='mpl20', remove_text=True,
-                  tol=0.025 if platform.machine() == 'arm64' else 0)
-def test_annotate_across_transforms():
-    x = np.linspace(0, 10, 200)
-    y = np.exp(-x) * np.sin(x)
-
-    fig, ax = plt.subplots(figsize=(3.39, 3))
-    ax.plot(x, y)
-    axins = ax.inset_axes([0.4, 0.5, 0.3, 0.3])
-    axins.set_aspect(0.2)
-    axins.xaxis.set_visible(False)
-    axins.yaxis.set_visible(False)
-    ax.annotate("", xy=(x[150], y[150]), xycoords=ax.transData,
-                xytext=(1, 0), textcoords=axins.transAxes,
-                arrowprops=dict(arrowstyle="->"))
-
-
-class _Translation(mtransforms.Transform):
-    input_dims = 1
-    output_dims = 1
-
-    def __init__(self, dx):
-        self.dx = dx
-
-    def transform(self, values):
-        return values + self.dx
-
-    def inverted(self):
-        return _Translation(-self.dx)
-
-
-@image_comparison(['secondary_xy.png'], style='mpl20',
-                  tol=0.027 if platform.machine() == 'arm64' else 0)
-def test_secondary_xy():
-    fig, axs = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)
-
-    def invert(x):
-        with np.errstate(divide='ignore'):
-            return 1 / x
-
-    for nn, ax in enumerate(axs):
-        ax.plot(np.arange(2, 11), np.arange(2, 11))
-        if nn == 0:
-            secax = ax.secondary_xaxis
-        else:
-            secax = ax.secondary_yaxis
-
-        secax(0.2, functions=(invert, invert))
-        secax(0.4, functions=(lambda x: 2 * x, lambda x: x / 2))
-        secax(0.6, functions=(lambda x: x**2, lambda x: x**(1/2)))
-        secax(0.8)
-        secax("top" if nn == 0 else "right", functions=_Translation(2))
-        secax(6.25, transform=ax.transData)
-
-
-def test_secondary_fail():
-    fig, ax = plt.subplots()
-    ax.plot(np.arange(2, 11), np.arange(2, 11))
-    with pytest.raises(ValueError):
-        ax.secondary_xaxis(0.2, functions=(lambda x: 1 / x))
-    with pytest.raises(ValueError):
-        ax.secondary_xaxis('right')
-    with pytest.raises(ValueError):
-        ax.secondary_yaxis('bottom')
-    with pytest.raises(TypeError):
-        ax.secondary_xaxis(0.2, transform='error')
-
-
-def test_secondary_resize():
-    fig, ax = plt.subplots(figsize=(10, 5))
-    ax.plot(np.arange(2, 11), np.arange(2, 11))
-
-    def invert(x):
-        with np.errstate(divide='ignore'):
-            return 1 / x
-
-    ax.secondary_xaxis('top', functions=(invert, invert))
-    fig.canvas.draw()
-    fig.set_size_inches((7, 4))
-    assert_allclose(ax.get_position().extents, [0.125, 0.1, 0.9, 0.9])
-
-
-def test_secondary_minorloc():
-    fig, ax = plt.subplots(figsize=(10, 5))
-    ax.plot(np.arange(2, 11), np.arange(2, 11))
-
-    def invert(x):
-        with np.errstate(divide='ignore'):
-            return 1 / x
-
-    secax = ax.secondary_xaxis('top', functions=(invert, invert))
-    assert isinstance(secax._axis.get_minor_locator(),
-                      mticker.NullLocator)
-    secax.minorticks_on()
-    assert isinstance(secax._axis.get_minor_locator(),
-                      mticker.AutoMinorLocator)
-    ax.set_xscale('log')
-    plt.draw()
-    assert isinstance(secax._axis.get_minor_locator(),
-                      mticker.LogLocator)
-    ax.set_xscale('linear')
-    plt.draw()
-    assert isinstance(secax._axis.get_minor_locator(),
-                      mticker.NullLocator)
-
-
-def test_secondary_formatter():
-    fig, ax = plt.subplots()
-    ax.set_xscale("log")
-    secax = ax.secondary_xaxis("top")
-    secax.xaxis.set_major_formatter(mticker.ScalarFormatter())
-    fig.canvas.draw()
-    assert isinstance(
-        secax.xaxis.get_major_formatter(), mticker.ScalarFormatter)
-
-
-def test_secondary_repr():
-    fig, ax = plt.subplots()
-    secax = ax.secondary_xaxis("top")
-    assert repr(secax) == '<SecondaryAxis: >'
-
-
-@image_comparison(['axis_options.png'], remove_text=True, style='mpl20')
-def test_axis_options():
-    fig, axes = plt.subplots(2, 3)
-    for i, option in enumerate(('scaled', 'tight', 'image')):
-        # Draw a line and a circle fitting within the boundaries of the line
-        # The circle should look like a circle for 'scaled' and 'image'
-        # High/narrow aspect ratio
-        axes[0, i].plot((1, 2), (1, 3.2))
-        axes[0, i].axis(option)
-        axes[0, i].add_artist(mpatches.Circle((1.5, 1.5), radius=0.5,
-                                              facecolor='none', edgecolor='k'))
-        # Low/wide aspect ratio
-        axes[1, i].plot((1, 2.25), (1, 1.75))
-        axes[1, i].axis(option)
-        axes[1, i].add_artist(mpatches.Circle((1.5, 1.25), radius=0.25,
-                                              facecolor='none', edgecolor='k'))
-
-
-def color_boxes(fig, ax):
-    """
-    Helper for the tests below that test the extents of various Axes elements
-    """
-    fig.canvas.draw()
-
-    renderer = fig.canvas.get_renderer()
-    bbaxis = []
-    for nn, axx in enumerate([ax.xaxis, ax.yaxis]):
-        bb = axx.get_tightbbox(renderer)
-        if bb:
-            axisr = mpatches.Rectangle(
-                (bb.x0, bb.y0), width=bb.width, height=bb.height,
-                linewidth=0.7, edgecolor='y', facecolor="none", transform=None,
-                zorder=3)
-            fig.add_artist(axisr)
-        bbaxis += [bb]
-
-    bbspines = []
-    for nn, a in enumerate(['bottom', 'top', 'left', 'right']):
-        bb = ax.spines[a].get_window_extent(renderer)
-        spiner = mpatches.Rectangle(
-            (bb.x0, bb.y0), width=bb.width, height=bb.height,
-            linewidth=0.7, edgecolor="green", facecolor="none", transform=None,
-            zorder=3)
-        fig.add_artist(spiner)
-        bbspines += [bb]
-
-    bb = ax.get_window_extent()
-    rect2 = mpatches.Rectangle(
-        (bb.x0, bb.y0), width=bb.width, height=bb.height,
-        linewidth=1.5, edgecolor="magenta", facecolor="none", transform=None,
-        zorder=2)
-    fig.add_artist(rect2)
-    bbax = bb
-
-    bb2 = ax.get_tightbbox(renderer)
-    rect2 = mpatches.Rectangle(
-        (bb2.x0, bb2.y0), width=bb2.width, height=bb2.height,
-        linewidth=3, edgecolor="red", facecolor="none", transform=None,
-        zorder=1)
-    fig.add_artist(rect2)
-    bbtb = bb2
-    return bbaxis, bbspines, bbax, bbtb
-
-
-def test_normal_axes():
-    with rc_context({'_internal.classic_mode': False}):
-        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
-        fig.canvas.draw()
-        plt.close(fig)
-        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-
-    # test the axis bboxes
-    target = [
-        [123.375, 75.88888888888886, 983.25, 33.0],
-        [85.51388888888889, 99.99999999999997, 53.375, 993.0]
-    ]
-    for nn, b in enumerate(bbaxis):
-        targetbb = mtransforms.Bbox.from_bounds(*target[nn])
-        assert_array_almost_equal(b.bounds, targetbb.bounds, decimal=2)
-
-    target = [
-        [150.0, 119.999, 930.0, 11.111],
-        [150.0, 1080.0, 930.0, 0.0],
-        [150.0, 119.9999, 11.111, 960.0],
-        [1068.8888, 119.9999, 11.111, 960.0]
-    ]
-    for nn, b in enumerate(bbspines):
-        targetbb = mtransforms.Bbox.from_bounds(*target[nn])
-        assert_array_almost_equal(b.bounds, targetbb.bounds, decimal=2)
-
-    target = [150.0, 119.99999999999997, 930.0, 960.0]
-    targetbb = mtransforms.Bbox.from_bounds(*target)
-    assert_array_almost_equal(bbax.bounds, targetbb.bounds, decimal=2)
-
-    target = [85.5138, 75.88888, 1021.11, 1017.11]
-    targetbb = mtransforms.Bbox.from_bounds(*target)
-    assert_array_almost_equal(bbtb.bounds, targetbb.bounds, decimal=2)
-
-    # test that get_position roundtrips to get_window_extent
-    axbb = ax.get_position().transformed(fig.transFigure).bounds
-    assert_array_almost_equal(axbb, ax.get_window_extent().bounds, decimal=2)
-
-
-def test_nodecorator():
-    with rc_context({'_internal.classic_mode': False}):
-        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
-        fig.canvas.draw()
-        ax.set(xticklabels=[], yticklabels=[])
-        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-
-    # test the axis bboxes
-    for nn, b in enumerate(bbaxis):
-        assert b is None
-
-    target = [
-        [150.0, 119.999, 930.0, 11.111],
-        [150.0, 1080.0, 930.0, 0.0],
-        [150.0, 119.9999, 11.111, 960.0],
-        [1068.8888, 119.9999, 11.111, 960.0]
-    ]
-    for nn, b in enumerate(bbspines):
-        targetbb = mtransforms.Bbox.from_bounds(*target[nn])
-        assert_allclose(b.bounds, targetbb.bounds, atol=1e-2)
-
-    target = [150.0, 119.99999999999997, 930.0, 960.0]
-    targetbb = mtransforms.Bbox.from_bounds(*target)
-    assert_allclose(bbax.bounds, targetbb.bounds, atol=1e-2)
-
-    target = [150., 120., 930., 960.]
-    targetbb = mtransforms.Bbox.from_bounds(*target)
-    assert_allclose(bbtb.bounds, targetbb.bounds, atol=1e-2)
-
-
-def test_displaced_spine():
-    with rc_context({'_internal.classic_mode': False}):
-        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
-        ax.set(xticklabels=[], yticklabels=[])
-        ax.spines.bottom.set_position(('axes', -0.1))
-        fig.canvas.draw()
-        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-
-    targets = [
-        [150., 24., 930., 11.111111],
-        [150.0, 1080.0, 930.0, 0.0],
-        [150.0, 119.9999, 11.111, 960.0],
-        [1068.8888, 119.9999, 11.111, 960.0]
-    ]
-    for target, bbspine in zip(targets, bbspines):
-        targetbb = mtransforms.Bbox.from_bounds(*target)
-        assert_allclose(bbspine.bounds, targetbb.bounds, atol=1e-2)
-
-    target = [150.0, 119.99999999999997, 930.0, 960.0]
-    targetbb = mtransforms.Bbox.from_bounds(*target)
-    assert_allclose(bbax.bounds, targetbb.bounds, atol=1e-2)
-
-    target = [150., 24., 930., 1056.]
-    targetbb = mtransforms.Bbox.from_bounds(*target)
-    assert_allclose(bbtb.bounds, targetbb.bounds, atol=1e-2)
-
-
-def test_tickdirs():
-    """
-    Switch the tickdirs and make sure the bboxes switch with them
-    """
-    targets = [[[150.0, 120.0, 930.0, 11.1111],
-                [150.0, 120.0, 11.111, 960.0]],
-               [[150.0, 108.8889, 930.0, 11.111111111111114],
-                [138.889, 120, 11.111, 960.0]],
-               [[150.0, 114.44444444444441, 930.0, 11.111111111111114],
-                [144.44444444444446, 119.999, 11.111, 960.0]]]
-    for dnum, dirs in enumerate(['in', 'out', 'inout']):
-        with rc_context({'_internal.classic_mode': False}):
-            fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
-            ax.tick_params(direction=dirs)
-            fig.canvas.draw()
-            bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-            for nn, num in enumerate([0, 2]):
-                targetbb = mtransforms.Bbox.from_bounds(*targets[dnum][nn])
-                assert_allclose(
-                    bbspines[num].bounds, targetbb.bounds, atol=1e-2)
-
-
-def test_minor_accountedfor():
-    with rc_context({'_internal.classic_mode': False}):
-        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
-        fig.canvas.draw()
-        ax.tick_params(which='both', direction='out')
-
-        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-        targets = [[150.0, 108.88888888888886, 930.0, 11.111111111111114],
-                   [138.8889, 119.9999, 11.1111, 960.0]]
-        for n in range(2):
-            targetbb = mtransforms.Bbox.from_bounds(*targets[n])
-            assert_allclose(
-                bbspines[n * 2].bounds, targetbb.bounds, atol=1e-2)
-
-        fig, ax = plt.subplots(dpi=200, figsize=(6, 6))
-        fig.canvas.draw()
-        ax.tick_params(which='both', direction='out')
-        ax.minorticks_on()
-        ax.tick_params(axis='both', which='minor', length=30)
-        fig.canvas.draw()
-        bbaxis, bbspines, bbax, bbtb = color_boxes(fig, ax)
-        targets = [[150.0, 36.66666666666663, 930.0, 83.33333333333334],
-                   [66.6667, 120.0, 83.3333, 960.0]]
-
-        for n in range(2):
-            targetbb = mtransforms.Bbox.from_bounds(*targets[n])
-            assert_allclose(
-                bbspines[n * 2].bounds, targetbb.bounds, atol=1e-2)
-
-
-@check_figures_equal(extensions=["png"])
-def test_axis_bool_arguments(fig_test, fig_ref):
-    # Test if False and "off" give the same
-    fig_test.add_subplot(211).axis(False)
-    fig_ref.add_subplot(211).axis("off")
-    # Test if True after False gives the same as "on"
-    ax = fig_test.add_subplot(212)
-    ax.axis(False)
-    ax.axis(True)
-    fig_ref.add_subplot(212).axis("on")
-
-
-def test_axis_extent_arg():
-    fig, ax = plt.subplots()
-    xmin = 5
-    xmax = 10
-    ymin = 15
-    ymax = 20
-    extent = ax.axis([xmin, xmax, ymin, ymax])
-
-    # test that the docstring is correct
-    assert tuple(extent) == (xmin, xmax, ymin, ymax)
-
-    # test that limits were set per the docstring
-    assert (xmin, xmax) == ax.get_xlim()
-    assert (ymin, ymax) == ax.get_ylim()
-
-
-def test_axis_extent_arg2():
-    # Same as test_axis_extent_arg, but with keyword arguments
-    fig, ax = plt.subplots()
-    xmin = 5
-    xmax = 10
-    ymin = 15
-    ymax = 20
-    extent = ax.axis(xmin=xmin, xmax=xmax, ymin=ymin, ymax=ymax)
-
-    # test that the docstring is correct
-    assert tuple(extent) == (xmin, xmax, ymin, ymax)
-
-    # test that limits were set per the docstring
-    assert (xmin, xmax) == ax.get_xlim()
-    assert (ymin, ymax) == ax.get_ylim()
-
-
-def test_hist_auto_bins():
-    _, bins, _ = plt.hist([[1, 2, 3], [3, 4, 5, 6]], bins='auto')
-    assert bins[0] <= 1
-    assert bins[-1] >= 6
-
-
-def test_hist_nan_data():
-    fig, (ax1, ax2) = plt.subplots(2)
-
-    data = [1, 2, 3]
-    nan_data = data + [np.nan]
-
-    bins, edges, _ = ax1.hist(data)
-    with np.errstate(invalid='ignore'):
-        nanbins, nanedges, _ = ax2.hist(nan_data)
-
-    np.testing.assert_allclose(bins, nanbins)
-    np.testing.assert_allclose(edges, nanedges)
-
-
-def test_hist_range_and_density():
-    _, bins, _ = plt.hist(np.random.rand(10), "auto",
-                          range=(0, 1), density=True)
-    assert bins[0] == 0
-    assert bins[-1] == 1
-
-
-def test_bar_errbar_zorder():
-    # Check that the zorder of errorbars is always greater than the bar they
-    # are plotted on
-    fig, ax = plt.subplots()
-    x = [1, 2, 3]
-    barcont = ax.bar(x=x, height=x, yerr=x, capsize=5, zorder=3)
-
-    data_line, caplines, barlinecols = barcont.errorbar.lines
-    for bar in barcont.patches:
-        for capline in caplines:
-            assert capline.zorder > bar.zorder
-        for barlinecol in barlinecols:
-            assert barlinecol.zorder > bar.zorder
-
-
-def test_set_ticks_inverted():
-    fig, ax = plt.subplots()
-    ax.invert_xaxis()
-    ax.set_xticks([.3, .7])
-    assert ax.get_xlim() == (1, 0)
-    ax.set_xticks([-1])
-    assert ax.get_xlim() == (1, -1)
-
-
-def test_aspect_nonlinear_adjustable_box():
-    fig = plt.figure(figsize=(10, 10))  # Square.
-
-    ax = fig.add_subplot()
-    ax.plot([.4, .6], [.4, .6])  # Set minpos to keep logit happy.
-    ax.set(xscale="log", xlim=(1, 10),
-           yscale="logit", ylim=(1/11, 1/1001),
-           aspect=1, adjustable="box")
-    ax.margins(0)
-    pos = fig.transFigure.transform_bbox(ax.get_position())
-    assert pos.height / pos.width == pytest.approx(2)
-
-
-def test_aspect_nonlinear_adjustable_datalim():
-    fig = plt.figure(figsize=(10, 10))  # Square.
-
-    ax = fig.add_axes([.1, .1, .8, .8])  # Square.
-    ax.plot([.4, .6], [.4, .6])  # Set minpos to keep logit happy.
-    ax.set(xscale="log", xlim=(1, 100),
-           yscale="logit", ylim=(1 / 101, 1 / 11),
-           aspect=1, adjustable="datalim")
-    ax.margins(0)
-    ax.apply_aspect()
-
-    assert ax.get_xlim() == pytest.approx([1*10**(1/2), 100/10**(1/2)])
-    assert ax.get_ylim() == (1 / 101, 1 / 11)
-
-
-def test_box_aspect():
-    # Test if axes with box_aspect=1 has same dimensions
-    # as axes with aspect equal and adjustable="box"
-
-    fig1, ax1 = plt.subplots()
-    axtwin = ax1.twinx()
-    axtwin.plot([12, 344])
-
-    ax1.set_box_aspect(1)
-    assert ax1.get_box_aspect() == 1.0
-
-    fig2, ax2 = plt.subplots()
-    ax2.margins(0)
-    ax2.plot([0, 2], [6, 8])
-    ax2.set_aspect("equal", adjustable="box")
-
-    fig1.canvas.draw()
-    fig2.canvas.draw()
-
-    bb1 = ax1.get_position()
-    bbt = axtwin.get_position()
-    bb2 = ax2.get_position()
-
-    assert_array_equal(bb1.extents, bb2.extents)
-    assert_array_equal(bbt.extents, bb2.extents)
-
-
-def test_box_aspect_custom_position():
-    # Test if axes with custom position and box_aspect
-    # behaves the same independent of the order of setting those.
-
-    fig1, ax1 = plt.subplots()
-    ax1.set_position([0.1, 0.1, 0.9, 0.2])
-    fig1.canvas.draw()
-    ax1.set_box_aspect(1.)
-
-    fig2, ax2 = plt.subplots()
-    ax2.set_box_aspect(1.)
-    fig2.canvas.draw()
-    ax2.set_position([0.1, 0.1, 0.9, 0.2])
-
-    fig1.canvas.draw()
-    fig2.canvas.draw()
-
-    bb1 = ax1.get_position()
-    bb2 = ax2.get_position()
-
-    assert_array_equal(bb1.extents, bb2.extents)
-
-
-def test_bbox_aspect_axes_init():
-    # Test that box_aspect can be given to axes init and produces
-    # all equal square axes.
-    fig, axs = plt.subplots(2, 3, subplot_kw=dict(box_aspect=1),
-                            constrained_layout=True)
-    fig.canvas.draw()
-    renderer = fig.canvas.get_renderer()
-    sizes = []
-    for ax in axs.flat:
-        bb = ax.get_window_extent(renderer)
-        sizes.extend([bb.width, bb.height])
-
-    assert_allclose(sizes, sizes[0])
-
-
-def test_set_aspect_negative():
-    fig, ax = plt.subplots()
-    with pytest.raises(ValueError, match="must be finite and positive"):
-        ax.set_aspect(-1)
-    with pytest.raises(ValueError, match="must be finite and positive"):
-        ax.set_aspect(0)
-    with pytest.raises(ValueError, match="must be finite and positive"):
-        ax.set_aspect(np.inf)
-    with pytest.raises(ValueError, match="must be finite and positive"):
-        ax.set_aspect(-np.inf)
-
-
-def test_redraw_in_frame():
-    fig, ax = plt.subplots(1, 1)
-    ax.plot([1, 2, 3])
-    fig.canvas.draw()
-    ax.redraw_in_frame()
-
-
-def test_invisible_axes_events():
-    # invisible axes should not respond to events...
-    fig, ax = plt.subplots()
-    assert fig.canvas.inaxes((200, 200)) is not None
-    ax.set_visible(False)
-    assert fig.canvas.inaxes((200, 200)) is None
-
-
-def test_xtickcolor_is_not_markercolor():
-    plt.rcParams['lines.markeredgecolor'] = 'white'
-    ax = plt.axes()
-    ticks = ax.xaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.tick1line.get_markeredgecolor() != 'white'
-
-
-def test_ytickcolor_is_not_markercolor():
-    plt.rcParams['lines.markeredgecolor'] = 'white'
-    ax = plt.axes()
-    ticks = ax.yaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.tick1line.get_markeredgecolor() != 'white'
-
-
-@pytest.mark.parametrize('axis', ('x', 'y'))
-@pytest.mark.parametrize('auto', (True, False, None))
-def test_unautoscale(axis, auto):
-    fig, ax = plt.subplots()
-    x = np.arange(100)
-    y = np.linspace(-.1, .1, 100)
-    ax.scatter(y, x)
-
-    get_autoscale_on = getattr(ax, f'get_autoscale{axis}_on')
-    set_lim = getattr(ax, f'set_{axis}lim')
-    get_lim = getattr(ax, f'get_{axis}lim')
-
-    post_auto = get_autoscale_on() if auto is None else auto
-
-    set_lim((-0.5, 0.5), auto=auto)
-    assert post_auto == get_autoscale_on()
-    fig.canvas.draw()
-    assert_array_equal(get_lim(), (-0.5, 0.5))
-
-
-@check_figures_equal(extensions=["png"])
-def test_polar_interpolation_steps_variable_r(fig_test, fig_ref):
-    l, = fig_test.add_subplot(projection="polar").plot([0, np.pi/2], [1, 2])
-    l.get_path()._interpolation_steps = 100
-    fig_ref.add_subplot(projection="polar").plot(
-        np.linspace(0, np.pi/2, 101), np.linspace(1, 2, 101))
-
-
-@mpl.style.context('default')
-def test_autoscale_tiny_sticky():
-    fig, ax = plt.subplots()
-    ax.bar(0, 1e-9)
-    fig.canvas.draw()
-    assert ax.get_ylim() == (0, 1.05e-9)
-
-
-def test_xtickcolor_is_not_xticklabelcolor():
-    plt.rcParams['xtick.color'] = 'yellow'
-    plt.rcParams['xtick.labelcolor'] = 'blue'
-    ax = plt.axes()
-    ticks = ax.xaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.tick1line.get_color() == 'yellow'
-        assert tick.label1.get_color() == 'blue'
-
-
-def test_ytickcolor_is_not_yticklabelcolor():
-    plt.rcParams['ytick.color'] = 'yellow'
-    plt.rcParams['ytick.labelcolor'] = 'blue'
-    ax = plt.axes()
-    ticks = ax.yaxis.get_major_ticks()
-    for tick in ticks:
-        assert tick.tick1line.get_color() == 'yellow'
-        assert tick.label1.get_color() == 'blue'
-
-
-def test_xaxis_offsetText_color():
-    plt.rcParams['xtick.labelcolor'] = 'blue'
-    ax = plt.axes()
-    assert ax.xaxis.offsetText.get_color() == 'blue'
-
-    plt.rcParams['xtick.color'] = 'yellow'
-    plt.rcParams['xtick.labelcolor'] = 'inherit'
-    ax = plt.axes()
-    assert ax.xaxis.offsetText.get_color() == 'yellow'
-
-
-def test_yaxis_offsetText_color():
-    plt.rcParams['ytick.labelcolor'] = 'green'
-    ax = plt.axes()
-    assert ax.yaxis.offsetText.get_color() == 'green'
-
-    plt.rcParams['ytick.color'] = 'red'
-    plt.rcParams['ytick.labelcolor'] = 'inherit'
-    ax = plt.axes()
-    assert ax.yaxis.offsetText.get_color() == 'red'
-
-
-@pytest.mark.parametrize('size', [size for size in mfont_manager.font_scalings
-                                  if size is not None] + [8, 10, 12])
-@mpl.style.context('default')
-def test_relative_ticklabel_sizes(size):
-    mpl.rcParams['xtick.labelsize'] = size
-    mpl.rcParams['ytick.labelsize'] = size
-    fig, ax = plt.subplots()
-    fig.canvas.draw()
-
-    for name, axis in zip(['x', 'y'], [ax.xaxis, ax.yaxis]):
-        for tick in axis.get_major_ticks():
-            assert tick.label1.get_size() == axis._get_tick_label_size(name)
-
-
-def test_multiplot_autoscale():
-    fig = plt.figure()
-    ax1, ax2 = fig.subplots(2, 1, sharex='all')
-    ax1.plot([18000, 18250, 18500, 18750], [2, 3, 2, 3])
-    ax2.axhspan(-5, 5)
-    xlim = ax1.get_xlim()
-    assert np.allclose(xlim, [18000, 18800])
-
-
-def test_sharing_does_not_link_positions():
-    fig = plt.figure()
-    ax0 = fig.add_subplot(221)
-    ax1 = fig.add_axes([.6, .6, .3, .3], sharex=ax0)
-    init_pos = ax1.get_position()
-    fig.subplots_adjust(left=0)
-    assert (ax1.get_position().get_points() == init_pos.get_points()).all()
-
-
-@check_figures_equal(extensions=["pdf"])
-def test_2dcolor_plot(fig_test, fig_ref):
-    color = np.array([0.1, 0.2, 0.3])
-    # plot with 1D-color:
-    axs = fig_test.subplots(5)
-    axs[0].plot([1, 2], [1, 2], c=color.reshape(-1))
-    with pytest.warns(match="argument looks like a single numeric RGB"):
-        axs[1].scatter([1, 2], [1, 2], c=color.reshape(-1))
-    axs[2].step([1, 2], [1, 2], c=color.reshape(-1))
-    axs[3].hist(np.arange(10), color=color.reshape(-1))
-    axs[4].bar(np.arange(10), np.arange(10), color=color.reshape(-1))
-    # plot with 2D-color:
-    axs = fig_ref.subplots(5)
-    axs[0].plot([1, 2], [1, 2], c=color.reshape((1, -1)))
-    axs[1].scatter([1, 2], [1, 2], c=color.reshape((1, -1)))
-    axs[2].step([1, 2], [1, 2], c=color.reshape((1, -1)))
-    axs[3].hist(np.arange(10), color=color.reshape((1, -1)))
-    axs[4].bar(np.arange(10), np.arange(10), color=color.reshape((1, -1)))
-
-
-@check_figures_equal(extensions=['png'])
-def test_shared_axes_clear(fig_test, fig_ref):
-    x = np.arange(0.0, 2*np.pi, 0.01)
-    y = np.sin(x)
-
-    axs = fig_ref.subplots(2, 2, sharex=True, sharey=True)
-    for ax in axs.flat:
-        ax.plot(x, y)
-
-    axs = fig_test.subplots(2, 2, sharex=True, sharey=True)
-    for ax in axs.flat:
-        ax.clear()
-        ax.plot(x, y)
-
-
-def test_shared_axes_retick():
-    fig, axs = plt.subplots(2, 2, sharex='all', sharey='all')
-
-    for ax in axs.flat:
-        ax.plot([0, 2], 'o-')
-
-    axs[0, 0].set_xticks([-0.5, 0, 1, 1.5])  # should affect all axes xlims
-    for ax in axs.flat:
-        assert ax.get_xlim() == axs[0, 0].get_xlim()
-
-    axs[0, 0].set_yticks([-0.5, 0, 2, 2.5])  # should affect all axes ylims
-    for ax in axs.flat:
-        assert ax.get_ylim() == axs[0, 0].get_ylim()
-
-
-@pytest.mark.parametrize('ha', ['left', 'center', 'right'])
-def test_ylabel_ha_with_position(ha):
-    fig = Figure()
-    ax = fig.subplots()
-    ax.set_ylabel("test", y=1, ha=ha)
-    ax.yaxis.set_label_position("right")
-    assert ax.yaxis.label.get_ha() == ha
-
-
-def test_bar_label_location_vertical():
-    ax = plt.gca()
-    xs, heights = [1, 2], [3, -4]
-    rects = ax.bar(xs, heights)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (xs[0], heights[0])
-    assert labels[0].get_horizontalalignment() == 'center'
-    assert labels[0].get_verticalalignment() == 'bottom'
-    assert labels[1].xy == (xs[1], heights[1])
-    assert labels[1].get_horizontalalignment() == 'center'
-    assert labels[1].get_verticalalignment() == 'top'
-
-
-def test_bar_label_location_vertical_yinverted():
-    ax = plt.gca()
-    ax.invert_yaxis()
-    xs, heights = [1, 2], [3, -4]
-    rects = ax.bar(xs, heights)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (xs[0], heights[0])
-    assert labels[0].get_horizontalalignment() == 'center'
-    assert labels[0].get_verticalalignment() == 'top'
-    assert labels[1].xy == (xs[1], heights[1])
-    assert labels[1].get_horizontalalignment() == 'center'
-    assert labels[1].get_verticalalignment() == 'bottom'
-
-
-def test_bar_label_location_horizontal():
-    ax = plt.gca()
-    ys, widths = [1, 2], [3, -4]
-    rects = ax.barh(ys, widths)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (widths[0], ys[0])
-    assert labels[0].get_horizontalalignment() == 'left'
-    assert labels[0].get_verticalalignment() == 'center'
-    assert labels[1].xy == (widths[1], ys[1])
-    assert labels[1].get_horizontalalignment() == 'right'
-    assert labels[1].get_verticalalignment() == 'center'
-
-
-def test_bar_label_location_horizontal_yinverted():
-    ax = plt.gca()
-    ax.invert_yaxis()
-    ys, widths = [1, 2], [3, -4]
-    rects = ax.barh(ys, widths)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (widths[0], ys[0])
-    assert labels[0].get_horizontalalignment() == 'left'
-    assert labels[0].get_verticalalignment() == 'center'
-    assert labels[1].xy == (widths[1], ys[1])
-    assert labels[1].get_horizontalalignment() == 'right'
-    assert labels[1].get_verticalalignment() == 'center'
-
-
-def test_bar_label_location_horizontal_xinverted():
-    ax = plt.gca()
-    ax.invert_xaxis()
-    ys, widths = [1, 2], [3, -4]
-    rects = ax.barh(ys, widths)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (widths[0], ys[0])
-    assert labels[0].get_horizontalalignment() == 'right'
-    assert labels[0].get_verticalalignment() == 'center'
-    assert labels[1].xy == (widths[1], ys[1])
-    assert labels[1].get_horizontalalignment() == 'left'
-    assert labels[1].get_verticalalignment() == 'center'
-
-
-def test_bar_label_location_horizontal_xyinverted():
-    ax = plt.gca()
-    ax.invert_xaxis()
-    ax.invert_yaxis()
-    ys, widths = [1, 2], [3, -4]
-    rects = ax.barh(ys, widths)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (widths[0], ys[0])
-    assert labels[0].get_horizontalalignment() == 'right'
-    assert labels[0].get_verticalalignment() == 'center'
-    assert labels[1].xy == (widths[1], ys[1])
-    assert labels[1].get_horizontalalignment() == 'left'
-    assert labels[1].get_verticalalignment() == 'center'
-
-
-def test_bar_label_location_center():
-    ax = plt.gca()
-    ys, widths = [1, 2], [3, -4]
-    rects = ax.barh(ys, widths)
-    labels = ax.bar_label(rects, label_type='center')
-    assert labels[0].xy == (0.5, 0.5)
-    assert labels[0].get_horizontalalignment() == 'center'
-    assert labels[0].get_verticalalignment() == 'center'
-    assert labels[1].xy == (0.5, 0.5)
-    assert labels[1].get_horizontalalignment() == 'center'
-    assert labels[1].get_verticalalignment() == 'center'
-
-
-@image_comparison(['test_centered_bar_label_nonlinear.svg'])
-def test_centered_bar_label_nonlinear():
-    _, ax = plt.subplots()
-    bar_container = ax.barh(['c', 'b', 'a'], [1_000, 5_000, 7_000])
-    ax.set_xscale('log')
-    ax.set_xlim(1, None)
-    ax.bar_label(bar_container, label_type='center')
-    ax.set_axis_off()
-
-
-def test_centered_bar_label_label_beyond_limits():
-    fig, ax = plt.subplots()
-
-    last = 0
-    for label, value in zip(['a', 'b', 'c'], [10, 20, 50]):
-        bar_container = ax.barh('col', value, label=label, left=last)
-        ax.bar_label(bar_container, label_type='center')
-        last += value
-    ax.set_xlim(None, 20)
-
-    fig.draw_without_rendering()
-
-
-def test_bar_label_location_errorbars():
-    ax = plt.gca()
-    xs, heights = [1, 2], [3, -4]
-    rects = ax.bar(xs, heights, yerr=1)
-    labels = ax.bar_label(rects)
-    assert labels[0].xy == (xs[0], heights[0] + 1)
-    assert labels[0].get_horizontalalignment() == 'center'
-    assert labels[0].get_verticalalignment() == 'bottom'
-    assert labels[1].xy == (xs[1], heights[1] - 1)
-    assert labels[1].get_horizontalalignment() == 'center'
-    assert labels[1].get_verticalalignment() == 'top'
-
-
-@pytest.mark.parametrize('fmt', [
-    '%.2f', '{:.2f}', '{:.2f}'.format
-])
-def test_bar_label_fmt(fmt):
-    ax = plt.gca()
-    rects = ax.bar([1, 2], [3, -4])
-    labels = ax.bar_label(rects, fmt=fmt)
-    assert labels[0].get_text() == '3.00'
-    assert labels[1].get_text() == '-4.00'
-
-
-def test_bar_label_fmt_error():
-    ax = plt.gca()
-    rects = ax.bar([1, 2], [3, -4])
-    with pytest.raises(TypeError, match='str or callable'):
-        _ = ax.bar_label(rects, fmt=10)
-
-
-def test_bar_label_labels():
-    ax = plt.gca()
-    rects = ax.bar([1, 2], [3, -4])
-    labels = ax.bar_label(rects, labels=['A', 'B'])
-    assert labels[0].get_text() == 'A'
-    assert labels[1].get_text() == 'B'
-
-
-def test_bar_label_nan_ydata():
-    ax = plt.gca()
-    bars = ax.bar([2, 3], [np.nan, 1])
-    labels = ax.bar_label(bars)
-    assert [l.get_text() for l in labels] == ['', '1']
-    assert labels[0].xy == (2, 0)
-    assert labels[0].get_verticalalignment() == 'bottom'
-
-
-def test_bar_label_nan_ydata_inverted():
-    ax = plt.gca()
-    ax.yaxis_inverted()
-    bars = ax.bar([2, 3], [np.nan, 1])
-    labels = ax.bar_label(bars)
-    assert [l.get_text() for l in labels] == ['', '1']
-    assert labels[0].xy == (2, 0)
-    assert labels[0].get_verticalalignment() == 'bottom'
-
-
-def test_nan_barlabels():
-    fig, ax = plt.subplots()
-    bars = ax.bar([1, 2, 3], [np.nan, 1, 2], yerr=[0.2, 0.4, 0.6])
-    labels = ax.bar_label(bars)
-    assert [l.get_text() for l in labels] == ['', '1', '2']
-    assert np.allclose(ax.get_ylim(), (0.0, 3.0))
-
-    fig, ax = plt.subplots()
-    bars = ax.bar([1, 2, 3], [0, 1, 2], yerr=[0.2, np.nan, 0.6])
-    labels = ax.bar_label(bars)
-    assert [l.get_text() for l in labels] == ['0', '1', '2']
-    assert np.allclose(ax.get_ylim(), (-0.5, 3.0))
-
-    fig, ax = plt.subplots()
-    bars = ax.bar([1, 2, 3], [np.nan, 1, 2], yerr=[np.nan, np.nan, 0.6])
-    labels = ax.bar_label(bars)
-    assert [l.get_text() for l in labels] == ['', '1', '2']
-    assert np.allclose(ax.get_ylim(), (0.0, 3.0))
-
-
-def test_patch_bounds():  # PR 19078
-    fig, ax = plt.subplots()
-    ax.add_patch(mpatches.Wedge((0, -1), 1.05, 60, 120, width=0.1))
-    bot = 1.9*np.sin(15*np.pi/180)**2
-    np.testing.assert_array_almost_equal_nulp(
-        np.array((-0.525, -(bot+0.05), 1.05, bot+0.1)), ax.dataLim.bounds, 16)
-
-
-@mpl.style.context('default')
-def test_warn_ignored_scatter_kwargs():
-    with pytest.warns(UserWarning,
-                      match=r"You passed a edgecolor/edgecolors"):
-        plt.scatter([0], [0], marker="+", s=500, facecolor="r", edgecolor="b")
-
-
-def test_artist_sublists():
-    fig, ax = plt.subplots()
-    lines = [ax.plot(np.arange(i, i + 5))[0] for i in range(6)]
-    col = ax.scatter(np.arange(5), np.arange(5))
-    im = ax.imshow(np.zeros((5, 5)))
-    patch = ax.add_patch(mpatches.Rectangle((0, 0), 5, 5))
-    text = ax.text(0, 0, 'foo')
-
-    # Get items, which should not be mixed.
-    assert list(ax.collections) == [col]
-    assert list(ax.images) == [im]
-    assert list(ax.lines) == lines
-    assert list(ax.patches) == [patch]
-    assert not ax.tables
-    assert list(ax.texts) == [text]
-
-    # Get items should work like lists/tuple.
-    assert ax.lines[0] is lines[0]
-    assert ax.lines[-1] is lines[-1]
-    with pytest.raises(IndexError, match='out of range'):
-        ax.lines[len(lines) + 1]
-
-    # Adding to other lists should produce a regular list.
-    assert ax.lines + [1, 2, 3] == [*lines, 1, 2, 3]
-    assert [1, 2, 3] + ax.lines == [1, 2, 3, *lines]
-
-    # Adding to other tuples should produce a regular tuples.
-    assert ax.lines + (1, 2, 3) == (*lines, 1, 2, 3)
-    assert (1, 2, 3) + ax.lines == (1, 2, 3, *lines)
-
-    # Lists should be empty after removing items.
-    col.remove()
-    assert not ax.collections
-    im.remove()
-    assert not ax.images
-    patch.remove()
-    assert not ax.patches
-    assert not ax.tables
-    text.remove()
-    assert not ax.texts
-
-    for ln in ax.lines:
-        ln.remove()
-    assert len(ax.lines) == 0
-
-
-def test_empty_line_plots():
-    # Incompatible nr columns, plot "nothing"
-    x = np.ones(10)
-    y = np.ones((10, 0))
-    _, ax = plt.subplots()
-    line = ax.plot(x, y)
-    assert len(line) == 0
-
-    # Ensure plot([],[]) creates line
-    _, ax = plt.subplots()
-    line = ax.plot([], [])
-    assert len(line) == 1
-
-
-@pytest.mark.parametrize('fmt, match', (
-    ("f", r"'f' is not a valid format string \(unrecognized character 'f'\)"),
-    ("o+", r"'o\+' is not a valid format string \(two marker symbols\)"),
-    (":-", r"':-' is not a valid format string \(two linestyle symbols\)"),
-    ("rk", r"'rk' is not a valid format string \(two color symbols\)"),
-    (":o-r", r"':o-r' is not a valid format string \(two linestyle symbols\)"),
-    ("C", r"'C' is not a valid format string \('C' must be followed by a number\)"),
-    (".C", r"'.C' is not a valid format string \('C' must be followed by a number\)"),
-))
-@pytest.mark.parametrize("data", [None, {"string": range(3)}])
-def test_plot_format_errors(fmt, match, data):
-    fig, ax = plt.subplots()
-    if data is not None:
-        match = match.replace("not", "neither a data key nor")
-    with pytest.raises(ValueError, match=r"\A" + match + r"\Z"):
-        ax.plot("string", fmt, data=data)
-
-
-def test_plot_format():
-    fig, ax = plt.subplots()
-    line = ax.plot([1, 2, 3], '1.0')
-    assert line[0].get_color() == (1.0, 1.0, 1.0, 1.0)
-    assert line[0].get_marker() == 'None'
-    fig, ax = plt.subplots()
-    line = ax.plot([1, 2, 3], '1')
-    assert line[0].get_marker() == '1'
-    fig, ax = plt.subplots()
-    line = ax.plot([1, 2], [1, 2], '1.0', "1")
-    fig.canvas.draw()
-    assert line[0].get_color() == (1.0, 1.0, 1.0, 1.0)
-    assert ax.get_yticklabels()[0].get_text() == '1'
-    fig, ax = plt.subplots()
-    line = ax.plot([1, 2], [1, 2], '1', "1.0")
-    fig.canvas.draw()
-    assert line[0].get_marker() == '1'
-    assert ax.get_yticklabels()[0].get_text() == '1.0'
-    fig, ax = plt.subplots()
-    line = ax.plot([1, 2, 3], 'k3')
-    assert line[0].get_marker() == '3'
-    assert line[0].get_color() == 'k'
-    fig, ax = plt.subplots()
-    line = ax.plot([1, 2, 3], '.C12:')
-    assert line[0].get_marker() == '.'
-    assert line[0].get_color() == mcolors.to_rgba('C12')
-    assert line[0].get_linestyle() == ':'
-
-
-def test_automatic_legend():
-    fig, ax = plt.subplots()
-    ax.plot("a", "b", data={"d": 2})
-    leg = ax.legend()
-    fig.canvas.draw()
-    assert leg.get_texts()[0].get_text() == 'a'
-    assert ax.get_yticklabels()[0].get_text() == 'a'
-
-    fig, ax = plt.subplots()
-    ax.plot("a", "b", "c", data={"d": 2})
-    leg = ax.legend()
-    fig.canvas.draw()
-    assert leg.get_texts()[0].get_text() == 'b'
-    assert ax.get_xticklabels()[0].get_text() == 'a'
-    assert ax.get_yticklabels()[0].get_text() == 'b'
-
-
-def test_plot_errors():
-    with pytest.raises(TypeError, match=r"plot\(\) got an unexpected keyword"):
-        plt.plot([1, 2, 3], x=1)
-    with pytest.raises(ValueError, match=r"plot\(\) with multiple groups"):
-        plt.plot([1, 2, 3], [1, 2, 3], [2, 3, 4], [2, 3, 4], label=['1', '2'])
-    with pytest.raises(ValueError, match="x and y must have same first"):
-        plt.plot([1, 2, 3], [1])
-    with pytest.raises(ValueError, match="x and y can be no greater than"):
-        plt.plot(np.ones((2, 2, 2)))
-    with pytest.raises(ValueError, match="Using arbitrary long args with"):
-        plt.plot("a", "b", "c", "d", data={"a": 2})
-
-
-def test_clim():
-    ax = plt.figure().add_subplot()
-    for plot_method in [
-            partial(ax.scatter, range(3), range(3), c=range(3)),
-            partial(ax.imshow, [[0, 1], [2, 3]]),
-            partial(ax.pcolor,  [[0, 1], [2, 3]]),
-            partial(ax.pcolormesh, [[0, 1], [2, 3]]),
-            partial(ax.pcolorfast, [[0, 1], [2, 3]]),
-    ]:
-        clim = (7, 8)
-        norm = plot_method(clim=clim).norm
-        assert (norm.vmin, norm.vmax) == clim
-
-
-def test_bezier_autoscale():
-    # Check that bezier curves autoscale to their curves, and not their
-    # control points
-    verts = [[-1, 0],
-             [0, -1],
-             [1, 0],
-             [1, 0]]
-    codes = [mpath.Path.MOVETO,
-             mpath.Path.CURVE3,
-             mpath.Path.CURVE3,
-             mpath.Path.CLOSEPOLY]
-    p = mpath.Path(verts, codes)
-
-    fig, ax = plt.subplots()
-    ax.add_patch(mpatches.PathPatch(p))
-    ax.autoscale()
-    # Bottom ylim should be at the edge of the curve (-0.5), and not include
-    # the control point (at -1)
-    assert ax.get_ylim()[0] == -0.5
-
-
-def test_small_autoscale():
-    # Check that paths with small values autoscale correctly #24097.
-    verts = np.array([
-        [-5.45, 0.00], [-5.45, 0.00], [-5.29, 0.00], [-5.29, 0.00],
-        [-5.13, 0.00], [-5.13, 0.00], [-4.97, 0.00], [-4.97, 0.00],
-        [-4.81, 0.00], [-4.81, 0.00], [-4.65, 0.00], [-4.65, 0.00],
-        [-4.49, 0.00], [-4.49, 0.00], [-4.33, 0.00], [-4.33, 0.00],
-        [-4.17, 0.00], [-4.17, 0.00], [-4.01, 0.00], [-4.01, 0.00],
-        [-3.85, 0.00], [-3.85, 0.00], [-3.69, 0.00], [-3.69, 0.00],
-        [-3.53, 0.00], [-3.53, 0.00], [-3.37, 0.00], [-3.37, 0.00],
-        [-3.21, 0.00], [-3.21, 0.01], [-3.05, 0.01], [-3.05, 0.01],
-        [-2.89, 0.01], [-2.89, 0.01], [-2.73, 0.01], [-2.73, 0.02],
-        [-2.57, 0.02], [-2.57, 0.04], [-2.41, 0.04], [-2.41, 0.04],
-        [-2.25, 0.04], [-2.25, 0.06], [-2.09, 0.06], [-2.09, 0.08],
-        [-1.93, 0.08], [-1.93, 0.10], [-1.77, 0.10], [-1.77, 0.12],
-        [-1.61, 0.12], [-1.61, 0.14], [-1.45, 0.14], [-1.45, 0.17],
-        [-1.30, 0.17], [-1.30, 0.19], [-1.14, 0.19], [-1.14, 0.22],
-        [-0.98, 0.22], [-0.98, 0.25], [-0.82, 0.25], [-0.82, 0.27],
-        [-0.66, 0.27], [-0.66, 0.29], [-0.50, 0.29], [-0.50, 0.30],
-        [-0.34, 0.30], [-0.34, 0.32], [-0.18, 0.32], [-0.18, 0.33],
-        [-0.02, 0.33], [-0.02, 0.32], [0.13, 0.32], [0.13, 0.33], [0.29, 0.33],
-        [0.29, 0.31], [0.45, 0.31], [0.45, 0.30], [0.61, 0.30], [0.61, 0.28],
-        [0.77, 0.28], [0.77, 0.25], [0.93, 0.25], [0.93, 0.22], [1.09, 0.22],
-        [1.09, 0.19], [1.25, 0.19], [1.25, 0.17], [1.41, 0.17], [1.41, 0.15],
-        [1.57, 0.15], [1.57, 0.12], [1.73, 0.12], [1.73, 0.10], [1.89, 0.10],
-        [1.89, 0.08], [2.05, 0.08], [2.05, 0.07], [2.21, 0.07], [2.21, 0.05],
-        [2.37, 0.05], [2.37, 0.04], [2.53, 0.04], [2.53, 0.02], [2.69, 0.02],
-        [2.69, 0.02], [2.85, 0.02], [2.85, 0.01], [3.01, 0.01], [3.01, 0.01],
-        [3.17, 0.01], [3.17, 0.00], [3.33, 0.00], [3.33, 0.00], [3.49, 0.00],
-        [3.49, 0.00], [3.65, 0.00], [3.65, 0.00], [3.81, 0.00], [3.81, 0.00],
-        [3.97, 0.00], [3.97, 0.00], [4.13, 0.00], [4.13, 0.00], [4.29, 0.00],
-        [4.29, 0.00], [4.45, 0.00], [4.45, 0.00], [4.61, 0.00], [4.61, 0.00],
-        [4.77, 0.00], [4.77, 0.00], [4.93, 0.00], [4.93, 0.00],
-    ])
-
-    minx = np.min(verts[:, 0])
-    miny = np.min(verts[:, 1])
-    maxx = np.max(verts[:, 0])
-    maxy = np.max(verts[:, 1])
-
-    p = mpath.Path(verts)
-
-    fig, ax = plt.subplots()
-    ax.add_patch(mpatches.PathPatch(p))
-    ax.autoscale()
-
-    assert ax.get_xlim()[0] <= minx
-    assert ax.get_xlim()[1] >= maxx
-    assert ax.get_ylim()[0] <= miny
-    assert ax.get_ylim()[1] >= maxy
-
-
-def test_get_xticklabel():
-    fig, ax = plt.subplots()
-    ax.plot(np.arange(10))
-    for ind in range(10):
-        assert ax.get_xticklabels()[ind].get_text() == f'{ind}'
-        assert ax.get_yticklabels()[ind].get_text() == f'{ind}'
-
-
-def test_bar_leading_nan():
-
-    barx = np.arange(3, dtype=float)
-    barheights = np.array([0.5, 1.5, 2.0])
-    barstarts = np.array([0.77]*3)
-
-    barx[0] = np.nan
-
-    fig, ax = plt.subplots()
-
-    bars = ax.bar(barx, barheights, bottom=barstarts)
-
-    hbars = ax.barh(barx, barheights, left=barstarts)
-
-    for bar_set in (bars, hbars):
-        # the first bar should have a nan in the location
-        nanful, *rest = bar_set
-        assert (~np.isfinite(nanful.xy)).any()
-        assert np.isfinite(nanful.get_width())
-        for b in rest:
-            assert np.isfinite(b.xy).all()
-            assert np.isfinite(b.get_width())
-
-
-@check_figures_equal(extensions=["png"])
-def test_bar_all_nan(fig_test, fig_ref):
-    mpl.style.use("mpl20")
-    ax_test = fig_test.subplots()
-    ax_ref = fig_ref.subplots()
-
-    ax_test.bar([np.nan], [np.nan])
-    ax_test.bar([1], [1])
-
-    ax_ref.bar([1], [1]).remove()
-    ax_ref.bar([1], [1])
-
-
-@image_comparison(["extent_units.png"], style="mpl20")
-def test_extent_units():
-    _, axs = plt.subplots(2, 2)
-    date_first = np.datetime64('2020-01-01', 'D')
-    date_last = np.datetime64('2020-01-11', 'D')
-    arr = [[i+j for i in range(10)] for j in range(10)]
-
-    axs[0, 0].set_title('Date extents on y axis')
-    im = axs[0, 0].imshow(arr, origin='lower',
-                          extent=[1, 11, date_first, date_last],
-                          cmap=mpl.colormaps["plasma"])
-
-    axs[0, 1].set_title('Date extents on x axis (Day of Jan 2020)')
-    im = axs[0, 1].imshow(arr, origin='lower',
-                          extent=[date_first, date_last, 1, 11],
-                          cmap=mpl.colormaps["plasma"])
-    axs[0, 1].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
-
-    im = axs[1, 0].imshow(arr, origin='lower',
-                          extent=[date_first, date_last,
-                                  date_first, date_last],
-                          cmap=mpl.colormaps["plasma"])
-    axs[1, 0].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
-    axs[1, 0].set(xlabel='Day of Jan 2020')
-
-    im = axs[1, 1].imshow(arr, origin='lower',
-                          cmap=mpl.colormaps["plasma"])
-    im.set_extent([date_last, date_first, date_last, date_first])
-    axs[1, 1].xaxis.set_major_formatter(mdates.DateFormatter('%d'))
-    axs[1, 1].set(xlabel='Day of Jan 2020')
-
-    with pytest.raises(TypeError, match=r"set_extent\(\) got an unexpected"):
-        im.set_extent([2, 12, date_first, date_last], clip=False)
-
-
-def test_cla_clears_children_axes_and_fig():
-    fig, ax = plt.subplots()
-    lines = ax.plot([], [], [], [])
-    img = ax.imshow([[1]])
-    for art in lines + [img]:
-        assert art.axes is ax
-        assert art.get_figure() is fig
-    ax.clear()
-    for art in lines + [img]:
-        assert art.axes is None
-        assert art.get_figure() is None
-
-
-def test_child_axes_removal():
-    fig, ax = plt.subplots()
-    marginal = ax.inset_axes([1, 0, .1, 1], sharey=ax)
-    marginal_twin = marginal.twinx()
-    marginal.remove()
-    ax.set(xlim=(-1, 1), ylim=(10, 20))
-
-
-def test_scatter_color_repr_error():
-
-    def get_next_color():
-        return 'blue'  # pragma: no cover
-    msg = (
-            r"'c' argument must be a color, a sequence of colors"
-            r", or a sequence of numbers, not 'red\\n'"
+        # For compatibility(!), get aliases from Line2D rather than Patch.
+        kwargs = cbook.normalize_kwargs(kwargs, mlines.Line2D)
+        # _get_patches_for_fill returns a generator, convert it to a list.
+        patches = [*self._get_patches_for_fill(self, *args, data=data, **kwargs)]
+        for poly in patches:
+            self.add_patch(poly)
+        self._request_autoscale_view()
+        return patches
+
+    def _fill_between_x_or_y(
+            self, ind_dir, ind, dep1, dep2=0, *,
+            where=None, interpolate=False, step=None, **kwargs):
+        # Common implementation between fill_between (*ind_dir*="x") and
+        # fill_betweenx (*ind_dir*="y").  *ind* is the independent variable,
+        # *dep* the dependent variable.  The docstring below is interpolated
+        # to generate both methods' docstrings.
+        """
+        Fill the area between two {dir} curves.
+
+        The curves are defined by the points (*{ind}*, *{dep}1*) and (*{ind}*,
+        *{dep}2*).  This creates one or multiple polygons describing the filled
+        area.
+
+        You may exclude some {dir} sections from filling using *where*.
+
+        By default, the edges connect the given points directly.  Use *step*
+        if the filling should be a step function, i.e. constant in between
+        *{ind}*.
+
+        Parameters
+        ----------
+        {ind} : array (length N)
+            The {ind} coordinates of the nodes defining the curves.
+
+        {dep}1 : array (length N) or scalar
+            The {dep} coordinates of the nodes defining the first curve.
+
+        {dep}2 : array (length N) or scalar, default: 0
+            The {dep} coordinates of the nodes defining the second curve.
+
+        where : array of bool (length N), optional
+            Define *where* to exclude some {dir} regions from being filled.
+            The filled regions are defined by the coordinates ``{ind}[where]``.
+            More precisely, fill between ``{ind}[i]`` and ``{ind}[i+1]`` if
+            ``where[i] and where[i+1]``.  Note that this definition implies
+            that an isolated *True* value between two *False* values in *where*
+            will not result in filling.  Both sides of the *True* position
+            remain unfilled due to the adjacent *False* values.
+
+        interpolate : bool, default: False
+            This option is only relevant if *where* is used and the two curves
+            are crossing each other.
+
+            Semantically, *where* is often used for *{dep}1* > *{dep}2* or
+            similar.  By default, the nodes of the polygon defining the filled
+            region will only be placed at the positions in the *{ind}* array.
+            Such a polygon cannot describe the above semantics close to the
+            intersection.  The {ind}-sections containing the intersection are
+            simply clipped.
+
+            Setting *interpolate* to *True* will calculate the actual
+            intersection point and extend the filled region up to this point.
+
+        step : {{'pre', 'post', 'mid'}}, optional
+            Define *step* if the filling should be a step function,
+            i.e. constant in between *{ind}*.  The value determines where the
+            step will occur:
+
+            - 'pre': The {dep} value is continued constantly to the left from
+              every *{ind}* position, i.e. the interval ``({ind}[i-1], {ind}[i]]``
+              has the value ``{dep}[i]``.
+            - 'post': The y value is continued constantly to the right from
+              every *{ind}* position, i.e. the interval ``[{ind}[i], {ind}[i+1])``
+              has the value ``{dep}[i]``.
+            - 'mid': Steps occur half-way between the *{ind}* positions.
+
+        Returns
+        -------
+        `.FillBetweenPolyCollection`
+            A `.FillBetweenPolyCollection` containing the plotted polygons.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            All other keyword arguments are passed on to
+            `.FillBetweenPolyCollection`. They control the `.Polygon` properties:
+
+            %(FillBetweenPolyCollection:kwdoc)s
+
+        See Also
+        --------
+        fill_between : Fill between two sets of y-values.
+        fill_betweenx : Fill between two sets of x-values.
+        """
+        dep_dir = mcoll.FillBetweenPolyCollection._f_dir_from_t(ind_dir)
+
+        if not mpl.rcParams["_internal.classic_mode"]:
+            kwargs = cbook.normalize_kwargs(kwargs, mcoll.Collection)
+            if not any(c in kwargs for c in ("color", "facecolor")):
+                kwargs["facecolor"] = self._get_patches_for_fill.get_next_color()
+
+        ind, dep1, dep2 = self._fill_between_process_units(
+            ind_dir, dep_dir, ind, dep1, dep2, **kwargs)
+
+        collection = mcoll.FillBetweenPolyCollection(
+            ind_dir, ind, dep1, dep2,
+            where=where, interpolate=interpolate, step=step, **kwargs)
+
+        self.add_collection(collection)
+        self._request_autoscale_view()
+        return collection
+
+    def _fill_between_process_units(self, ind_dir, dep_dir, ind, dep1, dep2, **kwargs):
+        """Handle united data, such as dates."""
+        return map(np.ma.masked_invalid, self._process_unit_info(
+            [(ind_dir, ind), (dep_dir, dep1), (dep_dir, dep2)], kwargs))
+
+    def fill_between(self, x, y1, y2=0, where=None, interpolate=False,
+                     step=None, **kwargs):
+        return self._fill_between_x_or_y(
+            "x", x, y1, y2,
+            where=where, interpolate=interpolate, step=step, **kwargs)
+
+    if _fill_between_x_or_y.__doc__:
+        fill_between.__doc__ = _fill_between_x_or_y.__doc__.format(
+            dir="horizontal", ind="x", dep="y"
         )
-    with pytest.raises(ValueError, match=msg):
-        c = 'red\n'
-        mpl.axes.Axes._parse_scatter_color_args(
-            c, None, kwargs={}, xsize=2, get_next_color_func=get_next_color)
+    fill_between = _preprocess_data(
+        _docstring.interpd(fill_between),
+        replace_names=["x", "y1", "y2", "where"])
 
+    def fill_betweenx(self, y, x1, x2=0, where=None,
+                      step=None, interpolate=False, **kwargs):
+        return self._fill_between_x_or_y(
+            "y", y, x1, x2,
+            where=where, interpolate=interpolate, step=step, **kwargs)
 
-def test_zorder_and_explicit_rasterization():
-    fig, ax = plt.subplots()
-    ax.set_rasterization_zorder(5)
-    ln, = ax.plot(range(5), rasterized=True, zorder=1)
-    with io.BytesIO() as b:
-        fig.savefig(b, format='pdf')
+    if _fill_between_x_or_y.__doc__:
+        fill_betweenx.__doc__ = _fill_between_x_or_y.__doc__.format(
+            dir="vertical", ind="y", dep="x"
+        )
+    fill_betweenx = _preprocess_data(
+        _docstring.interpd(fill_betweenx),
+        replace_names=["y", "x1", "x2", "where"])
 
+    #### plotting z(x, y): imshow, pcolor and relatives, contour
 
-@image_comparison(["preset_clip_paths.png"], remove_text=True, style="mpl20",
-                  tol=0.027 if platform.machine() == "arm64" else 0)
-def test_preset_clip_paths():
-    fig, ax = plt.subplots()
+    @_preprocess_data()
+    @_docstring.interpd
+    def imshow(self, X, cmap=None, norm=None, *, aspect=None,
+               interpolation=None, alpha=None,
+               vmin=None, vmax=None, colorizer=None, origin=None, extent=None,
+               interpolation_stage=None, filternorm=True, filterrad=4.0,
+               resample=None, url=None, **kwargs):
+        """
+        Display data as an image, i.e., on a 2D regular raster.
 
-    poly = mpl.patches.Polygon(
-        [[1, 0], [0, 1], [-1, 0], [0, -1]], facecolor="#ddffdd",
-        edgecolor="#00ff00", linewidth=2, alpha=0.5)
+        The input may either be actual RGB(A) data, or 2D scalar data, which
+        will be rendered as a pseudocolor image. For displaying a grayscale
+        image, set up the colormapping using the parameters
+        ``cmap='gray', vmin=0, vmax=255``.
 
-    ax.add_patch(poly)
+        The number of pixels used to render an image is set by the Axes size
+        and the figure *dpi*. This can lead to aliasing artifacts when
+        the image is resampled, because the displayed image size will usually
+        not match the size of *X* (see
+        :doc:`/gallery/images_contours_and_fields/image_antialiasing`).
+        The resampling can be controlled via the *interpolation* parameter
+        and/or :rc:`image.interpolation`.
 
-    line = mpl.lines.Line2D((-1, 1), (0.5, 0.5), clip_on=True, clip_path=poly)
-    line.set_path_effects([patheffects.withTickedStroke()])
-    ax.add_artist(line)
+        Parameters
+        ----------
+        X : array-like or PIL image
+            The image data. Supported array shapes are:
 
-    line = mpl.lines.Line2D((-1, 1), (-0.5, -0.5), color='r', clip_on=True,
-                            clip_path=poly)
-    ax.add_artist(line)
+            - (M, N): an image with scalar data. The values are mapped to
+              colors using normalization and a colormap. See parameters *norm*,
+              *cmap*, *vmin*, *vmax*.
+            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
+            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
+              i.e. including transparency.
 
-    poly2 = mpl.patches.Polygon(
-        [[-1, 1], [0, 1], [0, -0.25]], facecolor="#beefc0", alpha=0.3,
-        edgecolor="#faded0", linewidth=2, clip_on=True, clip_path=poly)
-    ax.add_artist(poly2)
+            The first two dimensions (M, N) define the rows and columns of
+            the image.
 
-    # When text clipping works, the "Annotation" text should be clipped
-    ax.annotate('Annotation', (-0.75, -0.75), xytext=(0.1, 0.75),
-                arrowprops={'color': 'k'}, clip_on=True, clip_path=poly)
+            Out-of-range RGB(A) values are clipped.
 
-    poly3 = mpl.patches.Polygon(
-        [[0, 0], [0, 0.5], [0.5, 0.5], [0.5, 0]], facecolor="g", edgecolor="y",
-        linewidth=2, alpha=0.3, clip_on=True, clip_path=poly)
+        %(cmap_doc)s
 
-    fig.add_artist(poly3, clip=True)
+            This parameter is ignored if *X* is RGB(A).
 
-    ax.set_xlim(-1, 1)
-    ax.set_ylim(-1, 1)
+        %(norm_doc)s
 
+            This parameter is ignored if *X* is RGB(A).
 
-@mpl.style.context('default')
-def test_rc_axes_label_formatting():
-    mpl.rcParams['axes.labelcolor'] = 'red'
-    mpl.rcParams['axes.labelsize'] = 20
-    mpl.rcParams['axes.labelweight'] = 'bold'
+        %(vmin_vmax_doc)s
 
-    ax = plt.axes()
-    assert ax.xaxis.label.get_color() == 'red'
-    assert ax.xaxis.label.get_fontsize() == 20
-    assert ax.xaxis.label.get_fontweight() == 'bold'
+            This parameter is ignored if *X* is RGB(A).
 
+        %(colorizer_doc)s
 
-@check_figures_equal(extensions=["png"])
-def test_ecdf(fig_test, fig_ref):
-    data = np.array([0, -np.inf, -np.inf, np.inf, 1, 1, 2])
-    weights = range(len(data))
-    axs_test = fig_test.subplots(1, 2)
-    for ax, orientation in zip(axs_test, ["vertical", "horizontal"]):
-        l0 = ax.ecdf(data, orientation=orientation)
-        l1 = ax.ecdf("d", "w", data={"d": np.ma.array(data), "w": weights},
-                     orientation=orientation,
-                     complementary=True, compress=True, ls=":")
-        assert len(l0.get_xdata()) == (~np.isnan(data)).sum() + 1
-        assert len(l1.get_xdata()) == len({*data[~np.isnan(data)]}) + 1
-    axs_ref = fig_ref.subplots(1, 2)
-    axs_ref[0].plot([-np.inf, -np.inf, -np.inf, 0, 1, 1, 2, np.inf],
-                    np.arange(8) / 7, ds="steps-post")
-    axs_ref[0].plot([-np.inf, 0, 1, 2, np.inf, np.inf],
-                    np.array([21, 20, 18, 14, 3, 0]) / 21,
-                    ds="steps-pre", ls=":")
-    axs_ref[1].plot(np.arange(8) / 7,
-                    [-np.inf, -np.inf, -np.inf, 0, 1, 1, 2, np.inf],
-                    ds="steps-pre")
-    axs_ref[1].plot(np.array([21, 20, 18, 14, 3, 0]) / 21,
-                    [-np.inf, 0, 1, 2, np.inf, np.inf],
-                    ds="steps-post", ls=":")
+            This parameter is ignored if *X* is RGB(A).
 
+        aspect : {'equal', 'auto'} or float or None, default: None
+            The aspect ratio of the Axes.  This parameter is particularly
+            relevant for images since it determines whether data pixels are
+            square.
 
-def test_ecdf_invalid():
-    with pytest.raises(ValueError):
-        plt.ecdf([1, np.nan])
-    with pytest.raises(ValueError):
-        plt.ecdf(np.ma.array([1, 2], mask=[True, False]))
+            This parameter is a shortcut for explicitly calling
+            `.Axes.set_aspect`. See there for further details.
 
+            - 'equal': Ensures an aspect ratio of 1. Pixels will be square
+              (unless pixel sizes are explicitly made non-square in data
+              coordinates using *extent*).
+            - 'auto': The Axes is kept fixed and the aspect is adjusted so
+              that the data fit in the Axes. In general, this will result in
+              non-square pixels.
 
-def test_fill_between_axes_limits():
-    fig, ax = plt.subplots()
-    x = np.arange(0, 4 * np.pi, 0.01)
-    y = 0.1*np.sin(x)
-    threshold = 0.075
-    ax.plot(x, y, color='black')
+            Normally, None (the default) means to use :rc:`image.aspect`.  However, if
+            the image uses a transform that does not contain the axes data transform,
+            then None means to not modify the axes aspect at all (in that case, directly
+            call `.Axes.set_aspect` if desired).
 
-    original_lims = (ax.get_xlim(), ax.get_ylim())
+        interpolation : str, default: :rc:`image.interpolation`
+            The interpolation method used.
 
-    ax.axhline(threshold, color='green', lw=2, alpha=0.7)
-    ax.fill_between(x, 0, 1, where=y > threshold,
-                    color='green', alpha=0.5, transform=ax.get_xaxis_transform())
+            Supported values are 'none', 'auto', 'nearest', 'bilinear',
+            'bicubic', 'spline16', 'spline36', 'hanning', 'hamming', 'hermite',
+            'kaiser', 'quadric', 'catrom', 'gaussian', 'bessel', 'mitchell',
+            'sinc', 'lanczos', 'blackman'.
 
-    assert (ax.get_xlim(), ax.get_ylim()) == original_lims
+            The data *X* is resampled to the pixel size of the image on the
+            figure canvas, using the interpolation method to either up- or
+            downsample the data.
 
+            If *interpolation* is 'none', then for the ps, pdf, and svg
+            backends no down- or upsampling occurs, and the image data is
+            passed to the backend as a native image.  Note that different ps,
+            pdf, and svg viewers may display these raw pixels differently. On
+            other backends, 'none' is the same as 'nearest'.
 
-def test_tick_param_labelfont():
-    fig, ax = plt.subplots()
-    ax.plot([1, 2, 3, 4], [1, 2, 3, 4])
-    ax.set_xlabel('X label in Impact font', fontname='Impact')
-    ax.set_ylabel('Y label in xkcd script', fontname='xkcd script')
-    ax.tick_params(color='r', labelfontfamily='monospace')
-    plt.title('Title in sans-serif')
-    for text in ax.get_xticklabels():
-        assert text.get_fontfamily()[0] == 'monospace'
+            If *interpolation* is the default 'auto', then 'nearest'
+            interpolation is used if the image is upsampled by more than a
+            factor of three (i.e. the number of display pixels is at least
+            three times the size of the data array).  If the upsampling rate is
+            smaller than 3, or the image is downsampled, then 'hanning'
+            interpolation is used to act as an anti-aliasing filter, unless the
+            image happens to be upsampled by exactly a factor of two or one.
 
+            See
+            :doc:`/gallery/images_contours_and_fields/interpolation_methods`
+            for an overview of the supported interpolation methods, and
+            :doc:`/gallery/images_contours_and_fields/image_antialiasing` for
+            a discussion of image antialiasing.
 
-def test_set_secondary_axis_color():
-    fig, ax = plt.subplots()
-    sax = ax.secondary_xaxis("top", color="red")
-    assert mcolors.same_color(sax.spines["bottom"].get_edgecolor(), "red")
-    assert mcolors.same_color(sax.spines["top"].get_edgecolor(), "red")
-    assert mcolors.same_color(sax.xaxis.get_tick_params()["color"], "red")
-    assert mcolors.same_color(sax.xaxis.get_tick_params()["labelcolor"], "red")
-    assert mcolors.same_color(sax.xaxis.label.get_color(), "red")
+            Some interpolation methods require an additional radius parameter,
+            which can be set by *filterrad*. Additionally, the antigrain image
+            resize filter is controlled by the parameter *filternorm*.
 
+        interpolation_stage : {'auto', 'data', 'rgba'}, default: 'auto'
+            Supported values:
 
-def test_xylim_changed_shared():
-    fig, axs = plt.subplots(2, sharex=True, sharey=True)
-    events = []
-    axs[1].callbacks.connect("xlim_changed", events.append)
-    axs[1].callbacks.connect("ylim_changed", events.append)
-    axs[0].set(xlim=[1, 3], ylim=[2, 4])
-    assert events == [axs[1], axs[1]]
+            - 'data': Interpolation is carried out on the data provided by the user
+              This is useful if interpolating between pixels during upsampling.
+            - 'rgba': The interpolation is carried out in RGBA-space after the
+              color-mapping has been applied. This is useful if downsampling and
+              combining pixels visually.
+            - 'auto': Select a suitable interpolation stage automatically. This uses
+              'rgba' when downsampling, or upsampling at a rate less than 3, and
+              'data' when upsampling at a higher rate.
 
+            See :doc:`/gallery/images_contours_and_fields/image_antialiasing` for
+            a discussion of image antialiasing.
 
-@image_comparison(["axhvlinespan_interpolation.png"], style="default")
-def test_axhvlinespan_interpolation():
-    ax = plt.figure().add_subplot(projection="polar")
-    ax.set_axis_off()
-    ax.axvline(.1, c="C0")
-    ax.axvspan(.2, .3, fc="C1")
-    ax.axvspan(.4, .5, .1, .2, fc="C2")
-    ax.axhline(1, c="C0", alpha=.5)
-    ax.axhspan(.8, .9, fc="C1", alpha=.5)
-    ax.axhspan(.6, .7, .8, .9, fc="C2", alpha=.5)
+        alpha : float or array-like, optional
+            The alpha blending value, between 0 (transparent) and 1 (opaque).
+            If *alpha* is an array, the alpha blending values are applied pixel
+            by pixel, and *alpha* must have the same shape as *X*.
 
+        origin : {'upper', 'lower'}, default: :rc:`image.origin`
+            Place the [0, 0] index of the array in the upper left or lower
+            left corner of the Axes. The convention (the default) 'upper' is
+            typically used for matrices and images.
 
-@check_figures_equal(extensions=["png"])
-@pytest.mark.parametrize("which", ("x", "y"))
-def test_axes_clear_behavior(fig_ref, fig_test, which):
-    """Test that the given tick params are not reset by ax.clear()."""
-    ax_test = fig_test.subplots()
-    ax_ref = fig_ref.subplots()
-    # the following tick params values are chosen to each create a visual difference
-    # from their defaults
-    target = {
-        "direction": "in",
-        "length": 10,
-        "width": 10,
-        "color": "xkcd:wine red",
-        "pad": 0,
-        "labelfontfamily": "serif",
-        "zorder": 7,
-        "labelrotation": 45,
-        "labelcolor": "xkcd:shocking pink",
-        # this overrides color + labelcolor, skip
-        # colors: ,
-        "grid_color": "xkcd:fluorescent green",
-        "grid_alpha": 0.5,
-        "grid_linewidth": 3,
-        "grid_linestyle": ":",
-        "bottom": False,
-        "top": True,
-        "left": False,
-        "right": True,
-        "labelbottom": True,
-        "labeltop": True,
-        "labelleft": True,
-        "labelright": True,
-    }
+            Note that the vertical axis points upward for 'lower'
+            but downward for 'upper'.
 
-    ax_ref.tick_params(axis=which, **target)
+            See the :ref:`imshow_extent` tutorial for
+            examples and a more detailed description.
 
-    ax_test.tick_params(axis=which, **target)
-    ax_test.clear()
+        extent : floats (left, right, bottom, top), optional
+            The bounding box in data coordinates that the image will fill.
+            These values may be unitful and match the units of the Axes.
+            The image is stretched individually along x and y to fill the box.
 
-    ax_ref.grid(True)
-    ax_test.grid(True)
+            The default extent is determined by the following conditions.
+            Pixels have unit size in data coordinates. Their centers are on
+            integer coordinates, and their center coordinates range from 0 to
+            columns-1 horizontally and from 0 to rows-1 vertically.
 
+            Note that the direction of the vertical axis and thus the default
+            values for top and bottom depend on *origin*:
 
-@pytest.mark.skipif(
-    sys.version_info[:3] == (3, 13, 0) and sys.version_info.releaselevel != "final",
-    reason="https://github.com/python/cpython/issues/124538",
-)
-def test_axes_clear_reference_cycle():
-    def assert_not_in_reference_cycle(start):
-        # Breadth first search. Return True if we encounter the starting node
-        to_visit = deque([start])
-        explored = set()
-        while len(to_visit) > 0:
-            parent = to_visit.popleft()
-            for child in gc.get_referents(parent):
-                if id(child) in explored:
-                    continue
-                assert child is not start
-                explored.add(id(child))
-                to_visit.append(child)
+            - For ``origin == 'upper'`` the default is
+              ``(-0.5, numcols-0.5, numrows-0.5, -0.5)``.
+            - For ``origin == 'lower'`` the default is
+              ``(-0.5, numcols-0.5, -0.5, numrows-0.5)``.
 
-    fig = Figure()
-    ax = fig.add_subplot()
-    points = np.random.rand(1000)
-    ax.plot(points, points)
-    ax.scatter(points, points)
-    ax_children = ax.get_children()
-    fig.clear()  # This should break the reference cycle
+            See the :ref:`imshow_extent` tutorial for
+            examples and a more detailed description.
 
-    # Care most about the objects that scale with number of points
-    big_artists = [
-        a for a in ax_children
-        if isinstance(a, (Line2D, PathCollection))
-    ]
-    assert len(big_artists) > 0
-    for big_artist in big_artists:
-        assert_not_in_reference_cycle(big_artist)
-    assert len(ax_children) > 0
-    for child in ax_children:
-        # Make sure this doesn't raise because the child is already removed.
+        filternorm : bool, default: True
+            A parameter for the antigrain image resize filter (see the
+            antigrain documentation).  If *filternorm* is set, the filter
+            normalizes integer values and corrects the rounding errors. It
+            doesn't do anything with the source floating point values, it
+            corrects only integers according to the rule of 1.0 which means
+            that any sum of pixel weights must be equal to 1.0.  So, the
+            filter function must produce a graph of the proper shape.
+
+        filterrad : float > 0, default: 4.0
+            The filter radius for filters that have a radius parameter, i.e.
+            when interpolation is one of: 'sinc', 'lanczos' or 'blackman'.
+
+        resample : bool, default: :rc:`image.resample`
+            When *True*, use a full resampling method.  When *False*, only
+            resample when the output image is larger than the input image.
+
+        url : str, optional
+            Set the url of the created `.AxesImage`. See `.Artist.set_url`.
+
+        Returns
+        -------
+        `~matplotlib.image.AxesImage`
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs : `~matplotlib.artist.Artist` properties
+            These parameters are passed on to the constructor of the
+            `.AxesImage` artist.
+
+        See Also
+        --------
+        matshow : Plot a matrix or an array as an image.
+
+        Notes
+        -----
+        Unless *extent* is used, pixel centers will be located at integer
+        coordinates. In other words: the origin will coincide with the center
+        of pixel (0, 0).
+
+        There are two common representations for RGB images with an alpha
+        channel:
+
+        -   Straight (unassociated) alpha: R, G, and B channels represent the
+            color of the pixel, disregarding its opacity.
+        -   Premultiplied (associated) alpha: R, G, and B channels represent
+            the color of the pixel, adjusted for its opacity by multiplication.
+
+        `~matplotlib.pyplot.imshow` expects RGB images adopting the straight
+        (unassociated) alpha representation.
+        """
+        im = mimage.AxesImage(self, cmap=cmap, norm=norm, colorizer=colorizer,
+                              interpolation=interpolation, origin=origin,
+                              extent=extent, filternorm=filternorm,
+                              filterrad=filterrad, resample=resample,
+                              interpolation_stage=interpolation_stage,
+                              **kwargs)
+
+        if aspect is None and not (
+                im.is_transform_set()
+                and not im.get_transform().contains_branch(self.transData)):
+            aspect = mpl.rcParams['image.aspect']
+        if aspect is not None:
+            self.set_aspect(aspect)
+
+        im.set_data(X)
+        im.set_alpha(alpha)
+        if im.get_clip_path() is None:
+            # image does not already have clipping set, clip to Axes patch
+            im.set_clip_path(self.patch)
+        im._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
+        im._scale_norm(norm, vmin, vmax)
+        im.set_url(url)
+
+        # update ax.dataLim, and, if autoscaling, set viewLim
+        # to tightly fit the image, regardless of dataLim.
+        im.set_extent(im.get_extent())
+
+        self.add_image(im)
+        return im
+
+    def _pcolorargs(self, funcname, *args, shading='auto', **kwargs):
+        # - create X and Y if not present;
+        # - reshape X and Y as needed if they are 1-D;
+        # - check for proper sizes based on `shading` kwarg;
+        # - reset shading if shading='auto' to flat or nearest
+        #   depending on size;
+
+        _valid_shading = ['gouraud', 'nearest', 'flat', 'auto']
         try:
-            child.remove()
-        except NotImplementedError:
-            pass  # not implemented is expected for some artists
+            _api.check_in_list(_valid_shading, shading=shading)
+        except ValueError:
+            _api.warn_external(f"shading value '{shading}' not in list of "
+                               f"valid values {_valid_shading}. Setting "
+                               "shading='auto'.")
+            shading = 'auto'
+
+        if len(args) == 1:
+            C = np.asanyarray(args[0])
+            nrows, ncols = C.shape[:2]
+            if shading in ['gouraud', 'nearest']:
+                X, Y = np.meshgrid(np.arange(ncols), np.arange(nrows))
+            else:
+                X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
+                shading = 'flat'
+            C = cbook.safe_masked_invalid(C, copy=True)
+            return X, Y, C, shading
+
+        if len(args) == 3:
+            # Check x and y for bad data...
+            C = np.asanyarray(args[2])
+            # unit conversion allows e.g. datetime objects as axis values
+            X, Y = args[:2]
+            X, Y = self._process_unit_info([("x", X), ("y", Y)], kwargs)
+            X, Y = (cbook.safe_masked_invalid(a, copy=True) for a in [X, Y])
+
+            if funcname == 'pcolormesh':
+                if np.ma.is_masked(X) or np.ma.is_masked(Y):
+                    raise ValueError(
+                        'x and y arguments to pcolormesh cannot have '
+                        'non-finite values or be of type '
+                        'numpy.ma.MaskedArray with masked values')
+            nrows, ncols = C.shape[:2]
+        else:
+            raise _api.nargs_error(funcname, takes="1 or 3", given=len(args))
+
+        Nx = X.shape[-1]
+        Ny = Y.shape[0]
+        if X.ndim != 2 or X.shape[0] == 1:
+            x = X.reshape(1, Nx)
+            X = x.repeat(Ny, axis=0)
+        if Y.ndim != 2 or Y.shape[1] == 1:
+            y = Y.reshape(Ny, 1)
+            Y = y.repeat(Nx, axis=1)
+        if X.shape != Y.shape:
+            raise TypeError(f'Incompatible X, Y inputs to {funcname}; '
+                            f'see help({funcname})')
+
+        if shading == 'auto':
+            if ncols == Nx and nrows == Ny:
+                shading = 'nearest'
+            else:
+                shading = 'flat'
+
+        if shading == 'flat':
+            if (Nx, Ny) != (ncols + 1, nrows + 1):
+                raise TypeError(f"Dimensions of C {C.shape} should"
+                                f" be one smaller than X({Nx}) and Y({Ny})"
+                                f" while using shading='flat'"
+                                f" see help({funcname})")
+        else:    # ['nearest', 'gouraud']:
+            if (Nx, Ny) != (ncols, nrows):
+                raise TypeError('Dimensions of C %s are incompatible with'
+                                ' X (%d) and/or Y (%d); see help(%s)' % (
+                                    C.shape, Nx, Ny, funcname))
+            if shading == 'nearest':
+                # grid is specified at the center, so define corners
+                # at the midpoints between the grid centers and then use the
+                # flat algorithm.
+                def _interp_grid(X):
+                    # helper for below
+                    if np.shape(X)[1] > 1:
+                        dX = np.diff(X, axis=1) * 0.5
+                        if not (np.all(dX >= 0) or np.all(dX <= 0)):
+                            _api.warn_external(
+                                f"The input coordinates to {funcname} are "
+                                "interpreted as cell centers, but are not "
+                                "monotonically increasing or decreasing. "
+                                "This may lead to incorrectly calculated cell "
+                                "edges, in which case, please supply "
+                                f"explicit cell edges to {funcname}.")
+
+                        hstack = np.ma.hstack if np.ma.isMA(X) else np.hstack
+                        X = hstack((X[:, [0]] - dX[:, [0]],
+                                    X[:, :-1] + dX,
+                                    X[:, [-1]] + dX[:, [-1]]))
+                    else:
+                        # This is just degenerate, but we can't reliably guess
+                        # a dX if there is just one value.
+                        X = np.hstack((X, X))
+                    return X
+
+                if ncols == Nx:
+                    X = _interp_grid(X)
+                    Y = _interp_grid(Y)
+                if nrows == Ny:
+                    X = _interp_grid(X.T).T
+                    Y = _interp_grid(Y.T).T
+                shading = 'flat'
+
+        C = cbook.safe_masked_invalid(C, copy=True)
+        return X, Y, C, shading
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def pcolor(self, *args, shading=None, alpha=None, norm=None, cmap=None,
+               vmin=None, vmax=None, colorizer=None, **kwargs):
+        r"""
+        Create a pseudocolor plot with a non-regular rectangular grid.
+
+        Call signature::
+
+            pcolor([X, Y,] C, /, **kwargs)
+
+        *X* and *Y* can be used to specify the corners of the quadrilaterals.
+
+        The arguments *X*, *Y*, *C* are positional-only.
+
+        .. hint::
+
+            ``pcolor()`` can be very slow for large arrays. In most
+            cases you should use the similar but much faster
+            `~.Axes.pcolormesh` instead. See
+            :ref:`Differences between pcolor() and pcolormesh()
+            <differences-pcolor-pcolormesh>` for a discussion of the
+            differences.
+
+        Parameters
+        ----------
+        C : 2D array-like
+            The color-mapped values.  Color-mapping is controlled by *cmap*,
+            *norm*, *vmin*, and *vmax*.
+
+        X, Y : array-like, optional
+            The coordinates of the corners of quadrilaterals of a pcolormesh::
+
+                (X[i+1, j], Y[i+1, j])       (X[i+1, j+1], Y[i+1, j+1])
+                                      ●╶───╴●
+                                      │     │
+                                      ●╶───╴●
+                    (X[i, j], Y[i, j])       (X[i, j+1], Y[i, j+1])
+
+            Note that the column index corresponds to the x-coordinate, and
+            the row index corresponds to y. For details, see the
+            :ref:`Notes <axes-pcolormesh-grid-orientation>` section below.
+
+            If ``shading='flat'`` the dimensions of *X* and *Y* should be one
+            greater than those of *C*, and the quadrilateral is colored due
+            to the value at ``C[i, j]``.  If *X*, *Y* and *C* have equal
+            dimensions, a warning will be raised and the last row and column
+            of *C* will be ignored.
+
+            If ``shading='nearest'``, the dimensions of *X* and *Y* should be
+            the same as those of *C* (if not, a ValueError will be raised). The
+            color ``C[i, j]`` will be centered on ``(X[i, j], Y[i, j])``.
+
+            If *X* and/or *Y* are 1-D arrays or column vectors they will be
+            expanded as needed into the appropriate 2D arrays, making a
+            rectangular grid.
+
+        shading : {'flat', 'nearest', 'auto'}, default: :rc:`pcolor.shading`
+            The fill style for the quadrilateral. Possible values:
+
+            - 'flat': A solid color is used for each quad. The color of the
+              quad (i, j), (i+1, j), (i, j+1), (i+1, j+1) is given by
+              ``C[i, j]``. The dimensions of *X* and *Y* should be
+              one greater than those of *C*; if they are the same as *C*,
+              then a deprecation warning is raised, and the last row
+              and column of *C* are dropped.
+            - 'nearest': Each grid point will have a color centered on it,
+              extending halfway between the adjacent grid centers.  The
+              dimensions of *X* and *Y* must be the same as *C*.
+            - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
+              larger than *C*.  Choose 'nearest' if dimensions are the same.
+
+            See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`
+            for more description.
+
+        %(cmap_doc)s
+
+        %(norm_doc)s
+
+        %(vmin_vmax_doc)s
+
+        %(colorizer_doc)s
+
+        edgecolors : {'none', None, 'face', color, color sequence}, optional
+            The color of the edges. Defaults to 'none'. Possible values:
+
+            - 'none' or '': No edge.
+            - *None*: :rc:`patch.edgecolor` will be used. Note that currently
+              :rc:`patch.force_edgecolor` has to be True for this to work.
+            - 'face': Use the adjacent face color.
+            - A color or sequence of colors will set the edge color.
+
+            The singular form *edgecolor* works as an alias.
+
+        alpha : float, default: None
+            The alpha blending value of the face color, between 0 (transparent)
+            and 1 (opaque). Note: The edgecolor is currently not affected by
+            this.
+
+        snap : bool, default: False
+            Whether to snap the mesh to pixel boundaries.
+
+        Returns
+        -------
+        `matplotlib.collections.PolyQuadMesh`
+
+        Other Parameters
+        ----------------
+        antialiaseds : bool, default: False
+            The default *antialiaseds* is False if the default
+            *edgecolors*\ ="none" is used.  This eliminates artificial lines
+            at patch boundaries, and works regardless of the value of alpha.
+            If *edgecolors* is not "none", then the default *antialiaseds*
+            is taken from :rc:`patch.antialiased`.
+            Stroking the edges may be preferred if *alpha* is 1, but will
+            cause artifacts otherwise.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Additionally, the following arguments are allowed. They are passed
+            along to the `~matplotlib.collections.PolyQuadMesh` constructor:
+
+        %(PolyCollection:kwdoc)s
+
+        See Also
+        --------
+        pcolormesh : for an explanation of the differences between
+            pcolor and pcolormesh.
+        imshow : If *X* and *Y* are each equidistant, `~.Axes.imshow` can be a
+            faster alternative.
+
+        Notes
+        -----
+        **Masked arrays**
+
+        *X*, *Y* and *C* may be masked arrays. If either ``C[i, j]``, or one
+        of the vertices surrounding ``C[i, j]`` (*X* or *Y* at
+        ``[i, j], [i+1, j], [i, j+1], [i+1, j+1]``) is masked, nothing is
+        plotted.
+
+        .. _axes-pcolor-grid-orientation:
+
+        **Grid orientation**
+
+        The grid orientation follows the standard matrix convention: An array
+        *C* with shape (nrows, ncolumns) is plotted with the column number as
+        *X* and the row number as *Y*.
+        """
+
+        if shading is None:
+            shading = mpl.rcParams['pcolor.shading']
+        shading = shading.lower()
+        X, Y, C, shading = self._pcolorargs('pcolor', *args, shading=shading,
+                                            kwargs=kwargs)
+        linewidths = (0.25,)
+        if 'linewidth' in kwargs:
+            kwargs['linewidths'] = kwargs.pop('linewidth')
+        kwargs.setdefault('linewidths', linewidths)
+
+        if 'edgecolor' in kwargs:
+            kwargs['edgecolors'] = kwargs.pop('edgecolor')
+        ec = kwargs.setdefault('edgecolors', 'none')
+
+        # aa setting will default via collections to patch.antialiased
+        # unless the boundary is not stroked, in which case the
+        # default will be False; with unstroked boundaries, aa
+        # makes artifacts that are often disturbing.
+        if 'antialiaseds' in kwargs:
+            kwargs['antialiased'] = kwargs.pop('antialiaseds')
+        if 'antialiased' not in kwargs and cbook._str_lower_equal(ec, "none"):
+            kwargs['antialiased'] = False
+
+        kwargs.setdefault('snap', False)
+
+        if np.ma.isMaskedArray(X) or np.ma.isMaskedArray(Y):
+            stack = np.ma.stack
+            X = np.ma.asarray(X)
+            Y = np.ma.asarray(Y)
+            # For bounds collections later
+            x = X.compressed()
+            y = Y.compressed()
+        else:
+            stack = np.stack
+            x = X
+            y = Y
+        coords = stack([X, Y], axis=-1)
+
+        collection = mcoll.PolyQuadMesh(
+            coords, array=C, cmap=cmap, norm=norm, colorizer=colorizer,
+            alpha=alpha, **kwargs)
+        collection._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
+        collection._scale_norm(norm, vmin, vmax)
+
+        # Transform from native to data coordinates?
+        t = collection._transform
+        if (not isinstance(t, mtransforms.Transform) and
+                hasattr(t, '_as_mpl_transform')):
+            t = t._as_mpl_transform(self.axes)
+
+        if t and any(t.contains_branch_seperately(self.transData)):
+            trans_to_data = t - self.transData
+            pts = np.vstack([x, y]).T.astype(float)
+            transformed_pts = trans_to_data.transform(pts)
+            x = transformed_pts[..., 0]
+            y = transformed_pts[..., 1]
+
+        self.add_collection(collection, autolim=False)
+
+        minx = np.min(x)
+        maxx = np.max(x)
+        miny = np.min(y)
+        maxy = np.max(y)
+        collection.sticky_edges.x[:] = [minx, maxx]
+        collection.sticky_edges.y[:] = [miny, maxy]
+        corners = (minx, miny), (maxx, maxy)
+        self.update_datalim(corners)
+        self._request_autoscale_view()
+        return collection
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def pcolormesh(self, *args, alpha=None, norm=None, cmap=None, vmin=None,
+                   vmax=None, colorizer=None, shading=None, antialiased=False,
+                   **kwargs):
+        """
+        Create a pseudocolor plot with a non-regular rectangular grid.
+
+        Call signature::
+
+            pcolormesh([X, Y,] C, /, **kwargs)
+
+        *X* and *Y* can be used to specify the corners of the quadrilaterals.
+
+        The arguments *X*, *Y*, *C* are positional-only.
+
+        .. hint::
+
+           `~.Axes.pcolormesh` is similar to `~.Axes.pcolor`. It is much faster
+           and preferred in most cases. For a detailed discussion on the
+           differences see :ref:`Differences between pcolor() and pcolormesh()
+           <differences-pcolor-pcolormesh>`.
+
+        Parameters
+        ----------
+        C : array-like
+            The mesh data. Supported array shapes are:
+
+            - (M, N) or M*N: a mesh with scalar data. The values are mapped to
+              colors using normalization and a colormap. See parameters *norm*,
+              *cmap*, *vmin*, *vmax*.
+            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
+            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
+              i.e. including transparency.
+
+            The first two dimensions (M, N) define the rows and columns of
+            the mesh data.
+
+        X, Y : array-like, optional
+            The coordinates of the corners of quadrilaterals of a pcolormesh::
+
+                (X[i+1, j], Y[i+1, j])       (X[i+1, j+1], Y[i+1, j+1])
+                                      ●╶───╴●
+                                      │     │
+                                      ●╶───╴●
+                    (X[i, j], Y[i, j])       (X[i, j+1], Y[i, j+1])
+
+            Note that the column index corresponds to the x-coordinate, and
+            the row index corresponds to y. For details, see the
+            :ref:`Notes <axes-pcolormesh-grid-orientation>` section below.
+
+            If ``shading='flat'`` the dimensions of *X* and *Y* should be one
+            greater than those of *C*, and the quadrilateral is colored due
+            to the value at ``C[i, j]``.  If *X*, *Y* and *C* have equal
+            dimensions, a warning will be raised and the last row and column
+            of *C* will be ignored.
+
+            If ``shading='nearest'`` or ``'gouraud'``, the dimensions of *X*
+            and *Y* should be the same as those of *C* (if not, a ValueError
+            will be raised).  For ``'nearest'`` the color ``C[i, j]`` is
+            centered on ``(X[i, j], Y[i, j])``.  For ``'gouraud'``, a smooth
+            interpolation is carried out between the quadrilateral corners.
+
+            If *X* and/or *Y* are 1-D arrays or column vectors they will be
+            expanded as needed into the appropriate 2D arrays, making a
+            rectangular grid.
+
+        %(cmap_doc)s
+
+        %(norm_doc)s
+
+        %(vmin_vmax_doc)s
+
+        %(colorizer_doc)s
+
+        edgecolors : {'none', None, 'face', color, color sequence}, optional
+            The color of the edges. Defaults to 'none'. Possible values:
+
+            - 'none' or '': No edge.
+            - *None*: :rc:`patch.edgecolor` will be used. Note that currently
+              :rc:`patch.force_edgecolor` has to be True for this to work.
+            - 'face': Use the adjacent face color.
+            - A color or sequence of colors will set the edge color.
+
+            The singular form *edgecolor* works as an alias.
+
+        alpha : float, default: None
+            The alpha blending value, between 0 (transparent) and 1 (opaque).
+
+        shading : {'flat', 'nearest', 'gouraud', 'auto'}, optional
+            The fill style for the quadrilateral; defaults to
+            :rc:`pcolor.shading`. Possible values:
+
+            - 'flat': A solid color is used for each quad. The color of the
+              quad (i, j), (i+1, j), (i, j+1), (i+1, j+1) is given by
+              ``C[i, j]``. The dimensions of *X* and *Y* should be
+              one greater than those of *C*; if they are the same as *C*,
+              then a deprecation warning is raised, and the last row
+              and column of *C* are dropped.
+            - 'nearest': Each grid point will have a color centered on it,
+              extending halfway between the adjacent grid centers.  The
+              dimensions of *X* and *Y* must be the same as *C*.
+            - 'gouraud': Each quad will be Gouraud shaded: The color of the
+              corners (i', j') are given by ``C[i', j']``. The color values of
+              the area in between is interpolated from the corner values.
+              The dimensions of *X* and *Y* must be the same as *C*. When
+              Gouraud shading is used, *edgecolors* is ignored.
+            - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
+              larger than *C*.  Choose 'nearest' if dimensions are the same.
+
+            See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`
+            for more description.
+
+        snap : bool, default: False
+            Whether to snap the mesh to pixel boundaries.
+
+        rasterized : bool, optional
+            Rasterize the pcolormesh when drawing vector graphics.  This can
+            speed up rendering and produce smaller files for large data sets.
+            See also :doc:`/gallery/misc/rasterization_demo`.
+
+        Returns
+        -------
+        `matplotlib.collections.QuadMesh`
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Additionally, the following arguments are allowed. They are passed
+            along to the `~matplotlib.collections.QuadMesh` constructor:
+
+        %(QuadMesh:kwdoc)s
+
+        See Also
+        --------
+        pcolor : An alternative implementation with slightly different
+            features. For a detailed discussion on the differences see
+            :ref:`Differences between pcolor() and pcolormesh()
+            <differences-pcolor-pcolormesh>`.
+        imshow : If *X* and *Y* are each equidistant, `~.Axes.imshow` can be a
+            faster alternative.
+
+        Notes
+        -----
+        **Masked arrays**
+
+        *C* may be a masked array. If ``C[i, j]`` is masked, the corresponding
+        quadrilateral will be transparent. Masking of *X* and *Y* is not
+        supported. Use `~.Axes.pcolor` if you need this functionality.
+
+        .. _axes-pcolormesh-grid-orientation:
+
+        **Grid orientation**
+
+        The grid orientation follows the standard matrix convention: An array
+        *C* with shape (nrows, ncolumns) is plotted with the column number as
+        *X* and the row number as *Y*.
+
+        .. _differences-pcolor-pcolormesh:
+
+        **Differences between pcolor() and pcolormesh()**
+
+        Both methods are used to create a pseudocolor plot of a 2D array
+        using quadrilaterals.
+
+        The main difference lies in the created object and internal data
+        handling:
+        While `~.Axes.pcolor` returns a `.PolyQuadMesh`, `~.Axes.pcolormesh`
+        returns a `.QuadMesh`. The latter is more specialized for the given
+        purpose and thus is faster. It should almost always be preferred.
+
+        There is also a slight difference in the handling of masked arrays.
+        Both `~.Axes.pcolor` and `~.Axes.pcolormesh` support masked arrays
+        for *C*. However, only `~.Axes.pcolor` supports masked arrays for *X*
+        and *Y*. The reason lies in the internal handling of the masked values.
+        `~.Axes.pcolor` leaves out the respective polygons from the
+        PolyQuadMesh. `~.Axes.pcolormesh` sets the facecolor of the masked
+        elements to transparent. You can see the difference when using
+        edgecolors. While all edges are drawn irrespective of masking in a
+        QuadMesh, the edge between two adjacent masked quadrilaterals in
+        `~.Axes.pcolor` is not drawn as the corresponding polygons do not
+        exist in the PolyQuadMesh. Because PolyQuadMesh draws each individual
+        polygon, it also supports applying hatches and linestyles to the collection.
+
+        Another difference is the support of Gouraud shading in
+        `~.Axes.pcolormesh`, which is not available with `~.Axes.pcolor`.
+
+        """
+        if shading is None:
+            shading = mpl.rcParams['pcolor.shading']
+        shading = shading.lower()
+        kwargs.setdefault('edgecolors', 'none')
+
+        X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
+                                            shading=shading, kwargs=kwargs)
+        coords = np.stack([X, Y], axis=-1)
+
+        kwargs.setdefault('snap', mpl.rcParams['pcolormesh.snap'])
+
+        collection = mcoll.QuadMesh(
+            coords, antialiased=antialiased, shading=shading,
+            array=C, cmap=cmap, norm=norm, colorizer=colorizer, alpha=alpha, **kwargs)
+        collection._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
+        collection._scale_norm(norm, vmin, vmax)
+
+        coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
+
+        # Transform from native to data coordinates?
+        t = collection._transform
+        if (not isinstance(t, mtransforms.Transform) and
+                hasattr(t, '_as_mpl_transform')):
+            t = t._as_mpl_transform(self.axes)
+
+        if t and any(t.contains_branch_seperately(self.transData)):
+            trans_to_data = t - self.transData
+            coords = trans_to_data.transform(coords)
+
+        self.add_collection(collection, autolim=False)
+
+        minx, miny = np.min(coords, axis=0)
+        maxx, maxy = np.max(coords, axis=0)
+        collection.sticky_edges.x[:] = [minx, maxx]
+        collection.sticky_edges.y[:] = [miny, maxy]
+        corners = (minx, miny), (maxx, maxy)
+        self.update_datalim(corners)
+        self._request_autoscale_view()
+        return collection
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def pcolorfast(self, *args, alpha=None, norm=None, cmap=None, vmin=None,
+                   vmax=None, colorizer=None, **kwargs):
+        """
+        Create a pseudocolor plot with a non-regular rectangular grid.
+
+        Call signature::
+
+            ax.pcolorfast([X, Y], C, /, **kwargs)
+
+        The arguments *X*, *Y*, *C* are positional-only.
+
+        This method is similar to `~.Axes.pcolor` and `~.Axes.pcolormesh`.
+        It's designed to provide the fastest pcolor-type plotting with the
+        Agg backend. To achieve this, it uses different algorithms internally
+        depending on the complexity of the input grid (regular rectangular,
+        non-regular rectangular or arbitrary quadrilateral).
+
+        .. warning::
+
+            This method is experimental. Compared to `~.Axes.pcolor` or
+            `~.Axes.pcolormesh` it has some limitations:
+
+            - It supports only flat shading (no outlines)
+            - It lacks support for log scaling of the axes.
+            - It does not have a pyplot wrapper.
+
+        Parameters
+        ----------
+        C : array-like
+            The image data. Supported array shapes are:
+
+            - (M, N): an image with scalar data.  Color-mapping is controlled
+              by *cmap*, *norm*, *vmin*, and *vmax*.
+            - (M, N, 3): an image with RGB values (0-1 float or 0-255 int).
+            - (M, N, 4): an image with RGBA values (0-1 float or 0-255 int),
+              i.e. including transparency.
+
+            The first two dimensions (M, N) define the rows and columns of
+            the image.
+
+            This parameter can only be passed positionally.
+
+        X, Y : tuple or array-like, default: ``(0, N)``, ``(0, M)``
+            *X* and *Y* are used to specify the coordinates of the
+            quadrilaterals. There are different ways to do this:
+
+            - Use tuples ``X=(xmin, xmax)`` and ``Y=(ymin, ymax)`` to define
+              a *uniform rectangular grid*.
+
+              The tuples define the outer edges of the grid. All individual
+              quadrilaterals will be of the same size. This is the fastest
+              version.
+
+            - Use 1D arrays *X*, *Y* to specify a *non-uniform rectangular
+              grid*.
+
+              In this case *X* and *Y* have to be monotonic 1D arrays of length
+              *N+1* and *M+1*, specifying the x and y boundaries of the cells.
+
+              The speed is intermediate. Note: The grid is checked, and if
+              found to be uniform the fast version is used.
+
+            - Use 2D arrays *X*, *Y* if you need an *arbitrary quadrilateral
+              grid* (i.e. if the quadrilaterals are not rectangular).
+
+              In this case *X* and *Y* are 2D arrays with shape (M + 1, N + 1),
+              specifying the x and y coordinates of the corners of the colored
+              quadrilaterals.
+
+              This is the most general, but the slowest to render.  It may
+              produce faster and more compact output using ps, pdf, and
+              svg backends, however.
+
+            These arguments can only be passed positionally.
+
+        %(cmap_doc)s
+
+            This parameter is ignored if *C* is RGB(A).
+
+        %(norm_doc)s
+
+            This parameter is ignored if *C* is RGB(A).
+
+        %(vmin_vmax_doc)s
+
+            This parameter is ignored if *C* is RGB(A).
+
+        %(colorizer_doc)s
+
+            This parameter is ignored if *C* is RGB(A).
+
+        alpha : float, default: None
+            The alpha blending value, between 0 (transparent) and 1 (opaque).
+
+        snap : bool, default: False
+            Whether to snap the mesh to pixel boundaries.
+
+        Returns
+        -------
+        `.AxesImage` or `.PcolorImage` or `.QuadMesh`
+            The return type depends on the type of grid:
+
+            - `.AxesImage` for a regular rectangular grid.
+            - `.PcolorImage` for a non-regular rectangular grid.
+            - `.QuadMesh` for a non-rectangular grid.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Supported additional parameters depend on the type of grid.
+            See return types of *image* for further description.
+        """
+
+        C = args[-1]
+        nr, nc = np.shape(C)[:2]
+        if len(args) == 1:
+            style = "image"
+            x = [0, nc]
+            y = [0, nr]
+        elif len(args) == 3:
+            x, y = args[:2]
+            x = np.asarray(x)
+            y = np.asarray(y)
+            if x.ndim == 1 and y.ndim == 1:
+                if x.size == 2 and y.size == 2:
+                    style = "image"
+                else:
+                    if x.size != nc + 1:
+                        raise ValueError(
+                            f"Length of X ({x.size}) must be one larger than the "
+                            f"number of columns in C ({nc})")
+                    if y.size != nr + 1:
+                        raise ValueError(
+                            f"Length of Y ({y.size}) must be one larger than the "
+                            f"number of rows in C ({nr})"
+                        )
+                    dx = np.diff(x)
+                    dy = np.diff(y)
+                    if (np.ptp(dx) < 0.01 * abs(dx.mean()) and
+                            np.ptp(dy) < 0.01 * abs(dy.mean())):
+                        style = "image"
+                    else:
+                        style = "pcolorimage"
+            elif x.ndim == 2 and y.ndim == 2:
+                style = "quadmesh"
+            else:
+                raise TypeError(
+                    f"When 3 positional parameters are passed to pcolorfast, the first "
+                    f"two (X and Y) must be both 1D or both 2D; the given X was "
+                    f"{x.ndim}D and the given Y was {y.ndim}D")
+        else:
+            raise _api.nargs_error('pcolorfast', '1 or 3', len(args))
+
+        mcolorizer.ColorizingArtist._check_exclusionary_keywords(colorizer, vmin=vmin,
+                                                                 vmax=vmax)
+        if style == "quadmesh":
+            # data point in each cell is value at lower left corner
+            coords = np.stack([x, y], axis=-1)
+            if np.ndim(C) not in {2, 3}:
+                raise ValueError("C must be 2D or 3D")
+            collection = mcoll.QuadMesh(
+                coords, array=C,
+                alpha=alpha, cmap=cmap, norm=norm, colorizer=colorizer,
+                antialiased=False, edgecolors="none")
+            self.add_collection(collection, autolim=False)
+            xl, xr, yb, yt = x.min(), x.max(), y.min(), y.max()
+            ret = collection
+
+        else:  # It's one of the two image styles.
+            extent = xl, xr, yb, yt = x[0], x[-1], y[0], y[-1]
+            if style == "image":
+                im = mimage.AxesImage(
+                    self, cmap=cmap, norm=norm, colorizer=colorizer,
+                    data=C, alpha=alpha, extent=extent,
+                    interpolation='nearest', origin='lower',
+                    **kwargs)
+            elif style == "pcolorimage":
+                im = mimage.PcolorImage(
+                    self, x, y, C,
+                    cmap=cmap, norm=norm, colorizer=colorizer, alpha=alpha,
+                    extent=extent, **kwargs)
+            self.add_image(im)
+            ret = im
+
+        if np.ndim(C) == 2:  # C.ndim == 3 is RGB(A) so doesn't need scaling.
+            ret._scale_norm(norm, vmin, vmax)
+
+        if ret.get_clip_path() is None:
+            # image does not already have clipping set, clip to Axes patch
+            ret.set_clip_path(self.patch)
+
+        ret.sticky_edges.x[:] = [xl, xr]
+        ret.sticky_edges.y[:] = [yb, yt]
+        self.update_datalim(np.array([[xl, yb], [xr, yt]]))
+        self._request_autoscale_view(tight=True)
+        return ret
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def contour(self, *args, **kwargs):
+        """
+        Plot contour lines.
+
+        Call signature::
+
+            contour([X, Y,] Z, /, [levels], **kwargs)
+
+        The arguments *X*, *Y*, *Z* are positional-only.
+        %(contour_doc)s
+        """
+        kwargs['filled'] = False
+        contours = mcontour.QuadContourSet(self, *args, **kwargs)
+        self._request_autoscale_view()
+        return contours
+
+    @_preprocess_data()
+    @_docstring.interpd
+    def contourf(self, *args, **kwargs):
+        """
+        Plot filled contours.
+
+        Call signature::
+
+            contourf([X, Y,] Z, /, [levels], **kwargs)
+
+        The arguments *X*, *Y*, *Z* are positional-only.
+        %(contour_doc)s
+        """
+        kwargs['filled'] = True
+        contours = mcontour.QuadContourSet(self, *args, **kwargs)
+        self._request_autoscale_view()
+        return contours
+
+    def clabel(self, CS, levels=None, **kwargs):
+        """
+        Label a contour plot.
+
+        Adds labels to line contours in given `.ContourSet`.
+
+        Parameters
+        ----------
+        CS : `.ContourSet` instance
+            Line contours to label.
+
+        levels : array-like, optional
+            A list of level values, that should be labeled. The list must be
+            a subset of ``CS.levels``. If not given, all levels are labeled.
+
+        **kwargs
+            All other parameters are documented in `~.ContourLabeler.clabel`.
+        """
+        return CS.clabel(levels, **kwargs)
+
+    #### Data analysis
+
+    @_api.make_keyword_only("3.9", "range")
+    @_preprocess_data(replace_names=["x", 'weights'], label_namer="x")
+    def hist(self, x, bins=None, range=None, density=False, weights=None,
+             cumulative=False, bottom=None, histtype='bar', align='mid',
+             orientation='vertical', rwidth=None, log=False,
+             color=None, label=None, stacked=False, **kwargs):
+        """
+        Compute and plot a histogram.
+
+        This method uses `numpy.histogram` to bin the data in *x* and count the
+        number of values in each bin, then draws the distribution either as a
+        `.BarContainer` or `.Polygon`. The *bins*, *range*, *density*, and
+        *weights* parameters are forwarded to `numpy.histogram`.
+
+        If the data has already been binned and counted, use `~.bar` or
+        `~.stairs` to plot the distribution::
+
+            counts, bins = np.histogram(x)
+            plt.stairs(counts, bins)
+
+        Alternatively, plot pre-computed bins and counts using ``hist()`` by
+        treating each bin as a single point with a weight equal to its count::
+
+            plt.hist(bins[:-1], bins, weights=counts)
+
+        The data input *x* can be a singular array, a list of datasets of
+        potentially different lengths ([*x0*, *x1*, ...]), or a 2D ndarray in
+        which each column is a dataset. Note that the ndarray form is
+        transposed relative to the list form. If the input is an array, then
+        the return value is a tuple (*n*, *bins*, *patches*); if the input is a
+        sequence of arrays, then the return value is a tuple
+        ([*n0*, *n1*, ...], *bins*, [*patches0*, *patches1*, ...]).
+
+        Masked arrays are not supported.
+
+        Parameters
+        ----------
+        x : (n,) array or sequence of (n,) arrays
+            Input values, this takes either a single array or a sequence of
+            arrays which are not required to be of the same length.
+
+        bins : int or sequence or str, default: :rc:`hist.bins`
+            If *bins* is an integer, it defines the number of equal-width bins
+            in the range.
+
+            If *bins* is a sequence, it defines the bin edges, including the
+            left edge of the first bin and the right edge of the last bin;
+            in this case, bins may be unequally spaced.  All but the last
+            (righthand-most) bin is half-open.  In other words, if *bins* is::
+
+                [1, 2, 3, 4]
+
+            then the first bin is ``[1, 2)`` (including 1, but excluding 2) and
+            the second ``[2, 3)``.  The last bin, however, is ``[3, 4]``, which
+            *includes* 4.
+
+            If *bins* is a string, it is one of the binning strategies
+            supported by `numpy.histogram_bin_edges`: 'auto', 'fd', 'doane',
+            'scott', 'stone', 'rice', 'sturges', or 'sqrt'.
+
+        range : tuple or None, default: None
+            The lower and upper range of the bins. Lower and upper outliers
+            are ignored. If not provided, *range* is ``(x.min(), x.max())``.
+            Range has no effect if *bins* is a sequence.
+
+            If *bins* is a sequence or *range* is specified, autoscaling
+            is based on the specified bin range instead of the
+            range of x.
+
+        density : bool, default: False
+            If ``True``, draw and return a probability density: each bin
+            will display the bin's raw count divided by the total number of
+            counts *and the bin width*
+            (``density = counts / (sum(counts) * np.diff(bins))``),
+            so that the area under the histogram integrates to 1
+            (``np.sum(density * np.diff(bins)) == 1``).
+
+            If *stacked* is also ``True``, the sum of the histograms is
+            normalized to 1.
+
+        weights : (n,) array-like or None, default: None
+            An array of weights, of the same shape as *x*.  Each value in
+            *x* only contributes its associated weight towards the bin count
+            (instead of 1).  If *density* is ``True``, the weights are
+            normalized, so that the integral of the density over the range
+            remains 1.
+
+        cumulative : bool or -1, default: False
+            If ``True``, then a histogram is computed where each bin gives the
+            counts in that bin plus all bins for smaller values. The last bin
+            gives the total number of datapoints.
+
+            If *density* is also ``True`` then the histogram is normalized such
+            that the last bin equals 1.
+
+            If *cumulative* is a number less than 0 (e.g., -1), the direction
+            of accumulation is reversed.  In this case, if *density* is also
+            ``True``, then the histogram is normalized such that the first bin
+            equals 1.
+
+        bottom : array-like, scalar, or None, default: None
+            Location of the bottom of each bin, i.e. bins are drawn from
+            ``bottom`` to ``bottom + hist(x, bins)`` If a scalar, the bottom
+            of each bin is shifted by the same amount. If an array, each bin
+            is shifted independently and the length of bottom must match the
+            number of bins. If None, defaults to 0.
+
+        histtype : {'bar', 'barstacked', 'step', 'stepfilled'}, default: 'bar'
+            The type of histogram to draw.
+
+            - 'bar' is a traditional bar-type histogram.  If multiple data
+              are given the bars are arranged side by side.
+            - 'barstacked' is a bar-type histogram where multiple
+              data are stacked on top of each other.
+            - 'step' generates a lineplot that is by default unfilled.
+            - 'stepfilled' generates a lineplot that is by default filled.
+
+        align : {'left', 'mid', 'right'}, default: 'mid'
+            The horizontal alignment of the histogram bars.
+
+            - 'left': bars are centered on the left bin edges.
+            - 'mid': bars are centered between the bin edges.
+            - 'right': bars are centered on the right bin edges.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            If 'horizontal', `~.Axes.barh` will be used for bar-type histograms
+            and the *bottom* kwarg will be the left edges.
+
+        rwidth : float or None, default: None
+            The relative width of the bars as a fraction of the bin width.  If
+            ``None``, automatically compute the width.
+
+            Ignored if *histtype* is 'step' or 'stepfilled'.
+
+        log : bool, default: False
+            If ``True``, the histogram axis will be set to a log scale.
+
+        color : :mpltype:`color` or list of :mpltype:`color` or None, default: None
+            Color or sequence of colors, one per dataset.  Default (``None``)
+            uses the standard line color sequence.
+
+        label : str or list of str, optional
+            String, or sequence of strings to match multiple datasets.  Bar
+            charts yield multiple patches per dataset, but only the first gets
+            the label, so that `~.Axes.legend` will work as expected.
+
+        stacked : bool, default: False
+            If ``True``, multiple data are stacked on top of each other If
+            ``False`` multiple data are arranged side by side if histtype is
+            'bar' or on top of each other if histtype is 'step'
+
+        Returns
+        -------
+        n : array or list of arrays
+            The values of the histogram bins. See *density* and *weights* for a
+            description of the possible semantics.  If input *x* is an array,
+            then this is an array of length *nbins*. If input is a sequence of
+            arrays ``[data1, data2, ...]``, then this is a list of arrays with
+            the values of the histograms for each of the arrays in the same
+            order.  The dtype of the array *n* (or of its element arrays) will
+            always be float even if no weighting or normalization is used.
+
+        bins : array
+            The edges of the bins. Length nbins + 1 (nbins left edges and right
+            edge of last bin).  Always a single array even when multiple data
+            sets are passed in.
+
+        patches : `.BarContainer` or list of a single `.Polygon` or list of \
+such objects
+            Container of individual artists used to create the histogram
+            or list of such containers if there are multiple input datasets.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            `~matplotlib.patches.Patch` properties. The following properties
+            additionally accept a sequence of values corresponding to the
+            datasets in *x*:
+            *edgecolor*, *facecolor*, *linewidth*, *linestyle*, *hatch*.
+
+            .. versionadded:: 3.10
+               Allowing sequences of values in above listed Patch properties.
+
+        See Also
+        --------
+        hist2d : 2D histogram with rectangular bins
+        hexbin : 2D histogram with hexagonal bins
+        stairs : Plot a pre-computed histogram
+        bar : Plot a pre-computed histogram
+
+        Notes
+        -----
+        For large numbers of bins (>1000), plotting can be significantly
+        accelerated by using `~.Axes.stairs` to plot a pre-computed histogram
+        (``plt.stairs(*np.histogram(data))``), or by setting *histtype* to
+        'step' or 'stepfilled' rather than 'bar' or 'barstacked'.
+        """
+        # Avoid shadowing the builtin.
+        bin_range = range
+        from builtins import range
+
+        if np.isscalar(x):
+            x = [x]
+
+        if bins is None:
+            bins = mpl.rcParams['hist.bins']
+
+        # Validate string inputs here to avoid cluttering subsequent code.
+        _api.check_in_list(['bar', 'barstacked', 'step', 'stepfilled'],
+                           histtype=histtype)
+        _api.check_in_list(['left', 'mid', 'right'], align=align)
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
+
+        if histtype == 'barstacked' and not stacked:
+            stacked = True
+
+        # Massage 'x' for processing.
+        x = cbook._reshape_2D(x, 'x')
+        nx = len(x)  # number of datasets
+
+        # Process unit information.  _process_unit_info sets the unit and
+        # converts the first dataset; then we convert each following dataset
+        # one at a time.
+        if orientation == "vertical":
+            convert_units = self.convert_xunits
+            x = [*self._process_unit_info([("x", x[0])], kwargs),
+                 *map(convert_units, x[1:])]
+        else:  # horizontal
+            convert_units = self.convert_yunits
+            x = [*self._process_unit_info([("y", x[0])], kwargs),
+                 *map(convert_units, x[1:])]
+
+        if bin_range is not None:
+            bin_range = convert_units(bin_range)
+
+        if not cbook.is_scalar_or_string(bins):
+            bins = convert_units(bins)
+
+        # We need to do to 'weights' what was done to 'x'
+        if weights is not None:
+            w = cbook._reshape_2D(weights, 'weights')
+        else:
+            w = [None] * nx
+
+        if len(w) != nx:
+            raise ValueError('weights should have the same shape as x')
+
+        input_empty = True
+        for xi, wi in zip(x, w):
+            len_xi = len(xi)
+            if wi is not None and len(wi) != len_xi:
+                raise ValueError('weights should have the same shape as x')
+            if len_xi:
+                input_empty = False
+
+        if color is None:
+            colors = [self._get_lines.get_next_color() for i in range(nx)]
+        else:
+            colors = mcolors.to_rgba_array(color)
+            if len(colors) != nx:
+                raise ValueError(f"The 'color' keyword argument must have one "
+                                 f"color per dataset, but {nx} datasets and "
+                                 f"{len(colors)} colors were provided")
+
+        hist_kwargs = dict()
+
+        # if the bin_range is not given, compute without nan numpy
+        # does not do this for us when guessing the range (but will
+        # happily ignore nans when computing the histogram).
+        if bin_range is None:
+            xmin = np.inf
+            xmax = -np.inf
+            for xi in x:
+                if len(xi):
+                    # python's min/max ignore nan,
+                    # np.minnan returns nan for all nan input
+                    xmin = min(xmin, np.nanmin(xi))
+                    xmax = max(xmax, np.nanmax(xi))
+            if xmin <= xmax:  # Only happens if we have seen a finite value.
+                bin_range = (xmin, xmax)
+
+        # If bins are not specified either explicitly or via range,
+        # we need to figure out the range required for all datasets,
+        # and supply that to np.histogram.
+        if not input_empty and len(x) > 1:
+            if weights is not None:
+                _w = np.concatenate(w)
+            else:
+                _w = None
+            bins = np.histogram_bin_edges(
+                np.concatenate(x), bins, bin_range, _w)
+        else:
+            hist_kwargs['range'] = bin_range
+
+        density = bool(density)
+        if density and not stacked:
+            hist_kwargs['density'] = density
+
+        # List to store all the top coordinates of the histograms
+        tops = []  # Will have shape (n_datasets, n_bins).
+        # Loop through datasets
+        for i in range(nx):
+            # this will automatically overwrite bins,
+            # so that each histogram uses the same bins
+            m, bins = np.histogram(x[i], bins, weights=w[i], **hist_kwargs)
+            tops.append(m)
+        tops = np.array(tops, float)  # causes problems later if it's an int
+        bins = np.array(bins, float)  # causes problems if float16
+        if stacked:
+            tops = tops.cumsum(axis=0)
+            # If a stacked density plot, normalize so the area of all the
+            # stacked histograms together is 1
+            if density:
+                tops = (tops / np.diff(bins)) / tops[-1].sum()
+        if cumulative:
+            slc = slice(None)
+            if isinstance(cumulative, Number) and cumulative < 0:
+                slc = slice(None, None, -1)
+            if density:
+                tops = (tops * np.diff(bins))[:, slc].cumsum(axis=1)[:, slc]
+            else:
+                tops = tops[:, slc].cumsum(axis=1)[:, slc]
+
+        patches = []
+
+        if histtype.startswith('bar'):
+
+            totwidth = np.diff(bins)
+
+            if rwidth is not None:
+                dr = np.clip(rwidth, 0, 1)
+            elif (len(tops) > 1 and
+                  ((not stacked) or mpl.rcParams['_internal.classic_mode'])):
+                dr = 0.8
+            else:
+                dr = 1.0
+
+            if histtype == 'bar' and not stacked:
+                width = dr * totwidth / nx
+                dw = width
+                boffset = -0.5 * dr * totwidth * (1 - 1 / nx)
+            elif histtype == 'barstacked' or stacked:
+                width = dr * totwidth
+                boffset, dw = 0.0, 0.0
+
+            if align == 'mid':
+                boffset += 0.5 * totwidth
+            elif align == 'right':
+                boffset += totwidth
+
+            if orientation == 'horizontal':
+                _barfunc = self.barh
+                bottom_kwarg = 'left'
+            else:  # orientation == 'vertical'
+                _barfunc = self.bar
+                bottom_kwarg = 'bottom'
+
+            for top, color in zip(tops, colors):
+                if bottom is None:
+                    bottom = np.zeros(len(top))
+                if stacked:
+                    height = top - bottom
+                else:
+                    height = top
+                bars = _barfunc(bins[:-1]+boffset, height, width,
+                                align='center', log=log,
+                                color=color, **{bottom_kwarg: bottom})
+                patches.append(bars)
+                if stacked:
+                    bottom = top
+                boffset += dw
+            # Remove stickies from all bars but the lowest ones, as otherwise
+            # margin expansion would be unable to cross the stickies in the
+            # middle of the bars.
+            for bars in patches[1:]:
+                for patch in bars:
+                    patch.sticky_edges.x[:] = patch.sticky_edges.y[:] = []
+
+        elif histtype.startswith('step'):
+            # these define the perimeter of the polygon
+            x = np.zeros(4 * len(bins) - 3)
+            y = np.zeros(4 * len(bins) - 3)
+
+            x[0:2*len(bins)-1:2], x[1:2*len(bins)-1:2] = bins, bins[:-1]
+            x[2*len(bins)-1:] = x[1:2*len(bins)-1][::-1]
+
+            if bottom is None:
+                bottom = 0
+
+            y[1:2*len(bins)-1:2] = y[2:2*len(bins):2] = bottom
+            y[2*len(bins)-1:] = y[1:2*len(bins)-1][::-1]
+
+            if log:
+                if orientation == 'horizontal':
+                    self.set_xscale('log', nonpositive='clip')
+                else:  # orientation == 'vertical'
+                    self.set_yscale('log', nonpositive='clip')
+
+            if align == 'left':
+                x -= 0.5*(bins[1]-bins[0])
+            elif align == 'right':
+                x += 0.5*(bins[1]-bins[0])
+
+            # If fill kwarg is set, it will be passed to the patch collection,
+            # overriding this
+            fill = (histtype == 'stepfilled')
+
+            xvals, yvals = [], []
+            for top in tops:
+                if stacked:
+                    # top of the previous polygon becomes the bottom
+                    y[2*len(bins)-1:] = y[1:2*len(bins)-1][::-1]
+                # set the top of this polygon
+                y[1:2*len(bins)-1:2] = y[2:2*len(bins):2] = top + bottom
+
+                # The starting point of the polygon has not yet been
+                # updated. So far only the endpoint was adjusted. This
+                # assignment closes the polygon. The redundant endpoint is
+                # later discarded (for step and stepfilled).
+                y[0] = y[-1]
+
+                if orientation == 'horizontal':
+                    xvals.append(y.copy())
+                    yvals.append(x.copy())
+                else:
+                    xvals.append(x.copy())
+                    yvals.append(y.copy())
+
+            # stepfill is closed, step is not
+            split = -1 if fill else 2 * len(bins)
+            # add patches in reverse order so that when stacking,
+            # items lower in the stack are plotted on top of
+            # items higher in the stack
+            for x, y, color in reversed(list(zip(xvals, yvals, colors))):
+                patches.append(self.fill(
+                    x[:split], y[:split],
+                    closed=True if fill else None,
+                    facecolor=color,
+                    edgecolor=None if fill else color,
+                    fill=fill if fill else None,
+                    zorder=None if fill else mlines.Line2D.zorder))
+            for patch_list in patches:
+                for patch in patch_list:
+                    if orientation == 'vertical':
+                        patch.sticky_edges.y.append(0)
+                    elif orientation == 'horizontal':
+                        patch.sticky_edges.x.append(0)
+
+            # we return patches, so put it back in the expected order
+            patches.reverse()
+
+        # If None, make all labels None (via zip_longest below); otherwise,
+        # cast each element to str, but keep a single str as it.
+        labels = [] if label is None else np.atleast_1d(np.asarray(label, str))
+
+        if histtype == "step":
+            edgecolors = itertools.cycle(np.atleast_1d(kwargs.get('edgecolor',
+                                                                  colors)))
+        else:
+            edgecolors = itertools.cycle(np.atleast_1d(kwargs.get("edgecolor", None)))
+
+        facecolors = itertools.cycle(np.atleast_1d(kwargs.get('facecolor', colors)))
+        hatches = itertools.cycle(np.atleast_1d(kwargs.get('hatch', None)))
+        linewidths = itertools.cycle(np.atleast_1d(kwargs.get('linewidth', None)))
+        linestyles = itertools.cycle(np.atleast_1d(kwargs.get('linestyle', None)))
+
+        for patch, lbl in itertools.zip_longest(patches, labels):
+            if not patch:
+                continue
+            p = patch[0]
+            kwargs.update({
+                'hatch': next(hatches),
+                'linewidth': next(linewidths),
+                'linestyle': next(linestyles),
+                'edgecolor': next(edgecolors),
+                'facecolor': next(facecolors),
+            })
+            p._internal_update(kwargs)
+            if lbl is not None:
+                p.set_label(lbl)
+            for p in patch[1:]:
+                p._internal_update(kwargs)
+                p.set_label('_nolegend_')
+
+        if nx == 1:
+            return tops[0], bins, patches[0]
+        else:
+            patch_type = ("BarContainer" if histtype.startswith("bar")
+                          else "list[Polygon]")
+            return tops, bins, cbook.silent_list(patch_type, patches)
+
+    @_preprocess_data()
+    def stairs(self, values, edges=None, *,
+               orientation='vertical', baseline=0, fill=False, **kwargs):
+        """
+        Draw a stepwise constant function as a line or a filled plot.
+
+        *edges* define the x-axis positions of the steps. *values* the function values
+        between these steps. Depending on *fill*, the function is drawn either as a
+        continuous line with vertical segments at the edges, or as a filled area.
+
+        Parameters
+        ----------
+        values : array-like
+            The step heights.
+
+        edges : array-like
+            The step positions, with ``len(edges) == len(vals) + 1``,
+            between which the curve takes on vals values.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            The direction of the steps. Vertical means that *values* are along
+            the y-axis, and edges are along the x-axis.
+
+        baseline : float, array-like or None, default: 0
+            The bottom value of the bounding edges or when
+            ``fill=True``, position of lower edge. If *fill* is
+            True or an array is passed to *baseline*, a closed
+            path is drawn.
+
+            If None, then drawn as an unclosed Path.
+
+        fill : bool, default: False
+            Whether the area under the step curve should be filled.
+
+            Passing both ``fill=True` and ``baseline=None`` will likely result in
+            undesired filling: the first and last points will be connected
+            with a straight line and the fill will be between this line and the stairs.
 
 
-def test_boxplot_tick_labels():
-    # Test the renamed `tick_labels` parameter.
-    # Test for deprecation of old name `labels`.
-    np.random.seed(19680801)
-    data = np.random.random((10, 3))
+        Returns
+        -------
+        StepPatch : `~matplotlib.patches.StepPatch`
 
-    fig, axs = plt.subplots(nrows=1, ncols=2, sharey=True)
-    # Should get deprecation warning for `labels`
-    with pytest.warns(mpl.MatplotlibDeprecationWarning,
-                      match='has been renamed \'tick_labels\''):
-        axs[0].boxplot(data, labels=['A', 'B', 'C'])
-    assert [l.get_text() for l in axs[0].get_xticklabels()] == ['A', 'B', 'C']
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
-    # Test the new tick_labels parameter
-    axs[1].boxplot(data, tick_labels=['A', 'B', 'C'])
-    assert [l.get_text() for l in axs[1].get_xticklabels()] == ['A', 'B', 'C']
+        **kwargs
+            `~matplotlib.patches.StepPatch` properties
 
+        """
 
-@needs_usetex
-@check_figures_equal()
-def test_latex_pie_percent(fig_test, fig_ref):
+        if 'color' in kwargs:
+            _color = kwargs.pop('color')
+        else:
+            _color = self._get_lines.get_next_color()
+        if fill:
+            kwargs.setdefault('linewidth', 0)
+            kwargs.setdefault('facecolor', _color)
+        else:
+            kwargs.setdefault('edgecolor', _color)
 
-    data = [20, 10, 70]
+        if edges is None:
+            edges = np.arange(len(values) + 1)
 
-    ax = fig_test.subplots()
-    ax.pie(data, autopct="%1.0f%%", textprops={'usetex': True})
+        edges, values, baseline = self._process_unit_info(
+            [("x", edges), ("y", values), ("y", baseline)], kwargs)
 
-    ax1 = fig_ref.subplots()
-    ax1.pie(data, autopct=r"%1.0f\%%", textprops={'usetex': True})
+        patch = mpatches.StepPatch(values,
+                                   edges,
+                                   baseline=baseline,
+                                   orientation=orientation,
+                                   fill=fill,
+                                   **kwargs)
+        self.add_patch(patch)
+        if baseline is None and fill:
+            _api.warn_external(
+                f"Both {baseline=} and {fill=} have been passed. "
+                "baseline=None is only intended for unfilled stair plots. "
+                "Because baseline is None, the Path used to draw the stairs will "
+                "not be closed, thus because fill is True the polygon will be closed "
+                "by drawing an (unstroked) edge from the first to last point.  It is "
+                "very likely that the resulting fill patterns is not the desired "
+                "result."
+            )
 
+        if baseline is not None:
+            if orientation == 'vertical':
+                patch.sticky_edges.y.append(np.min(baseline))
+                self.update_datalim([(edges[0], np.min(baseline))])
+            else:
+                patch.sticky_edges.x.append(np.min(baseline))
+                self.update_datalim([(np.min(baseline), edges[0])])
+        self._request_autoscale_view()
+        return patch
 
-@check_figures_equal(extensions=['png'])
-def test_violinplot_orientation(fig_test, fig_ref):
-    # Test the `orientation : {'vertical', 'horizontal'}`
-    # parameter and deprecation of `vert: bool`.
-    fig, axs = plt.subplots(nrows=1, ncols=3)
-    np.random.seed(19680801)
-    all_data = [np.random.normal(0, std, 100) for std in range(6, 10)]
+    @_api.make_keyword_only("3.9", "range")
+    @_preprocess_data(replace_names=["x", "y", "weights"])
+    @_docstring.interpd
+    def hist2d(self, x, y, bins=10, range=None, density=False, weights=None,
+               cmin=None, cmax=None, **kwargs):
+        """
+        Make a 2D histogram plot.
 
-    axs[0].violinplot(all_data)  # Default vertical plot.
-    # xticks and yticks should be at their default position.
-    assert all(axs[0].get_xticks() == np.array(
-        [0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5]))
-    assert all(axs[0].get_yticks() == np.array(
-        [-30., -20., -10., 0., 10., 20., 30.]))
+        Parameters
+        ----------
+        x, y : array-like, shape (n, )
+            Input values
 
-    # Horizontal plot using new `orientation` keyword.
-    axs[1].violinplot(all_data, orientation='horizontal')
-    # xticks and yticks should be swapped.
-    assert all(axs[1].get_xticks() == np.array(
-        [-30., -20., -10., 0., 10., 20., 30.]))
-    assert all(axs[1].get_yticks() == np.array(
-        [0.5, 1., 1.5, 2., 2.5, 3., 3.5, 4., 4.5]))
+        bins : None or int or [int, int] or array-like or [array, array]
 
-    plt.close()
+            The bin specification:
 
-    # Deprecation of `vert: bool` keyword
-    with pytest.warns(mpl.MatplotlibDeprecationWarning,
-                      match='vert: bool was deprecated in Matplotlib 3.10'):
-        # Compare images between a figure that
-        # uses vert and one that uses orientation.
-        ax_ref = fig_ref.subplots()
-        ax_ref.violinplot(all_data, vert=False)
+            - If int, the number of bins for the two dimensions
+              (``nx = ny = bins``).
+            - If ``[int, int]``, the number of bins in each dimension
+              (``nx, ny = bins``).
+            - If array-like, the bin edges for the two dimensions
+              (``x_edges = y_edges = bins``).
+            - If ``[array, array]``, the bin edges in each dimension
+              (``x_edges, y_edges = bins``).
 
-        ax_test = fig_test.subplots()
-        ax_test.violinplot(all_data, orientation='horizontal')
+            The default value is 10.
 
+        range : array-like shape(2, 2), optional
+            The leftmost and rightmost edges of the bins along each dimension
+            (if not specified explicitly in the bins parameters): ``[[xmin,
+            xmax], [ymin, ymax]]``. All values outside of this range will be
+            considered outliers and not tallied in the histogram.
 
-@check_figures_equal(extensions=['png'])
-def test_boxplot_orientation(fig_test, fig_ref):
-    # Test the `orientation : {'vertical', 'horizontal'}`
-    # parameter and deprecation of `vert: bool`.
-    fig, axs = plt.subplots(nrows=1, ncols=2)
-    np.random.seed(19680801)
-    all_data = [np.random.normal(0, std, 100) for std in range(6, 10)]
+        density : bool, default: False
+            Normalize histogram.  See the documentation for the *density*
+            parameter of `~.Axes.hist` for more details.
 
-    axs[0].boxplot(all_data)  # Default vertical plot.
-    # xticks and yticks should be at their default position.
-    assert all(axs[0].get_xticks() == np.array(
-        [1, 2, 3, 4]))
-    assert all(axs[0].get_yticks() == np.array(
-        [-30., -20., -10., 0., 10., 20., 30.]))
+        weights : array-like, shape (n, ), optional
+            An array of values w_i weighing each sample (x_i, y_i).
 
-    # Horizontal plot using new `orientation` keyword.
-    axs[1].boxplot(all_data, orientation='horizontal')
-    # xticks and yticks should be swapped.
-    assert all(axs[1].get_xticks() == np.array(
-        [-30., -20., -10., 0., 10., 20., 30.]))
-    assert all(axs[1].get_yticks() == np.array(
-        [1, 2, 3, 4]))
+        cmin, cmax : float, default: None
+            All bins that has count less than *cmin* or more than *cmax* will not be
+            displayed (set to NaN before passing to `~.Axes.pcolormesh`) and these count
+            values in the return value count histogram will also be set to nan upon
+            return.
 
-    plt.close()
+        Returns
+        -------
+        h : 2D array
+            The bi-dimensional histogram of samples x and y. Values in x are
+            histogrammed along the first dimension and values in y are
+            histogrammed along the second dimension.
+        xedges : 1D array
+            The bin edges along the x-axis.
+        yedges : 1D array
+            The bin edges along the y-axis.
+        image : `~.matplotlib.collections.QuadMesh`
 
-    # Deprecation of `vert: bool` keyword and
-    # 'boxplot.vertical' rcparam.
-    with pytest.warns(mpl.MatplotlibDeprecationWarning,
-                      match='was deprecated in Matplotlib 3.10'):
-        # Compare images between a figure that
-        # uses vert and one that uses orientation.
-        with mpl.rc_context({'boxplot.vertical': False}):
-            ax_ref = fig_ref.subplots()
-            ax_ref.boxplot(all_data)
+        Other Parameters
+        ----------------
+        %(cmap_doc)s
 
-        ax_test = fig_test.subplots()
-        ax_test.boxplot(all_data, orientation='horizontal')
+        %(norm_doc)s
 
+        %(vmin_vmax_doc)s
 
-@image_comparison(["use_colorizer_keyword.png"],
-                   tol=0.05 if platform.machine() == 'arm64' else 0)
-def test_use_colorizer_keyword():
-    # test using the colorizer keyword
-    np.random.seed(0)
-    rand_x = np.random.random(100)
-    rand_y = np.random.random(100)
-    c = np.arange(25, dtype='float32').reshape((5, 5))
+        %(colorizer_doc)s
 
-    fig, axes = plt.subplots(3, 4)
-    norm = mpl.colors.Normalize(4, 20)
-    cl = mpl.colorizer.Colorizer(norm=norm, cmap='RdBu')
+        alpha : ``0 <= scalar <= 1`` or ``None``, optional
+            The alpha blending value.
 
-    axes[0, 0].scatter(c, c, c=c, colorizer=cl)
-    axes[0, 1].hexbin(rand_x, rand_y, colorizer=cl, gridsize=(2, 2))
-    axes[0, 2].imshow(c, colorizer=cl)
-    axes[0, 3].pcolor(c, colorizer=cl)
-    axes[1, 0].pcolormesh(c, colorizer=cl)
-    axes[1, 1].pcolorfast(c, colorizer=cl)  # style = image
-    axes[1, 2].pcolorfast((0, 1, 2, 3, 4, 5), (0, 1, 2, 3, 5, 6),  c,
-                          colorizer=cl)  # style = pcolorimage
-    axes[1, 3].pcolorfast(c.T, c, c[:4, :4], colorizer=cl)  # style = quadmesh
-    axes[2, 0].contour(c, colorizer=cl)
-    axes[2, 1].contourf(c, colorizer=cl)
-    axes[2, 2].tricontour(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl)
-    axes[2, 3].tricontourf(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl)
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
 
-    fig.figimage(np.repeat(np.repeat(c, 15, axis=0), 15, axis=1), colorizer=cl)
-    remove_ticks_and_titles(fig)
+        **kwargs
+            Additional parameters are passed along to the
+            `~.Axes.pcolormesh` method and `~matplotlib.collections.QuadMesh`
+            constructor.
 
+        See Also
+        --------
+        hist : 1D histogram plotting
+        hexbin : 2D histogram with hexagonal bins
 
-def test_wrong_use_colorizer():
-    # test using the colorizer keyword and norm or cmap
-    np.random.seed(0)
-    rand_x = np.random.random(100)
-    rand_y = np.random.random(100)
-    c = np.arange(25, dtype='float32').reshape((5, 5))
+        Notes
+        -----
+        - Currently ``hist2d`` calculates its own axis limits, and any limits
+          previously set are ignored.
+        - Rendering the histogram with a logarithmic color scale is
+          accomplished by passing a `.colors.LogNorm` instance to the *norm*
+          keyword argument. Likewise, power-law normalization (similar
+          in effect to gamma correction) can be accomplished with
+          `.colors.PowerNorm`.
+        """
 
-    fig, axes = plt.subplots(3, 4)
-    norm = mpl.colors.Normalize(4, 20)
-    cl = mpl.colorizer.Colorizer(norm=norm, cmap='RdBu')
+        h, xedges, yedges = np.histogram2d(x, y, bins=bins, range=range,
+                                           density=density, weights=weights)
 
-    match_str = "The `colorizer` keyword cannot be used simultaneously"
-    kwrds = [{'vmin': 0}, {'vmax': 0}, {'norm': 'log'}, {'cmap': 'viridis'}]
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[0, 0].scatter(c, c, c=c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[0, 0].scatter(c, c, c=c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[0, 1].hexbin(rand_x, rand_y, colorizer=cl, gridsize=(2, 2), **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[0, 2].imshow(c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[0, 3].pcolor(c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[1, 0].pcolormesh(c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[1, 1].pcolorfast(c, colorizer=cl, **kwrd)  # style = image
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[1, 2].pcolorfast((0, 1, 2, 3, 4, 5), (0, 1, 2, 3, 5, 6),  c,
-                                  colorizer=cl, **kwrd)  # style = pcolorimage
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[1, 3].pcolorfast(c.T, c, c[:4, :4], colorizer=cl, **kwrd)  # quadmesh
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[2, 0].contour(c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[2, 1].contourf(c, colorizer=cl, **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[2, 2].tricontour(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl,
-                                  **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            axes[2, 3].tricontourf(c.T.ravel(), c.ravel(), c.ravel(), colorizer=cl,
-                                   **kwrd)
-    for kwrd in kwrds:
-        with pytest.raises(ValueError, match=match_str):
-            fig.figimage(c, colorizer=cl, **kwrd)
+        if cmin is not None:
+            h[h < cmin] = None
+        if cmax is not None:
+            h[h > cmax] = None
 
+        pc = self.pcolormesh(xedges, yedges, h.T, **kwargs)
+        self.set_xlim(xedges[0], xedges[-1])
+        self.set_ylim(yedges[0], yedges[-1])
 
-def test_bar_color_precedence():
-    # Test the precedence of 'color' and 'facecolor' in bar plots
-    fig, ax = plt.subplots()
+        return h, xedges, yedges, pc
 
-    # case 1: no color specified
-    bars = ax.bar([1, 2, 3], [4, 5, 6])
-    for bar in bars:
-        assert mcolors.same_color(bar.get_facecolor(), 'blue')
+    @_preprocess_data(replace_names=["x", "weights"], label_namer="x")
+    @_docstring.interpd
+    def ecdf(self, x, weights=None, *, complementary=False,
+             orientation="vertical", compress=False, **kwargs):
+        """
+        Compute and plot the empirical cumulative distribution function of *x*.
 
-    # case 2: Only 'color'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red')
-    for bar in bars:
-        assert mcolors.same_color(bar.get_facecolor(), 'red')
+        .. versionadded:: 3.8
 
-    # case 3: Only 'facecolor'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], facecolor='yellow')
-    for bar in bars:
-        assert mcolors.same_color(bar.get_facecolor(), 'yellow')
+        Parameters
+        ----------
+        x : 1d array-like
+            The input data.  Infinite entries are kept (and move the relevant
+            end of the ecdf from 0/1), but NaNs and masked values are errors.
 
-    # case 4: 'facecolor' and 'color'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red', facecolor='green')
-    for bar in bars:
-        assert mcolors.same_color(bar.get_facecolor(), 'green')
+        weights : 1d array-like or None, default: None
+            The weights of the entries; must have the same shape as *x*.
+            Weights corresponding to NaN data points are dropped, and then the
+            remaining weights are normalized to sum to 1.  If unset, all
+            entries have the same weight.
+
+        complementary : bool, default: False
+            Whether to plot a cumulative distribution function, which increases
+            from 0 to 1 (the default), or a complementary cumulative
+            distribution function, which decreases from 1 to 0.
+
+        orientation : {"vertical", "horizontal"}, default: "vertical"
+            Whether the entries are plotted along the x-axis ("vertical", the
+            default) or the y-axis ("horizontal").  This parameter takes the
+            same values as in `~.Axes.hist`.
+
+        compress : bool, default: False
+            Whether multiple entries with the same values are grouped together
+            (with a summed weight) before plotting.  This is mainly useful if
+            *x* contains many identical data points, to decrease the rendering
+            complexity of the plot. If *x* contains no duplicate points, this
+            has no effect and just uses some time and memory.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        Returns
+        -------
+        `.Line2D`
+
+        Notes
+        -----
+        The ecdf plot can be thought of as a cumulative histogram with one bin
+        per data entry; i.e. it reports on the entire dataset without any
+        arbitrary binning.
+
+        If *x* contains NaNs or masked entries, either remove them first from
+        the array (if they should not taken into account), or replace them by
+        -inf or +inf (if they should be sorted at the beginning or the end of
+        the array).
+        """
+        _api.check_in_list(["horizontal", "vertical"], orientation=orientation)
+        if "drawstyle" in kwargs or "ds" in kwargs:
+            raise TypeError("Cannot pass 'drawstyle' or 'ds' to ecdf()")
+        if np.ma.getmask(x).any():
+            raise ValueError("ecdf() does not support masked entries")
+        x = np.asarray(x)
+        if np.isnan(x).any():
+            raise ValueError("ecdf() does not support NaNs")
+        argsort = np.argsort(x)
+        x = x[argsort]
+        if weights is None:
+            # Ensure that we end at exactly 1, avoiding floating point errors.
+            cum_weights = (1 + np.arange(len(x))) / len(x)
+        else:
+            weights = np.take(weights, argsort)   # Reorder weights like we reordered x.
+            cum_weights = np.cumsum(weights / np.sum(weights))
+        if compress:
+            # Get indices of unique x values.
+            compress_idxs = [0, *(x[:-1] != x[1:]).nonzero()[0] + 1]
+            x = x[compress_idxs]
+            cum_weights = cum_weights[compress_idxs]
+        if orientation == "vertical":
+            if not complementary:
+                line, = self.plot([x[0], *x], [0, *cum_weights],
+                                  drawstyle="steps-post", **kwargs)
+            else:
+                line, = self.plot([*x, x[-1]], [1, *1 - cum_weights],
+                                  drawstyle="steps-pre", **kwargs)
+            line.sticky_edges.y[:] = [0, 1]
+        else:  # orientation == "horizontal":
+            if not complementary:
+                line, = self.plot([0, *cum_weights], [x[0], *x],
+                                  drawstyle="steps-pre", **kwargs)
+            else:
+                line, = self.plot([1, *1 - cum_weights], [*x, x[-1]],
+                                  drawstyle="steps-post", **kwargs)
+            line.sticky_edges.x[:] = [0, 1]
+        return line
+
+    @_api.make_keyword_only("3.9", "NFFT")
+    @_preprocess_data(replace_names=["x"])
+    @_docstring.interpd
+    def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
+            window=None, noverlap=None, pad_to=None,
+            sides=None, scale_by_freq=None, return_line=None, **kwargs):
+        r"""
+        Plot the power spectral density.
+
+        The power spectral density :math:`P_{xx}` by Welch's average
+        periodogram method.  The vector *x* is divided into *NFFT* length
+        segments.  Each segment is detrended by function *detrend* and
+        windowed by function *window*.  *noverlap* gives the length of
+        the overlap between segments.  The :math:`|\mathrm{fft}(i)|^2`
+        of each segment :math:`i` are averaged to compute :math:`P_{xx}`,
+        with a scaling to correct for power loss due to windowing.
+
+        If len(*x*) < *NFFT*, it will be zero padded to *NFFT*.
+
+        Parameters
+        ----------
+        x : 1-D array or sequence
+            Array or sequence containing the data
+
+        %(Spectral)s
+
+        %(PSD)s
+
+        noverlap : int, default: 0 (no overlap)
+            The number of points of overlap between segments.
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        return_line : bool, default: False
+            Whether to include the line object plotted in the returned values.
+
+        Returns
+        -------
+        Pxx : 1-D array
+            The values for the power spectrum :math:`P_{xx}` before scaling
+            (real valued).
+
+        freqs : 1-D array
+            The frequencies corresponding to the elements in *Pxx*.
+
+        line : `~matplotlib.lines.Line2D`
+            The line created by this function.
+            Only returned if *return_line* is True.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        specgram
+            Differs in the default overlap; in not returning the mean of the
+            segment periodograms; in returning the times of the segments; and
+            in plotting a colormap instead of a line.
+        magnitude_spectrum
+            Plots the magnitude spectrum.
+        csd
+            Plots the spectral density between two signals.
+
+        Notes
+        -----
+        For plotting, the power is plotted as
+        :math:`10\log_{10}(P_{xx})` for decibels, though *Pxx* itself
+        is returned.
+
+        References
+        ----------
+        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
+        John Wiley & Sons (1986)
+        """
+        if Fc is None:
+            Fc = 0
+
+        pxx, freqs = mlab.psd(x=x, NFFT=NFFT, Fs=Fs, detrend=detrend,
+                              window=window, noverlap=noverlap, pad_to=pad_to,
+                              sides=sides, scale_by_freq=scale_by_freq)
+        freqs += Fc
+
+        if scale_by_freq in (None, True):
+            psd_units = 'dB/Hz'
+        else:
+            psd_units = 'dB'
+
+        line = self.plot(freqs, 10 * np.log10(pxx), **kwargs)
+        self.set_xlabel('Frequency')
+        self.set_ylabel('Power Spectral Density (%s)' % psd_units)
+        self.grid(True)
+
+        vmin, vmax = self.get_ybound()
+        step = max(10 * int(np.log10(vmax - vmin)), 1)
+        ticks = np.arange(math.floor(vmin), math.ceil(vmax) + 1, step)
+        self.set_yticks(ticks)
+
+        if return_line is None or not return_line:
+            return pxx, freqs
+        else:
+            return pxx, freqs, line
+
+    @_api.make_keyword_only("3.9", "NFFT")
+    @_preprocess_data(replace_names=["x", "y"], label_namer="y")
+    @_docstring.interpd
+    def csd(self, x, y, NFFT=None, Fs=None, Fc=None, detrend=None,
+            window=None, noverlap=None, pad_to=None,
+            sides=None, scale_by_freq=None, return_line=None, **kwargs):
+        r"""
+        Plot the cross-spectral density.
+
+        The cross spectral density :math:`P_{xy}` by Welch's average
+        periodogram method.  The vectors *x* and *y* are divided into
+        *NFFT* length segments.  Each segment is detrended by function
+        *detrend* and windowed by function *window*.  *noverlap* gives
+        the length of the overlap between segments.  The product of
+        the direct FFTs of *x* and *y* are averaged over each segment
+        to compute :math:`P_{xy}`, with a scaling to correct for power
+        loss due to windowing.
+
+        If len(*x*) < *NFFT* or len(*y*) < *NFFT*, they will be zero
+        padded to *NFFT*.
+
+        Parameters
+        ----------
+        x, y : 1-D arrays or sequences
+            Arrays or sequences containing the data.
+
+        %(Spectral)s
+
+        %(PSD)s
+
+        noverlap : int, default: 0 (no overlap)
+            The number of points of overlap between segments.
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        return_line : bool, default: False
+            Whether to include the line object plotted in the returned values.
+
+        Returns
+        -------
+        Pxy : 1-D array
+            The values for the cross spectrum :math:`P_{xy}` before scaling
+            (complex valued).
+
+        freqs : 1-D array
+            The frequencies corresponding to the elements in *Pxy*.
+
+        line : `~matplotlib.lines.Line2D`
+            The line created by this function.
+            Only returned if *return_line* is True.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        psd : is equivalent to setting ``y = x``.
+
+        Notes
+        -----
+        For plotting, the power is plotted as
+        :math:`10 \log_{10}(P_{xy})` for decibels, though :math:`P_{xy}` itself
+        is returned.
+
+        References
+        ----------
+        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
+        John Wiley & Sons (1986)
+        """
+        if Fc is None:
+            Fc = 0
+
+        pxy, freqs = mlab.csd(x=x, y=y, NFFT=NFFT, Fs=Fs, detrend=detrend,
+                              window=window, noverlap=noverlap, pad_to=pad_to,
+                              sides=sides, scale_by_freq=scale_by_freq)
+        # pxy is complex
+        freqs += Fc
+
+        line = self.plot(freqs, 10 * np.log10(np.abs(pxy)), **kwargs)
+        self.set_xlabel('Frequency')
+        self.set_ylabel('Cross Spectrum Magnitude (dB)')
+        self.grid(True)
+
+        vmin, vmax = self.get_ybound()
+        step = max(10 * int(np.log10(vmax - vmin)), 1)
+        ticks = np.arange(math.floor(vmin), math.ceil(vmax) + 1, step)
+        self.set_yticks(ticks)
+
+        if return_line is None or not return_line:
+            return pxy, freqs
+        else:
+            return pxy, freqs, line
+
+    @_api.make_keyword_only("3.9", "Fs")
+    @_preprocess_data(replace_names=["x"])
+    @_docstring.interpd
+    def magnitude_spectrum(self, x, Fs=None, Fc=None, window=None,
+                           pad_to=None, sides=None, scale=None,
+                           **kwargs):
+        """
+        Plot the magnitude spectrum.
+
+        Compute the magnitude spectrum of *x*.  Data is padded to a
+        length of *pad_to* and the windowing function *window* is applied to
+        the signal.
+
+        Parameters
+        ----------
+        x : 1-D array or sequence
+            Array or sequence containing the data.
+
+        %(Spectral)s
+
+        %(Single_Spectrum)s
+
+        scale : {'default', 'linear', 'dB'}
+            The scaling of the values in the *spec*.  'linear' is no scaling.
+            'dB' returns the values in dB scale, i.e., the dB amplitude
+            (20 * log10). 'default' is 'linear'.
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        Returns
+        -------
+        spectrum : 1-D array
+            The values for the magnitude spectrum before scaling (real valued).
+
+        freqs : 1-D array
+            The frequencies corresponding to the elements in *spectrum*.
+
+        line : `~matplotlib.lines.Line2D`
+            The line created by this function.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        psd
+            Plots the power spectral density.
+        angle_spectrum
+            Plots the angles of the corresponding frequencies.
+        phase_spectrum
+            Plots the phase (unwrapped angle) of the corresponding frequencies.
+        specgram
+            Can plot the magnitude spectrum of segments within the signal in a
+            colormap.
+        """
+        if Fc is None:
+            Fc = 0
+
+        spec, freqs = mlab.magnitude_spectrum(x=x, Fs=Fs, window=window,
+                                              pad_to=pad_to, sides=sides)
+        freqs += Fc
+
+        yunits = _api.check_getitem(
+            {None: 'energy', 'default': 'energy', 'linear': 'energy',
+             'dB': 'dB'},
+            scale=scale)
+        if yunits == 'energy':
+            Z = spec
+        else:  # yunits == 'dB'
+            Z = 20. * np.log10(spec)
+
+        line, = self.plot(freqs, Z, **kwargs)
+        self.set_xlabel('Frequency')
+        self.set_ylabel('Magnitude (%s)' % yunits)
+
+        return spec, freqs, line
+
+    @_api.make_keyword_only("3.9", "Fs")
+    @_preprocess_data(replace_names=["x"])
+    @_docstring.interpd
+    def angle_spectrum(self, x, Fs=None, Fc=None, window=None,
+                       pad_to=None, sides=None, **kwargs):
+        """
+        Plot the angle spectrum.
+
+        Compute the angle spectrum (wrapped phase spectrum) of *x*.
+        Data is padded to a length of *pad_to* and the windowing function
+        *window* is applied to the signal.
+
+        Parameters
+        ----------
+        x : 1-D array or sequence
+            Array or sequence containing the data.
+
+        %(Spectral)s
+
+        %(Single_Spectrum)s
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        Returns
+        -------
+        spectrum : 1-D array
+            The values for the angle spectrum in radians (real valued).
+
+        freqs : 1-D array
+            The frequencies corresponding to the elements in *spectrum*.
+
+        line : `~matplotlib.lines.Line2D`
+            The line created by this function.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        magnitude_spectrum
+            Plots the magnitudes of the corresponding frequencies.
+        phase_spectrum
+            Plots the unwrapped version of this function.
+        specgram
+            Can plot the angle spectrum of segments within the signal in a
+            colormap.
+        """
+        if Fc is None:
+            Fc = 0
+
+        spec, freqs = mlab.angle_spectrum(x=x, Fs=Fs, window=window,
+                                          pad_to=pad_to, sides=sides)
+        freqs += Fc
+
+        lines = self.plot(freqs, spec, **kwargs)
+        self.set_xlabel('Frequency')
+        self.set_ylabel('Angle (radians)')
+
+        return spec, freqs, lines[0]
+
+    @_api.make_keyword_only("3.9", "Fs")
+    @_preprocess_data(replace_names=["x"])
+    @_docstring.interpd
+    def phase_spectrum(self, x, Fs=None, Fc=None, window=None,
+                       pad_to=None, sides=None, **kwargs):
+        """
+        Plot the phase spectrum.
+
+        Compute the phase spectrum (unwrapped angle spectrum) of *x*.
+        Data is padded to a length of *pad_to* and the windowing function
+        *window* is applied to the signal.
+
+        Parameters
+        ----------
+        x : 1-D array or sequence
+            Array or sequence containing the data
+
+        %(Spectral)s
+
+        %(Single_Spectrum)s
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        Returns
+        -------
+        spectrum : 1-D array
+            The values for the phase spectrum in radians (real valued).
+
+        freqs : 1-D array
+            The frequencies corresponding to the elements in *spectrum*.
+
+        line : `~matplotlib.lines.Line2D`
+            The line created by this function.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        See Also
+        --------
+        magnitude_spectrum
+            Plots the magnitudes of the corresponding frequencies.
+        angle_spectrum
+            Plots the wrapped version of this function.
+        specgram
+            Can plot the phase spectrum of segments within the signal in a
+            colormap.
+        """
+        if Fc is None:
+            Fc = 0
+
+        spec, freqs = mlab.phase_spectrum(x=x, Fs=Fs, window=window,
+                                          pad_to=pad_to, sides=sides)
+        freqs += Fc
+
+        lines = self.plot(freqs, spec, **kwargs)
+        self.set_xlabel('Frequency')
+        self.set_ylabel('Phase (radians)')
+
+        return spec, freqs, lines[0]
+
+    @_api.make_keyword_only("3.9", "NFFT")
+    @_preprocess_data(replace_names=["x", "y"])
+    @_docstring.interpd
+    def cohere(self, x, y, NFFT=256, Fs=2, Fc=0, detrend=mlab.detrend_none,
+               window=mlab.window_hanning, noverlap=0, pad_to=None,
+               sides='default', scale_by_freq=None, **kwargs):
+        r"""
+        Plot the coherence between *x* and *y*.
+
+        Coherence is the normalized cross spectral density:
+
+        .. math::
+
+          C_{xy} = \frac{|P_{xy}|^2}{P_{xx}P_{yy}}
+
+        Parameters
+        ----------
+        %(Spectral)s
+
+        %(PSD)s
+
+        noverlap : int, default: 0 (no overlap)
+            The number of points of overlap between blocks.
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        Returns
+        -------
+        Cxy : 1-D array
+            The coherence vector.
+
+        freqs : 1-D array
+            The frequencies for the elements in *Cxy*.
+
+        Other Parameters
+        ----------------
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        **kwargs
+            Keyword arguments control the `.Line2D` properties:
+
+            %(Line2D:kwdoc)s
+
+        References
+        ----------
+        Bendat & Piersol -- Random Data: Analysis and Measurement Procedures,
+        John Wiley & Sons (1986)
+        """
+        cxy, freqs = mlab.cohere(x=x, y=y, NFFT=NFFT, Fs=Fs, detrend=detrend,
+                                 window=window, noverlap=noverlap,
+                                 scale_by_freq=scale_by_freq, sides=sides,
+                                 pad_to=pad_to)
+        freqs += Fc
+
+        self.plot(freqs, cxy, **kwargs)
+        self.set_xlabel('Frequency')
+        self.set_ylabel('Coherence')
+        self.grid(True)
+
+        return cxy, freqs
+
+    @_api.make_keyword_only("3.9", "NFFT")
+    @_preprocess_data(replace_names=["x"])
+    @_docstring.interpd
+    def specgram(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
+                 window=None, noverlap=None,
+                 cmap=None, xextent=None, pad_to=None, sides=None,
+                 scale_by_freq=None, mode=None, scale=None,
+                 vmin=None, vmax=None, **kwargs):
+        """
+        Plot a spectrogram.
+
+        Compute and plot a spectrogram of data in *x*.  Data are split into
+        *NFFT* length segments and the spectrum of each section is
+        computed.  The windowing function *window* is applied to each
+        segment, and the amount of overlap of each segment is
+        specified with *noverlap*. The spectrogram is plotted as a colormap
+        (using imshow).
+
+        Parameters
+        ----------
+        x : 1-D array or sequence
+            Array or sequence containing the data.
+
+        %(Spectral)s
+
+        %(PSD)s
+
+        mode : {'default', 'psd', 'magnitude', 'angle', 'phase'}
+            What sort of spectrum to use.  Default is 'psd', which takes the
+            power spectral density.  'magnitude' returns the magnitude
+            spectrum.  'angle' returns the phase spectrum without unwrapping.
+            'phase' returns the phase spectrum with unwrapping.
+
+        noverlap : int, default: 128
+            The number of points of overlap between blocks.
+
+        scale : {'default', 'linear', 'dB'}
+            The scaling of the values in the *spec*.  'linear' is no scaling.
+            'dB' returns the values in dB scale.  When *mode* is 'psd',
+            this is dB power (10 * log10).  Otherwise, this is dB amplitude
+            (20 * log10). 'default' is 'dB' if *mode* is 'psd' or
+            'magnitude' and 'linear' otherwise.  This must be 'linear'
+            if *mode* is 'angle' or 'phase'.
+
+        Fc : int, default: 0
+            The center frequency of *x*, which offsets the x extents of the
+            plot to reflect the frequency range used when a signal is acquired
+            and then filtered and downsampled to baseband.
+
+        cmap : `.Colormap`, default: :rc:`image.cmap`
+
+        xextent : *None* or (xmin, xmax)
+            The image extent along the x-axis. The default sets *xmin* to the
+            left border of the first bin (*spectrum* column) and *xmax* to the
+            right border of the last bin. Note that for *noverlap>0* the width
+            of the bins is smaller than those of the segments.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        vmin, vmax : float, optional
+            vmin and vmax define the data range that the colormap covers.
+            By default, the colormap covers the complete value range of the
+            data.
+
+        **kwargs
+            Additional keyword arguments are passed on to `~.axes.Axes.imshow`
+            which makes the specgram image. The origin keyword argument
+            is not supported.
+
+        Returns
+        -------
+        spectrum : 2D array
+            Columns are the periodograms of successive segments.
+
+        freqs : 1-D array
+            The frequencies corresponding to the rows in *spectrum*.
+
+        t : 1-D array
+            The times corresponding to midpoints of segments (i.e., the columns
+            in *spectrum*).
+
+        im : `.AxesImage`
+            The image created by imshow containing the spectrogram.
+
+        See Also
+        --------
+        psd
+            Differs in the default overlap; in returning the mean of the
+            segment periodograms; in not returning times; and in generating a
+            line plot instead of colormap.
+        magnitude_spectrum
+            A single spectrum, similar to having a single segment when *mode*
+            is 'magnitude'. Plots a line instead of a colormap.
+        angle_spectrum
+            A single spectrum, similar to having a single segment when *mode*
+            is 'angle'. Plots a line instead of a colormap.
+        phase_spectrum
+            A single spectrum, similar to having a single segment when *mode*
+            is 'phase'. Plots a line instead of a colormap.
+
+        Notes
+        -----
+        The parameters *detrend* and *scale_by_freq* do only apply when *mode*
+        is set to 'psd'.
+        """
+        if NFFT is None:
+            NFFT = 256  # same default as in mlab.specgram()
+        if Fc is None:
+            Fc = 0  # same default as in mlab._spectral_helper()
+        if noverlap is None:
+            noverlap = 128  # same default as in mlab.specgram()
+        if Fs is None:
+            Fs = 2  # same default as in mlab._spectral_helper()
+
+        if mode == 'complex':
+            raise ValueError('Cannot plot a complex specgram')
+
+        if scale is None or scale == 'default':
+            if mode in ['angle', 'phase']:
+                scale = 'linear'
+            else:
+                scale = 'dB'
+        elif mode in ['angle', 'phase'] and scale == 'dB':
+            raise ValueError('Cannot use dB scale with angle or phase mode')
+
+        spec, freqs, t = mlab.specgram(x=x, NFFT=NFFT, Fs=Fs,
+                                       detrend=detrend, window=window,
+                                       noverlap=noverlap, pad_to=pad_to,
+                                       sides=sides,
+                                       scale_by_freq=scale_by_freq,
+                                       mode=mode)
+
+        if scale == 'linear':
+            Z = spec
+        elif scale == 'dB':
+            if mode is None or mode == 'default' or mode == 'psd':
+                Z = 10. * np.log10(spec)
+            else:
+                Z = 20. * np.log10(spec)
+        else:
+            raise ValueError(f'Unknown scale {scale!r}')
+
+        Z = np.flipud(Z)
+
+        if xextent is None:
+            # padding is needed for first and last segment:
+            pad_xextent = (NFFT-noverlap) / Fs / 2
+            xextent = np.min(t) - pad_xextent, np.max(t) + pad_xextent
+        xmin, xmax = xextent
+        freqs += Fc
+        extent = xmin, xmax, freqs[0], freqs[-1]
+
+        if 'origin' in kwargs:
+            raise _api.kwarg_error("specgram", "origin")
+
+        im = self.imshow(Z, cmap, extent=extent, vmin=vmin, vmax=vmax,
+                         origin='upper', **kwargs)
+        self.axis('auto')
+
+        return spec, freqs, t, im
+
+    @_api.make_keyword_only("3.9", "precision")
+    @_docstring.interpd
+    def spy(self, Z, precision=0, marker=None, markersize=None,
+            aspect='equal', origin="upper", **kwargs):
+        """
+        Plot the sparsity pattern of a 2D array.
+
+        This visualizes the non-zero values of the array.
+
+        Two plotting styles are available: image and marker. Both
+        are available for full arrays, but only the marker style
+        works for `scipy.sparse.spmatrix` instances.
+
+        **Image style**
+
+        If *marker* and *markersize* are *None*, `~.Axes.imshow` is used. Any
+        extra remaining keyword arguments are passed to this method.
+
+        **Marker style**
+
+        If *Z* is a `scipy.sparse.spmatrix` or *marker* or *markersize* are
+        *None*, a `.Line2D` object will be returned with the value of marker
+        determining the marker type, and any remaining keyword arguments
+        passed to `~.Axes.plot`.
+
+        Parameters
+        ----------
+        Z : (M, N) array-like
+            The array to be plotted.
+
+        precision : float or 'present', default: 0
+            If *precision* is 0, any non-zero value will be plotted. Otherwise,
+            values of :math:`|Z| > precision` will be plotted.
+
+            For `scipy.sparse.spmatrix` instances, you can also
+            pass 'present'. In this case any value present in the array
+            will be plotted, even if it is identically zero.
+
+        aspect : {'equal', 'auto', None} or float, default: 'equal'
+            The aspect ratio of the Axes.  This parameter is particularly
+            relevant for images since it determines whether data pixels are
+            square.
+
+            This parameter is a shortcut for explicitly calling
+            `.Axes.set_aspect`. See there for further details.
+
+            - 'equal': Ensures an aspect ratio of 1. Pixels will be square.
+            - 'auto': The Axes is kept fixed and the aspect is adjusted so
+              that the data fit in the Axes. In general, this will result in
+              non-square pixels.
+            - *None*: Use :rc:`image.aspect`.
+
+        origin : {'upper', 'lower'}, default: :rc:`image.origin`
+            Place the [0, 0] index of the array in the upper left or lower left
+            corner of the Axes. The convention 'upper' is typically used for
+            matrices and images.
+
+        Returns
+        -------
+        `~matplotlib.image.AxesImage` or `.Line2D`
+            The return type depends on the plotting style (see above).
+
+        Other Parameters
+        ----------------
+        **kwargs
+            The supported additional parameters depend on the plotting style.
+
+            For the image style, you can pass the following additional
+            parameters of `~.Axes.imshow`:
+
+            - *cmap*
+            - *alpha*
+            - *url*
+            - any `.Artist` properties (passed on to the `.AxesImage`)
+
+            For the marker style, you can pass any `.Line2D` property except
+            for *linestyle*:
+
+            %(Line2D:kwdoc)s
+        """
+        if marker is None and markersize is None and hasattr(Z, 'tocoo'):
+            marker = 's'
+        _api.check_in_list(["upper", "lower"], origin=origin)
+        if marker is None and markersize is None:
+            Z = np.asarray(Z)
+            mask = np.abs(Z) > precision
+
+            if 'cmap' not in kwargs:
+                kwargs['cmap'] = mcolors.ListedColormap(['w', 'k'],
+                                                        name='binary')
+            if 'interpolation' in kwargs:
+                raise _api.kwarg_error("spy", "interpolation")
+            if 'norm' not in kwargs:
+                kwargs['norm'] = mcolors.NoNorm()
+            ret = self.imshow(mask, interpolation='nearest',
+                              aspect=aspect, origin=origin,
+                              **kwargs)
+        else:
+            if hasattr(Z, 'tocoo'):
+                c = Z.tocoo()
+                if precision == 'present':
+                    y = c.row
+                    x = c.col
+                else:
+                    nonzero = np.abs(c.data) > precision
+                    y = c.row[nonzero]
+                    x = c.col[nonzero]
+            else:
+                Z = np.asarray(Z)
+                nonzero = np.abs(Z) > precision
+                y, x = np.nonzero(nonzero)
+            if marker is None:
+                marker = 's'
+            if markersize is None:
+                markersize = 10
+            if 'linestyle' in kwargs:
+                raise _api.kwarg_error("spy", "linestyle")
+            ret = mlines.Line2D(
+                x, y, linestyle='None', marker=marker, markersize=markersize,
+                **kwargs)
+            self.add_line(ret)
+            nr, nc = Z.shape
+            self.set_xlim(-0.5, nc - 0.5)
+            if origin == "upper":
+                self.set_ylim(nr - 0.5, -0.5)
+            else:
+                self.set_ylim(-0.5, nr - 0.5)
+            self.set_aspect(aspect)
+        self.title.set_y(1.05)
+        if origin == "upper":
+            self.xaxis.tick_top()
+        else:  # lower
+            self.xaxis.tick_bottom()
+        self.xaxis.set_ticks_position('both')
+        self.xaxis.set_major_locator(
+            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
+        self.yaxis.set_major_locator(
+            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
+        return ret
+
+    def matshow(self, Z, **kwargs):
+        """
+        Plot the values of a 2D matrix or array as color-coded image.
+
+        The matrix will be shown the way it would be printed, with the first
+        row at the top.  Row and column numbering is zero-based.
+
+        Parameters
+        ----------
+        Z : (M, N) array-like
+            The matrix to be displayed.
+
+        Returns
+        -------
+        `~matplotlib.image.AxesImage`
+
+        Other Parameters
+        ----------------
+        **kwargs : `~matplotlib.axes.Axes.imshow` arguments
+
+        See Also
+        --------
+        imshow : More general function to plot data on a 2D regular raster.
+
+        Notes
+        -----
+        This is just a convenience function wrapping `.imshow` to set useful
+        defaults for displaying a matrix. In particular:
+
+        - Set ``origin='upper'``.
+        - Set ``interpolation='nearest'``.
+        - Set ``aspect='equal'``.
+        - Ticks are placed to the left and above.
+        - Ticks are formatted to show integer indices.
+
+        """
+        Z = np.asanyarray(Z)
+        kw = {'origin': 'upper',
+              'interpolation': 'nearest',
+              'aspect': 'equal',          # (already the imshow default)
+              **kwargs}
+        im = self.imshow(Z, **kw)
+        self.title.set_y(1.05)
+        self.xaxis.tick_top()
+        self.xaxis.set_ticks_position('both')
+        self.xaxis.set_major_locator(
+            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
+        self.yaxis.set_major_locator(
+            mticker.MaxNLocator(nbins=9, steps=[1, 2, 5, 10], integer=True))
+        return im
+
+    @_api.make_keyword_only("3.9", "vert")
+    @_preprocess_data(replace_names=["dataset"])
+    def violinplot(self, dataset, positions=None, vert=None,
+                   orientation='vertical', widths=0.5, showmeans=False,
+                   showextrema=True, showmedians=False, quantiles=None,
+                   points=100, bw_method=None, side='both',):
+        """
+        Make a violin plot.
+
+        Make a violin plot for each column of *dataset* or each vector in
+        sequence *dataset*.  Each filled area extends to represent the
+        entire data range, with optional lines at the mean, the median,
+        the minimum, the maximum, and user-specified quantiles.
+
+        Parameters
+        ----------
+        dataset : Array or a sequence of vectors.
+            The input data.
+
+        positions : array-like, default: [1, 2, ..., n]
+            The positions of the violins; i.e. coordinates on the x-axis for
+            vertical violins (or y-axis for horizontal violins).
+
+        vert : bool, optional
+            .. deprecated:: 3.10
+                Use *orientation* instead.
+
+                If this is given during the deprecation period, it overrides
+                the *orientation* parameter.
+
+            If True, plots the violins vertically.
+            If False, plots the violins horizontally.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            If 'horizontal', plots the violins horizontally.
+            Otherwise, plots the violins vertically.
+
+            .. versionadded:: 3.10
+
+        widths : float or array-like, default: 0.5
+            The maximum width of each violin in units of the *positions* axis.
+            The default is 0.5, which is half the available space when using default
+            *positions*.
+
+        showmeans : bool, default: False
+            Whether to show the mean with a line.
+
+        showextrema : bool, default: True
+            Whether to show extrema with a line.
+
+        showmedians : bool, default: False
+            Whether to show the median with a line.
+
+        quantiles : array-like, default: None
+            If not None, set a list of floats in interval [0, 1] for each violin,
+            which stands for the quantiles that will be rendered for that
+            violin.
+
+        points : int, default: 100
+            The number of points to evaluate each of the gaussian kernel density
+            estimations at.
+
+        bw_method : {'scott', 'silverman'} or float or callable, default: 'scott'
+            The method used to calculate the estimator bandwidth.  If a
+            float, this will be used directly as `kde.factor`.  If a
+            callable, it should take a `matplotlib.mlab.GaussianKDE` instance as
+            its only parameter and return a float.
+
+        side : {'both', 'low', 'high'}, default: 'both'
+            'both' plots standard violins. 'low'/'high' only
+            plots the side below/above the positions value.
+
+        data : indexable object, optional
+            DATA_PARAMETER_PLACEHOLDER
+
+        Returns
+        -------
+        dict
+            A dictionary mapping each component of the violinplot to a
+            list of the corresponding collection instances created. The
+            dictionary has the following keys:
+
+            - ``bodies``: A list of the `~.collections.PolyCollection`
+              instances containing the filled area of each violin.
+
+            - ``cmeans``: A `~.collections.LineCollection` instance that marks
+              the mean values of each of the violin's distribution.
+
+            - ``cmins``: A `~.collections.LineCollection` instance that marks
+              the bottom of each violin's distribution.
+
+            - ``cmaxes``: A `~.collections.LineCollection` instance that marks
+              the top of each violin's distribution.
+
+            - ``cbars``: A `~.collections.LineCollection` instance that marks
+              the centers of each violin's distribution.
+
+            - ``cmedians``: A `~.collections.LineCollection` instance that
+              marks the median values of each of the violin's distribution.
+
+            - ``cquantiles``: A `~.collections.LineCollection` instance created
+              to identify the quantile values of each of the violin's
+              distribution.
+
+        See Also
+        --------
+        .Axes.violin : Draw a violin from pre-computed statistics.
+        boxplot : Draw a box and whisker plot.
+        """
+
+        def _kde_method(X, coords):
+            # Unpack in case of e.g. Pandas or xarray object
+            X = cbook._unpack_to_numpy(X)
+            # fallback gracefully if the vector contains only one value
+            if np.all(X[0] == X):
+                return (X[0] == coords).astype(float)
+            kde = mlab.GaussianKDE(X, bw_method)
+            return kde.evaluate(coords)
+
+        vpstats = cbook.violin_stats(dataset, _kde_method, points=points,
+                                     quantiles=quantiles)
+        return self.violin(vpstats, positions=positions, vert=vert,
+                           orientation=orientation, widths=widths,
+                           showmeans=showmeans, showextrema=showextrema,
+                           showmedians=showmedians, side=side)
+
+    @_api.make_keyword_only("3.9", "vert")
+    def violin(self, vpstats, positions=None, vert=None,
+               orientation='vertical', widths=0.5, showmeans=False,
+               showextrema=True, showmedians=False, side='both'):
+        """
+        Draw a violin plot from pre-computed statistics.
+
+        Draw a violin plot for each column of *vpstats*. Each filled area
+        extends to represent the entire data range, with optional lines at the
+        mean, the median, the minimum, the maximum, and the quantiles values.
+
+        Parameters
+        ----------
+        vpstats : list of dicts
+            A list of dictionaries containing stats for each violin plot.
+            Required keys are:
+
+            - ``coords``: A list of scalars containing the coordinates that
+              the violin's kernel density estimate were evaluated at.
+
+            - ``vals``: A list of scalars containing the values of the
+              kernel density estimate at each of the coordinates given
+              in *coords*.
+
+            - ``mean``: The mean value for this violin's dataset.
+
+            - ``median``: The median value for this violin's dataset.
+
+            - ``min``: The minimum value for this violin's dataset.
+
+            - ``max``: The maximum value for this violin's dataset.
+
+            Optional keys are:
+
+            - ``quantiles``: A list of scalars containing the quantile values
+              for this violin's dataset.
+
+        positions : array-like, default: [1, 2, ..., n]
+            The positions of the violins; i.e. coordinates on the x-axis for
+            vertical violins (or y-axis for horizontal violins).
+
+        vert : bool, optional
+            .. deprecated:: 3.10
+                Use *orientation* instead.
+
+                If this is given during the deprecation period, it overrides
+                the *orientation* parameter.
+
+            If True, plots the violins vertically.
+            If False, plots the violins horizontally.
+
+        orientation : {'vertical', 'horizontal'}, default: 'vertical'
+            If 'horizontal', plots the violins horizontally.
+            Otherwise, plots the violins vertically.
+
+            .. versionadded:: 3.10
+
+        widths : float or array-like, default: 0.5
+            The maximum width of each violin in units of the *positions* axis.
+            The default is 0.5, which is half available space when using default
+            *positions*.
+
+        showmeans : bool, default: False
+            Whether to show the mean with a line.
+
+        showextrema : bool, default: True
+            Whether to show extrema with a line.
+
+        showmedians : bool, default: False
+            Whether to show the median with a line.
+
+        side : {'both', 'low', 'high'}, default: 'both'
+            'both' plots standard violins. 'low'/'high' only
+            plots the side below/above the positions value.
+
+        Returns
+        -------
+        dict
+            A dictionary mapping each component of the violinplot to a
+            list of the corresponding collection instances created. The
+            dictionary has the following keys:
+
+            - ``bodies``: A list of the `~.collections.PolyCollection`
+              instances containing the filled area of each violin.
+
+            - ``cmeans``: A `~.collections.LineCollection` instance that marks
+              the mean values of each of the violin's distribution.
+
+            - ``cmins``: A `~.collections.LineCollection` instance that marks
+              the bottom of each violin's distribution.
+
+            - ``cmaxes``: A `~.collections.LineCollection` instance that marks
+              the top of each violin's distribution.
+
+            - ``cbars``: A `~.collections.LineCollection` instance that marks
+              the centers of each violin's distribution.
+
+            - ``cmedians``: A `~.collections.LineCollection` instance that
+              marks the median values of each of the violin's distribution.
+
+            - ``cquantiles``: A `~.collections.LineCollection` instance created
+              to identify the quantiles values of each of the violin's
+              distribution.
+
+        See Also
+        --------
+        violinplot :
+            Draw a violin plot from data instead of pre-computed statistics.
+        """
+
+        # Statistical quantities to be plotted on the violins
+        means = []
+        mins = []
+        maxes = []
+        medians = []
+        quantiles = []
+
+        qlens = []  # Number of quantiles in each dataset.
+
+        artists = {}  # Collections to be returned
+
+        N = len(vpstats)
+        datashape_message = ("List of violinplot statistics and `{0}` "
+                             "values must have the same length")
+
+        # vert and orientation parameters are linked until vert's
+        # deprecation period expires. If both are selected,
+        # vert takes precedence.
+        if vert is not None:
+            _api.warn_deprecated(
+                "3.10",
+                name="vert: bool",
+                alternative="orientation: {'vertical', 'horizontal'}"
+                )
+            orientation = 'vertical' if vert else 'horizontal'
+        _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
+
+        # Validate positions
+        if positions is None:
+            positions = range(1, N + 1)
+        elif len(positions) != N:
+            raise ValueError(datashape_message.format("positions"))
+
+        # Validate widths
+        if np.isscalar(widths):
+            widths = [widths] * N
+        elif len(widths) != N:
+            raise ValueError(datashape_message.format("widths"))
+
+        # Validate side
+        _api.check_in_list(["both", "low", "high"], side=side)
+
+        # Calculate ranges for statistics lines (shape (2, N)).
+        line_ends = [[-0.25 if side in ['both', 'low'] else 0],
+                     [0.25 if side in ['both', 'high'] else 0]] \
+                          * np.array(widths) + positions
+
+        # Colors.
+        if mpl.rcParams['_internal.classic_mode']:
+            fillcolor = 'y'
+            linecolor = 'r'
+        else:
+            fillcolor = linecolor = self._get_lines.get_next_color()
+
+        # Check whether we are rendering vertically or horizontally
+        if orientation == 'vertical':
+            fill = self.fill_betweenx
+            if side in ['low', 'high']:
+                perp_lines = functools.partial(self.hlines, colors=linecolor,
+                                                capstyle='projecting')
+                par_lines = functools.partial(self.vlines, colors=linecolor,
+                                                capstyle='projecting')
+            else:
+                perp_lines = functools.partial(self.hlines, colors=linecolor)
+                par_lines = functools.partial(self.vlines, colors=linecolor)
+        else:
+            fill = self.fill_between
+            if side in ['low', 'high']:
+                perp_lines = functools.partial(self.vlines, colors=linecolor,
+                                                capstyle='projecting')
+                par_lines = functools.partial(self.hlines, colors=linecolor,
+                                                capstyle='projecting')
+            else:
+                perp_lines = functools.partial(self.vlines, colors=linecolor)
+                par_lines = functools.partial(self.hlines, colors=linecolor)
+
+        # Render violins
+        bodies = []
+        for stats, pos, width in zip(vpstats, positions, widths):
+            # The 0.5 factor reflects the fact that we plot from v-p to v+p.
+            vals = np.array(stats['vals'])
+            vals = 0.5 * width * vals / vals.max()
+            bodies += [fill(stats['coords'],
+                            -vals + pos if side in ['both', 'low'] else pos,
+                            vals + pos if side in ['both', 'high'] else pos,
+                            facecolor=fillcolor, alpha=0.3)]
+            means.append(stats['mean'])
+            mins.append(stats['min'])
+            maxes.append(stats['max'])
+            medians.append(stats['median'])
+            q = stats.get('quantiles')  # a list of floats, or None
+            if q is None:
+                q = []
+            quantiles.extend(q)
+            qlens.append(len(q))
+        artists['bodies'] = bodies
+
+        if showmeans:  # Render means
+            artists['cmeans'] = perp_lines(means, *line_ends)
+        if showextrema:  # Render extrema
+            artists['cmaxes'] = perp_lines(maxes, *line_ends)
+            artists['cmins'] = perp_lines(mins, *line_ends)
+            artists['cbars'] = par_lines(positions, mins, maxes)
+        if showmedians:  # Render medians
+            artists['cmedians'] = perp_lines(medians, *line_ends)
+        if quantiles:  # Render quantiles: each width is repeated qlen times.
+            artists['cquantiles'] = perp_lines(
+                quantiles, *np.repeat(line_ends, qlens, axis=1))
+
+        return artists
+
+    # Methods that are entirely implemented in other modules.
+
+    table = _make_axes_method(mtable.table)
+
+    # args can be either Y or y1, y2, ... and all should be replaced
+    stackplot = _preprocess_data()(_make_axes_method(mstack.stackplot))
+
+    streamplot = _preprocess_data(
+            replace_names=["x", "y", "u", "v", "start_points"])(
+        _make_axes_method(mstream.streamplot))
+
+    tricontour = _make_axes_method(mtri.tricontour)
+    tricontourf = _make_axes_method(mtri.tricontourf)
+    tripcolor = _make_axes_method(mtri.tripcolor)
+    triplot = _make_axes_method(mtri.triplot)
+
+    def _get_aspect_ratio(self):
+        """
+        Convenience method to calculate the aspect ratio of the Axes in
+        the display coordinate system.
+        """
+        figure_size = self.get_figure().get_size_inches()
+        ll, ur = self.get_position() * figure_size
+        width, height = ur - ll
+        return height / (width * self.get_data_ratio())

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2426,10 +2426,12 @@ class Axes(_AxesBase):
         Other Parameters
         ----------------
         color : :mpltype:`color` or list of :mpltype:`color`, optional
-            The colors of the bar faces.
+            The colors of the bar faces. This is an alias for *facecolor*.
+            If both are given, *facecolor* takes precedence.
 
         facecolor : :mpltype:`color` or list of :mpltype:`color`, optional
             The colors of the bar faces.
+            If both *color* and *facecolor are given, *facecolor* takes precedence.
 
         edgecolor : :mpltype:`color` or list of :mpltype:`color`, optional
             The colors of the bar edges.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2320,9 +2320,8 @@ class Axes(_AxesBase):
             # we do by default and convert dx by itself.
             dx = convert(dx)
         return dx
-    
-    @staticmethod
-    def _parse_bar_color_args(kwargs, get_next_color_func):
+
+    def _parse_bar_color_args(self, kwargs):
         """
         Helper function to process color-related arguments of `.Axes.bar`.
 
@@ -2330,7 +2329,7 @@ class Axes(_AxesBase):
 
         - kwargs['facecolor']
         - kwargs['color']
-        - 'b' if in classic mode else the result of ``get_next_color_func()``
+        - 'Result of ``self._get_patches_for_fill.get_next_color``
 
         Argument precedence for edgecolors:
 
@@ -2340,13 +2339,13 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
+        self : Axes
+
         kwargs : dict
             Additional kwargs. If these keys exist, we pop and process them:
             'facecolor', 'edgecolor', 'color'
             Note: The dict is modified by this function.
-        get_next_color_func : callable
-            A callable that returns a color. This color is used as facecolor
-            if no other color is provided.
+
 
         Returns
         -------
@@ -2361,18 +2360,18 @@ class Axes(_AxesBase):
         edgecolor = kwargs.pop('edgecolor', color)
 
         facecolor = (facecolor if facecolor is not None
-                 else "b" if mpl.rcParams['_internal.classic_mode']
-                 else get_next_color_func())
-        
+                     else self._get_patches_for_fill.get_next_color())
+
         try:
             facecolor = mcolors.to_rgba_array(facecolor)
         except ValueError as err:
             raise ValueError(
-                "'facecolor' or 'color' argument must be a valid color or sequence of colors."
+                "'facecolor' or 'color' argument must be a valid color or"
+                    "sequence of colors."
             ) from err
 
         return facecolor, edgecolor
-    
+
     @_preprocess_data()
     @_docstring.interpd
     def bar(self, x, height, width=0.8, bottom=None, *, align="center",
@@ -2496,8 +2495,8 @@ class Axes(_AxesBase):
         bar. See :doc:`/gallery/lines_bars_and_markers/bar_stacked`.
         """
         kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
-        color, edgecolor = self._parse_bar_color_args(kwargs, self._get_patches_for_fill.get_next_color)
-        
+        color, edgecolor = self._parse_bar_color_args(kwargs)
+
         linewidth = kwargs.pop('linewidth', None)
         hatch = kwargs.pop('hatch', None)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9456,31 +9456,24 @@ def test_wrong_use_colorizer():
 
 def test_bar_color_precedence():
     # Test the precedence of 'color' and 'facecolor' in bar plots
-    to_rgba = mcolors.to_rgba
     fig, ax = plt.subplots()
 
-    # Case 1: Only 'color'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red')
-    for bar in bars:
-        assert to_rgba(bar.get_facecolor()) == to_rgba('red')
-
-    ax.cla()
-
-    # Case 2: Only 'facecolor'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], facecolor='blue')
-    for bar in bars:
-        assert to_rgba(bar.get_facecolor()) == to_rgba('blue')
-
-    ax.cla()
-
-    # Case 2: 'facecolor' and 'color'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red', facecolor='green')
-    for bar in bars:
-        assert to_rgba(bar.get_facecolor()) == to_rgba('green')
-
-    ax.cla()
-
-    # Case 4: None
+    # case 1: no color specified
     bars = ax.bar([1, 2, 3], [4, 5, 6])
     for bar in bars:
-        assert to_rgba(bar.get_facecolor()) == to_rgba('blue')
+        assert mcolors.same_color(bar.get_facecolor(), 'blue')
+
+    # case 2: Only 'color'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red')
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'red')
+
+    # case 3: Only 'facecolor'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], facecolor='blue')
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'blue')
+
+    # case 4: 'facecolor' and 'color'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red', facecolor='green')
+    for bar in bars:
+        assert mcolors.same_color(bar.get_facecolor(), 'green')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9469,9 +9469,9 @@ def test_bar_color_precedence():
         assert mcolors.same_color(bar.get_facecolor(), 'red')
 
     # case 3: Only 'facecolor'
-    bars = ax.bar([21, 22, 23], [4, 5, 6], facecolor='blue')
+    bars = ax.bar([21, 22, 23], [4, 5, 6], facecolor='yellow')
     for bar in bars:
-        assert mcolors.same_color(bar.get_facecolor(), 'blue')
+        assert mcolors.same_color(bar.get_facecolor(), 'yellow')
 
     # case 4: 'facecolor' and 'color'
     bars = ax.bar([31, 32, 33], [4, 5, 6], color='red', facecolor='green')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2200,7 +2200,7 @@ def test_bar_hatches(fig_test, fig_ref):
     y = [2, 3]
     hatches = ['x', 'o']
     for i in range(2):
-        ax_ref.bar(x[i], y[i], facecolor='C0', hatch=hatches[i])
+        ax_ref.bar(x[i], y[i], color='C0', hatch=hatches[i])
 
     ax_test.bar(x, y, hatch=hatches)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9469,11 +9469,11 @@ def test_bar_color_precedence():
         assert mcolors.same_color(bar.get_facecolor(), 'red')
 
     # case 3: Only 'facecolor'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], facecolor='blue')
+    bars = ax.bar([21, 22, 23], [4, 5, 6], facecolor='blue')
     for bar in bars:
         assert mcolors.same_color(bar.get_facecolor(), 'blue')
 
     # case 4: 'facecolor' and 'color'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red', facecolor='green')
+    bars = ax.bar([31, 32, 33], [4, 5, 6], color='red', facecolor='green')
     for bar in bars:
         assert mcolors.same_color(bar.get_facecolor(), 'green')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2200,7 +2200,7 @@ def test_bar_hatches(fig_test, fig_ref):
     y = [2, 3]
     hatches = ['x', 'o']
     for i in range(2):
-        ax_ref.bar(x[i], y[i], color='C0', hatch=hatches[i])
+        ax_ref.bar(x[i], y[i], facecolor='C0', hatch=hatches[i])
 
     ax_test.bar(x, y, hatch=hatches)
 
@@ -9452,3 +9452,35 @@ def test_wrong_use_colorizer():
     for kwrd in kwrds:
         with pytest.raises(ValueError, match=match_str):
             fig.figimage(c, colorizer=cl, **kwrd)
+
+
+def test_bar_color_precedence():
+    # Test the precedence of 'color' and 'facecolor' in bar plots
+    to_rgba = mcolors.to_rgba
+    fig, ax = plt.subplots()
+
+    # Case 1: Only 'color'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red')
+    for bar in bars:
+        assert to_rgba(bar.get_facecolor()) == to_rgba('red')
+
+    ax.cla()
+
+    # Case 2: Only 'facecolor'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], facecolor='blue')
+    for bar in bars:
+        assert to_rgba(bar.get_facecolor()) == to_rgba('blue')
+
+    ax.cla()
+
+    # Case 2: 'facecolor' and 'color'
+    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red', facecolor='green')
+    for bar in bars:
+        assert to_rgba(bar.get_facecolor()) == to_rgba('green')
+
+    ax.cla()
+
+    # Case 4: None
+    bars = ax.bar([1, 2, 3], [4, 5, 6])
+    for bar in bars:
+        assert to_rgba(bar.get_facecolor()) == to_rgba('blue')

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9464,7 +9464,7 @@ def test_bar_color_precedence():
         assert mcolors.same_color(bar.get_facecolor(), 'blue')
 
     # case 2: Only 'color'
-    bars = ax.bar([1, 2, 3], [4, 5, 6], color='red')
+    bars = ax.bar([11, 12, 13], [4, 5, 6], color='red')
     for bar in bars:
         assert mcolors.same_color(bar.get_facecolor(), 'red')
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
This PR introduces the `_parse_bar_color_args function`, which provides consistency in color bar arguments by establishing a parameter precedence, "similar" to the one used in `scatter`:

facecolor: facecolor -> color -> 'b' if in classic mode else the result of `get_next_color_func()`

edgecolor: edgecolor -> color -> None

This ensures that when edgecolors is not explicitly defined, it tries color. Additionally, this change allows facecolor to accept sequences of colors, ensuring consistency in argument handling, as issued in #29090. The tests are consistent with examples in #29072.

**Examples:**

- `plt.bar([1, 2, 3], [1, 2, 3], color=['none', 'C2', 'none'], edgecolor=['C1', 'C2', 'C3'])`
![Figure_1](https://github.com/user-attachments/assets/39a484d3-b698-46cf-a8c5-b3e381bde1b2)
 
- `plt.bar([1, 2, 3], [1, 2, 3], color=['none', 'C2', 'none'])`
![Figure_2](https://github.com/user-attachments/assets/2f827727-2f20-4d22-9e4b-34cef9cfe7a8)

- `plt.bar([1, 2, 3], [1, 2, 3])
`![Figure_3](https://github.com/user-attachments/assets/8c80e5b1-0e89-4c39-abc7-e8bbc82428b8)

- `plt.bar([1, 2, 3], [1, 2, 3],facecolor=('none', 'C2', 'none'))`
![Figure_4](https://github.com/user-attachments/assets/25be5c66-6ccf-4aa0-9e56-dd73b0e00f6c)

- `plt.bar([1, 2, 3], [1, 2, 3], color=('C1', 'C2', 'C3'), facecolor=('none', 'C2', 'none'))`
![Figure_5](https://github.com/user-attachments/assets/81893f8c-8ddb-4c17-8a4f-d22c3cc82cfb)



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #29090" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
