### PR TITLE
DOC: Add plt.show() to introductory pyplot example

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -15,6 +15,7 @@ programmatic plot generation::
     x = np.arange(0, 5, 0.1)
     y = np.sin(x)
     plt.plot(x, y)
+    plt.show()
 
 The explicit object-oriented API is recommended for complex plots, though
 pyplot is still usually used to create the figure and often the Axes in the
@@ -29,6 +30,7 @@ figure. See `.pyplot.figure`, `.pyplot.subplots`, and
     y = np.sin(x)
     fig, ax = plt.subplots()
     ax.plot(x, y)
+    plt.show()
 
 
 See :ref:`api_interfaces` for an explanation of the tradeoffs between the


### PR DESCRIPTION
Closes #29227 

As detailed in https://github.com/matplotlib/matplotlib/issues/29227#issuecomment-2522782159:

> I very much believe plt.show() should be added here:
> 
> - This is a first-point-of-contact example. We shouldn't expect that readers are fiamiliar with the details when show() is necessary or not.
> This is an otherwise complete and working example, including imports and data. As the OP noted it is surprising if this does not generate any output by default.
> - The plotting workflow is 1. create a figure 2. add contents 3. output the figure. We shouldn't leave out the third step. Since this is not the place to discuss all aspects of figure output (you could use savefig() instead of show(), jupyter has an auto-show, etc.) using plt.show() is a good default choise for output.

