### PR TITLE
FIX: Correct variable name from _frame to _frames in PillowWriter class

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -496,7 +496,7 @@ class PillowWriter(AbstractMovieWriter):
             "RGBA", self.frame_size, buf.getbuffer(), "raw", "RGBA", 0, 1)
         if im.getextrema()[3][0] < 255:
             # This frame has transparency, so we'll just add it as is.
-            self._frame.append(im)
+            self._frames.append(im)
         else:
             # Without transparency, we switch to RGB mode, which converts to P mode a
             # little better if needed (specifically, this helps with GIF output.)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Correct the variable name from `_frame` to `_frames` in the PillowWriter class to ensure proper functionality.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #29519" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
