### PR TITLE
ci: rotate soon-to-be-unsupported GitHub Actions ubuntu-20.04 runner out of roster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,26 +48,17 @@ jobs:
       matrix:
         include:
           - name-suffix: "(Minimum Versions)"
-            os: ubuntu-20.04
-            python-version: '3.10'
+            os: ubuntu-22.04
+            python-version: '3.11'
             extra-requirements: '-c requirements/testing/minver.txt'
             delete-font-cache: true
-            # Oldest versions with Py3.10 wheels.
-            pyqt5-ver: '==5.15.5 sip==6.3.0'
-            pyqt6-ver: '==6.2.0 PyQt6-Qt6==6.2.0'
-            pyside2-ver: '==5.15.2.1'
-            pyside6-ver: '==6.2.0'
-          - os: ubuntu-20.04
-            python-version: '3.10'
-            extra-requirements: '-r requirements/testing/extra.txt'
-            CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
-            # https://github.com/matplotlib/matplotlib/pull/26052#issuecomment-1574595954
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
-            pyqt6-ver: '!=6.5.1,!=6.6.0,!=6.7.1'
+            pyqt6-ver: '!=6.6.0'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
             pyside6-ver: '!=6.5.1'
           - os: ubuntu-22.04
             python-version: '3.11'
+            CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
             pyqt6-ver: '!=6.6.0'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
@@ -178,11 +169,7 @@ jobs:
             if [[ "${{ matrix.name-suffix }}" != '(Minimum Versions)' ]]; then
               sudo apt-get install -yy --no-install-recommends ffmpeg poppler-utils
             fi
-            if [[ "${{ matrix.os }}" = ubuntu-20.04 ]]; then
-              sudo apt-get install -yy --no-install-recommends libopengl0
-            else  # ubuntu-22.04
-              sudo apt-get install -yy --no-install-recommends gir1.2-gtk-4.0
-            fi
+            sudo apt-get install -yy --no-install-recommends gir1.2-gtk-4.0
             ;;
           macOS)
             brew update


### PR DESCRIPTION
## PR summary

- Why is this change necessary?

GitHub Actions will soon remove support for the Ubuntu 20.04 runner, as described at: https://github.com/actions/runner-images/issues/11101

- What problem does it solve?

This pull request raises the baseline runner image from Ubuntu 20.04 to Ubuntu 22.04, allowing GitHub Actions checks to continue after the removal of the former runner image.

- What is the reasoning for this implementation?

Ubuntu 20.04 is only used in the `tests.yml` workflows, for jobs where Ubuntu 22.04 is already in parallel use.  As a result, the approach taken here is to rotate Ubuntu 20.04 out of the roster, and to replace the entry that previously used it with Ubuntu 22.04 instead.

In addition, the fact that we no longer use Ubuntu 20.04 at all during GHA CI means that we can remove two previously-added Python package version pins:

 - a99ffa9f557ec224550af393b5c95fa2e5fc0a56
 - 89fb6d4f339b2c347d0da31ce5519e1e21b7590e

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

Resolves #29766.