### PR TITLE
MNT: Move test for old ipython behavior to minver tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -59,12 +59,7 @@ jobs:
             pyside6-ver: '==6.2.0'
           - os: ubuntu-20.04
             python-version: '3.10'
-            # One CI run tests ipython/matplotlib-inline before backend mapping moved to mpl
-            extra-requirements:
-              -r requirements/testing/extra.txt
-              "ipython==7.29.0"
-              "ipykernel==5.5.6"
-              "matplotlib-inline<0.1.7"
+            extra-requirements: '-r requirements/testing/extra.txt'
             CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
             # https://github.com/matplotlib/matplotlib/pull/26052#issuecomment-1574595954
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html

--- a/requirements/testing/minver.txt
+++ b/requirements/testing/minver.txt
@@ -13,3 +13,11 @@ pillow==9.0.1
 pyparsing==2.3.1
 pytest==7.0.0
 python-dateutil==2.7
+
+# Test ipython/matplotlib-inline before backend mapping moved to mpl.
+# This should be tested for a reasonably long transition period,
+# but we will eventually remove the test when we no longer support
+# ipython/matplotlib-inline versions from before the transition.
+ipython==7.29.0
+ipykernel==5.5.6
+matplotlib-inline<0.1.7


### PR DESCRIPTION
While not exactly a minver test, it's semantically related in that it changes rather old package versions. This should help declutter the test matrix and make the upcoming transition to newer ubuntu images and dropping python 3.10 simpler (related #29766).
