### PR TITLE
Update version switcher for 3.10.1

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "3.10 (stable)",
-        "version": "3.10.0",
+        "version": "3.10.1",
         "url": "https://matplotlib.org/stable/",
         "preferred": true
     },


### PR DESCRIPTION
Might fix https://github.com/matplotlib/matplotlib/issues/29712? At least this brings the version switcher up to date.