### PR TITLE
Don't drag draggables on scroll events

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1486,7 +1486,15 @@ class DraggableBase:
     def __init__(self, ref_artist, use_blit=False):
         self.ref_artist = ref_artist
         if not ref_artist.pickable():
-            ref_artist.set_picker(True)
+            ref_artist.set_picker(
+                lambda artist, mouseevent: (
+                    (
+                        artist.contains(mouseevent) and
+                        mouseevent.name != "scroll_event"
+                    ),
+                    {}
+                )
+            )
         self.got_artist = False
         self._use_blit = use_blit and self.canvas.supports_blit
         callbacks = self.canvas.callbacks

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1486,15 +1486,7 @@ class DraggableBase:
     def __init__(self, ref_artist, use_blit=False):
         self.ref_artist = ref_artist
         if not ref_artist.pickable():
-            ref_artist.set_picker(
-                lambda artist, mouseevent: (
-                    (
-                        artist.contains(mouseevent) and
-                        mouseevent.name != "scroll_event"
-                    ),
-                    {}
-                )
-            )
+            ref_artist.set_picker(self._picker)
         self.got_artist = False
         self._use_blit = use_blit and self.canvas.supports_blit
         callbacks = self.canvas.callbacks
@@ -1507,6 +1499,10 @@ class DraggableBase:
                 ("motion_notify_event", self.on_motion),
             ]
         ]
+
+    @staticmethod
+    def _picker(artist, mouseevent):
+        return (artist.contains(mouseevent) and mouseevent.name != "scroll_event"), {}
 
     # A property, not an attribute, to maintain picklability.
     canvas = property(lambda self: self.ref_artist.get_figure(root=True).canvas)

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1502,6 +1502,7 @@ class DraggableBase:
 
     @staticmethod
     def _picker(artist, mouseevent):
+        # A custom picker to prevent dragging on mouse scroll events
         return (artist.contains(mouseevent) and mouseevent.name != "scroll_event"), {}
 
     # A property, not an attribute, to maintain picklability.


### PR DESCRIPTION
## PR summary
Fixes https://github.com/matplotlib/matplotlib/issues/29142; replaces https://github.com/matplotlib/matplotlib/pull/29270. The solution here is to set a custom picker on `DraggableBase` that doesn't fire if the event is a scroll event.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
