### PR TITLE
Prevent draggable legend from being stuck after scroll event

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1488,6 +1488,8 @@ class DraggableBase:
 
     def on_pick(self, evt):
         if self._check_still_parented():
+            if evt.name == "scroll_event":
+                return
             if evt.artist == self.ref_artist:
                 self.mouse_x = evt.mouseevent.x
                 self.mouse_y = evt.mouseevent.y


### PR DESCRIPTION
Fixes: #29142

This PR addresses an issue where the draggable legend in Matplotlib becomes stuck to the cursor after a scroll event while hovering over the legend. To "unstick" the legend, users must left-click, which is unintuitive.