### PR TITLE
MNT: Deprecate other capitalization than "None" in matplotlibrc

### DIFF
--- a/doc/api/next_api_changes/deprecations/ 29529-TH.rst
+++ b/doc/api/next_api_changes/deprecations/ 29529-TH.rst
@@ -1,0 +1,7 @@
+Capitalization of None in matplotlibrc
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In :file:`matplotlibrc` config files every capitalization of None was
+accepted for denoting the Python constant `None`. This is deprecated. The
+only accepted capitalization is now None, i.e. starting with a capital letter
+and all other letters in lowercase.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -191,6 +191,14 @@ def _make_type_validator(cls, *, allow_none=False):
     def validator(s):
         if (allow_none and
                 (s is None or cbook._str_lower_equal(s, "none"))):
+            if cbook._str_lower_equal(s, "none") and s != "None":
+                _api.warn_deprecated(
+                    "3.11",
+                    message=f"Using the capitalization {s!r} in matplotlibrc for "
+                            "*None* is deprecated in %(removal)s and will lead to an "
+                            "error from version 3.13 onward. Please use 'None' "
+                            "instead."
+                )
             return None
         if cls is str and not isinstance(s, str):
             raise ValueError(f'Could not convert {s!r} to str')


### PR DESCRIPTION
The `*_or_None` validators have accepted any capitalization of the string "none" as input. This is overly permissive and will likely lead to conflicts in the future because we cannot distinguish between resolving to `None` and `"none"` which may be need for some parameters in the future.

Inspired by #29481.
