### PR TITLE
Fix alt and caption handling in Sphinx directives

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -876,7 +876,7 @@ def run(arguments, content, options, state_machine, state, lineno):
 
     # Properly indent the caption
     if caption and config.plot_srcset:
-        caption = f':caption: {caption}'
+        caption = ':caption: ' + caption.replace('\n', ' ')
     elif caption:
         caption = '\n' + '\n'.join('      ' + line.strip()
                                    for line in caption.split('\n'))
@@ -895,6 +895,9 @@ def run(arguments, content, options, state_machine, state, lineno):
 
         if nofigs:
             images = []
+
+        if 'alt' in options:
+            options['alt'] = options['alt'].replace('\n', ' ')
 
         opts = [
             f':{key}: {val}' for key, val in options.items()

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -75,22 +75,25 @@ def test_tinypages(tmp_path):
     # Plot 13 shows close-figs in action
     assert filecmp.cmp(range_4, plot_file(13))
     # Plot 14 has included source
-    html_contents = (html_dir / 'some_plots.html').read_bytes()
+    html_contents = (html_dir / 'some_plots.html').read_text(encoding='utf-8')
 
-    assert b'# Only a comment' in html_contents
+    assert '# Only a comment' in html_contents
     # check plot defined in external file.
     assert filecmp.cmp(range_4, img_dir / 'range4.png')
     assert filecmp.cmp(range_6, img_dir / 'range6_range6.png')
     # check if figure caption made it into html file
-    assert b'This is the caption for plot 15.' in html_contents
-    # check if figure caption using :caption: made it into html file
-    assert b'Plot 17 uses the caption option.' in html_contents
+    assert 'This is the caption for plot 15.' in html_contents
+    # check if figure caption using :caption: made it into html file (because this plot
+    # doesn't use srcset, the caption preserves newlines in the output.)
+    assert 'Plot 17 uses the caption option,\nwith multi-line input.' in html_contents
+    # check if figure alt text using :alt: made it into html file
+    assert 'Plot 17 uses the alt option, with multi-line input.' in html_contents
     # check if figure caption made it into html file
-    assert b'This is the caption for plot 18.' in html_contents
+    assert 'This is the caption for plot 18.' in html_contents
     # check if the custom classes made it into the html file
-    assert b'plot-directive my-class my-other-class' in html_contents
+    assert 'plot-directive my-class my-other-class' in html_contents
     # check that the multi-image caption is applied twice
-    assert html_contents.count(b'This caption applies to both plots.') == 2
+    assert html_contents.count('This caption applies to both plots.') == 2
     # Plot 21 is range(6) plot via an include directive. But because some of
     # the previous plots are repeated, the argument to plot_file() is only 17.
     assert filecmp.cmp(range_6, plot_file(17))

--- a/lib/matplotlib/tests/tinypages/some_plots.rst
+++ b/lib/matplotlib/tests/tinypages/some_plots.rst
@@ -135,7 +135,12 @@ Plot 16 uses a specific function in a file with plot commands:
 Plot 17 gets a caption specified by the :caption: option:
 
 .. plot::
-   :caption: Plot 17 uses the caption option.
+   :caption:
+      Plot 17 uses the caption option,
+      with multi-line input.
+   :alt:
+      Plot 17 uses the alt option,
+      with multi-line input.
 
    plt.figure()
    plt.plot(range(6))


### PR DESCRIPTION
## PR summary

We currently template new reST to be re-parsed after the plot is created, but incorrectly copied the `alt` and `caption` values when they were wrapped.
In the future, we should probably drop this template and directly create the nodes we need, but I assume that `TEMPLATE` is not private right now for the purpose of letting people modify it.

Additionally, change `figmpl` to use Sphinx/docutils' tag creation functions. These functions correctly escape attributes and so fixes invalid HTML when alt text contains quotes. I also dropped some attributes if they were empty (e.g., we no longer get `style="" class=""` if those aren't specified.)
For example, this is broken on the [dark colour map image](https://matplotlib.org/3.10.0/users/prev_whats_new/whats_new_3.10.0.html#dark-mode-diverging-colormaps) which has quoted colour map names in the alt text.

Fixes #29649

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines