### PR TITLE
MNT: Use Gcf.destroy(manager) instead of Gcf.destroy(manager.num)

### DIFF
--- a/lib/matplotlib/_pylab_helpers.py
+++ b/lib/matplotlib/_pylab_helpers.py
@@ -68,10 +68,10 @@ class Gcf:
     @classmethod
     def destroy_fig(cls, fig):
         """Destroy figure *fig*."""
-        num = next((manager.num for manager in cls.figs.values()
-                    if manager.canvas.figure == fig), None)
-        if num is not None:
-            cls.destroy(num)
+        manager = next((manager for manager in cls.figs.values()
+                       if manager.canvas.figure == fig), None)
+        if manager is not None:
+            cls.destroy(manager)
 
     @classmethod
     def destroy_all(cls):


### PR DESCRIPTION
Going through manager.num is unnecessary as destroy() only looks up the manager for the given number again.

As the docstring of destroy() explains:

> It is recommended to pass a manager instance, to avoid confusion when two managers share the same number.

https://github.com/matplotlib/matplotlib/blob/90385b4e26efc4b3a0c6c2497e97dac36fc94841/lib/matplotlib/_pylab_helpers.py#L45-L54

