### PR TITLE
ci: Install libnotify4 on all Ubuntu

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -155,6 +155,7 @@ jobs:
               libffi-dev \
               libgeos-dev \
               libgirepository1.0-dev \
+              libnotify4 \
               libsdl2-2.0-0 \
               libxkbcommon-x11-0 \
               libxcb-cursor0 \
@@ -181,8 +182,7 @@ jobs:
             if [[ "${{ matrix.os }}" = ubuntu-20.04 ]]; then
               sudo apt-get install -yy --no-install-recommends libopengl0
             else  # ubuntu-22.04
-              sudo apt-get install -yy --no-install-recommends \
-                gir1.2-gtk-4.0 libnotify4
+              sudo apt-get install -yy --no-install-recommends gir1.2-gtk-4.0
             fi
             ;;
           macOS)


### PR DESCRIPTION
## PR summary

Whatever used to require it seems to have dropped it, causing issues with wxPython on Ubuntu 20.04 now.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines