### PR TITLE
DOC: Duplicate catergorial values are mapped to the same position

### DIFF
--- a/galleries/examples/lines_bars_and_markers/categorical_variables.py
+++ b/galleries/examples/lines_bars_and_markers/categorical_variables.py
@@ -20,7 +20,10 @@ fig.suptitle('Categorical Plotting')
 
 
 # %%
-# This works on both Axes:
+# Categorical values are a mapping from names to positions. This means that
+# values that occur multiple times are mapped to the same position. See the
+# ``cat`` and ``dog`` values "happy" and "bored" on the y-axis in the following
+# example.
 
 cat = ["bored", "happy", "bored", "bored", "happy", "bored"]
 dog = ["happy", "happy", "happy", "happy", "bored", "bored"]


### PR DESCRIPTION
I repurposed the existing example. It's natural and expected that categoricals also work on the y-axis, so I removed the explicit mentioning of this. Instead, the example already shows nicely how duplicate values are handled.
