### PR TITLE
WIP: Try running windows tests with a single worker

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ stages:
               fi
               echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
 
-              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 2 \
+              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 1 \
                   --maxfail=50 --timeout=300 --durations=25 \
                   --junitxml=junit/test-results.xml --cov-report=xml --cov=lib
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ stages:
               fi
               echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
 
-              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 1  \
+              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 1 \
                   --maxfail=50 --timeout=300 --durations=25 \
                   --junitxml=junit/test-results.xml --cov-report=xml --cov=lib
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -147,7 +147,7 @@ stages:
               fi
               echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
 
-              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 1 \
+              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 1  \
                   --maxfail=50 --timeout=300 --durations=25 \
                   --junitxml=junit/test-results.xml --cov-report=xml --cov=lib
 


### PR DESCRIPTION
Alternative approach on narrowing down the subprocess failures. Assumption is that no timeout will occour if all tests are run sequentially.

See https://github.com/matplotlib/matplotlib/issues/29797#issuecomment-2833795708

*Note:* This is not intended to be merged. It's only a test PR to narrow down the issue and confirm above assumption.