### PR TITLE
Use _val_or_rc in more places

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -168,11 +168,8 @@ class Axes(_AxesBase):
             Other keyword arguments are text properties, see `.Text` for a list
             of valid text properties.
         """
-        if loc is None:
-            loc = mpl.rcParams['axes.titlelocation']
-
-        if y is None:
-            y = mpl.rcParams['axes.titley']
+        loc = mpl._val_or_rc(loc, 'axes.titlelocation').lower()
+        y = mpl._val_or_rc(y, 'axes.titley')
         if y is None:
             y = 1.0
         else:
@@ -182,18 +179,16 @@ class Axes(_AxesBase):
         titles = {'left': self._left_title,
                   'center': self.title,
                   'right': self._right_title}
-        title = _api.check_getitem(titles, loc=loc.lower())
+        title = _api.check_getitem(titles, loc=loc)
         default = {
             'fontsize': mpl.rcParams['axes.titlesize'],
             'fontweight': mpl.rcParams['axes.titleweight'],
             'verticalalignment': 'baseline',
-            'horizontalalignment': loc.lower()}
+            'horizontalalignment': loc}
         titlecolor = mpl.rcParams['axes.titlecolor']
         if not cbook._str_lower_equal(titlecolor, 'auto'):
             default["color"] = titlecolor
-        if pad is None:
-            pad = mpl.rcParams['axes.titlepad']
-        self._set_title_offset_trans(float(pad))
+        self._set_title_offset_trans(float(mpl._val_or_rc(pad, 'axes.titlepad')))
         title.set_text(label)
         title.update(default)
         if fontdict is not None:
@@ -3160,8 +3155,7 @@ class Axes(_AxesBase):
             markerfmt = "o"
         if markerfmt == '':
             markerfmt = ' '  # = empty line style; '' would resolve rcParams
-        markerstyle, markermarker, markercolor = \
-            _process_plot_format(markerfmt)
+        markerstyle, markermarker, markercolor = _process_plot_format(markerfmt)
         if markermarker is None:
             markermarker = 'o'
         if markerstyle is None:
@@ -3176,8 +3170,7 @@ class Axes(_AxesBase):
         basestyle, basemarker, basecolor = _process_plot_format(basefmt)
 
         # New behaviour in 3.1 is to use a LineCollection for the stemlines
-        if linestyle is None:
-            linestyle = mpl.rcParams['lines.linestyle']
+        linestyle = mpl._val_or_rc(linestyle, 'lines.linestyle')
         xlines = self.vlines if orientation == "vertical" else self.hlines
         stemlines = xlines(
             locs, bottom, heads,
@@ -3745,8 +3738,7 @@ class Axes(_AxesBase):
 
         # Make the style dict for caps (the "hats").
         eb_cap_style = {**base_style, 'linestyle': 'none'}
-        if capsize is None:
-            capsize = mpl.rcParams["errorbar.capsize"]
+        capsize = mpl._val_or_rc(capsize, "errorbar.capsize")
         if capsize > 0:
             eb_cap_style['markersize'] = 2. * capsize
         if capthick is not None:
@@ -4100,27 +4092,18 @@ class Axes(_AxesBase):
         """
 
         # Missing arguments default to rcParams.
-        if whis is None:
-            whis = mpl.rcParams['boxplot.whiskers']
-        if bootstrap is None:
-            bootstrap = mpl.rcParams['boxplot.bootstrap']
+        whis = mpl._val_or_rc(whis, 'boxplot.whiskers')
+        bootstrap = mpl._val_or_rc(bootstrap, 'boxplot.bootstrap')
 
         bxpstats = cbook.boxplot_stats(x, whis=whis, bootstrap=bootstrap,
                                        labels=tick_labels, autorange=autorange)
