### PR TITLE
Fix: Ensure ScalarFormatter.set_useOffset properly distinguishes betw…

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -858,7 +858,7 @@ class TestScalarFormatter:
         tmp_form.set_useOffset(0.5)
         assert not tmp_form.get_useOffset()
         assert tmp_form.offset == 0.5
-    
+
     def test_set_use_offset_bool(self):
         tmp_form = mticker.ScalarFormatter()
         tmp_form.set_useOffset(True)
@@ -868,7 +868,7 @@ class TestScalarFormatter:
         tmp_form.set_useOffset(False)
         assert not tmp_form.get_useOffset()
         assert tmp_form.offset == 0
-    
+
     def test_set_use_offset_int(self):
         tmp_form = mticker.ScalarFormatter()
         tmp_form.set_useOffset(1)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -858,6 +858,22 @@ class TestScalarFormatter:
         tmp_form.set_useOffset(0.5)
         assert not tmp_form.get_useOffset()
         assert tmp_form.offset == 0.5
+    
+    def test_set_use_offset_bool(self):
+        tmp_form = mticker.ScalarFormatter()
+        tmp_form.set_useOffset(True)
+        assert tmp_form.get_useOffset()
+        assert tmp_form.offset == 0
+
+        tmp_form.set_useOffset(False)
+        assert not tmp_form.get_useOffset()
+        assert tmp_form.offset == 0
+    
+    def test_set_use_offset_int(self):
+        tmp_form = mticker.ScalarFormatter()
+        tmp_form.set_useOffset(1)
+        assert not tmp_form.get_useOffset()
+        assert tmp_form.offset == 1
 
     def test_use_locale(self):
         conv = locale.localeconv()

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -510,7 +510,7 @@ class ScalarFormatter(Formatter):
         will be formatted as ``0, 2, 4, 6, 8`` plus an offset ``+1e5``, which
         is written to the edge of the axis.
         """
-        if val in [True, False]:
+        if isinstance(val, bool):
             self.offset = 0
             self._useOffset = val
         else:


### PR DESCRIPTION
Fixes: #29532 
- Updated the ScalarFormatter.set_useOffset method to explicitly check for boolean types using isinstance(val, bool).
- This ensures that numeric values are treated as explicit offsets and not as enabling the automatic offset mode.