### PR TITLE
Remove apply_theta_transforms argument

### DIFF
--- a/doc/api/next_api_changes/removals/xxxxxx-DS.rst
+++ b/doc/api/next_api_changes/removals/xxxxxx-DS.rst
@@ -1,0 +1,10 @@
+``apply_theta_transforms`` option in ``PolarTransform``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Applying theta transforms in `~matplotlib.projections.polar.PolarTransform` and
+`~matplotlib.projections.polar.InvertedPolarTransform` has been removed, and
+the ``apply_theta_transforms`` keyword argument removed from both classes.
+
+If you need to retain the behaviour where theta values
+are transformed, chain the ``PolarTransform`` with a `~matplotlib.transforms.Affine2D`
+transform that performs the theta shift and/or sign shift.

--- a/galleries/examples/axisartist/demo_axis_direction.py
+++ b/galleries/examples/axisartist/demo_axis_direction.py
@@ -22,7 +22,7 @@ def setup_axes(fig, rect):
     grid_helper = GridHelperCurveLinear(
         (
             Affine2D().scale(np.pi/180., 1.) +
-            PolarAxes.PolarTransform(apply_theta_transforms=False)
+            PolarAxes.PolarTransform()
         ),
         extreme_finder=angle_helper.ExtremeFinderCycle(
             20, 20,

--- a/galleries/examples/axisartist/demo_curvelinear_grid.py
+++ b/galleries/examples/axisartist/demo_curvelinear_grid.py
@@ -54,8 +54,7 @@ def curvelinear_test2(fig):
 
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
-    tr = Affine2D().scale(np.pi/180, 1) + PolarAxes.PolarTransform(
-        apply_theta_transforms=False)
+    tr = Affine2D().scale(np.pi/180, 1) + PolarAxes.PolarTransform()
     # Polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes
     # (min, max of the coordinate within the view).

--- a/galleries/examples/axisartist/demo_floating_axes.py
+++ b/galleries/examples/axisartist/demo_floating_axes.py
@@ -54,7 +54,7 @@ def setup_axes2(fig, rect):
     With custom locator and formatter.
     Note that the extreme values are swapped.
     """
-    tr = PolarAxes.PolarTransform(apply_theta_transforms=False)
+    tr = PolarAxes.PolarTransform()
 
     pi = np.pi
     angle_ticks = [(0, r"$0$"),
@@ -99,8 +99,7 @@ def setup_axes3(fig, rect):
     # scale degree to radians
     tr_scale = Affine2D().scale(np.pi/180., 1.)
 
-    tr = tr_rotate + tr_scale + PolarAxes.PolarTransform(
-        apply_theta_transforms=False)
+    tr = tr_rotate + tr_scale + PolarAxes.PolarTransform()
 
     grid_locator1 = angle_helper.LocatorHMS(4)
     tick_formatter1 = angle_helper.FormatterHMS()

--- a/galleries/examples/axisartist/demo_floating_axis.py
+++ b/galleries/examples/axisartist/demo_floating_axis.py
@@ -22,8 +22,7 @@ import mpl_toolkits.axisartist.angle_helper as angle_helper
 def curvelinear_test2(fig):
     """Polar projection, but in a rectangular box."""
     # see demo_curvelinear_grid.py for details
-    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform(
-        apply_theta_transforms=False)
+    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform()
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20,
                                                      20,

--- a/galleries/examples/axisartist/simple_axis_pad.py
+++ b/galleries/examples/axisartist/simple_axis_pad.py
@@ -21,8 +21,7 @@ def setup_axes(fig, rect):
     """Polar projection, but in a rectangular box."""
 
     # see demo_curvelinear_grid.py for details
-    tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform(
-        apply_theta_transforms=False)
+    tr = Affine2D().scale(np.pi/180., 1.) + PolarAxes.PolarTransform()
 
     extreme_finder = angle_helper.ExtremeFinderCycle(20, 20,
                                                      lon_cycle=360,

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -15,20 +15,6 @@ import matplotlib.transforms as mtransforms
 from matplotlib.spines import Spine
 
 
-def _apply_theta_transforms_warn():
-    _api.warn_deprecated(
-                "3.9",
-                message=(
-                    "Passing `apply_theta_transforms=True` (the default) "
-                    "is deprecated since Matplotlib %(since)s. "
-                    "Support for this will be removed in Matplotlib in %(removal)s. "
-                    "To prevent this warning, set `apply_theta_transforms=False`, "
-                    "and make sure to shift theta values before being passed to "
-                    "this transform."
-                )
-            )
-
-
 class PolarTransform(mtransforms.Transform):
     r"""
     The base polar transform.
@@ -48,8 +34,7 @@ class PolarTransform(mtransforms.Transform):
 
     input_dims = output_dims = 2
 
-    def __init__(self, axis=None, use_rmin=True, *,
-                 apply_theta_transforms=True, scale_transform=None):
+    def __init__(self, axis=None, use_rmin=True, *, scale_transform=None):
         """
         Parameters
         ----------
@@ -64,15 +49,12 @@ class PolarTransform(mtransforms.Transform):
         super().__init__()
         self._axis = axis
         self._use_rmin = use_rmin
-        self._apply_theta_transforms = apply_theta_transforms
         self._scale_transform = scale_transform
-        if apply_theta_transforms:
-            _apply_theta_transforms_warn()
 
     __str__ = mtransforms._make_str_method(
         "_axis",
-        use_rmin="_use_rmin",
-        apply_theta_transforms="_apply_theta_transforms")
+        use_rmin="_use_rmin"
+    )
 
     def _get_rorigin(self):
         # Get lower r limit after being scaled by the radial scale transform
@@ -82,11 +64,6 @@ class PolarTransform(mtransforms.Transform):
     def transform_non_affine(self, values):
         # docstring inherited
         theta, r = np.transpose(values)
-        # PolarAxes does not use the theta transforms here, but apply them for
-        # backwards-compatibility if not being used by it.
-        if self._apply_theta_transforms and self._axis is not None:
-            theta *= self._axis.get_theta_direction()
-            theta += self._axis.get_theta_offset()
         if self._use_rmin and self._axis is not None:
             r = (r - self._get_rorigin()) * self._axis.get_rsign()
         r = np.where(r >= 0, r, np.nan)
@@ -148,10 +125,7 @@ class PolarTransform(mtransforms.Transform):
 
     def inverted(self):
         # docstring inherited
-        return PolarAxes.InvertedPolarTransform(
-            self._axis, self._use_rmin,
-            apply_theta_transforms=self._apply_theta_transforms
-        )
+        return PolarAxes.InvertedPolarTransform(self._axis, self._use_rmin)
 
 
 class PolarAffine(mtransforms.Affine2DBase):
@@ -209,8 +183,7 @@ class InvertedPolarTransform(mtransforms.Transform):
     """
     input_dims = output_dims = 2
 
-    def __init__(self, axis=None, use_rmin=True,
-                 *, apply_theta_transforms=True):
+    def __init__(self, axis=None, use_rmin=True):
         """
         Parameters
         ----------
@@ -225,26 +198,16 @@ class InvertedPolarTransform(mtransforms.Transform):
         super().__init__()
         self._axis = axis
         self._use_rmin = use_rmin
-        self._apply_theta_transforms = apply_theta_transforms
-        if apply_theta_transforms:
-            _apply_theta_transforms_warn()
 
     __str__ = mtransforms._make_str_method(
         "_axis",
-        use_rmin="_use_rmin",
-        apply_theta_transforms="_apply_theta_transforms")
+        use_rmin="_use_rmin")
 
     def transform_non_affine(self, values):
         # docstring inherited
         x, y = values.T
         r = np.hypot(x, y)
         theta = (np.arctan2(y, x) + 2 * np.pi) % (2 * np.pi)
-        # PolarAxes does not use the theta transforms here, but apply them for
-        # backwards-compatibility if not being used by it.
-        if self._apply_theta_transforms and self._axis is not None:
-            theta -= self._axis.get_theta_offset()
-            theta *= self._axis.get_theta_direction()
-            theta %= 2 * np.pi
         if self._use_rmin and self._axis is not None:
             r += self._axis.get_rorigin()
             r *= self._axis.get_rsign()
@@ -254,7 +217,6 @@ class InvertedPolarTransform(mtransforms.Transform):
         # docstring inherited
         return PolarAxes.PolarTransform(
             self._axis, self._use_rmin,
-            apply_theta_transforms=self._apply_theta_transforms
         )
 
 
@@ -895,7 +857,6 @@ class PolarAxes(Axes):
         # data.  This one is aware of rmin
         self.transProjection = self.PolarTransform(
             self,
-            apply_theta_transforms=False,
             scale_transform=self.transScale
         )
         # Add dependency on rorigin.

--- a/lib/matplotlib/projections/polar.pyi
+++ b/lib/matplotlib/projections/polar.pyi
@@ -18,7 +18,6 @@ class PolarTransform(mtransforms.Transform):
         axis: PolarAxes | None = ...,
         use_rmin: bool = ...,
         *,
-        apply_theta_transforms: bool = ...,
         scale_transform: mtransforms.Transform | None = ...,
     ) -> None: ...
     def inverted(self) -> InvertedPolarTransform: ...
@@ -35,8 +34,6 @@ class InvertedPolarTransform(mtransforms.Transform):
         self,
         axis: PolarAxes | None = ...,
         use_rmin: bool = ...,
-        *,
-        apply_theta_transforms: bool = ...,
     ) -> None: ...
     def inverted(self) -> PolarTransform: ...
 

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -891,8 +891,7 @@ CompositeGenericTransform(
                 Affine2D().scale(1.0))),
         PolarTransform(
             PolarAxes(0.125,0.1;0.775x0.8),
-            use_rmin=True,
-            apply_theta_transforms=False)),
+            use_rmin=True)),
     CompositeGenericTransform(
         CompositeGenericTransform(
             PolarAffine(

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1553,7 +1553,7 @@ class _AnnotationBase:
             return self.axes.transData
         elif coords == 'polar':
             from matplotlib.projections import PolarAxes
-            tr = PolarAxes.PolarTransform(apply_theta_transforms=False)
+            tr = PolarAxes.PolarTransform()
             trans = tr + self.axes.transData
             return trans
 

--- a/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_floating_axes.py
@@ -26,7 +26,7 @@ def test_curvelinear3():
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
-          mprojections.PolarAxes.PolarTransform(apply_theta_transforms=False))
+          mprojections.PolarAxes.PolarTransform())
     grid_helper = GridHelperCurveLinear(
         tr,
         extremes=(0, 360, 10, 3),
@@ -75,7 +75,7 @@ def test_curvelinear4():
     fig = plt.figure(figsize=(5, 5))
 
     tr = (mtransforms.Affine2D().scale(np.pi / 180, 1) +
-          mprojections.PolarAxes.PolarTransform(apply_theta_transforms=False))
+          mprojections.PolarAxes.PolarTransform())
     grid_helper = GridHelperCurveLinear(
         tr,
         extremes=(120, 30, 10, 0),

--- a/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
@@ -83,7 +83,7 @@ def test_polar_box():
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
     tr = (Affine2D().scale(np.pi / 180., 1.) +
-          PolarAxes.PolarTransform(apply_theta_transforms=False))
+          PolarAxes.PolarTransform())
 
     # polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes
@@ -146,7 +146,7 @@ def test_axis_direction():
     # PolarAxes.PolarTransform takes radian. However, we want our coordinate
     # system in degree
     tr = (Affine2D().scale(np.pi / 180., 1.) +
-          PolarAxes.PolarTransform(apply_theta_transforms=False))
+          PolarAxes.PolarTransform())
 
     # polar projection, which involves cycle, and also has limits in
     # its coordinates, needs a special method to find the extremes


### PR DESCRIPTION
This removes the deprecation that was introduced in https://github.com/matplotlib/matplotlib/pull/24834.