### PR TITLE
Changed "Autoscaling axes" to "Autoscaling axes on user guide page for issue & closes #29906

### DIFF
--- a/galleries/users_explain/axes/autoscale.py
+++ b/galleries/users_explain/axes/autoscale.py
@@ -3,7 +3,7 @@
 
 .. _autoscale:
 
-Autoscaling Axis
+Axis autoscaling
 ================
 
 The limits on an axis can be set manually (e.g. ``ax.set_xlim(xmin, xmax)``)

--- a/galleries/users_explain/axes/index.rst
+++ b/galleries/users_explain/axes/index.rst
@@ -34,7 +34,7 @@ annotations like x- and y-labels, titles, and legends.
 
     arranging_axes
     colorbar_placement
-    Autoscaling axes <autoscale>
+    autoscale
 
 .. toctree::
     :maxdepth: 2


### PR DESCRIPTION
Closes #29906

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:
This is a small grammatical error on the "https://matplotlib.org/stable/users/index.html" page. Under the Axes & Subplots section, the "Autoscaling Axes" is to be changed to "Axis Autoscaling" (as recommended by @timhoffm)  that closes #29906. I didn't check many things on the checklist since it's just a text change, which I tested and is working locally.

- Why is this change necessary?
- It is a grammatical error that clears confusion.

- What problem does it solve?
- It just resolves a grammatical error in the documentation

- What is the reasoning for this implementation?
- The rst file generates all the necessary documentation 

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

Current webpage:
![Screenshot 2025-04-13 at 9 46 56 PM](https://github.com/user-attachments/assets/acc17f7a-01f1-4ed5-9c21-ab45e607d5c9)

After change:
<img width="1440" alt="Screenshot 2025-04-18 at 11 17 05 AM" src="https://github.com/user-attachments/assets/d89ba22f-1977-4ccd-a3b0-07ef735e97fe" />
