### PR TITLE
Add test cases for patch.force_edgecolor behavior with facecolor="none"

### DIFF
--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -1066,3 +1066,30 @@ def test_patch_hatchcolor_fallback_logic():
     # hatch.color rcParam is set to 'edge' and edgecolor is not set
     rect = Rectangle((0, 0), 1, 1, hatch='//')
     assert mcolors.same_color(rect.get_hatchcolor(), mpl.rcParams['patch.edgecolor'])
+
+
+def test_facecolor_none_force_edgecolor_false():
+    rcParams['patch.force_edgecolor'] = False   # default value
+    rect = Rectangle((0, 0), 1, 1, facecolor="none")
+    assert rect.get_edgecolor() == (0.0, 0.0, 0.0, 0.0)
+
+
+def test_facecolor_none_force_edgecolor_true():
+    rcParams['patch.force_edgecolor'] = True
+    rect = Rectangle((0, 0), 1, 1, facecolor="none")
+    assert rect.get_edgecolor() == (0.0, 0.0, 0.0, 1)
+
+
+def test_facecolor_none_edgecolor_force_edgcolor():
+
+    # Case 1:force_edgecolor =False -> rcParams['patch.edgecolor'] should NOT be applied
+    rcParams['patch.force_edgecolor'] = False
+    rcParams['patch.edgecolor'] = 'red'
+    rect = Rectangle((0, 0), 1, 1, facecolor="none")
+    assert not mcolors.same_color(rect.get_edgecolor(), rcParams['patch.edgecolor'])
+
+    # Case 2:force_edgecolor =True -> rcParams['patch.edgecolor'] SHOULD be applied
+    rcParams['patch.force_edgecolor'] = True
+    rcParams['patch.edgecolor'] = 'red'
+    rect = Rectangle((0, 0), 1, 1, facecolor="none")
+    assert mcolors.same_color(rect.get_edgecolor(), rcParams['patch.edgecolor'])

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -1080,7 +1080,7 @@ def test_facecolor_none_force_edgecolor_true():
     assert rect.get_edgecolor() == (0.0, 0.0, 0.0, 1)
 
 
-def test_facecolor_none_edgecolor_force_edgcolor():
+def test_facecolor_none_edgecolor_force_edgecolor():
 
     # Case 1:force_edgecolor =False -> rcParams['patch.edgecolor'] should NOT be applied
     rcParams['patch.force_edgecolor'] = False


### PR DESCRIPTION
Fixes: #29261

This commit adds test cases to verify the behavior of `patch.force_edgecolor` when `facecolor="none"`.