### PR TITLE
Fix typo: missing singlequote in unrecognized backend exception

### DIFF
--- a/lib/matplotlib/backends/registry.py
+++ b/lib/matplotlib/backends/registry.py
@@ -407,7 +407,7 @@ class BackendRegistry:
             return self.resolve_backend(gui_or_backend)
         except Exception:  # KeyError ?
             raise RuntimeError(
-                f"'{gui_or_backend} is not a recognised GUI loop or backend name")
+                f"'{gui_or_backend}' is not a recognised GUI loop or backend name")
 
 
 # Singleton


### PR DESCRIPTION
## PR summary
I hope I don't bother you with this _tiny_ PR, but I'd like to have typos addressed eventually. :)
Using some crude RegEx searches (`f"'\{.+"` etc.), I made sure that no similar typos exist.

This is the code in question:
https://github.com/matplotlib/matplotlib/blob/6378dd0277f2900eb9ad5843b674f7fbe77719bf/lib/matplotlib/backends/registry.py#L405-L410

I cross-checked the code style with similar messages in the same file:
https://github.com/matplotlib/matplotlib/blob/6378dd0277f2900eb9ad5843b674f7fbe77719bf/lib/matplotlib/backends/registry.py#L368-L369

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines