### PR TITLE
github: added explicit do not merge label to label check

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -16,7 +16,7 @@ jobs:
       has_tag: >-
          ${{contains(github.event.pull_request.labels.*.name, 'status: needs comment/discussion') ||
             contains(github.event.pull_request.labels.*.name, 'status: waiting for other PR')     ||
-            contains(github.event.pull_request.labels.*.name, 'status: do not merge') }}
+            contains(github.event.pull_request.labels.*.name, 'DO NOT MERGE') }}
     steps:
       - name: Check for label
         if: ${{'true' == env.has_tag}}
@@ -24,7 +24,7 @@ jobs:
           echo "This PR cannot be merged because it has one of the following labels: "
           echo "* status: needs comment/discussion"
           echo "* status: waiting for other PR"
-          echo "* status: do not merge"
+          echo "* DO NOT MERGE"
           exit 1
       - name: Allow merging
         if: ${{'false' == env.has_tag}}


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Since we already run a check that blocks merging on certain labels, added a specific "do not merge" for situations where it doesn't fit the other do not merge categories. 

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
