### PR TITLE
ci: Add an ARM Linux test workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,7 +78,7 @@ jobs:
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
             extra-requirements: '-r requirements/testing/extra.txt'
-          - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
             python-version: '3.12'
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
             pyqt6-ver: '!=6.6.0'
@@ -282,10 +282,13 @@ jobs:
               echo 'PyGObject 3 is available' || echo 'PyGObject 3 is not available'
             )
 
-          python -mpip install --upgrade pyqt5${{ matrix.pyqt5-ver }} &&
-            python -c 'import PyQt5.QtCore' &&
-            echo 'PyQt5 is available' ||
-            echo 'PyQt5 is not available'
+          # PyQt5 does not have any wheels for ARM on Linux.
+          if [[ "${{ matrix.os }}" != 'ubuntu-22.04-arm' ]]; then
+            python -mpip install --upgrade --only-binary :all: pyqt5${{ matrix.pyqt5-ver }} &&
+              python -c 'import PyQt5.QtCore' &&
+              echo 'PyQt5 is available' ||
+              echo 'PyQt5 is not available'
+          fi
           # Even though PySide2 wheels can be installed on Python 3.12+, they are broken and since PySide2 is
           # deprecated, they are unlikely to be fixed. For the same deprecation reason, there are no wheels
           # on M1 macOS, so don't bother there either.
@@ -296,16 +299,16 @@ jobs:
               echo 'PySide2 is available' ||
               echo 'PySide2 is not available'
           fi
-          python -mpip install --upgrade pyqt6${{ matrix.pyqt6-ver }} &&
+          python -mpip install --upgrade --only-binary :all: pyqt6${{ matrix.pyqt6-ver }} &&
             python -c 'import PyQt6.QtCore' &&
             echo 'PyQt6 is available' ||
             echo 'PyQt6 is not available'
-          python -mpip install --upgrade pyside6${{ matrix.pyside6-ver }} &&
+          python -mpip install --upgrade --only-binary :all: pyside6${{ matrix.pyside6-ver }} &&
             python -c 'import PySide6.QtCore' &&
             echo 'PySide6 is available' ||
             echo 'PySide6 is not available'
 
-          python -mpip install --upgrade \
+          python -mpip install --upgrade --only-binary :all: \
             -f "https://extras.wxpython.org/wxPython4/extras/linux/gtk3/${{ matrix.os }}" \
             wxPython &&
             python -c 'import wx' &&

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1454,7 +1454,8 @@ def test_pcolormesh_small():
 
 
 @image_comparison(['pcolormesh_alpha'], extensions=["png", "pdf"],
-                  remove_text=True)
+                  remove_text=True,
+                  tol=0.2 if platform.machine() == "aarch64" else 0)
 def test_pcolormesh_alpha():
     # Remove this line when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False
@@ -9162,8 +9163,10 @@ def test_zorder_and_explicit_rasterization():
         fig.savefig(b, format='pdf')
 
 
-@image_comparison(["preset_clip_paths.png"], remove_text=True, style="mpl20",
-                  tol=0.027 if platform.machine() in ("arm64", "ppc64le") else 0)
+@image_comparison(
+    ["preset_clip_paths.png"],
+    remove_text=True, style="mpl20",
+    tol=0.027 if platform.machine() in ("aarch64", "arm64", "ppc64le") else 0)
 def test_preset_clip_paths():
     fig, ax = plt.subplots()
 


### PR DESCRIPTION
## PR summary

Like the macOS jobs are mixed between Intel and ARM, this changes one of the Linux jobs to use ARM.

We'll see if we need to make any changes as in #24597 after the build is complete.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines