### PR TITLE
Add oxipng to pre-commit

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,11 @@ jobs:
           persist-credentials: false
       - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16  # v2.0.6
         with:
-          extra-args: --hook-stage manual --all-files
+          extra-args: --hook-stage manual --all-files --skip oxipng
+      # Only run oxipng on the last diff, because we haven't updated all images.
+      - uses: j178/prek-action@bdca6f102f98e2b4c7029491a53dfd366469e33d  # v2.0.4
+        with:
+          extra-args: --hook-stage manual --from-ref origin/${{ github.base_ref }} oxipng
 
   ruff:
     name: ruff

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -135,3 +135,7 @@ repos:
         name: "Validate Conda environment file"
         files: ^environment\.yml$
         args: ["--verbose", "--schemafile", "ci/schemas/conda-environment.json"]
+  - repo: https://github.com/oxipng/oxipng
+    rev: 628e241e23f368097883807fa6e985ccf7c00357  # frozen: v10.1.1
+    hooks:
+      - id: oxipng


### PR DESCRIPTION
## PR summary

@oscargus suggested oxipng in #29816.

I went with the hook suggestion of `-o 4` compression (though their normal default is 2), though maybe we want to up it to the max, since it shouldn't happen very often. I did not enable metadata stripping (as suggested) since knowing what version of Matplotlib was used for the plot might be useful. I also didn't add alpha channel optmization, as they say it is technically lossy.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines