### PR TITLE
Fix building freetype 2.6.1 on macOS clang 18

### DIFF
--- a/subprojects/packagefiles/freetype-2.6.1-meson/src/gzip/zconf.h
+++ b/subprojects/packagefiles/freetype-2.6.1-meson/src/gzip/zconf.h
@@ -1,0 +1,284 @@
+/* zconf.h -- configuration of the zlib compression library
+ * Copyright (C) 1995-2002 Jean-loup Gailly.
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+
+/* @(#) $Id$ */
+
+#ifndef _ZCONF_H
+#define _ZCONF_H
+
+/*
+ * If you *really* need a unique prefix for all types and library functions,
+ * compile with -DZ_PREFIX. The "standard" zlib should be compiled without it.
+ */
+#ifdef Z_PREFIX
+#  define deflateInit_         z_deflateInit_
+#  define deflate              z_deflate
+#  define deflateEnd           z_deflateEnd
+#  define inflateInit_         z_inflateInit_
+#  define inflate              z_inflate
+#  define inflateEnd           z_inflateEnd
+#  define deflateInit2_        z_deflateInit2_
+#  define deflateSetDictionary z_deflateSetDictionary
+#  define deflateCopy          z_deflateCopy
+#  define deflateReset         z_deflateReset
+#  define deflateParams        z_deflateParams
+#  define inflateInit2_        z_inflateInit2_
+#  define inflateSetDictionary z_inflateSetDictionary
+#  define inflateSync          z_inflateSync
+#  define inflateSyncPoint     z_inflateSyncPoint
+#  define inflateReset         z_inflateReset
+#  define compress             z_compress
+#  define compress2            z_compress2
+#  define uncompress           z_uncompress
+#  define adler32              z_adler32
+#  define crc32                z_crc32
+#  define get_crc_table        z_get_crc_table
+
+#  define Byte   z_Byte
+#  define uInt   z_uInt
+#  define uLong  z_uLong
+#  define Bytef  z_Bytef
+#  define charf  z_charf
+#  define intf   z_intf
+#  define uIntf  z_uIntf
+#  define uLongf z_uLongf
+#  define voidpf z_voidpf
+#  define voidp  z_voidp
+#endif
+
+#if (defined(_WIN32) || defined(__WIN32__)) && !defined(WIN32)
+#  define WIN32
+#endif
+#if defined(__GNUC__) || defined(WIN32) || defined(__386__) || defined(i386)
+#  ifndef __32BIT__
+#    define __32BIT__
+#  endif
+#endif
+#if defined(__MSDOS__) && !defined(MSDOS)
+#  define MSDOS
+#endif
+
+/* WinCE doesn't have errno.h */
+#ifdef _WIN32_WCE
+#  define NO_ERRNO_H
+#endif
+
+
+/*
+ * Compile with -DMAXSEG_64K if the alloc function cannot allocate more
+ * than 64k bytes at a time (needed on systems with 16-bit int).
+ */
+#if defined(MSDOS) && !defined(__32BIT__)
+#  define MAXSEG_64K
+#endif
+#ifdef MSDOS
+#  define UNALIGNED_OK
+#endif
+
+#if (defined(MSDOS) || defined(_WINDOWS) || defined(WIN32))  && !defined(STDC)
+#  define STDC
+#endif
+#if defined(__STDC__) || defined(__cplusplus) || defined(__OS2__)
+#  ifndef STDC
+#    define STDC
+#  endif
+#endif
+
+#ifndef STDC
+#  ifndef const /* cannot use !defined(STDC) && !defined(const) on Mac */
+#    define const
+#  endif
+#endif
+
+/* Some Mac compilers merge all .h files incorrectly: */
+#if defined(__MWERKS__) || defined(applec) ||defined(THINK_C) ||defined(__SC__)
+#  define NO_DUMMY_DECL
+#endif
+
+/* Old Borland C and LCC incorrectly complains about missing returns: */
+#if defined(__BORLANDC__) && (__BORLANDC__ < 0x500)
+#  define NEED_DUMMY_RETURN
+#endif
+
+#if defined(__LCC__)
+#  define  NEED_DUMMY_RETURN
+#endif
+
+/* Maximum value for memLevel in deflateInit2 */
+#ifndef MAX_MEM_LEVEL
+#  ifdef MAXSEG_64K
+#    define MAX_MEM_LEVEL 8
+#  else
+#    define MAX_MEM_LEVEL 9
+#  endif
+#endif
+
+/* Maximum value for windowBits in deflateInit2 and inflateInit2.
+ * WARNING: reducing MAX_WBITS makes minigzip unable to extract .gz files
+ * created by gzip. (Files created by minigzip can still be extracted by
+ * gzip.)
+ */
+#ifndef MAX_WBITS
+#  define MAX_WBITS   15 /* 32K LZ77 window */
+#endif
+
+/* The memory requirements for deflate are (in bytes):
+            (1 << (windowBits+2)) +  (1 << (memLevel+9))
+ that is: 128K for windowBits=15  +  128K for memLevel = 8  (default values)
+ plus a few kilobytes for small objects. For example, if you want to reduce
+ the default memory requirements from 256K to 128K, compile with
+     make CFLAGS="-O -DMAX_WBITS=14 -DMAX_MEM_LEVEL=7"
+ Of course this will generally degrade compression (there's no free lunch).
+
+   The memory requirements for inflate are (in bytes) 1 << windowBits
+ that is, 32K for windowBits=15 (default value) plus a few kilobytes
+ for small objects.
+*/
+
+                        /* Type declarations */
+
+#ifndef OF /* function prototypes */
+#  ifdef STDC
+#    define OF(args)  args
+#  else
+#    define OF(args)  ()
+#  endif
+#endif
+
+/* The following definitions for FAR are needed only for MSDOS mixed
+ * model programming (small or medium model with some far allocations).
+ * This was tested only with MSC; for other MSDOS compilers you may have
+ * to define NO_MEMCPY in zutil.h.  If you don't need the mixed model,
+ * just define FAR to be empty.
+ */
+#if (defined(M_I86SM) || defined(M_I86MM)) && !defined(__32BIT__)
+   /* MSC small or medium model */
+#  define SMALL_MEDIUM
+#  ifdef _MSC_VER
+#    define FAR _far
+#  else
+#    define FAR far
+#  endif
+#endif
+#if defined(__BORLANDC__) && (defined(__SMALL__) || defined(__MEDIUM__))
+#  ifndef __32BIT__
+#    define SMALL_MEDIUM
+#    define FAR _far
+#  endif
+#endif
+
+/* Compile with -DZLIB_DLL for Windows DLL support */
+#if defined(ZLIB_DLL)
+#  if defined(_WINDOWS) || defined(WINDOWS)
+#    ifdef FAR
+#      undef FAR
+#    endif
+#    include <windows.h>
+#    define ZEXPORT(x)  x WINAPI
+#    ifdef WIN32
+#      define ZEXPORTVA(x)  x WINAPIV
+#    else
+#      define ZEXPORTVA(x)  x FAR _cdecl _export
+#    endif
+#  endif
+#  if defined (__BORLANDC__)
+#    if (__BORLANDC__ >= 0x0500) && defined (WIN32)
+#      include <windows.h>
+#      define ZEXPORT(x) x __declspec(dllexport) WINAPI
+#      define ZEXPORTRVA(x)  x __declspec(dllexport) WINAPIV
+#    else
+#      if defined (_Windows) && defined (__DLL__)
+#        define ZEXPORT(x) x _export
+#        define ZEXPORTVA(x) x _export
+#      endif
+#    endif
+#  endif
+#endif
+
+
+#ifndef ZEXPORT
+#  define ZEXPORT(x)   static x
+#endif
+#ifndef ZEXPORTVA
+#  define ZEXPORTVA(x)   static x
+#endif
+#ifndef ZEXTERN
+#  define ZEXTERN(x) static x
+#endif
+#ifndef ZEXTERNDEF
+#  define ZEXTERNDEF(x)  static x
+#endif
+
+#ifndef FAR
+#   define FAR
+#endif
+
+#if !defined(__MACTYPES__)
+typedef unsigned char  Byte;  /* 8 bits */
+#endif
+typedef unsigned int   uInt;  /* 16 bits or more */
+typedef unsigned long  uLong; /* 32 bits or more */
+
+#ifdef SMALL_MEDIUM
+   /* Borland C/C++ and some old MSC versions ignore FAR inside typedef */
+#  define Bytef Byte FAR
+#else
+   typedef Byte  FAR Bytef;
+#endif
+typedef char  FAR charf;
+typedef int   FAR intf;
+typedef uInt  FAR uIntf;
+typedef uLong FAR uLongf;
+
+#ifdef STDC
+   typedef void FAR *voidpf;
+   typedef void     *voidp;
+#else
+   typedef Byte FAR *voidpf;
+   typedef Byte     *voidp;
+#endif
+
+#ifdef HAVE_UNISTD_H
+#  include <sys/types.h> /* for off_t */
+#  include <unistd.h>    /* for SEEK_* and off_t */
+#  define z_off_t  off_t
+#endif
+#ifndef SEEK_SET
+#  define SEEK_SET        0       /* Seek from beginning of file.  */
+#  define SEEK_CUR        1       /* Seek from current position.  */
+#  define SEEK_END        2       /* Set file pointer to EOF plus "offset" */
+#endif
+#ifndef z_off_t
+#  define  z_off_t long
+#endif
+
+/* MVS linker does not support external names larger than 8 bytes */
+#if defined(__MVS__)
+#   pragma map(deflateInit_,"DEIN")
+#   pragma map(deflateInit2_,"DEIN2")
+#   pragma map(deflateEnd,"DEEND")
+#   pragma map(inflateInit_,"ININ")
+#   pragma map(inflateInit2_,"ININ2")
+#   pragma map(inflateEnd,"INEND")
+#   pragma map(inflateSync,"INSY")
+#   pragma map(inflateSetDictionary,"INSEDI")
+#   pragma map(inflate_blocks,"INBL")
+#   pragma map(inflate_blocks_new,"INBLNE")
+#   pragma map(inflate_blocks_free,"INBLFR")
+#   pragma map(inflate_blocks_reset,"INBLRE")
+#   pragma map(inflate_codes_free,"INCOFR")
+#   pragma map(inflate_codes,"INCO")
+#   pragma map(inflate_fast,"INFA")
+#   pragma map(inflate_flush,"INFLU")
+#   pragma map(inflate_mask,"INMA")
+#   pragma map(inflate_set_dictionary,"INSEDI2")
+#   pragma map(inflate_copyright,"INCOPY")
+#   pragma map(inflate_trees_bits,"INTRBI")
+#   pragma map(inflate_trees_dynamic,"INTRDY")
+#   pragma map(inflate_trees_fixed,"INTRFI")
+#   pragma map(inflate_trees_free,"INTRFR")
+#endif
+
+#endif /* _ZCONF_H */


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Freetype 2.6.1 has an outdated copy of a zlib header (like from ~1998) which has a bad check for choosing whether to define Byte on macOS. This adds a patched version of the zconf.h header that has a proper check for __MACTYPES__, which is defined by the macOS SDK.

