### PR TITLE
avoid-unnecessary-warning-in-_pcolorargs-function

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6034,7 +6034,8 @@ class Axes(_AxesBase):
                     # monotonicity of Y coords needs to be checked.
                     if np.shape(X)[1] > 1:
                         dX = np.diff(X, axis=1) * 0.5
-                        if not (np.all(dX >= 0) or np.all(dX <= 0)):
+                        if (require_monotonicity and
+                                not (np.all(dX >= 0) or np.all(dX <= 0))):
                             _api.warn_external(
                                 f"The input coordinates to {funcname} are "
                                 "interpreted as cell centers, but are not "

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6035,7 +6035,7 @@ class Axes(_AxesBase):
                     if np.shape(X)[1] > 1:
                         dX = np.diff(X, axis=1) * 0.5
                         if (require_monotonicity and
-                                not (np.all(dX >= 0) or np.all(dX <= 0))):
+                            not (np.all(dX >= 0) or np.all(dX <= 0))):
                             _api.warn_external(
                                 f"The input coordinates to {funcname} are "
                                 "interpreted as cell centers, but are not "

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6027,8 +6027,11 @@ class Axes(_AxesBase):
                 # grid is specified at the center, so define corners
                 # at the midpoints between the grid centers and then use the
                 # flat algorithm.
-                def _interp_grid(X):
-                    # helper for below
+                def _interp_grid(X, require_monotonicity=False):
+                    # helper for below. To ensure the cell edges are calculated 
+                    # correctly, when expanding columns, the monotonicity of 
+                    # X coords needs to be checked. When expanding rows, the 
+                    # monotonicity of Y coords needs to be checked.
                     if np.shape(X)[1] > 1:
                         dX = np.diff(X, axis=1) * 0.5
                         if not (np.all(dX >= 0) or np.all(dX <= 0)):
@@ -6051,11 +6054,11 @@ class Axes(_AxesBase):
                     return X
 
                 if ncols == Nx:
-                    X = _interp_grid(X)
+                    X = _interp_grid(X, require_monotonicity=True)
                     Y = _interp_grid(Y)
                 if nrows == Ny:
                     X = _interp_grid(X.T).T
-                    Y = _interp_grid(Y.T).T
+                    Y = _interp_grid(Y.T, require_monotonicity=True).T
                 shading = 'flat'
 
         C = cbook.safe_masked_invalid(C, copy=True)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6028,9 +6028,9 @@ class Axes(_AxesBase):
                 # at the midpoints between the grid centers and then use the
                 # flat algorithm.
                 def _interp_grid(X, require_monotonicity=False):
-                    # helper for below. To ensure the cell edges are calculated 
-                    # correctly, when expanding columns, the monotonicity of 
-                    # X coords needs to be checked. When expanding rows, the 
+                    # helper for below. To ensure the cell edges are calculated
+                    # correctly, when expanding columns, the monotonicity of
+                    # X coords needs to be checked. When expanding rows, the
                     # monotonicity of Y coords needs to be checked.
                     if np.shape(X)[1] > 1:
                         dX = np.diff(X, axis=1) * 0.5

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6035,7 +6035,7 @@ class Axes(_AxesBase):
                     if np.shape(X)[1] > 1:
                         dX = np.diff(X, axis=1) * 0.5
                         if (require_monotonicity and
-                            not (np.all(dX >= 0) or np.all(dX <= 0))):
+                                not (np.all(dX >= 0) or np.all(dX <= 0))):
                             _api.warn_external(
                                 f"The input coordinates to {funcname} are "
                                 "interpreted as cell centers, but are not "

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1608,7 +1608,8 @@ def test_pcolorargs():
     noise_X = np.random.random(X.shape)
     noise_Y = np.random.random(Y.shape)
     with pytest.warns(UserWarning,
-            match='are not monotonically increasing or decreasing') as record:
+                      match='are not monotonically increasing or '
+                            'decreasing') as record:
         # Small perturbations in coordinates will not disrupt the monotonicity
         # of the X-coords and Y-coords in their respective directions.
         # Therefore, no warnings will be triggered.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1600,15 +1600,15 @@ def test_pcolorargs():
                       match='are not monotonically increasing or decreasing'):
         ax.pcolormesh(X, Y, Z, shading='auto')
     # The case of specifying coordinates by inputting 2D arrays.
-    x = np.linspace(-1,1,3)
-    y = np.linspace(-1,1,3)
+    x = np.linspace(-1, 1, 3)
+    y = np.linspace(-1, 1, 3)
     X, Y = np.meshgrid(x, y)
     Z = np.zeros(X.shape)
     np.random.seed(19680801)
     noise_X = np.random.random(X.shape)
     noise_Y = np.random.random(Y.shape)
     with pytest.warns(UserWarning,
-        match='are not monotonically increasing or decreasing') as record:
+            match='are not monotonically increasing or decreasing') as record:
         # Small perturbations in coordinates will not disrupt the monotonicity
         # of the X-coords and Y-coords in their respective directions.
         # Therefore, no warnings will be triggered.


### PR DESCRIPTION
## PR summary

Within the `_interp_grid function`, unnecessary warnings may be triggered when expanding the grid coordinates. As long as the X coordinates and Y coordinates remain monotonic in their respective directions, negative area grids can be avoided. Therefore, the `require_monotonicity` keyword has been added to avoid triggering monotonicity warnings indiscriminately when calling the function.

Running the following code on the original code before modification will trigger warnings, but the drawn grid is normal because the X and Y coordinates are monotonically increasing in their respective directions. Therefore, I think warnings should not be triggered in this case.

![output](https://github.com/user-attachments/assets/31fab8fa-d833-4d83-95ca-93e8e58a1f4f)

```Python
import matplotlib.pyplot as plt
import numpy as np

# generate meshgrid
x = np.linspace(0, 3, 7)  
y = np.linspace(0, 5, 11)
X, Y = np.meshgrid(x, y) 

# add noise to X and Y
factor = 0.15
np.random.seed(31312021)
X = X + factor*np.random.random(X.shape)
Y = Y + factor*np.random.random(Y.shape)

# color value
Z = X + Y

# plot scatter and pcolormesh
fig, ax = plt.subplots(figsize=(5, 4))

qmesh = ax.pcolormesh(X, Y, Z, shading='nearest', edgecolors='k', lw=0.1)    
_ = ax.scatter(X.ravel(), Y.ravel(), s=24, c=Z.ravel(), edgecolors='k')  

# add colorbar and set axis
fig.colorbar(qmesh, ax=ax)
ax.set_xlim(-0.5,3.6)
ax.set_ylim(-0.5,5.8)
ax.set_aspect('equal')
plt.show()

# UserWarning: The input coordinates to pcolormesh are interpreted as cell 
# centers, but are not monotonically increasing or decreasing. 
# This may lead to incorrectly calculated cell edges, in which case, 
# please supply explicit cell edges to pcolormesh.
# qmesh = ax.pcolormesh(X, Y, Z, shading='nearest', edgecolors='k', lw=0.1)
```

In this Pull Request, only several lines of code have been modified, and several lines of non-docstring type comments have been added to a non-public function. Therefore, no code testing has been done(I'll try it later, thank you).


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
