### PR TITLE
Allow setting of aspect ratio for Axes in rcParams - Draft PR

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -680,7 +680,7 @@ class _AxesBase(martist.Artist):
             raise ValueError('Width and height specified must be non-negative')
         self._originalPosition = self._position.frozen()
         self.axes = self
-        self._aspect = 'auto'
+        self._aspect = None
         self._adjustable = 'box'
         self._anchor = 'C'
         self._stale_viewlims = dict.fromkeys(self._axis_names, False)
@@ -1656,9 +1656,12 @@ class _AxesBase(martist.Artist):
         """
         Return the aspect ratio of the Axes scaling.
 
-        This is either "auto" or a float giving the ratio of y/x-scale.
+        This is either "auto", "equal" or a float giving the ratio of y/x-scale.
         """
-        return self._aspect
+        if self._aspect:
+            return self._aspect
+        aspect = mpl.rcParams['axes.aspect']
+        return aspect if aspect != 'equal' else 1
 
     def set_aspect(self, aspect, adjustable=None, anchor=None, share=False):
         """

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -390,6 +390,7 @@
 #axes.labelpad:      4.0     # space between label and axis
 #axes.labelweight:   normal  # weight of the x and y labels
 #axes.labelcolor:    black
+#axes.aspect:        auto    # {auto, equal} or a number
 #axes.axisbelow:     line    # draw axis gridlines and ticks:
                              #     - below patches (True)
                              #     - above patches but below lines ('line')

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -185,6 +185,7 @@ axes.labelsize      : medium  # fontsize of the x any y labels
 axes.labelpad       : 5.0     # space between label and axis
 axes.labelweight    : normal  # weight of the x and y labels
 axes.labelcolor     : k
+axes.aspect         : auto    # auto | equal | a number
 axes.axisbelow      : False   # whether axis gridlines and ticks are below
                               # the axes elements (lines, text, etc)
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1108,6 +1108,8 @@ _validators = {
     "axes.spines.bottom":    validate_bool,  # denoting data boundary.
     "axes.spines.top":       validate_bool,
 
+    "axes.aspect": validate_aspect,  # auto, equal, a number
+
     "axes.titlesize":     validate_fontsize,  # Axes title fontsize
     "axes.titlelocation": ["left", "center", "right"],  # Axes title alignment
     "axes.titleweight":   validate_fontweight,  # Axes title font weight


### PR DESCRIPTION
** DRAFT PR **

closes #8088

Implementing feature that allows the setting of a default aspect ratio for axes, not just images. New features involves the addition of the rcParam: axes.aspect.

Below is a screenshot showing the feature in action (before the last couple of recent upstream commits were merged into the branch):
![image](https://github.com/user-attachments/assets/c05df1eb-86cc-4828-a1b7-74fe757199ba)



