### PR TITLE
MNT: Temporarily skip failing test to unbreak CI

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -241,6 +241,9 @@ def test_interactive_backend(env, toolbar):
             pytest.skip("toolmanager is not implemented for macosx.")
     if env["MPLBACKEND"] == "wx":
         pytest.skip("wx backend is deprecated; tests failed on appveyor")
+    if env["MPLBACKEND"] == "wxagg" and toolbar == "toolmanager":
+        pytest.skip("Temporarily deactivated: show() changes figure height "
+                    "and thus fails the test")
     try:
         proc = _run_helper(
             _test_interactive_impl,


### PR DESCRIPTION
Works around the failure #29129. A proper analysis and resolution is still needed.
