### PR TITLE
Speed up Collection.set_paths

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1340,9 +1340,9 @@ def _to_unmasked_float_array(x):
     values are converted to nans.
     """
     if hasattr(x, 'mask'):
-        return np.ma.asarray(x, float).filled(np.nan)
+        return np.ma.asanyarray(x, float).filled(np.nan)
     else:
-        return np.asarray(x, float)
+        return np.asanyarray(x, float)
 
 
 def _check_1d(x):

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1246,11 +1246,12 @@ class PolyCollection(_CollectionWithSizes):
             verts_pad = np.concatenate((verts, verts[:, :1]), axis=1)
             # Creating the codes once is much faster than having Path do it
             # separately each time by passing closed=True.
-            codes = np.empty(verts_pad.shape[1], dtype=mpath.Path.code_type)
-            codes[:] = mpath.Path.LINETO
-            codes[0] = mpath.Path.MOVETO
-            codes[-1] = mpath.Path.CLOSEPOLY
-            self._paths = [mpath.Path(xy, codes) for xy in verts_pad]
+            example_path = mpath.Path(verts_pad[0], closed=True)
+            # Looking up the values once speeds up the iteration a bit
+            _make_path = mpath.Path._fast_from_codes_and_verts
+            codes = example_path.codes
+            self._paths = [_make_path(xy, codes, internals_from=example_path)
+                           for xy in verts_pad]
             return
 
         self._paths = []

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1242,15 +1242,14 @@ class PolyCollection(_CollectionWithSizes):
             return
 
         # Fast path for arrays
-        if isinstance(verts, np.ndarray) and len(verts.shape) == 3:
+        if isinstance(verts, np.ndarray) and len(verts.shape) == 3 and verts.size:
             verts_pad = np.concatenate((verts, verts[:, :1]), axis=1)
-            # Creating the codes once is much faster than having Path do it
-            # separately each time by passing closed=True.
-            example_path = mpath.Path(verts_pad[0], closed=True)
-            # Looking up the values once speeds up the iteration a bit
+            # It's faster to create the codes and internal flags once in a
+            # template path and reuse them.
+            template_path = mpath.Path(verts_pad[0], closed=True)
+            codes = template_path.codes
             _make_path = mpath.Path._fast_from_codes_and_verts
-            codes = example_path.codes
-            self._paths = [_make_path(xy, codes, internals_from=example_path)
+            self._paths = [_make_path(xy, codes, internals_from=template_path)
                            for xy in verts_pad]
             return
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -76,7 +76,6 @@ class Path:
         made up front in the constructor that will not change when the
         data changes.
     """
-
     code_type = np.uint8
 
     # Path codes

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -987,12 +987,6 @@ def test_transformed_path():
                     [(0, 0), (r2, r2), (0, 2 * r2), (-r2, r2)],
                     atol=1e-15)
 
-    # Changing the path does not change the result (it's cached).
-    path._vertices = [(0, 0)] * 4
-    assert_allclose(trans_path.get_fully_transformed_path().vertices,
-                    [(0, 0), (r2, r2), (0, 2 * r2), (-r2, r2)],
-                    atol=1e-15)
-
 
 def test_transformed_patch_path():
     trans = mtransforms.Affine2D()

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -988,7 +988,7 @@ def test_transformed_path():
                     atol=1e-15)
 
     # Changing the path does not change the result (it's cached).
-    path.points = [(0, 0)] * 4
+    path._vertices = [(0, 0)] * 4
     assert_allclose(trans_path.get_fully_transformed_path().vertices,
                     [(0, 0), (r2, r2), (0, 2 * r2), (-r2, r2)],
                     atol=1e-15)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -1367,7 +1367,7 @@ def _zalpha(colors, zs):
     #        Should really normalize against the viewing depth.
     if len(colors) == 0 or len(zs) == 0:
         return np.zeros((0, 4))
-    norm = Normalize(min(zs), max(zs))
+    norm = Normalize(np.min(zs), np.max(zs))
     sats = 1 - norm(zs) * 0.7
     rgba = np.broadcast_to(mcolors.to_rgba_array(colors), (len(zs), 4))
     return np.column_stack([rgba[:, :3], rgba[:, 3] * sats])

--- a/lib/mpl_toolkits/mplot3d/proj3d.py
+++ b/lib/mpl_toolkits/mplot3d/proj3d.py
@@ -164,8 +164,7 @@ def _proj_transform_vectors(vecs, M):
 
 def _proj_transform_vec_clip(vec, M, focal_length):
     vecw = np.dot(M, vec.data)
-    w = vecw[3]
-    txs, tys, tzs = vecw[0] / w, vecw[1] / w, vecw[2] / w
+    txs, tys, tzs = vecw[0:3] / vecw[3]
     if np.isinf(focal_length):  # don't clip orthographic projection
         tis = np.ones(txs.shape, dtype=bool)
     else:


### PR DESCRIPTION
## PR summary
This builds on https://github.com/matplotlib/matplotlib/pull/16793 to implement `__slots__` on Path objects, and to improve a lighter weight creation path. Relative to that MR, it does not modify the garbage collection on Paths, and adds a smattering of minor 3D rendering improvements. For a 200x200 plot_surface test case, I am seeing a 1.3x speedup after averaging over a few profiler runs, though note that this gives better performance over a much wider scope as well.

Relevant issue which this won't fully close: https://github.com/matplotlib/matplotlib/issues/16659

```python
import time
import numpy as np
import matplotlib.pyplot as plt

fig = plt.figure()
ax = fig.add_subplot(111, projection='3d')

x = y = np.linspace(-1, 1, 200)
X, Y = np.meshgrid(x, y)
Z = X ** 2 + Y ** 2

print("Timing...")

start_time = time.perf_counter()
ax.plot_surface(X, Y, Z, rstride=1, cstride=1)
fig.canvas.draw()
end_time = time.perf_counter()

plt.close()
print(f"Time taken: {end_time - start_time:.4f} seconds")

```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
