### PR TITLE
key name change 'buttons'->'button'

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -292,7 +292,7 @@ class FigureCanvasWebAggCore(backend_agg.FigureCanvasAgg):
                 (MouseButton.MIDDLE, 4),
                 (MouseButton.BACK, 8),
                 (MouseButton.FORWARD, 16),
-            ] if event['buttons'] & mask  # State *after* press/release.
+            ] if event['button'] & mask  # State *after* press/release.
         }
         modifiers = event['modifiers']
         guiEvent = event.get('guiEvent')


### PR DESCRIPTION
KeyError raised by `ipympl` resolved by this change. Restores interactive functionality in notebooks

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
use of Ipympl in notebook raised KeyError. Changing `"buttons"`>>`"button"`  resolves the issue


## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue] --- HAVE NOT SEARCHED ISSUES (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
   (no change to source requiring new doc)

# Example of error:
![image](https://github.com/user-attachments/assets/f5857a0b-7a34-4aea-b842-25b2d8a1c7ba)

# Example after commit:
![image](https://github.com/user-attachments/assets/958975fa-1e00-4c96-b651-e6507db708ec)
