### PR TITLE
Backport PR #29616 on branch v3.10.x (FIX: Fix unit example so that we can unpin numpy<2.1)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -98,7 +98,7 @@ commands:
     parameters:
       numpy_version:
         type: string
-        default: "~=2.0.0"
+        default: ""
     steps:
       - run:
           name: Install Python dependencies

--- a/environment.yml
+++ b/environment.yml
@@ -18,7 +18,7 @@ dependencies:
   - kiwisolver>=1.3.1
   - pybind11>=2.13.2
   - meson-python>=0.13.1
-  - numpy<2.1
+  - numpy
   - pillow>=8
   - pkg-config
   - pygobject

--- a/galleries/examples/units/basic_units.py
+++ b/galleries/examples/units/basic_units.py
@@ -193,6 +193,11 @@ class TaggedValue(metaclass=TaggedValueMeta):
 
 
 class BasicUnit:
+    # numpy scalars convert eager and np.float64(2) * BasicUnit('cm')
+    # would thus return a numpy scalar. To avoid this, we increase the
+    # priority of the BasicUnit.
+    __array_priority__ = np.float64(0).__array_priority__ + 1
+
     def __init__(self, name, fullname=None):
         self.name = name
         if fullname is None:


### PR DESCRIPTION
## PR summary

Backport of #29616 to `v3.10.x` branch