### PR TITLE
Remove md5 usage to prevent issues on FIPS enabled systems (closes #29603)

### DIFF
--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -146,7 +146,7 @@ def latex2html(node, source):
     fontset = node['fontset']
     fontsize = node['fontsize']
     name = 'math-{}'.format(
-        hashlib.md5(f'{latex}{fontset}{fontsize}'.encode()).hexdigest()[-10:])
+        hashlib.sha256(f'{latex}{fontset}{fontsize}'.encode()).hexdigest()[-10:])
 
     destdir = Path(setup.app.builder.outdir, '_images', 'mathmpl')
     destdir.mkdir(parents=True, exist_ok=True)

--- a/lib/matplotlib/sphinxext/mathmpl.py
+++ b/lib/matplotlib/sphinxext/mathmpl.py
@@ -146,7 +146,10 @@ def latex2html(node, source):
     fontset = node['fontset']
     fontsize = node['fontsize']
     name = 'math-{}'.format(
-        hashlib.sha256(f'{latex}{fontset}{fontsize}'.encode()).hexdigest()[-10:])
+        hashlib.sha256(
+            f'{latex}{fontset}{fontsize}'.encode(),
+            usedforsecurity=False,
+        ).hexdigest()[-10:])
 
     destdir = Path(setup.app.builder.outdir, '_images', 'mathmpl')
     destdir.mkdir(parents=True, exist_ok=True)

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -46,22 +46,20 @@ def get_cache_dir():
 
 
 def get_file_hash(path, block_size=2 ** 20):
-    md5 = hashlib.md5()
+    sha256 = hashlib.sha256()
     with open(path, 'rb') as fd:
         while True:
             data = fd.read(block_size)
             if not data:
                 break
-            md5.update(data)
+            sha256.update(data)
 
     if Path(path).suffix == '.pdf':
-        md5.update(str(mpl._get_executable_info("gs").version)
-                   .encode('utf-8'))
+        sha256.update(str(mpl._get_executable_info("gs").version).encode('utf-8'))
     elif Path(path).suffix == '.svg':
-        md5.update(str(mpl._get_executable_info("inkscape").version)
-                   .encode('utf-8'))
+        sha256.update(str(mpl._get_executable_info("inkscape").version).encode('utf-8'))
 
-    return md5.hexdigest()
+    return sha256.hexdigest()
 
 
 class _ConverterError(Exception):

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -46,7 +46,7 @@ def get_cache_dir():
 
 
 def get_file_hash(path, block_size=2 ** 20):
-    sha256 = hashlib.sha256()
+    sha256 = hashlib.sha256(usedforsecurity=False)
     with open(path, 'rb') as fd:
         while True:
             data = fd.read(block_size)

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -168,7 +168,7 @@ class TexManager:
         Return a filename based on a hash of the string, fontsize, and dpi.
         """
         src = cls._get_tex_source(tex, fontsize) + str(dpi)
-        filehash = hashlib.md5(src.encode('utf-8')).hexdigest()
+        filehash = hashlib.sha256(src.encode('utf-8')).hexdigest()
         filepath = Path(cls._texcache)
 
         num_letters, num_levels = 2, 2

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -168,7 +168,10 @@ class TexManager:
         Return a filename based on a hash of the string, fontsize, and dpi.
         """
         src = cls._get_tex_source(tex, fontsize) + str(dpi)
-        filehash = hashlib.sha256(src.encode('utf-8')).hexdigest()
+        filehash = hashlib.sha256(
+            src.encode('utf-8'),
+            usedforsecurity=False
+        ).hexdigest()
         filepath = Path(cls._texcache)
 
         num_letters, num_levels = 2, 2


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

If you use a FIPS (Federal Information Processing Standards) compliant Python install, then you cannot use `pyplot.show` to display a plot with  `plt.rcParams['text.usetex'] = True` due to a `hashlib.md5` call in [texmanager.py](https://github.com/matplotlib/matplotlib/blob/24bb51c834f7e6714e9ad8e24f7edb6c903028fe/lib/matplotlib/texmanager.py#L171).

Instead of just fixing the one instance I ran into, I changed the other usages of `hashlib.md5` in the codebase to nip those in the bud.

Per https://docs.python.org/3/library/hashlib.html#hash-algorithms, note that `sha256` is in `hashlib.algorithms_guaranteed` (while `md5` might not be), so it seems like a reasonable drop-in-place replacement.

> Constructors for hash algorithms that are always present in this module are [sha1()](https://docs.python.org/3/library/hashlib.html#hashlib.sha1), [sha224()](https://docs.python.org/3/library/hashlib.html#hashlib.sha224), [sha256()](https://docs.python.org/3/library/hashlib.html#hashlib.sha256), [sha384()](https://docs.python.org/3/library/hashlib.html#hashlib.sha384), [sha512()](https://docs.python.org/3/library/hashlib.html#hashlib.sha512), [sha3_224()](https://docs.python.org/3/library/hashlib.html#hashlib.sha3_224), [sha3_256()](https://docs.python.org/3/library/hashlib.html#hashlib.sha3_256), [sha3_384()](https://docs.python.org/3/library/hashlib.html#hashlib.sha3_384), [sha3_512()](https://docs.python.org/3/library/hashlib.html#hashlib.sha3_512), [shake_128()](https://docs.python.org/3/library/hashlib.html#hashlib.shake_128), [shake_256()](https://docs.python.org/3/library/hashlib.html#hashlib.shake_256), [blake2b()](https://docs.python.org/3/library/hashlib.html#hashlib.blake2b), and [blake2s()](https://docs.python.org/3/library/hashlib.html#hashlib.blake2s). [md5()](https://docs.python.org/3/library/hashlib.html#hashlib.md5) is normally available as well, though it may be missing or blocked if you are using a rare “FIPS compliant” build of Python. These correspond to [algorithms_guaranteed](https://docs.python.org/3/library/hashlib.html#hashlib.algorithms_guaranteed).

I think that these changes should be entirely transparent to end-users (unless they're on FIPS-enabled systems) and are merely implementation details, and thus do not require documentation changes. Correct me if this understanding is incorrect.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #29603" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/29603)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
  - Not sure if this applies quite as heavily, I'd consider all tests passing after to be sufficient.
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
