### PR TITLE
Remove erroneous statement in multipage PDF example

### DIFF
--- a/galleries/examples/misc/multipage_pdf.py
+++ b/galleries/examples/misc/multipage_pdf.py
@@ -6,9 +6,10 @@ Multipage PDF
 This is a demo of creating a pdf file with several pages,
 as well as adding metadata and annotations to pdf files.
 
-If you want to use a multipage pdf file using LaTeX, you need
-to use ``from matplotlib.backends.backend_pgf import PdfPages``.
-This version however does not support `.attach_note`.
+If you want to use a multipage pdf file using LaTeX, you 
+need to use `from matplotlib.backends.backend_pgf import 
+PdfPages`. The `pgf` backend, however, does not support `attach_note`, 
+whereas the `pdf` backend does.
 """
 
 import datetime

--- a/galleries/examples/misc/multipage_pdf.py
+++ b/galleries/examples/misc/multipage_pdf.py
@@ -6,10 +6,6 @@ Multipage PDF
 This is a demo of creating a pdf file with several pages,
 as well as adding metadata and annotations to pdf files.
 
-If you want to use a multipage pdf file using LaTeX, you 
-need to use `from matplotlib.backends.backend_pgf import 
-PdfPages`. The `pgf` backend, however, does not support `attach_note`, 
-whereas the `pdf` backend does.
 """
 
 import datetime


### PR DESCRIPTION
 ### PR summary

-  The PR fixes the issue #29428. This pull request clarifies the backend support for the attach_note feature in the multipage_pdf example documentation.
- The original documentation was unclear about which backend supports the attach_note feature. The use of the word "this" in the documentation created ambiguity, as it wasn't clear whether it referred to the PDF backend or the PGF backend.
- The wording in the documentation has been updated to ensure that users can quickly and easily understand the backend support for the attach_note feature without needing to infer it through multiple clicks and context clues.


 ### PR checklist
 

- [ ] Closes #0000: This PR is linked to the issue regarding the unclear documentation on backend support for attach_note.
- [N/A]  New and changed code is tested: Not applicable as this is a documentation-only change.
- [N/A]  Plotting related features are demonstrated in an example: Not applicable as this is a documentation-only change.
- [N/A]  New Features and API Changes are noted with a directive and release note: Not applicable as this is a documentation-only change.
- [x]  Documentation complies with general and docstring guidelines: The updated documentation complies with the guidelines specified in the Matplotlib documentation standards.


