### PR TITLE
Remove hatchcolors parameter from draw_quad_mesh

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -258,7 +258,7 @@ class RendererBase:
 
     def draw_quad_mesh(self, gc, master_transform, meshWidth, meshHeight,
                        coordinates, offsets, offsetTrans, facecolors,
-                       antialiased, edgecolors, *, hatchcolors=None):
+                       antialiased, edgecolors):
         """
         Draw a quadmesh.
 
@@ -271,14 +271,11 @@ class RendererBase:
 
         if edgecolors is None:
             edgecolors = facecolors
-        if hatchcolors is None:
-            hatchcolors = []
         linewidths = np.array([gc.get_linewidth()], float)
 
         return self.draw_path_collection(
             gc, master_transform, paths, [], offsets, offsetTrans, facecolors,
-            edgecolors, linewidths, [], [antialiased], [None], 'screen',
-            hatchcolors=hatchcolors)
+            edgecolors, linewidths, [], [antialiased], [None], 'screen')
 
     def draw_gouraud_triangles(self, gc, triangles_array, colors_array,
                                transform):

--- a/lib/matplotlib/backend_bases.pyi
+++ b/lib/matplotlib/backend_bases.pyi
@@ -78,8 +78,6 @@ class RendererBase:
         facecolors: Sequence[ColorType],
         antialiased: bool,
         edgecolors: Sequence[ColorType] | ColorType | None,
-        *,
-        hatchcolors: Sequence[ColorType] | ColorType | None = None,
     ) -> None: ...
     def draw_gouraud_triangles(
         self,

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -2547,8 +2547,7 @@ class QuadMesh(_MeshData, Collection):
                 coordinates, offsets, offset_trf,
                 # Backends expect flattened rgba arrays (n*m, 4) for fc and ec
                 self.get_facecolor().reshape((-1, 4)),
-                self._antialiased, self.get_edgecolors().reshape((-1, 4)),
-                hatchcolors=self.get_hatchcolor().reshape((-1, 4)))
+                self._antialiased, self.get_edgecolors().reshape((-1, 4)))
         gc.restore()
         renderer.close_group(self.__class__.__name__)
         self.stale = False

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -190,8 +190,7 @@ class RendererAgg
                         agg::trans_affine &offset_trans,
                         ColorArray &facecolors,
                         bool antialiased,
-                        ColorArray &edgecolors,
-                        ColorArray &hatchcolors);
+                        ColorArray &edgecolors);
 
     template <class PointArray, class ColorArray>
     void draw_gouraud_triangles(GCAgg &gc,
@@ -1163,8 +1162,7 @@ inline void RendererAgg::draw_quad_mesh(GCAgg &gc,
                                         agg::trans_affine &offset_trans,
                                         ColorArray &facecolors,
                                         bool antialiased,
-                                        ColorArray &edgecolors,
-                                        ColorArray &hatchcolors)
+                                        ColorArray &edgecolors)
 {
     QuadMeshGenerator<CoordinateArray> path_generator(mesh_width, mesh_height, coordinates);
 
@@ -1172,6 +1170,7 @@ inline void RendererAgg::draw_quad_mesh(GCAgg &gc,
     array::scalar<double, 1> linewidths(gc.linewidth);
     array::scalar<uint8_t, 1> antialiaseds(antialiased);
     DashesVector linestyles;
+    ColorArray hatchcolors = py::array_t<double>().reshape({0, 4}).unchecked<double, 2>();
 
     _draw_path_collection_generic(gc,
                                   master_transform,

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -182,14 +182,12 @@ PyRendererAgg_draw_quad_mesh(RendererAgg *self,
                              agg::trans_affine offset_trans,
                              py::array_t<double> facecolors_obj,
                              bool antialiased,
-                             py::array_t<double> edgecolors_obj,
-                             py::array_t<double> hatchcolors_obj)
+                             py::array_t<double> edgecolors_obj)
 {
     auto coordinates = coordinates_obj.mutable_unchecked<3>();
     auto offsets = convert_points(offsets_obj);
     auto facecolors = convert_colors(facecolors_obj);
     auto edgecolors = convert_colors(edgecolors_obj);
-    auto hatchcolors = convert_colors(hatchcolors_obj);
 
     self->draw_quad_mesh(gc,
             master_transform,
@@ -200,8 +198,7 @@ PyRendererAgg_draw_quad_mesh(RendererAgg *self,
             offset_trans,
             facecolors,
             antialiased,
-            edgecolors,
-            hatchcolors);
+            edgecolors);
 }
 
 static void
@@ -240,8 +237,7 @@ PYBIND11_MODULE(_backend_agg, m, py::mod_gil_not_used())
         .def("draw_quad_mesh", &PyRendererAgg_draw_quad_mesh,
              "gc"_a, "master_transform"_a, "mesh_width"_a, "mesh_height"_a,
              "coordinates"_a, "offsets"_a, "offset_trans"_a, "facecolors"_a,
-             "antialiased"_a, "edgecolors"_a, py::kw_only(),
-             "hatchcolors"_a = py::array_t<double>().reshape({0, 4}))
+             "antialiased"_a, "edgecolors"_a)
         .def("draw_gouraud_triangles", &PyRendererAgg_draw_gouraud_triangles,
              "gc"_a, "points"_a, "colors"_a, "trans"_a = nullptr)
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

Fixes #29883 

Removes the `hatchcolors` parameter from `draw_quad_mesh()`, as `QuadMesh` doesn't support hatching.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
