### PR TITLE
Fix #29780: caps of the error bars were unintentionally adopting the …color red, which was set globally in mpl.rcParams under the 'lines.markeredgecolor' parameter.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3723,7 +3723,7 @@ class Axes(_AxesBase):
                     'zorder', 'rasterized'):
             if key in kwargs:
                 eb_cap_style[key] = kwargs[key]
-        eb_cap_style['color'] = ecolor
+        eb_cap_style["markeredgecolor"] = ecolor
 
         barcols = []
         caplines = {'x': [], 'y': []}

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9685,3 +9685,40 @@ def test_bar_shape_mismatch():
     )
     with pytest.raises(ValueError, match=error_message):
         plt.bar(x, height)
+
+
+def test_caps_color():
+    """
+     Tests that the color of the caps is set correctly when 'ecolor' is provided.
+     """
+     # Creates a simple plot with error bars and a specified ecolor
+    x = np.linspace(0, 10, 10)
+    y = np.sin(x)
+    yerr = 0.1
+    mpl.rcParams['lines.markeredgecolor'] = 'green'
+    ecolor = 'red'
+
+    fig, ax = plt.subplots()
+    errorbars = ax.errorbar(x, y, yerr=yerr, ecolor=ecolor, fmt='o', capsize=5)
+
+    # Tests if the caps have the specified color
+    for cap in errorbars[2]:
+        assert mcolors.same_color(cap.get_edgecolor(), ecolor)
+
+
+def test_caps_no_ecolor():
+    """
+    Tests that the color of the caps is set to default (blue) when 'ecolor' is not provided.
+    """
+    # Creates a simple plot with error bars without specifying ecolor
+    x = np.linspace(0, 10, 10)
+    y = np.sin(x)
+    yerr = 0.1
+    mpl.rcParams['lines.markeredgecolor'] = 'green'
+
+    fig, ax = plt.subplots()
+    errorbars = ax.errorbar(x, y, yerr=yerr, fmt='o', capsize=5)
+
+    # Tesrts if the caps have the default color (blue)
+    for cap in errorbars[2]:
+        assert mcolors.same_color(cap.get_edgecolor(), "blue")


### PR DESCRIPTION

The root cause of the problem was that the marker edge color defined globally (mpl.rcParams['lines.markeredgecolor']) was being inherited by the caps as part of the error bar plot. This caused the color of the caps to match the global red color, even when only the error bars were supposed to be red (through the ecolor parameter). To solve this, we needed to ensure that the caps would use the specified ecolor independently of the global mpl.rcParams['lines.markeredgecolor']. This was achieved by setting the marker edge color for the caps separately, rather than relying on the global configuration.

