### PR TITLE
Don't fail on equal-but-differently-named cmaps in qt figureoptions.

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -149,7 +149,7 @@ def figure_edit(axes, parent=None):
     cmaps = [(cmap, name) for name, cmap in sorted(cm._colormaps.items())]
     for label, mappable in labeled_mappables:
         cmap = mappable.get_cmap()
-        if cmap not in cm._colormaps.values():
+        if cmap.name not in cm._colormaps:
             cmaps = [(cmap, cmap.name), *cmaps]
         low, high = mappable.get_clim()
         mappabledata = [


### PR DESCRIPTION
Currently, opening the Qt figureoptions UI for an image whose cmap is not registered in the colormap registry, has a name not matching any registry entry, but is actually equal (`==`, i.e. has the same LUT and colorbar-extension attributes) to a registry entry, leads to an error. A typical example would be
```
import cmap, pylab as p  # third-party
p.imshow([[0, 1]], cmap=cmap.Colormap("bids:magma").to_mpl())
```
and opening the qt figure options; this leads to the error "index 'bids:magma' is invalid ...".

Note that if the cmap is different from any registered cmap then we already add it to the UI combobox (try e.g. `cmap=cmap.Colormap("imagej:fire")`); the only problem was if it was equal to a registered cmap (this arises because when the code was originally written, cmap instance equality was by identity, not by comparing LUTs, so the `cmap not in cm._colormaps.values()` check behaved differently).

Fix that by checking whether the colormap *name* is registered.  The behavior is still ill-defined in the opposite (theoretical) case of an unregistered cmap different from any registered cmap but with a matching name, but I'd argue that case is more pathological.

Test by running the above code and opening the qt figureoptions.

(aka how some code I wrote 9 years ago (#5469, a bit scary it's been that long) got broken by some code written 5.5 years later (#20227), and how to fix that with a one-line patch with 20 lines of explanation.  I guess that's technically a regression :-))

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
