### PR TITLE
nearest is changed to flat

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5919,6 +5919,8 @@ class Axes(_AxesBase):
             C = np.asanyarray(args[0])
             nrows, ncols = C.shape[:2]
             if shading in ['gouraud', 'nearest']:
+                if shading == 'nearest':
+                    shading = 'flat'
                 X, Y = np.meshgrid(np.arange(ncols), np.arange(nrows))
             else:
                 X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))


### PR DESCRIPTION
## PR summary

- as the nearest is changing the shading to flat after finding the edges and corners of the grid, if x and y are not given, this code changes it to flat.


## PR checklist

- [ ] closes issue #29179

