### PR TITLE
FIX: Typing of FuncAnimation

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1769,8 +1769,8 @@ class FuncAnimation(TimedAnimation):
             self._drawn_artists = self._init_func()
             if self._blit:
                 if self._drawn_artists is None:
-                    raise RuntimeError('The init_func must return a '
-                                       'sequence of Artist objects.')
+                    raise RuntimeError('When blit=True, the init_func must '
+                                       'return a sequence of Artist objects.')
                 for a in self._drawn_artists:
                     a.set_animated(self._blit)
         self._save_seq = []
@@ -1787,8 +1787,8 @@ class FuncAnimation(TimedAnimation):
 
         if self._blit:
 
-            err = RuntimeError('The animation function must return a sequence '
-                               'of Artist objects.')
+            err = RuntimeError('When blit=True, the animation function must '
+                               'return a sequence of Artist objects.')
             try:
                 # check if a sequence
                 iter(self._drawn_artists)

--- a/lib/matplotlib/animation.pyi
+++ b/lib/matplotlib/animation.pyi
@@ -206,9 +206,9 @@ class FuncAnimation(TimedAnimation):
     def __init__(
         self,
         fig: Figure,
-        func: Callable[..., Iterable[Artist]],
+        func: Callable[..., Iterable[Artist] | None],
         frames: Iterable | int | Callable[[], Generator] | None = ...,
-        init_func: Callable[[], Iterable[Artist]] | None = ...,
+        init_func: Callable[[], Iterable[Artist] | None] | None = ...,
         fargs: tuple[Any, ...] | None = ...,
         save_count: int | None = ...,
         *,


### PR DESCRIPTION
`func` and `init_func` may return None (which is ok if `blit=False`). Since gating the allowed signature on the state of `blit` is not feasible, we err on the side on being too permissive in the type definition: Rather not flag a type error and only raise on runtime than complain on an actually working signature.

Closes #29960.

