### PR TITLE
FIX: pass renderer through `_auto_legend_data`

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -934,7 +934,7 @@ class Legend(Artist):
         self.texts = text_list
         self.legend_handles = handle_list
 
-    def _auto_legend_data(self):
+    def _auto_legend_data(self, renderer):
         """
         Return display coordinates for hit testing for "best" positioning.
 
@@ -969,7 +969,7 @@ class Legend(Artist):
                 if len(hoffsets):
                     offsets.extend(transOffset.transform(hoffsets))
             elif isinstance(artist, Text):
-                bboxes.append(artist.get_window_extent())
+                bboxes.append(artist.get_window_extent(renderer))
 
         return bboxes, lines, offsets
 
@@ -1150,7 +1150,7 @@ class Legend(Artist):
 
         start_time = time.perf_counter()
 
-        bboxes, lines, offsets = self._auto_legend_data()
+        bboxes, lines, offsets = self._auto_legend_data(renderer)
 
         bbox = Bbox.from_bounds(0, 0, width, height)
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1,4 +1,5 @@
 import collections
+import io
 import itertools
 import platform
 import time
@@ -1425,6 +1426,21 @@ def test_legend_text():
         leg_bboxes.append(
             leg.get_window_extent().transformed(ax.transAxes.inverted()))
     assert_allclose(leg_bboxes[1].bounds, leg_bboxes[0].bounds)
+
+
+def test_legend_annotate():
+    fig, ax = plt.subplots()
+
+    ax.plot([1, 2, 3], label="Line")
+    ax.annotate("a", xy=(1, 1))
+    ax.legend(loc=0)
+
+    with mock.patch.object(
+            fig, '_get_renderer', wraps=fig._get_renderer) as mocked_get_renderer:
+        fig.savefig(io.BytesIO())
+
+    # Finding the legend position should not require _get_renderer to be called
+    mocked_get_renderer.assert_not_called()
 
 
 def test_boxplot_legend_labels():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Fixes #29301.

The problem was that `FigureCanvasPS._print_figure` essentially got into a loop of calling itself: somewhere within [figure.draw](https://github.com/matplotlib/matplotlib/blob/28f69ba98708393deb0f35501940f40b0f081504/lib/matplotlib/backends/backend_ps.py#L1050) we needed to call `figure._get_renderer` in order to calculate the annotation window extent and therefore the legend position.  `_get_renderer` ultimately calls `FigureCanvasPS._print_figure` again.  I haven't quite followed why, but by the time we get to the end of `FigureCanvasPS._print_figure`, [_ps_writer](https://github.com/matplotlib/matplotlib/blob/28f69ba98708393deb0f35501940f40b0f081504/lib/matplotlib/backends/backend_ps.py#L1102) which should contain all the information about the artists is empty.

We can avoid all this by just passing the renderer we already have hold of to `get_window_extent`.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
