### PR TITLE
fix #29410 Modifying Axes' position also alters the original Bbox object used for initialization

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -647,7 +647,7 @@ class _AxesBase(martist.Artist):
             args = (rect,)
         subplotspec = None
         if len(args) == 1 and isinstance(args[0], mtransforms.Bbox):
-            self._position = args[0]
+            self._position = args[0].frozen()
         elif len(args) == 1 and np.iterable(args[0]):
             self._position = mtransforms.Bbox.from_bounds(*args[0])
         else:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9583,11 +9583,12 @@ def test_bar_color_precedence():
         assert mcolors.same_color(bar.get_facecolor(), 'green')
 
 
-def test_axes_set_position_external_bbox_unchanged():
+@check_figures_equal(extensions=['png'])
+def test_axes_set_position_external_bbox_unchanged(fig_test, fig_ref):
     # From #29410: Modifying Axes' position also alters the original Bbox
     # object used for initialization
     bbox = mtransforms.Bbox([[0.0, 0.0], [1.0, 1.0]])
-    fig = plt.figure()
-    ax = fig.add_axes(bbox)
-    ax.set_position([0.25, 0.25, 0.5, 0.5])
+    ax_test = fig_test.add_axes(bbox)
+    ax_test.set_position([0.25, 0.25, 0.5, 0.5])
     assert (bbox.x0, bbox.y0, bbox.width, bbox.height) == (0.0, 0.0, 1.0, 1.0)
+    ax_ref = fig_ref.add_axes([0.25, 0.25, 0.5, 0.5])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9581,3 +9581,13 @@ def test_bar_color_precedence():
     bars = ax.bar([31, 32, 33], [4, 5, 6], color='red', facecolor='green')
     for bar in bars:
         assert mcolors.same_color(bar.get_facecolor(), 'green')
+
+
+def test_axes_set_position_external_bbox_unchanged():
+    # From #29410: Modifying Axes' position also alters the original Bbox
+    # object used for initialization
+    bbox = mtransforms.Bbox([[0.0, 0.0], [1.0, 1.0]])
+    fig = plt.figure()
+    ax = fig.add_axes(bbox)
+    ax.set_position([0.25, 0.25, 0.5, 0.5])
+    assert (bbox.x0, bbox.y0, bbox.width, bbox.height) == (0.0, 0.0, 1.0, 1.0)


### PR DESCRIPTION
## PR summary

This PR fix #29410 Modifying Axes' position also alters the original Bbox object used for initialization.

Making a copy of the reference Bbox using its `.frozen()` method solves the problem.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
