### PR TITLE
Simplify `colored_line()` implementation in Multicolored lines example

### DIFF
--- a/galleries/examples/lines_bars_and_markers/multicolored_line.py
+++ b/galleries/examples/lines_bars_and_markers/multicolored_line.py
@@ -21,7 +21,7 @@ import numpy as np
 from matplotlib.collections import LineCollection
 
 
-def colored_line(x, y, c, ax=None, scalex=True, scaley=True, **lc_kwargs):
+def colored_line(x, y, c, ax=None, **lc_kwargs):
     """
     Plot a line with a color specified along the line by a third value.
 
@@ -38,10 +38,7 @@ def colored_line(x, y, c, ax=None, scalex=True, scaley=True, **lc_kwargs):
         The color values, which should be the same size as x and y.
     ax : matplotlib.axes.Axes, optional
         The axes to plot on. If not provided, the current axes will be used.
-    scalex, scaley : bool
-        These parameters determine if the view limits are adapted to the data limits.
-        The values are passed on to autoscale_view.
-    **lc_kwargs : Any
+    **lc_kwargs
         Any additional arguments to pass to matplotlib.collections.LineCollection
         constructor. This should not include the array keyword argument because
         that is set to the color argument. If provided, it will be overridden.
@@ -63,13 +60,11 @@ def colored_line(x, y, c, ax=None, scalex=True, scaley=True, **lc_kwargs):
         (xy[0, :][None, :], (xy[:-1, :] + xy[1:, :]) / 2, xy[-1, :][None, :]), axis=0
     )
     segments = np.stack((xy_mid[:-1, :], xy, xy_mid[1:, :]), axis=-2)
-    # Note that segments is [
-    #   [[x[0], y[0]], [x[0], y[0]], [mean(x[0], x[1]), mean(y[0], y[1])]],
-    #   [[mean(x[0], x[1]), mean(y[0], y[1])], [x[1], y[1]],
-    #    [mean(x[1], x[2]), mean(y[1], y[2])]],
-    #   ...
-    #   [[mean(x[-2], x[-1]), mean(y[-2], y[-1])], [x[-1], y[-1]], [x[-1], y[-1]]]
-    # ]
+    # Note that 
+    # segments[0, :, :] is [xy[0, :], xy[0, :], (xy[0, :] + xy[1, :]) / 2]
+    # segments[i, :, :] is [(xy[i - 1, :] + xy[i, :]) / 2, xy[i, :], 
+    #     (xy[i, :] + xy[i + 1, :]) / 2] if i not in {0, len(x) - 1}
+    # segments[-1, :, :] is [(xy[-2, :] + xy[-1, :]) / 2, xy[-1, :], xy[-1, :]]
 
     lc_kwargs["array"] = c
     lc = LineCollection(segments, **lc_kwargs)
@@ -79,7 +74,6 @@ def colored_line(x, y, c, ax=None, scalex=True, scaley=True, **lc_kwargs):
     ax.add_collection(lc)
     ax.autoscale_view(scalex=scalex, scaley=scaley)
 
-    # Return the LineCollection object
     return lc
 
 

--- a/galleries/examples/lines_bars_and_markers/multicolored_line.py
+++ b/galleries/examples/lines_bars_and_markers/multicolored_line.py
@@ -60,9 +60,9 @@ def colored_line(x, y, c, ax=None, **lc_kwargs):
         (xy[0, :][None, :], (xy[:-1, :] + xy[1:, :]) / 2, xy[-1, :][None, :]), axis=0
     )
     segments = np.stack((xy_mid[:-1, :], xy, xy_mid[1:, :]), axis=-2)
-    # Note that 
+    # Note that
     # segments[0, :, :] is [xy[0, :], xy[0, :], (xy[0, :] + xy[1, :]) / 2]
-    # segments[i, :, :] is [(xy[i - 1, :] + xy[i, :]) / 2, xy[i, :], 
+    # segments[i, :, :] is [(xy[i - 1, :] + xy[i, :]) / 2, xy[i, :],
     #     (xy[i, :] + xy[i + 1, :]) / 2] if i not in {0, len(x) - 1}
     # segments[-1, :, :] is [(xy[-2, :] + xy[-1, :]) / 2, xy[-1, :], xy[-1, :]]
 
@@ -72,7 +72,7 @@ def colored_line(x, y, c, ax=None, **lc_kwargs):
     # Plot the line collection to the axes
     ax = ax or plt.gca()
     ax.add_collection(lc)
-    ax.autoscale_view(scalex=scalex, scaley=scaley)
+    ax.autoscale_view()
 
     return lc
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

- Reduces the number of lines.
- Stops using Numpy functions which is not array-api compatible (`hstack`, `column_stack`, etc.), which improves readability.
- Calls `autoscale_view`, thus `set_xlim`, etc. need not to be called manually.
- Adds `stacklevel=2` in `warnings.warn`.
- (Note: I have created a dedicated package for this function: https://github.com/34j/matplotlib-multicolored-line)

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
