### PR TITLE
Add quotes around [dev] in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@
 #
 #   conda env create -f environment.yml
 #   conda activate mpl-dev
-#   pip install -e .[dev]
+#   pip install --verbose --no-build-isolation --editable ".[dev]"
 #
 ---
 name: mpl-dev


### PR DESCRIPTION
Closes #29241 by improving the comment which explains how to up the dev environment using conda. 

Update comment describing conda dev set up

- Update commented commands in environment.yml to match
 the command in development_setup.rst
- This version of the command does not cause issues with
zsh (due to the quotation marks).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
