### PR TITLE
BUG: Fix regression with set_hatchcolor

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -439,8 +439,6 @@ class Patch(artist.Artist):
         ----------
         color : :mpltype:`color` or 'edge' or None
         """
-        if cbook._str_equal(color, 'edge'):
-            color = 'edge'
         self._original_hatchcolor = color
         self._set_hatchcolor(color)
 

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -425,7 +425,7 @@ class Patch(artist.Artist):
 
     def _set_hatchcolor(self, color):
         color = mpl._val_or_rc(color, 'hatch.color')
-        if color == 'edge':
+        if isinstance(color, str) and color == 'edge':
             self._hatch_color = 'edge'
         else:
             self._hatch_color = colors.to_rgba(color, self._alpha)

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -425,7 +425,7 @@ class Patch(artist.Artist):
 
     def _set_hatchcolor(self, color):
         color = mpl._val_or_rc(color, 'hatch.color')
-        if isinstance(color, str) and color == 'edge':
+        if cbook._str_equal(color, 'edge'):
             self._hatch_color = 'edge'
         else:
             self._hatch_color = colors.to_rgba(color, self._alpha)

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -1023,6 +1023,9 @@ def test_patch_hatchcolor_inherit_logic():
         rect.set_edgecolor('green')
         assert mcolors.same_color(rect.get_hatchcolor(), 'purple')
 
+    # Smoke test for setting with numpy array
+    rect.set_hatchcolor(np.ones(3))
+
 
 def test_patch_hatchcolor_fallback_logic():
     # Test for when hatchcolor parameter is passed


### PR DESCRIPTION
Fixes a regression introduced in #28104 (cc @timhoffm @Impaler343 ):
```
>>> import numpy as np
>>> import matplotlib.patches
>>> rect = matplotlib.patches.Rectangle([0, 0], 1, 1)
>>> rect.set_hatchcolor(np.zeros(3))
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/larsoner/python/matplotlib/lib/matplotlib/patches.py", line 445, in set_hatchcolor
    self._set_hatchcolor(color)
  File "/home/larsoner/python/matplotlib/lib/matplotlib/patches.py", line 428, in _set_hatchcolor
    if color == 'edge':
       ^^^^^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```