### PR TITLE
feat(CI): add Codecov Test Analytics for flaky and failed tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,39 +52,30 @@ jobs:
             python-version: '3.11'
             extra-requirements: '-c requirements/testing/minver.txt'
             delete-font-cache: true
-            codecov-test-results-action-os: 'linux'
           - os: ubuntu-22.04
             python-version: '3.11'
             CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
             extra-requirements: '-r requirements/testing/extra.txt'
-            codecov-test-results-action-os: 'linux'
           - os: ubuntu-22.04-arm
             python-version: '3.12'
-            codecov-test-results-action-os: 'linux-arm64'
           - os: ubuntu-22.04
             python-version: '3.13'
-            codecov-test-results-action-os: 'linux'
           - name-suffix: "Free-threaded"
             os: ubuntu-22.04
             python-version: '3.13t'
-            codecov-test-results-action-os: 'linux'
           - os: ubuntu-24.04
             python-version: '3.12'
-            codecov-test-results-action-os: 'linux'
           - os: macos-13  # This runner is on Intel chips.
             # merge numpy and pandas install in nighties test when this runner is dropped
             python-version: '3.10'
-            codecov-test-results-action-os: 'macos'
           - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.12'
             # https://github.com/matplotlib/matplotlib/issues/29732
             pygobject-ver: '<3.52.0'
-            codecov-test-results-action-os: 'macos'
           - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.13'
             # https://github.com/matplotlib/matplotlib/issues/29732
             pygobject-ver: '<3.52.0'
-            codecov-test-results-action-os: 'macos'
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -400,7 +391,8 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          os: ${{ matrix.codecov-test-results-action-os }}
+          flags: ${{matrix.os}},${{matrix.python-version}}
+          os: ${{ matrix.os == 'ubuntu-22.04-arm' && 'linux-arm64' || '' }}
 
       - name: Upload code coverage
         if: ${{ !cancelled() && github.event_name != 'schedule' }}


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs: -->

Hi, Gio from Codecov here. I saw that you used Codecov already, and I thought you could benefit from catching any flaky or failed tests. We released a [Test Analytics](https://docs.codecov.com/docs/test-analytics) product that might be helpful and would love your feedback.

**Changes:**
* feat: add junitxml format to be ingested by the codecov test analytics action
* feat: add the codecov test analytics action to the CI pipeline

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
