### PR TITLE
BUG: ensure that errorbar does not error on masked negative errors.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3756,8 +3756,7 @@ class Axes(_AxesBase):
                     f"'{dep_axis}err' must not contain None. "
                     "Use NaN if you want to skip a value.")
 
-            res = np.zeros(err.shape, dtype=bool)  # Default in case of nan
-            if np.any(np.less(err, -err, out=res, where=(err == err))):
+            if np.any((err < -err) & (err == err)):
                 # like err<0, but also works for timedelta and nan.
                 raise ValueError(
                     f"'{dep_axis}err' must not contain negative values")

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3756,8 +3756,12 @@ class Axes(_AxesBase):
                     f"'{dep_axis}err' must not contain None. "
                     "Use NaN if you want to skip a value.")
 
-            if np.any((err < -err) & (err == err)):
-                # like err<0, but also works for timedelta and nan.
+            # Raise if any errors are negative, but not if they are nan.
+            # To avoid nan comparisons (which lead to warnings on some
+            # platforms), we select with `err==err` (which is False for nan).
+            # Also, since datetime.timedelta cannot be compared with 0,
+            # we compare with the negative error instead.
+            if np.any((check := err[err == err]) < -check):
                 raise ValueError(
                     f"'{dep_axis}err' must not contain negative values")
             # This is like

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4538,6 +4538,19 @@ def test_errorbar_nan(fig_test, fig_ref):
     ax.errorbar([4], [3], [6], fmt="C0")
 
 
+@check_figures_equal()
+def test_errorbar_masked_negative(fig_test, fig_ref):
+    ax = fig_test.add_subplot()
+    xs = range(5)
+    mask = np.array([False, False, True, True, False])
+    ys = np.ma.array([1, 2, 2, 2, 3], mask=mask)
+    es = np.ma.array([4, 5, -1, -10, 6], mask=mask)
+    ax.errorbar(xs, ys, es)
+    ax = fig_ref.add_subplot()
+    ax.errorbar([0, 1], [1, 2], [4, 5])
+    ax.errorbar([4], [3], [6], fmt="C0")
+
+
 @image_comparison(['hist_stacked_stepfilled.png', 'hist_stacked_stepfilled.png'])
 def test_hist_stacked_stepfilled():
     # make some data

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4532,10 +4532,10 @@ def test_errorbar_nan(fig_test, fig_ref):
     xs = range(5)
     ys = np.array([1, 2, np.nan, np.nan, 3])
     es = np.array([4, 5, np.nan, np.nan, 6])
-    ax.errorbar(xs, ys, es)
+    ax.errorbar(xs, ys, yerr=es)
     ax = fig_ref.add_subplot()
-    ax.errorbar([0, 1], [1, 2], [4, 5])
-    ax.errorbar([4], [3], [6], fmt="C0")
+    ax.errorbar([0, 1], [1, 2], yerr=[4, 5])
+    ax.errorbar([4], [3], yerr=[6], fmt="C0")
 
 
 @check_figures_equal()
@@ -4545,10 +4545,10 @@ def test_errorbar_masked_negative(fig_test, fig_ref):
     mask = np.array([False, False, True, True, False])
     ys = np.ma.array([1, 2, 2, 2, 3], mask=mask)
     es = np.ma.array([4, 5, -1, -10, 6], mask=mask)
-    ax.errorbar(xs, ys, es)
+    ax.errorbar(xs, ys, yerr=es)
     ax = fig_ref.add_subplot()
-    ax.errorbar([0, 1], [1, 2], [4, 5])
-    ax.errorbar([4], [3], [6], fmt="C0")
+    ax.errorbar([0, 1], [1, 2], yerr=[4, 5])
+    ax.errorbar([4], [3], yerr=[6], fmt="C0")
 
 
 @image_comparison(['hist_stacked_stepfilled.png', 'hist_stacked_stepfilled.png'])


### PR DESCRIPTION
`errorbar` checks that errors are not negative, but a bit convolutedly, in order to avoid triggering on nan. Unfortunately, the work-around for nan means that possible masks get discarded, and hence passing in a masked error array that has a negative but masked value leads to an exception. This PR solves that by simply combining the test for                                                                                                       
negative values with the indirect isnan test (err == err), so that if a masked array is passed, the test values are masked and ignored in the check.

As a bonus, this also means that astropy's ``Masked`` arrays can now be used -- those refuse to write output of tests to unmasked values since that would discard the mask (which is indeed the underlying problem here) -- see 
https://github.com/astropy/astropy/issues/17996

p.s. I checked that the test case that I added fails on current main. The test case is based on the one for `nan` right above - let me know if this is an OK location for it.

EDIT: updated to simplify the check without using any storing of outputs. This means we can also continue to use astropy's Quantity for error bars (and just shows how damn careful one has to be, sigh).

EDIT 2: second commit prevents any comparison of `nan < nan`, which causes `RuntimeError` that I did not see locally.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

