### PR TITLE
Add HandlerPatchCollection to support legends for PatchCollection

### DIFF
--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -810,3 +810,42 @@ class HandlerPolyCollection(HandlerBase):
         self.update_prop(p, orig_handle, legend)
         p.set_transform(trans)
         return [p]
+    
+from matplotlib.legend_handler import HandlerPatchCollection
+
+_default_handler_map[PatchCollection] = HandlerPatchCollection()
+
+
+from matplotlib.patches import Patch
+from matplotlib.collections import PatchCollection
+
+class HandlerPatchCollection(HandlerPatch):
+    """
+    Handler for PatchCollection, e.g. from matplotlib.collections.
+    Uses the properties of the first patch in the collection.
+    """
+
+    def create_artists(self, legend, orig_handle,
+                       xdescent, ydescent, width, height, fontsize, trans):
+        p = Patch()
+
+        try:
+            fc = orig_handle.get_facecolor()[0]
+            ec = orig_handle.get_edgecolor()[0]
+            lw = orig_handle.get_linewidths()[0]
+            ls = orig_handle.get_linestyle()[0]
+        except IndexError:
+            fc, ec, lw, ls = 'gray', 'black', 1.0, 'solid'
+
+        p.set_facecolor(fc)
+        p.set_edgecolor(ec)
+        p.set_linewidth(lw)
+        p.set_linestyle(ls)
+
+        self.update_prop(p, orig_handle, legend)
+        p.set_transform(trans)
+        p.set_xy([[-xdescent, -ydescent],
+                  [-xdescent + width, -ydescent],
+                  [-xdescent + width, -ydescent + height],
+                  [-xdescent, -ydescent + height]])
+        return [p]


### PR DESCRIPTION
### Summary

This PR adds a default legend handler for `matplotlib.collections.PatchCollection`, enabling automatic legend support without the need for manual proxy artists.

### Motivation

As discussed in issue #23998, currently `PatchCollection` objects do not appear in legends because they lack a registered legend handler. This change introduces a `HandlerPatchCollection` that extracts visual properties from the first patch in the collection and uses them to generate a representative patch for the legend.

### Implementation

- Introduced `HandlerPatchCollection` (subclassing `HandlerPatch`) that mirrors `HandlerPolyCollection`.
- Registered the handler in `_default_handler_map` to enable automatic use.

### Related Issues

Fixes #23998  
Closes #24028

### Example

```python
from matplotlib.patches import Polygon
from matplotlib.collections import PatchCollection
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
p1 = Polygon([[0, 0], [1, 1], [2, 0]])
p2 = Polygon([[3, 0], [4, 1], [5, 0]])
coll = PatchCollection([p1, p2], label='Polygons', facecolor='cyan')
ax.add_collection(coll)
ax.set_xlim(0, 6)
ax.set_ylim(0, 2)
ax.legend()
plt.show()