For posterity, the failure occurred over on conda-forge and looked like:
```
FAILED: subprojects/freetype-2.6.1/libfreetype.a.p/src_gzip_ftgzip.c.o 
x86_64-apple-darwin13.4.0-clang -Isubprojects/freetype-2.6.1/libfreetype.a.p -Isubprojects/freetype-2.6.1 -I../subprojects/freetype-2.6.1 -I../subprojects/freetype-2.6.1/include -fvisibility=hidden -flto -fdiagnostics-color=always -DNDEBUG -Wall -Winvalid-pch -O3 -march=core2 -mtune=haswell -mssse3 -ftree-vectorize -fPIC -fstack-protector-strong -O2 -pipe -isystem /Users/runner/miniforge3/conda-bld/matplotlib-suite_1733188751163/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/include -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/matplotlib-suite_1733188751163/work=/usr/local/src/conda/matplotlib-base-3.9.3 -fdebug-prefix-map=/Users/runner/miniforge3/conda-bld/matplotlib-suite_1733188751163/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl=/usr/local/src/conda-prefix -D_FORTIFY_SOURCE=2 -isystem /Users/runner/miniforge3/conda-bld/matplotlib-suite_1733188751163/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/include -mmacosx-version-min=10.13 -mmacosx-version-min=10.13 -DFT2_BUILD_LIBRARY '-DFT_CONFIG_CONFIG_H=<ftconfig.h>' '-DFT_CONFIG_OPTIONS_H=<ftoption.h>' -MD -MQ subprojects/freetype-2.6.1/libfreetype.a.p/src_gzip_ftgzip.c.o -MF subprojects/freetype-2.6.1/libfreetype.a.p/src_gzip_ftgzip.c.o.d -o subprojects/freetype-2.6.1/libfreetype.a.p/src_gzip_ftgzip.c.o -c ../subprojects/freetype-2.6.1/src/gzip/ftgzip.c
In file included from ../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:65:
In file included from ../subprojects/freetype-2.6.1/src/gzip/zlib.h:34:
../subprojects/freetype-2.6.1/src/gzip/zconf.h:228:12: error: unknown type name 'Byte'
  228 |    typedef Byte  FAR Bytef;
      |            ^
In file included from ../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:83:
../subprojects/freetype-2.6.1/src/gzip/inftrees.h:22:7: error: unknown type name 'Byte'
   22 |       Byte Exop;        /* number of extra bits or operation */
      |       ^
../subprojects/freetype-2.6.1/src/gzip/inftrees.h:23:7: error: unknown type name 'Byte'
   23 |       Byte Bits;        /* number of bits in this code or subcode */
      |       ^
In file included from ../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:91:
../subprojects/freetype-2.6.1/src/gzip/inftrees.c:247:21: error: use of undeclared identifier 'Byte'
  247 |           r.bits = (Byte)l;     /* bits to dump before this table */
      |                     ^
../subprojects/freetype-2.6.1/src/gzip/inftrees.c:248:21: error: use of undeclared identifier 'Byte'
  248 |           r.exop = (Byte)j;     /* bits in this table */
      |                     ^
../subprojects/freetype-2.6.1/src/gzip/inftrees.c:258:17: error: use of undeclared identifier 'Byte'
  258 |       r.bits = (Byte)(k - w);
      |                 ^
../subprojects/freetype-2.6.1/src/gzip/inftrees.c:263:19: error: use of undeclared identifier 'Byte'
  263 |         r.exop = (Byte)(*p < 256 ? 0 : 32 + 64);     /* 256 is end-of-block */
      |                   ^
../subprojects/freetype-2.6.1/src/gzip/inftrees.c:268:19: error: use of undeclared identifier 'Byte'
  268 |         r.exop = (Byte)(e[*p - s] + 16 + 64);/* non-simple--look up in lists */
      |                   ^
In file included from ../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:93:
../subprojects/freetype-2.6.1/src/gzip/infcodes.c:50:3: error: unknown type name 'Byte'
   50 |   Byte lbits;           /* ltree bits decoded per branch */
      |   ^
../subprojects/freetype-2.6.1/src/gzip/infcodes.c:51:3: error: unknown type name 'Byte'
   51 |   Byte dbits;           /* dtree bits decoder per branch */
      |   ^
../subprojects/freetype-2.6.1/src/gzip/infcodes.c:70:17: error: use of undeclared identifier 'Byte'
   70 |     c->lbits = (Byte)bl;
      |                 ^
../subprojects/freetype-2.6.1/src/gzip/infcodes.c:71:17: error: use of undeclared identifier 'Byte'
   71 |     c->dbits = (Byte)bd;
      |                 ^
../subprojects/freetype-2.6.1/src/gzip/infcodes.c:204:9: error: use of undeclared identifier 'Byte'
  204 |         OUTBYTE(*f++)
      |         ^
../subprojects/freetype-2.6.1/src/gzip/infutil.h:83:27: note: expanded from macro 'OUTBYTE'
   83 | #define OUTBYTE(a) {*q++=(Byte)(a);m--;}
      |                           ^
In file included from ../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:93:
../subprojects/freetype-2.6.1/src/gzip/infcodes.c:213:7: error: use of undeclared identifier 'Byte'
  213 |       OUTBYTE(c->sub.lit)
      |       ^
../subprojects/freetype-2.6.1/src/gzip/infutil.h:83:27: note: expanded from macro 'OUTBYTE'
   83 | #define OUTBYTE(a) {*q++=(Byte)(a);m--;}
      |                           ^
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:305:23: warning: incompatible pointer types assigning to 'Bytef *' (aka 'int *') from 'FT_Byte[4096]' (aka 'unsigned char[4096]') [-Wincompatible-pointer-types]
  305 |     zstream->next_in  = zip->buffer;
      |                       ^ ~~~~~~~~~~~
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:354:26: warning: incompatible pointer types assigning to 'Bytef *' (aka 'int *') from 'FT_Byte[4096]' (aka 'unsigned char[4096]') [-Wincompatible-pointer-types]
  354 |       zstream->next_in   = zip->input;
      |                          ^ ~~~~~~~~~~
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:356:26: warning: incompatible pointer types assigning to 'Bytef *' (aka 'int *') from 'FT_Byte[4096]' (aka 'unsigned char[4096]') [-Wincompatible-pointer-types]
  356 |       zstream->next_out  = zip->buffer;
      |                          ^ ~~~~~~~~~~~
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:401:23: warning: incompatible pointer types assigning to 'Bytef *' (aka 'int *') from 'FT_Byte[4096]' (aka 'unsigned char[4096]') [-Wincompatible-pointer-types]
  401 |     zstream->next_in  = zip->input;
      |                       ^ ~~~~~~~~~~
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:416:24: warning: incompatible pointer types assigning to 'Bytef *' (aka 'int *') from 'FT_Byte *' (aka 'unsigned char *') [-Wincompatible-pointer-types]
  416 |     zstream->next_out  = zip->cursor;
      |                        ^ ~~~~~~~~~~~
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:435:20: warning: incompatible pointer types assigning to 'FT_Byte *' (aka 'unsigned char *') from 'Bytef *' (aka 'int *') [-Wincompatible-pointer-types]
  435 |         zip->limit = zstream->next_out;
      |                    ^ ~~~~~~~~~~~~~~~~~
../subprojects/freetype-2.6.1/src/gzip/ftgzip.c:730:22: warning: incompatible pointer types assigning to 'Bytef *' (aka 'int *') from 'FT_Byte *' (aka 'unsigned char *') [-Wincompatible-pointer-types]
  730 |     stream.next_out  = output;
      |                      ^ ~~~~~~
7 warnings and 14 errors generated.
```

I'm using the Meson support for dropping in a new entire file, but the diff vs. the version that shipped with freetype 2.6.1:
```diff
--- zconf.h.orig	2024-12-02 16:53:07
+++ zconf.h	2024-12-02 16:53:14
@@ -215,7 +215,7 @@
 #   define FAR
 #endif
 
-#if !defined(MACOS) && !defined(TARGET_OS_MAC)
+#if !defined(__MACTYPES__)
 typedef unsigned char  Byte;  /* 8 bits */
 #endif
 typedef unsigned int   uInt;  /* 16 bits or more */
```

Research shows this change came to [zlib around 1.2.0](https://github.com/madler/zlib/blob/ef24c4c7502169f016dcd2a26923dbaf3216748c/ChangeLog#L1124), released over 20 years ago. 🤯 