### PR TITLE
DOC: fix footnote in choosing colormaps guide

### DIFF
--- a/galleries/users_explain/colors/colormaps.py
+++ b/galleries/users_explain/colors/colormaps.py
@@ -178,7 +178,7 @@ plot_color_gradients('Sequential (2)',
 #
 # Berlin, Managua, and Vanimo are dark-mode diverging colormaps, with minimum
 # lightness at the center, and maximum at the extremes. These are taken from
-# F. Crameri's [scientific colour maps]_ version 8.0.1.
+# F. Crameri's [scientific-colour-maps]_ version 8.0.1.
 
 plot_color_gradients('Diverging',
                      ['PiYG', 'PRGn', 'BrBG', 'PuOr', 'RdGy', 'RdBu', 'RdYlBu',
@@ -446,4 +446,4 @@ for cmap_category, cmap_list in cmaps.items():
 # .. [colorblindness] http://www.color-blindness.com/
 # .. [IBM] https://doi.org/10.1109/VISUAL.1995.480803
 # .. [turbo] https://ai.googleblog.com/2019/08/turbo-improved-rainbow-colormap-for.html
-# .. [scientific colour maps] https://doi.org/10.5281/zenodo.1243862
+# .. [scientific-colour-maps] https://doi.org/10.5281/zenodo.1243862


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->


## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->
Fixes #29312.  The footnote syntax seems not to like spaces so I swapped them for hyphens, consistent with the [kovesi-colormaps] footnote.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
