### PR TITLE
Rework mapping of dvi glyph indices to freetype indices.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -30,7 +30,7 @@ import sys
 
 import numpy as np
 
-from matplotlib import _api, cbook
+from matplotlib import _api, cbook, font_manager
 
 _log = logging.getLogger(__name__)
 
@@ -578,7 +578,7 @@ class DviFont:
        Size of the font in Adobe points, converted from the slightly
        smaller TeX points.
     """
-    __slots__ = ('texname', 'size', '_scale', '_vf', '_tfm')
+    __slots__ = ('texname', 'size', '_scale', '_vf', '_tfm', '_encoding')
 
     def __init__(self, scale, tfm, texname, vf):
         _api.check_isinstance(bytes, texname=texname)
@@ -587,6 +587,7 @@ class DviFont:
         self.texname = texname
         self._vf = vf
         self.size = scale * (72.0 / (72.27 * 2**16))
+        self._encoding = None
 
     widths = _api.deprecated("3.11")(property(lambda self: [
         (1000 * self._tfm.width.get(char, 0)) >> 20
@@ -601,6 +602,35 @@ class DviFont:
 
     def __repr__(self):
         return f"<{type(self).__name__}: {self.texname}>"
+
+    # TODO: Make this public when {xe,lua}tex support is merged; simultaneously
+    # deprecate Text.glyph_name_or_index.
+    def _index_dvi_to_freetype(self, idx):
+        """Convert dvi glyph indices to FreeType ones."""
+        # Glyphs indices stored in the dvi file map to FreeType glyph indices
+        # (i.e., which can be passed to FT_Load_Glyph) in various ways:
+        # - if pdftex.map specifies an ".enc" file for the font, that file maps
+        #   dvi indices to Adobe glyph names, which can then be converted to
+        #   FreeType glyph indices with FT_Get_Name_Index.
+        # - if no ".enc" file is specified, then the font must be a Type 1
+        #   font, and dvi indices directly index into the font's CharStrings
+        #   vector.
+        # - (xetex & luatex, currently unsupported, can also declare "native
+        #   fonts", for which dvi indices are equal to FreeType indices.)
+        if self._encoding is None:
+            psfont = PsfontsMap(find_tex_file("pdftex.map"))[self.texname]
+            if psfont.filename is None:
+                raise ValueError("No usable font file found for {} ({}); "
+                                 "the font may lack a Type-1 version"
+                                 .format(psfont.psname.decode("ascii"),
+                                         psfont.texname.decode("ascii")))
+            face = font_manager.get_font(psfont.filename)
+            if psfont.encoding:
+                self._encoding = [face.get_name_index(name)
+                                  for name in _parse_enc(psfont.encoding)]
+            else:
+                self._encoding = face._get_type1_encoding_vector()
+        return self._encoding[idx]
 
     def _width_of(self, char):
         """Width of char in dvi units."""
@@ -1002,8 +1032,7 @@ def _parse_enc(path):
     Returns
     -------
     list
-        The nth entry of the list is the PostScript glyph name of the nth
-        glyph.
+        The nth list item is the PostScript glyph name of the nth glyph.
     """
     no_comments = re.sub("%.*", "", Path(path).read_text(encoding="ascii"))
     array = re.search(r"(?s)\[(.*)\]", no_comments).group(1)

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -238,17 +238,8 @@ class TextToPath:
             if char_id not in glyph_map:
                 font.clear()
                 font.set_size(self.FONT_SCALE, self.DPI)
-                glyph_name_or_index = text.glyph_name_or_index
-                if isinstance(glyph_name_or_index, str):
-                    index = font.get_name_index(glyph_name_or_index)
-                    font.load_glyph(index, flags=LoadFlags.TARGET_LIGHT)
-                elif isinstance(glyph_name_or_index, int):
-                    self._select_native_charmap(font)
-                    font.load_char(
-                        glyph_name_or_index, flags=LoadFlags.TARGET_LIGHT)
-                else:  # Should not occur.
-                    raise TypeError(f"Glyph spec of unexpected type: "
-                                    f"{glyph_name_or_index!r}")
+                idx = text.font._index_dvi_to_freetype(text.glyph)
+                font.load_glyph(idx, flags=LoadFlags.TARGET_LIGHT)
                 glyph_map_new[char_id] = font.get_path()
 
             glyph_ids.append(char_id)
@@ -268,23 +259,6 @@ class TextToPath:
 
         return (list(zip(glyph_ids, xpositions, ypositions, sizes)),
                 glyph_map_new, myrects)
