### PR TITLE
Update diagram in subplots_adjust documentation to clarify parameters

### DIFF
--- a/doc/_embedded_plots/figure_subplots_adjust.py
+++ b/doc/_embedded_plots/figure_subplots_adjust.py
@@ -1,31 +1,34 @@
 import matplotlib.pyplot as plt
 
 
-def arrow(p1, p2, **props):
-    overlay.annotate(
-        "", p1, p2, xycoords='figure fraction',
-        arrowprops=dict(arrowstyle="<->", shrinkA=0, shrinkB=0, **props))
-
 fig, axs = plt.subplots(2, 2, figsize=(6.5, 4))
 fig.set_facecolor('lightblue')
 fig.subplots_adjust(0.1, 0.1, 0.9, 0.9, 0.4, 0.4)
 
 overlay = fig.add_axes([0, 0, 1, 1], zorder=100)
 overlay.axis("off")
+xycoords='figure fraction'
+arrowprops=dict(arrowstyle="<->", shrinkA=0, shrinkB=0)
 
 for ax in axs.flat:
     ax.set(xticks=[], yticks=[])
 
-arrow((0, 0.75), (0.1, 0.75))  # left
-arrow((0.435, 0.25), (0.565, 0.25))  # wspace
-arrow((0, 0.8), (0.9, 0.8))  # right
+overlay.annotate("", (0, 0.75), (0.1, 0.75),
+                 xycoords=xycoords, arrowprops=arrowprops)  # left
+overlay.annotate("", (0.435, 0.25), (0.565, 0.25),
+                 xycoords=xycoords, arrowprops=arrowprops)  # wspace
+overlay.annotate("", (0, 0.8), (0.9, 0.8),
+                 xycoords=xycoords, arrowprops=arrowprops)  # right
 fig.text(0.05, 0.7, "left", ha="center")
 fig.text(0.5, 0.3, "wspace", ha="center")
 fig.text(0.05, 0.83, "right", ha="center")
 
-arrow((0.75, 0), (0.75, 0.1))  # bottom
-arrow((0.25, 0.435), (0.25, 0.565))  # hspace
-arrow((0.80, 0), (0.8, 0.9))  # top
+overlay.annotate("", (0.75, 0), (0.75, 0.1),
+                 xycoords=xycoords, arrowprops=arrowprops)  # bottom
+overlay.annotate("", (0.25, 0.435), (0.25, 0.565),
+                 xycoords=xycoords, arrowprops=arrowprops)  # hspace
+overlay.annotate("", (0.8, 0), (0.8, 0.9),
+                 xycoords=xycoords, arrowprops=arrowprops)  # top
 fig.text(0.65, 0.05, "bottom", va="center")
 fig.text(0.28, 0.5, "hspace", va="center")
 fig.text(0.82, 0.05, "top", va="center")

--- a/doc/_embedded_plots/figure_subplots_adjust.py
+++ b/doc/_embedded_plots/figure_subplots_adjust.py
@@ -1,28 +1,30 @@
 import matplotlib.pyplot as plt
 
-
 def arrow(p1, p2, **props):
-    axs[0, 0].annotate(
-        "", p1, p2,  xycoords='figure fraction',
+    overlay.annotate(
+        "", p1, p2, xycoords='figure fraction',
         arrowprops=dict(arrowstyle="<->", shrinkA=0, shrinkB=0, **props))
-
 
 fig, axs = plt.subplots(2, 2, figsize=(6.5, 4))
 fig.set_facecolor('lightblue')
 fig.subplots_adjust(0.1, 0.1, 0.9, 0.9, 0.4, 0.4)
+
+overlay = fig.add_axes([0, 0, 1, 1], zorder=100)
+overlay.axis("off")
+
 for ax in axs.flat:
     ax.set(xticks=[], yticks=[])
 
 arrow((0, 0.75), (0.1, 0.75))  # left
-arrow((0.435, 0.75), (0.565, 0.75))  # wspace
-arrow((0.9, 0.75), (1, 0.75))  # right
+arrow((0.435, 0.25), (0.565, 0.25))  # wspace
+arrow((0.1, 0.8), (1, 0.8))  # right
 fig.text(0.05, 0.7, "left", ha="center")
-fig.text(0.5, 0.7, "wspace", ha="center")
-fig.text(0.95, 0.7, "right", ha="center")
+fig.text(0.5, 0.3, "wspace", ha="center")
+fig.text(0.95, 0.83, "right", ha="center")
 
-arrow((0.25, 0), (0.25, 0.1))  # bottom
+arrow((0.75, 0), (0.75, 0.1))  # bottom
 arrow((0.25, 0.435), (0.25, 0.565))  # hspace
-arrow((0.25, 0.9), (0.25, 1))  # top
-fig.text(0.28, 0.05, "bottom", va="center")
+arrow((0.80, 0.1), (0.8, 1))  # top
+fig.text(0.65, 0.05, "bottom", va="center")
 fig.text(0.28, 0.5, "hspace", va="center")
-fig.text(0.28, 0.95, "top", va="center")
+fig.text(0.75, 0.95, "top", va="center")

--- a/doc/_embedded_plots/figure_subplots_adjust.py
+++ b/doc/_embedded_plots/figure_subplots_adjust.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 
+
 def arrow(p1, p2, **props):
     overlay.annotate(
         "", p1, p2, xycoords='figure fraction',
@@ -17,14 +18,14 @@ for ax in axs.flat:
 
 arrow((0, 0.75), (0.1, 0.75))  # left
 arrow((0.435, 0.25), (0.565, 0.25))  # wspace
-arrow((0.1, 0.8), (1, 0.8))  # right
+arrow((0, 0.8), (0.9, 0.8))  # right
 fig.text(0.05, 0.7, "left", ha="center")
 fig.text(0.5, 0.3, "wspace", ha="center")
-fig.text(0.95, 0.83, "right", ha="center")
+fig.text(0.05, 0.83, "right", ha="center")
 
 arrow((0.75, 0), (0.75, 0.1))  # bottom
 arrow((0.25, 0.435), (0.25, 0.565))  # hspace
-arrow((0.80, 0.1), (0.8, 1))  # top
+arrow((0.80, 0), (0.8, 0.9))  # top
 fig.text(0.65, 0.05, "bottom", va="center")
 fig.text(0.28, 0.5, "hspace", va="center")
-fig.text(0.75, 0.95, "top", va="center")
+fig.text(0.82, 0.05, "top", va="center")


### PR DESCRIPTION
## PR summary
This pull request addresses an issue in the documentation for [](https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure.subplots_adjust.html#matplotlib.figure.Figure.subplots_adjust) where the diagram incorrectly implied that the left, right, top, and bottom parameters were distances from the nearest subplot edges. In reality, these parameters represent distances from the edges of the figure (the overall plotting area).

- Why is this change necessary?
The current diagram is misleading and contradicts the correct usage of subplots_adjust, potentially causing confusion for users trying to control subplot layout. 

- What is the reasoning for this implementation?
The implementation involves updating the Python script (doc/_embedded_plots/figure_subplots_adjust.py) that generates the diagram embedded in the documentation. The plotting code has been modified to accurately represent the relationship between the subplots_adjust parameters and the figure edges, matching the function's actual behavior.

## PR checklist

- [ ]  closes #30022 [matplotlib.figure.Figure.subplots_adjust figure](https://github.com/matplotlib/matplotlib/issues/30022#issuecomment-2861297324)
- [N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in [figure_subplots_adjust.py](https://github.com/matplotlib/matplotlib/blob/main/doc/_embedded_plots/figure_subplots_adjust.py)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
