### PR TITLE
Update antialiased default to auto and fix documentation errors

### DIFF
--- a/galleries/examples/images_contours_and_fields/image_antialiasing.py
+++ b/galleries/examples/images_contours_and_fields/image_antialiasing.py
@@ -63,10 +63,10 @@ axs[1].set_title('(4, 4) Up-sampled', fontsize='medium')
 #
 # ``interpolation_stage='data'``: Data -> Interpolate/Resample -> Normalize -> RGBA
 #
-# For both keyword arguments, Matplotlib has a default "auto", that is
-# recommended for most situations, and is described below.  Note that this
-# default behaves differently if the image is being down- or up-sampled, as
-# described below.
+# For both keyword arguments, Matplotlib uses a default value of "auto" as
+# specified by the rcParam, which is recommended for most situations.
+# This default behavior is explained below. Note that the behavior may differ if the
+# image is being down- or up-sampled, as outlined below.
 #
 # Down-sampling and modest up-sampling
 # ====================================

--- a/galleries/examples/images_contours_and_fields/image_antialiasing.py
+++ b/galleries/examples/images_contours_and_fields/image_antialiasing.py
@@ -63,7 +63,7 @@ axs[1].set_title('(4, 4) Up-sampled', fontsize='medium')
 #
 # ``interpolation_stage='data'``: Data -> Interpolate/Resample -> Normalize -> RGBA
 #
-# For both keyword arguments, Matplotlib has a default "antialiased", that is
+# For both keyword arguments, Matplotlib has a default "auto", that is
 # recommended for most situations, and is described below.  Note that this
 # default behaves differently if the image is being down- or up-sampled, as
 # described below.
@@ -166,16 +166,19 @@ for ax, interp in zip(axs, ['hanning', 'lanczos']):
 # %%
 # A final example shows the desirability of performing the anti-aliasing at the
 # RGBA stage when using non-trivial interpolation kernels.  In the following,
-# the data in the upper 100 rows is exactly 0.0, and data in the inner circle
+# the data in the outer circle is exactly 0.0, and data in the inner circle
 # is exactly 2.0. If we perform the *interpolation_stage* in 'data' space and
 # use an anti-aliasing filter (first panel), then floating point imprecision
 # makes some of the data values just a bit less than zero or a bit more than
 # 2.0, and they get assigned the under- or over- colors. This can be avoided if
-# you do not use an anti-aliasing filter (*interpolation* set set to
+# you do not use an anti-aliasing filter (*interpolation* set to
 # 'nearest'), however, that makes the part of the data susceptible to Moiré
 # patterns much worse (second panel).  Therefore, we recommend the default
 # *interpolation* of 'hanning'/'auto', and *interpolation_stage* of
 # 'rgba'/'auto' for most down-sampling situations (last panel).
+# In this example, the data values are clipped at the edges of the color range.
+# The interpolation uses the 'nearest' method, and as a result, no
+# floating-point imprecision is visible in the first panel.
 
 a = alarge + 1
 cmap = plt.get_cmap('RdBu_r')


### PR DESCRIPTION
<!--
Thank you so much for your PR! To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This PR updates the comments in the `image_antialiasing.py` example to clarify the behavior of interpolation and anti-aliasing. Specifically, it mentions that data values are clipped at the edges of the color range and no floating-point imprecision is visible.

Minor formatting fixes are also included.

## PR checklist
- [x] "closes #29541" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
