### PR TITLE
Added figsize and layout getters and setters for Figure.__init__

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2644,6 +2644,18 @@ None}, default: None
         self._axstack = _AxesStack()  # track all figure Axes and current Axes
         self.clear()
 
+    def set_figsize(self, fig_size_params):
+        self.set_size_inches(fig_size_params[0], fig_size_params[1])
+
+    def get_figsize(self):
+        return self.get_size_inches()
+
+    def set_layout(self, layout_params):
+        self.set_layout_engine(layout_params)
+
+    def get_layout(self):
+        return self.get_layout_engine()
+
     def pick(self, mouseevent):
         if not self.canvas.widgetlock.locked():
             super().pick(mouseevent)


### PR DESCRIPTION
## PR summary
This fixes Add setter/getter methods for figsize and layout keyword parameters to Figure.__init__ https://github.com/matplotlib/matplotlib/issues/24617

It adds getters and setters for :
figsize
layout
Code is cherry picked from https://github.com/matplotlib/matplotlib/pull/21549

- I saw that the getter and setter methods for subplotpars were in another PR

<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes https://github.com/matplotlib/matplotlib/issues/24617 "
- [ ] This is my first PR so I am unsure how testing works; help is greatly appreciated

- As a newer dev, constructive criticism on my code, PR, or any other etiquette is also greatly appreciated 

