### PR TITLE
Tweak minimal checks for GUI binding installs.

### DIFF
--- a/galleries/users_explain/figure/backends.rst
+++ b/galleries/users_explain/figure/backends.rst
@@ -292,14 +292,12 @@ program that can be run to test basic functionality.  If this test fails, try re
 QtAgg, QtCairo, Qt5Agg, and Qt5Cairo
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Test ``PyQt5``.
-
-If you have ``PySide`` or ``PyQt6`` installed rather than ``PyQt5``, just change the import
-accordingly:
+Test ``PyQt6`` (if you have ``PyQt5``, ``PySide2`` or ``PySide6`` installed
+rather than ``PyQt6``, just change the import accordingly):
 
 .. code-block:: bash
 
-   python -c "from PyQt5.QtWidgets import *; app = QApplication([]); win = QMainWindow(); win.show(); app.exec()"
+   python3 -c "from PyQt6.QtWidgets import *; app = QApplication([]); win = QMainWindow(); win.show(); app.exec()"
 
 
 TkAgg and TkCairo
@@ -325,14 +323,9 @@ wxAgg and wxCairo
 
 Test ``wx``:
 
-.. code-block:: python3
+.. code-block:: bash
 
-   import wx
-
-   app = wx.App(False)  # Create a new app, don't redirect stdout/stderr to a window.
-   frame = wx.Frame(None, wx.ID_ANY, "Hello World") # A Frame is a top-level window.
-   frame.Show(True)     # Show the frame.
-   app.MainLoop()
+   python3 -c "import wx; app = wx.App(); frame = wx.Frame(None); frame.Show(); app.MainLoop()"
 
 If the test works for your desired backend but you still cannot get Matplotlib to display a figure, then contact us (see
 :ref:`get-help`).


### PR DESCRIPTION
Make the wx test a one-liner like other backends.  Use PyQt6 as default qt (matching the default in qt_compat).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
