### PR TITLE
DOC: Set stable version to 3.9.3

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "3.9 (stable)",
-        "version": "3.9.2",
+        "version": "3.9.3",
         "url": "https://matplotlib.org/stable/",
         "preferred": true
     },


### PR DESCRIPTION
## PR summary

The merge will probably go `v3.9.x` -> `v3.10.x` -> `main`, and I don't want to wait that long to ensure that the stable docs don't have the "unstable" banner.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines