### PR TITLE
BUGFIX: use axes unit information in ConnectionPatch 

### DIFF
--- a/lib/matplotlib/category.py
+++ b/lib/matplotlib/category.py
@@ -17,7 +17,7 @@ import logging
 
 import numpy as np
 
-from matplotlib import _api, ticker, units
+from matplotlib import _api, cbook, ticker, units
 
 
 _log = logging.getLogger(__name__)
@@ -55,7 +55,8 @@ class StrCategoryConverter(units.ConversionInterface):
         values = np.atleast_1d(np.array(value, dtype=object))
         # force an update so it also does type checking
         unit.update(values)
-        return np.vectorize(unit._mapping.__getitem__, otypes=[float])(values)
+        s = np.vectorize(unit._mapping.__getitem__, otypes=[float])(values)
+        return s if not cbook.is_scalar_or_string(value) else s[0]
 
     @staticmethod
     def axisinfo(unit, axis):

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4596,8 +4596,8 @@ class ConnectionPatch(FancyArrowPatch):
 
         fig = self.get_figure(root=False)
         if s in ["figure points", "axes points"]:
-            x *= fig.dpi / 72
-            y *= fig.dpi / 72
+            x = x * fig.dpi / 72
+            y = y * fig.dpi / 72
             s = s.replace("points", "pixels")
         elif s == "figure fraction":
             s = fig.transFigure

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4589,10 +4589,15 @@ class ConnectionPatch(FancyArrowPatch):
         s0 = s  # For the error message, if needed.
         if axes is None:
             axes = self.axes
-        xy = np.array(xy)
+
+        # preserve mixed type input (such as str, int)
+        x = np.array(xy[0])
+        y = np.array(xy[1])
+
         fig = self.get_figure(root=False)
         if s in ["figure points", "axes points"]:
-            xy *= fig.dpi / 72
+            x *= fig.dpi / 72
+            y *= fig.dpi / 72
             s = s.replace("points", "pixels")
         elif s == "figure fraction":
             s = fig.transFigure
@@ -4600,12 +4605,11 @@ class ConnectionPatch(FancyArrowPatch):
             s = fig.transSubfigure
         elif s == "axes fraction":
             s = axes.transAxes
-        x, y = xy
 
         if s == 'data':
             trans = axes.transData
-            x = float(self.convert_xunits(x))
-            y = float(self.convert_yunits(y))
+            x = cbook._to_unmasked_float_array(axes.xaxis.convert_units(x))
+            y = cbook._to_unmasked_float_array(axes.yaxis.convert_units(y))
             return trans.transform((x, y))
         elif s == 'offset points':
             if self.xycoords == 'offset points':  # prevent recursion

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -606,6 +606,28 @@ def test_connection_patch_fig(fig_test, fig_ref):
     fig_ref.add_artist(con)
 
 
+@check_figures_equal(extensions=["png"])
+def test_connection_patch_pixel_points(fig_test, fig_ref):
+    xyA_pts = (.3, .2)
+    xyB_pts = (-30, -20)
+
+    ax1, ax2 = fig_test.subplots(1, 2)
+    con = mpatches.ConnectionPatch(xyA=xyA_pts, coordsA="axes points", axesA=ax1,
+                                   xyB=xyB_pts, coordsB="figure points",
+                                   arrowstyle="->", shrinkB=5)
+    fig_test.add_artist(con)
+
+    plt.rcParams["savefig.dpi"] = plt.rcParams["figure.dpi"]
+
+    ax1, ax2 = fig_ref.subplots(1, 2)
+    xyA_pix = (xyA_pts[0]*(fig_ref.dpi/72), xyA_pts[1]*(fig_ref.dpi/72))
+    xyB_pix = (xyB_pts[0]*(fig_ref.dpi/72), xyB_pts[1]*(fig_ref.dpi/72))
+    con = mpatches.ConnectionPatch(xyA=xyA_pix, coordsA="axes pixels", axesA=ax1,
+                                   xyB=xyB_pix, coordsB="figure pixels",
+                                   arrowstyle="->", shrinkB=5)
+    fig_ref.add_artist(con)
+
+
 def test_datetime_rectangle():
     # Check that creating a rectangle with timedeltas doesn't fail
     from datetime import datetime, timedelta

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
+import matplotlib.patches as mpatches
 import matplotlib.units as munits
 from matplotlib.category import StrCategoryConverter, UnitData
 from matplotlib.dates import DateConverter
@@ -336,3 +337,17 @@ def test_plot_kernel():
     # just a smoketest that fail
     kernel = Kernel([1, 2, 3, 4, 5])
     plt.plot(kernel)
+
+
+def test_connection_patch_units(pd):
+    # tests that this doesn't raise an error
+    fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(10, 5))
+    x = pd.Timestamp('2017-01-01T12')
+    ax1.axvline(x)
+    y = "test test"
+    ax2.axhline(y)
+    arr = mpatches.ConnectionPatch((x, 0), (0, y),
+                                   coordsA='data', coordsB='data',
+                                   axesA=ax1, axesB=ax2)
+    fig.add_artist(arr)
+    fig.draw_without_rendering()


### PR DESCRIPTION
This PR lets connection patch use the convertor info from the axes that's already being passed in for "data" to support unitized data. I think the original behavior is a bug b/ the original code called the artist convertors but they didn't do anything b/c the artist convertors are looking up the artist axes which doesn't exist b/c connection patch is a figure level artist.

Modifies string convertor to return a scaler when input is only one value b/c that's what the connection patch transform function expects. This is inspired by the datetime convertor, which already behaves this way. 

Updated summary based on @QuLogic's review to reflect current implementation/behavior.

This PR is motivated by the following code, which on main draws the respective plots but crashes at rendering the connection patch because it doesn't know about the convertors:


```python
fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(10, 5))
x = pd.Timestamp('2017-01-01T12')
ax1.axvline(x)
y = "test test"
ax2.axhline(y)
arr = mpatches.ConnectionPatch((x, 0), (0, y), coordsA='data', coordsB='data', axesA=ax1, axesB=ax2)
fig.add_artist(arr)
```
With the changes in this PR, the ConnectionPatch now renders:
![Figure_1](https://github.com/user-attachments/assets/6bb23d48-6734-4b8a-9b48-c1b43aa4fbbc)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
