### PR TITLE
Fix dead links in dev workflow docs

### DIFF
--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -138,12 +138,9 @@ The editing workflow
    Note the ``-am`` options to ``commit``. The ``m`` flag signals that you are
    going to type a message on the command line.  The ``a`` flag stages every
    file that has been modified, except files listed in ``.gitignore``. For more
-   information, see `why the -a flag?`_ and the
-   `git commit <https://git-scm.com/docs/git-commit>`_  manual page.
+   information, see the `git commit <https://git-scm.com/docs/git-commit>`_  manual page.
 #. To push the changes up to your forked repo on GitHub, do a ``git
    push``.
-
-.. _why the -a flag?: http://gitready.com/beginner/2009/01/18/the-staging-area.html
 
 
 Verify your changes

--- a/galleries/examples/misc/multipage_pdf.py
+++ b/galleries/examples/misc/multipage_pdf.py
@@ -6,9 +6,10 @@ Multipage PDF
 This is a demo of creating a pdf file with several pages,
 as well as adding metadata and annotations to pdf files.
 
-If you want to use a multipage pdf file using LaTeX, you need
-to use ``from matplotlib.backends.backend_pgf import PdfPages``.
-This version however does not support `.attach_note`.
+If you want to use a multipage pdf file using LaTeX, you 
+need to use `from matplotlib.backends.backend_pgf import 
+PdfPages`. The `pgf` backend, however, does not support `attach_note`, 
+whereas the `pdf` backend does.
 """
 
 import datetime

--- a/galleries/examples/misc/multipage_pdf.py
+++ b/galleries/examples/misc/multipage_pdf.py
@@ -6,10 +6,6 @@ Multipage PDF
 This is a demo of creating a pdf file with several pages,
 as well as adding metadata and annotations to pdf files.
 
-If you want to use a multipage pdf file using LaTeX, you 
-need to use `from matplotlib.backends.backend_pgf import 
-PdfPages`. The `pgf` backend, however, does not support `attach_note`, 
-whereas the `pdf` backend does.
 """
 
 import datetime


### PR DESCRIPTION
## PR summary

- This pull request addresses the removal of a broken link in the doc/devel/development_workflow.rst and updates the content to improve clarity and accuracy.
- The original link to [why-the-flag?](https://gitready.com/beginner/2009/01/18/the-staging-area.html) was broken, and the resources are no longer available. 
- Resolving the issue by replacing "For more information, see [why the -a flag?](http://gitready.com/beginner/2009/01/18/the-staging-area.html) and the [git commit](https://git-scm.com/docs/git-commit) manual page." to "For more information, see the [git commit](https://git-scm.com/docs/git-commit) manual page."

Closes #29305.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] This PR fixes the issue where the link in development_workflow.rst was broken. Closes #29305  [issue](https://github.com/matplotlib/matplotlib/issues/29305)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines


<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
