### PR TITLE
ENH: Add support for per-label padding in bar_label

### DIFF
--- a/doc/users/next_whats_new/bar_label_padding_update.rst
+++ b/doc/users/next_whats_new/bar_label_padding_update.rst
@@ -1,0 +1,5 @@
+Array-like padding accepted for ``bar_label``
+--------------------------------------------------------------------------
+``bar_label`` will now accept both a float value or an array-like object
+for padding. If an array-like is provided, the padding values are applied
+to each label individually. Must have the same length as container.

--- a/doc/users/next_whats_new/bar_label_padding_update.rst
+++ b/doc/users/next_whats_new/bar_label_padding_update.rst
@@ -1,5 +1,4 @@
-Array-like padding accepted for ``bar_label``
---------------------------------------------------------------------------
-``bar_label`` will now accept both a float value or an array-like object
-for padding. If an array-like is provided, the padding values are applied
-to each label individually. Must have the same length as container.
+``bar_label`` supports individual padding per label
+---------------------------------------------------
+``bar_label`` will now accept both a float value or an array-like for
+padding. The array-like defines the padding for each label individually.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2888,7 +2888,6 @@ class Axes(_AxesBase):
             Distance of label from the end of the bar, in points.
             If an array-like is provided, the padding values are applied
             to each label individually. Must have the same length as container.
-            
             .. versionadded:: 3.11
 
         **kwargs

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2939,16 +2939,16 @@ class Axes(_AxesBase):
 
         if np.iterable(padding):
             # if padding iterable, check length
-            padding_array = np.asarray(padding)
-            if len(padding_array) != len(bars):
+            padding = np.asarray(padding)
+            if len(padding) != len(bars):
                 raise ValueError(
                     f"padding must be of length {len(bars)} when passed as a sequence")
         else:
             # single value, apply to all labels
-            padding_array = [padding] * len(bars)
+            padding = [padding] * len(bars)
 
         for bar, err, dat, lbl, pad in itertools.zip_longest(
-                bars, errs, datavalues, labels, padding_array
+                bars, errs, datavalues, labels, padding
         ):
             (x0, y0), (x1, y1) = bar.get_bbox().get_points()
             xc, yc = (x0 + x1) / 2, (y0 + y1) / 2

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2888,6 +2888,8 @@ class Axes(_AxesBase):
             Distance of label from the end of the bar, in points.
             If an array-like is provided, the padding values are applied
             to each label individually. Must have the same length as container.
+            
+            .. versionadded:: 3.11
 
         **kwargs
             Any remaining keyword arguments are passed through to

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2937,23 +2937,18 @@ class Axes(_AxesBase):
 
         annotations = []
 
-        try:
-            if not isinstance(padding, (str, bytes)) and np.iterable(padding):
-                # if padding iterable, check length
-                padding_array = np.asarray(padding)
-                if len(padding_array) != len(bars):
-                    raise ValueError(
-                        f"padding must be of length {len(bars)} when passed as a sequence")
-                padding_list = list(padding_array)
-            else:
-                # single value, apply to all labels
-                padding_list = [padding] * len(bars)
-        except (TypeError, ValueError):
-            # not iterable or wrong length, use scalar padding
-            padding_list = [padding] * len(bars)
+        if np.iterable(padding):
+            # if padding iterable, check length
+            padding_array = np.asarray(padding)
+            if len(padding_array) != len(bars):
+                raise ValueError(
+                    f"padding must be of length {len(bars)} when passed as a sequence")
+        else:
+            # single value, apply to all labels
+            padding_array = [padding] * len(bars)
 
         for bar, err, dat, lbl, pad in itertools.zip_longest(
-                bars, errs, datavalues, labels, padding_list
+                bars, errs, datavalues, labels, padding_array
         ):
             (x0, y0), (x1, y1) = bar.get_bbox().get_points()
             xc, yc = (x0 + x1) / 2, (y0 + y1) / 2

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -268,7 +268,7 @@ class Axes(_AxesBase):
         *,
         fmt: str | Callable[[float], str] = ...,
         label_type: Literal["center", "edge"] = ...,
-        padding: float = ...,
+        padding: float | ArrayLike = ...,
         **kwargs
     ) -> list[Annotation]: ...
     def broken_barh(

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3025,7 +3025,7 @@ def bar_label(
     *,
     fmt: str | Callable[[float], str] = "%g",
     label_type: Literal["center", "edge"] = "edge",
-    padding: float = 0,
+    padding: float | ArrayLike = 0,
     **kwargs,
 ) -> list[Annotation]:
     return gca().bar_label(

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8877,8 +8877,6 @@ def test_bar_label_padding():
     assert labels1[0].xyann[1] == 5
     assert labels1[1].xyann[1] == 5
 
-    ax = plt.gca()
-    rects = ax.bar(xs, heights)
     labels2 = ax.bar_label(rects, padding=[2, 8])  # test array-like values
     assert labels2[0].xyann[1] == 2
     assert labels2[1].xyann[1] == 8

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8868,6 +8868,25 @@ def test_bar_label_nan_ydata_inverted():
     assert labels[0].get_verticalalignment() == 'bottom'
 
 
+def test_bar_label_padding():
+    """Test that bar_label accepts both float and array-like padding."""
+    ax = plt.gca()
+    xs, heights = [1, 2], [3, 4]
+    rects = ax.bar(xs, heights)
+    labels1 = ax.bar_label(rects, padding=5)  # test float value
+    assert labels1[0].xyann[1] == 5
+    assert labels1[1].xyann[1] == 5
+
+    ax = plt.gca()
+    rects = ax.bar(xs, heights)
+    labels2 = ax.bar_label(rects, padding=[2, 8])  # test array-like values
+    assert labels2[0].xyann[1] == 2
+    assert labels2[1].xyann[1] == 8
+
+    with pytest.raises(ValueError, match="padding must be of length"):
+        ax.bar_label(rects, padding=[1, 2, 3])
+
+
 def test_nan_barlabels():
     fig, ax = plt.subplots()
     bars = ax.bar([1, 2, 3], [np.nan, 1, 2], yerr=[0.2, 0.4, 0.6])


### PR DESCRIPTION

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
This change implements support for per-label padding in the bar_label function.

- What problem does it solve?
Currently, the bar_label function only accepts a float value for the padding parameter, which applies the same padding to all labels. This makes it difficult to adjust individual labels that need more space to avoid overlap with other elements.

- What is the reasoning for this implementation?
This PR allows for a continued use of a singular float value or an array-like object with per-label padding in order to customize labels and avoid overlap.

Example usage:
ax.bar_label(bars, padding=[3, 3, 3, 15])

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X ] "closes #29647 " is in the body of the PR description to [(https://github.com/matplotlib/matplotlib/issues/29647)]
- [ X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [X ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
