### PR TITLE
Change `.T` to `.transpose()` in `_reshape_2D`

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1387,7 +1387,7 @@ def _reshape_2D(X, name):
 
     # Iterate over columns for ndarrays.
     if isinstance(X, np.ndarray):
-        X = X.T
+        X = X.transpose()
 
         if len(X) == 0:
             return [[]]


### PR DESCRIPTION
Hi!

This PR introduces a small change to `lib/matplotlib/cbook.py`. To make `.T` [Array API compatible](https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.T.html) it must raise an exception for scalar arrays and arrays with `ndim != 2`.
In https://github.com/numpy/numpy/pull/28678 we first introduce a warning for that purpose.

matplotlib that is used in NumPy docs-check CI job causes a failure by raising multiple warnings from `plt.hist`. This backward-compatible change fixes it. `.transpose()` stays the same as it isn't covered in Array API. 