### PR TITLE
Revert "NEP 29 > SPEC 0 in dependency policy"

### DIFF
--- a/doc/devel/min_dep_policy.rst
+++ b/doc/devel/min_dep_policy.rst
@@ -10,8 +10,8 @@ For the purpose of this document, 'minor version' is in the sense of SemVer
 major/macro and minor/meso releases.  For projects that use date-based
 versioning, every release is a 'minor version'.
 
-Matplotlib follows the recommendations in `SPEC 0
-<https://scientific-python.org/specs/spec-0000/>`__.
+Matplotlib follows `NEP 29
+<https://numpy.org/neps/nep-0029-deprecation_policy.html>`__.
 
 Python and NumPy
 ================


### PR DESCRIPTION
Reverts matplotlib/matplotlib#29744 - as noted in https://github.com/matplotlib/matplotlib/pull/29744#issuecomment-2718535658 the text below is not consistent with SPEC 0, so making this change requires a better/more complete PR explaining the changes, and leaving time for discussion/input on changing it.