### PR TITLE
Fix loading of Type1 "native" charmap.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1132,7 +1132,6 @@ if __name__ == '__main__':
     import fontTools.agl
 
     from matplotlib.ft2font import FT2Font
-    from matplotlib.textpath import TextToPath
 
     parser = ArgumentParser()
     parser.add_argument("filename")
@@ -1155,14 +1154,13 @@ if __name__ == '__main__':
                 print(f"font: {font.texname.decode('latin-1')} "
                       f"(scale: {font._scale / 2 ** 20}) at {fontpath}")
                 face = FT2Font(fontpath)
-                TextToPath._select_native_charmap(face)
                 _print_fields("x", "y", "glyph", "chr", "w")
                 for text in group:
                     if psfont.encoding:
                         glyph_name = _parse_enc(psfont.encoding)[text.glyph]
                     else:
-                        glyph_name = face.get_glyph_name(
-                            face.get_char_index(text.glyph))
+                        encoding_vector = face._get_type1_encoding_vector()
+                        glyph_name = face.get_glyph_name(encoding_vector[text.glyph])
                     glyph_str = fontTools.agl.toUnicode(glyph_name)
                     _print_fields(text.x, text.y, text.glyph, glyph_str, text.width)
             if page.boxes:


### PR DESCRIPTION
Type1 fonts have a "native" charmap (mapping of indices to glyphs (\*)), which is simply the order in which glyphs are physically listed in the file (see section 2.2 of Type1 reference linked below); this charmap needed when decoding dvi files for usetex mode (as dvi represent glyphs with these indices).  Usually, this charmap is tagged as "ADOBE_STANDARD" or "ADOBE_CUSTOM", which is the heuristic we previously used to load it, but it is unclear to me whether this is guaranteed (reference section 10.3), and FreeType may supply its own reencodings (it already does so to try to provide a unicode charmap).  Instead, directly read and return the encoding vector via FreeType's Type1-specific API.  (The choice to return an mapping of Type1 indices to FreeType-internal indices, rather than Type1 indices to glyph names, is motivated by upcoming changes for {xe,lua}tex support, which also use FreeType-internal indices.)

Type1 reference:
https://adobe-type-tools.github.io/font-tech-notes/pdfs/T1_SPEC.pdf

(\*) Not all glyphs correspond to a unicode codepoint (e.g. a font can contain arbitrary ligatures that are not representable in unicode), which is (one of the reasons) why fonts provide their own indexing methods.

(This is tested by the same test as #12928.)

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
