### PR TITLE
FIX: pyplot.matshow figure handling

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -997,8 +997,8 @@ default: None
         root_fig = num.get_figure(root=True)
         if root_fig.canvas.manager is None:
             raise ValueError("The passed figure is not managed by pyplot")
-        elif any([figsize, dpi, facecolor, edgecolor, not frameon,
-                  kwargs]) and root_fig.canvas.manager.num in allnums:
+        elif (any(param is not None for param in [figsize, dpi, facecolor, edgecolor])
+              or not frameon or kwargs) and root_fig.canvas.manager.num in allnums:
             _api.warn_external(
                 "Ignoring specified arguments in this call because figure "
                 f"with num: {root_fig.canvas.manager.num} already exists")
@@ -1010,8 +1010,8 @@ default: None
     if num is None:
         num = next_num
     else:
-        if any([figsize, dpi, facecolor, edgecolor, not frameon,
-                kwargs]) and num in allnums:
+        if (any(param is not None for param in [figsize, dpi, facecolor, edgecolor])
+              or not frameon or kwargs) and num in allnums:
             _api.warn_external(
                 "Ignoring specified arguments in this call "
                 f"because figure with num: {num} already exists")
@@ -2663,9 +2663,13 @@ def matshow(A: ArrayLike, fignum: None | int = None, **kwargs) -> AxesImage:
     if fignum == 0:
         ax = gca()
     else:
-        # Extract actual aspect ratio of array and make appropriately sized
-        # figure.
-        fig = figure(fignum, figsize=figaspect(A))
+        if fignum is not None and fignum_exists(fignum):
+            # Do not try to set a figure size.
+            figsize = None
+        else:
+            # Extract actual aspect ratio of array and make appropriately sized figure.
+            figsize = figaspect(A)
+        fig = figure(fignum, figsize=figsize)
         ax = fig.add_axes((0.15, 0.09, 0.775, 0.775))
     im = ax.matshow(A, **kwargs)
     sci(im)

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -460,13 +460,13 @@ def test_figure_hook():
 
 
 def test_multiple_same_figure_calls():
-    fig = mpl.pyplot.figure(1, figsize=(1, 2))
+    fig = plt.figure(1, figsize=(1, 2))
     with pytest.warns(UserWarning, match="Ignoring specified arguments in this call"):
-        fig2 = mpl.pyplot.figure(1, figsize=(3, 4))
+        fig2 = plt.figure(1, figsize=np.array([3, 4]))
     with pytest.warns(UserWarning, match="Ignoring specified arguments in this call"):
-        mpl.pyplot.figure(fig, figsize=(5, 6))
+        plt.figure(fig, figsize=np.array([5, 6]))
     assert fig is fig2
-    fig3 = mpl.pyplot.figure(1)  # Checks for false warnings
+    fig3 = plt.figure(1)  # Checks for false warnings
     assert fig is fig3
 
 
@@ -476,3 +476,11 @@ def test_close_all_warning():
     # Check that the warning is issued when 'all' is passed to plt.figure
     with pytest.warns(UserWarning, match="closes all existing figures"):
         fig2 = plt.figure("all")
+
+
+def test_matshow():
+    fig = plt.figure()
+    arr = [[0, 1], [1, 2]]
+
+    # Smoke test that matshow does not ask for a new figsize on the existing figure
+    plt.matshow(arr, fignum=fig.number)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Fixes the bug parts of #29540 

* The warning check in `plt.figure` now copes if _figsize_ is passed as an array
* `matshow` no longer passes _figsize_ if the figure already exists

The doc/typing aspects of #29540 are handled in #29545

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
