### PR TITLE
Bug Fix: Normalize kwargs for Histogram

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6997,6 +6997,8 @@ such objects
         (``plt.stairs(*np.histogram(data))``), or by setting *histtype* to
         'step' or 'stepfilled' rather than 'bar' or 'barstacked'.
         """
+        kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
+
         # Avoid shadowing the builtin.
         bin_range = range
         from builtins import range

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6997,11 +6997,11 @@ such objects
         (``plt.stairs(*np.histogram(data))``), or by setting *histtype* to
         'step' or 'stepfilled' rather than 'bar' or 'barstacked'.
         """
-        kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
-
         # Avoid shadowing the builtin.
         bin_range = range
         from builtins import range
+
+        kwargs = cbook.normalize_kwargs(kwargs, mpatches.Patch)
 
         if np.isscalar(x):
             x = [x]


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->

Closes #28884 by normalizing kwargs for hist. The behavior of shortened options, such as ls and ec, now behave as expected. 

```python
pyplot.hist([1,2,3,4,5],bins=5,histtype='step',ls=':')
pyplot.savefig('test.pdf')
```

now produces [test.pdf](https://github.com/user-attachments/files/18615675/test.pdf)

First brought to my attention by @ecrohr

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
