### PR TITLE
ci: Introduce ubuntu-24.04 to restore GTK test coverage with recent PyGObject versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,12 @@ jobs:
             pyqt6-ver: '!=6.6.0'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
+          - os: ubuntu-24.04
+            python-version: '3.12'
+            # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
+            pyqt6-ver: '!=6.6.0'
+            # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
+            pyside6-ver: '!=6.5.1'
           - os: macos-13  # This runner is on Intel chips.
             # merge numpy and pandas install in nighties test when this runner is dropped
             python-version: '3.10'
@@ -136,7 +142,6 @@ jobs:
               libcairo2-dev \
               libffi-dev \
               libgeos-dev \
-              libgirepository1.0-dev \
               libnotify4 \
               libsdl2-2.0-0 \
               libxkbcommon-x11-0 \
@@ -161,7 +166,14 @@ jobs:
             if [[ "${{ matrix.name-suffix }}" != '(Minimum Versions)' ]]; then
               sudo apt-get install -yy --no-install-recommends ffmpeg poppler-utils
             fi
-            sudo apt-get install -yy --no-install-recommends gir1.2-gtk-4.0
+            if [[ "${{ matrix.os }}" = ubuntu-22.04 || "${{ matrix.os }}" = ubuntu-22.04-arm ]]; then
+              sudo apt-get install -yy --no-install-recommends \
+                gir1.2-gtk-4.0 \
+                libgirepository1.0-dev
+            else  # ubuntu-24.04
+              sudo apt-get install -yy --no-install-recommends \
+                libgirepository-2.0-dev
+            fi
             ;;
           macOS)
             brew update
@@ -384,11 +396,17 @@ jobs:
         if: ${{ !cancelled() && github.event_name != 'schedule' }}
         run: |
           if [[ "${{ runner.os }}" != 'macOS' ]]; then
-            lcov --rc lcov_branch_coverage=1 --capture --directory . \
-              --output-file coverage.info
-            lcov --rc lcov_branch_coverage=1 --output-file coverage.info \
-              --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
-            lcov --rc lcov_branch_coverage=1 --list coverage.info
+            LCOV_IGNORE_ERRORS=','  # do not ignore any lcov errors by default
+            if [[ "${{ matrix.os }}" = ubuntu-24.04 ]]; then
+              # filter mismatch and unused-entity errors detected by lcov 2.x
+              LCOV_IGNORE_ERRORS='mismatch,unused'
+            fi
+            lcov --rc lcov_branch_coverage=1 --ignore-errors $LCOV_IGNORE_ERRORS \
+              --capture --directory . --output-file coverage.info
+            lcov --rc lcov_branch_coverage=1 --ignore-errors $LCOV_IGNORE_ERRORS \
+              --output-file coverage.info --extract coverage.info $PWD/src/'*' $PWD/lib/'*'
+            lcov --rc lcov_branch_coverage=1 --ignore-errors $LCOV_IGNORE_ERRORS \
+              --list coverage.info
             find . -name '*.gc*' -delete
           else
             xcrun llvm-profdata merge -sparse default.*.profraw \


### PR DESCRIPTION
## PR summary

- Why is this change necessary?

GitHub Actions continuous integration unit test coverage is reduced on Linux due to an unsatisfied system dependency requested by recent versions of the Python `PyGObject` library.

In particular, `PyGObject` version 3.52.0 introduces a requirement for `girepository-2.0`: https://gitlab.gnome.org/GNOME/pygobject/-/blob/e3dee9719e7249acfa7e78a3bbae251301a134a4/NEWS#L9-10

The relevant system package to fulfil the requirement is not available on Ubuntu 22.04, and seems unlikely to become available on that platform.  This causes some Linux GTK UI tests in the CI here to be skipped.

- What problem does it solve?

Test coverage can be improved by including an Ubuntu 24.04 test job using a host that provides the `girepository-2.0` dependency.

- What is the reasoning for this implementation?

This is intended to be a minimal approach, adding a single job to the existing `tests.yml` workflow definitions.

A compatible possibility would be to place an upper-bound on the version of `PyGObject` installed during jobs on previous versions of Ubuntu.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

Resolves #29749