### PR TITLE
Feature: Added setter/getter methods for missing kwargs in Figure.__init__

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2648,6 +2648,19 @@ None}, default: None
         if not self.canvas.widgetlock.locked():
             super().pick(mouseevent)
 
+    def set_figsize(self, _figsize):
+        self.set_size_inches(_figsize, forward=True)
+
+    def get_figsize(self):
+        return self.get_size_inches
+    
+    def set_subplotpars(self, _subplotpars):
+        '''self.subplotpars = _subplotpars
+        self.subplots_adjust(self.subplotpars)'''
+
+    def get_subplotpars(self):
+        return self.subplotpars
+
     def _check_layout_engines_compat(self, old, new):
         """
         Helper for set_layout engine

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -17,6 +17,7 @@ from matplotlib.testing.decorators import image_comparison, check_figures_equal
 from matplotlib.axes import Axes
 from matplotlib.backend_bases import KeyEvent, MouseEvent
 from matplotlib.figure import Figure, FigureBase
+from matplotlib.figure import SubplotParams
 from matplotlib.layout_engine import (ConstrainedLayoutEngine,
                                       TightLayoutEngine,
                                       PlaceHolderLayoutEngine)
@@ -1819,3 +1820,11 @@ def test_subfigure_stale_propagation():
     sfig2.stale = True
     assert sfig1.stale
     assert fig.stale
+
+def test_figsize_getter_setter():
+    fig = plt.figure()
+    test_size_get = fig.get_figsize()
+    assert len(test_size_get) == 2
+
+    fig.set_figsize((5, 5))
+    assert fig.get_figsize() == (5, 5)


### PR DESCRIPTION
This seeks to solve the problem outlined in issue [#24617](https://github.com/slightnacl/matplotlib/issues/24617), where there where setter/getter methods available for fig.set() that were not available on Figure(). This change adds setters and getters for both thefigsize parameter and the subplotpars parameter.
Tests were also included in the testing directory under figure.py to verify the addition and functionality of the methods.