### PR TITLE
backend_bases.pyi: `@overload` `FigureCanvasBase.mpl_connect()` for different event types

### DIFF
--- a/lib/matplotlib/backend_bases.pyi
+++ b/lib/matplotlib/backend_bases.pyi
@@ -19,7 +19,7 @@ from matplotlib.text import Text
 from matplotlib.transforms import Bbox, BboxBase, Transform, TransformedPath
 
 from collections.abc import Callable, Iterable, Sequence
-from typing import Any, IO, Literal, NamedTuple, TypeVar
+from typing import Any, IO, Literal, NamedTuple, TypeVar, overload
 from numpy.typing import ArrayLike
 from .typing import ColorType, LineStyleType, CapStyleType, JoinStyleType
 
@@ -352,6 +352,40 @@ class FigureCanvasBase:
     def get_default_filetype(cls) -> str: ...
     def get_default_filename(self) -> str: ...
     _T = TypeVar("_T", bound=FigureCanvasBase)
+
+    @overload
+    def mpl_connect(
+        self,
+        s: Literal[
+            "button_press_event",
+            "motion_notify_event",
+            "scroll_event",
+            "figure_enter_event",
+            "figure_leave_event",
+            "axes_enter_event",
+            "axes_leave_event",
+            "button_release_event",
+        ],
+        func: Callable[[MouseEvent], Any],
+    ) -> int: ...
+
+    @overload
+    def mpl_connect(
+        self,
+        s: Literal["key_press_event", "key_release_event"],
+        func: Callable[[KeyEvent], Any],
+    ) -> int: ...
+
+    @overload
+    def mpl_connect(self, s: Literal["pick_event"], func: Callable[[PickEvent], Any]) -> int: ...
+
+    @overload
+    def mpl_connect(self, s: Literal["resize_event"], func: Callable[[ResizeEvent], Any]) -> int: ...
+
+    @overload
+    def mpl_connect(self, s: Literal["close_event"], func: Callable[[CloseEvent], Any]) -> int: ...
+
+    @overload
     def mpl_connect(self, s: str, func: Callable[[Event], Any]) -> int: ...
     def mpl_disconnect(self, cid: int) -> None: ...
     def new_timer(


### PR DESCRIPTION
## PR summary
- What problem does it solve?

I've found it a bit annoying that my type checker complains when i pass in a function `f: Callable[[PickEvent],Any]` to `mpl_connect("pick_event",f)`. This PR adds `@overload`s to tell type checkers like pyright that you can do that.

- What is the reasoning for this implementation?

I thought about putting the strings inside a underscored variable, but wasn't sure if it made more sense than just listing them out. I also thought about using ruff, but i didn't want to mess with L509,511.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines