### PR TITLE
BLD: Ensure meson.build has the right version of Python

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,10 @@
 project(
   'matplotlib',
   'c', 'cpp',
-  version: run_command(find_program('python3'), '-m', 'setuptools_scm', check: true).stdout().strip(),
+  version: run_command(
+    # Also keep version in sync with pyproject.toml.
+    find_program('python3', 'python', version: '>= 3.11'),
+    '-m', 'setuptools_scm', check: true).stdout().strip(),
   # qt_editor backend is MIT
   # ResizeObserver at end of lib/matplotlib/backends/web_backend/js/mpl.js is CC0
   # Carlogo, STIX and Computer Modern is OFL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dependencies = [
     "pyparsing >= 3",
     "python-dateutil >= 2.7",
 ]
+# Also keep in sync with find_program of meson.build.
 requires-python = ">=3.11"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## PR summary

If `python3` is in the path, it might be picked up instead of the one used to build. This is the case on GitHub actions, where cibuildwheel seems to explicitly call the Python (3.11+) it wants, but `python3` is in the hosted tool cache as an older version (3.9) that gets picked by Meson. This matters because we need to run `setuptools_scm` to produce the version, and it may not be installed in the `PATH`-based copy.

By specifying the version, Meson should skip the `PATH` option, and choose its final fallback, the interpreter that it is itself running on. While still not guaranteed to be correct everywhere, this should at least work for CI.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines