### PR TITLE
fix: broken link

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,7 +17,7 @@ body:
       description: >-
         If possible, please provide a minimum self-contained example.  If you
         have used generative AI as an aid see
-        https://dev.matplotlib.org/devel/contributing.html#generative_ai.
+        https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
       placeholder: Paste your code here. This field is automatically formatted as Python code.
       render: Python
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,8 +16,8 @@ issue #8576".
 
 If possible, please provide a minimum self-contained example.  If you have used
 generative AI as an aid in preparing this PR, see
-https://dev.matplotlib.org/devel/contributing.html#generative_ai.
 
+https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
 -->
 
 


### PR DESCRIPTION
## PR summary

Fixes broken link in bug report and PR templates

Old Link: https://dev.matplotlib.org/devel/contributing.html#generative_ai.
New Link: https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage




## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [NA ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [NA ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ NA] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
