### PR TITLE
Update cibuildwheel workflow

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -34,7 +34,7 @@ jobs:
                  'CI: Run cibuildwheel')
       )
     name: Build sdist
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     outputs:
       SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
 
@@ -119,9 +119,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cibw_archs: "x86_64"
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             cibw_archs: "aarch64"
           - os: windows-latest
             cibw_archs: "auto64"
@@ -149,16 +149,9 @@ jobs:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}
         env:
           CIBW_BUILD: "cp313-* cp313t-*"
-          CIBW_BUILD_FRONTEND:
-            "pip; args: --pre --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple"
-          CIBW_FREE_THREADED_SUPPORT: true
+          CIBW_ENABLE: cpython-freethreading
           # No free-threading wheels available for aarch64 on Pillow.
           CIBW_TEST_SKIP: "cp313t-manylinux_aarch64"
-          # We need pre-releases to get the nightly wheels.
-          CIBW_BEFORE_TEST: >-
-            pip install --pre
-            --extra-index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-            contourpy numpy pillow
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.12
@@ -192,14 +185,7 @@ jobs:
         env:
           CIBW_BUILD: "pp310-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          # Work around for https://github.com/pypa/setuptools/issues/4571
-          # This can be removed once kiwisolver has wheels for PyPy 3.10
-          # https://github.com/nucleic/kiwi/pull/182
-          CIBW_BEFORE_TEST: >-
-            export PIP_CONSTRAINT=pypy-constraint.txt &&
-            echo "setuptools!=72.2.0" > $PIP_CONSTRAINT &&
-            pip install kiwisolver &&
-            unset PIP_CONSTRAINT
+          CIBW_ENABLE: pypy
         if: matrix.cibw_archs != 'aarch64' && matrix.os != 'windows-latest'
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882  # v4.4.3


### PR DESCRIPTION
## PR summary

- cibuildwheel runs builds in a container, so there's no need to pin the runner to old `ubuntu-20.04`, which will be EOL early next year.
- cibuildwheel is warning about using other variables than `CIBW_ENABLE`, so switch to that.
- All dependencies should have Python 3.13 wheels now, so we won't need the nightly builds.
- kiwisolver has a PyPy 3.10 wheel, so we don't need that workaround any more.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines