### PR TITLE
MNT: Turn Axes._axis_map into a static dict instead of a property

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -565,12 +565,6 @@ class _AxesBase(martist.Artist):
     dataLim: mtransforms.Bbox
     """The bounding `.Bbox` enclosing all data displayed in the Axes."""
 
-    @property
-    def _axis_map(self):
-        """A mapping of axis names, e.g. 'x', to `Axis` instances."""
-        return {name: getattr(self, f"{name}axis")
-                for name in self._axis_names}
-
     def __str__(self):
         return "{0}({1[0]:g},{1[1]:g};{1[2]:g}x{1[3]:g})".format(
             type(self).__name__, self._position.bounds)
@@ -685,6 +679,9 @@ class _AxesBase(martist.Artist):
 
         # this call may differ for non-sep axes, e.g., polar
         self._init_axis()
+        self._axis_map = {
+            name: getattr(self, f"{name}axis") for name in self._axis_names
+        }  # A mapping of axis names, e.g. 'x', to `Axis` instances.
         self._facecolor = mpl._val_or_rc(facecolor, 'axes.facecolor')
         self._frameon = frameon
         self.set_axisbelow(mpl.rcParams['axes.axisbelow'])

--- a/lib/matplotlib/axes/_base.pyi
+++ b/lib/matplotlib/axes/_base.pyi
@@ -5,7 +5,7 @@ from collections.abc import Callable, Iterable, Iterator, Sequence
 from matplotlib import cbook
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes
-from matplotlib.axis import XAxis, YAxis, Tick
+from matplotlib.axis import Axis, XAxis, YAxis, Tick
 from matplotlib.backend_bases import RendererBase, MouseButton, MouseEvent
 from matplotlib.cbook import CallbackRegistry
 from matplotlib.container import Container
@@ -62,6 +62,7 @@ class _AxesBase(martist.Artist):
     child_axes: list[_AxesBase]
     legend_: Legend | None
     title: Text
+    _axis_map: dict[str, Axis]
     _projection_init: Any
 
     def __init__(


### PR DESCRIPTION
The axes (`self.xaxis`, `self.yaxis`) as well as their names (`self._axis_names`) cannot be changed at run time. Therefore, we don't have to recompute the `_axis_map` on every access. Instead, we can do this once after `_init_axis()` and store the resulting dict.

