### PR TITLE
Feature Implementation for "setting spine default location displacement rcParams" *ATTEMPT 2* - DRAFT PR

### DIFF
--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -420,6 +420,11 @@
 #axes.spines.top:    True
 #axes.spines.right:  True
 
+#axes.spines.left.position:   outward, 0.0 # set (outward, axes, data) position
+#axes.spines.bottom.position: outward, 0.0
+#axes.spines.top.position:    outward, 0.0
+#axes.spines.right.position:  outward, 0.0
+
 #axes.unicode_minus: True  # use Unicode for the minus symbol rather than hyphen.  See
                            # https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
 #axes.prop_cycle: cycler(color='tab10')

--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -215,6 +215,11 @@ axes.prop_cycle    : cycler('color', 'bgrcmyk')
                                            # as list of string colorspecs:
                                            # single letter, long name, or
                                            # web-style hex
+axes.spines.bottom.position: outward, 0.0
+axes.spines.left.position:   outward, 0.0
+axes.spines.right.position:  outward, 0.0
+axes.spines.top.position:    outward, 0.0
+
 axes.autolimit_mode : round_numbers
 axes.xmargin        : 0  # x margin.  See `axes.Axes.margins`
 axes.ymargin        : 0  # y margin See `axes.Axes.margins`

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1108,6 +1108,11 @@ _validators = {
     "axes.spines.bottom":    validate_bool,  # denoting data boundary.
     "axes.spines.top":       validate_bool,
 
+    "axes.spines.left.position":      validate_anylist,
+    "axes.spines.right.position":     validate_anylist,
+    "axes.spines.bottom.position":    validate_anylist,
+    "axes.spines.top.position":       validate_anylist,
+
     "axes.titlesize":     validate_fontsize,  # Axes title fontsize
     "axes.titlelocation": ["left", "center", "right"],  # Axes title alignment
     "axes.titleweight":   validate_fontweight,  # Axes title font weight

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -202,8 +202,12 @@ class Spine(mpatches.Patch):
 
     def _ensure_position_is_set(self):
         if self._position is None:
-            # default position
-            self._position = ('outward', 0.0)  # in points
+            # default position in points
+            default_pos = mpl.rcParams[f'axes.spines.{self.spine_type}.position']
+            if len(default_pos) == 1:
+                self._position = default_pos[0]
+            else:
+                self._position = [default_pos[0], float(default_pos[1])]
             self.set_position(self._position)
 
     def register_axis(self, axis):


### PR DESCRIPTION
** DRAFT PULL REQUEST **

closes #13930 

This PR is a re-attempt of PR #30011 which I think I messed up. I address the comments made in that PR conversation as well.

Implementing feature to set default spine positions for top, left, right and bottom using rcParams. Feature implementation involves the addition of four new rcParams:

axes.spines.left.position
axes.spines.right.position
axes.spines.bottom.position
axes.spines.top.position

The default value for the rcParams is ('outward', 0.0). The 'axes.spines.{spine_type}.position' format for the rcParams was chosen, as 'axes.spines.{spine_type}' is already taken for another purpose, I believe whether to show or not show an axis.

The rcParams can be set to ('outward' | 'axes' | 'data', amount) or 'center' or 'zero'

Below is a screenshot showing the feature in action.

![image](https://github.com/user-attachments/assets/fb796c53-24da-4e40-b98d-8789d1e739f7)