### PR TITLE
TST: Simplify parts of animation tests

### DIFF
--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -158,8 +158,7 @@ WRITER_OUTPUT = [
 def gen_writers():
     for writer, output in WRITER_OUTPUT:
         if not animation.writers.is_available(writer):
-            mark = pytest.mark.skip(
-                f"writer '{writer}' not available on this system")
+            mark = pytest.mark.skip(f"writer '{writer}' not available on this system")
             yield pytest.param(writer, None, output, marks=[mark])
             yield pytest.param(writer, None, Path(output), marks=[mark])
             continue
@@ -175,7 +174,7 @@ def gen_writers():
 # matplotlib.testing.image_comparison
 @pytest.mark.parametrize('writer, frame_format, output', gen_writers())
 @pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
-def test_save_animation_smoketest(tmpdir, writer, frame_format, output, anim):
+def test_save_animation_smoketest(tmp_path, writer, frame_format, output, anim):
     if frame_format is not None:
         plt.rcParams["animation.frame_format"] = frame_format
     anim = animation.FuncAnimation(**anim)
@@ -187,17 +186,14 @@ def test_save_animation_smoketest(tmpdir, writer, frame_format, output, anim):
         dpi = 100.
         codec = 'h264'
 
-    # Use temporary directory for the file-based writers, which produce a file
-    # per frame with known names.
-    with tmpdir.as_cwd():
-        anim.save(output, fps=30, writer=writer, bitrate=500, dpi=dpi,
-                  codec=codec)
+    anim.save(tmp_path / output, fps=30, writer=writer, bitrate=500, dpi=dpi,
+              codec=codec)
 
     del anim
 
 
 @pytest.mark.parametrize('writer, frame_format, output', gen_writers())
-def test_grabframe(tmpdir, writer, frame_format, output):
+def test_grabframe(tmp_path, writer, frame_format, output):
     WriterClass = animation.writers[writer]
 
     if frame_format is not None:
@@ -214,18 +210,14 @@ def test_grabframe(tmpdir, writer, frame_format, output):
         codec = 'h264'
 
     test_writer = WriterClass()
-    # Use temporary directory for the file-based writers, which produce a file
-    # per frame with known names.
-    with tmpdir.as_cwd():
-        with test_writer.saving(fig, output, dpi):
-            # smoke test it works
-            test_writer.grab_frame()
-            for k in {'dpi', 'bbox_inches', 'format'}:
-                with pytest.raises(
-                        TypeError,
-                        match=f"grab_frame got an unexpected keyword argument {k!r}"
-                ):
-                    test_writer.grab_frame(**{k: object()})
+    with test_writer.saving(fig, tmp_path / output, dpi):
+        # smoke test it works
+        test_writer.grab_frame()
+        for k in {'dpi', 'bbox_inches', 'format'}:
+            with pytest.raises(
+                    TypeError,
+                    match=f"grab_frame got an unexpected keyword argument {k!r}"):
+                test_writer.grab_frame(**{k: object()})
 
 
 @pytest.mark.parametrize('writer', [
@@ -295,32 +287,18 @@ def test_movie_writer_registry():
         reason="animation writer not installed")),
      "to_jshtml"])
 @pytest.mark.parametrize('anim', [dict(frames=1)], indirect=['anim'])
-def test_embed_limit(method_name, caplog, tmpdir, anim):
+def test_embed_limit(method_name, caplog, anim):
     caplog.set_level("WARNING")
-    with tmpdir.as_cwd():
-        with mpl.rc_context({"animation.embed_limit": 1e-6}):  # ~1 byte.
-            getattr(anim, method_name)()
+    with mpl.rc_context({"animation.embed_limit": 1e-6}):  # ~1 byte.
+        getattr(anim, method_name)()
     assert len(caplog.records) == 1
     record, = caplog.records
     assert (record.name == "matplotlib.animation"
             and record.levelname == "WARNING")
 
 
