### PR TITLE
DOC: Add install instructions for pixi and uv

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -43,9 +43,10 @@ Install
 
         .. warning::
 
-           The ``tkagg`` backend is not available because Python versions
-           distributed by uv do not contain tk bindings that are usable by
-           Matplotlib (see `this issue`_ for details). If you want Matplotlib
+           If you install Python with ``uv`` then the ``tkagg`` backend
+           will not be available because python-build-standalone (used by uv
+           to distribute Python) does not contain tk bindings that are usable by
+           Matplotlib (see `this issue`_ for details).  If you want Matplotlib
            to be able to display plots in a window, you should install one of
            the other :ref:`supported GUI frameworks <optional_dependencies>`,
            e.g.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -29,6 +29,33 @@ Install
 
             conda install -c conda-forge matplotlib
 
+    .. tab-item:: pixi
+
+        .. code-block:: bash
+
+            pixi add matplotlib
+
+    .. tab-item:: uv
+
+        .. code-block:: bash
+
+            uv add matplotlib
+
+        .. warning::
+
+           The ``tkagg`` backend is not available because Python versions
+           distributed by uv do not contain tk bindings that are usable by
+           Matplotlib (see `this issue`_ for details). If you want Matplotlib
+           to be able to display plots in a window, you should install one of
+           the other :ref:`supported GUI frameworks <optional_dependencies>`,
+           e.g.
+
+           .. code-block:: bash
+
+               uv add matplotlib pyside6
+
+           .. _this issue: https://github.com/astral-sh/uv/issues/6893#issuecomment-2565965851
+
     .. tab-item:: other
 
         .. rst-class:: section-toc

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -28,7 +28,8 @@ precompiled wheel for your OS and Python.
    The following backends work out of the box: Agg, ps, pdf, svg
 
    Python is typically shipped with tk bindings which are used by
-   TkAgg.
+   TkAgg. Notably, python-build-standalone -- used by ``uv``  -- does
+   not include tk bindings that are usable by Matplotlib.
 
    For support of other GUI frameworks, LaTeX rendering, saving
    animations and a larger selection of file formats, you can

--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -28,7 +28,7 @@ precompiled wheel for your OS and Python.
    The following backends work out of the box: Agg, ps, pdf, svg
 
    Python is typically shipped with tk bindings which are used by
-   TkAgg. Notably, python-build-standalone -- used by ``uv``  -- does
+   TkAgg. Notably, python-build-standalone – used by ``uv`` – does
    not include tk bindings that are usable by Matplotlib.
 
    For support of other GUI frameworks, LaTeX rendering, saving


### PR DESCRIPTION
Closes #29746.

Notes on issues with uv an tk taken from
https://github.com/astral-sh/uv/issues/6893#issuecomment-2565965851

I'm open whether pyside6 is the right example for installing another GUI framework, but (i) I think we should have one install command written out that has a working interactive backend (ii) I somehow prefer Qt, but think that the permissively licensed pyside6 may in general be the better recommendation compared to PyQt6.