-        if notch is None:
-            notch = mpl.rcParams['boxplot.notch']
-        if patch_artist is None:
-            patch_artist = mpl.rcParams['boxplot.patchartist']
-        if meanline is None:
-            meanline = mpl.rcParams['boxplot.meanline']
-        if showmeans is None:
-            showmeans = mpl.rcParams['boxplot.showmeans']
-        if showcaps is None:
-            showcaps = mpl.rcParams['boxplot.showcaps']
-        if showbox is None:
-            showbox = mpl.rcParams['boxplot.showbox']
-        if showfliers is None:
-            showfliers = mpl.rcParams['boxplot.showfliers']
+        notch = mpl._val_or_rc(notch, 'boxplot.notch')
+        patch_artist = mpl._val_or_rc(patch_artist, 'boxplot.patchartist')
+        meanline = mpl._val_or_rc(meanline, 'boxplot.meanline')
+        showmeans = mpl._val_or_rc(showmeans, 'boxplot.showmeans')
+        showcaps = mpl._val_or_rc(showcaps, 'boxplot.showcaps')
+        showbox = mpl._val_or_rc(showbox, 'boxplot.showbox')
+        showfliers = mpl._val_or_rc(showfliers, 'boxplot.showfliers')
 
         if boxprops is None:
             boxprops = {}
@@ -4931,8 +4914,7 @@ class Axes(_AxesBase):
         scales = s   # Renamed for readability below.
 
         # load default marker from rcParams
-        if marker is None:
-            marker = mpl.rcParams['scatter.marker']
+        marker = mpl._val_or_rc(marker, 'scatter.marker')
 
         if isinstance(marker, mmarkers.MarkerStyle):
             marker_obj = marker
