### PR TITLE
Update backend_qt.py: parent not passed to __init__ on subplottool

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -856,7 +856,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
 
 class SubplotToolQt(QtWidgets.QDialog):
     def __init__(self, targetfig, parent):
-        super().__init__()
+        super().__init__(parent)
         self.setWindowIcon(QtGui.QIcon(
             str(cbook._get_data_path("images/matplotlib.png"))))
         self.setObjectName("SubplotTool")


### PR DESCRIPTION
This PR passes the `parent` of an initialised `SubplotToolQt` to its inherited `__init__`.

It is missed here, but not on other classes.

