### PR TITLE
FIX: Add version gate to GTK4 calls when necessary

### DIFF
--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -29,6 +29,8 @@ from ._backend_gtk import (  # noqa: F401 # pylint: disable=W0611
     TimerGTK as TimerGTK4,
 )
 
+_GOBJECT_GE_3_47 = gi.version_info >= (3, 47, 0)
+
 
 class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
     required_interactive_framework = "gtk4"
@@ -115,7 +117,7 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
         MouseEvent(
             "scroll_event", self, *self._mpl_coords(), step=dy,
             modifiers=self._mpl_modifiers(controller),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
         return True
 
@@ -124,7 +126,7 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
             "button_press_event", self, *self._mpl_coords((x, y)),
             controller.get_current_button(),
             modifiers=self._mpl_modifiers(controller),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
         self.grab_focus()
 
@@ -133,14 +135,14 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
             "button_release_event", self, *self._mpl_coords((x, y)),
             controller.get_current_button(),
             modifiers=self._mpl_modifiers(controller),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
 
     def key_press_event(self, controller, keyval, keycode, state):
         KeyEvent(
             "key_press_event", self, self._get_key(keyval, keycode, state),
             *self._mpl_coords(),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
         return True
 
@@ -148,7 +150,7 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
         KeyEvent(
             "key_release_event", self, self._get_key(keyval, keycode, state),
             *self._mpl_coords(),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
         return True
 
@@ -157,21 +159,21 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
             "motion_notify_event", self, *self._mpl_coords((x, y)),
             buttons=self._mpl_buttons(controller),
             modifiers=self._mpl_modifiers(controller),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
 
     def enter_notify_event(self, controller, x, y):
         LocationEvent(
             "figure_enter_event", self, *self._mpl_coords((x, y)),
             modifiers=self._mpl_modifiers(),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
 
     def leave_notify_event(self, controller):
         LocationEvent(
             "figure_leave_event", self, *self._mpl_coords(),
             modifiers=self._mpl_modifiers(),
-            guiEvent=controller.get_current_event(),
+            guiEvent=controller.get_current_event() if _GOBJECT_GE_3_47 else None,
         )._process()
 
     def resize_event(self, area, width, height):


### PR DESCRIPTION
## PR summary

`get_current_event()` calls within pygobject would cause segfaults. This was fixed in 3.47, so gate the guiEvent information to only access that method in versions that don't segfault.

closes #29350

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
