### PR TITLE
Fix typo in _LazyTickList class comment (lis -> list)

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -539,7 +539,7 @@ class _LazyTickList:
             # attribute (e.g. in certain projection classes which override
             # e.g. get_xaxis_text1_transform).  In order to avoid infinite
             # recursion, first set the majorTicks on the instance temporarily
-            # to an empty lis. Then create the tick; note that _get_tick()
+            # to an empty list. Then create the tick; note that _get_tick()
             # may call reset_ticks(). Therefore, the final tick list is
             # created and assigned afterwards.
             if self._major:


### PR DESCRIPTION
## PR summary
Fix a typo in the comment of _LazyTickList class where "lis" was written instead of "list".

- Why is this change necessary?
  To improve code documentation clarity and fix incorrect spelling.
  
- What problem does it solve?
  Corrects a spelling mistake in the comments that could cause confusion.
  
- What is the reasoning for this implementation?
  Simple text correction from 'lis' to 'list' to maintain proper documentation.

## PR checklist
- [N/A] "closes #0000" - no related issue
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines