### PR TITLE
Add inline notebook to test data

### DIFF
--- a/lib/matplotlib/tests/meson.build
+++ b/lib/matplotlib/tests/meson.build
@@ -103,6 +103,7 @@ install_data(
   'cmr10.pfb',
   'mpltest.ttf',
   'test_nbagg_01.ipynb',
+  'test_inline_01.ipynb',
   install_tag: 'tests',
   install_dir: py3.get_install_dir(subdir: 'matplotlib/tests/'))
 


### PR DESCRIPTION
## PR summary


There is a new test notebook in 3.10.0 which was not added to the appropriate tag to install test data if so desired. Hence, the unit tests of an installed package (`pytest --pyargs matplotlib.tests`) currently fail. Adding the file to the meson tag fixes it (when `tests` is added to the meson install tags).

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
