### PR TITLE
pyplot figure context manager

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -50,7 +50,7 @@ import logging
 import sys
 import threading
 import time
-from typing import TYPE_CHECKING, cast, overload
+from typing import TYPE_CHECKING, cast, overload, TypeVar
 
 from cycler import cycler  # noqa: F401
 import matplotlib
@@ -872,6 +872,18 @@ def xkcd(
 
 ## Figures ##
 
+F = TypeVar("F", bound=Figure)
+
+
+class PyplotFigure(Figure):
+
+    def __enter__(self) -> "PyplotFigure":
+        return self
+
+    def __exit__(self, *args, **kwargs):
+        close(self)
+
+
 def figure(
     # autoincrement if None, else integer from 1-N
     num: int | str | Figure | SubFigure | None = None,
@@ -885,10 +897,10 @@ def figure(
     # defaults to rc figure.edgecolor
     edgecolor: ColorType | None = None,
     frameon: bool = True,
-    FigureClass: type[Figure] = Figure,
+    FigureClass: type[F] = PyplotFigure,
     clear: bool = False,
     **kwargs
-) -> Figure:
+) -> F:
     """
     Create a new figure, or activate an existing figure.
 

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -484,3 +484,10 @@ def test_matshow():
 
     # Smoke test that matshow does not ask for a new figsize on the existing figure
     plt.matshow(arr, fignum=fig.number)
+
+
+def test_pyplotfig_context_manager():
+
+    with plt.figure() as fig:
+        ax = fig.subplots()
+        ax.plot([1,2,3], [4,5,6])


### PR DESCRIPTION
## PR summary
Adds a context manager to the default figure class returned by `plt.figure()`.

Relevant issues: https://github.com/matplotlib/matplotlib/issues/5218/

The discussion in the above issue suggests this feature should not live in the `Figure` class, but rather in `pyplot`. The discussion also suggests that the use case is limited, with which I disagree. The common usecase I have found is around interacting with other libraries, where they accept a figure as input. I don't know what they do with it, perhaps one could argue the consumer should close the figure, but I assume there is a reason they do not.

Example 1: https://panel.holoviz.org/reference/panes/Matplotlib.html#using-the-matplotlib-pyplot-interface
Example 2: https://jeltef.github.io/PyLaTeX/current/examples/matplotlib_ex.html

Example usage:
```python
import matplotlib.pyplot as plt

with plt.figure() as fig:
    do_something_with_fig(fig)
# fig is now closed
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

