### PR TITLE
Shorten Agg template usage with class template argument deduction.

### DIFF
--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -296,23 +296,15 @@ template <class path_t>
 inline void
 RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face, GCAgg &gc)
 {
-    typedef agg::conv_stroke<path_t> stroke_t;
-    typedef agg::conv_dash<path_t> dash_t;
-    typedef agg::conv_stroke<dash_t> stroke_dash_t;
-    typedef agg::pixfmt_amask_adaptor<pixfmt, alpha_mask_type> pixfmt_amask_type;
-    typedef agg::renderer_base<pixfmt_amask_type> amask_ren_type;
-    typedef agg::renderer_scanline_aa_solid<amask_ren_type> amask_aa_renderer_type;
-    typedef agg::renderer_scanline_bin_solid<amask_ren_type> amask_bin_renderer_type;
-
     // Render face
     if (face.first) {
         theRasterizer.add_path(path);
 
         if (gc.isaa) {
             if (has_clippath) {
-                pixfmt_amask_type pfa(pixFmt, alphaMask);
-                amask_ren_type r(pfa);
-                amask_aa_renderer_type ren(r);
+                auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+                auto r = agg::renderer_base{pfa};
+                auto ren = agg::renderer_scanline_aa_solid{r};
                 ren.color(face.second);
                 agg::render_scanlines(theRasterizer, scanlineAlphaMask, ren);
             } else {
@@ -321,9 +313,9 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
             }
         } else {
             if (has_clippath) {
-                pixfmt_amask_type pfa(pixFmt, alphaMask);
-                amask_ren_type r(pfa);
-                amask_bin_renderer_type ren(r);
+                auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+                auto r = agg::renderer_base{pfa};
+                auto ren = agg::renderer_scanline_bin_solid{r};
                 ren.color(face.second);
                 agg::render_scanlines(theRasterizer, scanlineAlphaMask, ren);
             } else {
@@ -341,19 +333,15 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
         rendererBase.reset_clipping(true);
 
         // Create and transform the path
-        typedef agg::conv_transform<mpl::PathIterator> hatch_path_trans_t;
-        typedef agg::conv_curve<hatch_path_trans_t> hatch_path_curve_t;
-        typedef agg::conv_stroke<hatch_path_curve_t> hatch_path_stroke_t;
-
         mpl::PathIterator hatch_path(gc.hatchpath);
         agg::trans_affine hatch_trans;
         hatch_trans *= agg::trans_affine_scaling(1.0, -1.0);
         hatch_trans *= agg::trans_affine_translation(0.0, 1.0);
         hatch_trans *= agg::trans_affine_scaling(static_cast<double>(hatch_size),
                                                  static_cast<double>(hatch_size));
-        hatch_path_trans_t hatch_path_trans(hatch_path, hatch_trans);
-        hatch_path_curve_t hatch_path_curve(hatch_path_trans);
-        hatch_path_stroke_t hatch_path_stroke(hatch_path_curve);
+        auto hatch_path_trans = agg::conv_transform{hatch_path, hatch_trans};
+        auto hatch_path_curve = agg::conv_curve{hatch_path_trans};
+        auto hatch_path_stroke = agg::conv_stroke{hatch_path_curve};
         hatch_path_stroke.width(points_to_pixels(gc.hatch_linewidth));
         hatch_path_stroke.line_cap(agg::square_cap);
 
@@ -377,18 +365,16 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
         }
 
         // Transfer the hatch to the main image buffer
-        typedef agg::image_accessor_wrap<pixfmt,
-                                         agg::wrap_mode_repeat_auto_pow2,
-                                         agg::wrap_mode_repeat_auto_pow2> img_source_type;
-        typedef agg::span_pattern_rgba<img_source_type> span_gen_type;
         agg::span_allocator<agg::rgba8> sa;
-        img_source_type img_src(hatch_img_pixf);
-        span_gen_type sg(img_src, 0, 0);
+        auto img_src = agg::image_accessor_wrap<
+            pixfmt, agg::wrap_mode_repeat_auto_pow2, agg::wrap_mode_repeat_auto_pow2>{
+                hatch_img_pixf};
+        auto sg = agg::span_pattern_rgba{img_src, 0, 0};
         theRasterizer.add_path(path);
 
         if (has_clippath) {
-            pixfmt_amask_type pfa(pixFmt, alphaMask);
-            amask_ren_type ren(pfa);
+            auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+            auto ren = agg::renderer_base{pfa};
             agg::render_scanlines_aa(theRasterizer, slineP8, ren, sa, sg);
         } else {
             agg::render_scanlines_aa(theRasterizer, slineP8, rendererBase, sa, sg);
@@ -402,16 +388,16 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
             linewidth = (linewidth < 0.5) ? 0.5 : mpl_round(linewidth);
         }
         if (gc.dashes.size() == 0) {
-            stroke_t stroke(path);
+            auto stroke = agg::conv_stroke{path};
             stroke.width(points_to_pixels(gc.linewidth));
             stroke.line_cap(gc.cap);
             stroke.line_join(gc.join);
             stroke.miter_limit(points_to_pixels(gc.linewidth));
             theRasterizer.add_path(stroke);
         } else {
-            dash_t dash(path);
+            auto dash = agg::conv_dash{path};
             gc.dashes.dash_to_stroke(dash, dpi, gc.isaa);
-            stroke_dash_t stroke(dash);
+            auto stroke = agg::conv_stroke{dash};
             stroke.line_cap(gc.cap);
             stroke.line_join(gc.join);
             stroke.width(linewidth);
@@ -421,9 +407,9 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
 
         if (gc.isaa) {
             if (has_clippath) {
-                pixfmt_amask_type pfa(pixFmt, alphaMask);
-                amask_ren_type r(pfa);
-                amask_aa_renderer_type ren(r);
+                auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+                auto r = agg::renderer_base{pfa};
+                auto ren = agg::renderer_scanline_aa_solid{r};
                 ren.color(gc.color);
                 agg::render_scanlines(theRasterizer, scanlineAlphaMask, ren);
             } else {
@@ -432,9 +418,9 @@ RendererAgg::_draw_path(path_t &path, bool has_clippath, const facepair_t &face,
             }
         } else {
             if (has_clippath) {
-                pixfmt_amask_type pfa(pixFmt, alphaMask);
-                amask_ren_type r(pfa);
-                amask_bin_renderer_type ren(r);
+                auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+                auto r = agg::renderer_base{pfa};
+                auto ren = agg::renderer_scanline_bin_solid{r};
                 ren.color(gc.color);
                 agg::render_scanlines(theRasterizer, scanlineAlphaMask, ren);
             } else {
@@ -449,14 +435,6 @@ template <class PathIterator>
 inline void
 RendererAgg::draw_path(GCAgg &gc, PathIterator &path, agg::trans_affine &trans, agg::rgba &color)
 {
-    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removed_t;
-    typedef PathClipper<nan_removed_t> clipped_t;
-    typedef PathSnapper<clipped_t> snapped_t;
-    typedef PathSimplifier<snapped_t> simplify_t;
-    typedef agg::conv_curve<simplify_t> curve_t;
-    typedef Sketch<curve_t> sketch_t;
-
     facepair_t face(color.a != 0.0, color);
 
     theRasterizer.reset_clipping();
@@ -473,13 +451,15 @@ RendererAgg::draw_path(GCAgg &gc, PathIterator &path, agg::trans_affine &trans, 
         snapping_linewidth = 0.0;
     }
 
-    transformed_path_t tpath(path, trans);
-    nan_removed_t nan_removed(tpath, true, path.has_codes());
-    clipped_t clipped(nan_removed, clip, width, height);
-    snapped_t snapped(clipped, gc.snap_mode, path.total_vertices(), snapping_linewidth);
-    simplify_t simplified(snapped, simplify, path.simplify_threshold());
-    curve_t curve(simplified);
-    sketch_t sketch(curve, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness);
+    auto tpath = agg::conv_transform{path, trans};
+    auto nan_removed = PathNanRemover{tpath, true, path.has_codes()};
+    auto clipped = PathClipper(nan_removed, clip, width, height);
+    auto snapped = PathSnapper{
+        clipped, gc.snap_mode, path.total_vertices(), snapping_linewidth};
+    auto simplified = PathSimplifier{snapped, simplify, path.simplify_threshold()};
+    auto curve = agg::conv_curve{simplified};
+    auto sketch = Sketch{
+        curve, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness};
 
     _draw_path(sketch, has_clippath, face, gc);
 }
@@ -492,28 +472,19 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
                                       agg::trans_affine &trans,
                                       agg::rgba color)
 {
-    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removed_t;
-    typedef PathSnapper<nan_removed_t> snap_t;
-    typedef agg::conv_curve<snap_t> curve_t;
-    typedef agg::conv_stroke<curve_t> stroke_t;
-    typedef agg::pixfmt_amask_adaptor<pixfmt, alpha_mask_type> pixfmt_amask_type;
-    typedef agg::renderer_base<pixfmt_amask_type> amask_ren_type;
-    typedef agg::renderer_scanline_aa_solid<amask_ren_type> amask_aa_renderer_type;
-
     // Deal with the difference in y-axis direction
     marker_trans *= agg::trans_affine_scaling(1.0, -1.0);
 
     trans *= agg::trans_affine_scaling(1.0, -1.0);
     trans *= agg::trans_affine_translation(0.5, (double)height + 0.5);
 
-    transformed_path_t marker_path_transformed(marker_path, marker_trans);
-    nan_removed_t marker_path_nan_removed(marker_path_transformed, true, marker_path.has_codes());
-    snap_t marker_path_snapped(marker_path_nan_removed,
-                               gc.snap_mode,
-                               marker_path.total_vertices(),
-                               points_to_pixels(gc.linewidth));
-    curve_t marker_path_curve(marker_path_snapped);
+    auto marker_path_transformed = agg::conv_transform{marker_path, marker_trans};
+    auto marker_path_nan_removed = PathNanRemover{
+        marker_path_transformed, true, marker_path.has_codes()};
+    auto marker_path_snapped = PathSnapper{
+        marker_path_nan_removed,
+        gc.snap_mode, marker_path.total_vertices(), points_to_pixels(gc.linewidth)};
+    auto marker_path_curve = agg::conv_curve{marker_path_snapped};
 
     if (!marker_path_snapped.is_snapping()) {
         // If the path snapper isn't in effect, at least make sure the marker
@@ -522,10 +493,11 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
         marker_trans *= agg::trans_affine_translation(0.5, 0.5);
     }
 
-    transformed_path_t path_transformed(path, trans);
-    nan_removed_t path_nan_removed(path_transformed, false, false);
-    snap_t path_snapped(path_nan_removed, SNAP_FALSE, path.total_vertices(), 0.0);
-    curve_t path_curve(path_snapped);
+    auto path_transformed = agg::conv_transform{path, trans};
+    auto path_nan_removed = PathNanRemover{path_transformed, false, false};
+    auto path_snapped = PathSnapper{
+        path_nan_removed, SNAP_FALSE, path.total_vertices(), 0.0};
+    auto path_curve = agg::conv_curve{path_snapped};
     path_curve.rewind(0);
 
     facepair_t face(color.a != 0.0, color);
@@ -559,7 +531,7 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
                                       scanlines.max_y());
         }
 
-        stroke_t stroke(marker_path_curve);
+        auto stroke = agg::conv_stroke{marker_path_curve};
         stroke.width(points_to_pixels(gc.linewidth));
         stroke.line_cap(gc.cap);
         stroke.line_join(gc.join);
@@ -611,9 +583,9 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
                     continue;
                 }
 
-                pixfmt_amask_type pfa(pixFmt, alphaMask);
-                amask_ren_type r(pfa);
-                amask_aa_renderer_type ren(r);
+                auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+                auto r = agg::renderer_base{pfa};
+                auto ren = agg::renderer_scanline_aa_solid{r};
 
                 if (face.first) {
                     ren.color(face.second);
@@ -721,14 +693,6 @@ class font_to_rgba
 template <class ImageArray>
 inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, int y, double angle)
 {
-    typedef agg::span_allocator<agg::rgba8> color_span_alloc_type;
-    typedef agg::span_interpolator_linear<> interpolator_type;
-    typedef agg::image_accessor_clip<agg::pixfmt_gray8> image_accessor_type;
-    typedef agg::span_image_filter_gray<image_accessor_type, interpolator_type> image_span_gen_type;
-    typedef font_to_rgba<image_span_gen_type> span_gen_type;
-    typedef agg::renderer_scanline_aa<renderer_base, color_span_alloc_type, span_gen_type>
-    renderer_type;
-
     theRasterizer.reset_clipping();
     rendererBase.reset_clipping(true);
     if (angle != 0.0) {
@@ -760,12 +724,12 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
 
         agg::image_filter_lut filter;
         filter.calculate(agg::image_filter_spline36());
-        interpolator_type interpolator(inv_mtx);
-        color_span_alloc_type sa;
-        image_accessor_type ia(pixf_img, agg::gray8(0));
-        image_span_gen_type image_span_generator(ia, interpolator, filter);
-        span_gen_type output_span_generator(&image_span_generator, gc.color);
-        renderer_type ri(rendererBase, sa, output_span_generator);
+        auto interpolator = agg::span_interpolator_linear{inv_mtx};
+        auto sa = agg::span_allocator<agg::rgba8>{};
+        auto ia = agg::image_accessor_clip{pixf_img, agg::gray8(0)};
+        auto image_span_generator = agg::span_image_filter_gray{ia, interpolator, filter};
+        auto output_span_generator = font_to_rgba{&image_span_generator, gc.color};
+        auto ri = agg::renderer_scanline_aa{rendererBase, sa, output_span_generator};
 
         theRasterizer.add_path(rect2);
         agg::render_scanlines(theRasterizer, slineP8, ri);
@@ -861,28 +825,16 @@ inline void RendererAgg::draw_image(GCAgg &gc,
         agg::trans_affine inv_mtx(mtx);
         inv_mtx.invert();
 
-        typedef agg::span_allocator<agg::rgba8> color_span_alloc_type;
-        typedef agg::image_accessor_clip<pixfmt> image_accessor_type;
-        typedef agg::span_interpolator_linear<> interpolator_type;
-        typedef agg::span_image_filter_rgba_nn<image_accessor_type, interpolator_type>
-        image_span_gen_type;
-        typedef agg::span_converter<image_span_gen_type, span_conv_alpha> span_conv;
+        auto sa = agg::span_allocator<agg::rgba8>{};
+        auto ia = agg::image_accessor_clip{pixf, agg::rgba8(0, 0, 0, 0)};
+        auto interpolator = agg::span_interpolator_linear{inv_mtx};
+        auto image_span_generator = agg::span_image_filter_rgba_nn{ia, interpolator};
+        auto conv_alpha = span_conv_alpha{alpha};
+        auto spans = agg::span_converter{image_span_generator, conv_alpha};
 
-        color_span_alloc_type sa;
-        image_accessor_type ia(pixf, agg::rgba8(0, 0, 0, 0));
-        interpolator_type interpolator(inv_mtx);
-        image_span_gen_type image_span_generator(ia, interpolator);
-        span_conv_alpha conv_alpha(alpha);
-        span_conv spans(image_span_generator, conv_alpha);
-
-        typedef agg::pixfmt_amask_adaptor<pixfmt, alpha_mask_type> pixfmt_amask_type;
-        typedef agg::renderer_base<pixfmt_amask_type> amask_ren_type;
-        typedef agg::renderer_scanline_aa<amask_ren_type, color_span_alloc_type, span_conv>
-            renderer_type_alpha;
-
-        pixfmt_amask_type pfa(pixFmt, alphaMask);
-        amask_ren_type r(pfa);
-        renderer_type_alpha ri(r, sa, spans);
+        auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+        auto r = agg::renderer_base{pfa};
+        auto ri = agg::renderer_scanline_aa{r, sa, spans};
 
         theRasterizer.add_path(rect2);
         agg::render_scanlines(theRasterizer, scanlineAlphaMask, ri);
@@ -919,17 +871,6 @@ inline void RendererAgg::_draw_path_collection_generic(GCAgg &gc,
                                                        bool check_snap,
                                                        bool has_codes)
 {
-    typedef agg::conv_transform<typename PathGenerator::path_iterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removed_t;
-    typedef PathClipper<nan_removed_t> clipped_t;
-    typedef PathSnapper<clipped_t> snapped_t;
-    typedef agg::conv_curve<snapped_t> snapped_curve_t;
-    typedef agg::conv_curve<clipped_t> curve_t;
-    typedef Sketch<clipped_t> sketch_clipped_t;
-    typedef Sketch<curve_t> sketch_curve_t;
-    typedef Sketch<snapped_t> sketch_snapped_t;
-    typedef Sketch<snapped_curve_t> sketch_snapped_curve_t;
-
     size_t Npaths = path_generator.num_paths();
     size_t Noffsets = safe_first_shape(offsets);
     size_t N = std::max(Npaths, Noffsets);
@@ -1005,27 +946,31 @@ inline void RendererAgg::_draw_path_collection_generic(GCAgg &gc,
         }
 
         gc.isaa = antialiaseds(i % Naa);
-        transformed_path_t tpath(path, trans);
-        nan_removed_t nan_removed(tpath, true, has_codes);
-        clipped_t clipped(nan_removed, do_clip, width, height);
+        auto tpath = agg::conv_transform{path, trans};
+        auto nan_removed = PathNanRemover{tpath, true, has_codes};
+        auto clipped = PathClipper(nan_removed, do_clip, width, height);
         if (check_snap) {
-            snapped_t snapped(
-                clipped, gc.snap_mode, path.total_vertices(), points_to_pixels(gc.linewidth));
+            auto snapped = PathSnapper{
+                clipped, gc.snap_mode, path.total_vertices(), points_to_pixels(gc.linewidth)};
             if (has_codes) {
-                snapped_curve_t curve(snapped);
-                sketch_snapped_curve_t sketch(curve, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness);
+                auto curve = agg::conv_curve{snapped};
+                auto sketch = Sketch{
+                    curve, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness};
                 _draw_path(sketch, has_clippath, face, gc);
             } else {
-                sketch_snapped_t sketch(snapped, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness);
+                auto sketch = Sketch{
+                    snapped, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness};
                 _draw_path(sketch, has_clippath, face, gc);
             }
         } else {
             if (has_codes) {
-                curve_t curve(clipped);
-                sketch_curve_t sketch(curve, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness);
+                auto curve = agg::conv_curve{clipped};
+                auto sketch = Sketch{
+                    curve, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness};
                 _draw_path(sketch, has_clippath, face, gc);
             } else {
-                sketch_clipped_t sketch(clipped, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness);
+                auto sketch = Sketch{
+                    clipped, gc.sketch.scale, gc.sketch.length, gc.sketch.randomness};
                 _draw_path(sketch, has_clippath, face, gc);
             }
         }
@@ -1220,14 +1165,9 @@ inline void RendererAgg::_draw_gouraud_triangle(PointArray &points,
     theRasterizer.add_path(span_gen);
 
     if (has_clippath) {
-        typedef agg::pixfmt_amask_adaptor<pixfmt, alpha_mask_type> pixfmt_amask_type;
-        typedef agg::renderer_base<pixfmt_amask_type> amask_ren_type;
-        typedef agg::renderer_scanline_aa<amask_ren_type, span_alloc_t, span_gen_t>
-        amask_aa_renderer_type;
-
-        pixfmt_amask_type pfa(pixFmt, alphaMask);
-        amask_ren_type r(pfa);
-        amask_aa_renderer_type ren(r, span_alloc, span_gen);
+        auto pfa = agg::pixfmt_amask_adaptor{pixFmt, alphaMask};
+        auto r = agg::renderer_base{pfa};
+        auto ren = agg::renderer_scanline_aa{r, span_alloc, span_gen};
         agg::render_scanlines(theRasterizer, scanlineAlphaMask, ren);
     } else {
         agg::render_scanlines_aa(theRasterizer, slineP8, rendererBase, span_alloc, span_gen);

--- a/src/_path.h
+++ b/src/_path.h
@@ -239,24 +239,17 @@ inline void points_in_path(PointArray &points,
                            agg::trans_affine &trans,
                            ResultArray &result)
 {
-    typedef agg::conv_transform<PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> no_nans_t;
-    typedef agg::conv_curve<no_nans_t> curve_t;
-    typedef agg::conv_contour<curve_t> contour_t;
-
     for (auto i = 0; i < safe_first_shape(points); ++i) {
         result[i] = false;
     }
-
     if (path.total_vertices() < 3) {
         return;
     }
-
-    transformed_path_t trans_path(path, trans);
-    no_nans_t no_nans_path(trans_path, true, path.has_codes());
-    curve_t curved_path(no_nans_path);
+    auto trans_path = agg::conv_transform{path, trans};
+    auto no_nans_path = PathNanRemover{trans_path, true, path.has_codes()};
+    auto curved_path = agg::conv_curve{no_nans_path};
     if (r != 0.0) {
-        contour_t contoured_path(curved_path);
+        auto contoured_path = agg::conv_contour{curved_path};
         contoured_path.width(r);
         point_in_path_impl(points, contoured_path, result);
     } else {
@@ -286,11 +279,6 @@ template <class PathIterator>
 inline bool point_on_path(
     double x, double y, const double r, PathIterator &path, agg::trans_affine &trans)
 {
-    typedef agg::conv_transform<PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> no_nans_t;
-    typedef agg::conv_curve<no_nans_t> curve_t;
-    typedef agg::conv_stroke<curve_t> stroke_t;
-
     py::ssize_t shape[] = {1, 2};
     py::array_t<double> points_arr(shape);
     *points_arr.mutable_data(0, 0) = x;
@@ -300,10 +288,10 @@ inline bool point_on_path(
     int result[1];
     result[0] = 0;
 
-    transformed_path_t trans_path(path, trans);
-    no_nans_t nan_removed_path(trans_path, true, path.has_codes());
-    curve_t curved_path(nan_removed_path);
-    stroke_t stroked_path(curved_path);
+    auto trans_path = agg::conv_transform{path, trans};
+    auto nan_removed_path = PathNanRemover{trans_path, true, path.has_codes()};
+    auto curved_path = agg::conv_curve{nan_removed_path};
+    auto stroked_path = agg::conv_stroke{curved_path};
     stroked_path.width(r * 2.0);
     point_in_path_impl(points, stroked_path, result);
     return result[0] != 0;
@@ -352,13 +340,11 @@ inline void update_limits(double x, double y, extent_limits &e)
 template <class PathIterator>
 void update_path_extents(PathIterator &path, agg::trans_affine &trans, extent_limits &extents)
 {
-    typedef agg::conv_transform<PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removed_t;
     double x, y;
     unsigned code;
 
-    transformed_path_t tpath(path, trans);
-    nan_removed_t nan_removed(tpath, true, path.has_codes());
+    auto tpath = agg::conv_transform{path, trans};
+    auto nan_removed = PathNanRemover{tpath, true, path.has_codes()};
 
     nan_removed.rewind(0);
 
@@ -481,17 +467,13 @@ bool path_in_path(PathIterator1 &a,
                   PathIterator2 &b,
                   agg::trans_affine &btrans)
 {
-    typedef agg::conv_transform<PathIterator2> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> no_nans_t;
-    typedef agg::conv_curve<no_nans_t> curve_t;
-
     if (a.total_vertices() < 3) {
         return false;
     }
 
-    transformed_path_t b_path_trans(b, btrans);
-    no_nans_t b_no_nans(b_path_trans, true, b.has_codes());
-    curve_t b_curved(b_no_nans);
+    auto b_path_trans = agg::conv_transform{b, btrans};
+    auto b_no_nans = PathNanRemover{b_path_trans, true, b.has_codes()};
+    auto b_curved = agg::conv_curve{b_no_nans};
 
     double x, y;
     b_curved.rewind(0);
@@ -655,8 +637,7 @@ clip_path_to_rect(PathIterator &path, agg::rect_d &rect, bool inside, std::vecto
         std::swap(ymin, ymax);
     }
 
-    typedef agg::conv_curve<PathIterator> curve_t;
-    curve_t curve(path);
+    auto curve = agg::conv_curve{path};
 
     Polygon polygon1, polygon2;
     double x = 0, y = 0;
@@ -849,18 +830,15 @@ inline bool segments_intersect(const double &x1,
 template <class PathIterator1, class PathIterator2>
 bool path_intersects_path(PathIterator1 &p1, PathIterator2 &p2)
 {
-    typedef PathNanRemover<mpl::PathIterator> no_nans_t;
-    typedef agg::conv_curve<no_nans_t> curve_t;
-
     if (p1.total_vertices() < 2 || p2.total_vertices() < 2) {
         return false;
     }
 
-    no_nans_t n1(p1, true, p1.has_codes());
-    no_nans_t n2(p2, true, p2.has_codes());
+    auto n1 = PathNanRemover{p1, true, p1.has_codes()},
+         n2 = PathNanRemover{p2, true, p2.has_codes()};
 
-    curve_t c1(n1);
-    curve_t c2(n2);
+    auto c1 = agg::conv_curve{n1},
+         c2 = agg::conv_curve{n2};
 
     double x11, y11, x12, y12;
     double x21, y21, x22, y22;
@@ -913,15 +891,12 @@ bool path_intersects_rectangle(PathIterator &path,
                                double rect_x2, double rect_y2,
                                bool filled)
 {
-    typedef PathNanRemover<mpl::PathIterator> no_nans_t;
-    typedef agg::conv_curve<no_nans_t> curve_t;
-
     if (path.total_vertices() == 0) {
         return false;
     }
 
-    no_nans_t no_nans(path, true, path.has_codes());
-    curve_t curve(no_nans);
+    auto no_nans = PathNanRemover{path, true, path.has_codes()};
+    auto curve = agg::conv_curve{no_nans};
 
     double cx = (rect_x1 + rect_x2) * 0.5, cy = (rect_y1 + rect_y2) * 0.5;
     double w = fabs(rect_x1 - rect_x2), h = fabs(rect_y1 - rect_y2);
@@ -959,20 +934,14 @@ void convert_path_to_polygons(PathIterator &path,
                               int closed_only,
                               std::vector<Polygon> &result)
 {
-    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removal_t;
-    typedef PathClipper<nan_removal_t> clipped_t;
-    typedef PathSimplifier<clipped_t> simplify_t;
-    typedef agg::conv_curve<simplify_t> curve_t;
-
     bool do_clip = width != 0.0 && height != 0.0;
     bool simplify = path.should_simplify();
 
-    transformed_path_t tpath(path, trans);
-    nan_removal_t nan_removed(tpath, true, path.has_codes());
-    clipped_t clipped(nan_removed, do_clip, width, height);
-    simplify_t simplified(clipped, simplify, path.simplify_threshold());
-    curve_t curve(simplified);
+    auto tpath = agg::conv_transform{path, trans};
+    auto nan_removed = PathNanRemover{tpath, true, path.has_codes()};
+    auto clipped = PathClipper(nan_removed, do_clip, width, height);
+    auto simplified = PathSimplifier{clipped, simplify, path.simplify_threshold()};
+    auto curve = agg::conv_curve{simplified};
 
     Polygon *polygon = &result.emplace_back();
     double x, y;
@@ -1022,19 +991,12 @@ void cleanup_path(PathIterator &path,
                   std::vector<double> &vertices,
                   std::vector<unsigned char> &codes)
 {
-    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removal_t;
-    typedef PathClipper<nan_removal_t> clipped_t;
-    typedef PathSnapper<clipped_t> snapped_t;
-    typedef PathSimplifier<snapped_t> simplify_t;
-    typedef agg::conv_curve<simplify_t> curve_t;
-    typedef Sketch<curve_t> sketch_t;
-
-    transformed_path_t tpath(path, trans);
-    nan_removal_t nan_removed(tpath, remove_nans, path.has_codes());
-    clipped_t clipped(nan_removed, do_clip, rect);
-    snapped_t snapped(clipped, snap_mode, path.total_vertices(), stroke_width);
-    simplify_t simplified(snapped, do_simplify, path.simplify_threshold());
+    auto tpath = agg::conv_transform{path, trans};
+    auto nan_removed = PathNanRemover{tpath, remove_nans, path.has_codes()};
+    auto clipped = PathClipper{nan_removed, do_clip, rect};
+    auto snapped = PathSnapper{
+        clipped, snap_mode, path.total_vertices(), stroke_width};
+    auto simplified = PathSimplifier{snapped, do_simplify, path.simplify_threshold()};
 
     vertices.reserve(path.total_vertices() * 2);
     codes.reserve(path.total_vertices());
@@ -1042,8 +1004,9 @@ void cleanup_path(PathIterator &path,
     if (return_curves && sketch_params.scale == 0.0) {
         __cleanup_path(simplified, vertices, codes);
     } else {
-        curve_t curve(simplified);
-        sketch_t sketch(curve, sketch_params.scale, sketch_params.length, sketch_params.randomness);
+        auto curve = agg::conv_curve{simplified};
+        auto sketch = Sketch{
+            curve, sketch_params.scale, sketch_params.length, sketch_params.randomness};
         __cleanup_path(sketch, vertices, codes);
     }
 }
@@ -1178,22 +1141,14 @@ bool convert_to_string(PathIterator &path,
                        bool postfix,
                        std::string& buffer)
 {
-    size_t buffersize;
-    typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
-    typedef PathNanRemover<transformed_path_t> nan_removal_t;
-    typedef PathClipper<nan_removal_t> clipped_t;
-    typedef PathSimplifier<clipped_t> simplify_t;
-    typedef agg::conv_curve<simplify_t> curve_t;
-    typedef Sketch<curve_t> sketch_t;
-
     bool do_clip = (clip_rect.x1 < clip_rect.x2 && clip_rect.y1 < clip_rect.y2);
 
-    transformed_path_t tpath(path, trans);
-    nan_removal_t nan_removed(tpath, true, path.has_codes());
-    clipped_t clipped(nan_removed, do_clip, clip_rect);
-    simplify_t simplified(clipped, simplify, path.simplify_threshold());
+    auto tpath = agg::conv_transform{path, trans};
+    auto nan_removed = PathNanRemover{tpath, true, path.has_codes()};
+    auto clipped = PathClipper{nan_removed, do_clip, clip_rect};
+    auto simplified = PathSimplifier{clipped, simplify, path.simplify_threshold()};
 
-    buffersize = (size_t) path.total_vertices() * (precision + 5) * 4;
+    size_t buffersize = (size_t) path.total_vertices() * (precision + 5) * 4;
     if (buffersize == 0) {
         return true;
     }
@@ -1207,8 +1162,9 @@ bool convert_to_string(PathIterator &path,
     if (sketch_params.scale == 0.0) {
         return __convert_to_string(simplified, precision, codes, postfix, buffer);
     } else {
-        curve_t curve(simplified);
-        sketch_t sketch(curve, sketch_params.scale, sketch_params.length, sketch_params.randomness);
+        auto curve = agg::conv_curve{simplified};
+        auto sketch = Sketch{
+            curve, sketch_params.scale, sketch_params.length, sketch_params.randomness};
         return __convert_to_string(sketch, precision, codes, postfix, buffer);
     }
 


### PR DESCRIPTION
Many parts of the Agg & path processing pipeline work by constructing nested templated objects that represent steps of the processing pipeline, e.g. (simplified example)
```
agg::conv_transform<mpl::PathIterator>  // The processing step.
    tpath  // The name of the result.
        (path, trans);  // The arguments passed to the processing step.
PathNanRemover<agg::conv_transform<mpl::PathIterator>>
    nan_removed
        (tpath, true, path.has_codes());
```
The current implementation makes the code shorter by introducing alias typenames for the types at each intermediate step.

As of C++17, this can be made simpler and shorter because class template argument deduction ("CTAD") allows not specifying the template arguments (in angle brackets) anymore, i.e. one can write
```
agg::conv_transform tpath(path, trans);
PathNanRemover nan_removed(tpath, true, path.has_codes());
```
and the compiler will auto-fill in the required types.

Furthermore, because these steps can be seen as a pipeline (even though they are implemented as the construction of nested objects), it may feel more natural to write them as repeated "function" (constructor) application, i.e.
```
auto tpath = agg::conv_transform{path, trans};
auto nan_removed = PathNanRemover{tpath, true, path.has_codes()};
```

Perform this transformation whereever applicable.

(Noted while looking at the implementation for https://github.com/matplotlib/matplotlib/issues/29711#issuecomment-2729139906...)

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
