### PR TITLE
Add WebAggWidget backend

### DIFF
--- a/lib/matplotlib/backends/backend_webagg_widget.py
+++ b/lib/matplotlib/backends/backend_webagg_widget.py
@@ -1,0 +1,113 @@
+"""Display a WebAgg HTML Widget in a Jupyter Notebook."""
+
+import io
+from base64 import b64encode
+
+import matplotlib as mpl
+from matplotlib.backend_bases import _Backend
+from matplotlib._pylab_helpers import Gcf
+from matplotlib.backends import backend_webagg_core as core
+from matplotlib.backends.backend_webagg import WebAggApplication
+
+try:
+    from IPython.display import display
+except ImportError as err:
+    raise RuntimeError("The WebAggWidget backend requires IPython.") from err
+
+try:
+    from ipywidgets import HTML, Layout
+except ImportError as err:
+    raise RuntimeError("The WebAggWidget backend requires ipywidgets.") from err
+
+
+class WebAggFigureWidget(HTML):
+    _margin_x, _margin_y = (20, 80)
+
+    def __init__(self, f=None):
+        super().__init__()
+
+        self.f = f
+        self._webagg_address = (
+            "http://{0}:{1}/{2}".format(
+                mpl.rcParams["webagg.address"],
+                WebAggApplication.port,
+                self.f.number
+                )
+            )
+        self._setup_widget()
+
+    def _setup_widget(self):
+        # TODO find a better way to get the required size to show the full figure
+        w = int(self.f.dpi * self.f.get_figwidth() + self._margin_x)
+        # 40 px is appended as space for the toolbar.
+        h = int((self.f.dpi * self.f.get_figheight() + self._margin_y))
+        layout = Layout(width=f"{w}px", height=f"{h}px")
+
+        self.value = (
+            f"<iframe src={self._webagg_address} "
+            "style='width: 100%; height: 100%; border:none;' scrolling='no' "
+            "frameborder='0' allowtransparency='true'></iframe>"
+            )
+        self.layout = layout
+
+        # Add a callback to dynamically adjust the widget layout on resize of the figure
+        def cb(event):
+            self.layout.width = f"{(event.width + self._margin_x):.0f}px"
+            self.layout.height = f"{(event.height + self._margin_y):.0f}px"
+        self.f.canvas.mpl_connect("resize_event", cb)
+
+    def _repr_mimebundle_(self, **kwargs):
+        # attach a png of the figure for static display
+        buf = io.BytesIO()
+        self.f.savefig(buf, format='png', dpi='figure')
+        data_url = b64encode(buf.getvalue()).decode('utf-8')
+
+        data = {
+            'text/plain': str(self.f),
+            'image/png': data_url,
+            'application/vnd.jupyter.widget-view+json': {
+                'version_major': 2,
+                'version_minor': 0,
+                'model_id': self._model_id
+            }
+        }
+        return data
+
+
+class FigureManagerWebAggWidget(core.FigureManagerWebAgg):
+    _toolbar2_class = core.NavigationToolbar2WebAgg
+
+    @classmethod
+    def pyplot_show(cls, *, block=None):
+        managers = Gcf.get_all_fig_managers()
+        for m in managers:
+            # Only display figures that have not yet been shown
+            if m.canvas._webagg_widget is None:
+                display(m.canvas._get_widget())
+
+
+class FigureCanvasWebAggWidget(core.FigureCanvasWebAggCore):
+    manager_class = FigureManagerWebAggWidget
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self._webagg_widget = None
+
+    def _get_widget(self):
+        # Return cached widget if it already exists
+        if self._webagg_widget is None:
+            WebAggApplication.initialize()
+            WebAggApplication.start()
+
+            self._webagg_widget = WebAggFigureWidget(f=self.figure)
+
+        return self._webagg_widget
+
+    def show(self):
+        return self._get_widget()
+
+@_Backend.export
+class _BackendWebAggWidget(_Backend):
+    FigureCanvas = FigureCanvasWebAggWidget
+    FigureManager = FigureManagerWebAggWidget


### PR DESCRIPTION
I've been playing around a bit with `webagg` and `jupyter notebooks` to finally get a backend that 
fully supports the interactive features of [EOmaps](https://github.com/raphaelquast/EOmaps)... (e.g. that properly supports blitting)

In the process, I've noticed that it is possible to create a quite minimalist implementation of a `webagg` based backend for `jupyter notebooks` that does the job nicely!

The idea here is the following:
- use a `ipywidgets` `HTML` widget to `<iframe>` the generated `webagg` page into the notebook.
- adjust the size of the widget via a ´"resize_event"` callback on the figure

This works really nice out of the box and together with #27160 it is a backend that finally supports blitting in jupyter notebooks without any lags or glitches. 


Would be nice to get an opinion from your side on this idea (and if you think something like this should go into matplotlib or if this is better kept inside `EOmaps` and loaded with `%matplotlib module://eomaps.backend_webagg_widget`.



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
