### PR TITLE
Spacing for description of linecolor

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8555,8 +8555,8 @@ such objects
             .. versionadded:: 3.11
 
         linecolor : :mpltype:`color` or list of :mpltype:`color`, optional
-          If provided, will set the line color(s) of the violins (the
-          horizontal and vertical spines and body edges).
+            If provided, will set the line color(s) of the violins (the
+            horizontal and vertical spines and body edges).
 
             .. versionadded:: 3.11
 
@@ -8697,8 +8697,8 @@ such objects
             .. versionadded:: 3.11
 
         linecolor : :mpltype:`color` or list of :mpltype:`color`, optional
-          If provided, will set the line color(s) of the violins (the
-          horizontal and vertical spines and body edges).
+            If provided, will set the line color(s) of the violins (the
+            horizontal and vertical spines and body edges).
 
             .. versionadded:: 3.11
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Just adding the right number of spaces in the docstring of ``violinplot`` and ``violin``. This is in reference to my previous PR #27304. 

## PR checklist
- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

The documentation looks like this: 
![image](https://github.com/user-attachments/assets/e8d30668-faf3-48ea-bf80-b4df4bf26d24)
