### PR TITLE
Improve layout of cheatsheets in sidebar

### DIFF
--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -208,3 +208,15 @@ div.wide-table table th.stub {
 .section-toc.toctree-wrapper .toctree-l1>ul{
     padding-left: 0;
 }
+
+.sidebar-cheatsheets {
+    margin-bottom: 3em;
+}
+
+.sidebar-cheatsheets > h3 {
+    margin-top: 0;
+}
+
+.sidebar-cheatsheets > img {
+    width: 100%;
+}

--- a/doc/_templates/cheatsheet_sidebar.html
+++ b/doc/_templates/cheatsheet_sidebar.html
@@ -1,6 +1,6 @@
 
 <div class="sidebar-cheatsheets">
-  <h3>Matplotlib cheatsheets</h3>
+  <h3>Cheatsheets</h3>
   <a href="https://matplotlib.org/cheatsheets/">
     <img src="_static/mpl_cheatsheet1.png"
          alt="Matplotlib cheatsheets"


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This improves the layout of the cheatsheets so:

- The image takes up the full width of the sidebar
- The heading is aligned with the top of the RH sidebar
- The title drops "Matplotlib" (there are already many 'Matplotlib' strings on the home page 😄) and is now just "Cheatsheets"

Note this depends on https://github.com/matplotlib/mpl-sphinx-theme/pull/97 to remove existing CSS for styling the cheatsheets that was in the theme.

For a before/after comparison, see the companion PR at https://github.com/matplotlib/mpl-sphinx-theme/pull/97

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
