### PR TITLE
Deprecate unused 'origin' and 'extent' in tricontour and tricontour

### DIFF
--- a/lib/matplotlib/tri/_tricontour.py
+++ b/lib/matplotlib/tri/_tricontour.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from matplotlib._api.deprecation import delete_parameter
 from matplotlib import _docstring
 from matplotlib.contour import ContourSet
 from matplotlib.tri._triangulation import Triangulation
@@ -219,6 +220,9 @@ antialiased : bool, optional
 
 @_docstring.Substitution(func='tricontour', type='lines')
 @_docstring.interpd
+@delete_parameter("3.9", "tricontour", "origin")
+@delete_parameter("3.9", "tricontour", "extent")
+
 def tricontour(ax, *args, **kwargs):
     """
     %(_tricontour_doc)s


### PR DESCRIPTION
As recommended by @rcomer i just used the decorator to take care of the issue.

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/24006)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines