### PR TITLE
Blocked set_clim() callbacks to prevent inconsistent state (#29522)

### DIFF
--- a/lib/matplotlib/colorizer.py
+++ b/lib/matplotlib/colorizer.py
@@ -279,9 +279,9 @@ class Colorizer:
             if vmax is not None:
                 self.norm.vmax = colors._sanitize_extrema(vmax)
 
-        # self.changed() will now emit a update signal if the limits are changed
+        # emit a update signal if the limits are changed
         if orig_vmin_vmax != (self.norm.vmin, self.norm.vmax):
-            self.changed()
+            self.norm.callbacks.process('changed')
 
     def get_clim(self):
         """

--- a/lib/matplotlib/colorizer.py
+++ b/lib/matplotlib/colorizer.py
@@ -269,6 +269,8 @@ class Colorizer:
             except (TypeError, ValueError):
                 pass
 
+        orig_vmin_vmax = self.norm.vmin, self.norm.vmax
+
         # Blocked context manager prevents callbacks from being triggered
         # until both vmin and vmax are updated
         with self.norm.callbacks.blocked(signal='changed'):
@@ -277,8 +279,9 @@ class Colorizer:
             if vmax is not None:
                 self.norm.vmax = colors._sanitize_extrema(vmax)
 
-        # self.changed() will now emit a update signal after both the limits are set
-        self.changed()
+        # self.changed() will now emit a update signal if the limits are changed
+        if orig_vmin_vmax != (self.norm.vmin, self.norm.vmax):
+            self.changed()
 
     def get_clim(self):
         """

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -18,8 +18,6 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.ticker import FixedLocator, LogFormatter, StrMethodFormatter
 from matplotlib.testing.decorators import check_figures_equal
 
-import unittest.mock
-
 
 def _get_cmap_norms():
     """
@@ -660,26 +658,6 @@ def test_colorbar_scale_reset():
     pcm.norm = LogNorm()
     assert pcm.norm.vmin == z.min()
     assert pcm.norm.vmax == z.max()
-
-
-def test_set_clim_emits_single_callback():
-    data = np.array([[1, 2], [3, 4]])
-    fig, ax = plt.subplots()
-    image = ax.imshow(data, cmap='viridis')
-
-    callback = unittest.mock.Mock()
-    image.norm.callbacks.connect('changed', callback)
-
-    # Initial callback count should be zero
-    assert callback.call_count == 0
-
-    # Call set_clim() to update the limits
-    image.set_clim(1, 5)
-
-    # Assert that only one "changed" callback is sent after calling set_clim()
-    callback.assert_called_once()
-
-    plt.close(fig)
 
 
 def test_colorbar_get_ticks_2():

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -18,6 +18,8 @@ from matplotlib.colorbar import Colorbar
 from matplotlib.ticker import FixedLocator, LogFormatter, StrMethodFormatter
 from matplotlib.testing.decorators import check_figures_equal
 
+import unittest.mock
+
 
 def _get_cmap_norms():
     """
@@ -658,6 +660,26 @@ def test_colorbar_scale_reset():
     pcm.norm = LogNorm()
     assert pcm.norm.vmin == z.min()
     assert pcm.norm.vmax == z.max()
+
+
+def test_set_clim_emits_single_callback():
+    data = np.array([[1, 2], [3, 4]])
+    fig, ax = plt.subplots()
+    image = ax.imshow(data, cmap='viridis')
+
+    callback = unittest.mock.Mock()
+    image.norm.callbacks.connect('changed', callback)
+
+    # Initial callback count should be zero
+    assert callback.call_count == 0
+
+    # Call set_clim() to update the limits
+    image.set_clim(1, 5)
+
+    # Assert that only one "changed" callback is sent after calling set_clim()
+    callback.assert_called_once()
+
+    plt.close(fig)
 
 
 def test_colorbar_get_ticks_2():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1613,16 +1613,13 @@ def test_set_clim_emits_single_callback():
     callback = unittest.mock.Mock()
     image.norm.callbacks.connect('changed', callback)
 
-    # Initial callback count should be zero
-    assert callback.call_count == 0
+    callback.assert_not_called()
 
     # Call set_clim() to update the limits
     image.set_clim(1, 5)
 
     # Assert that only one "changed" callback is sent after calling set_clim()
     callback.assert_called_once()
-
-    plt.close(fig)
 
 
 def test_norm_callback():

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1605,6 +1605,26 @@ def test_norm_deepcopy():
     assert norm2.vmin == norm.vmin
 
 
+def test_set_clim_emits_single_callback():
+    data = np.array([[1, 2], [3, 4]])
+    fig, ax = plt.subplots()
+    image = ax.imshow(data, cmap='viridis')
+
+    callback = unittest.mock.Mock()
+    image.norm.callbacks.connect('changed', callback)
+
+    # Initial callback count should be zero
+    assert callback.call_count == 0
+
+    # Call set_clim() to update the limits
+    image.set_clim(1, 5)
+
+    # Assert that only one "changed" callback is sent after calling set_clim()
+    callback.assert_called_once()
+
+    plt.close(fig)
+
+
 def test_norm_callback():
     increment = unittest.mock.Mock(return_value=None)
 


### PR DESCRIPTION
closes #29522 

- Why is this change necessary? What problem does it solve? What is the reasoning for this implementation?
Previously when norm's limits were updated, self.changed() was called through the callbacks attached to the norm, these callbacks were fired immediately leading to inconsistent state and causing the bug. 
This change blocks the immediate callbacks and emits a update signal after both the limits have been set.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

