### PR TITLE
DOC: scales - built in options and custom scale usefulness

### DIFF
--- a/galleries/examples/scales/custom_scale.py
+++ b/galleries/examples/scales/custom_scale.py
@@ -5,13 +5,25 @@
 Custom scale
 ============
 
-Create a custom scale, by implementing the scaling use for latitude data in a
-Mercator Projection.
+Custom scales can be created in two ways
 
-Unless you are making special use of the `.Transform` class, you probably
-don't need to use this verbose method, and instead can use `~.scale.FuncScale`
-and the ``'function'`` option of `~.Axes.set_xscale` and `~.Axes.set_yscale`.
-See the last example in :doc:`/gallery/scales/scales`.
+#. For simple cases, use `~.scale.FuncScale` and the ``'function'`` option of
+   `~.Axes.set_xscale` and `~.Axes.set_yscale`.  See the last example in
+   :doc:`/gallery/scales/scales`.
+
+#. Create a custom scale class such as the one in this example, which implements
+   the scaling use for latitude data in a Mercator Projection.  This more complicated
+   approach is useful when
+
+   * You are making special use of the `.Transform` class, such as the special
+     handling of values beyond the threshold in ``MercatorLatitudeTransform``
+     below.
+
+   * You want to override the default locators and formatters for the axis
+     (``set_default_locators_and_formatters`` below).
+
+   * You want to limit the range of the the axis (``limit_range_for_scale`` below).
+
 """
 
 import numpy as np

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -760,26 +760,15 @@ class Axis(martist.Artist):
 
         Parameters
         ----------
-        value : {"linear", "log", "symlog", "logit", ...} or `.ScaleBase`
-            The axis scale type to apply.
+        value : str or `.ScaleBase`
+            The axis scale type to apply.  Valid string values are the names of scale
+            classes ("linear", "log", "function",...).  These may be the names of any
+            of the :ref:`built-in scales<builtin_scales>` or of any custom scales
+            registered using `matplotlib.scale.register_scale`.
 
         **kwargs
-            Different keyword arguments are accepted, depending on the scale.
-            See the respective class keyword arguments:
-
-            - `matplotlib.scale.LinearScale`
-            - `matplotlib.scale.LogScale`
-            - `matplotlib.scale.SymmetricalLogScale`
-            - `matplotlib.scale.LogitScale`
-            - `matplotlib.scale.FuncScale`
-            - `matplotlib.scale.AsinhScale`
-
-        Notes
-        -----
-        By default, Matplotlib supports the above-mentioned scales.
-        Additionally, custom scales may be registered using
-        `matplotlib.scale.register_scale`. These scales can then also
-        be used here.
+            If *value* is a string, keywords are passed to the instantiation method of
+            the respective class.
         """
         name = self._get_axis_name()
         old_default_lims = (self.get_major_locator()

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -3,7 +3,9 @@ Scales define the distribution of data values on an axis, e.g. a log scaling.
 
 The mapping is implemented through `.Transform` subclasses.
 
-The following scales are builtin:
+The following scales are built-in:
+
+.. _builtin_scales:
 
 ============= ===================== ================================ =================================
 Name          Class                 Transform                        Inverted transform


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Today I spent way too long trying to wrap my head around why someone might write a custom scale.  I have updated the example with what I think I have understood.  Also updated the `set_[xy]scale` docstring as it was missing some built-in options, and I think we can be clearer about what happens to `**kwargs`.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
