### PR TITLE
DOC: fix the bug of examples\event_handling

### DIFF
--- a/galleries/examples/event_handling/data_browser.py
+++ b/galleries/examples/event_handling/data_browser.py
@@ -82,7 +82,7 @@ class PointBrowser:
                  transform=ax2.transAxes, va='top')
         ax2.set_ylim(-0.5, 1.5)
         self.selected.set_visible(True)
-        self.selected.set_data(xs[dataind], ys[dataind])
+        self.selected.set_data([xs[dataind]], [ys[dataind]])
 
         self.text.set_text('selected: %d' % dataind)
         fig.canvas.draw()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## DOC: fix the bug of examples\event_handling\data_browser.py

Closes #22329 

Matplotlib now enforces that line data modifications must be sequences. However, the example script has not been updated accordingly, which will cause errors when running it.

```
Traceback (most recent call last):
  ...
  File "...\matplotlib\galleries\examples\event_handling\data_browser.py", line 72, in on_pick
    self.update()
  File "...\matplotlib\galleries\examples\event_handling\data_browser.py", line 92, in update
    self.selected.set_data(xs[dataind], ys[dataind])
  File "...\site-packages\matplotlib\lines.py", line 665, in set_data
    self.set_xdata(x)
  File "...\matplotlib\lines.py", line 1289, in set_xdata
    raise RuntimeError('x must be a sequence')
RuntimeError: x must be a sequence
```
Updated script to fix this bug.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
