### PR TITLE
ft2font: Avoid undefined enum values

### DIFF
--- a/lib/matplotlib/ft2font.pyi
+++ b/lib/matplotlib/ft2font.pyi
@@ -25,10 +25,10 @@ class FaceFlags(Flag):
     CID_KEYED = cast(int, ...)
     TRICKY = cast(int, ...)
     COLOR = cast(int, ...)
-    # VARIATION = cast(int, ...)  # FT 2.9
-    # SVG = cast(int, ...)  # FT 2.12
-    # SBIX = cast(int, ...)  # FT 2.12
-    # SBIX_OVERLAY = cast(int, ...)  # FT 2.12
+    VARIATION = cast(int, ...)
+    SVG = cast(int, ...)
+    SBIX = cast(int, ...)
+    SBIX_OVERLAY = cast(int, ...)
 
 class Kerning(Enum):
     DEFAULT = cast(int, ...)
@@ -52,9 +52,9 @@ class LoadFlags(Flag):
     LINEAR_DESIGN = cast(int, ...)
     NO_AUTOHINT = cast(int, ...)
     COLOR = cast(int, ...)
-    COMPUTE_METRICS = cast(int, ...)  # FT 2.6.1
-    # BITMAP_METRICS_ONLY = cast(int, ...)  # FT 2.7.1
-    # NO_SVG = cast(int, ...)  # FT 2.13.1
+    COMPUTE_METRICS = cast(int, ...)
+    BITMAP_METRICS_ONLY = cast(int, ...)
+    NO_SVG = cast(int, ...)
     # The following should be unique, but the above can be OR'd together.
     TARGET_NORMAL = cast(int, ...)
     TARGET_LIGHT = cast(int, ...)

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -66,6 +66,19 @@ const char *FaceFlags__doc__ = R"""(
     .. versionadded:: 3.10
 )""";
 
