### PR TITLE
DOC: remove redundant gridspec from example

### DIFF
--- a/galleries/examples/lines_bars_and_markers/scatter_hist.py
+++ b/galleries/examples/lines_bars_and_markers/scatter_hist.py
@@ -90,11 +90,10 @@ scatter_hist(x, y, ax, ax_histx, ax_histy)
 
 # Create a Figure, which doesn't have to be square.
 fig = plt.figure(layout='constrained')
-# Create the main Axes, leaving 25% of the figure space at the top and on the
-# right to position marginals.
-ax = fig.add_gridspec(top=0.75, right=0.75).subplots()
+# Create the main Axes.
+ax = fig.add_subplot()
 # The main Axes' aspect can be fixed.
-ax.set(aspect=1)
+ax.set_aspect('equal')
 # Create marginal Axes, which have 25% of the size of the main Axes.  Note that
 # the inset Axes are positioned *outside* (on the right and the top) of the
 # main Axes, by specifying axes coordinates greater than 1.  Axes coordinates


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Since this example uses constrained layout, the 75% modification on the gridspec has no effect.  We can therefore simplify this axes creation.  (I have a use-case where constrained layout needs to run more times to fit everything properly.  I saw this example and thought maybe using the 75% approach would help the constrained layout algorithm by starting closer to where it needs to go, but it made no difference to my use-case either).

Also switched out `set(aspect=` for `set_aspect(` following guidance at https://github.com/matplotlib/matplotlib/issues/28693#issuecomment-2278075085.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