@@ -6478,9 +6460,7 @@ class Axes(_AxesBase):
         `~.Axes.pcolormesh`, which is not available with `~.Axes.pcolor`.
 
         """
-        if shading is None:
-            shading = mpl.rcParams['pcolor.shading']
-        shading = shading.lower()
+        shading = mpl._val_or_rc(shading, 'pcolor.shading').lower()
         kwargs.setdefault('edgecolors', 'none')
 
         X, Y, C, shading = self._pcolorargs('pcolormesh', *args,
@@ -6985,8 +6965,7 @@ such objects
         if np.isscalar(x):
             x = [x]
 
-        if bins is None:
-            bins = mpl.rcParams['hist.bins']
+        bins = mpl._val_or_rc(bins, 'hist.bins')
 
         # Validate string inputs here to avoid cluttering subsequent code.
         _api.check_in_list(['bar', 'barstacked', 'step', 'stepfilled'],

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -220,10 +220,8 @@ class _process_plot_var_args:
         self.set_prop_cycle(None)
 
     def set_prop_cycle(self, cycler):
-        if cycler is None:
-            cycler = mpl.rcParams['axes.prop_cycle']
         self._idx = 0
-        self._cycler_items = [*cycler]
+        self._cycler_items = [*mpl._val_or_rc(cycler, 'axes.prop_cycle')]
 
     def __call__(self, axes, *args, data=None, return_kwargs=False, **kwargs):
         axes._process_unit_info(kwargs=kwargs)
@@ -687,9 +685,7 @@ class _AxesBase(martist.Artist):
 
         # this call may differ for non-sep axes, e.g., polar
         self._init_axis()
-        if facecolor is None:
-            facecolor = mpl.rcParams['axes.facecolor']
-        self._facecolor = facecolor
+        self._facecolor = mpl._val_or_rc(facecolor, 'axes.facecolor')
         self._frameon = frameon
         self.set_axisbelow(mpl.rcParams['axes.axisbelow'])
 
@@ -3587,8 +3583,7 @@ class _AxesBase(martist.Artist):
                                 f"supplied")
 
         else:
-            loc = (loc if loc is not None
-                   else mpl.rcParams['xaxis.labellocation'])
+            loc = mpl._val_or_rc(loc, 'xaxis.labellocation')
             _api.check_in_list(('left', 'center', 'right'), loc=loc)
 
             x = {
@@ -3856,8 +3851,7 @@ class _AxesBase(martist.Artist):
                                 f"supplied")
 
         else:
-            loc = (loc if loc is not None
-                   else mpl.rcParams['yaxis.labellocation'])
+            loc = mpl._val_or_rc(loc, 'yaxis.labellocation')
             _api.check_in_list(('bottom', 'center', 'top'), loc=loc)
 
             y, ha = {

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -89,9 +89,9 @@ class Tick(martist.Artist):
 
         if gridOn is None:
             which = mpl.rcParams['axes.grid.which']
-            if major and (which in ('both', 'major')):
+            if major and which in ('both', 'major'):
                 gridOn = mpl.rcParams['axes.grid']
-            elif (not major) and (which in ('both', 'minor')):
+            elif not major and which in ('both', 'minor'):
                 gridOn = mpl.rcParams['axes.grid']
             else:
                 gridOn = False
@@ -104,31 +104,15 @@ class Tick(martist.Artist):
 
         name = self.__name__
         major_minor = "major" if major else "minor"
-
-        if size is None:
-            size = mpl.rcParams[f"{name}.{major_minor}.size"]
-        self._size = size
-
-        if width is None:
-            width = mpl.rcParams[f"{name}.{major_minor}.width"]
-        self._width = width
-
-        if color is None:
-            color = mpl.rcParams[f"{name}.color"]
-
-        if pad is None:
-            pad = mpl.rcParams[f"{name}.{major_minor}.pad"]
-        self._base_pad = pad
-
-        if labelcolor is None:
-            labelcolor = mpl.rcParams[f"{name}.labelcolor"]
-
+        self._size = mpl._val_or_rc(size, f"{name}.{major_minor}.size")
+        self._width = mpl._val_or_rc(width, f"{name}.{major_minor}.width")
+        self._base_pad = mpl._val_or_rc(pad, f"{name}.{major_minor}.pad")
+        color = mpl._val_or_rc(color, f"{name}.color")
+        labelcolor = mpl._val_or_rc(labelcolor, f"{name}.labelcolor")
         if cbook._str_equal(labelcolor, 'inherit'):
             # inherit from tick color
             labelcolor = mpl.rcParams[f"{name}.color"]
-
-        if labelsize is None:
-            labelsize = mpl.rcParams[f"{name}.labelsize"]
+        labelsize = mpl._val_or_rc(labelsize, f"{name}.labelsize")
 
         self._set_labelrotation(labelrotation)
 
@@ -154,12 +138,12 @@ class Tick(martist.Artist):
         self.tick1line = mlines.Line2D(
             [], [],
             color=color, linestyle="none", zorder=zorder, visible=tick1On,
-            markeredgecolor=color, markersize=size, markeredgewidth=width,
+            markeredgecolor=color, markersize=self._size, markeredgewidth=self._width,
         )
         self.tick2line = mlines.Line2D(
             [], [],
             color=color, linestyle="none", zorder=zorder, visible=tick2On,
-            markeredgecolor=color, markersize=size, markeredgewidth=width,
+            markeredgecolor=color, markersize=self._size, markeredgewidth=self._width,
         )
         self.gridline = mlines.Line2D(
             [], [],
@@ -208,10 +192,8 @@ class Tick(martist.Artist):
         # the tick{1,2}line markers.  From the user perspective this should always be
         # called through _apply_params, which further updates ticklabel positions using
         # the new pads.
-        if tickdir is None:
-            tickdir = mpl.rcParams[f'{self.__name__}.direction']
-        else:
-            _api.check_in_list(['in', 'out', 'inout'], tickdir=tickdir)
+        tickdir = mpl._val_or_rc(tickdir, f'{self.__name__}.direction')
+        _api.check_in_list(['in', 'out', 'inout'], tickdir=tickdir)
         self._tickdir = tickdir
 
     def get_tickdir(self):

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2115,8 +2115,7 @@ class FigureCanvasBase:
                     filename = filename.rstrip('.') + '.' + format
         format = format.lower()
 
-        if dpi is None:
-            dpi = rcParams['savefig.dpi']
+        dpi = mpl._val_or_rc(dpi, 'savefig.dpi')
         if dpi == 'figure':
             dpi = getattr(self.figure, '_original_dpi', self.figure.dpi)
 
@@ -2129,15 +2128,12 @@ class FigureCanvasBase:
               cbook._setattr_cm(self.figure.canvas, _is_saving=True),
               ExitStack() as stack):
 
-            for prop in ["facecolor", "edgecolor"]:
-                color = locals()[prop]
-                if color is None:
-                    color = rcParams[f"savefig.{prop}"]
+            for prop, color in [("facecolor", facecolor), ("edgecolor", edgecolor)]:
+                color = mpl._val_or_rc(color, f"savefig.{prop}")
                 if not cbook._str_equal(color, "auto"):
                     stack.enter_context(self.figure._cm_set(**{prop: color}))
 
-            if bbox_inches is None:
-                bbox_inches = rcParams['savefig.bbox']
+            bbox_inches = mpl._val_or_rc(bbox_inches, 'savefig.bbox')
 
             layout_engine = self.figure.get_layout_engine()
             if layout_engine is not None or bbox_inches == "tight":

--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -270,8 +270,7 @@ def get_cmap(name=None, lut=None):
     -------
     Colormap
     """
