### PR TITLE
Overloading the definition of axline

### DIFF
--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -139,15 +139,21 @@ class Axes(_AxesBase):
         self, x: float = ..., ymin: float = ..., ymax: float = ..., **kwargs
     ) -> Line2D: ...
 
-    # TODO: Could separate the xy2 and slope signatures
+    @overload
     def axline(
         self,
         xy1: tuple[float, float],
-        xy2: tuple[float, float] | None = ...,
-        *,
-        slope: float | None = ...,
+        xy2: tuple[float, float],
         **kwargs
     ) -> AxLine: ...
+    @overload
+    def axline(
+        self,
+        xy1: tuple[float, float],
+        slope: float,
+        **kwargs
+    ) -> AxLine: ...
+
     def axhspan(
         self, ymin: float, ymax: float, xmin: float = ..., xmax: float = ..., **kwargs
     ) -> Rectangle: ...


### PR DESCRIPTION
Originally within lib/matplotlib/axes/_axes.pyi,

There was a TODO item:

```
# TODO: Could separate the xy2 and slope signatures
    def axline(
        self,
        xy1: tuple[float, float],
        xy2: tuple[float, float] | None = ...,
        *,
        slope: float | None = ...,
        **kwargs
    ) -> AxLine: ...
```

This change is to overload the definition of axline with two separate definitions, with one needed to specify `xy2` and the other to specify `slope`.

Since this is my first contribution to Matplotlib, I am opening a PR to first verify what I am doing fits the developers' requirements, and make changes as I discover more places needed to be changed, as well as making changes according to the developers' feedback.

This PR resolves issue #29234.