### PR TITLE
CI: Try skipping wx on py310

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -304,14 +304,14 @@ jobs:
             python -c 'import PySide6.QtCore' &&
             echo 'PySide6 is available' ||
             echo 'PySide6 is not available'
-
-          python -mpip install --upgrade \
-            -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}" \
-            wxPython &&
-            python -c 'import wx' &&
-            echo 'wxPython is available' ||
-            echo 'wxPython is not available'
-
+          if [[ "${{ matrix.python-version }}" != '3.10' ]]; then
+            python -mpip install --upgrade \
+              -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}" \
+              wxPython &&
+              python -c 'import wx' &&
+              echo 'wxPython is available' ||
+              echo 'wxPython is not available'
+            fi
           fi  # Skip backends on Python 3.13t.
 
       - name: Install the nightly dependencies


### PR DESCRIPTION
The "are you installed" check is failing and printing a message.  However, because the failure is on import loading shared objects, we still try to run tests against it.

This is yet another example of the limitations of wheels.

We probably should debug why wxpython broke (it could either be the wheels changed to newly require libnotify or that the system dependencies changed and we stopped getting it by chance), but in the interest of un-breaking CI this just turns off wx for py310.