### PR TITLE
DOC: Simplify annotation arrow style reference

### DIFF
--- a/galleries/examples/text_labels_and_annotations/fancyarrow_demo.py
+++ b/galleries/examples/text_labels_and_annotations/fancyarrow_demo.py
@@ -19,35 +19,31 @@ ncol = 2
 nrow = (len(styles) + 1) // ncol
 axs = (plt.figure(figsize=(4 * ncol, 1 + nrow))
        .add_gridspec(1 + nrow, ncol,
-                     wspace=.7, left=.1, right=.9, bottom=0, top=1).subplots())
+                     wspace=0, hspace=0, left=0, right=1, bottom=0, top=1).subplots())
 for ax in axs.flat:
+    ax.set_xlim(-0.5, 4)
     ax.set_axis_off()
 for ax in axs[0, :]:
-    ax.text(0, .5, "arrowstyle",
-            transform=ax.transAxes, size="large", color="tab:blue",
-            horizontalalignment="center", verticalalignment="center")
-    ax.text(.35, .5, "default parameters",
-            transform=ax.transAxes,
-            horizontalalignment="left", verticalalignment="center")
+    ax.text(-0.25, 0.5, "arrowstyle", size="large", color="tab:blue")
+    ax.text(1.25, .5, "default parameters", size="large")
 for ax, (stylename, stylecls) in zip(axs[1:, :].T.flat, styles.items()):
-    l, = ax.plot(.25, .5, "ok", transform=ax.transAxes)
-    ax.annotate(stylename, (.25, .5), (-0.1, .5),
-                xycoords="axes fraction", textcoords="axes fraction",
-                size="large", color="tab:blue",
-                horizontalalignment="center", verticalalignment="center",
+    # draw dot and annotation with arrowstyle
+    l, = ax.plot(1, 0, "o", color="grey")
+    ax.annotate(stylename, (1, 0), (0, 0),
+                size="large", color="tab:blue", ha="center", va="center",
                 arrowprops=dict(
                     arrowstyle=stylename, connectionstyle="arc3,rad=-0.05",
                     color="k", shrinkA=5, shrinkB=5, patchB=l,
                 ),
-                bbox=dict(boxstyle="square", fc="w"))
+                bbox=dict(boxstyle="square", fc="w", ec="grey"))
+    # draw default parameters
     # wrap at every nth comma (n = 1 or 2, depending on text length)
     s = str(inspect.signature(stylecls))[1:-1]
     n = 2 if s.count(',') > 3 else 1
-    ax.text(.35, .5,
+    ax.text(1.25, 0,
             re.sub(', ', lambda m, c=itertools.count(1): m.group()
                    if next(c) % n else '\n', s),
-            transform=ax.transAxes,
-            horizontalalignment="left", verticalalignment="center")
+            verticalalignment="center")
 
 plt.show()
 


### PR DESCRIPTION
Position everything in data coordiates rather than Axes coordinates. While the code is not the primary goal of this example, it's slightly simpler to follow if we keep everything in data coordinates, which is what all the commands (plot, text, annotate) are by default in.

The output is basically unchanged, with the exception of making the point marker and the textbox edge dark grey so that the black arrow stands out more.