+#ifndef FT_FACE_FLAG_VARIATION  // backcompat: ft 2.9.0.
+#define FT_FACE_FLAG_VARIATION (1L << 15)
+#endif
+#ifndef FT_FACE_FLAG_SVG  // backcompat: ft 2.12.0.
+#define FT_FACE_FLAG_SVG (1L << 16)
+#endif
+#ifndef FT_FACE_FLAG_SBIX  // backcompat: ft 2.12.0.
+#define FT_FACE_FLAG_SBIX (1L << 17)
+#endif
+#ifndef FT_FACE_FLAG_SBIX_OVERLAY  // backcompat: ft 2.12.0.
+#define FT_FACE_FLAG_SBIX_OVERLAY (1L << 18)
+#endif
+
 enum class FaceFlags : FT_Long {
 #define DECLARE_FLAG(name) name = FT_FACE_FLAG_##name
     DECLARE_FLAG(SCALABLE),
@@ -83,18 +96,10 @@ enum class FaceFlags : FT_Long {
     DECLARE_FLAG(CID_KEYED),
     DECLARE_FLAG(TRICKY),
     DECLARE_FLAG(COLOR),
-#ifdef FT_FACE_FLAG_VARIATION  // backcompat: ft 2.9.0.
     DECLARE_FLAG(VARIATION),
-#endif
-#ifdef FT_FACE_FLAG_SVG  // backcompat: ft 2.12.0.
     DECLARE_FLAG(SVG),
-#endif
-#ifdef FT_FACE_FLAG_SBIX  // backcompat: ft 2.12.0.
     DECLARE_FLAG(SBIX),
-#endif
-#ifdef FT_FACE_FLAG_SBIX_OVERLAY  // backcompat: ft 2.12.0.
     DECLARE_FLAG(SBIX_OVERLAY),
-#endif
 #undef DECLARE_FLAG
 };
 
@@ -115,14 +120,10 @@ P11X_DECLARE_ENUM(
     {"CID_KEYED", FaceFlags::CID_KEYED},
     {"TRICKY", FaceFlags::TRICKY},
     {"COLOR", FaceFlags::COLOR},
-    // backcompat: ft 2.9.0.
-    // {"VARIATION", FaceFlags::VARIATION},
-    // backcompat: ft 2.12.0.
-    // {"SVG", FaceFlags::SVG},
-    // backcompat: ft 2.12.0.
-    // {"SBIX", FaceFlags::SBIX},
-    // backcompat: ft 2.12.0.
-    // {"SBIX_OVERLAY", FaceFlags::SBIX_OVERLAY},
+    {"VARIATION", FaceFlags::VARIATION},
+    {"SVG", FaceFlags::SVG},
+    {"SBIX", FaceFlags::SBIX},
+    {"SBIX_OVERLAY", FaceFlags::SBIX_OVERLAY},
 );
 
 const char *LoadFlags__doc__ = R"""(
@@ -133,6 +134,16 @@ const char *LoadFlags__doc__ = R"""(
 
     .. versionadded:: 3.10
 )""";
+
+#ifndef FT_LOAD_COMPUTE_METRICS  // backcompat: ft 2.6.1.
+#define FT_LOAD_COMPUTE_METRICS (1L << 21)
+#endif
+#ifndef FT_LOAD_BITMAP_METRICS_ONLY  // backcompat: ft 2.7.1.
+#define FT_LOAD_BITMAP_METRICS_ONLY (1L << 22)
+#endif
+#ifndef FT_LOAD_NO_SVG  // backcompat: ft 2.13.1.
+#define FT_LOAD_NO_SVG (1L << 24)
+#endif
 
 enum class LoadFlags : FT_Int32 {
 #define DECLARE_FLAG(name) name = FT_LOAD_##name
@@ -152,15 +163,9 @@ enum class LoadFlags : FT_Int32 {
     DECLARE_FLAG(LINEAR_DESIGN),
     DECLARE_FLAG(NO_AUTOHINT),
     DECLARE_FLAG(COLOR),
-#ifdef FT_LOAD_COMPUTE_METRICS  // backcompat: ft 2.6.1.
     DECLARE_FLAG(COMPUTE_METRICS),
-#endif
-#ifdef FT_LOAD_BITMAP_METRICS_ONLY  // backcompat: ft 2.7.1.
     DECLARE_FLAG(BITMAP_METRICS_ONLY),
-#endif
-#ifdef FT_LOAD_NO_SVG  // backcompat: ft 2.13.1.
     DECLARE_FLAG(NO_SVG),
-#endif
     DECLARE_FLAG(TARGET_NORMAL),
     DECLARE_FLAG(TARGET_LIGHT),
     DECLARE_FLAG(TARGET_MONO),
@@ -187,12 +192,9 @@ P11X_DECLARE_ENUM(
     {"LINEAR_DESIGN", LoadFlags::LINEAR_DESIGN},
     {"NO_AUTOHINT", LoadFlags::NO_AUTOHINT},
     {"COLOR", LoadFlags::COLOR},
-    // backcompat: ft 2.6.1.
     {"COMPUTE_METRICS", LoadFlags::COMPUTE_METRICS},
-    // backcompat: ft 2.7.1.
-    // {"BITMAP_METRICS_ONLY", LoadFlags::BITMAP_METRICS_ONLY},
-    // backcompat: ft 2.13.1.
-    // {"NO_SVG", LoadFlags::NO_SVG},
+    {"BITMAP_METRICS_ONLY", LoadFlags::BITMAP_METRICS_ONLY},
+    {"NO_SVG", LoadFlags::NO_SVG},
     // These must be unique, but the others can be OR'd together; I don't know if
     // there's any way to really enforce that.
     {"TARGET_NORMAL", LoadFlags::TARGET_NORMAL},


### PR DESCRIPTION
## PR summary

By simply defining them if not available.

This fixes the latter half of https://github.com/matplotlib/matplotlib/issues/29396#issuecomment-2576910230

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines