### PR TITLE
Check Axes/Figure import paths in boilerplate.py

### DIFF
--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -459,5 +459,13 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         pyplot_path = Path(sys.argv[1])
     else:
-        pyplot_path = Path(__file__).parent / "../lib/matplotlib/pyplot.py"
+        mpl_path = (Path(__file__).parent / ".." /"lib"/"matplotlib").resolve()
+        pyplot_path = mpl_path / "pyplot.py"
+        for cls in [Axes, Figure]:
+            if mpl_path not in  Path(inspect.getfile(cls)).parents:
+                raise RuntimeError(
+                    f"{cls.__name__} import path is not {mpl_path}.\n"
+                    "Please make sure your Matplotlib installation "
+                    "is from the same source checkout as boilerplate.py"
+                )
     build_pyplot(pyplot_path)


### PR DESCRIPTION
Before this PR, if the Matplotlib installed in the current environment is not the same as the source tree `boilerplate.py` is from, the `Axes`/`Figure` classes not taken from the correct source tree. This adds a guard to make sure this isn't the case.

I have confirmed locally this prevents situations like those described in https://github.com/matplotlib/matplotlib/issues/29921

I can't think of a situation where one wants to deliberately generate `pyplot.py` from another source tree, but if there is manually specifying the other source tree as an argument to `boilerplate.py` should still work.

Fixes https://github.com/matplotlib/matplotlib/issues/29921.