### PR TITLE
DOC: Fix type descriptions in fill_between docstring

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5582,16 +5582,16 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        {ind} : array (length N)
+        {ind} : array-like
             The {ind} coordinates of the nodes defining the curves.
 
-        {dep}1 : array (length N) or scalar
+        {dep}1 : array-like or float
             The {dep} coordinates of the nodes defining the first curve.
 
-        {dep}2 : array (length N) or scalar, default: 0
+        {dep}2 : array-like or float, default: 0
             The {dep} coordinates of the nodes defining the second curve.
 
-        where : array of bool (length N), optional
+        where : array-like of bool, optional
             Define *where* to exclude some {dir} regions from being filled.
             The filled regions are defined by the coordinates ``{ind}[where]``.
             More precisely, fill between ``{ind}[i]`` and ``{ind}[i+1]`` if

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1288,16 +1288,16 @@ class FillBetweenPolyCollection(PolyCollection):
             - 'x': the curves are ``(t, f1)`` and ``(t, f2)``.
             - 'y': the curves are ``(f1, t)`` and ``(f2, t)``.
 
-        t : array (length N)
+        t : array-like
             The ``t_direction`` coordinates of the nodes defining the curves.
 
-        f1 : array (length N) or scalar
+        f1 : array-like or float
             The other coordinates of the nodes defining the first curve.
 
-        f2 : array (length N) or scalar
+        f2 : array-like or float
             The other coordinates of the nodes defining the second curve.
 
-        where : array of bool (length N), optional
+        where : array-like of bool, optional
             Define *where* to exclude some {dir} regions from being filled.
             The filled regions are defined by the coordinates ``t[where]``.
             More precisely, fill between ``t[i]`` and ``t[i+1]`` if
@@ -1368,16 +1368,16 @@ class FillBetweenPolyCollection(PolyCollection):
 
         Parameters
         ----------
-        t : array (length N)
+        t : array-like
             The ``self.t_direction`` coordinates of the nodes defining the curves.
 
-        f1 : array (length N) or scalar
+        f1 : array-like or float
             The other coordinates of the nodes defining the first curve.
 
-        f2 : array (length N) or scalar
+        f2 : array-like or float
             The other coordinates of the nodes defining the second curve.
 
-        where : array of bool (length N), optional
+        where : array-like of bool, optional
             Define *where* to exclude some {dir} regions from being filled.
             The filled regions are defined by the coordinates ``t[where]``.
             More precisely, fill between ``t[i]`` and ``t[i+1]`` if


### PR DESCRIPTION
Coerce to our standard type descriptions
https://matplotlib.org/devdocs/devel/document.html#parameter-type-descriptions

