### PR TITLE
Correct doc for axvline arg x which sets x not y

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -818,7 +818,7 @@ class Axes(_AxesBase):
         Parameters
         ----------
         x : float, default: 0
-            y position in :ref:`data coordinates <coordinate-systems>`.
+            x position in :ref:`data coordinates <coordinate-systems>`.
 
         ymin : float, default: 0
             The start y-position in :ref:`axes coordinates <coordinate-systems>`.


### PR DESCRIPTION
As reported in the issue which this closes #29606 , the docstring for the argument x of `axvline` says that it sets y, but really it sets x.  Perhaps this was a copy'n'paste error from [`axhline`](https://matplotlib.org/devdocs/api/_as_gen/matplotlib.axes.Axes.axhline.html)?  Where the first argument is y which does set y.

This commit simply emends the doc from y to x to reflect the behaviour.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines