### PR TITLE
Enable Awkward Array Support in _unpack_to_numpy for Improved Array-like Compatibility

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2341,6 +2341,10 @@ def _is_tensorflow_array(x):
 
 def _unpack_to_numpy(x):
     """Internal helper to extract data from e.g. pandas and xarray objects."""
+     if isinstance(x, ak.Array):
+        # Normalize irregular akward arrays in 1D numpy array
+        xtmp = ak.to_numpy(ak.flatten(x))
+        return xtmp
     if isinstance(x, np.ndarray):
         # If numpy, return directly
         return x


### PR DESCRIPTION
PR Summary

Why is this change necessary?
The _unpack_to_numpy function currently supports a range of array-like objects but does not account for the awkward.Array type, which is widely used for data with irregular or nested structures. This change makes it easier for users to visualize data stored in awkward.Arrays without needing manual conversions, especially useful when subarray lengths vary.

What problem does it solve?
This PR modifies _unpack_to_numpy to recognize and handle awkward.Arrays, flattening them and converting them to numpy.ndarray format for direct compatibility with Matplotlib’s plotting functions. It addresses compatibility issues and prevents errors when attempting to plot irregular arrays.

Reasoning for Implementation
The enhancement involves:

1.Detecting if the input array is an awkward.Array.
2.Flattening nested or non-uniform awkward.Arrays using ak.flatten.
3.Converting the result to numpy.ndarray via ak.to_numpy().

This maintains backward compatibility and aligns with existing helper functions that aim to standardize various array-like formats for Matplotlib.

PR Checklist

- "closes #22879" 
- New and changed code is teste
- New Features and API Changes are noted with a directive and release note