-    if name is None:
-        name = mpl.rcParams['image.cmap']
+    name = mpl._val_or_rc(name, 'image.cmap')
     if isinstance(name, colors.Colormap):
         return name
     _api.check_in_list(sorted(_colormaps), name=name)
@@ -302,7 +301,7 @@ def _ensure_cmap(cmap):
     """
     if isinstance(cmap, colors.Colormap):
         return cmap
-    cmap_name = cmap if cmap is not None else mpl.rcParams["image.cmap"]
+    cmap_name = mpl._val_or_rc(cmap, "image.cmap")
     # use check_in_list to ensure type stability of the exception raised by
     # the internal usage of this (ValueError vs KeyError)
     if cmap_name not in _colormaps:

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -702,12 +702,8 @@ class ContourSet(ContourLabeler, mcoll.Collection):
             self.origin = mpl.rcParams['image.origin']
 
         self._orig_linestyles = linestyles  # Only kept for user access.
-        self.negative_linestyles = negative_linestyles
-        # If negative_linestyles was not defined as a keyword argument, define
-        # negative_linestyles with rcParams
-        if self.negative_linestyles is None:
-            self.negative_linestyles = \
-                mpl.rcParams['contour.negative_linestyle']
+        self.negative_linestyles = mpl._val_or_rc(negative_linestyles,
+                                                  'contour.negative_linestyle')
 
         kwargs = self._process_args(*args, **kwargs)
         self._process_levels()
@@ -1314,8 +1310,7 @@ class QuadContourSet(ContourSet):
         else:
             import contourpy
 
-            if algorithm is None:
-                algorithm = mpl.rcParams['contour.algorithm']
+            algorithm = mpl._val_or_rc(algorithm, 'contour.algorithm')
             mpl.rcParams.validate["contour.algorithm"](algorithm)
             self._algorithm = algorithm
 

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2270,10 +2270,8 @@ class SubFigure(FigureBase):
         super().__init__(**kwargs)
         if facecolor is None:
             facecolor = "none"
-        if edgecolor is None:
-            edgecolor = mpl.rcParams['figure.edgecolor']
-        if frameon is None:
-            frameon = mpl.rcParams['figure.frameon']
+        edgecolor = mpl._val_or_rc(edgecolor, 'figure.edgecolor')
+        frameon = mpl._val_or_rc(frameon, 'figure.frameon')
 
         self._subplotspec = subplotspec
         self._parent = parent
@@ -2609,16 +2607,11 @@ None}, default: None
         self._button_pick_id = connect('button_press_event', self.pick)
         self._scroll_pick_id = connect('scroll_event', self.pick)
 
-        if figsize is None:
-            figsize = mpl.rcParams['figure.figsize']
-        if dpi is None:
-            dpi = mpl.rcParams['figure.dpi']
-        if facecolor is None:
-            facecolor = mpl.rcParams['figure.facecolor']
-        if edgecolor is None:
-            edgecolor = mpl.rcParams['figure.edgecolor']
-        if frameon is None:
-            frameon = mpl.rcParams['figure.frameon']
+        figsize = mpl._val_or_rc(figsize, 'figure.figsize')
+        dpi = mpl._val_or_rc(dpi, 'figure.dpi')
+        facecolor = mpl._val_or_rc(facecolor, 'figure.facecolor')
+        edgecolor = mpl._val_or_rc(edgecolor, 'figure.edgecolor')
+        frameon = mpl._val_or_rc(frameon, 'figure.frameon')
 
         if not np.isfinite(figsize).all() or (np.array(figsize) < 0).any():
             raise ValueError('figure size must be positive finite not '
@@ -2891,8 +2884,7 @@ None}, default: None
             If a dict, pass it as kwargs to `.Figure.tight_layout`, overriding the
             default paddings.
         """
