### PR TITLE
add itemboxalign option to legend constructor

### DIFF
--- a/doc/users/next_whats_new/legend_itemboxalign.rst
+++ b/doc/users/next_whats_new/legend_itemboxalign.rst
@@ -1,0 +1,25 @@
+Adding itembox alignment option for legends
+---------------------------------------------------------
+
+`~.Legend` previously always aligns items using the "baseline" option, which results in
+the appearance of vertical centering of the artist and label for multi-line labels.
+This is sometimes hard to read. The introduction of the `itemboxalign` parameter allows
+the user to change this behavior and choose a different desired vertical alignment.
+
+.. plot::
+    :include-source: true
+    :alt: A legend with artist and label aligned to 'top' rather than 'baseline'
+
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(1, 2)
+
+    ax[0].plot([5, 2, 8], label='long\nlabel')
+    ax[0].plot([4, 9, 1], label='another\nlong\nlabel')
+    ax[0].legend(title="align=baseline (default)")
+
+    ax[1].plot([5, 2, 8], label='long\nlabel')
+    ax[1].plot([4, 9, 1], label='another\nlong\nlabel')
+    ax[1].legend(title="align=top", itemboxalign='top')
+
+    plt.show()

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -374,6 +374,7 @@ class Legend(Artist):
         handletextpad=None,  # pad between the legend handle and text
         borderaxespad=None,  # pad between the Axes and legend border
         columnspacing=None,  # spacing between columns
+        itemboxalign="baseline", # vertical alignment of each entry in legend
 
         ncols=1,     # number of columns
         mode=None,  # horizontal distribution of columns: None or "expand"
@@ -453,6 +454,7 @@ class Legend(Artist):
         self.handletextpad = mpl._val_or_rc(handletextpad, 'legend.handletextpad')
         self.borderaxespad = mpl._val_or_rc(borderaxespad, 'legend.borderaxespad')
         self.columnspacing = mpl._val_or_rc(columnspacing, 'legend.columnspacing')
+        self.itemboxalign = mpl._val_or_rc(itemboxalign, 'legend.itemboxalign')
         self.shadow = mpl._val_or_rc(shadow, 'legend.shadow')
 
         if reverse:
@@ -908,7 +910,7 @@ class Legend(Artist):
             itemboxes = [HPacker(pad=0,
                                  sep=self.handletextpad * fontsize,
                                  children=[h, t] if markerfirst else [t, h],
-                                 align="baseline")
+                                 align=self.itemboxalign)
                          for h, t in handles_and_labels_column]
             # pack columnbox
             alignment = "baseline" if markerfirst else "right"

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -246,6 +246,11 @@ borderaxespad : float, default: :rc:`legend.borderaxespad`
 columnspacing : float, default: :rc:`legend.columnspacing`
     The spacing between columns, in font-size units.
 
+itemboxalign : str, default: 'baseline'
+    The vertical alignment for each item box consisting of an artist and a label.
+
+    ..versionadded:: 3.10
+
 handler_map : dict or None
     The custom dictionary mapping instances or types to a legend
     handler. This *handler_map* updates the default handler map
@@ -374,7 +379,7 @@ class Legend(Artist):
         handletextpad=None,  # pad between the legend handle and text
         borderaxespad=None,  # pad between the Axes and legend border
         columnspacing=None,  # spacing between columns
-        itemboxalign="baseline", # vertical alignment of each entry in legend
+        itemboxalign="baseline",  # vertical alignment of each entry in legend
 
         ncols=1,     # number of columns
         mode=None,  # horizontal distribution of columns: None or "expand"
@@ -454,8 +459,9 @@ class Legend(Artist):
         self.handletextpad = mpl._val_or_rc(handletextpad, 'legend.handletextpad')
         self.borderaxespad = mpl._val_or_rc(borderaxespad, 'legend.borderaxespad')
         self.columnspacing = mpl._val_or_rc(columnspacing, 'legend.columnspacing')
-        self.itemboxalign = mpl._val_or_rc(itemboxalign, 'legend.itemboxalign')
         self.shadow = mpl._val_or_rc(shadow, 'legend.shadow')
+
+        self.itemboxalign = itemboxalign
 
         if reverse:
             labels = [*reversed(labels)]


### PR DESCRIPTION
## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->

This pull request adds the option "itemboxalign" to the Legend constructor. From the proposed announcement .rst:

Legend previously always aligns items using the "baseline" option, which results in
the appearance of vertical centering of the artist and label for multi-line labels.
This is sometimes hard to read. The introduction of the `itemboxalign` parameter to the Legend constructor
allows the user to change this behavior and choose a different desired vertical alignment.

```
import matplotlib.pyplot as plt

fig, ax = plt.subplots(1, 2)

ax[0].plot([5, 2, 8], label='long\nlabel')
ax[0].plot([4, 9, 1], label='another\nlong\nlabel')
ax[0].legend(title="align=baseline (default)")

ax[1].plot([5, 2, 8], label='long\nlabel')
ax[1].plot([4, 9, 1], label='another\nlong\nlabel')
ax[1].legend(title="align=top", itemboxalign='top')

plt.show()
```

![image](https://github.com/user-attachments/assets/9c4330b2-fc12-40ba-88e7-54564ffff7cc)

I chose the name "itemboxalign" on a whim based on the existing rendering code in Legend. I think the name could be better, such as:

itemboxalignment
itemboxverticalalign
itemboxverticalalign(ment)
labelverticalalign(ment)

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines