### PR TITLE
Remove rcParams deprecation machinery

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -638,18 +638,6 @@ def matplotlib_fname():
                        "install is broken")
 
 
-# rcParams deprecated and automatically mapped to another key.
-# Values are tuples of (version, new_name, f_old2new, f_new2old).
-_deprecated_map = {}
-# rcParams deprecated; some can manually be mapped to another key.
-# Values are tuples of (version, new_name_or_None).
-_deprecated_ignore_map = {}
-# rcParams deprecated; can use None to suppress warnings; remain actually
-# listed in the rcParams.
-# Values are tuples of (version,)
-_deprecated_remain_as_none = {}
-
-
 @_docstring.Substitution(
     "\n".join(map("- {}".format, sorted(rcsetup._validators, key=str.lower)))
 )
@@ -747,21 +735,7 @@ class RcParams(MutableMapping, dict):
 
     def __setitem__(self, key, val):
         try:
-            if key in _deprecated_map:
-                version, alt_key, alt_val, inverse_alt = _deprecated_map[key]
-                _api.warn_deprecated(
-                    version, name=key, obj_type="rcparam", alternative=alt_key)
-                key = alt_key
-                val = alt_val(val)
-            elif key in _deprecated_remain_as_none and val is not None:
-                version, = _deprecated_remain_as_none[key]
-                _api.warn_deprecated(version, name=key, obj_type="rcparam")
-            elif key in _deprecated_ignore_map:
-                version, alt_key = _deprecated_ignore_map[key]
-                _api.warn_deprecated(
-                    version, name=key, obj_type="rcparam", alternative=alt_key)
-                return
-            elif key == 'backend':
+            if key == 'backend':
                 if val is rcsetup._auto_backend_sentinel:
                     if 'backend' in self:
                         return
@@ -776,21 +750,9 @@ class RcParams(MutableMapping, dict):
                 f"a list of valid parameters)") from err
 
     def __getitem__(self, key):
-        if key in _deprecated_map:
-            version, alt_key, alt_val, inverse_alt = _deprecated_map[key]
-            _api.warn_deprecated(
-                version, name=key, obj_type="rcparam", alternative=alt_key)
-            return inverse_alt(self._get(alt_key))
-
-        elif key in _deprecated_ignore_map:
-            version, alt_key = _deprecated_ignore_map[key]
-            _api.warn_deprecated(
-                version, name=key, obj_type="rcparam", alternative=alt_key)
-            return self._get(alt_key) if alt_key else None
-
         # In theory, this should only ever be used after the global rcParams
         # has been set up, but better be safe e.g. in presence of breakpoints.
-        elif key == "backend" and self is globals().get("rcParams"):
+        if key == "backend" and self is globals().get("rcParams"):
             val = self._get(key)
             if val is rcsetup._auto_backend_sentinel:
                 from matplotlib import pyplot as plt
@@ -817,6 +779,8 @@ class RcParams(MutableMapping, dict):
 
     def __iter__(self):
         """Yield sorted list of keys."""
+        # Deprecation warnings are silenced to cover the case where some
+        # rcParams entries are being deprecated.
         with _api.suppress_matplotlib_deprecation_warning():
             yield from sorted(dict.__iter__(self))
 
@@ -938,11 +902,6 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
                 except Exception as msg:
                     _log.warning('Bad value in file %r, line %d (%r): %s',
                                  fname, line_no, line.rstrip('\n'), msg)
-        elif key in _deprecated_ignore_map:
-            version, alt_key = _deprecated_ignore_map[key]
-            _api.warn_deprecated(
-                version, name=key, alternative=alt_key, obj_type='rcparam',
-                addendum="Please update your matplotlibrc.")
         else:
             # __version__ must be looked up as an attribute to trigger the
             # module-level __getattr__.

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -564,40 +564,6 @@ def test_backend_fallback_headful(tmp_path):
 
 
 def test_deprecation(monkeypatch):
-    monkeypatch.setitem(
-        mpl._deprecated_map, "patch.linewidth",
-        ("0.0", "axes.linewidth", lambda old: 2 * old, lambda new: new / 2))
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        assert mpl.rcParams["patch.linewidth"] \
-            == mpl.rcParams["axes.linewidth"] / 2
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        mpl.rcParams["patch.linewidth"] = 1
-    assert mpl.rcParams["axes.linewidth"] == 2
-
-    monkeypatch.setitem(
-        mpl._deprecated_ignore_map, "patch.edgecolor",
-        ("0.0", "axes.edgecolor"))
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        assert mpl.rcParams["patch.edgecolor"] \
-            == mpl.rcParams["axes.edgecolor"]
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        mpl.rcParams["patch.edgecolor"] = "#abcd"
-    assert mpl.rcParams["axes.edgecolor"] != "#abcd"
-
-    monkeypatch.setitem(
-        mpl._deprecated_ignore_map, "patch.force_edgecolor",
-        ("0.0", None))
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        assert mpl.rcParams["patch.force_edgecolor"] is None
-
-    monkeypatch.setitem(
-        mpl._deprecated_remain_as_none, "svg.hashsalt",
-        ("0.0",))
-    with pytest.warns(mpl.MatplotlibDeprecationWarning):
-        mpl.rcParams["svg.hashsalt"] = "foobar"
-    assert mpl.rcParams["svg.hashsalt"] == "foobar"  # Doesn't warn.
-    mpl.rcParams["svg.hashsalt"] = None  # Doesn't warn.
-
     mpl.rcParams.update(mpl.rcParams.copy())  # Doesn't warn.
     # Note that the warning suppression actually arises from the
     # iteration over the updater rcParams being protected by


### PR DESCRIPTION
Closes #29562 (plus a second commit which flattens a bit the logic in `__setitem__`, in particular to avoid nested try... excepts).