### PR TITLE
DOC: Add missing examples for legend outside positions

### DIFF
--- a/galleries/users_explain/axes/legend_guide.py
+++ b/galleries/users_explain/axes/legend_guide.py
@@ -175,7 +175,7 @@ fig.legend(loc='outside upper right')
 #
 ucl = ['upper', 'center', 'lower']
 lcr = ['left', 'center', 'right']
-fig, ax = plt.subplots(figsize=(6, 4), layout='constrained', facecolor='0.7')
+fig, ax = plt.subplots(figsize=(6, 4), layout='constrained', facecolor='0.95')
 
 ax.plot([1, 2], [1, 2], label='TEST')
 # Place a legend to the right of this smaller subplot.
@@ -188,12 +188,14 @@ for loc in [
         'outside lower right']:
     fig.legend(loc=loc, title=loc)
 
-fig, ax = plt.subplots(figsize=(6, 4), layout='constrained', facecolor='0.7')
+fig, ax = plt.subplots(figsize=(6, 4), layout='constrained', facecolor='0.95')
 ax.plot([1, 2], [1, 2], label='test')
 
 for loc in [
         'outside left upper',
         'outside right upper',
+        'outside left center',
+        'outside right center',
         'outside left lower',
         'outside right lower']:
     fig.legend(loc=loc, title=loc)


### PR DESCRIPTION
Also made the background lighter, which IMHO looks more pleasing.

Old example: https://matplotlib.org/devdocs/users/explain/axes/legend_guide.html#legend-location

New: plot
![image](https://github.com/user-attachments/assets/bcd81291-a027-4639-a5ea-6f4124c9cb19)
