### PR TITLE
TST: Make refcount tests more resilient to Python changes

### DIFF
--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -26,11 +26,12 @@ def test_quiver_memory_leak():
 
     Q = draw_quiver(ax)
     ttX = Q.X
+    orig_refcount = sys.getrefcount(ttX)
     Q.remove()
 
     del Q
 
-    assert sys.getrefcount(ttX) == 2
+    assert sys.getrefcount(ttX) < orig_refcount
 
 
 @pytest.mark.skipif(platform.python_implementation() != 'CPython',
@@ -43,9 +44,9 @@ def test_quiver_key_memory_leak():
     qk = ax.quiverkey(Q, 0.5, 0.92, 2, r'$2 \frac{m}{s}$',
                       labelpos='W',
                       fontproperties={'weight': 'bold'})
-    assert sys.getrefcount(qk) == 3
+    orig_refcount = sys.getrefcount(qk)
     qk.remove()
-    assert sys.getrefcount(qk) == 2
+    assert sys.getrefcount(qk) < orig_refcount
 
 
 def test_quiver_number_of_args():


### PR DESCRIPTION
## PR summary

Check the change of the refcount, instead of the absolute value, as suggested by @ngoldbaum in https://github.com/matplotlib/matplotlib/issues/29959#issuecomment-2824739314.

I did not test against Python 3.14, but perhaps @befeleme could.

## PR checklist
- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines