### PR TITLE
Simplify synthetic event generation in interactive pan/zoom tests.

### DIFF
--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -540,18 +540,7 @@ def test_interactive_pan_zoom_events(tool, button, patch_vis, forward_nav, t_s):
                 ylim_b = init_ylim
 
         tb.zoom()
-        tb.press_zoom(start_event)
-        tb.drag_zoom(drag_event)
-        tb.release_zoom(stop_event)
 
-        assert ax_t.get_xlim() == pytest.approx(xlim_t, abs=0.15)
-        assert ax_t.get_ylim() == pytest.approx(ylim_t, abs=0.15)
-        assert ax_b.get_xlim() == pytest.approx(xlim_b, abs=0.15)
-        assert ax_b.get_ylim() == pytest.approx(ylim_b, abs=0.15)
-
-        # Check if twin-axes are properly triggered
-        assert ax_t.get_xlim() == pytest.approx(ax_t_twin.get_xlim(), abs=0.15)
-        assert ax_b.get_xlim() == pytest.approx(ax_b_twin.get_xlim(), abs=0.15)
     else:
         # Evaluate expected limits
         # (call start_pan to make sure ax._pan_start is set)
@@ -576,15 +565,16 @@ def test_interactive_pan_zoom_events(tool, button, patch_vis, forward_nav, t_s):
                 ylim_b = init_ylim
 
         tb.pan()
-        tb.press_pan(start_event)
-        tb.drag_pan(drag_event)
-        tb.release_pan(stop_event)
 
-        assert ax_t.get_xlim() == pytest.approx(xlim_t, abs=0.15)
-        assert ax_t.get_ylim() == pytest.approx(ylim_t, abs=0.15)
-        assert ax_b.get_xlim() == pytest.approx(xlim_b, abs=0.15)
-        assert ax_b.get_ylim() == pytest.approx(ylim_b, abs=0.15)
+    start_event._process()
+    drag_event._process()
+    stop_event._process()
 
-        # Check if twin-axes are properly triggered
-        assert ax_t.get_xlim() == pytest.approx(ax_t_twin.get_xlim(), abs=0.15)
-        assert ax_b.get_xlim() == pytest.approx(ax_b_twin.get_xlim(), abs=0.15)
+    assert ax_t.get_xlim() == pytest.approx(xlim_t, abs=0.15)
+    assert ax_t.get_ylim() == pytest.approx(ylim_t, abs=0.15)
+    assert ax_b.get_xlim() == pytest.approx(xlim_b, abs=0.15)
+    assert ax_b.get_ylim() == pytest.approx(ylim_b, abs=0.15)
+
+    # Check if twin-axes are properly triggered
+    assert ax_t.get_xlim() == pytest.approx(ax_t_twin.get_xlim(), abs=0.15)
+    assert ax_b.get_xlim() == pytest.approx(ax_b_twin.get_xlim(), abs=0.15)

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2138,14 +2138,12 @@ def test_toolbar_zoom_pan(tool, button, key, expected):
     tb = NavigationToolbar2(fig.canvas)
     if tool == "zoom":
         tb.zoom()
-        tb.press_zoom(start_event)
-        tb.drag_zoom(drag_event)
-        tb.release_zoom(stop_event)
     else:
         tb.pan()
-        tb.press_pan(start_event)
-        tb.drag_pan(drag_event)
-        tb.release_pan(stop_event)
+
+    start_event._process()
+    drag_event._process()
+    stop_event._process()
 
     # Should be close, but won't be exact due to screen integer resolution
     xlim, ylim, zlim = expected


### PR DESCRIPTION
The same events can be indiscriminately sent to test panning and zooming, and just calling _process() on the events actually tests a bigger part of the pipeline than calling specifically {press,drag,release}_{pan,zoom}.

Followup to #29066.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
