### PR TITLE
ENH: introduce wedge_labels parameter for `pie`

### DIFF
--- a/doc/api/next_api_changes/deprecations/29152_REC.rst
+++ b/doc/api/next_api_changes/deprecations/29152_REC.rst
@@ -1,0 +1,13 @@
+``pie`` *labels* and *labeldistance* parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Currently the *labels* parameter of `~.Axes.pie` is used both for annotating the
+pie wedges directly, and for automatic legend entries.  For consistency
+with other plotting methods, in future *labels* will only be used for the legend.
+
+The *labeldistance* parameter will therefore default to ``None`` from Matplotlib
+3.14, when it will also be deprecated and then removed in Matplotlib 3.16.  To
+preserve the existing behavior for now, set ``labeldistance=1.1``.  For the longer
+term, to place labels on the wedges use the new *wedge_labels* and
+*wedge_label_distance* parameters of `~.Axes.pie` or the `~.Axes.pie_label` method.
+Note that `~.Axes.pie_label` allows for more customization of the label positions via
+the *rotate* and *alignment* parameters as well as *distance*.

--- a/doc/release/next_whats_new/pie_wedge_labels.rst
+++ b/doc/release/next_whats_new/pie_wedge_labels.rst
@@ -1,0 +1,26 @@
+New *wedge_labels* parameter for pie
+------------------------------------
+
+`~.Axes.pie` now accepts a *wedge_labels* parameter as a shortcut to the
+`~.Axes.pie_label` method. This may be used for simple annotation of the wedges
+of the pie chart.  It can take
+
+* a list of strings, similar to the existing *labels* parameter
+* a format string similar to the existing *autopct* parameter, except that it
+  uses the `str.format` method and it can handle absolute values as well as
+  fractions/percentages
+
+*wedge_labels* has an accompanying *wedge_label_distance* parameter, to control
+the distance of the labels from the center of the pie.
+
+
+.. plot::
+    :include-source: true
+    :alt: Two pie charts.  The chart on the left has labels 'foo' and 'bar' outside the wedges.  The chart on the right has labels '1' and '2' inside the wedges.
+
+    import matplotlib.pyplot as plt
+
+    fig, (ax1, ax2) = plt.subplots(ncols=2, layout='constrained')
+
+    ax1.pie([1, 2], wedge_labels=['foo', 'bar'], wedge_label_distance=1.1)
+    ax2.pie([1, 2], wedge_labels='{absval:d}', wedge_label_distance=0.6)

--- a/galleries/examples/misc/svg_filter_pie.py
+++ b/galleries/examples/misc/svg_filter_pie.py
@@ -28,11 +28,11 @@ explode = (0, 0.05, 0, 0)
 
 # We want to draw the shadow for each pie, but we will not use "shadow"
 # option as it doesn't save the references to the shadow patches.
-pie = ax.pie(fracs, explode=explode, labels=labels, autopct='%1.1f%%')
+pie = ax.pie(fracs, explode=explode, wedge_labels=labels, wedge_label_distance=1.1)
 
-for w in pie.wedges:
+for w, label in zip(pie.wedges, labels):
     # set the id with the label.
-    w.set_gid(w.get_label())
+    w.set_gid(label)
 
     # we don't want to draw the edge of the pie
     w.set_edgecolor("none")

--- a/galleries/examples/pie_and_polar_charts/bar_of_pie.py
+++ b/galleries/examples/pie_and_polar_charts/bar_of_pie.py
@@ -25,8 +25,11 @@ labels = ['Approve', 'Disapprove', 'Undecided']
 explode = [0.1, 0, 0]
 # rotate so that first wedge is split by the x-axis
 angle = -180 * overall_ratios[0]
-pie = ax1.pie(overall_ratios, autopct='%1.1f%%', startangle=angle,
-              labels=labels, explode=explode)
+pie = ax1.pie(overall_ratios, startangle=angle, explode=explode)
+
+# label the wedges with our label strings and the ratios as percentages
+ax1.pie_label(pie, labels, distance=1.1)
+ax1.pie_label(pie, '{frac:.1%}', distance=0.6)
 
 # bar chart parameters
 age_ratios = [.33, .54, .07, .06]

