### PR TITLE
Enable linting of .pyi files

### DIFF
--- a/lib/matplotlib/__init__.pyi
+++ b/lib/matplotlib/__init__.pyi
@@ -26,6 +26,8 @@ __all__ = [
     "interactive",
     "is_interactive",
     "colormaps",
+    "multivar_colormaps",
+    "bivar_colormaps",
     "color_sequences",
 ]
 

--- a/lib/matplotlib/_enums.pyi
+++ b/lib/matplotlib/_enums.pyi
@@ -1,4 +1,3 @@
-from typing import cast
 from enum import Enum
 
 

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -2,7 +2,6 @@ from matplotlib.axes._base import _AxesBase
 from matplotlib.axes._secondary_axes import SecondaryAxis
 
 from matplotlib.artist import Artist
-from matplotlib.backend_bases import RendererBase
 from matplotlib.collections import (
     Collection,
     FillBetweenPolyCollection,
@@ -32,7 +31,6 @@ import matplotlib.table as mtable
 import matplotlib.stackplot as mstack
 import matplotlib.streamplot as mstream
 
-import datetime
 import PIL.Image
 from collections.abc import Callable, Iterable, Sequence
 from typing import Any, Literal, overload

--- a/lib/matplotlib/colorizer.pyi
+++ b/lib/matplotlib/colorizer.pyi
@@ -1,6 +1,5 @@
 from matplotlib import cbook, colorbar, colors, artist
 
-from typing import overload
 import numpy as np
 from numpy.typing import ArrayLike
 

--- a/lib/matplotlib/colors.pyi
+++ b/lib/matplotlib/colors.pyi
@@ -196,8 +196,8 @@ class BivarColormap:
     M: int
     n_variates: int
     def __init__(
-    	self, N: int = ..., M: int | None = ..., shape: Literal['square', 'circle', 'ignore', 'circleignore'] = ...,
-    	origin: Sequence[float] = ..., name: str = ...
+        self, N: int = ..., M: int | None = ..., shape: Literal['square', 'circle', 'ignore', 'circleignore'] = ...,
+        origin: Sequence[float] = ..., name: str = ...
     ) -> None: ...
     @overload
     def __call__(
@@ -245,8 +245,8 @@ class SegmentedBivarColormap(BivarColormap):
 
 class BivarColormapFromImage(BivarColormap):
     def __init__(
-    	self, lut: np.ndarray, shape: Literal['square', 'circle', 'ignore', 'circleignore'] = ...,
-    	origin: Sequence[float] = ..., name: str = ...
+        self, lut: np.ndarray, shape: Literal['square', 'circle', 'ignore', 'circleignore'] = ...,
+        origin: Sequence[float] = ..., name: str = ...
     ) -> None: ...
 
 class Normalize:

--- a/lib/matplotlib/contour.pyi
+++ b/lib/matplotlib/contour.pyi
@@ -1,7 +1,7 @@
 import matplotlib.cm as cm
 from matplotlib.artist import Artist
 from matplotlib.axes import Axes
-from matplotlib.collections import Collection, PathCollection
+from matplotlib.collections import Collection
 from matplotlib.colorizer import Colorizer, ColorizingArtist
 from matplotlib.colors import Colormap, Normalize
 from matplotlib.path import Path

--- a/lib/matplotlib/table.pyi
+++ b/lib/matplotlib/table.pyi
@@ -8,7 +8,7 @@ from .transforms import Bbox
 from .typing import ColorType
 
 from collections.abc import Sequence
-from typing import Any, Literal, TYPE_CHECKING
+from typing import Any, Literal
 
 from pandas import DataFrame
 

--- a/lib/matplotlib/text.pyi
+++ b/lib/matplotlib/text.pyi
@@ -14,7 +14,7 @@ from .transforms import (
     Transform,
 )
 
-from collections.abc import Callable, Iterable
+from collections.abc import Iterable
 from typing import Any, Literal
 from .typing import ColorType, CoordsType
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,8 +99,6 @@ exclude = [
     "tools/gh_api.py",
     ".tox",
     ".eggs",
-    # TODO: fix .pyi files
-    "*.pyi",
     # TODO: fix .ipynb files
     "*.ipynb"
 ]
@@ -173,6 +171,7 @@ external = [
 convention = "numpy"
 
 [tool.ruff.lint.per-file-ignores]
+"*.pyi" = ["E501"]
 "doc/conf.py" = ["E402"]
 "galleries/examples/animation/frame_grabbing_sgskip.py" = ["E402"]
 "galleries/examples/images_contours_and_fields/tricontour_demo.py" = ["E201"]


### PR DESCRIPTION
Enables linting of .pyi files. Most of the fixes here are line length, other fixes are:

- Fix `__all__` in `__init__.pyi`
- Remove unused imports