### PR TITLE
Bump pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -50,7 +50,7 @@ repos:
       - id: ruff
         args: [--fix, --show-fixes]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.3.0
+    rev: v2.4.1
     hooks:
       - id: codespell
         files: ^.*\.(py|c|cpp|h|m|md|rst|yml)$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
       - id: trailing-whitespace
         exclude_types: [svg]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.14.1
+    rev: v1.15.0
     hooks:
       - id: mypy
         additional_dependencies:
@@ -44,7 +44,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.0
+    rev: v0.11.5
     hooks:
       # Run the linter.
       - id: ruff
@@ -60,7 +60,7 @@ repos:
           - "--skip"
           - "doc/project/credits.rst"
   - repo: https://github.com/pycqa/isort
-    rev: 5.13.2
+    rev: 6.0.1
     hooks:
       - id: isort
         name: isort (python)
@@ -73,12 +73,12 @@ repos:
           - sphinx>=1.8.1
           - tomli
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.35.1
+    rev: v1.37.0
     hooks:
       - id: yamllint
         args: ["--strict", "--config-file=.yamllint.yml"]
   - repo: https://github.com/python-jsonschema/check-jsonschema
-    rev: 0.30.0
+    rev: 0.33.0
     hooks:
       # TODO: Re-enable this when https://github.com/microsoft/azure-pipelines-vscode/issues/567 is fixed.
       # - id: check-azure-pipelines

--- a/ci/codespell-ignore-words.txt
+++ b/ci/codespell-ignore-words.txt
@@ -1,4 +1,5 @@
 aas
+ABD
 axises
 coo
 curvelinear

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2122,9 +2122,9 @@ default: %(va)s
             # go through the unique keys,
             for name in unique_ids:
                 # sort out where each axes starts/ends
-                indx = np.argwhere(mosaic == name)
-                start_row, start_col = np.min(indx, axis=0)
-                end_row, end_col = np.max(indx, axis=0) + 1
+                index = np.argwhere(mosaic == name)
+                start_row, start_col = np.min(index, axis=0)
+                end_row, end_col = np.max(index, axis=0) + 1
                 # and construct the slice object
                 slc = (slice(start_row, end_row), slice(start_col, end_col))
                 # some light error checking


### PR DESCRIPTION
Replaces https://github.com/matplotlib/matplotlib/pull/29884 - instead of rebasing that (because we switched out `flake8`), it was easier to manually update and make the fixes.