### PR TITLE
Tick rendering speedups

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -155,7 +155,7 @@ class Spine(mpatches.Patch):
         if self.axis is None or not self.axis.get_visible():
             return bb
         bboxes = [bb]
-        drawn_ticks = self.axis._update_ticks()
+        drawn_ticks = self.axis._get_ticks_to_draw(update=True)
 
         major_tick = next(iter({*drawn_ticks} & {*self.axis.majorTicks}), None)
         minor_tick = next(iter({*drawn_ticks} & {*self.axis.minorTicks}), None)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3128,7 +3128,8 @@ def test_log_scales():
     ax.invert_yaxis()
     ax.set_xscale('log', base=9.0)
     xticks, yticks = (
-        [(t.get_loc(), t.label1.get_text()) for t in axis._update_ticks()]
+        [(t.get_loc(), t.label1.get_text())
+         for t in axis._get_ticks_to_draw(update=True)]
         for axis in [ax.xaxis, ax.yaxis]
     )
     assert xticks == [

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -456,6 +456,9 @@ class Axes3D(Axes):
                 artist.do_3d_projection()
 
         if self._axis3don:
+            # Update ticks
+            for axis in self._axis_map.values():
+                axis._update_ticks()
             # Draw panes first
             for axis in self._axis_map.values():
                 axis.draw_pane(renderer)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
I'm starting an effort to speed up 3D rendering, spinning up a profiler on some test cases. For this MR, I'm focusing on draw speed for an empty plot.

Based on [`py-spy`](https://github.com/benfred/py-spy) profiling, the largest proportion of render time is dedicated to handling tick marks. This PR implements several optimizations to speed up tick drawing. Based on averaging 6x runs of the below script that executes 100x draw calls, the average render time for the basic empty plot decreased from 23.1 ms to 19.1 ms, which is a 21% improvement. Qualitatively, rotating the plot definitely feels snappier on my machine.

```python
import matplotlib.pyplot as plt
import time

fig = plt.figure()
ax = fig.add_subplot(111, projection='3d')
ax.view_init(0, 0, 0)

plt.show(block=False)
plt.pause(1)

# Start timing
start_time = time.perf_counter()

n = 100
pause_time = 0.1
for i in range(n):
    ax.view_init(0, 0, i*10)
    plt.draw()
    plt.pause(pause_time)

# End timing
end_time = time.perf_counter()

# Calculate actual computation time by subtracting pauses
total_pause_time = n * pause_time
computation_time = (end_time - start_time) - total_pause_time
print(f"Total time: {end_time - start_time:.4f} seconds")
print(f"Computation time (excluding pauses): {computation_time:.4f} seconds")
print(f"Average time per loop: {computation_time / n * 1000:.2f} ms")
```

Attached are representative before and after profiler runs, which can be uploaded to https://www.speedscope.app/ to view
[profile_ticks_speedups.speedscope.json](https://github.com/user-attachments/files/18284234/profile_ticks_speedups.speedscope.json)
[profile_ticks_base.speedscope.json](https://github.com/user-attachments/files/18284235/profile_ticks_base.speedscope.json)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
