### PR TITLE
Backport PR #29992 on v3.10.x: Update pinned oldest win image on azure

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ stages:
               vmImage: 'macOS-latest'
               python.version: '3.11'
             Windows_py310:
-              vmImage: 'windows-2019'  # keep one job pinned to the oldest image
+              vmImage: 'windows-2022'  # keep one job pinned to the oldest image
               python.version: '3.10'
             Windows_py311:
               vmImage: 'windows-latest'
@@ -181,50 +181,22 @@ stages:
                 VS=$(ls -d /c/Program\ Files*/Microsoft\ Visual\ Studio/*/Enterprise)
                 echo "Visual Studio: ${VS}"
                 DIR="$VS/Common7/IDE/Extensions/Microsoft/CodeCoverage.Console"
-                if [[ -d $DIR ]]; then
-                  # This is for MSVC 2022 (on windows-latest).
-                  TOOL="$DIR/Microsoft.CodeCoverage.Console.exe"
-                  for f in build/cp*/src/*.pyd; do
-                    echo $f
-                    echo "=============================="
-                    "$TOOL" instrument $f --session-id $SESSION_ID \
-                      --log-level Verbose --log-file instrument.log
-                    cat instrument.log
-                    rm instrument.log
-                  done
-                  echo "Starting $TOOL in server mode"
-                  "$TOOL" collect \
-                      --session-id $SESSION_ID --server-mode \
-                      --output-format cobertura --output extensions.xml \
-                      --log-level Verbose --log-file extensions.log &
-                  VS_VER=2022
-                else
-                DIR="$VS"/Team\ Tools/Dynamic\ Code\ Coverage\ Tools/amd64
-                if [[ -d $DIR ]]; then
-                  # This is for MSVC 2019 (on windows-2019).
-                  VSINSTR="$VS"/Team\ Tools/Performance\ Tools/vsinstr.exe
-                  for f in build/cp*/src/*.pyd; do
-                    "$VSINSTR" $f -Verbose -Coverage
-                  done
-                  TOOL="$DIR/CodeCoverage.exe"
-                  cat > extensions.config << EOF
-              <CodeCoverage>
-                <CollectFromChildProcesses>true</CollectFromChildProcesses>
-                <ModulePaths>
-                  <Include>
-                    <ModulePath>.*\\.*\.pyd</ModulePath>
-                  </Include>
-                </ModulePaths>
-              </CodeCoverage>
-              EOF
-                  echo "Starting $TOOL in server mode"
-                  "$TOOL" collect \
-                    -config:extensions.config -session:$SESSION_ID \
-                    -output:extensions.coverage -verbose &
-                  echo "Started $TOOL"
-                  VS_VER=2019
-                fi
-                fi
+                # This is for MSVC 2022 (on windows-latest).
+                TOOL="$DIR/Microsoft.CodeCoverage.Console.exe"
+                for f in build/cp*/src/*.pyd; do
+                  echo $f
+                  echo "=============================="
+                  "$TOOL" instrument $f --session-id $SESSION_ID \
+                    --log-level Verbose --log-file instrument.log
+                  cat instrument.log
+                  rm instrument.log
+                done
+                echo "Starting $TOOL in server mode"
+                "$TOOL" collect \
+                    --session-id $SESSION_ID --server-mode \
+                    --output-format cobertura --output extensions.xml \
+                    --log-level Verbose --log-file extensions.log &
+                VS_VER=2022
                 echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
               fi
               PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 2 \


### PR DESCRIPTION
Manual backport of #29992.  Conflicts were because we have more runners on the v3.10.x branch:

* We still support python 3.10 here so the minimum image is used for that instead of python 3.11
* #29171 was not backported so we have multiple platforms and so the modified if-loop is more nested

(cherry picked from commit ab102c079ae0474861bbb1dcc64da436d1a84f8b)
