### PR TITLE
FIX: make_image should not modify original array

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -439,6 +439,8 @@ class _ImageBase(mcolorizer.ColorizingArtist):
             if not (A.ndim == 2 or A.ndim == 3 and A.shape[-1] in (3, 4)):
                 raise ValueError(f"Invalid shape {A.shape} for image data")
 
+            float_rgba_in = A.ndim == 3 and A.shape[-1] == 4 and A.dtype.kind == 'f'
+
             # if antialiased, this needs to change as window sizes
             # change:
             interpolation_stage = self._interpolation_stage
@@ -520,6 +522,9 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                 # Resample in premultiplied alpha space.  (TODO: Consider
                 # implementing premultiplied-space resampling in
                 # span_image_resample_rgba_affine::generate?)
+                if float_rgba_in and np.ndim(alpha) == 0 and np.any(A[..., 3] < 1):
+                    # Do not modify original RGBA input
+                    A = A.copy()
                 A[..., :3] *= A[..., 3:]
                 res = _resample(self, A, out_shape, t)
                 np.divide(res[..., :3], res[..., 3:], out=res[..., :3],

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -281,6 +281,33 @@ def test_imshow_alpha(fig_test, fig_ref):
     ax3.imshow(rgbau)
 
 
+@pytest.mark.parametrize('n_channels, is_int, alpha_arr, opaque',
+                         [(3, False, False, False),  # RGB float
+                          (4, False, False, False),  # RGBA float
+                          (4, False, True, False),   # RGBA float with alpha array
+                          (4, False, False, True),   # RGBA float with solid color
+                          (4, True, False, False)])  # RGBA unint8
+def test_imshow_multi_draw(n_channels, is_int, alpha_arr, opaque):
+    if is_int:
+        array = np.random.randint(0, 256, (2, 2, n_channels))
+    else:
+        array = np.random.random((2, 2, n_channels))
+        if opaque:
+            array[:, :, 3] = 1
+
+    if alpha_arr:
+        alpha = np.array([[0.3, 0.5], [1, 0.8]])
+    else:
+        alpha = None
+
+    fig, ax = plt.subplots()
+    im = ax.imshow(array, alpha=alpha)
+    fig.draw_without_rendering()
+
+    # Draw should not modify original array
+    np.testing.assert_array_equal(array, im._A)
+
+
 def test_cursor_data():
     from matplotlib.backend_bases import MouseEvent
 


### PR DESCRIPTION


<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

Fixes #29891.  The problem is that we divide the RGB part of the array by its alpha on each draw.  The simple fix is to make a copy but I assume for efficiency we should only copy when necessary.
    
* If we didn't start with RGBA, we already made a copy
* If alpha was an array, we already made a copy
* If the alpha channel is one everywhere, it does not matter


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