-@pytest.mark.parametrize(
-    "method_name",
-    [pytest.param("to_html5_video", marks=pytest.mark.skipif(
-        not animation.writers.is_available(mpl.rcParams["animation.writer"]),
-        reason="animation writer not installed")),
-     "to_jshtml"])
-@pytest.mark.parametrize('anim', [dict(frames=1)], indirect=['anim'])
-def test_cleanup_temporaries(method_name, tmpdir, anim):
-    with tmpdir.as_cwd():
-        getattr(anim, method_name)()
-        assert list(Path(str(tmpdir)).iterdir()) == []
-
-
 @pytest.mark.skipif(shutil.which("/bin/sh") is None, reason="requires a POSIX OS")
-def test_failing_ffmpeg(tmpdir, monkeypatch, anim):
+def test_failing_ffmpeg(tmp_path, monkeypatch, anim):
     """
     Test that we correctly raise a CalledProcessError when ffmpeg fails.
 
@@ -328,13 +306,12 @@ def test_failing_ffmpeg(tmpdir, monkeypatch, anim):
     succeeds when called with no arguments (so that it gets registered by
     `isAvailable`), but fails otherwise, and add it to the $PATH.
     """
-    with tmpdir.as_cwd():
-        monkeypatch.setenv("PATH", ".:" + os.environ["PATH"])
-        exe_path = Path(str(tmpdir), "ffmpeg")
-        exe_path.write_bytes(b"#!/bin/sh\n[[ $@ -eq 0 ]]\n")
-        os.chmod(exe_path, 0o755)
-        with pytest.raises(subprocess.CalledProcessError):
-            anim.save("test.mpeg")
+    monkeypatch.setenv("PATH", str(tmp_path), prepend=":")
+    exe_path = tmp_path / "ffmpeg"
+    exe_path.write_bytes(b"#!/bin/sh\n[[ $@ -eq 0 ]]\n")
+    os.chmod(exe_path, 0o755)
+    with pytest.raises(subprocess.CalledProcessError):
+        anim.save("test.mpeg")
 
 
 @pytest.mark.parametrize("cache_frame_data", [False, True])
@@ -418,7 +395,7 @@ def test_draw_frame(return_value):
         )
 
 
-def test_exhausted_animation(tmpdir):
+def test_exhausted_animation(tmp_path):
     fig, ax = plt.subplots()
 
     def update(frame):
@@ -429,14 +406,13 @@ def test_exhausted_animation(tmpdir):
         cache_frame_data=False
     )
 
-    with tmpdir.as_cwd():
-        anim.save("test.gif", writer='pillow')
+    anim.save(tmp_path / "test.gif", writer='pillow')
 
     with pytest.warns(UserWarning, match="exhausted"):
         anim._start()
 
 
-def test_no_frame_warning(tmpdir):
+def test_no_frame_warning():
     fig, ax = plt.subplots()
 
     def update(frame):
@@ -452,7 +428,7 @@ def test_no_frame_warning(tmpdir):
 
 
 @check_figures_equal(extensions=["png"])
-def test_animation_frame(tmpdir, fig_test, fig_ref):
+def test_animation_frame(tmp_path, fig_test, fig_ref):
     # Test the expected image after iterating through a few frames
     # we save the animation to get the iteration because we are not
     # in an interactive framework.
@@ -473,8 +449,7 @@ def test_animation_frame(tmpdir, fig_test, fig_ref):
     anim = animation.FuncAnimation(
         fig_test, animate, init_func=init, frames=5,
         blit=True, repeat=False)
-    with tmpdir.as_cwd():
-        anim.save("test.gif")
+    anim.save(tmp_path / "test.gif")
 
     # Reference figure without animation
     ax = fig_ref.add_subplot()


### PR DESCRIPTION
## PR summary

The animation writers will put its temporary files in `TemporaryDirectory`, so there's no need to `chdir` to avoid polluting the current directory. Instead, just save directly to a temporary file name.

For the same reason, drop `test_cleanup_temporaries`, which is now just a test for the Python standard library.

Also, at some point, `pytest` will want to deprecate the `tmpdir` fixture, so switch to `tmp_path`.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines