### PR TITLE
Reorder kwonly kwargs in Colorbar & related docs.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -226,15 +226,26 @@ class Colorbar:
     mappable : `.ScalarMappable`
         The mappable whose colormap and norm will be used.
 
-        To show the under- and over- value colors, the mappable's norm should
-        be specified as ::
+        To show the colors versus index instead of on a 0-1 scale, set the
+        mappable's norm to ``colors.NoNorm()``.
 
-            norm = colors.Normalize(clip=False)
+    alpha : float
+        The colorbar transparency between 0 (transparent) and 1 (opaque).
 
-        To show the colors versus index instead of on a 0-1 scale, use::
+    location : None or {'left', 'right', 'top', 'bottom'}
+        Set the colorbar's *orientation* and *ticklocation*. Colorbars on
+        the left and right are vertical, colorbars at the top and bottom
+        are horizontal. The *ticklocation* is the same as *location*, so if
+        *location* is 'top', the ticks are on the top. *orientation* and/or
+        *ticklocation* can be provided as well and overrides the value set by
+        *location*, but there will be an error for incompatible combinations.
 
-            norm=colors.NoNorm()
+        .. versionadded:: 3.7
 
+    %(_colormap_kw_doc)s
+
+    Other Parameters
+    ----------------
     cmap : `~matplotlib.colors.Colormap`, default: :rc:`image.cmap`
         The colormap to use.  This parameter is ignored, unless *mappable* is
         None.
@@ -242,9 +253,6 @@ class Colorbar:
     norm : `~matplotlib.colors.Normalize`
         The normalization to use.  This parameter is ignored, unless *mappable*
         is None.
-
-    alpha : float
-        The colorbar transparency between 0 (transparent) and 1 (opaque).
 
     orientation : None or {'vertical', 'horizontal'}
         If None, use the value determined by *location*. If both
@@ -257,40 +265,27 @@ class Colorbar:
         *location*, so a colorbar to the left will have ticks to the left. If
         *location* is None, the ticks will be at the bottom for a horizontal
         colorbar and at the right for a vertical.
-
-    %(_colormap_kw_doc)s
-
-    location : None or {'left', 'right', 'top', 'bottom'}
-        Set the *orientation* and *ticklocation* of the colorbar using a
-        single argument. Colorbars on the left and right are vertical,
-        colorbars at the top and bottom are horizontal. The *ticklocation* is
-        the same as *location*, so if *location* is 'top', the ticks are on
-        the top. *orientation* and/or *ticklocation* can be provided as well
-        and overrides the value set by *location*, but there will be an error
-        for incompatible combinations.
-
-        .. versionadded:: 3.7
     """
 
     n_rasterize = 50  # rasterize solids if number of colors >= n_rasterize
 
-    def __init__(self, ax, mappable=None, *, cmap=None,
-                 norm=None,
-                 alpha=None,
-                 values=None,
-                 boundaries=None,
-                 orientation=None,
-                 ticklocation='auto',
-                 extend=None,
-                 spacing='uniform',  # uniform or proportional
-                 ticks=None,
-                 format=None,
-                 drawedges=False,
-                 extendfrac=None,
-                 extendrect=False,
-                 label='',
-                 location=None,
-                 ):
+    def __init__(
+        self, ax, mappable=None, *,
+        alpha=None,
+        location=None,
+        extend=None,
+        extendfrac=None,
+        extendrect=False,
+        ticks=None,
+        format=None,
+        values=None,
+        boundaries=None,
+        spacing='uniform',
+        drawedges=False,
+        label='',
+        cmap=None, norm=None,  # redundant with *mappable*
+        orientation=None, ticklocation='auto',  # redundant with *location*
+    ):
 
         if mappable is None:
             mappable = cm.ScalarMappable(norm=norm, cmap=cmap)


### PR DESCRIPTION
Move "redundant" kwargs (cmap/norm can be specified via mappable; orientation/ticklocation can be specified via location) to the end of the kwarg list and under an "Other Parameters" section.

Also remove mention of Normalize(clip=False);

    imshow(rand(10, 10),
           cmap=mpl.colormaps["viridis"].with_extremes(under="w", over="k"))
    colorbar(extend="both")

seems enough to have over/under colors show up, i.e. no need to fiddle with the clip parameter.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see
https://dev.matplotlib.org/devel/contributing.html#generative_ai.

-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
