### PR TITLE
Ensure polar plot radial lower limit remains at 0 after set_rticks + plot

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3056,6 +3056,10 @@ class _AxesBase(martist.Artist):
 
             if not self._tight:
                 x0, x1 = locator.view_limits(x0, x1)
+
+            # Enforce lower radial limit of 0 for polar plots
+            if name == 'y' and self.name == 'polar':
+                x0 = 0
             set_bound(x0, x1)
             # End of definition of internal function 'handle_single_axis'.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3056,10 +3056,6 @@ class _AxesBase(martist.Artist):
 
             if not self._tight:
                 x0, x1 = locator.view_limits(x0, x1)
-
-            # Enforce lower radial limit of 0 for polar plots
-            if name == 'y' and self.name == 'polar':
-                x0 = 0
             set_bound(x0, x1)
             # End of definition of internal function 'handle_single_axis'.
 

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1292,9 +1292,10 @@ class PolarAxes(Axes):
         return Axes.set_yscale(self, *args, **kwargs)
 
     def set_rticks(self, *args, **kwargs):
-        Axes.set_yticks(self, *args, **kwargs)
+        result = Axes.set_yticks(self, *args, **kwargs)
         self.yaxis.set_major_locator(
             self.RadialLocator(self.yaxis.get_major_locator(), self))
+        return result
 
     def set_thetagrids(self, angles, labels=None, fmt=None, **kwargs):
         """

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -1292,7 +1292,9 @@ class PolarAxes(Axes):
         return Axes.set_yscale(self, *args, **kwargs)
 
     def set_rticks(self, *args, **kwargs):
-        return Axes.set_yticks(self, *args, **kwargs)
+        Axes.set_yticks(self, *args, **kwargs)
+        self.yaxis.set_major_locator(
+            self.RadialLocator(self.yaxis.get_major_locator(), self))
 
     def set_thetagrids(self, angles, labels=None, fmt=None, **kwargs):
         """

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -506,3 +506,11 @@ def test_polar_errorbar(order):
         ax.errorbar(theta, r, xerr=0.1, yerr=0.1, capsize=7, fmt="o", c="seagreen")
         ax.set_theta_zero_location("N")
         ax.set_theta_direction(-1)
+
+
+def test_radial_limit_after_plot():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='polar')
+    ax.set_rticks([1, 2, 3, 4])
+    ax.plot([0, 1], [2, 3])
+    assert ax.get_ylim()[0] == (0)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -509,9 +509,20 @@ def test_polar_errorbar(order):
 
 
 def test_radial_limits_behavior():
+    # r=0 is kept as limit if positive data and ticks are used
+    # negative ticks or data result in negativ limits
     fig = plt.figure()
     ax = fig.add_subplot(projection='polar')
+    assert ax.get_ylim() == (0, 1)
+    # upper limit is expanded to include the ticks, but lower limit stays at 0
     ax.set_rticks([1, 2, 3, 4])
-    assert ax.get_ylim()[0] == 0
-    ax.plot([0, 1], [2, 3])
-    assert ax.get_ylim()[0] == 0
+    assert ax.get_ylim() == (0, 4)
+    # upper limit is autoscaled to data, but lower limit limit stays 0
+    ax.plot([1, 2], [1, 2])
+    assert ax.get_ylim() == (0, 2.05)
+    # negative ticks also expand the negative limit
+    ax.set_rticks([-1, 0, 1, 2])
+    assert ax.get_ylim() == (-1, 2.05)
+    # negative data also autoscales to negative limits
+    ax.plot([1, 2], [-1, -2])
+    ax.get_ylim() == (-2.2, 2.2)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -512,6 +512,6 @@ def test_radial_limits_behavior():
     fig = plt.figure()
     ax = fig.add_subplot(projection='polar')
     ax.set_rticks([1, 2, 3, 4])
-    assert ax.get_ylim()[0] == (0)
+    assert ax.get_ylim()[0] == 0
     ax.plot([0, 1], [2, 3])
     assert ax.get_ylim()[0] == 0

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -510,7 +510,7 @@ def test_polar_errorbar(order):
 
 def test_radial_limits_behavior():
     # r=0 is kept as limit if positive data and ticks are used
-    # negative ticks or data result in negativ limits
+    # negative ticks or data result in negative limits
     fig = plt.figure()
     ax = fig.add_subplot(projection='polar')
     assert ax.get_ylim() == (0, 1)
@@ -519,10 +519,10 @@ def test_radial_limits_behavior():
     assert ax.get_ylim() == (0, 4)
     # upper limit is autoscaled to data, but lower limit limit stays 0
     ax.plot([1, 2], [1, 2])
-    assert ax.get_ylim() == (0, 2.05)
+    assert ax.get_ylim() == (0, 2)
     # negative ticks also expand the negative limit
     ax.set_rticks([-1, 0, 1, 2])
-    assert ax.get_ylim() == (-1, 2.05)
+    assert ax.get_ylim() == (-1, 2)
     # negative data also autoscales to negative limits
     ax.plot([1, 2], [-1, -2])
     ax.get_ylim() == (-2.2, 2.2)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -508,9 +508,10 @@ def test_polar_errorbar(order):
         ax.set_theta_direction(-1)
 
 
-def test_radial_limit_after_plot():
+def test_radial_limits_behavior():
     fig = plt.figure()
     ax = fig.add_subplot(projection='polar')
     ax.set_rticks([1, 2, 3, 4])
-    ax.plot([0, 1], [2, 3])
     assert ax.get_ylim()[0] == (0)
+    ax.plot([0, 1], [2, 3])
+    assert ax.get_ylim()[0] == 0

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -525,4 +525,4 @@ def test_radial_limits_behavior():
     assert ax.get_ylim() == (-1, 2)
     # negative data also autoscales to negative limits
     ax.plot([1, 2], [-1, -2])
-    ax.get_ylim() == (-2.2, 2.2)
+    assert ax.get_ylim() == (-2, 2)


### PR DESCRIPTION
**Update:** The final implementation differs from the original proposal. The solution now preserves the `RadialLocator` behavior that was being overwritten on `set_rticks` instead of modifying `handle_single_axis`. The test was renamed to `test_radial_limits_behavior`.


## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs: -->

- Why is this change necessary?
 When using `set_rticks` followed by `plot` in polar plots, the lower radial limit (which should
always be 0) was being overwritten by autoscaling logic. This caused visual artifacts and
incorrect axis behavior in polar plots.

- What problem does it solve?
This fix prevents the radial origin from moving away from 0 when setting radial ticks with
`set_rticks` and adding data with `plot`.

- What is the reasoning for this implementation?
  - Modified `handle_single_axis` in `autoscale_view` to explicitly enforce lower limit of 0 for polar plots
  - Added test `test_radial_limit_after_plot` to verify  limit stays at 0 after `set_rticks` + `plot`

Example:
```
fig = plt.figure()
ax = fig.add_subplot(projection='polar')
ax.set_rticks([1, 2, 3, 4])  # Would previously allow lower limit > 0
ax.plot([0, 1], [2, 3])      # Now maintains lower limit at 0

```

Closes #29528


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #29528" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/29528)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

