### PR TITLE
Backport PR #29997 on branch v3.10.x (BLD: Ensure meson.build has the right version of Python)

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,10 @@
 project(
   'matplotlib',
   'c', 'cpp',
-  version: run_command(find_program('python3'), '-m', 'setuptools_scm', check: true).stdout().strip(),
+  version: run_command(
+    # Also keep version in sync with pyproject.toml.
+    find_program('python3', 'python', version: '>= 3.10'),
+    '-m', 'setuptools_scm', check: true).stdout().strip(),
   # qt_editor backend is MIT
   # ResizeObserver at end of lib/matplotlib/backends/web_backend/js/mpl.js is CC0
   # Carlogo, STIX and Computer Modern is OFL

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dependencies = [
     "pyparsing >= 2.3.1",
     "python-dateutil >= 2.7",
 ]
+# Also keep in sync with find_program of meson.build.
 requires-python = ">=3.10"
 
 [project.optional-dependencies]


### PR DESCRIPTION
## PR summary

With correction to the Python version, that should be 3.10 for this branch.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines