### PR TITLE
Backport PR #29796 on branch v3.10.1-doc: ci: rotate soon-to-be-unsupported GitHub Actions ubuntu-20.04 runner out of roster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -48,7 +48,7 @@ jobs:
       matrix:
         include:
           - name-suffix: "(Minimum Versions)"
-            os: ubuntu-20.04
+            os: ubuntu-22.04
             python-version: '3.10'
             extra-requirements: '-c requirements/testing/minver.txt'
             delete-font-cache: true
@@ -57,17 +57,9 @@ jobs:
             pyqt6-ver: '==6.2.0 PyQt6-Qt6==6.2.0'
             pyside2-ver: '==5.15.2.1'
             pyside6-ver: '==6.2.0'
-          - os: ubuntu-20.04
-            python-version: '3.10'
-            extra-requirements: '-r requirements/testing/extra.txt'
-            CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
-            # https://github.com/matplotlib/matplotlib/pull/26052#issuecomment-1574595954
-            # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
-            pyqt6-ver: '!=6.5.1,!=6.6.0,!=6.7.1'
-            # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
-            pyside6-ver: '!=6.5.1'
           - os: ubuntu-22.04
             python-version: '3.11'
+            CFLAGS: "-fno-lto"  # Ensure that disabling LTO works.
             # https://www.riverbankcomputing.com/pipermail/pyqt/2023-November/045606.html
             pyqt6-ver: '!=6.6.0'
             # https://bugreports.qt.io/projects/PYSIDE/issues/PYSIDE-2346
@@ -175,11 +167,7 @@ jobs:
               texlive-luatex \
               texlive-pictures \
               texlive-xetex
-            if [[ "${{ matrix.os }}" = ubuntu-20.04 ]]; then
-              sudo apt-get install -yy --no-install-recommends libopengl0
-            else  # ubuntu-22.04
-              sudo apt-get install -yy --no-install-recommends gir1.2-gtk-4.0
-            fi
+            sudo apt-get install -yy --no-install-recommends gir1.2-gtk-4.0
             ;;
           macOS)
             brew update


### PR DESCRIPTION
Manual backport of https://github.com/matplotlib/matplotlib/pull/29796. The conflict was because main has some extra lines from https://github.com/matplotlib/matplotlib/pull/29171 right before the if-loop we're removing here.

(cherry picked from commit 0d11978c9f933a9fc7a585891b350c09958e034b)


