### PR TITLE
ci: Re-add tests with optimization enabled

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -78,6 +78,7 @@ jobs:
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
             extra-requirements: '-r requirements/testing/extra.txt'
+            python-optimize: 'true'
           - os: ubuntu-22.04-arm
             python-version: '3.12'
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
@@ -363,6 +364,9 @@ jobs:
         run: |
           if [[ "${{ matrix.python-version }}" == '3.13t' ]]; then
             export PYTHON_GIL=0
+          fi
+          if [[ "${{ matrix.python-optimize }}" == 'true' ]]; then
+            export PYTHONOPTIMIZE=2
           fi
           pytest -rfEsXR -n auto \
             --maxfail=50 --timeout=300 --durations=25 \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
               "ipython==7.29.0"
               "ipykernel==5.5.6"
               "matplotlib-inline<0.1.7"
-            CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
+            lto: "--config-settings=setup-args=-Db_lto=false"  # Ensure that disabling LTO works.
             # https://github.com/matplotlib/matplotlib/pull/26052#issuecomment-1574595954
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
             pyqt6-ver: '!=6.5.1,!=6.6.0,!=6.7.1'
@@ -348,7 +348,7 @@ jobs:
           fi
 
           python -m pip install --no-deps --no-build-isolation --verbose \
-            --config-settings=setup-args="-DrcParams-backend=Agg" \
+            --config-settings=setup-args="-DrcParams-backend=Agg" ${{ matrix.lto }} \
             --editable .[dev]
 
           if [[ "${{ runner.os }}" != 'macOS' ]]; then

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -1,5 +1,6 @@
 import io
 from itertools import chain
+import sys
 
 import numpy as np
 
@@ -256,7 +257,9 @@ def test_setp():
     # Check *file* argument
     sio = io.StringIO()
     plt.setp(lines1, 'zorder', file=sio)
-    assert sio.getvalue() == '  zorder: float\n'
+    # With optimization, docstrings are stripped so the automated types don't work.
+    expected = 'unknown' if sys.flags.optimize >= 2 else 'float'
+    assert sio.getvalue() == f'  zorder: {expected}\n'
 
 
 def test_None_zorder():
@@ -361,6 +364,8 @@ def test_set_signature():
     assert 'myparam2' in MyArtist2.set.__doc__
 
 
+@pytest.mark.skipif(sys.flags.optimize >= 2,
+                    reason='Python optimization is enabled and docstrings are stripped')
 def test_set_is_overwritten():
     """set() defined in Artist subclasses should not be overwritten."""
     class MyArtist3(martist.Artist):

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -44,6 +44,8 @@ def test_importable_with_no_home(tmp_path):
         env={**os.environ, "MPLCONFIGDIR": str(tmp_path)}, check=True)
 
 
+@pytest.mark.skipif(sys.flags.optimize >= 2,
+                    reason='Python optimization is enabled and docstrings are stripped')
 def test_use_doc_standard_backends():
     """
     Test that the standard backends mentioned in the docstring of


### PR DESCRIPTION
## PR summary

Note that a few tests require skips, as they check for docstrings.

This PR also fixes testing with LTO disabled (it previously just set a variable in the matrix and did nothing with it.)

Fixes #10312

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines