### PR TITLE
add detail to doc string in Line3DCollection

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -447,7 +447,7 @@ class Line3DCollection(LineCollection):
         """
         Parameters
         ----------
-        segments : list of (N, 3) array-like
+        lines : list of (N, 3) array-like
             A sequence ``[line0, line1, ...]`` where each line is a (N, 3)-shape
             array-like containing points:: line0 = [(x0, y0, z0), (x1, y1, z1), ...]
             Each line can contain a different number of points.

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -444,6 +444,38 @@ class Line3DCollection(LineCollection):
     def __init__(self, lines, axlim_clip=False, **kwargs):
         super().__init__(lines, **kwargs)
         self._axlim_clip = axlim_clip
+        """
+        Parameters
+        ----------
+        segments : list of (N, 3) array-like
+            A sequence ``[line0, line1, ...]`` where each line is a (N, 3)-shape
+            array-like containing points::
+
+                line0 = [(x0, y0, z0), (x1, y1, z1), ...]
+
+            Each line can contain a different number of points.
+        linewidths : float or list of float, default: :rc:`lines.linewidth`
+            The width of each line in points.
+        colors : :mpltype:`color` or list of color, default: :rc:`lines.color`
+            A sequence of RGBA tuples (e.g., arbitrary color strings, etc, not
+            allowed).
+        antialiaseds : bool or list of bool, default: :rc:`lines.antialiased`
+            Whether to use antialiasing for each line.
+        zorder : float, default: 2
+            zorder of the lines once drawn.
+
+        facecolors : :mpltype:`color` or list of :mpltype:`color`, default: 'none'
+            When setting *facecolors*, each line is interpreted as a boundary
+            for an area, implicitly closing the path from the last point to the
+            first point. The enclosed area is filled with *facecolor*.
+            In order to manually specify what should count as the "interior" of
+            each line, please use `.PathCollection` instead, where the
+            "interior" can be specified by appropriate usage of
+            `~.path.Path.CLOSEPOLY`.
+
+        **kwargs
+            Forwarded to `.Collection`.      
+        """
 
     def set_sort_zpos(self, val):
         """Set the position to use for z-sorting."""

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -449,10 +449,7 @@ class Line3DCollection(LineCollection):
         ----------
         segments : list of (N, 3) array-like
             A sequence ``[line0, line1, ...]`` where each line is a (N, 3)-shape
-            array-like containing points::
-
-                line0 = [(x0, y0, z0), (x1, y1, z1), ...]
-
+            array-like containing points:: line0 = [(x0, y0, z0), (x1, y1, z1), ...]
             Each line can contain a different number of points.
         linewidths : float or list of float, default: :rc:`lines.linewidth`
             The width of each line in points.
@@ -461,9 +458,6 @@ class Line3DCollection(LineCollection):
             allowed).
         antialiaseds : bool or list of bool, default: :rc:`lines.antialiased`
             Whether to use antialiasing for each line.
-        zorder : float, default: 2
-            zorder of the lines once drawn.
-
         facecolors : :mpltype:`color` or list of :mpltype:`color`, default: 'none'
             When setting *facecolors*, each line is interpreted as a boundary
             for an area, implicitly closing the path from the last point to the
@@ -472,9 +466,7 @@ class Line3DCollection(LineCollection):
             each line, please use `.PathCollection` instead, where the
             "interior" can be specified by appropriate usage of
             `~.path.Path.CLOSEPOLY`.
-
-        **kwargs
-            Forwarded to `.Collection`.      
+        **kwargs : Forwarded to `.Collection`.
         """
 
     def set_sort_zpos(self, val):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->
closes issue #26739

Updates `Line3DCollection` doc string to be similar to that of `LineCollection` doc string parameters.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ✅ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ✅ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->