-
-    @staticmethod
-    def _select_native_charmap(font):
-        # Select the native charmap. (we can't directly identify it but it's
-        # typically an Adobe charmap).
-        for charmap_code in [
-                1094992451,  # ADOBE_CUSTOM.
-                1094995778,  # ADOBE_STANDARD.
-        ]:
-            try:
-                font.select_charmap(charmap_code)
-            except (ValueError, RuntimeError):
-                pass
-            else:
-                break
-        else:
-            _log.warning("No supported encoding in font (%s).", font.fname)
 
 
 text_to_path = TextToPath()

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1431,6 +1431,32 @@ PyFT2Font_get_image(PyFT2Font *self)
     return py::array_t<unsigned char>(dims, im.get_buffer());
 }
 
+const char *PyFT2Font__get_type1_encoding_vector__doc__ = R"""(
+    Return a list mapping CharString indices of a Type 1 font to FreeType glyph indices.
+
+    Returns
+    -------
+    list[int]
+)""";
+
+static std::array<FT_UInt, 256>
+PyFT2Font__get_type1_encoding_vector(PyFT2Font *self)
+{
+    auto face = self->x->get_face();
+    auto indices = std::array<FT_UInt, 256>{};
+    for (auto i = 0; i < indices.size(); ++i) {
+        auto len = FT_Get_PS_Font_Value(face, PS_DICT_ENCODING_ENTRY, i, nullptr, 0);
+        if (len == -1) {
+            throw std::runtime_error{
+                "FT_Get_PS_Font_Value tried to access a non-existent value"};
+        }
+        auto buf = std::unique_ptr<char[]>{new char[len]};
+        FT_Get_PS_Font_Value(face, PS_DICT_ENCODING_ENTRY, i, buf.get(), len);
+        indices[i] = FT_Get_Name_Index(face, buf.get());
+    }
+    return indices;
+}
+
 static const char *
 PyFT2Font_postscript_name(PyFT2Font *self)
 {
@@ -1761,6 +1787,8 @@ PYBIND11_MODULE(ft2font, m, py::mod_gil_not_used())
              PyFT2Font_get_sfnt_table__doc__)
         .def("get_path", &PyFT2Font_get_path, PyFT2Font_get_path__doc__)
         .def("get_image", &PyFT2Font_get_image, PyFT2Font_get_image__doc__)
+        .def("_get_type1_encoding_vector", &PyFT2Font__get_type1_encoding_vector,
+             PyFT2Font__get_type1_encoding_vector__doc__)
 
         .def_property_readonly("postscript_name", &PyFT2Font_postscript_name,
                                "PostScript name of the font.")


### PR DESCRIPTION
In 89a7e19, an API for converting "dvi glyph indices" (as stored in a dvi file) to FreeType-compatible keys (either "indices into the native charmap" or "glyph names") was introduced.  It was intended that end users (i.e., backends) would check the type of `text.glyph_name_or_index` ((A) int or (B) str) and load the glyph accordingly ((A) `FT_Set_Charmap(native_cmap); FT_Load_Char(index);` or (B) `FT_Load_Glyph(FT_Get_Name_Index(name));`); however, with the future introduction of {xe,lua}tex support (#29807), this kind of type checking becomes inconvenient, because {xe,lua}tex's "dvi glyph indices", which are directly equal to FreeType glyph indices (i.e. they would be loaded with `FT_Load_Glyph(index);`), would normally also be converted to ints.

This PR introduces a new API (`_index_dvi_to_freetype`) to perform this mapping, always mapping to FreeType glyph indices (i.e. one can always just call `FT_Load_Glyph` on the result).  To do so, in case (A) it loads itself the native charmap (something the end user needed to do by themselves previously) and performs the cmap-to-index conversion (`FT_Get_Char_Index`) previously implicit in `FT_Load_Char`; in case (B) it performs itself the name-to-index conversion (`FT_Get_Name_Index`).  When {xe,lua}tex support is introduced in the future, `_index_dvi_to_freetype` will just return the index as is.  Note that this API is intentionally kept private for now (even though it is used by textpath) and the old APIs are not deprecated yet; I intend to wait until {xe,lua}tex support is actually merged to do so, to avoid possible future back-and-forth changes on the public APIs.

In case (A), this PR also improves on the detection of the native charmap, which was previously detected via heuristics (`_select_native_charmap`), but is now read by directly accessing the Type 1 font "encoding vector".

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
