### PR TITLE
Fix typo in deprecation notes for 3.10.0

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.10.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.10.0/deprecations.rst
@@ -5,6 +5,7 @@ Many plotting functions will restrict positional arguments to the first few para
 in the future. All further configuration parameters will have to be passed as keyword
 arguments. This is to enforce better code and and allow for future changes with reduced
 risk of breaking existing code.
+
 Changing ``Figure.number``
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

This PR fixes a minor typo in the API release notes for 3.10.0.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
