### PR TITLE
Use set_window_title rather than set_label to set title of webagg figure

### DIFF
--- a/doc/api/next_api_changes/behavior/29256_IMT.rst
+++ b/doc/api/next_api_changes/behavior/29256_IMT.rst
@@ -1,0 +1,6 @@
+Setting titles of figures using webagg backend
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously when using the ``webagg`` backend the title of a figure was set using
+``figure.set_label``. Now it is set using ``figure.canvas.manager.set_window_title``
+which is more consistent with other backends.

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -328,10 +328,8 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
         getattr(self.toolbar, event['name'])()
 
     def handle_refresh(self, event):
-        figure_label = self.figure.get_label()
-        if not figure_label:
-            figure_label = f"Figure {self.manager.num}"
-        self.send_event('figure_label', label=figure_label)
+        if self.manager:
+            self.send_event('figure_label', label=self.manager.get_window_title())
         self._force_full = True
         if self.toolbar:
             # Normal toolbar init would refresh this, but it happens before the


### PR DESCRIPTION
Closes #29256.

Previously when using the `webagg` backend if you wanted to change the title above a figure you would use `figure.set_label('whatever')` and if you used `figure.canvas.manager.set_window_title('whatever')` it would be ignored. This was inconsistent with other backends which use the latter.

This PR changes the behaviour so that `figure.canvas.manager.set_window_title('whatever')` is used now for `webagg`, the same as the other backends.

There is no test as there isn't currently any visual testing of the `webagg` backend. There is some draft work underway in #23540 for this. So here is a demonstration instead, using this code:
```python
import matplotlib as mpl
mpl.use('webagg')
import matplotlib.pyplot as plt

fig1, ax1 = plt.subplots(figsize=(3, 2))
ax1.plot([1, 3, 2, 4])
fig1.canvas.manager.set_window_title('My line plot')

fig2, ax2 = plt.subplots(figsize=(3, 2))
ax2.contourf([[1, 2], [3, 4]])
fig2.canvas.manager.set_window_title('My contour plot')

fig3, ax3 = plt.subplots(figsize=(3, 2))
ax3.bar(x=[0, 1], height=[1, 2])

plt.show()
```
the `webagg` output is:

<img width="976" alt="Screenshot 2024-12-17 at 17 01 44" src="https://github.com/user-attachments/assets/efa1ded1-99a7-4d40-b8fd-70f9fa386709" />

which is consistent with the output produced by e.g. the `qtagg` backend:

<img width="618" alt="Screenshot 2024-12-17 at 17 02 26" src="https://github.com/user-attachments/assets/20fbf3f6-55a4-46c3-8ad6-54b4c98b32ec" />

## PR checklist

- [x] "closes #29256" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
