### PR TITLE
MNT: Reduce the use of get_xticklabels() in examples

### DIFF
--- a/galleries/examples/subplots_axes_and_figures/shared_axis_demo.py
+++ b/galleries/examples/subplots_axes_and_figures/shared_axis_demo.py
@@ -15,22 +15,10 @@ turn off the tick labels on one Axes.
 
 The example below shows how to customize the tick labels on the
 various axes.  Shared axes share the tick locator, tick formatter,
-view limits, and transformation (e.g., log, linear).  But the ticklabels
+view limits, and transformation (e.g., log, linear). But the tick labels
 themselves do not share properties.  This is a feature and not a bug,
 because you may want to make the tick labels smaller on the upper
 axes, e.g., in the example below.
-
-If you want to turn off the ticklabels for a given Axes (e.g., on
-subplot(211) or subplot(212)), you cannot do the standard trick::
-
-   setp(ax2, xticklabels=[])
-
-because this changes the tick Formatter, which is shared among all
-Axes.  But you can alter the visibility of the labels, which is a
-property::
-
-  setp(ax2.get_xticklabels(), visible=False)
-
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -42,6 +30,7 @@ s3 = np.sin(4 * np.pi * t)
 
 ax1 = plt.subplot(311)
 plt.plot(t, s1)
+# reduce the fontsize of the tick labels
 plt.tick_params('x', labelsize=6)
 
 # share x only

--- a/galleries/examples/text_labels_and_annotations/date.py
+++ b/galleries/examples/text_labels_and_annotations/date.py
@@ -58,7 +58,6 @@ ax.set_title('Manual DateFormatter', loc='left', y=0.85, x=0.02,
 # Text in the x-axis will be displayed in 'YYYY-mm' format.
 ax.xaxis.set_major_formatter(mdates.DateFormatter('%Y-%b'))
 # Rotates and right-aligns the x labels so they don't crowd each other.
-for label in ax.get_xticklabels(which='major'):
-    label.set(rotation=30, horizontalalignment='right')
+ax.xaxis.set_tick_params(rotation=30, rotation_mode='xtick')
 
 plt.show()

--- a/galleries/examples/ticks/centered_ticklabels.py
+++ b/galleries/examples/ticks/centered_ticklabels.py
@@ -3,16 +3,12 @@
 Center labels between ticks
 ===========================
 
-Ticklabels are aligned relative to their associated tick. The alignment
-'center', 'left', or 'right' can be controlled using the horizontal alignment
-property::
-
-    for label in ax.get_xticklabels():
-        label.set_horizontalalignment('right')
+Tick labels are aligned relative to their associated tick, and are by default
+centered.
 
 However, there is no direct way to center the labels between ticks. To fake
-this behavior, one can place a label on the minor ticks in between the major
-ticks, and hide the major tick labels and minor ticks.
+this behavior, one can a place a minor tick in between the major ticks. Then
+label the minor tick and hide the minor tick lines and the major tick labels.
 
 Here is an example that labels the months, centered between the ticks.
 """
@@ -34,15 +30,13 @@ ax.xaxis.set_major_locator(dates.MonthLocator())
 # 16 is a slight approximation since months differ in number of days.
 ax.xaxis.set_minor_locator(dates.MonthLocator(bymonthday=16))
 
+# The NullFormatter removes the major tick labels
 ax.xaxis.set_major_formatter(ticker.NullFormatter())
 ax.xaxis.set_minor_formatter(dates.DateFormatter('%b'))
 
-# Remove the tick lines
+# Remove the minor tick lines
 ax.tick_params(axis='x', which='minor', tick1On=False, tick2On=False)
 
-# Align the minor tick label
-for label in ax.get_xticklabels(minor=True):
-    label.set_horizontalalignment('center')
 imid = len(r) // 2
 ax.set_xlabel(str(r["date"][imid].item().year))
 plt.show()

--- a/galleries/examples/ticks/centered_ticklabels.py
+++ b/galleries/examples/ticks/centered_ticklabels.py
@@ -7,8 +7,8 @@ Tick labels are aligned relative to their associated tick, and are by default
 centered.
 
 However, there is no direct way to center the labels between ticks. To fake
-this behavior, one can a place a minor tick in between the major ticks. Then
-label the minor tick and hide the minor tick lines and the major tick labels.
+this behavior, one can place a minor tick in between the major ticks. Then
+label the minor tick, and hide the minor tick lines and the major tick labels.
 
 Here is an example that labels the months, centered between the ticks.
 """

--- a/galleries/examples/ticks/date_concise_formatter.py
+++ b/galleries/examples/ticks/date_concise_formatter.py
@@ -40,10 +40,7 @@ lims = [(np.datetime64('2005-02'), np.datetime64('2005-04')),
 for nn, ax in enumerate(axs):
     ax.plot(dates, y)
     ax.set_xlim(lims[nn])
-    # rotate_labels...
-    for label in ax.get_xticklabels():
-        label.set_rotation(40)
-        label.set_horizontalalignment('right')
+    ax.tick_params(axis='x', rotation=40, rotation_mode='xtick')
 axs[0].set_title('Default Date Formatter')
 plt.show()
 

--- a/galleries/examples/units/evans_test.py
+++ b/galleries/examples/units/evans_test.py
@@ -77,11 +77,11 @@ fig.subplots_adjust(bottom=0.2)
 # plot specifying units
 ax2.plot(x, y, 'o', xunits=2.0)
 ax2.set_title("xunits = 2.0")
-plt.setp(ax2.get_xticklabels(), rotation=30, ha='right')
+ax2.tick_params(axis='x', rotation=30, rotation_mode='xtick')
 
 # plot without specifying units; will use the None branch for axisinfo
 ax1.plot(x, y)  # uses default units
 ax1.set_title('default units')
-plt.setp(ax1.get_xticklabels(), rotation=30, ha='right')
+ax1.tick_params(axis='x', rotation=30, rotation_mode='xtick')
 
 plt.show()

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1390,8 +1390,7 @@ default: %(va)s
         Example with rotated xtick labels::
 
             fig, axs = plt.subplots(1, 2)
-            for tick in axs[0].get_xticklabels():
-                tick.set_rotation(55)
+            axs[0].tick_params(axis='x', rotation=55)
             axs[0].set_xlabel('XLabel 0')
             axs[1].set_xlabel('XLabel 1')
             fig.align_xlabels()


### PR DESCRIPTION
Working towards #29594. In particular, usage of `tick_params()` is superior in that it's an axis-wide setting that is applied to new/changed ticks. In contrast, manipulating volatile tick instances may result in inconsistency if the plot is further modified afterwards.

Note this needs the new text rotation mode "xtick" and is thus targeted at 3.11.