### PR TITLE
FIX: pyplot auto-backend detection case-sensitivity fixup

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -2715,12 +2715,15 @@ def polar(*args, **kwargs) -> list[Line2D]:
 # If rcParams['backend_fallback'] is true, and an interactive backend is
 # requested, ignore rcParams['backend'] and force selection of a backend that
 # is compatible with the current running interactive framework.
-if (rcParams["backend_fallback"]
-        and rcParams._get_backend_or_none() in (  # type: ignore[attr-defined]
-            set(backend_registry.list_builtin(BackendFilter.INTERACTIVE)) -
-            {'webagg', 'nbagg'})
-        and cbook._get_running_interactive_framework()):
-    rcParams._set("backend", rcsetup._auto_backend_sentinel)
+if rcParams["backend_fallback"]:
+    requested_backend = rcParams._get_backend_or_none()  # type: ignore[attr-defined]
+    requested_backend = None if requested_backend is None else requested_backend.lower()
+    available_backends = backend_registry.list_builtin(BackendFilter.INTERACTIVE)
+    if (
+        requested_backend in (set(available_backends) - {'webagg', 'nbagg'})
+        and cbook._get_running_interactive_framework()
+    ):
+        rcParams._set("backend", rcsetup._auto_backend_sentinel)
 
 # fmt: on
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -521,10 +521,11 @@ def test_rcparams_reset_after_fail():
 
 
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
-def test_backend_fallback_headless(tmp_path):
+def test_backend_fallback_headless_invalid_backend(tmp_path):
     env = {**os.environ,
            "DISPLAY": "", "WAYLAND_DISPLAY": "",
            "MPLBACKEND": "", "MPLCONFIGDIR": str(tmp_path)}
+    # plotting should fail with the tkagg backend selected in a headless environment
     with pytest.raises(subprocess.CalledProcessError):
         subprocess_run_for_testing(
             [sys.executable, "-c",
@@ -534,6 +535,28 @@ def test_backend_fallback_headless(tmp_path):
              "matplotlib.pyplot.plot(42);"
              ],
             env=env, check=True, stderr=subprocess.DEVNULL)
+
+
+@pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
+def test_backend_fallback_headless_auto_backend(tmp_path):
+    # specify a headless mpl environment, but request a graphical (tk) backend
+    env = {**os.environ,
+           "DISPLAY": "", "WAYLAND_DISPLAY": "",
+           "MPLBACKEND": "TkAgg", "MPLCONFIGDIR": str(tmp_path)}
+
+    # allow fallback to an available interactive backend explicitly in configuration
+    rc_path = tmp_path / "matplotlibrc"
+    rc_path.write_text("backend_fallback: true")
+
+    # plotting should succeed, by falling back to use the generic agg backend
+    backend = subprocess_run_for_testing(
+        [sys.executable, "-c",
+         "import matplotlib.pyplot;"
+         "matplotlib.pyplot.plot(42);"
+         "print(matplotlib.get_backend());"
+         ],
+        env=env, text=True, check=True, capture_output=True).stdout
+    assert backend.strip().lower() == "agg"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## PR summary
There seems to be a case-sensitivity bug in the `matplotlib.pyplot` module code that decides whether to configure backend autodetection, and I think that this is the cause of the bug reported in #29713.

The bug means that a current interactive environment value of `TkAgg` is not detected as one of the possible values from a set that includes the string `tkagg` -- and so an auto-backend is _not_ configured, as it would have been previously in v3.8.3 of this library.

A minimal repro example is provided below, for use in a container environment with no graphical/GUI environment available:

```pyi
>>> import matplotlib.pyplot
>>> matplotlib.pyplot.new_figure_manager()
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    matplotlib.pyplot.new_figure_manager()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/matplotlib/pyplot.py", line 551, in new_figure_manager
    _warn_if_gui_out_of_main_thread()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/matplotlib/pyplot.py", line 528, in _warn_if_gui_out_of_main_thread
    canvas_class = cast(type[FigureCanvasBase], _get_backend_mod().FigureCanvas)
                                                ~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3/dist-packages/matplotlib/pyplot.py", line 369, in _get_backend_mod
    switch_backend(rcParams._get("backend"))
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/matplotlib/pyplot.py", line 433, in switch_backend
    raise ImportError(
    ...<2 lines>...
            newbackend, required_framework, current_framework))
ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running
```

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] ~~*Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)~~ N/A
- [ ] ~~*New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)~~ N/A
- [ ] ~~Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines~~ N/A

Closes #29713.