### PR TITLE
DOC: List min. Python version for Matplotlib 3.10

### DIFF
--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -115,6 +115,7 @@ specification of the dependencies.
 ==========  ========  ======
 Matplotlib  Python    NumPy
 ==========  ========  ======
+`3.10`_     3.10      1.23.0
 `3.9`_      3.9       1.23.0
 `3.8`_      3.9       1.21.0
 `3.7`_      3.8       1.20.0
@@ -136,6 +137,7 @@ Matplotlib  Python    NumPy
 1.0         2.4       1.1
 ==========  ========  ======
 
+.. _`3.10`: https://matplotlib.org/3.10.0/devel/dependencies.html
 .. _`3.9`: https://matplotlib.org/3.9.0/devel/dependencies.html
 .. _`3.8`: https://matplotlib.org/3.8.0/devel/dependencies.html
 .. _`3.7`: https://matplotlib.org/3.7.0/devel/dependencies.html


### PR DESCRIPTION
Side-note: We haven't increased the NumPy version.