### PR TITLE
Update figure.py

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -3219,7 +3219,43 @@ None}, default: None
         matplotlib.figure.Figure.set_size_inches
         """
         self.set_size_inches(self.get_figwidth(), val, forward=forward)
+    def set_figratio(self, width=None, height=None, aspect=None, forward=True):
+    """
+    Set the size of the figure using a width, height, or aspect ratio.
+    Parameters
+    ----------
+    width : float, optional
+        The width of the figure in inches. If None, the width is taken from rcParams["figure.figsize"].
+    height : float, optional
+        The height of the figure in inches. If None, the height is taken from rcParams["figure.figsize"].
+    aspect : float, optional
+        The aspect ratio to adjust the size. If set, the height or width will be adjusted accordingly.
+    forward : bool, optional
+        See `set_size_inches` for details.
+    
+    Raises
+    ------
+    ValueError
+        If neither width nor height nor aspect is provided.
+    """
+    figsize_default = plt.rcParams["figure.figsize"]
 
+    if width is not None and height is not None:
+        self.set_size_inches(width, height, forward=forward)
+    elif aspect is not None:
+        if height is not None:
+            self.set_size_inches(self.get_figwidth() * aspect, height, forward=forward)
+        elif width is not None:
+            self.set_size_inches(width, self.get_figheight() * aspect, forward=forward)
+        else:
+            self.set_size_inches(self.get_figwidth() * aspect, self.get_figheight() * aspect, forward=forward)
+    else:
+        if width is None:
+            width = figsize_default[0]  
+        if height is None:
+            height = figsize_default[1]  
+        self.set_size_inches(width, height, forward=forward)
+        
     def clear(self, keep_observers=False):
         # docstring inherited
         super().clear(keep_observers=keep_observers)


### PR DESCRIPTION
This PR introduces a new method, set_figratio, to the matplotlib.figure.Figure class. The purpose of this method is to allow users to set the figure's height and width while optionally preserving the aspect ratio between them. It also supports the ability to use the default figure size values defined in rcParams when one of the dimensions (width or height) is None. This provides a more convenient and flexible approach for adjusting the figure's size based on either fixed dimensions or aspect ratios, addressing a common need for publication-style figure formatting.

Changes made:
Introduced set_figratio to adjust the figure's width and height or aspect ratio.
Added support for None in the figsize parameter, automatically using the default size from rcParams when needed.
Simplified the figure resizing logic based on aspect ratios, ensuring better compatibility with user-defined figure sizes.
Motivation:
This feature was requested in relation to issue #28758, where users wanted the ability to specify a width or height and automatically adjust the other dimension based on a given aspect ratio. This method aims to streamline that process and allow for a simpler workflow when creating figures with publication-specific sizes.

PR checklist
 "closes #28758" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/28758)
 new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
 Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
 New Features and API Changes are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
 Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines