### PR TITLE
Handle MOVETO's, CLOSEPOLY's and empty paths in Path.interpolated

### DIFF
--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -667,12 +667,26 @@ class Path:
 
     def interpolated(self, steps):
         """
-        Return a new path resampled to length N x *steps*.
+        Return a new path with each segment divided into *steps* parts.
 
-        Codes other than `LINETO` are not handled correctly.
+        Codes other than `LINETO` and `MOVETO` are not handled correctly.
+
+        Parameters
+        ----------
+        steps : int
+            The number of segments in the new path for each in the original.
+
+        Returns
+        -------
+        Path
+            The interpolated path.
         """
         if steps == 1:
             return self
+
+        if self.codes is not None and self.MOVETO in self.codes[1:]:
+            return self.make_compound_path(
+                *(p.interpolated(steps) for p in self._iter_connected_components()))
 
         vertices = simple_linear_interpolation(self.vertices, steps)
         codes = self.codes

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -681,7 +681,7 @@ class Path:
         Path
             The interpolated path.
         """
-        if steps == 1:
+        if steps == 1 or len(self) == 0:
             return self
 
         if self.codes is not None and self.MOVETO in self.codes[1:]:

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -669,7 +669,7 @@ class Path:
         """
         Return a new path with each segment divided into *steps* parts.
 
-        Codes other than `LINETO` and `MOVETO` are not handled correctly.
+        Codes other than `LINETO`, `MOVETO`, and `CLOSEPOLY` are not handled correctly.
 
         Parameters
         ----------
@@ -688,7 +688,14 @@ class Path:
             return self.make_compound_path(
                 *(p.interpolated(steps) for p in self._iter_connected_components()))
 
-        vertices = simple_linear_interpolation(self.vertices, steps)
+        if self.codes is not None and self.CLOSEPOLY in self.codes and not np.all(
+                self.vertices[self.codes == self.CLOSEPOLY] == self.vertices[0]):
+            vertices = self.vertices.copy()
+            vertices[self.codes == self.CLOSEPOLY] = vertices[0]
+        else:
+            vertices = self.vertices
+
+        vertices = simple_linear_interpolation(vertices, steps)
         codes = self.codes
         if codes is not None:
             new_codes = np.full((len(codes) - 1) * steps + 1, Path.LINETO,

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -559,3 +559,61 @@ def test_interpolated_moveto():
     # Result should have two subpaths with six LINETOs each
     expected_subpath_codes = [Path.MOVETO] + [Path.LINETO] * 6
     np.testing.assert_array_equal(result.codes, expected_subpath_codes * 2)
+
+
+def test_interpolated_closepoly():
+    codes = [Path.MOVETO] + [Path.LINETO]*2 + [Path.CLOSEPOLY]
+    vertices = [(4, 3), (5, 4), (5, 3), (0, 0)]
+
+    path = Path(vertices, codes)
+    result = path.interpolated(2)
+
+    expected_vertices = np.array([[4, 3],
+                                  [4.5, 3.5],
+                                  [5, 4],
+                                  [5, 3.5],
+                                  [5, 3],
+                                  [4.5, 3],
+                                  [4, 3]])
+    expected_codes = [Path.MOVETO] + [Path.LINETO]*5 + [Path.CLOSEPOLY]
+
+    np.testing.assert_allclose(result.vertices, expected_vertices)
+    np.testing.assert_array_equal(result.codes, expected_codes)
+
+    # Usually closepoly is the last vertex but does not have to be.
+    codes += [Path.LINETO]
+    vertices += [(2, 1)]
+
+    path = Path(vertices, codes)
+    result = path.interpolated(2)
+
+    extra_expected_vertices = np.array([[3, 2],
+                                        [2, 1]])
+    expected_vertices = np.concatenate([expected_vertices, extra_expected_vertices])
+
+    expected_codes += [Path.LINETO] * 2
+
+    np.testing.assert_allclose(result.vertices, expected_vertices)
+    np.testing.assert_array_equal(result.codes, expected_codes)
+
+
+def test_interpolated_moveto_closepoly():
+    # Initial path has two closed subpaths
+    codes = ([Path.MOVETO] + [Path.LINETO]*2 + [Path.CLOSEPOLY]) * 2
+    vertices = [(4, 3), (5, 4), (5, 3), (0, 0), (8, 6), (10, 8), (10, 6), (0, 0)]
+
+    path = Path(vertices, codes)
+    result = path.interpolated(2)
+
+    expected_vertices1 = np.array([[4, 3],
+                                   [4.5, 3.5],
+                                   [5, 4],
+                                   [5, 3.5],
+                                   [5, 3],
+                                   [4.5, 3],
+                                   [4, 3]])
+    expected_vertices = np.concatenate([expected_vertices1, expected_vertices1 * 2])
+    expected_codes = ([Path.MOVETO] + [Path.LINETO]*5 + [Path.CLOSEPOLY]) * 2
+
+    np.testing.assert_allclose(result.vertices, expected_vertices)
+    np.testing.assert_array_equal(result.codes, expected_codes)

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -617,3 +617,8 @@ def test_interpolated_moveto_closepoly():
 
     np.testing.assert_allclose(result.vertices, expected_vertices)
     np.testing.assert_array_equal(result.codes, expected_codes)
+
+
+def test_interpolated_empty_path():
+    path = Path(np.zeros((0, 2)))
+    assert path.interpolated(42) is path

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -541,3 +541,21 @@ def test_cleanup_closepoly():
         cleaned = p.cleaned(remove_nans=True)
         assert len(cleaned) == 1
         assert cleaned.codes[0] == Path.STOP
+
+
+def test_interpolated_moveto():
+    # Initial path has two subpaths with two LINETOs each
+    vertices = np.array([[0, 0],
+                         [0, 1],
+                         [1, 2],
+                         [4, 4],
+                         [4, 5],
+                         [5, 5]])
+    codes = [Path.MOVETO, Path.LINETO, Path.LINETO] * 2
+
+    path = Path(vertices, codes)
+    result = path.interpolated(3)
+
+    # Result should have two subpaths with six LINETOs each
+    expected_subpath_codes = [Path.MOVETO] + [Path.LINETO] * 6
+    np.testing.assert_array_equal(result.codes, expected_subpath_codes * 2)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
Fixes #29917.  The geo projection's path transform relies on `Path.interpolated`
https://github.com/matplotlib/matplotlib/blob/b7e7663155d83fecc82556ec1135f22cf81778f5/lib/matplotlib/projections/geo.py#L249-L252

At v3.8 `ContourSet` changed from having one path per contour to one path per level, and so its paths can now contain internal `MOVETO`'s.  We can make the `interpolated` method handle those by just splitting the path up, applying itself to each sub-path, and re-joining the result.  The example code provided in #29917 now gives

![Figure_1](https://github.com/user-attachments/assets/6559d360-1fb5-4cc5-9e04-728c62f9f467)

For `contour` the given example also had one or more empty paths which caused an exception in the interpolation.  We can just pass those straight out again.

![Figure_1](https://github.com/user-attachments/assets/934e0927-c180-4dc4-b681-411b088273f8)

I welcome better wording for the docstring, though I do not think the original was correct since a unclosed path with N vertices would have become a path with `(N-1) * steps + 1` vertices.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
