### PR TITLE
TST: pin flake8

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -55,7 +55,7 @@ dependencies:
   # testing
   - black<24
   - coverage
-  - flake8>=3.8<7.2
+  - flake8>=3.8,<7.2
   - flake8-docstrings>=1.4.0
   - gtk4
   - ipykernel

--- a/environment.yml
+++ b/environment.yml
@@ -55,7 +55,7 @@ dependencies:
   # testing
   - black<24
   - coverage
-  - flake8>=3.8
+  - flake8>=3.8<7.2
   - flake8-docstrings>=1.4.0
   - gtk4
   - ipykernel

--- a/requirements/testing/flake8.txt
+++ b/requirements/testing/flake8.txt
@@ -1,6 +1,6 @@
 # Extra pip requirements for the GitHub Actions flake8 build
 
-flake8>=3.8<7.2
+flake8>=3.8,<7.2
 # versions less than 5.1.0 raise on some interp'd docstrings
 pydocstyle>=5.1.0
 # 1.4.0 adds docstring-convention=all

--- a/requirements/testing/flake8.txt
+++ b/requirements/testing/flake8.txt
@@ -1,6 +1,6 @@
 # Extra pip requirements for the GitHub Actions flake8 build
 
-flake8>=3.8
+flake8>=3.8<7.2
 # versions less than 5.1.0 raise on some interp'd docstrings
 pydocstyle>=5.1.0
 # 1.4.0 adds docstring-convention=all


### PR DESCRIPTION
Flake8 7.2.0 doesn't like 

https://github.com/matplotlib/matplotlib/blob/2933275ae2426c07fd00b7a3da3726515825c930/lib/matplotlib/_mathtext.py#L1612-L1624

But that code passed before.  Seems like maybe a bug on their end?  But I'm not familiar with `nonlocal` to be honest.  

This PR just pins flake8 to unbreak CI