-        if tight is None:
-            tight = mpl.rcParams['figure.autolayout']
+        tight = mpl._val_or_rc(tight, 'figure.autolayout')
         _tight = 'tight' if bool(tight) else 'none'
         _tight_parameters = tight if isinstance(tight, dict) else {}
         self.set_layout_engine(_tight, **_tight_parameters)
@@ -2923,8 +2915,7 @@ None}, default: None
         ----------
         constrained : bool or dict or None
         """
-        if constrained is None:
-            constrained = mpl.rcParams['figure.constrained_layout.use']
+        constrained = mpl._val_or_rc(constrained, 'figure.constrained_layout.use')
         _constrained = 'constrained' if bool(constrained) else 'none'
         _parameters = constrained if isinstance(constrained, dict) else {}
         self.set_layout_engine(_constrained, **_parameters)
@@ -3451,8 +3442,7 @@ None}, default: None
         """
 
         kwargs.setdefault('dpi', mpl.rcParams['savefig.dpi'])
-        if transparent is None:
-            transparent = mpl.rcParams['savefig.transparent']
+        transparent = mpl._val_or_rc(transparent, 'savefig.transparent')
 
         with ExitStack() as stack:
             if transparent:

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -789,8 +789,7 @@ class FontProperties:
         font names.  Real font names are not supported when
         :rc:`text.usetex` is `True`. Default: :rc:`font.family`
         """
-        if family is None:
-            family = mpl.rcParams['font.family']
+        family = mpl._val_or_rc(family, 'font.family')
         if isinstance(family, str):
             family = [family]
         self._family = family
@@ -803,8 +802,7 @@ class FontProperties:
         ----------
         style : {'normal', 'italic', 'oblique'}, default: :rc:`font.style`
         """
-        if style is None:
-            style = mpl.rcParams['font.style']
+        style = mpl._val_or_rc(style, 'font.style')
         _api.check_in_list(['normal', 'italic', 'oblique'], style=style)
         self._slant = style
 
@@ -816,8 +814,7 @@ class FontProperties:
         ----------
         variant : {'normal', 'small-caps'}, default: :rc:`font.variant`
         """
-        if variant is None:
-            variant = mpl.rcParams['font.variant']
+        variant = mpl._val_or_rc(variant, 'font.variant')
         _api.check_in_list(['normal', 'small-caps'], variant=variant)
         self._variant = variant
 
@@ -832,8 +829,7 @@ class FontProperties:
 'extra bold', 'black'}, default: :rc:`font.weight`
             If int, must be in the range  0-1000.
         """
-        if weight is None:
-            weight = mpl.rcParams['font.weight']
+        weight = mpl._val_or_rc(weight, 'font.weight')
         if weight in weight_dict:
             self._weight = weight
             return
