### PR TITLE
DOC: Clearer wording for the installation of external dependencies

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -211,7 +211,7 @@ Additionally, the following non-Python dependencies must also be installed local
 .. rst-class:: checklist
 
 * :ref:`c++ compiler<compile-dependencies>`
-* :ref:`documentation build dependencies <doc-dependencies-external>`
+* :ref:`external tools used by the documentation build <doc-dependencies-external>`
 
 
 For a full list of dependencies, see :ref:`dependencies`. External dependencies do not


### PR DESCRIPTION
I've stumbled over this when reading the instructions. While this is in the section "Install external dependencies", I was unclear whether that link would go to / cover the whole doc dependencies. Stating that these are only the "external tools for the documentation build" is a bit clearer.

