### PR TITLE
Pending warning for deprecated parameter 'vert' of box and violin on 3.10

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3875,9 +3875,11 @@ class Axes(_AxesBase):
             control is provided by the *flierprops* parameter.
 
         vert : bool, optional
-            .. deprecated:: 3.10
+            .. deprecated:: 3.11
                 Use *orientation* instead.
 
+                This is a pending deprecation for 3.10, with full deprecation
+                in 3.11 and removal in 3.13.
                 If this is given during the deprecation period, it overrides
                 the *orientation* parameter.
 
@@ -4222,9 +4224,11 @@ class Axes(_AxesBase):
             The default is ``0.5*(width of the box)``, see *widths*.
 
         vert : bool, optional
-            .. deprecated:: 3.10
+            .. deprecated:: 3.11
                 Use *orientation* instead.
 
+                This is a pending deprecation for 3.10, with full deprecation
+                in 3.11 and removal in 3.13.
                 If this is given during the deprecation period, it overrides
                 the *orientation* parameter.
 
@@ -4361,9 +4365,10 @@ class Axes(_AxesBase):
             vert = mpl.rcParams['boxplot.vertical']
         else:
             _api.warn_deprecated(
-                "3.10",
+                "3.11",
                 name="vert: bool",
-                alternative="orientation: {'vertical', 'horizontal'}"
+                alternative="orientation: {'vertical', 'horizontal'}",
+                pending=True,
             )
         if vert is False:
             orientation = 'horizontal'
@@ -8642,10 +8647,11 @@ such objects
         # vert takes precedence.
         if vert is not None:
             _api.warn_deprecated(
-                "3.10",
+                "3.11",
                 name="vert: bool",
-                alternative="orientation: {'vertical', 'horizontal'}"
-                )
+                alternative="orientation: {'vertical', 'horizontal'}",
+                pending=True,
+            )
             orientation = 'vertical' if vert else 'horizontal'
         _api.check_in_list(['horizontal', 'vertical'], orientation=orientation)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9315,7 +9315,9 @@ def test_violinplot_orientation(fig_test, fig_ref):
     # Compare images between a figure that
     # uses vert and one that uses orientation.
     ax_ref = fig_ref.subplots()
-    ax_ref.violinplot(all_data, vert=False)
+
+    with pytest.warns(PendingDeprecationWarning, match='vert: bool'):
+        ax_ref.violinplot(all_data, vert=False)
 
     ax_test = fig_test.subplots()
     ax_test.violinplot(all_data, orientation='horizontal')


### PR DESCRIPTION
The new parameter, 'orientation', was only added in the current release, so downstream wanting to avoid warnings
would require version gates. Therefore delaying by at least one release to ease the transition.

This was motivated by Pandas failing tests on this warning.

This portion is made direct to v3.10.x with #29155 being the accompanying version to edit the deprecation on main.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
