### PR TITLE
Improve documentation for color_sequences with ( example )

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -175,3 +175,80 @@ About us
             :maxdepth: 2
 
             project/index.rst
+
+.. _color-sequences:
+
+Color Sequences in Matplotlib
+=============================
+
+Matplotlib provides a powerful system for defining custom color sequences,
+ or color cycles, which are essential for creating consistent, visually appealing plots. 
+ By customizing color sequences, users can control the color schemes used in their plots to improve accessibility and
+  make their visualizations clearer.
+
+What Are Color Sequences?
+--------------------------
+
+In Matplotlib, color sequences are essentially ordered lists of colors 
+that can be used across multiple plots. They allow for consistency in the colors used
+ for different lines, markers, and other visual elements in your plots. Color sequences can be customized and applied through the `cycler` module or in style sheets.
+
+Defining a Custom Color Cycle
+------------------------------
+
+To define a custom color cycle, we use the `cycler` module 
+from Matplotlib. Here's how to define and apply your own color sequence:
+
+.. code-block:: python
+
+    import matplotlib.pyplot as plt
+    from cycler import cycler
+
+    # Define a custom color cycle
+    custom_cycle = cycler(color=["#E63946", "#F4A261", "#2A9D8F", "#264653"])
+
+    # Apply the custom color cycle
+    plt.rc("axes", prop_cycle=custom_cycle)
+
+    # Create a simple plot to visualize the color sequence
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], [4, 5, 6], label="Line 1")
+    ax.plot([1, 2, 3], [6, 7, 8], label="Line 2")
+    ax.legend()
+    plt.show()
+
+Using Color Sequences in Style Sheets
+--------------------------------------
+
+You can also apply custom color sequences by defining them in a
+ Matplotlib style sheet (`.mplstyle` file). This is especially useful if you want to 
+ keep your color settings consistent across different projects.
+
+Here's how you can define a custom color cycle in a style sheet:
+
+.. code-block:: plaintext
+
+    axes.prop_cycle: cycler(color=["#E63946", "#F4A261", "#2A9D8F", "#264653"])
+
+Benefits of Using Custom Color Sequences
+-----------------------------------------
+
+Custom color sequences are beneficial for several reasons:
+
+- **Consistency**: They ensure that your plots have a uniform color 
+scheme across multiple figures.
+- **Accessibility**: By using colorblind-friendly colors, you can make your
+ visualizations more accessible to a wider audience.
+- **Aesthetics**: Custom color sequences allow you to create more visually appealing
+ plots that match your preferred style or brand.
+
+Conclusion
+----------
+
+Color sequences are a powerful tool in Matplotlib for customizing the appearance of your plots.
+ By defining your own color cycles and using them consistently, you can create more accessible and 
+ aesthetically pleasing visualizations.
+  Experiment with your own color sequences and see how they improve your plots.
+
+For more information on colormaps and color customization, 
+check out the [colormap tutorial](https://matplotlib.org/stable/tutorials/colors/colormap.html).


### PR DESCRIPTION
here this (PR) improves the documentation for color_sequences by
adding clear examples demonstrating how to define color cycles both manually and also for using the color_sequences registry
main point is - benefits of using color_sequences over manual definitions, such as reusability, consistency, and easier customization and clarifying the differences between color_sequences and manually defined color cycles to help to understand their distinct purposes.
I think first I have add this all information in wrong file may be this time its correct
and the current documentation lacked detailed examples and clear explanations regarding the color_sequences registry. this PR aims to address those gaps, making it easier to use

important Changes is:
added new content under the User Guide section related to color management.
Included two code examples: 1. manual color cycle Example and second one 
2. using color_sequences registry Example=

# Example 1: manually defining a color cycle
import matplotlib.pyplot as plt
from cycler import cycler
plt.rc('axes', prop_cycle=cycler('color', ['#FF5733', '#33FF57', '#3357FF']))
plt.plot([1, 2, 3], [4, 5, 6])
plt.plot([1, 2, 3], [6, 5, 4])
plt.show()
 
# Example 2: Using color_sequences registry
from matplotlib import rcParams
rcParams['axes.prop_cycle'] = plt.cm.get_cmap('tab10').colors
plt.plot([1, 2, 3], [4, 5, 6])
plt.plot([1, 2, 3], [6, 5, 4])
plt.show()

improvements for documentation are -
clarity: user can now easily understand the differences between manual and registry-based methods and second is practical Value: the added examples allow  to  user apply these concepts immediately and color management.

and by the way thank you for the previous review I incorporated the feedbacks by
adding comprehensive examples and explaining the core concepts more clearly and also I came to know that ensuring the documentation fits logically within the User Guide:)





