### PR TITLE
Test doc build time on CI without sphinx-gallery

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,7 +147,7 @@ commands:
               export RELEASE_TAG='-t release'
             fi
             mkdir -p logs
-            make html O="-T $RELEASE_TAG -j4 -w /tmp/sphinxerrorswarnings.log"
+            make html O="-T $RELEASE_TAG -j4 -w /tmp/sphinxerrorswarnings.log -D plot_gallery=0"
             rm -r build/html/_sources
           working_directory: doc
       - save_cache:


### PR DESCRIPTION
DO NOT MERGE. This is a test to see how much time we spent on running the gallery examples. See https://github.com/matplotlib/matplotlib/issues/22956#issuecomment-2603238292