--- a/galleries/examples/pie_and_polar_charts/pie_features.py
+++ b/galleries/examples/pie_and_polar_charts/pie_features.py
@@ -15,15 +15,15 @@ This example illustrates various parameters of `~matplotlib.axes.Axes.pie`.
 # ------------
 #
 # Plot a pie chart of animals and label the slices. To add
-# labels, pass a list of labels to the *labels* parameter
+# labels, pass a list of labels to the *wedge_labels* parameter.
 
 import matplotlib.pyplot as plt
 
 labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
-sizes = [15, 30, 45, 10]
+sizes = [12, 24, 36, 8]
 
 fig, ax = plt.subplots()
-ax.pie(sizes, labels=labels)
+ax.pie(sizes, wedge_labels=labels)
 
 # %%
 # Each slice of the pie chart is a `.patches.Wedge` object; therefore in
@@ -31,16 +31,44 @@ ax.pie(sizes, labels=labels)
 # the *wedgeprops* argument, as demonstrated in
 # :doc:`/gallery/pie_and_polar_charts/nested_pie`.
 #
+# Set label positions
+# -------------------
+# If you want the labels outside the pie, set a *wedge_label_distance* greater than 1.
+# This is the distance from the center of the pie as a fraction of its radius.
+
+fig, ax = plt.subplots()
+ax.pie(sizes, wedge_labels=labels, wedge_label_distance=1.1)
+
+# %%
+#
 # Auto-label slices
 # -----------------
 #
-# Pass a function or format string to *autopct* to label slices.
+# Pass a format string to *wedge_labels* to label slices with their values...
 
 fig, ax = plt.subplots()
-ax.pie(sizes, labels=labels, autopct='%1.1f%%')
+ax.pie(sizes, wedge_labels='{absval:.1f}')
 
 # %%
-# By default, the label values are obtained from the percent size of the slice.
+#
+# ...or with their percentages...
+
+fig, ax = plt.subplots()
+ax.pie(sizes, wedge_labels='{frac:.1%}')
+
+# %%
+#
+# ...or both.
+
+fig, ax = plt.subplots()
+ax.pie(sizes, wedge_labels='{absval:d}\n{frac:.1%}')
+
+# %%
+#
+# For more control over labels, or to add multiple sets, see
+# :doc:`/gallery/pie_and_polar_charts/pie_label`.
+
+# %%
 #
 # Color slices
 # ------------
@@ -48,8 +76,7 @@ ax.pie(sizes, labels=labels, autopct='%1.1f%%')
 # Pass a list of colors to *colors* to set the color of each slice.
 
 fig, ax = plt.subplots()
-ax.pie(sizes, labels=labels,
-       colors=['olivedrab', 'rosybrown', 'gray', 'saddlebrown'])
+ax.pie(sizes, colors=['olivedrab', 'rosybrown', 'gray', 'saddlebrown'])
 
 # %%
 # Hatch slices
