### PR TITLE
Adding figratio to matplotlib to allow dynamic change of figure size based upon width/height and aspect

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3220,6 +3220,44 @@ None}, default: None
         """
         self.set_size_inches(self.get_figwidth(), val, forward=forward)
 
+    def set_figratio(self, width=None, height=None, aspect=None, forward=True):
+        """
+        Set the height of the figure in inches.
+
+        Parameters
+        ----------
+        height : float
+        width : float
+        aspect: float
+        forward : bool
+            See `set_size_inches`.
+
+        See Also
+        --------
+        matplotlib.figure.Figure.set_figwidth
+        matplotlib.figure.Figure.set_figheight
+        matplotlib.figure.Figure.set_size_inches
+        """
+        if height and width:
+            self.set_size_inches(width, height, forward=forward)
+        elif aspect:
+            if height:
+                self.set_size_inches(
+                    self.get_figwidth()*aspect, height, forward=forward
+                )
+            elif width:
+                self.set_size_inches(
+                    width, self.get_figheight()*aspect, forward=forward
+                )
+            else:
+                self.set_size_inches(
+                    self.get_figwidth()*aspect,
+                    self.get_figheight()*aspect,
+                    forward=forward
+                )
+        else:
+            raise ValueError("No value passed for aspect")
+
     def clear(self, keep_observers=False):
         # docstring inherited
         super().clear(keep_observers=keep_observers)

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -436,6 +436,49 @@ def test_set_fig_size():
     assert fig.get_figheight() == 3
 
 
+def test_set_fig_ratio():
+    # defining plt fig
+    fig = plt.figure()
+
+    # setting width and height individually
+    fig.set_figwidth(5)
+    fig.set_figheight(1)
+
+    # setting width and height with figratio
+    fig.set_figratio(2, 4)
+    assert fig.get_figwidth() == 2
+    assert fig.get_figheight() == 4
+
+    # setting width with value and height with aspect
+    fig.set_figratio(width=3, aspect=2)
+    assert fig.get_figwidth() == 3
+    assert fig.get_figheight() == 8
+
+    # setting height with value and width with aspect
+    fig.set_figratio(height=3, aspect=2)
+    assert fig.get_figwidth() == 6
+    assert fig.get_figheight() == 3
+
+    # upsizing width and height with an aspect of 4
+    fig.set_figratio(aspect=4)
+    assert fig.get_figwidth() == 24
+    assert fig.get_figheight() == 12
+
+    # error checking for when only width is passed in
+    try:
+        fig.set_figratio(width=4)
+    except ValueError:
+        assert fig.get_figwidth() == 24
+        assert fig.get_figheight() == 12
+
+    # error checking for when only height is passed in
+    try:
+        fig.set_figratio(height=4)
+    except ValueError:
+        assert fig.get_figwidth() == 24
+        assert fig.get_figheight() == 12
+
+
 def test_axes_remove():
     fig, axs = plt.subplots(2, 2)
     axs[-1, -1].remove()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
It is an improvement to matplotlib and adds functionality to the module

- What problem does it solve?
closes #28758 

- What is the reasoning for this implementation?
Simple implementation to make resizing more intuitive for papers in the appropriate format. 

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

`# defining plt fig
    fig = plt.figure()

    # setting width and height individually
    fig.set_figwidth(5)
    fig.set_figheight(1)
    # setting width with value and height with aspect
    fig.set_figratio(width=3, aspect=2)
`
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [y] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [y] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [y] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
