### PR TITLE
Update colorbar with new colorizer API

### DIFF
--- a/lib/matplotlib/colorbar.pyi
+++ b/lib/matplotlib/colorbar.pyi
@@ -22,11 +22,8 @@ class _ColorbarSpine(mspines.Spines):
 
 class Colorbar:
     n_rasterize: int
-    mappable: cm.ScalarMappable | colorizer.ColorizingArtist
     ax: Axes
     alpha: float | None
-    cmap: colors.Colormap
-    norm: colors.Normalize
     values: Sequence[float] | None
     boundaries: Sequence[float] | None
     extend: Literal["neither", "both", "min", "max"]
@@ -44,7 +41,7 @@ class Colorbar:
     def __init__(
         self,
         ax: Axes,
-        mappable: cm.ScalarMappable | colorizer.ColorizingArtist | None = ...,
+        mappable: cm.ScalarMappable | colorizer.ColorizingArtist | colorizer.Colorizer | None = ...,
         *,
         cmap: str | colors.Colormap | None = ...,
         norm: colors.Normalize | None = ...,
@@ -63,6 +60,16 @@ class Colorbar:
         label: str = ...,
         location: Literal["left", "right", "top", "bottom"] | None = ...
     ) -> None: ...
+    @property
+    def mappable(self) -> cm.ScalarMappable | colorizer.ColorizingArtist : ...
+    @property
+    def colorizer(self) -> colorizer.Colorizer : ...
+    @colorizer.setter
+    def colorizer(self, colorizer) -> None : ...
+    @property
+    def cmap(self) -> colors.Colormap : ...
+    @property
+    def norm(self) -> colors.Normalize : ...
     @property
     def long_axis(self) -> Axis: ...
     @property

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1200,17 +1200,17 @@ default: %(va)s
         Parameters
         ----------
         mappable
-            The `matplotlib.cm.ScalarMappable` (i.e., `.AxesImage`,
-            `.ContourSet`, etc.) described by this colorbar.  This argument is
-            mandatory for the `.Figure.colorbar` method but optional for the
-            `.pyplot.colorbar` function, which sets the default to the current
-            image.
+            The `matplotlib.colorizer.ColorizingArtist` (i.e., `.AxesImage`,
+            `.ContourSet`, etc.) or `matplotlib.colorizer.Colorizer` described
+            by this colorbar.  This argument is mandatory for the
+            `.Figure.colorbar` method but optional for the `.pyplot.colorbar`
+            function, which sets the default to the current image.
 
-            Note that one can create a `.ScalarMappable` "on-the-fly" to
-            generate colorbars not attached to a previously drawn artist, e.g.
+            Note that one can create a `.Colorizer` "on-the-fly" to
+            generate colorbars not attached an artist, e.g.
             ::
 
-                fig.colorbar(cm.ScalarMappable(norm=norm, cmap=cmap), ax=ax)
+                fig.colorbar(colorizer.Colorizer(norm=norm, cmap=cmap), ax=ax)
 
         cax : `~matplotlib.axes.Axes`, optional
             Axes into which the colorbar will be drawn.  If `None`, then a new

--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -169,7 +169,7 @@ class FigureBase(Artist):
     ) -> Text: ...
     def colorbar(
         self,
-        mappable: ScalarMappable | ColorizingArtist,
+        mappable: ScalarMappable | ColorizingArtist | Colorizer,
         cax: Axes | None = ...,
         ax: Axes | Iterable[Axes] | None = ...,
         use_gridspec: bool = ...,

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1239,3 +1239,13 @@ def test_colorbar_format_string_and_old():
     plt.imshow([[0, 1]])
     cb = plt.colorbar(format="{x}%")
     assert isinstance(cb._formatter, StrMethodFormatter)
+
+
+def test_colorizer():
+    fig, ax = plt.subplots()
+    c = mpl.colorizer.Colorizer(norm=mcolors.Normalize(), cmap='viridis')
+    fig.colorbar(c, cax=ax)
+    c.vmin = -1
+    c.vmax = 2
+    np.testing.assert_almost_equal(ax.yaxis.get_ticklocs()[0], -1)
+    np.testing.assert_almost_equal(ax.yaxis.get_ticklocs()[-1], 2)


### PR DESCRIPTION
Updates colorbar.colorbar to accept a colorizer.Colorizer object, in addition to colorizer.ColorizingArtist. This commit also changes the docs from referencing cm.ScalarMappable to referencing colorizer.ColorizingArtist.

## PR summary
With the introduction of `colorizer.Colorizer` and `colorizer.ColorizingArtist` (#28658) we have separated the norm→color pipeline from the artist. However, the colorbar API has not been updated since these changes took effect. 

Consider [this example](https://matplotlib.org/stable/users/explain/colors/colorbar_only.html#basic-continuous-colorbar):
```
fig, ax = plt.subplots(figsize=(6, 1), layout='constrained')

norm = mpl.colors.Normalize(vmin=5, vmax=10)

fig.colorbar(mpl.cm.ScalarMappable(norm=norm, cmap='cool'),
             cax=ax, orientation='horizontal', label='Some Units')
```
![image](https://github.com/user-attachments/assets/a99ec444-1f7c-48e7-8fe3-b2c5dc83b24a)

With the new colorizer API, one would expect be able to replace `cm.ScalarMappable` above with `colorizer.Colorizer`, however, this is currently not possible, and one must instead replace `cm.ScalarMappable` above with `colorizer.ColorizingArtist`, which requires a `colorizer.Colorizer` as input.

```py 
fig.colorbar(mpl.colorizer.ColorizingArtist(mpl.colorizer.Colorizer(norm=norm, cmap='cool')),
             cax=ax, orientation='horizontal', label='Some Units')
```
This is despite the fact that the norm→color pipeline is entirely contained in the colorizer, and it fails only because of a single call to `self.mappable.get_array()` within `colorbar.Colorbar()`.

This PR updates `colorbar.colorbar()` so that it can accept a `colorizer.Colorizer` as an alternative to `colorizer.ColorizingArtist`.

```py
fig.colorbar(mpl.colorizer.Colorizer(norm=norm, cmap='cool'),
             cax=ax, orientation='horizontal', label='Some Units')
```

The following additional changes are included in this PR:
* Changes the docs from referencing `cm.ScalarMappable` to `colorizer.ColorizingArtist`.
* Updates `colorbar.Colorbar` to the new colorizer API by adding `.colorizer` as a mutable property on a `colorbar.Colorbar` [this must be mutable as it is mutable for `ColorizingArtist` and when it changes on the artist it must change on the colorbar]
* makes the `.norm` and `.cmap` of a colorbar properties that get the relevant property from the colorizer. This also makes the explicitly immutable.
* makes the `.mappable` on a `colorbar.Colorbar` explicitly immutable.




## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [¹] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

 ¹ I would like to update https://matplotlib.org/stable/users/explain/colors/colorbar_only.html and https://matplotlib.org/stable/gallery/images_contours_and_fields/multi_image.html but I think that would benefit from having this PR be implemented first.