### PR TITLE
Retarget PR#29175 to main

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -1382,6 +1382,7 @@ def _generate_normals(polygons):
         v2 = np.empty((len(polygons), 3))
         for poly_i, ps in enumerate(polygons):
             n = len(ps)
+            ps = np.asarray(ps)
             i1, i2, i3 = 0, n//3, 2*n//3
             v1[poly_i, :] = ps[i1, :] - ps[i2, :]
             v2[poly_i, :] = ps[i2, :] - ps[i3, :]

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -3,7 +3,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from matplotlib.backend_bases import MouseEvent
-from mpl_toolkits.mplot3d.art3d import Line3DCollection, _all_points_on_plane
+from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection, _all_points_on_plane
 
 
 def test_scatter_3d_projection_conservation():
@@ -85,3 +85,32 @@ def test_all_points_on_plane():
     # All points lie on a plane
     points = np.array([[0, 0, 0], [0, 1, 0], [1, 0, 0], [1, 1, 0], [1, 2, 0]])
     assert _all_points_on_plane(*points.T)
+
+
+def test_generate_normals():
+
+    # Following code is an example taken from
+    # https://stackoverflow.com/questions/18897786/transparency-for-poly3dcollection-plot-in-matplotlib
+    # and modified to test _generate_normals function
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+
+    x = [0, 2, 1, 1]
+    y = [0, 0, 1, 0]
+    z = [0, 0, 0, 1]
+
+    # deliberately use nested tuple
+    vertices = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
+
+    tupleList = list(zip(x, y, z))
+
+    poly3d = [[tupleList[vertices[ix][iy]] for iy in range(len(vertices[0]))]
+              for ix in range(len(vertices))]
+    ax.scatter(x, y, z)
+    collection = Poly3DCollection(poly3d, alpha=0.2, edgecolors='r', shade=True)
+    face_color = [0.5, 0.5, 1]  # alternative: matplotlib.colors.rgb2hex([0.5, 0.5, 1])
+    collection.set_facecolor(face_color)
+    ax.add_collection3d(collection)
+
+    plt.draw()

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -88,29 +88,11 @@ def test_all_points_on_plane():
 
 
 def test_generate_normals():
-
-    # Following code is an example taken from
-    # https://stackoverflow.com/questions/18897786/transparency-for-poly3dcollection-plot-in-matplotlib
-    # and modified to test _generate_normals function
+    # Smoke test for https://github.com/matplotlib/matplotlib/issues/29156
+    vertices = ((0, 0, 0), (0, 5, 0), (5, 5, 0), (5, 0, 0))
+    shape = Poly3DCollection([vertices], edgecolors='r', shade=True)
 
     fig = plt.figure()
-    ax = fig.add_subplot(111, projection='3d')
-
-    x = [0, 2, 1, 1]
-    y = [0, 0, 1, 0]
-    z = [0, 0, 0, 1]
-
-    # deliberately use nested tuple
-    vertices = ((0, 1, 2), (0, 1, 3), (0, 2, 3), (1, 2, 3))
-
-    tupleList = list(zip(x, y, z))
-
-    poly3d = [[tupleList[vertices[ix][iy]] for iy in range(len(vertices[0]))]
-              for ix in range(len(vertices))]
-    ax.scatter(x, y, z)
-    collection = Poly3DCollection(poly3d, alpha=0.2, edgecolors='r', shade=True)
-    face_color = [0.5, 0.5, 1]  # alternative: matplotlib.colors.rgb2hex([0.5, 0.5, 1])
-    collection.set_facecolor(face_color)
-    ax.add_collection3d(collection)
-
-    plt.draw()
+    ax = fig.add_subplot(projection='3d')
+    ax.add_collection3d(shape)
+    plt.show()

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -95,4 +95,4 @@ def test_generate_normals():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
     ax.add_collection3d(shape)
-    plt.show()
+    plt.draw()

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -3,7 +3,11 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 from matplotlib.backend_bases import MouseEvent
-from mpl_toolkits.mplot3d.art3d import Line3DCollection, Poly3DCollection, _all_points_on_plane
+from mpl_toolkits.mplot3d.art3d import (
+    Line3DCollection,
+    Poly3DCollection,
+    _all_points_on_plane,
+)
 
 
 def test_scatter_3d_projection_conservation():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
https://github.com/matplotlib/matplotlib/pull/29175 accidentally targeted the `v3.9.x` branch instead of `main`, retargeting.

Closes https://github.com/matplotlib/matplotlib/issues/29156

I think only one review needed for this one.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
