### PR TITLE
Added elif for taking NumPy Array for imsave

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -1586,9 +1586,11 @@ def imsave(fname, arr, vmin=None, vmax=None, cmap=None, format=None,
             # because that's what backend_agg passes, and can be in fact used
             # as is, saving a few operations.
             rgba = arr
+        elif arr.ndim == 3 and arr.shape[-1] in (3,4):
+                rgba = arr
         else:
             sm = mcolorizer.Colorizer(cmap=cmap)
-            sm.set_clim(vmin, vmax)
+            sm.set_clim(vim, vmax)
             rgba = sm.to_rgba(arr, bytes=True)
         if pil_kwargs is None:
             pil_kwargs = {}


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
The previous implementation did not distinguish between grayscale and RGB(A) images correctly;
- RGB(A) NumPy arrays were unnecessarily processed with a colormap, causing incorrect color interpretation.
- This ensures imsave works with both grayscale and RGB(A) inputs.
What this PR changes:
- added an elif statement in imsave to allow it to bypass the colormap transformation for 3D arrays
- addresses issue #29183 


-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ X ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
