### PR TITLE
DOC: Update scales overview

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -86,6 +86,8 @@ list_all = [
     "color_demo",
     #  pies
     "pie_features", "pie_demo2",
+    # scales
+    "scales",  # Scales overview
 
     # **Plot Types
     # Basic

--- a/galleries/examples/scales/scales.py
+++ b/galleries/examples/scales/scales.py
@@ -5,56 +5,42 @@ Scales overview
 
 Illustrate the scale transformations applied to axes, e.g. log, symlog, logit.
 
-The last two examples are examples of using the ``'function'`` scale by
-supplying forward and inverse functions for the scale transformation.
+See `matplotlib.scale` for a full list of built-in scales, and
+:doc:`/gallery/scales/custom_scale` for how to create your own scale.
 """
 
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib.ticker import FixedLocator, NullFormatter
+x = np.arange(400)
+y = np.linspace(0.002, 1, 400)
 
-# Fixing random state for reproducibility
-np.random.seed(19680801)
-
-# make up some data in the interval ]0, 1[
-y = np.random.normal(loc=0.5, scale=0.4, size=1000)
-y = y[(y > 0) & (y < 1)]
-y.sort()
-x = np.arange(len(y))
-
-# plot with various axes scales
 fig, axs = plt.subplots(3, 2, figsize=(6, 8), layout='constrained')
 
-# linear
-ax = axs[0, 0]
-ax.plot(x, y)
-ax.set_yscale('linear')
-ax.set_title('linear')
-ax.grid(True)
+axs[0, 0].plot(x, y)
+axs[0, 0].set_yscale('linear')
+axs[0, 0].set_title('linear')
+axs[0, 0].grid(True)
 
+axs[0, 1].plot(x, y)
+axs[0, 1].set_yscale('log')
+axs[0, 1].set_title('log')
+axs[0, 1].grid(True)
 
-# log
-ax = axs[0, 1]
-ax.plot(x, y)
-ax.set_yscale('log')
-ax.set_title('log')
-ax.grid(True)
+axs[1, 0].plot(x, y - y.mean())
+axs[1, 0].set_yscale('symlog', linthresh=0.02)
+axs[1, 0].set_title('symlog')
+axs[1, 0].grid(True)
 
+axs[1, 1].plot(x, y)
+axs[1, 1].set_yscale('logit')
+axs[1, 1].set_title('logit')
+axs[1, 1].grid(True)
 
-# symmetric log
-ax = axs[1, 1]
-ax.plot(x, y - y.mean())
-ax.set_yscale('symlog', linthresh=0.02)
-ax.set_title('symlog')
-ax.grid(True)
-
-# logit
-ax = axs[1, 0]
-ax.plot(x, y)
-ax.set_yscale('logit')
-ax.set_title('logit')
-ax.grid(True)
+axs[2, 0].plot(x, y - y.mean())
+axs[2, 0].set_yscale('asinh', linear_width=0.01)
+axs[2, 0].set_title('asinh')
+axs[2, 0].grid(True)
 
 
 # Function x**(1/2)
@@ -66,38 +52,11 @@ def inverse(x):
     return x**2
 
 
-ax = axs[2, 0]
-ax.plot(x, y)
-ax.set_yscale('function', functions=(forward, inverse))
-ax.set_title('function: $x^{1/2}$')
-ax.grid(True)
-ax.yaxis.set_major_locator(FixedLocator(np.arange(0, 1, 0.2)**2))
-ax.yaxis.set_major_locator(FixedLocator(np.arange(0, 1, 0.2)))
-
-
-# Function Mercator transform
-def forward(a):
-    a = np.deg2rad(a)
-    return np.rad2deg(np.log(np.abs(np.tan(a) + 1.0 / np.cos(a))))
-
-
-def inverse(a):
-    a = np.deg2rad(a)
-    return np.rad2deg(np.arctan(np.sinh(a)))
-
-ax = axs[2, 1]
-
-t = np.arange(0, 170.0, 0.1)
-s = t / 2.
-
-ax.plot(t, s, '-', lw=2)
-
-ax.set_yscale('function', functions=(forward, inverse))
-ax.set_title('function: Mercator')
-ax.grid(True)
-ax.set_xlim([0, 180])
-ax.yaxis.set_minor_formatter(NullFormatter())
-ax.yaxis.set_major_locator(FixedLocator(np.arange(0, 90, 10)))
+axs[2, 1].plot(x, y)
+axs[2, 1].set_yscale('function', functions=(forward, inverse))
+axs[2, 1].set_title('function: $x^{1/2}$')
+axs[2, 1].grid(True)
+axs[2, 1].set_yticks(np.arange(0, 1.2, 0.2))
 
 plt.show()
 
@@ -110,7 +69,6 @@ plt.show()
 #
 #    - `matplotlib.axes.Axes.set_xscale`
 #    - `matplotlib.axes.Axes.set_yscale`
-#    - `matplotlib.axis.Axis.set_major_locator`
 #    - `matplotlib.scale.LinearScale`
 #    - `matplotlib.scale.LogScale`
 #    - `matplotlib.scale.SymmetricalLogScale`


### PR DESCRIPTION
- replace the second "function" scale example by "asinh". We do not need two "function" scale examples, and "asinh" is worth noting.
- simplify code (use linear y instead of random almost linear y, use set_yticks() instead of a locator, ...)
- Move to first place in the gallery section
