### PR TITLE
Fix/deep copy recurse

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -285,7 +285,12 @@ class Path:
         p._readonly = False
         return p
 
-    deepcopy = __deepcopy__
+    def deepcopy(self, memo=None):
+        """
+        Return a shallow copy of the `Path`, which will share the
+        vertices and codes with the source `Path`.
+        """
+        return copy.deepcopy(self, memo=memo)
 
     @classmethod
     def make_compound_path_from_polys(cls, XY):

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -38,6 +38,7 @@ of how to use transforms.
 import copy
 import functools
 import itertools
+import sys
 import textwrap
 import weakref
 import math
@@ -139,7 +140,12 @@ class TransformNode:
             for k, v in self._parents.items() if v is not None}
 
     def __copy__(self):
-        other = copy.copy(super())
+        if sys.version_info >= (3, 14):
+            from copy import _reconstruct
+            rv = super().__reduce_ex__(4)
+            other = _reconstruct(self, None, *rv)
+        else:
+            other = copy.copy(super())
         # If `c = a + b; a1 = copy(a)`, then modifications to `a1` do not
         # propagate back to `c`, i.e. we need to clear the parents of `a1`.
         other._parents = {}


### PR DESCRIPTION
## PR summary

See python/cpython#126817 for upstream discussion.

This works around the change by using (private) methods from the copy module to
re-implement the path though copy/deepcopy that we would like to use but avoid
the special-casing for `super()` objects that is breaking us.

We could vendor the current versions of `_keep_alive` (weakref work to manage
lifecycles) and `_reconstruct` (where the recursion happens) to superficially
avoid using private functions from CPython.  However, if these functions do
change significantly I worry that our copies would not inter-operate anyway.

Closes #29157

Without these changes there are two classes of failures
 - infinite recursion with Paths
 - failing to be able to mutate copied Transforms

The tests (mostly) pass [^] for me locally with a py314 build with this branch (and you have to be on 3.14 to hit the new code!) 


I think we should hold of merging this until closer to py314 being release (so some time over the summer) to see if upstream will change their mind about the change that is affecting us, but if we do need to merge this we should backport it has as we can as this is a show-stopping issue (infinite loop on render).

The new code should work on all our supported versions of Python, but at least for now my view is we should version gate the fishy stuff (using private methods) to only the versions of Python where we have to.

I have no idea if this is going to work as expected on pypy.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [/] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [/] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [/] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines


[^1]: there are 6 failures, but I'm pretty confident they are unrelated