### PR TITLE
Relax conditions for warning on updating converters

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1842,11 +1842,15 @@ class Axis(martist.Artist):
         self._converter_is_explicit = True
 
     def _set_converter(self, converter):
-        if self._converter == converter:
+        if self._converter is converter or self._converter == converter:
             return
         if self._converter_is_explicit:
             raise RuntimeError("Axis already has an explicit converter set")
-        elif self._converter is not None:
+        elif (
+            self._converter is not None and
+            not isinstance(converter, type(self._converter)) and
+            not isinstance(self._converter, type(converter))
+        ):
             _api.warn_external(
                 "This axis already has a converter set and "
                 "is updating to a potentially incompatible converter"

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -6,6 +6,7 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib.units as munits
 from matplotlib.category import StrCategoryConverter, UnitData
+from matplotlib.dates import DateConverter
 import numpy as np
 import pytest
 
@@ -240,6 +241,7 @@ def test_explicit_converter():
     d1 = {"a": 1, "b": 2}
     str_cat_converter = StrCategoryConverter()
     str_cat_converter_2 = StrCategoryConverter()
+    date_converter = DateConverter()
 
     # Explicit is set
     fig1, ax1 = plt.subplots()
@@ -254,12 +256,18 @@ def test_explicit_converter():
     with pytest.raises(RuntimeError):
         ax1.xaxis.set_converter(str_cat_converter_2)
 
-    # Warn when implicit overridden
     fig2, ax2 = plt.subplots()
     ax2.plot(d1.keys(), d1.values())
 
+    # No error when equivalent type is used
+    ax2.xaxis.set_converter(str_cat_converter)
+
+    fig3, ax3 = plt.subplots()
+    ax3.plot(d1.keys(), d1.values())
+
+    # Warn when implicit overridden
     with pytest.warns():
-        ax2.xaxis.set_converter(str_cat_converter)
+        ax3.xaxis.set_converter(date_converter)
 
 
 def test_empty_default_limits(quantity_converter):


### PR DESCRIPTION
Allow sub/superclass without warning.

This was motivated by Pandas, as they have several instances of the same class in the registry.
We also had this internally, though resolved that by using the same instance for multiple registry
entries rather than by relaxing the warning. This becomes impractical when dealing with downstream.

It may have been sufficient to allow only identical types, but to be safe, decided to allow both
sub- and superclass relationships.
The purpose of the warning was that it gets overwritten without heeding prior data provided which
would break in unexpected ways.
The most common case for this is when one converter class operates on multiple data types, but
separate instances of the class are in the registry. So while the previous data is compatible the
equality check still failed. Requiring downstream to implement equality checks seems impractical.

Additionally used both `is` and `==` for the earlier short circuit, which should in most cases be
identical operations, but just in case.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
