### PR TITLE
CI: add py312 and py313 on windows on azure to test matrix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -55,6 +55,12 @@ stages:
             Windows_py311:
               vmImage: 'windows-latest'
               python.version: '3.11'
+            Windows_py312:
+              vmImage: 'windows-latest'
+              python.version: '3.12'
+            Windows_py313:
+              vmImage: 'windows-latest'
+              python.version: '3.13'
           maxParallel: 4
         pool:
           vmImage: '$(vmImage)'


### PR DESCRIPTION
Noted will looking at #29472 that we are only testing py310 and py311 on either windows platform.