### PR TITLE
FIX: Make stem() baseline follow the curvature in polar plots

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3194,6 +3194,8 @@ class Axes(_AxesBase):
         baseline, = self.plot(baseline_x, baseline_y,
                               color=basecolor, linestyle=basestyle,
                               marker=basemarker, label="_nolegend_")
+        baseline.get_path()._interpolation_steps = \
+            mpl.axis.GRIDLINE_INTERPOLATION_STEPS
 
         stem_container = StemContainer((markerline, stemlines, baseline),
                                        label=label)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4617,6 +4617,17 @@ def test_stem_orientation():
             orientation='horizontal')
 
 
+def test_stem_polar_baseline():
+    """Test that the baseline is interpolated so that it will follow the radius."""
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='polar')
+    x = np.linspace(1.57, 3.14, 10)
+    y = np.linspace(0, 1, 10)
+    bottom = 0.5
+    container = ax.stem(x, y, bottom=bottom)
+    assert container.baseline.get_path()._interpolation_steps > 100
+
+
 @image_comparison(['hist_stacked_stepfilled_alpha'])
 def test_hist_stacked_stepfilled_alpha():
     # make some data


### PR DESCRIPTION
Closes #29484.

Note: There's precedence for a similar special-casing on polar Axes for errorbars: https://github.com/matplotlib/matplotlib/blob/3fb9c0961b5c8d5753c88ac37c08cda58a4b7839/lib/matplotlib/axes/_axes.py#L3798
