### PR TITLE
CI: remove xfail on OSX + tk due to issues in image

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -107,13 +107,7 @@ def _get_available_interactive_backends():
         elif env["MPLBACKEND"].startswith('wx') and sys.platform == 'darwin':
             # ignore on macosx because that's currently broken (github #16849)
             marks.append(pytest.mark.xfail(reason='github #16849'))
-        elif (env['MPLBACKEND'] == 'tkagg' and
-              ('TF_BUILD' in os.environ or 'GITHUB_ACTION' in os.environ) and
-              sys.platform == 'darwin' and
-              sys.version_info[:2] < (3, 11)
-              ):
-            marks.append(  # https://github.com/actions/setup-python/issues/649
-                pytest.mark.xfail(reason='Tk version mismatch on Azure macOS CI'))
+
         envs.append(({**env, 'BACKEND_DEPS': ','.join(deps)}, marks))
     return envs
 


### PR DESCRIPTION
Per https://github.com/actions/setup-python/issues/649#issuecomment-2606366298 the issue is fixed upstream and we can remove our xfail marker.