@@ -58,22 +85,9 @@ ax.pie(sizes, labels=labels,
 # Pass a list of hatch patterns to *hatch* to set the pattern of each slice.
 
 fig, ax = plt.subplots()
-ax.pie(sizes, labels=labels, hatch=['**O', 'oO', 'O.O', '.||.'])
+ax.pie(sizes, hatch=['**O', 'oO', 'O.O', '.||.'])
 
 # %%
-# Swap label and autopct text positions
-# -------------------------------------
-# Use the *labeldistance* and *pctdistance* parameters to position the *labels*
-# and *autopct* text respectively.
-
-fig, ax = plt.subplots()
-ax.pie(sizes, labels=labels, autopct='%1.1f%%',
-       pctdistance=1.25, labeldistance=.6)
-
-# %%
-# *labeldistance* and *pctdistance* are ratios of the radius; therefore they
-# vary between ``0`` for the center of the pie and ``1`` for the edge of the
-# pie, and can be set to greater than ``1`` to place text outside the pie.
 #
 # Explode, shade, and rotate slices
 # ---------------------------------
@@ -86,11 +100,10 @@ ax.pie(sizes, labels=labels, autopct='%1.1f%%',
 #
 # This example orders the slices, separates (explodes) them, and rotates them.
 
-explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+explode = (0, 0.2, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
 fig, ax = plt.subplots()
-ax.pie(sizes, explode=explode, labels=labels, autopct='%1.1f%%',
-       shadow=True, startangle=90)
+ax.pie(sizes, explode=explode, wedge_labels='{frac:.1%}', shadow=True, startangle=90)
 plt.show()
 
 # %%
@@ -107,8 +120,7 @@ plt.show()
 
 fig, ax = plt.subplots()
 
-ax.pie(sizes, labels=labels, autopct='%.0f%%',
-       textprops={'size': 'small'}, radius=0.5)
+ax.pie(sizes, wedge_labels='{frac:.1%}', textprops={'size': 'small'}, radius=0.5)
 plt.show()
 
 # %%
@@ -119,8 +131,8 @@ plt.show()
 # the `.Shadow` patch. This can be used to modify the default shadow.
 
 fig, ax = plt.subplots()
-ax.pie(sizes, explode=explode, labels=labels, autopct='%1.1f%%',
-       shadow={'ox': -0.04, 'edgecolor': 'none', 'shade': 0.9}, startangle=90)
+ax.pie(sizes, explode=explode, shadow={'ox': -0.04, 'edgecolor': 'none', 'shade': 0.9},
+       startangle=90)
 plt.show()
 
 # %%

--- a/lib/matplotlib/_api/__init__.pyi
+++ b/lib/matplotlib/_api/__init__.pyi
@@ -19,6 +19,7 @@ from .deprecation import (  # noqa: F401, re-exported API
 _T = TypeVar("_T")
 
 class _Unset: ...
+UNSET = _Unset()
 
 class classproperty(Any):
     def __init__(

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -41,6 +41,7 @@ from matplotlib.container import (
     BarContainer, ErrorbarContainer, PieContainer, StemContainer)
 from matplotlib.text import Text
 from matplotlib.transforms import _ScaledRotation
+from matplotlib._api import UNSET as _UNSET
 
 _log = logging.getLogger(__name__)
 
@@ -3534,13 +3535,13 @@ or pandas.DataFrame
         self.add_container(stem_container)
         return stem_container
 
-    @_api.make_keyword_only("3.10", "explode")
-    @_preprocess_data(replace_names=["x", "explode", "labels", "colors"])
-    def pie(self, x, explode=None, labels=None, colors=None,
-            autopct=None, pctdistance=0.6, shadow=False, labeldistance=1.1,
-            startangle=0, radius=1, counterclock=True,
-            wedgeprops=None, textprops=None, center=(0, 0),
-            frame=False, rotatelabels=False, *, normalize=True, hatch=None):
+    @_preprocess_data(replace_names=["x", "explode", "labels", "colors",
+                                     "wedge_labels"])
+    def pie(self, x, *, explode=None, labels=None, colors=None, wedge_labels=None,
+            wedge_label_distance=0.6, autopct=None, pctdistance=0.6, shadow=False,
+            labeldistance=_UNSET, startangle=0, radius=1, counterclock=True,
+            wedgeprops=None, textprops=None, center=(0, 0), frame=False,
+            rotatelabels=False, normalize=True, hatch=None):
         """
         Plot a pie chart.
 
@@ -3560,7 +3561,13 @@ or pandas.DataFrame
             of the radius with which to offset each wedge.
 
         labels : list, default: None
-            A sequence of strings providing the labels for each wedge
+            A sequence of strings providing the legend labels for each wedge.
+
+            .. deprecated:: 3.12
+                In future these labels will not appear on the wedges but only
+                be made available for the legend (see *labeldistance* below).
+                To place labels on the wedges, use *wedge_labels* or the
+                `pie_label` method.
 
         colors : :mpltype:`color` or list of :mpltype:`color`, default: None
             A sequence of colors through which the pie chart will cycle.  If
@@ -3573,11 +3580,34 @@ or pandas.DataFrame
 
             .. versionadded:: 3.7
 
+        wedge_labels : str or list of str, optional
+            A sequence of strings providing the labels for each wedge, or a format
+            string with ``absval`` and/or ``frac`` placeholders.  For example, to label
+            each wedge with its value and the percentage in brackets::
+
+                wedge_labels="{absval:d} ({frac:.0%})"
+
+            For more control or to add multiple sets of labels, use `pie_label`
+            instead.
+
+            .. versionadded:: 3.12
+
+        wedge_label_distance : float, default: 0.6
+            The radial position of the wedge labels, relative to the pie radius.
+            Values > 1 are outside the wedge and values < 1 are inside the wedge.
+
+            .. versionadded:: 3.12
+
         autopct : None or str or callable, default: None
             If not *None*, *autopct* is a string or function used to label the
             wedges with their numeric value. The label will be placed inside
             the wedge. If *autopct* is a format string, the label will be
             ``fmt % pct``. If *autopct* is a function, then it will be called.
+
+            .. admonition:: Discouraged
+
+                Consider using the *wedge_labels* parameter or `pie_label`
+                method instead.
 
         pctdistance : float, default: 0.6
             The relative distance along the radius at which the text
@@ -3590,6 +3620,11 @@ or pandas.DataFrame
             drawn. To draw the labels inside the pie, set  *labeldistance* < 1.
             If set to ``None``, labels are not drawn but are still stored for
             use in `.legend`.
+
+            .. deprecated:: 3.12
+                From v3.14 *labeldistance* will default to ``None`` and will
+                later be removed altogether.  Use *wedge_labels* and
+                *wedge_label_distance* or the `pie_label` method instead.
 
         shadow : bool or dict, default: False
             If bool, whether to draw a shadow beneath the pie. If dict, draw a shadow
@@ -3672,8 +3707,33 @@ or pandas.DataFrame
             raise ValueError('Cannot plot an unnormalized pie with sum(x) > 1')
         else:
             fracs = x
+
+        if labeldistance is _UNSET:
+            # NB: when the labeldistance default changes, both labeldistance and
+            # rotatelabels should be deprecated for removal.
+            if labels is not None:
+                msg = (
+                    "From %(removal)s labeldistance will default to None, so that the "
+                    "strings provided in the labels parameter are only available for "
+                    "the legend.  Later labeldistance will be removed completely.  To "
+                    "preserve existing behavior for now, pass labeldistance=1.1.  "
+                    "Consider using the wedge_labels parameter or the pie_label method "
+                    "instead of the labels parameter."
+                    )
+                _api.warn_deprecated("3.12", message=msg)
+            labeldistance = 1.1
+
         if labels is None:
             labels = [''] * len(x)
+        else:
+            if wedge_labels is not None and labeldistance is not None:
+                raise ValueError(
+                    'wedge_labels is a replacement for labels when annotating the '
+                    'wedges, so the two should not be used together unless '
+                    'labeldistance is None.  To add multiple sets of labels, use the '
+                    'pie_label method.'
+                    )
+
         if explode is None:
             explode = [0] * len(x)
         if len(x) != len(labels):
@@ -3731,11 +3791,16 @@ or pandas.DataFrame
 
         pc = PieContainer(slices, x, normalize)
 
-        if labeldistance is None:
+        if wedge_labels is not None:
+            self.pie_label(pc, wedge_labels, distance=wedge_label_distance,
+                           textprops=textprops)
+
+        elif labeldistance is None:
             # Insert an empty list of texts for backwards compatibility of the
             # return value.
             pc.add_texts([])
-        else:
+
+        if labeldistance is not None:
             # Add labels to the wedges.
             labels_textprops = {
                 'fontsize': mpl.rcParams['xtick.labelsize'],

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -31,6 +31,7 @@ import matplotlib.tri as mtri
 import matplotlib.table as mtable
 import matplotlib.stackplot as mstack
 import matplotlib.streamplot as mstream
+from matplotlib._api import _Unset
 
 import PIL.Image
 from collections.abc import Callable, Iterable, Sequence
@@ -310,10 +311,12 @@ class Axes(_AxesBase):
         explode: ArrayLike | None = ...,
         labels: Sequence[str] | None = ...,
         colors: ColorType | Sequence[ColorType] | None = ...,
+        wedge_labels: str | Sequence | None = ...,
+        wedge_label_distance: float | Sequence = ...,
         autopct: str | Callable[[float], str] | None = ...,
         pctdistance: float = ...,
         shadow: bool = ...,
-        labeldistance: float | None = ...,
+        labeldistance: float | None | _Unset = ...,
         startangle: float = ...,
         radius: float = ...,
         counterclock: bool = ...,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -60,6 +60,7 @@ from cycler import cycler  # noqa: F401
 import matplotlib
 import matplotlib.image
 from matplotlib import _api
+from matplotlib._api import UNSET as _UNSET
 # Re-exported (import x as x) for typing.
 from matplotlib import get_backend as get_backend, rcParams as rcParams
 from matplotlib import cm as cm  # noqa: F401
@@ -153,6 +154,7 @@ if TYPE_CHECKING:
         LogLevel
     )
     from matplotlib.widgets import SubplotTool
+    from matplotlib._api import _Unset
 
     _P = ParamSpec('_P')
     _R = TypeVar('_R')
@@ -3963,13 +3965,16 @@ def phase_spectrum(
 @_copy_docstring_and_deprecators(Axes.pie)
 def pie(
     x: ArrayLike,
+    *,
     explode: ArrayLike | None = None,
     labels: Sequence[str] | None = None,
     colors: ColorType | Sequence[ColorType] | None = None,
+    wedge_labels: str | Sequence | None = None,
+    wedge_label_distance: float | Sequence = 0.6,
     autopct: str | Callable[[float], str] | None = None,
     pctdistance: float = 0.6,
     shadow: bool = False,
-    labeldistance: float | None = 1.1,
+    labeldistance: float | None | _Unset = _UNSET,
     startangle: float = 0,
     radius: float = 1,
     counterclock: bool = True,
@@ -3978,7 +3983,6 @@ def pie(
     center: tuple[float, float] = (0, 0),
     frame: bool = False,
     rotatelabels: bool = False,
-    *,
     normalize: bool = True,
     hatch: str | Sequence[str] | None = None,
     data=None,
@@ -3988,6 +3992,8 @@ def pie(
         explode=explode,
         labels=labels,
         colors=colors,
+        wedge_labels=wedge_labels,
+        wedge_label_distance=wedge_label_distance,
         autopct=autopct,
         pctdistance=pctdistance,
         shadow=shadow,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6628,8 +6628,23 @@ def test_pie_default():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
     fig1, ax1 = plt.subplots(figsize=(8, 6))
-    ax1.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90)
+    ax1.pie(sizes, explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90)
+
+
+@image_comparison(['pie_default.png'], style='mpl20')
+def test_pie_default_legacy():
+    # Same as above, but uses labels parameter.  Remove after labeldistance
+    # parameter deprecation expires.
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+    fig1, ax1 = plt.subplots(figsize=(8, 6))
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        ax1.pie(sizes, explode=explode, labels=labels, colors=colors,
+                autopct='%1.1f%%', shadow=True, startangle=90)
 
 
 @image_comparison(['pie_linewidth_0.png', 'pie_linewidth_0.png', 'pie_linewidth_0.png'],
@@ -6641,27 +6656,30 @@ def test_pie_linewidth_0():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes, explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             wedgeprops={'linewidth': 0})
     # Set aspect ratio to be equal so that pie is drawn as a circle.
     plt.axis('equal')
 
-    # Reuse testcase from above for a labeled data test
+    # Reuse testcase from above for a labeled data test.  Include legend labels
+    # to smoke test that they are correctly unpacked.
     data = {"l": labels, "s": sizes, "c": colors, "ex": explode}
     fig = plt.figure()
     ax = fig.gca()
-    ax.pie("s", explode="ex", labels="l", colors="c",
+    ax.pie("s", explode="ex", wedge_labels="l", colors="c", wedge_label_distance=1.1,
            autopct='%1.1f%%', shadow=True, startangle=90,
-           wedgeprops={'linewidth': 0}, data=data)
+           labels="l", labeldistance=None, wedgeprops={'linewidth': 0},
+           data=data)
     ax.axis('equal')
 
     # And again to test the pyplot functions which should also be able to be
     # called with a data kwarg
     plt.figure()
-    plt.pie("s", explode="ex", labels="l", colors="c",
+    plt.pie("s", explode="ex", wedge_labels="l", colors="c", wedge_label_distance=1.1,
             autopct='%1.1f%%', shadow=True, startangle=90,
-            wedgeprops={'linewidth': 0}, data=data)
+            labels="l", labeldistance=None, wedgeprops={'linewidth': 0},
+            data=data)
     plt.axis('equal')
 
 
@@ -6674,8 +6692,8 @@ def test_pie_center_radius():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes, explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             wedgeprops={'linewidth': 0}, center=(1, 2), radius=1.5)
 
     plt.annotate("Center point", xy=(1, 2), xytext=(1, 1.3),
@@ -6694,8 +6712,8 @@ def test_pie_linewidth_2():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes, explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             wedgeprops={'linewidth': 2})
     # Set aspect ratio to be equal so that pie is drawn as a circle.
     plt.axis('equal')
@@ -6709,8 +6727,8 @@ def test_pie_ccw_true():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
 
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes, explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             counterclock=True)
     # Set aspect ratio to be equal so that pie is drawn as a circle.
     plt.axis('equal')
@@ -6725,18 +6743,18 @@ def test_pie_frame_grid():
     # only "explode" the 2nd slice (i.e. 'Hogs')
     explode = (0, 0.1, 0, 0)
 
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes, explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             wedgeprops={'linewidth': 0},
             frame=True, center=(2, 2))
 
-    plt.pie(sizes[::-1], explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes[::-1], explode=explode, wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             wedgeprops={'linewidth': 0},
             frame=True, center=(5, 2))
 
-    plt.pie(sizes, explode=explode[::-1], labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
+    plt.pie(sizes, explode=explode[::-1], wedge_labels=labels, wedge_label_distance=1.1,
+            colors=colors, autopct='%1.1f%%', shadow=True, startangle=90,
             wedgeprops={'linewidth': 0},
             frame=True, center=(3, 5))
     # Set aspect ratio to be equal so that pie is drawn as a circle.
@@ -6744,16 +6762,34 @@ def test_pie_frame_grid():
 
 
 @image_comparison(['pie_rotatelabels_true.png'], style='mpl20')
-def test_pie_rotatelabels_true():
+def test_pie_label_rotate():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
     sizes = [15, 30, 45, 10]
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
-    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Frogs')
 
-    plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90,
-            rotatelabels=True)
+    pie = plt.pie(sizes, explode=explode, wedge_labels='{frac:.1%}', colors=colors,
+                  shadow=True, startangle=90)
+    plt.pie_label(pie, labels, distance=1.1, rotate=True)
+    # Set aspect ratio to be equal so that pie is drawn as a circle.
+    plt.axis('equal')
+
+
+@image_comparison(['pie_rotatelabels_true.png'], style='mpl20')
+def test_pie_rotatelabels_true():
+    # As above but using legacy labels and rotatelabels parameters.  Remove
+    # when the labeldistance parameter deprecation expires.
+    # The slices will be ordered and plotted counter-clockwise.
+    labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
+    sizes = [15, 30, 45, 10]
+    colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
+    explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Frogs')
+
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        plt.pie(sizes, explode=explode, labels=labels, colors=colors,
+                autopct='%1.1f%%', shadow=True, startangle=90,
+                rotatelabels=True)
     # Set aspect ratio to be equal so that pie is drawn as a circle.
     plt.axis('equal')
 
@@ -6765,7 +6801,7 @@ def test_pie_nolabel_but_legend():
     colors = ['yellowgreen', 'gold', 'lightskyblue', 'lightcoral']
     explode = (0, 0.1, 0, 0)  # only "explode" the 2nd slice (i.e. 'Hogs')
     plt.pie(sizes, explode=explode, labels=labels, colors=colors,
-            autopct='%1.1f%%', shadow=True, startangle=90, labeldistance=None,
+            wedge_labels='{frac:.1%}', shadow=True, startangle=90, labeldistance=None,
             rotatelabels=True)
     plt.axis('equal')
     plt.ylim(-1.2, 1.2)
@@ -6806,9 +6842,13 @@ def test_pie_textprops():
                      rotation_mode="anchor",
                      size=12, color="red")
 
-    _, texts, autopct = plt.gca().pie(data, labels=labels, autopct='%.2f',
-                                      textprops=textprops)
-    for labels in [texts, autopct]:
+    fig, ax = plt.subplots()
+
+    pie1 = ax.pie(data, wedge_labels=labels, autopct='%.2f', textprops=textprops)
+    with pytest.warns(mpl.MatplotlibDeprecationWarning):
+        pie2 = ax.pie(data, labels=labels, textprops=textprops)
+
+    for labels in pie1.texts + pie2.texts:
         for tx in labels:
             assert tx.get_ha() == textprops["horizontalalignment"]
             assert tx.get_va() == textprops["verticalalignment"]
@@ -6836,7 +6876,7 @@ def test_pie_invalid_labels():
     # Test ValueError raised when feeding short labels list to axes.pie
     fig, ax = plt.subplots()
     with pytest.raises(ValueError):
-        ax.pie([1, 2, 3], labels=["One", "Two"])
+        ax.pie([1, 2, 3], labels=["One", "Two"], labeldistance=None)
 
 
 def test_pie_invalid_radius():
@@ -6844,6 +6884,13 @@ def test_pie_invalid_radius():
     fig, ax = plt.subplots()
     with pytest.raises(ValueError):
         ax.pie([1, 2, 3], radius=-5)
+
+
+def test_pie_wedge_labels_and_labels():
+    fig, ax = plt.subplots()
+    with pytest.raises(ValueError, match='wedge_labels is a replacement for labels'):
+        ax.pie([1, 2], wedge_labels=['spam', 'eggs'], labels=['bacon', 'beans'],
+               labeldistance=1.2)
 
 
 def test_normalize_kwarg_pie():
@@ -10323,13 +10370,13 @@ def test_pie_non_finite_values():
     df = [5, float('nan'), float('inf')]
 
     with pytest.raises(ValueError, match='Wedge sizes must be finite numbers'):
-        ax.pie(df, labels=['A', 'B', 'C'])
+        ax.pie(df)
 
 
 def test_pie_all_zeros():
     fig, ax = plt.subplots()
     with pytest.raises(ValueError, match="All wedge sizes are zero"):
-        ax.pie([0, 0], labels=["A", "B"])
+        ax.pie([0, 0])
 
 
 def test_animated_artists_not_drawn_by_default():

--- a/lib/matplotlib/tests/test_container.py
+++ b/lib/matplotlib/tests/test_container.py
@@ -57,10 +57,13 @@ def test_barcontainer_position_centers__bottoms__tops():
 
 def test_piecontainer_remove():
     fig, ax = plt.subplots()
-    pie = ax.pie([2, 3], labels=['foo', 'bar'], autopct="%1.0f%%")
+    pie = ax.pie([2, 3], wedge_labels=['foo', 'bar'], autopct="%1.0f%%")
     ax.pie_label(pie, ['baz', 'qux'])
+
     assert len(ax.patches) == 2
-    assert len(ax.texts) == 6
+    # We have added 6 labels but pie also adds an empty Text artist to each
+    # wedge if labeldistance is not None and labels is not passed
+    assert len(ax.texts) == 8
 
     pie.remove()
     assert not ax.patches

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -95,6 +95,8 @@ class value_formatter:
             self._repr = "np.mean"
         elif value is _api.deprecation._deprecated_parameter:
             self._repr = "_api.deprecation._deprecated_parameter"
+        elif value is _api.UNSET:
+            self._repr = "_UNSET"
         elif isinstance(value, Enum):
             # Enum str is Class.Name whereas their repr is <Class.Name: value>.
             self._repr = f'{type(value).__name__}.{value.name}'


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->
The proposal evolved through the below discussion.  The idea is to introduce a new _wedge_labels_ parameter to `pie` which supersedes *autopct*, via its use of the `str.format` method, but it can also take a list of labels consistent with the existing *labels* parameter.

* Introduce *wedge_labels* as a shortcut to the `pie_label` method introduced in #30733.
* Introduce *wedge_label_distance* (default 0.6) to specify how far the *wedge_labels* are from the pie centre.
* Deprecate the *labeldistance* parameter in two steps: First change the default to `None` (which means *labels* are only used for the legend).  Later remove this parameter altogether - direct to use *wedge_labels* instead. 
   * This differs from the approach agreed below because it gets us there in fewer steps, and gives downstream more overlap when *wedge_labels* is available and *labeldistance=float* is not yet deprecated. See https://github.com/matplotlib/matplotlib/pull/29152#issuecomment-2559382405.
* Discourage using `autopct` in favour of `wedge_labels`.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
