### PR TITLE
Fix log scaling for pcolor and pcolormesh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6481,8 +6481,7 @@ class Axes(_AxesBase):
         maxx, maxy = np.max(coords, axis=0)
         collection.sticky_edges.x[:] = [minx, maxx]
         collection.sticky_edges.y[:] = [miny, maxy]
-        corners = (minx, miny), (maxx, maxy)
-        self.update_datalim(corners)
+        self.update_datalim(coords)
         self._request_autoscale_view()
         return collection
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6231,6 +6231,8 @@ class Axes(_AxesBase):
         collection._check_exclusionary_keywords(colorizer, vmin=vmin, vmax=vmax)
         collection._scale_norm(norm, vmin, vmax)
 
+        coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
+
         # Transform from native to data coordinates?
         t = collection._transform
         if (not isinstance(t, mtransforms.Transform) and
@@ -6239,20 +6241,15 @@ class Axes(_AxesBase):
 
         if t and any(t.contains_branch_seperately(self.transData)):
             trans_to_data = t - self.transData
-            pts = np.vstack([x, y]).T.astype(float)
-            transformed_pts = trans_to_data.transform(pts)
-            x = transformed_pts[..., 0]
-            y = transformed_pts[..., 1]
+            coords = trans_to_data.transform(coords)
 
         self.add_collection(collection, autolim=False)
 
-        minx = np.min(x)
-        maxx = np.max(x)
-        miny = np.min(y)
-        maxy = np.max(y)
+        minx, miny = np.min(coords, axis=0)
+        maxx, maxy = np.max(coords, axis=0)
         collection.sticky_edges.x[:] = [minx, maxx]
         collection.sticky_edges.y[:] = [miny, maxy]
-        self.update_datalim(coords.reshape(-1, 2))
+        self.update_datalim(coords)
         self._request_autoscale_view()
         return collection
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6252,8 +6252,7 @@ class Axes(_AxesBase):
         maxy = np.max(y)
         collection.sticky_edges.x[:] = [minx, maxx]
         collection.sticky_edges.y[:] = [miny, maxy]
-        corners = (minx, miny), (maxx, maxy)
-        self.update_datalim(corners)
+        self.update_datalim(coords.reshape(-1, 2))
         self._request_autoscale_view()
         return collection
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6232,25 +6232,7 @@ class Axes(_AxesBase):
         collection._scale_norm(norm, vmin, vmax)
 
         coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
-
-        # Transform from native to data coordinates?
-        t = collection._transform
-        if (not isinstance(t, mtransforms.Transform) and
-                hasattr(t, '_as_mpl_transform')):
-            t = t._as_mpl_transform(self.axes)
-
-        if t and any(t.contains_branch_seperately(self.transData)):
-            trans_to_data = t - self.transData
-            coords = trans_to_data.transform(coords)
-
-        self.add_collection(collection, autolim=False)
-
-        minx, miny = np.min(coords, axis=0)
-        maxx, maxy = np.max(coords, axis=0)
-        collection.sticky_edges.x[:] = [minx, maxx]
-        collection.sticky_edges.y[:] = [miny, maxy]
-        self.update_datalim(coords)
-        self._request_autoscale_view()
+        self._update_pocolor_lims(collection, coords)
         return collection
 
     @_preprocess_data()
@@ -6460,7 +6442,13 @@ class Axes(_AxesBase):
         collection._scale_norm(norm, vmin, vmax)
 
         coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
+        self._update_pocolor_lims(collection, coords)
+        return collection
 
+    def _update_pocolor_lims(self, collection, coords):
+        """
+        Common code for updating lims in pcolor() and pcolormesh() methods.
+        """
         # Transform from native to data coordinates?
         t = collection._transform
         if (not isinstance(t, mtransforms.Transform) and
@@ -6479,7 +6467,7 @@ class Axes(_AxesBase):
         collection.sticky_edges.y[:] = [miny, maxy]
         self.update_datalim(coords)
         self._request_autoscale_view()
-        return collection
+
 
     @_preprocess_data()
     @_docstring.interpd

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6232,7 +6232,7 @@ class Axes(_AxesBase):
         collection._scale_norm(norm, vmin, vmax)
 
         coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
-        self._update_pocolor_lims(collection, coords)
+        self._update_pcolor_lims(collection, coords)
         return collection
 
     @_preprocess_data()
@@ -6442,10 +6442,10 @@ class Axes(_AxesBase):
         collection._scale_norm(norm, vmin, vmax)
 
         coords = coords.reshape(-1, 2)  # flatten the grid structure; keep x, y
-        self._update_pocolor_lims(collection, coords)
+        self._update_pcolor_lims(collection, coords)
         return collection
 
-    def _update_pocolor_lims(self, collection, coords):
+    def _update_pcolor_lims(self, collection, coords):
         """
         Common code for updating lims in pcolor() and pcolormesh() methods.
         """

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6468,7 +6468,6 @@ class Axes(_AxesBase):
         self.update_datalim(coords)
         self._request_autoscale_view()
 
-
     @_preprocess_data()
     @_docstring.interpd
     def pcolorfast(self, *args, alpha=None, norm=None, cmap=None, vmin=None,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1571,6 +1571,25 @@ def test_pcolor_datetime_axis():
             label.set_rotation(30)
 
 
+@check_figures_equal(extensions=["png"])
+def test_pcolor_log_scale(fig_test, fig_ref):
+    """
+    Check that setting a log scale sets good default axis limits
+    when using pcolor.
+    """
+    x = np.linspace(0, 1, 11)
+    y = np.linspace(1, 2, 5)
+    X, Y = np.meshgrid(x, y)
+    C = X[:-1, :-1] + Y[:-1, :-1]
+
+    ax = fig_test.subplots()
+    ax.pcolor(X, Y, C)
+    ax.set_xscale('log')
+
+    ax = fig_ref.subplots()
+    ax.pcolor(X, Y, C)
+    ax.set_xlim(1e-1, 1e0)
+    ax.set_xscale('log')
 
 
 def test_pcolorargs():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1497,6 +1497,27 @@ def test_pcolormesh_nearest_noargs(fig_test, fig_ref):
     ax.pcolormesh(x, y, C, shading="nearest")
 
 
+@check_figures_equal(extensions=["png"])
+def test_pcolormesh_log_scale(fig_test, fig_ref):
+    """
+    Check that setting a log scale sets good default axis limits
+    when using pcolormesh.
+    """
+    x = np.linspace(0, 1, 11)
+    y = np.linspace(1, 2, 5)
+    X, Y = np.meshgrid(x, y)
+    C = X + Y
+
+    ax = fig_test.subplots()
+    ax.pcolormesh(X, Y, C)
+    ax.set_xscale('log')
+
+    ax = fig_ref.subplots()
+    ax.pcolormesh(X, Y, C)
+    ax.set_xlim(1e-2, 1e1)
+    ax.set_xscale('log')
+
+
 @image_comparison(['pcolormesh_datetime_axis.png'], style='mpl20')
 def test_pcolormesh_datetime_axis():
     # Remove this line when this test image is regenerated.
@@ -1548,6 +1569,8 @@ def test_pcolor_datetime_axis():
         for label in ax.get_xticklabels():
             label.set_ha('right')
             label.set_rotation(30)
+
+
 
 
 def test_pcolorargs():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Fixes https://github.com/matplotlib/matplotlib/issues/29615. Instead of explicitly setting the data lims with the min/max values of the edges, pass all the values to allow `update_datalim` to handle them appropriately. I also took the oppurtunity to de-duplicate the limit setting code in `pcolor()` and `pcolormesh()`, since I needed to update them to match anyway.

The tests are both very similar, but I couldn't think of a good way to de-duplicate testing `pcolor` and `pcolormesh` - suggestions very welcome.

In terms of performance, running the below script locally I see ~10% slowdown with pcolormesh, and no significant slowdown with pcolor.

```python
import numpy as np
import matplotlib.pyplot as plt
import time

x = np.arange(512, dtype=float)
y = np.arange(512, dtype=float)
z = np.arange(len(x) * len(y)).reshape(len(x), len(y))

ts = []
t = time.time()
for i in range(25):
    fig, ax = plt.subplots()

    # ax.pcolor(x, y, z)
    ax.pcolormesh(x, y, z)
    ax.set_yscale("log")

    fig.canvas.draw()
    dt = time.time() - t

    if i > 0:
        # Allow one warmup loop
        ts.append(dt)
        print(f"t = {dt} s")
    plt.close("all")
    t = time.time()

print(f"Mean:  {np.mean(ts)}")
print(f"Stdev: {np.std(ts)}")
```

### pcolormesh
Before:
Mean:  0.08725245793660481
Stdev: 0.005315622438177594

After:
Mean:  0.09809311230977376
Stdev: 0.006966432274025711

### pcolor
Before:
Mean:  1.8416528701782227
Stdev: 0.020062453166251135

After:
Mean:  1.8436991373697917
Stdev: 0.021314677717322438

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
