### PR TITLE
FIX: issue #13919

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -124,24 +124,32 @@ class Tick(martist.Artist):
                 zorder = mlines.Line2D.zorder
         self._zorder = zorder
 
-        grid_color = (mpl._val_or_rc(grid_color, "grid.color")
-                      if mpl.rcParams[f"grid.{major_minor}.color"] == "none"
-                      else mpl._val_or_rc(grid_color, f"grid.{major_minor}.color"))
-        grid_linestyle = (mpl._val_or_rc(grid_linestyle, "grid.linestyle")
-                          if mpl.rcParams[f"grid.{major_minor}.linestyle"] == "none"
-                          else mpl._val_or_rc(grid_linestyle, f"grid.{major_minor}.linestyle"))
-        grid_linewidth = (mpl._val_or_rc(grid_linewidth, "grid.linewidth")
-                          if mpl.rcParams[f"grid.{major_minor}.linewidth"] is None
-                          else mpl._val_or_rc(grid_linewidth, f"grid.{major_minor}.linewidth"))
+        grid_color = (
+            mpl._val_or_rc(grid_color, "grid.color")
+            if mpl.rcParams[f"grid.{major_minor}.color"] == "none"
+            else mpl._val_or_rc(grid_color, f"grid.{major_minor}.color")
+        )
+        grid_linestyle = (
+            mpl._val_or_rc(grid_linestyle, "grid.linestyle")
+            if mpl.rcParams[f"grid.{major_minor}.linestyle"] == "none"
+            else mpl._val_or_rc(grid_linestyle, f"grid.{major_minor}.linestyle")
+        )
+        grid_linewidth = (
+            mpl._val_or_rc(grid_linewidth, "grid.linewidth")
+            if mpl.rcParams[f"grid.{major_minor}.linewidth"] is None
+            else mpl._val_or_rc(grid_linewidth, f"grid.{major_minor}.linewidth")
+        )
         if grid_alpha is None and not mcolors._has_alpha_channel(grid_color):
             # alpha precedence: kwarg > color alpha > rcParams['grid.alpha']
             # Note: only resolve to rcParams if the color does not have alpha
             # otherwise `grid(color=(1, 1, 1, 0.5))` would work like
             #   grid(color=(1, 1, 1, 0.5), alpha=rcParams['grid.alpha'])
             # so the that the rcParams default would override color alpha.
