### PR TITLE
Use functools.cache instead of lru_cache to establish singletons.

### DIFF
--- a/lib/matplotlib/_fontconfig_pattern.py
+++ b/lib/matplotlib/_fontconfig_pattern.py
@@ -9,7 +9,7 @@ A module for parsing and generating `fontconfig patterns`_.
 # there would have created cyclical dependency problems, because it also needs
 # to be available from `matplotlib.rcsetup` (for parsing matplotlibrc files).
 
-from functools import lru_cache, partial
+from functools import cache, lru_cache, partial
 import re
 
 from pyparsing import (
@@ -52,7 +52,7 @@ _CONSTANTS = {
 }
 
 
-@lru_cache  # The parser instance is a singleton.
+@cache  # The parser instance is a singleton.
 def _make_fontconfig_parser():
     def comma_separated(elem):
         return elem + ZeroOrMore(Suppress(",") + elem)

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -19,7 +19,7 @@ Interface::
 
 from collections import namedtuple
 import enum
-from functools import lru_cache, partial, wraps
+from functools import cache, lru_cache, partial, wraps
 import logging
 import os
 from pathlib import Path
@@ -1020,7 +1020,7 @@ def _parse_enc(path):
 
 
 class _LuatexKpsewhich:
-    @lru_cache  # A singleton.
+    @cache  # A singleton.
     def __new__(cls):
         self = object.__new__(cls)
         self._proc = self._new_proc()

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 from base64 import b64encode
 import copy
 import dataclasses
-from functools import lru_cache
+from functools import cache, lru_cache
 import functools
 from io import BytesIO
 import json
@@ -247,7 +247,7 @@ def _get_win32_installed_fonts():
     return items
 
 
-@lru_cache
+@cache
 def _get_fontconfig_fonts():
     """Cache and list the font paths known to ``fc-list``."""
     try:
@@ -261,7 +261,7 @@ def _get_fontconfig_fonts():
     return [Path(os.fsdecode(fname)) for fname in out.split(b'\n')]
 
 
-@lru_cache
+@cache
 def _get_macos_fonts():
     """Cache and list the font paths known to ``system_profiler SPFontsDataType``."""
     try:


### PR DESCRIPTION
The intent is clearer (and cache is slightly more optimized).

Followup to #24980.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
