### PR TITLE
Correct rightparen typo

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -515,7 +515,7 @@ class BakomaFonts(TruetypeFonts):
         }
 
     for alias, target in [(r'\leftparen', '('),
-                          (r'\rightparent', ')'),
+                          (r'\rightparen', ')'),
                           (r'\leftbrace', '{'),
                           (r'\rightbrace', '}'),
                           (r'\leftbracket', '['),


### PR DESCRIPTION
While trying to figure out what's going on in #29886 I noticed that matplotlib currently incorrectly handles `\rightparen` because of a typo as `\rightparent`. This (tiny) PR fixes that.

I still don't understand what's going on in #29886.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
