### PR TITLE
FIX: Fix unit example so that we can unpin numpy>2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
     parameters:
       numpy_version:
         type: string
-        default: "~=2.0.0"
+        default: ""
     steps:
       - run:
           name: Install Python dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - kiwisolver>=1.3.1
   - pybind11>=2.13.2
   - meson-python>=0.13.1
-  - numpy<2.1
+  - numpy
   - pillow>=9
   - pkg-config
   - pygobject

--- a/galleries/examples/units/basic_units.py
+++ b/galleries/examples/units/basic_units.py
@@ -193,6 +193,11 @@ class TaggedValue(metaclass=TaggedValueMeta):
 
 
 class BasicUnit:
+    # numpy scalars convert eager and np.float64(2) * BasicUnit('cm')
+    # would thus return a numpy scalar. To avoid this, we increase the
+    # priority of the BasicUnit.
+    __array_priority__ = np.float64(0).__array_priority__ + 1
+
     def __init__(self, name, fullname=None):
         self.name = name
         if fullname is None:


### PR DESCRIPTION
Closes #28780.

The underlying problem is that operations on numpy scalars try to eagerly convert the other operand to an array. As a result `scalar = np .float64(2); scalar * radians` would result in a numpy scalar. But we don't want that.

Instead we enforce `radians.__rmul__(scalar)` by giving the unit a higher `__array_priority__`. See also https://github.com/numpy/numpy/issues/17650.

I haven't found any specific change notes on this in numpy 2.1. Interestingly, the full story is even more complex. Also for numpy<2.1 `radians.__rmul__(scalar)` is not called, but there seems another mechanism through `__array__` and `__array_warp__` catching back in so that the result is again a TaggedValue. But I have not fully investigated why it worked previously. In fact, we want the solution here with going through `__rmul__`, and that works for all numpy versions.