@@ -858,8 +854,7 @@ class FontProperties:
 'ultra-expanded'}, default: :rc:`font.stretch`
             If int, must be in the range  0-1000.
         """
-        if stretch is None:
-            stretch = mpl.rcParams['font.stretch']
+        stretch = mpl._val_or_rc(stretch, 'font.stretch')
         if stretch in stretch_dict:
             self._stretch = stretch
             return
@@ -884,8 +879,7 @@ class FontProperties:
             If a float, the font size in points. The string values denote
             sizes relative to the default font size.
         """
-        if size is None:
-            size = mpl.rcParams['font.size']
+        size = mpl._val_or_rc(size, 'font.size')
         try:
             size = float(size)
         except ValueError:
@@ -1609,8 +1603,7 @@ def get_font(font_filepaths, hinting_factor=None):
     else:
         paths = tuple(_cached_realpath(fname) for fname in font_filepaths)
 
-    if hinting_factor is None:
-        hinting_factor = mpl.rcParams['text.hinting_factor']
+    hinting_factor = mpl._val_or_rc(hinting_factor, 'text.hinting_factor')
 
     return _get_font(
         # must be a tuple to be cached

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -262,8 +262,7 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                  **kwargs
                  ):
         super().__init__(self._get_colorizer(cmap, norm, colorizer))
-        if origin is None:
-            origin = mpl.rcParams['image.origin']
+        origin = mpl._val_or_rc(origin, 'image.origin')
         _api.check_in_list(["upper", "lower"], origin=origin)
         self.origin = origin
         self.set_filternorm(filternorm)
@@ -1576,10 +1575,8 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
     else:
         # Don't bother creating an image; this avoids rounding errors on the
         # size when dividing and then multiplying by dpi.
-        if origin is None:
-            origin = mpl.rcParams["image.origin"]
-        else:
-            _api.check_in_list(('upper', 'lower'), origin=origin)
+        origin = mpl._val_or_rc(origin, "image.origin")
+        _api.check_in_list(('upper', 'lower'), origin=origin)
         if origin == "lower":
             arr = arr[::-1]
         if (isinstance(arr, memoryview) and arr.format == "B"

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -581,9 +581,8 @@ class Legend(Artist):
             'markeredgecolor': ['get_markeredgecolor', 'get_edgecolor'],
             'mec':             ['get_markeredgecolor', 'get_edgecolor'],
         }
-        labelcolor = mpl._val_or_rc(labelcolor, 'legend.labelcolor')
-        if labelcolor is None:
-            labelcolor = mpl.rcParams['text.color']
+        labelcolor = mpl._val_or_rc(mpl._val_or_rc(labelcolor, 'legend.labelcolor'),
+                                    'text.color')
         if isinstance(labelcolor, str) and labelcolor in color_getters:
             getter_names = color_getters[labelcolor]
             for handle, text in zip(self.legend_handles, self.texts):

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -327,28 +327,16 @@ class Line2D(Artist):
         if not np.iterable(ydata):
             raise RuntimeError('ydata must be a sequence')
 
-        if linewidth is None:
-            linewidth = mpl.rcParams['lines.linewidth']
-
-        if linestyle is None:
-            linestyle = mpl.rcParams['lines.linestyle']
-        if marker is None:
-            marker = mpl.rcParams['lines.marker']
-        if color is None:
-            color = mpl.rcParams['lines.color']
-
-        if markersize is None:
-            markersize = mpl.rcParams['lines.markersize']
-        if antialiased is None:
-            antialiased = mpl.rcParams['lines.antialiased']
-        if dash_capstyle is None:
-            dash_capstyle = mpl.rcParams['lines.dash_capstyle']
-        if dash_joinstyle is None:
-            dash_joinstyle = mpl.rcParams['lines.dash_joinstyle']
-        if solid_capstyle is None:
-            solid_capstyle = mpl.rcParams['lines.solid_capstyle']
-        if solid_joinstyle is None:
-            solid_joinstyle = mpl.rcParams['lines.solid_joinstyle']
+        linewidth = mpl._val_or_rc(linewidth, 'lines.linewidth')
+        linestyle = mpl._val_or_rc(linestyle, 'lines.linestyle')
+        marker = mpl._val_or_rc(marker, 'lines.marker')
+        color = mpl._val_or_rc(color, 'lines.color')
+        markersize = mpl._val_or_rc(markersize, 'lines.markersize')
+        antialiased = mpl._val_or_rc(antialiased, 'lines.antialiased')
+        dash_capstyle = mpl._val_or_rc(dash_capstyle, 'lines.dash_capstyle')
+        dash_joinstyle = mpl._val_or_rc(dash_joinstyle, 'lines.dash_joinstyle')
+        solid_capstyle = mpl._val_or_rc(solid_capstyle, 'lines.solid_capstyle')
+        solid_joinstyle = mpl._val_or_rc(solid_joinstyle, 'lines.solid_joinstyle')
 
         if drawstyle is None:
             drawstyle = 'default'
