### PR TITLE
Fix typo in solarized example plot.

### DIFF
--- a/galleries/examples/style_sheets/plot_solarizedlight2.py
+++ b/galleries/examples/style_sheets/plot_solarizedlight2.py
@@ -32,7 +32,7 @@ with plt.style.context('Solarize_Light2'):
     plt.plot(x, np.sin(x) + x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 2 * x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 3 * x + np.random.randn(50))
-    plt.plot(x, np.sin(x) + 4 + np.random.randn(50))
+    plt.plot(x, np.sin(x) + 4 * x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 5 * x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 6 * x + np.random.randn(50))
     plt.plot(x, np.sin(x) + 7 * x + np.random.randn(50))


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Closes #29535. There was a mistake in the [solarized style sheet example](https://matplotlib.org/devdocs/gallery/style_sheets/plot_solarizedlight2.html). There was a `* x` missing in one example plot line so it looked odd. Now it looks nicer. Its a really minor change.

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #29535" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
