### PR TITLE
CI: allow pandas install to fail on nightly test run

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -98,6 +98,7 @@ jobs:
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
           - os: macos-13  # This runner is on Intel chips.
+            # merge numpy and pandas install in nighties test when this runner is dropped
             python-version: '3.10'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
@@ -320,7 +321,13 @@ jobs:
           python -m pip install pytz tzdata  # Must be installed for Pandas.
           python -m pip install \
             --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-            --upgrade --only-binary=:all: numpy pandas
+            --upgrade --only-binary=:all: numpy
+          # wheels for intel osx is not always available on nightly wheels index, merge this back into
+          # the above install command when the OSX-13 (intel) runners are dropped.
+          python -m pip install \
+            --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
+            --upgrade --only-binary=:all: pandas || true
+
 
       - name: Install Matplotlib
         run: |


### PR DESCRIPTION
Pandas appears to no longer be uploading py310 on intel wheels to the nightly index.

closes #29327