@@ -1253,8 +1241,7 @@ class Line2D(Artist):
         ew : float
              Marker edge width, in points.
         """
-        if ew is None:
-            ew = mpl.rcParams['lines.markeredgewidth']
+        ew = mpl._val_or_rc(ew, 'lines.markeredgewidth')
         if self._markeredgewidth != ew:
             self.stale = True
         self._markeredgewidth = ew

--- a/lib/matplotlib/markers.py
+++ b/lib/matplotlib/markers.py
@@ -282,8 +282,7 @@ class MarkerStyle:
             The part of the marker surface that is colored with
             markerfacecolor.
         """
-        if fillstyle is None:
-            fillstyle = mpl.rcParams['markers.fillstyle']
+        fillstyle = mpl._val_or_rc(fillstyle, 'markers.fillstyle')
         _api.check_in_list(self.fillstyles, fillstyle=fillstyle)
         self._fillstyle = fillstyle
 

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1343,9 +1343,7 @@ or callable, default: value of *xycoords*
 
         If *s* is not given, reset to :rc:`legend.fontsize`.
         """
-        if s is None:
-            s = mpl.rcParams["legend.fontsize"]
-
+        s = mpl._val_or_rc(s, "legend.fontsize")
         self.prop = FontProperties(size=s)
         self.stale = True
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -354,9 +354,7 @@ class Patch(artist.Artist):
         ----------
         aa : bool or None
         """
-        if aa is None:
-            aa = mpl.rcParams['patch.antialiased']
-        self._antialiased = aa
+        self._antialiased = mpl._val_or_rc(aa, 'patch.antialiased')
         self.stale = True
 
     def _set_edgecolor(self, color):
@@ -386,8 +384,7 @@ class Patch(artist.Artist):
         self._set_edgecolor(color)
 
     def _set_facecolor(self, color):
-        if color is None:
-            color = mpl.rcParams['patch.facecolor']
+        color = mpl._val_or_rc(color, 'patch.facecolor')
         alpha = self._alpha if self._fill else 0
         self._facecolor = colors.to_rgba(color, alpha)
         self.stale = True
