### PR TITLE
[Bug Fix] Fix reverse mapping for _translate_tick_params

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1053,8 +1053,8 @@ class Axis(martist.Artist):
             )
         return self._translate_tick_params(self._minor_tick_kw, reverse=True)
 
-    @staticmethod
-    def _translate_tick_params(kw, reverse=False):
+    @classmethod
+    def _translate_tick_params(cls, kw, reverse=False):
         """
         Translate the kwargs supported by `.Axis.set_tick_params` to kwargs
         supported by `.Tick._apply_params`.
@@ -1096,10 +1096,20 @@ class Axis(martist.Artist):
             'labeltop': 'label2On',
         }
         if reverse:
-            kwtrans = {
-                oldkey: kw_.pop(newkey)
-                for oldkey, newkey in keymap.items() if newkey in kw_
-            }
+            kwtrans = {}
+            is_x_axis = cls.axis_name == 'x'
+            for oldkey, newkey in keymap.items():
+                if newkey in kw_:
+                    if is_x_axis and newkey == 'label1On':
+                        kwtrans['labelbottom'] = kw_.pop(newkey)
+                    elif is_x_axis and newkey == 'tick1On':
+                        kwtrans['bottom'] = kw_.pop(newkey)
+                    elif is_x_axis and newkey == 'label2On':
+                        kwtrans['labeltop'] = kw_.pop(newkey)
+                    elif is_x_axis and newkey == 'tick2On':
+                        kwtrans['top'] = kw_.pop(newkey)
+                    else:
+                        kwtrans[oldkey] = kw_.pop(newkey)
         else:
             kwtrans = {
                 newkey: kw_.pop(oldkey)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1098,16 +1098,11 @@ class Axis(martist.Artist):
         if reverse:
             kwtrans = {}
             is_x_axis = cls.axis_name == 'x'
+            y_axis_keys = ['left', 'right', 'labelleft', 'labelright']
             for oldkey, newkey in keymap.items():
                 if newkey in kw_:
-                    if is_x_axis and newkey == 'label1On':
-                        kwtrans['labelbottom'] = kw_.pop(newkey)
-                    elif is_x_axis and newkey == 'tick1On':
-                        kwtrans['bottom'] = kw_.pop(newkey)
-                    elif is_x_axis and newkey == 'label2On':
-                        kwtrans['labeltop'] = kw_.pop(newkey)
-                    elif is_x_axis and newkey == 'tick2On':
-                        kwtrans['top'] = kw_.pop(newkey)
+                    if is_x_axis and oldkey in y_axis_keys:
+                        continue
                     else:
                         kwtrans[oldkey] = kw_.pop(newkey)
         else:

--- a/lib/matplotlib/tests/test_axis.py
+++ b/lib/matplotlib/tests/test_axis.py
@@ -29,3 +29,12 @@ def test_axis_not_in_layout():
     # Positions should not be affected by overlapping 100 label
     assert ax1_left.get_position().bounds == ax2_left.get_position().bounds
     assert ax1_right.get_position().bounds == ax2_right.get_position().bounds
+
+
+def test_translate_tick_params_reverse():
+    fig, ax = plt.subplots()
+    kw = {'label1On': 'a', 'label2On': 'b', 'tick1On': 'c', 'tick2On': 'd'}
+    assert (ax.xaxis._translate_tick_params(kw, reverse=True) ==
+            {'labelbottom': 'a', 'labeltop': 'b', 'bottom': 'c', 'top': 'd'})
+    assert (ax.yaxis._translate_tick_params(kw, reverse=True) ==
+            {'labelleft': 'a', 'labelright': 'b', 'left': 'c', 'right': 'd'})


### PR DESCRIPTION
## PR summary

Hi. This fixes a bug in `_translate_tick_params` where some keys are not being mapped correctly with `reverse=True` and `cls.axis_name = 'x'`. 

For example, both 'left' and 'bottom' are mapped to 'tick1On', making the reverse ambiguous. 

Separated from #28968 because this is an independent bug.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines