### PR TITLE
Uptade fix number of levels with log contour

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -960,13 +960,12 @@ class ContourSet(ContourLabeler, mcoll.Collection):
             label.set_color(self.labelMappable.to_rgba(cv))
         super().changed()
 
-    def _autolev(self, N):
+    def _autolev(self, N, *, using_default):
         """
         Select contour levels to span the data.
-
         The target number of levels, *N*, is used only when the
-        scale is not log and default locator is used.
-
+        locator is not set and the scale is log or the default
+        locator is used.
         We need two more levels for filled contours than for
         line contours, because for the latter we need to specify
         the lower and upper boundary of each range. For example,
@@ -976,7 +975,12 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         """
         if self.locator is None:
             if self.logscale:
-                self.locator = ticker.LogLocator()
+                if using_default:
+                    # Let log locator choose instead of using hard coded value
+                    # set in self._process_contour_level_args()
+                    self.locator = ticker.LogLocator()
+                else:
+                    self.locator = ticker.LogLocator(numticks=N)
             else:
                 self.locator = ticker.MaxNLocator(N + 1, min_n_ticks=1)
 
@@ -993,13 +997,24 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         i0 = under[-1] if len(under) else 0
         over = np.nonzero(lev > self.zmax)[0]
         i1 = over[0] + 1 if len(over) else len(lev)
+
         if self.extend in ('min', 'both'):
             i0 += 1
         if self.extend in ('max', 'both'):
             i1 -= 1
 
+        # Ensure at least 3 levels and handle log scale specifically
         if i1 - i0 < 3:
             i0, i1 = 0, len(lev)
+
+        # Handle log scale adjustments if levels are still insufficient
+        if self.logscale and len(lev) < N:
+            self.locator = ticker.LogLocator(numticks=N+1)
+            lev = self.locator.tick_values(self.zmin, self.zmax)
+            under = np.nonzero(lev < self.zmin)[0]
+            i0 = under[-1] if len(under) else 0
+            over = np.nonzero(lev > self.zmax)[0]
+            i1 = over[0] + 1 if len(over) else len(lev)
 
         return lev[i0:i1]
 
@@ -1020,7 +1035,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         else:
             levels_arg = self.levels
         if isinstance(levels_arg, Integral):
-            self.levels = self._autolev(levels_arg)
+            self.levels = self._autolev(levels_arg, using_default=self.levels is None)
         else:
             self.levels = np.asarray(levels_arg, np.float64)
         if self.filled and len(self.levels) < 2:


### PR DESCRIPTION
## PR summary
By passing an integer value in the levels argument to specify the maximum number of contour levels, the program didn't always respect this limit in practice.
Adjusts the behavior so that the number of contour levels is generated as requested, even when using a logarithmic scale.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