@@ -434,11 +431,9 @@ class Patch(artist.Artist):
         ----------
         w : float or None
         """
-        if w is None:
-            w = mpl.rcParams['patch.linewidth']
+        w = mpl._val_or_rc(w, 'patch.linewidth')
         self._linewidth = float(w)
-        self._dash_pattern = mlines._scale_dashes(
-            *self._unscaled_dash_pattern, w)
+        self._dash_pattern = mlines._scale_dashes(*self._unscaled_dash_pattern, w)
         self.stale = True
 
     def set_linestyle(self, ls):

--- a/lib/matplotlib/streamplot.py
+++ b/lib/matplotlib/streamplot.py
@@ -110,8 +110,7 @@ def streamplot(axes, x, y, u, v, density=1, linewidth=None, color=None,
     if color is None:
         color = axes._get_lines.get_next_color()
 
-    if linewidth is None:
-        linewidth = mpl.rcParams['lines.linewidth']
+    linewidth = mpl._val_or_rc(linewidth, 'lines.linewidth')
 
     line_kw = {}
     arrow_kw = dict(arrowstyle=arrowstyle, mutation_scale=10 * arrowsize)

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -323,10 +323,8 @@ class TexManager:
     @classmethod
     def get_grey(cls, tex, fontsize=None, dpi=None):
         """Return the alpha channel."""
-        if not fontsize:
-            fontsize = mpl.rcParams['font.size']
-        if not dpi:
-            dpi = mpl.rcParams['savefig.dpi']
+        fontsize = mpl._val_or_rc(fontsize, 'font.size')
+        dpi = mpl._val_or_rc(dpi, 'savefig.dpi')
         key = cls._get_tex_source(tex, fontsize), dpi
         alpha = cls._grey_arrayd.get(key)
         if alpha is None:

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -188,8 +188,7 @@ class Text(Artist):
             linespacing = 1.2  # Maybe use rcParam later.
         self.set_linespacing(linespacing)
         self.set_rotation_mode(rotation_mode)
-        self.set_antialiased(antialiased if antialiased is not None else
-                             mpl.rcParams['text.antialiased'])
+        self.set_antialiased(mpl._val_or_rc(antialiased, 'text.antialiased'))
 
     def update(self, kwargs):
         # docstring inherited
@@ -1336,10 +1335,7 @@ class Text(Artist):
             Whether to render using TeX, ``None`` means to use
             :rc:`text.usetex`.
         """
-        if usetex is None:
-            self._usetex = mpl.rcParams['text.usetex']
-        else:
-            self._usetex = bool(usetex)
+        self._usetex = bool(mpl._val_or_rc(usetex, 'text.usetex'))
         self.stale = True
 
     def get_usetex(self):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -451,10 +451,8 @@ class ScalarFormatter(Formatter):
 
     def __init__(self, useOffset=None, useMathText=None, useLocale=None, *,
                  usetex=None):
-        if useOffset is None:
-            useOffset = mpl.rcParams['axes.formatter.useoffset']
-        self._offset_threshold = \
-            mpl.rcParams['axes.formatter.offset_threshold']
+        useOffset = mpl._val_or_rc(useOffset, 'axes.formatter.useoffset')
+        self._offset_threshold = mpl.rcParams['axes.formatter.offset_threshold']
         self.set_useOffset(useOffset)
         self.set_usetex(usetex)
         self.set_useMathText(useMathText)
@@ -540,10 +538,7 @@ class ScalarFormatter(Formatter):
         val : bool or None
             *None* resets to :rc:`axes.formatter.use_locale`.
         """
-        if val is None:
-            self._useLocale = mpl.rcParams['axes.formatter.use_locale']
-        else:
-            self._useLocale = val
+        self._useLocale = mpl._val_or_rc(val, 'axes.formatter.use_locale')
 
     useLocale = property(fget=get_useLocale, fset=set_useLocale)
 

--- a/lib/mpl_toolkits/axisartist/axisline_style.py
+++ b/lib/mpl_toolkits/axisartist/axisline_style.py
@@ -177,8 +177,7 @@ class AxislineStyle(_Style):
                 .. versionadded:: 3.7
             """
 
-            if facecolor is None:
-                facecolor = mpl.rcParams['axes.edgecolor']
+            facecolor = mpl._val_or_rc(facecolor, 'axes.edgecolor')
             self.size = size
             self._facecolor = facecolor
             super().__init__(size=size)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -4016,8 +4016,7 @@ class Axes3D(Axes):
 
         # Determine style for stem lines.
         linestyle, linemarker, linecolor = _process_plot_format(linefmt)
-        if linestyle is None:
-            linestyle = mpl.rcParams['lines.linestyle']
+        linestyle = mpl._val_or_rc(linestyle, 'lines.linestyle')
 
         # Plot everything in required order.
         baseline, = self.plot(basex, basey, basefmt, zs=bottom,


### PR DESCRIPTION
## PR summary

In some cases where the variable was not used again, I assigned directly to the final variable/attribute. But most of the changes are to the same variables.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines