### PR TITLE
DOC: add color sequences reference example

### DIFF
--- a/galleries/examples/color/color_sequences.py
+++ b/galleries/examples/color/color_sequences.py
@@ -1,0 +1,65 @@
+"""
+=====================
+Named color sequences
+=====================
+
+Matplotlib's `~matplotlib.colors.ColorSequenceRegistry` allows access to
+predefined lists of colors by name e.g.
+``colors = matplotlib.color_sequences['Set1']``.  This example shows all of the
+built in color sequences.
+
+User-defined sequences can be added via `.ColorSequenceRegistry.register`.
+"""
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import matplotlib as mpl
+
+
+def plot_color_sequences(names, ax):
+    # Display each named color sequence horizontally on the supplied axes.
+
+    for n, name in enumerate(names):
+        colors = mpl.color_sequences[name]
+        n_colors = len(colors)
+        x = np.arange(n_colors)
+        y = np.full_like(x, n)
+
+        ax.scatter(x, y, facecolor=colors, edgecolor='dimgray', s=200, zorder=2)
+
+    ax.set_yticks(range(len(names)), labels=names)
+    ax.grid(visible=True, axis='y')
+    ax.yaxis.set_inverted(True)
+    ax.xaxis.set_visible(False)
+    ax.spines[:].set_visible(False)
+    ax.tick_params(left=False)
+
+
+built_in_color_sequences = [
+    'tab10', 'tab20', 'tab20b', 'tab20c', 'Pastel1', 'Pastel2', 'Paired',
+    'Accent', 'Dark2', 'Set1', 'Set2', 'Set3', 'petroff10']
+
+
+fig, ax = plt.subplots(figsize=(6.4, 9.6), layout='constrained')
+
+plot_color_sequences(built_in_color_sequences, ax)
+ax.set_title('Built In Color Sequences')
+
+plt.show()
+
+
+# %%
+#
+# .. admonition:: References
+#
+#    The use of the following functions, methods, classes and modules is shown
+#    in this example:
+#
+#    - `matplotlib.colors.ColorSequenceRegistry`
+#    - `matplotlib.axes.Axes.scatter`
+#
+# .. tags::
+#
+#    styling: color
+#    purpose: reference

--- a/galleries/examples/color/individual_colors_from_cmap.py
+++ b/galleries/examples/color/individual_colors_from_cmap.py
@@ -38,7 +38,9 @@ plt.show()
 # Extracting colors from a discrete colormap
 # ------------------------------------------
 # The list of all colors in a `.ListedColormap` is available as the ``colors``
-# attribute.
+# attribute.  Note that all the colors from Matplotlib's qualitative color maps
+# are also available as color sequences, so may be accessed more directly from
+# the color sequence registry.  See :doc:`/gallery/color/color_sequences`.
 
 colors = mpl.colormaps['Dark2'].colors
 

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -108,6 +108,7 @@ class ColorSequenceRegistry(Mapping):
         import matplotlib as mpl
         colors = mpl.color_sequences['tab10']
 
+    For a list of built in color sequences, see :doc:`/gallery/color/color_sequences`.
     The returned lists are copies, so that their modification does not change
     the global definition of the color sequence.
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Introducing the Matplotlib Abacus!

![image](https://github.com/user-attachments/assets/f81ac21a-d22e-4b3b-b3a2-409d1d0f0f6f)

I did not know that the color sequence registry was a thing.  Once I did know, the next thing I wanted to know was what sequences are available.  This PR adds an example showing all the built in sequences, analogous to the [Colormaps reference](https://matplotlib.org/stable/gallery/color/colormap_reference.html#sphx-glr-gallery-color-colormap-reference-py) and [List of Named Colors](https://matplotlib.org/stable/gallery/color/named_colors.html#sphx-glr-gallery-color-named-colors-py).

I am in two minds whether to add a second plot with a newly registered color sequence or to leave this as a purely reference example of what is available by default.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
