### PR TITLE
DOC: Use float instead for scalar for type descriptions in docstrings

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1016,7 +1016,7 @@ class Artist:
 
         Parameters
         ----------
-        alpha : scalar or None
+        alpha : float or None
             *alpha* must be within the 0-1 range, inclusive.
         """
         if alpha is not None and not isinstance(alpha, Real):
@@ -1035,7 +1035,7 @@ class Artist:
 
         Parameters
         ----------
-        alpha : array-like or scalar or None
+        alpha : array-like or float or None
             All values must be within the 0-1 range, inclusive.
             Masked values and nans are not supported.
         """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1613,7 +1613,7 @@ class Axes(_AxesBase):
 
         Parameters
         ----------
-        x, y : array-like or scalar
+        x, y : array-like or float
             The horizontal / vertical coordinates of the data points.
             *x* values are optional and default to ``range(len(y))``.
 
@@ -4231,13 +4231,13 @@ class Axes(_AxesBase):
             A list of dictionaries containing stats for each boxplot.
             Required keys are:
 
-            - ``med``: Median (scalar).
-            - ``q1``, ``q3``: First & third quartiles (scalars).
-            - ``whislo``, ``whishi``: Lower & upper whisker positions (scalars).
+            - ``med``: Median (float).
+            - ``q1``, ``q3``: First & third quartiles (float).
+            - ``whislo``, ``whishi``: Lower & upper whisker positions (float).
 
             Optional keys are:
 
-            - ``mean``: Mean (scalar).  Needed if ``showmeans=True``.
+            - ``mean``: Mean (float).  Needed if ``showmeans=True``.
             - ``fliers``: Data beyond the whiskers (array-like).
               Needed if ``showfliers=True``.
             - ``cilo``, ``cihi``: Lower & upper confidence intervals
@@ -6872,7 +6872,7 @@ class Axes(_AxesBase):
             ``True``, then the histogram is normalized such that the first bin
             equals 1.
 
-        bottom : array-like, scalar, or None, default: None
+        bottom : array-like or float, default: 0
             Location of the bottom of each bin, i.e. bins are drawn from
             ``bottom`` to ``bottom + hist(x, bins)`` If a scalar, the bottom
             of each bin is shifted by the same amount. If an array, each bin

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -428,11 +428,11 @@ class RendererBase:
         gc : `.GraphicsContextBase`
             A graphics context with clipping information.
 
-        x : scalar
+        x : float
             The distance in physical units (i.e., dots or pixels) from the left
             hand side of the canvas.
 
-        y : scalar
+        y : float
             The distance in physical units (i.e., dots or pixels) from the
             bottom side of the canvas.
 

--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -21,9 +21,9 @@ class MixedModeRenderer:
         ----------
         figure : `~matplotlib.figure.Figure`
             The figure instance.
-        width : scalar
+        width : float
             The width of the canvas in logical units
-        height : scalar
+        height : float
             The height of the canvas in logical units
         dpi : float
             The dpi of the canvas

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -743,7 +743,7 @@ class Colormap:
         r"""
         Parameters
         ----------
-        X : float or int, `~numpy.ndarray` or scalar
+        X : float or int or array-like
             The data value(s) to convert to RGBA.
             For floats, *X* should be in the interval ``[0.0, 1.0]`` to
             return the RGBA values ``X*100`` percent along the Colormap line.
@@ -771,7 +771,7 @@ class Colormap:
         r"""
         Parameters
         ----------
-        X : float or int, `~numpy.ndarray` or scalar
+        X : float or int or array-like
             The data value(s) to convert to RGBA.
             For floats, *X* should be in the interval ``[0.0, 1.0]`` to
             return the RGBA values ``X*100`` percent along the Colormap line.
@@ -1609,7 +1609,7 @@ class BivarColormap:
         r"""
         Parameters
         ----------
-        X : tuple (X0, X1), X0 and X1: float or int `~numpy.ndarray` or scalar
+        X : tuple (X0, X1), X0 and X1: float or int or array-like
             The data value(s) to convert to RGBA.
 
             - For floats, *X* should be in the interval ``[0.0, 1.0]`` to


### PR DESCRIPTION
In agreement with our standard type descriptions
https://matplotlib.org/devdocs/devel/document.html#parameter-type-descriptions

