### PR TITLE
added venv to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.swp
 .idea
 .vscode/
-venv/
 
 # Compiled source #
 ###################
@@ -103,6 +102,16 @@ __pycache__
 __conda_version__.txt
 lib/png.lib
 lib/z.lib
+
+# Environments #
+################
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
 
 # Jupyter files #
 #################

--- a/.gitignore
+++ b/.gitignore
@@ -15,7 +15,6 @@
 *.swp
 .idea
 .vscode/
-envs/
 venv/
 
 # Compiled source #

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,8 @@
 *.swp
 .idea
 .vscode/
+envs/
+venv/
 
 # Compiled source #
 ###################


### PR DESCRIPTION
## PR summary

The commit adds venv/ to the .gitignore file to prevent the tracking of Python virtual environments so only relevant project files are committed.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https//matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
