### PR TITLE
DOC: better separation of codespace instructions

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -34,6 +34,22 @@ repository, you should first fork this repository by *clicking* the
 This creates a copy of the code under your account on the GitHub server. See `the GitHub
 documentation <https://docs.github.com/get-started/quickstart/fork-a-repo>`__ for more details.
 
+Decide whether to work locally or in GitHub Codespaces
+======================================================
+
+You can either work locally on your machine, or online in
+`GitHub Codespaces <github-codespaces_>`_, a cloud-based in-browser development
+environment.  If you are making a one-off, relatively simple change then
+working in GitHub Codespaces can be a good option because most of the setting
+up is done for you and you can skip the next few sections!  If you are making
+extensive or frequent contributions to Matplotlib then it is probably worth
+taking the time to set up on your local machine: As well as having the
+convenience of your local familiar tools, you will not need to worry about
+Codespace's monthly usage limits.
+
+If you want to use Codespaces, skip to :ref:`development-codespaces`,
+otherwise, continue with the next section.
+
 Retrieve the latest version of the code
 =======================================
 
@@ -106,8 +122,8 @@ code, as described in :ref:`development-workflow`.
 
 .. _dev-environment:
 
-Create a dedicated environment
-==============================
+Create a dedicated python environment
+=====================================
 You should set up a dedicated environment to decouple your Matplotlib
 development from other Python and Matplotlib installations on your system.
 
@@ -158,49 +174,6 @@ setup.
 
       Remember to activate the environment whenever you start working on Matplotlib!
 
-   .. tab-item:: :octicon:`codespaces` GitHub Codespaces
-
-      `GitHub Codespaces <https://docs.github.com/codespaces>`_ is a cloud-based
-      in-browser development environment that comes with the appropriate setup to
-      contribute to Matplotlib.
-
-      #. Open codespaces on your fork by clicking on the green :octicon:`code` ``Code``
-         button on the GitHub web interface and selecting the ``Codespaces`` tab.
-
-      #. Next, click on "Open codespaces on <your branch name>". You will be
-         able to change branches later, so you can select the default
-         ``main`` branch.
-
-      #. After the codespace is created, you will be taken to a new browser
-         tab where you can use the terminal to activate a pre-defined conda
-         environment called ``mpl-dev``::
-
-         conda activate mpl-dev
-
-      Remember to activate the *mpl-dev* environment whenever you start working on
-      Matplotlib.
-
-      If you need to open a GUI window with Matplotlib output on Codespaces, our
-      configuration includes a `light-weight Fluxbox-based desktop
-      <https://github.com/devcontainers/features/tree/main/src/desktop-lite>`_.
-      You can use it by connecting to this desktop via your web browser. To do this:
-
-      #. Press ``F1`` or ``Ctrl/Cmd+Shift+P`` and select
-         ``Ports: Focus on Ports View`` in the VSCode session to bring it into
-         focus. Open the ports view in your tool, select the ``noVNC`` port, and
-         click the Globe icon.
-      #. In the browser that appears, click the Connect button and enter the desktop
-         password (``vscode`` by default).
-
-      Check the `GitHub instructions
-      <https://github.com/devcontainers/features/tree/main/src/desktop-lite#connecting-to-the-desktop>`_
-      for more details on connecting to the desktop.
-
-      If you also built the documentation pages, you can view them using Codespaces.
-      Use the "Extensions" icon in the activity bar to install the "Live Server"
-      extension. Locate the ``doc/build/html`` folder in the Explorer, right click
-      the file you want to open and select "Open with Live Server."
-
 
 Install external dependencies
 =============================
@@ -216,6 +189,54 @@ Additionally, the following non-Python dependencies must also be installed local
 
 For a full list of dependencies, see :ref:`dependencies`. External dependencies do not
 need to be installed when working in codespaces.
+
+.. _development-codespaces:
+
+:octicon:`codespaces` Create a GitHub Codespace
+===============================================
+
+`GitHub Codespaces <github-codespaces_>`_ is a cloud-based
+in-browser development environment that comes with the appropriate setup to
+contribute to Matplotlib.
+
+#. Open codespaces on your fork by clicking on the green :octicon:`code` ``Code``
+   button on the GitHub web interface and selecting the ``Codespaces`` tab.
+
+#. Next, click on "Open codespaces on <your branch name>". You will be
+   able to change branches later, so you can select the default
+   ``main`` branch.
+
+#. After the codespace is created, you will be taken to a new browser
+   tab where you can use the terminal to activate a pre-defined conda
+   environment called ``mpl-dev``::
+
+      conda activate mpl-dev
+
+Remember to activate the *mpl-dev* environment whenever you start working on
+Matplotlib.
+
+If you need to open a GUI window with Matplotlib output on Codespaces, our
+configuration includes a `light-weight Fluxbox-based desktop
+<https://github.com/devcontainers/features/tree/main/src/desktop-lite>`_.
+You can use it by connecting to this desktop via your web browser. To do this:
+
+#. Press ``F1`` or ``Ctrl/Cmd+Shift+P`` and select
+   ``Ports: Focus on Ports View`` in the VSCode session to bring it into
+   focus. Open the ports view in your tool, select the ``noVNC`` port, and
+   click the Globe icon.
+#. In the browser that appears, click the Connect button and enter the desktop
+   password (``vscode`` by default).
+
+Check the `GitHub instructions
+<https://github.com/devcontainers/features/tree/main/src/desktop-lite#connecting-to-the-desktop>`_
+for more details on connecting to the desktop.
+
+If you also built the documentation pages, you can view them using Codespaces.
+Use the "Extensions" icon in the activity bar to install the "Live Server"
+extension. Locate the ``doc/build/html`` folder in the Explorer, right click
+the file you want to open and select "Open with Live Server."
+
+.. _`github-codespaces`: https://docs.github.com/codespaces
 
 .. _development-install:
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Currently the codespace instructions are a third tab next to setting up your python environment with either `venv` or `conda`.  This feels a bit out of place to me because the instructions are about more than just getting your python environment: they also include how to get an interactive gui or view the docs under codespaces.  Additionally, when you spin up a codespaces instance, your clone is already there, upstream is already set and all the non-python dependencies are in place.  So we can skip sections that are currently before and after the "create a dedicated environment" section.  The instructions themselves are unchanged, just moved from the tab to a new section.  I also added some brief guidance on why you might or might not want to choose codespaces.

Closes #29524


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