-            grid_alpha = (mpl.rcParams["grid.alpha"] 
-                          if f"grid.{major_minor}.alpha" not in mpl.rcParams
-                          else mpl.rcParams[f"grid.{major_minor}.alpha"])
+            grid_alpha = (
+                mpl.rcParams["grid.alpha"]
+                if f"grid.{major_minor}.alpha" not in mpl.rcParams
+                else mpl.rcParams[f"grid.{major_minor}.alpha"]
+            )
         grid_kw = {k[5:]: v for k, v in kwargs.items()}
 
         self.tick1line = mlines.Line2D(

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -124,16 +124,24 @@ class Tick(martist.Artist):
                 zorder = mlines.Line2D.zorder
         self._zorder = zorder
 
-        grid_color = mpl._val_or_rc(grid_color, "grid.color")
-        grid_linestyle = mpl._val_or_rc(grid_linestyle, "grid.linestyle")
-        grid_linewidth = mpl._val_or_rc(grid_linewidth, "grid.linewidth")
+        grid_color = (mpl._val_or_rc(grid_color, "grid.color")
+                      if mpl.rcParams[f"grid.{major_minor}.color"] == "none"
+                      else mpl._val_or_rc(grid_color, f"grid.{major_minor}.color"))
+        grid_linestyle = (mpl._val_or_rc(grid_linestyle, "grid.linestyle")
+                          if mpl.rcParams[f"grid.{major_minor}.linestyle"] == "none"
+                          else mpl._val_or_rc(grid_linestyle, f"grid.{major_minor}.linestyle"))
+        grid_linewidth = (mpl._val_or_rc(grid_linewidth, "grid.linewidth")
+                          if mpl.rcParams[f"grid.{major_minor}.linewidth"] is None
+                          else mpl._val_or_rc(grid_linewidth, f"grid.{major_minor}.linewidth"))
         if grid_alpha is None and not mcolors._has_alpha_channel(grid_color):
             # alpha precedence: kwarg > color alpha > rcParams['grid.alpha']
             # Note: only resolve to rcParams if the color does not have alpha
             # otherwise `grid(color=(1, 1, 1, 0.5))` would work like
             #   grid(color=(1, 1, 1, 0.5), alpha=rcParams['grid.alpha'])
             # so the that the rcParams default would override color alpha.
-            grid_alpha = mpl.rcParams["grid.alpha"]
+            grid_alpha = (mpl.rcParams["grid.alpha"] 
+                          if f"grid.{major_minor}.alpha" not in mpl.rcParams
+                          else mpl.rcParams[f"grid.{major_minor}.alpha"])
         grid_kw = {k[5:]: v for k, v in kwargs.items()}
 
         self.tick1line = mlines.Line2D(

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -535,6 +535,16 @@
 #grid.linewidth: 0.8        # in points
 #grid.alpha:     1.0        # transparency, between 0.0 and 1.0
 
+#grid.major.color:     None # If None defaults to grid.color
+#grid.major.linestyle: None # If None defaults to grid.linestyle
+#grid.major.linewidth: None # If None defaults to grid.linewidth
+#grid.major.alpha:     None # If None defaults to grid.alpha
+
+#grid.minor.color:     None # If None defaults to grid.color
+#grid.minor.linestyle: None # If None defaults to grid.linestyle
+#grid.minor.linewidth: None # If None defaults to grid.linewidth
+#grid.minor.alpha:     None # If None defaults to grid.alpha
+
 
 ## ***************************************************************************
 ## * LEGEND                                                                  *

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1237,6 +1237,16 @@ _validators = {
     "grid.linewidth":    validate_float,     # in points
     "grid.alpha":        validate_float,
 
+    "grid.major.color":        validate_color,  # grid color
+    "grid.major.linestyle":    _validate_linestyle,  # solid
+    "grid.major.linewidth":    validate_float_or_None,     # in points
+    "grid.major.alpha":        validate_float_or_None,
+
+    "grid.minor.color":        validate_color,  # grid color
+    "grid.minor.linestyle":    _validate_linestyle,  # solid
+    "grid.minor.linewidth":    validate_float_or_None,     # in points
+    "grid.minor.alpha":        validate_float_or_None,
+
     ## figure props
     # figure title
     "figure.titlesize":   validate_fontsize,


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->
Possibly closes #13919  issue. Additionally, PR #26121 also tried to solve the same issue but I understand that it is not backwards compatible and there haven't been any updates since 2023. My implementation should be backwards compatible.

I have tested the code with pytest. Some tests failed on my machine, but all were latex tests. The problem is probably my latex installation.

I also tested to code with a small python script that:

1. Modifies the rcParams at runtime for 3 different scenarios and uses
2. Uses mstyle files for the same 3 scenario

The results were identical and as expected.

### Test
My test script:
```python
# test_grid_rcparams.py
import matplotlib as mpl
import matplotlib.pyplot as plt

dpi = 150
#---------------------------------------------
# RUNTIME
#---------------------------------------------
mpl.rcdefaults()
mpl.rcParams["axes.grid"] = True
mpl.rcParams["ytick.minor.visible"] = True
mpl.rcParams["xtick.minor.visible"] = True
mpl.rcParams["axes.grid.which"] = "both"
mpl.rcParams["grid.color"] = "red"
mpl.rcParams["grid.linewidth"] = 1
mpl.rcParams["grid.linestyle"] = "-"
mpl.rcParams["grid.alpha"] = 1
plt.figure()
plt.plot([0, 1], [0, 1])
plt.gcf().savefig("runtime1.png", dpi=dpi)

mpl.rcdefaults()
mpl.rcParams["axes.grid"] = True
mpl.rcParams["ytick.minor.visible"] = True
mpl.rcParams["xtick.minor.visible"] = True
mpl.rcParams["axes.grid.which"] = "both"
mpl.rcParams["grid.color"] = "red"
mpl.rcParams["grid.linewidth"] = 1
mpl.rcParams["grid.linestyle"] = "-"
mpl.rcParams["grid.alpha"] = 1

mpl.rcParams["grid.major.color"] = "black"
mpl.rcParams["grid.major.linewidth"] = 2
mpl.rcParams["grid.major.linestyle"] = ":"
plt.figure()
plt.plot([0, 1], [0, 1])
plt.gcf().savefig("runtime2.png", dpi=dpi)

mpl.rcdefaults()
mpl.rcParams["axes.grid"] = True
mpl.rcParams["ytick.minor.visible"] = True
mpl.rcParams["xtick.minor.visible"] = True
mpl.rcParams["axes.grid.which"] = "both"
mpl.rcParams["grid.color"] = "red"
mpl.rcParams["grid.linewidth"] = 1
mpl.rcParams["grid.linestyle"] = "-"
mpl.rcParams["grid.alpha"] = 1

mpl.rcParams["grid.minor.color"] = "red"
mpl.rcParams["grid.minor.linewidth"] = 0.5
mpl.rcParams["grid.minor.linestyle"] = ":"
mpl.rcParams["grid.minor.alpha"] = 0.5
plt.figure()
plt.plot([0, 1], [0, 1])
plt.gcf().savefig("runtime3.png", dpi=dpi)


#---------------------------------------------
# MSTYLE FILE
#---------------------------------------------
mpl.rcdefaults()
plt.style.use("./style1.mstyle")
plt.figure()
plt.plot([0, 1], [0, 1])
plt.gcf().savefig("mstyle1.png", dpi=dpi)

mpl.rcdefaults()
plt.style.use("./style2.mstyle")
plt.figure()
plt.plot([0, 1], [0, 1])
plt.gcf().savefig("mstyle2.png", dpi=dpi)

mpl.rcdefaults()
plt.style.use("./style3.mstyle")
plt.figure()
plt.plot([0, 1], [0, 1])
plt.gcf().savefig("mstyle3.png", dpi=dpi)
```

```text
# style1.mstyle
axes.grid: True
ytick.minor.visible: True
xtick.minor.visible: True
axes.grid.which: both
grid.color: red
grid.linewidth: 1
grid.linestyle: -
grid.alpha: 1
```

```text
# style2.mstyle
axes.grid: True
ytick.minor.visible: True
xtick.minor.visible: True
axes.grid.which: both
grid.color: red
grid.linewidth: 1
grid.linestyle: -
grid.alpha: 1

grid.major.color: black
grid.major.linewidth: 2
grid.major.linestyle: :
```

```text
# style3.mstyle
axes.grid: True
ytick.minor.visible: True
xtick.minor.visible: True
axes.grid.which: both
grid.color: red
grid.linewidth: 1
grid.linestyle: -
grid.alpha: 1

grid.minor.color: red
grid.minor.linewidth: 0.5
grid.minor.linestyle: :
grid.minor.alpha: 0.5
```

### Results
![mstyle1](https://github.com/user-attachments/assets/8522cd5b-0f1d-4c20-88be-057e0afa4a0d)
![mstyle2](https://github.com/user-attachments/assets/f82cb0f4-8186-48cb-b712-42010456d590)
![mstyle3](https://github.com/user-attachments/assets/07f05688-d8d9-4ecf-85ac-57e42ab40890)
![runtime1](https://github.com/user-attachments/assets/debb069f-08d4-44a8-9778-65c2738bdb76)
![runtime2](https://github.com/user-attachments/assets/a62844fc-e6de-4ddb-bbbf-d5134a41ff49)
![runtime3](https://github.com/user-attachments/assets/ba0bc294-150c-44bb-8331-4d3a69b9cb90)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #13919" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
