### PR TITLE
Micro-optimize _to_rgba_no_colorcycle.

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -372,40 +372,31 @@ def _to_rgba_no_colorcycle(c, alpha=None):
             # This may turn c into a non-string, so we check again below.
             c = _colors_full_map[c]
         except KeyError:
-            if len(orig_c) != 1:
+            if len(c) != 1:
                 try:
                     c = _colors_full_map[c.lower()]
                 except KeyError:
                     pass
     if isinstance(c, str):
-        # hex color in #rrggbb format.
-        match = re.match(r"\A#[a-fA-F0-9]{6}\Z", c)
-        if match:
-            return (tuple(int(n, 16) / 255
-                          for n in [c[1:3], c[3:5], c[5:7]])
-                    + (alpha if alpha is not None else 1.,))
-        # hex color in #rgb format, shorthand for #rrggbb.
-        match = re.match(r"\A#[a-fA-F0-9]{3}\Z", c)
-        if match:
-            return (tuple(int(n, 16) / 255
-                          for n in [c[1]*2, c[2]*2, c[3]*2])
-                    + (alpha if alpha is not None else 1.,))
-        # hex color with alpha in #rrggbbaa format.
-        match = re.match(r"\A#[a-fA-F0-9]{8}\Z", c)
-        if match:
-            color = [int(n, 16) / 255
-                     for n in [c[1:3], c[3:5], c[5:7], c[7:9]]]
-            if alpha is not None:
-                color[-1] = alpha
-            return tuple(color)
-        # hex color with alpha in #rgba format, shorthand for #rrggbbaa.
-        match = re.match(r"\A#[a-fA-F0-9]{4}\Z", c)
-        if match:
-            color = [int(n, 16) / 255
-                     for n in [c[1]*2, c[2]*2, c[3]*2, c[4]*2]]
-            if alpha is not None:
-                color[-1] = alpha
-            return tuple(color)
+        if re.fullmatch("#[a-fA-F0-9]+", c):
+            if len(c) == 7:  # #rrggbb hex format.
+                return (*[n / 0xff for n in bytes.fromhex(c[1:])],
+                        alpha if alpha is not None else 1.)
+            elif len(c) == 4:  # #rgb hex format, shorthand for #rrggbb.
+                return (*[int(n, 16) / 0xf for n in c[1:]],
+                        alpha if alpha is not None else 1.)
+            elif len(c) == 9:  # #rrggbbaa hex format.
+                color = [n / 0xff for n in bytes.fromhex(c[1:])]
+                if alpha is not None:
+                    color[-1] = alpha
+                return tuple(color)
+            elif len(c) == 5:  # #rgba hex format, shorthand for #rrggbbaa.
+                color = [int(n, 16) / 0xf for n in c[1:]]
+                if alpha is not None:
+                    color[-1] = alpha
+                return tuple(color)
+            else:
+                raise ValueError(f"Invalid hex color specifier: {orig_c!r}")
         # string gray.
         try:
             c = float(c)


### PR DESCRIPTION
This patch speeds up conversions of `#rgba`-type formats by between 25% and 40% (while shortening the implementation), although real benefits should be limited because of caching in to_rgba.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
