### PR TITLE
ci: restrict 'pygobject-ver' for Ubuntu 22.04 jobs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,17 +52,27 @@ jobs:
             python-version: '3.11'
             extra-requirements: '-c requirements/testing/minver.txt'
             delete-font-cache: true
+            # https://github.com/matplotlib/matplotlib/issues/29844
+            pygobject-ver: '<3.52.0'
           - os: ubuntu-22.04
             python-version: '3.11'
             CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
             extra-requirements: '-r requirements/testing/extra.txt'
+            # https://github.com/matplotlib/matplotlib/issues/29844
+            pygobject-ver: '<3.52.0'
           - os: ubuntu-22.04-arm
             python-version: '3.12'
+            # https://github.com/matplotlib/matplotlib/issues/29844
+            pygobject-ver: '<3.52.0'
           - os: ubuntu-22.04
             python-version: '3.13'
+            # https://github.com/matplotlib/matplotlib/issues/29844
+            pygobject-ver: '<3.52.0'
           - name-suffix: "Free-threaded"
             os: ubuntu-22.04
             python-version: '3.13t'
+            # https://github.com/matplotlib/matplotlib/issues/29844
+            pygobject-ver: '<3.52.0'
           - os: ubuntu-24.04
             python-version: '3.12'
           - os: macos-13  # This runner is on Intel chips.


### PR DESCRIPTION
## PR summary
- Why is this change necessary?

Unit test coverage for GTK (both v3 and v3) in our GitHub Actions CI `tests.yml` workflow is largely skipped at the moment.

This is because recent versions of `PyGObject` -- as required for `import gi` to succeed -- are incompatible with the `girepository-1.0` system dependency that we install on our Ubuntu 22.04 runners.

Specifically, as noted in #29844, `PyGObject` v3.52 adds a requirement on `girepository-2.0`.

The goal here is to re-enable GTK-related test coverage.

- What problem does it solve?

To work around the problem, this pull request suggests pinning the upper-bound version of the `PyGObject` library that we install on the affected Ubuntu 22.04 runners.

- What is the reasoning for this implementation?

1. The `girepository-2.0` system dependency is unavailable on Ubuntu 22.04 (`jammy`) and may not become available on that OS version.

2. We have existing test coverage of `PyGObject` v3.52 on Ubuntu 24.04 [with `girepository-2.0`](https://github.com/matplotlib/matplotlib/blob/7d5d0278fb5296a368a1ef910e67a8fa9a1f2fb8/.github/workflows/tests.yml#L173-L176) - so my reasoning (also described [here](https://github.com/matplotlib/matplotlib/issues/29844#issuecomment-2768859641)) is that retaining coverage of `girepository-1.0` is worthwhile.

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is (will be, in this case) [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

Resolves #29844.

Edit: attempt to clarify the nature of the problem that is being solved by this.
Edit: plurality fixup
Edit: rephrase description again.
Edit: clarify that this may not be a temporary fix (`girepository-2.0` may not become available on Ubuntu 22.04).