### PR TITLE
FIX: zero width lines need no pattern

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -77,7 +77,7 @@ def _scale_dashes(offset, dashes, lw):
         return offset, dashes
     scaled_offset = offset * lw
     scaled_dashes = ([x * lw if x is not None else None for x in dashes]
-                     if dashes is not None else None)
+                     if dashes is not None and lw > 0 else None)
     return scaled_offset, scaled_dashes
 
 

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -681,6 +681,16 @@ def test_set_wrong_linestyle():
 
 
 @mpl.style.context('default')
+def test_zero_linewidth_scaling():
+    c = Collection()
+    c.set_linestyle('dashed')
+    c.set_linewidth(0)
+
+    # With a zero linewidth, there can be no pattern
+    assert c.get_linestyle() == [(0, None)]
+
+
+@mpl.style.context('default')
 def test_capstyle():
     col = mcollections.PathCollection([])
     assert col.get_capstyle() is None


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->
Proposal to fix #28298.  If the linewidth is zero then the dash pattern is arbitrary, so set the scaled pattern to `None`, which is the same as solid lines.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
