### PR TITLE
Improve repr of mathtext internal structures; minor cleanup.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -14,6 +14,7 @@ import re
 import types
 import unicodedata
 import string
+import textwrap
 import typing as T
 from typing import NamedTuple
 
@@ -1165,12 +1166,16 @@ class List(Box):
         self.glue_sign    = 0    # 0: normal, -1: shrinking, 1: stretching
         self.glue_order   = 0    # The order of infinity (0 - 3) for the glue
 
-    def __repr__(self) -> str:
-        return '{}<w={:.02f} h={:.02f} d={:.02f} s={:.02f}>[{}]'.format(
+    def __repr__(self):
+        return "{}<w={:.02f} h={:.02f} d={:.02f} s={:.02f}>[{}]".format(
             super().__repr__(),
             self.width, self.height,
             self.depth, self.shift_amount,
-            ', '.join([repr(x) for x in self.children]))
+            "\n" + textwrap.indent(
+                "\n".join(map("{!r},".format, self.children)),
+                "  ") + "\n"
+            if self.children else ""
+        )
 
     def _set_glue(self, x: float, sign: int, totals: list[float],
                   error_type: str) -> None:
@@ -1604,7 +1609,7 @@ def ship(box: Box, xy: tuple[float, float] = (0, 0)) -> Output:
         return -1e9 if value < -1e9 else +1e9 if value > +1e9 else value
 
     def hlist_out(box: Hlist) -> None:
-        nonlocal cur_v, cur_h, off_h, off_v
+        nonlocal cur_v, cur_h
 
         cur_g = 0
         cur_glue = 0.
@@ -1667,7 +1672,7 @@ def ship(box: Box, xy: tuple[float, float] = (0, 0)) -> Output:
                 cur_h += rule_width
 
     def vlist_out(box: Vlist) -> None:
-        nonlocal cur_v, cur_h, off_h, off_v
+        nonlocal cur_v, cur_h
 
         cur_g = 0
         cur_glue = 0.

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -4,8 +4,9 @@ import io
 from pathlib import Path
 import platform
 import re
-from xml.etree import ElementTree as ET
+import textwrap
 from typing import Any
+from xml.etree import ElementTree as ET
 
 import numpy as np
 from packaging.version import parse as parse_version
@@ -16,7 +17,8 @@ import pytest
 import matplotlib as mpl
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 import matplotlib.pyplot as plt
-from matplotlib import mathtext, _mathtext
+from matplotlib import font_manager as fm, mathtext, _mathtext
+from matplotlib.ft2font import LoadFlags
 
 pyparsing_version = parse_version(pyparsing.__version__)
 
@@ -558,3 +560,41 @@ def test_mathtext_operators():
 def test_boldsymbol(fig_test, fig_ref):
     fig_test.text(0.1, 0.2, r"$\boldsymbol{\mathrm{abc0123\alpha}}$")
     fig_ref.text(0.1, 0.2, r"$\mathrm{abc0123\alpha}$")
+
+
+def test_box_repr():
+    s = repr(_mathtext.Parser().parse(
+        r"$\frac{1}{2}$",
+        _mathtext.DejaVuSansFonts(fm.FontProperties(), LoadFlags.NO_HINTING),
+        fontsize=12, dpi=100))
+    assert s == textwrap.dedent("""\
+        Hlist<w=9.49 h=16.08 d=6.64 s=0.00>[
+          Hlist<w=0.00 h=0.00 d=0.00 s=0.00>[],
+          Hlist<w=9.49 h=16.08 d=6.64 s=0.00>[
+            Hlist<w=9.49 h=16.08 d=6.64 s=0.00>[
+              Vlist<w=7.40 h=22.72 d=0.00 s=6.64>[
+                HCentered<w=7.40 h=8.67 d=0.00 s=0.00>[
+                  Glue,
+                  Hlist<w=7.40 h=8.67 d=0.00 s=0.00>[
+                    `1`,
+                    k2.36,
+                  ],
+                  Glue,
+                ],
+                Vbox,
+                Hrule,
+                Vbox,
+                HCentered<w=7.40 h=8.84 d=0.00 s=0.00>[
+                  Glue,
+                  Hlist<w=7.40 h=8.84 d=0.00 s=0.00>[
+                    `2`,
+                    k2.02,
+                  ],
+                  Glue,
+                ],
+              ],
+              Hbox,
+            ],
+          ],
+          Hlist<w=0.00 h=0.00 d=0.00 s=0.00>[],
+        ]""")


### PR DESCRIPTION
- Improve the repr of mathtext boxes (see test_box_repr; previously the entire repr would be in a single line).  Boxes are internal objects not exposed by any public API so the change is purely for debugging purposes.
- In ship, off_h and off_v are never modified, so there's no need to declare them as nonlocal in the nested functions.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
